### PR TITLE
Causes build scripts to fail immediately if a single command fails.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Cause the script to exit if a single command fails.
+set -e
+
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 # Determine how many parallel jobs to use for make based on the number of cores

--- a/src/common/thirdparty/build-redis.sh
+++ b/src/common/thirdparty/build-redis.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
 if [ ! -f redis-3.2.3/src/redis-server ]; then
   wget http://download.redis.io/releases/redis-3.2.3.tar.gz
   tar xvfz redis-3.2.3.tar.gz


### PR DESCRIPTION
I would have made the same change to `install-dependencies.sh`, but on Travis on Mac OS X, brew throws an error when it tries to install boost because the boost libraries are already there.