### PR TITLE
Wait until data is ready to read in manager_tests.

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <execinfo.h>
 
 #ifndef RAY_COMMON_DEBUG
 #define LOG_DEBUG(M, ...)
@@ -21,21 +22,18 @@
 #define LOG_INFO(M, ...) \
   fprintf(stderr, "[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
-#define CHECK(COND)                        \
-  do {                                     \
-    if (!(COND)) {                         \
-      LOG_ERR("Check failure: %s", #COND); \
-      exit(-1);                            \
-    }                                      \
+#define CHECKM(COND, M, ...)                                                \
+  do {                                                                      \
+    if (!(COND)) {                                                          \
+      LOG_ERR("Check failure: %s \n" M, #COND, ##__VA_ARGS__);              \
+      void *buffer[255];                                                    \
+      const int calls = backtrace(buffer, sizeof(buffer) / sizeof(void *)); \
+      backtrace_symbols_fd(buffer, calls, 1);                               \
+      exit(-1);                                                             \
+    }                                                                       \
   } while (0);
 
-#define CHECKM(COND, M, ...)                                   \
-  do {                                                         \
-    if (!(COND)) {                                             \
-      LOG_ERR("Check failure: %s \n" M, #COND, ##__VA_ARGS__); \
-      exit(-1);                                                \
-    }                                                          \
-  } while (0);
+#define CHECK(COND) CHECKM(COND, "")
 
 /** This macro indicates that this pointer owns the data it is pointing to
  *  and is responsible for freeing it. */

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <unistd.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 
@@ -228,6 +229,13 @@ TEST read_write_object_chunk_test(void) {
    * - Check that the data matches.
    */
   write_object_chunk(remote_mock->write_conn, &remote_buf);
+  /* Wait until the data is ready to be read. */
+  struct pollfd poll_list[1];
+  poll_list[0].fd = get_client_sock(remote_mock->read_conn);
+  poll_list[0].events = POLLIN;
+  int retval = poll(poll_list, (unsigned long) 1, -1);
+  ASSERT(retval > 0);
+  /* Read the data. */
   int done = read_object_chunk(remote_mock->read_conn, &local_buf);
   ASSERT(done);
   ASSERT_EQ(memcmp(remote_buf.data, local_buf.data, data_size), 0);


### PR DESCRIPTION
The following sometimes failed before, but it should work now.

```
cd src/plasma
make test
```

pcmoritz: Also added printing backtraces in CHECK and CHECKM like so:

```
.[ERROR] (io.c:154: errno: Resource temporarily unavailable) Check failure: client_fd >= 0
0   manager_tests                       0x0000000108429b05 accept_client + 213
1   manager_tests                       0x000000010842015e new_client_connection + 30
2   manager_tests                       0x0000000108415505 init_plasma_mock + 229
3   manager_tests                       0x0000000108415ecc request_transfer_retry_test + 76
4   manager_tests                       0x0000000108415736 plasma_manager_tests + 246
5   manager_tests                       0x00000001084174e4 greatest_run_suite + 228
6   manager_tests                       0x0000000108417227 main + 183
7   libdyld.dylib                       0x00007fff9503f5ad start + 1
8   ???                                 0x0000000000000001 0x0 + 1
```
