### PR TITLE
[Plasma] Subscribe without polling

### DIFF
--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -44,6 +44,11 @@ void free_scheduler_state(scheduler_state *s) {
   }
   utarray_free(s->task_queue);
   utarray_free(s->available_workers);
+  available_object *available_obj, *tmp;
+  HASH_ITER(handle, s->local_objects, available_obj, tmp) {
+    HASH_DELETE(handle, s->local_objects, available_obj);
+    free(available_obj);
+  }
   free(s);
 }
 

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -364,7 +364,9 @@ void send_notifications(event_loop *loop,
           "The socket's send buffer is full, so we are caching this "
           "notification and will send it later.");
       /* Add a callback to the event loop to send queued notifications whenever
-       * there is room in the socket's send buffer. */
+       * there is room in the socket's send buffer. Callbacks can be added
+       * more than once here and will be overwritten. The callback is removed
+       * at the end of the method. */
       event_loop_add_file(plasma_state->loop, client_sock, EVENT_LOOP_WRITE,
                           send_notifications, plasma_state);
       break;


### PR DESCRIPTION
This registers the file descriptor we write subscription events to only with the event loop if there is data to be written. Without this fix, the plasma store will invoke send_notifications whenever the socket is writable, which will lead to 100% cpu utilization.
