### PR TITLE
Add basic LRU eviction for the plasma store.

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -31,13 +31,13 @@ if [[ $platform == "linux" ]]; then
   # These commands must be kept in sync with the installation instructions.
   sudo apt-get update
   sudo apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
-  sudo pip install funcsigs colorama redis
+  sudo pip install funcsigs colorama psutil redis
   sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
 elif [[ $platform == "macosx" ]]; then
   # These commands must be kept in sync with the installation instructions.
   brew install git cmake automake autoconf libtool boost
   sudo easy_install pip
-  sudo pip install numpy funcsigs colorama redis --ignore-installed six
+  sudo pip install numpy funcsigs colorama psutil redis --ignore-installed six
   sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
 fi
 

--- a/src/photon/test/test.py
+++ b/src/photon/test/test.py
@@ -23,7 +23,7 @@ class TestPhotonClient(unittest.TestCase):
     # Start Plasma.
     plasma_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../plasma/build/plasma_store")
     plasma_socket = "/tmp/plasma_store{}".format(random.randint(0, 10000))
-    self.p2 = subprocess.Popen([plasma_executable, "-s", plasma_socket])
+    self.p2 = subprocess.Popen([plasma_executable, "-s", plasma_socket, "-m", "1000000000"])
     time.sleep(0.1)
     self.plasma_client = plasma.PlasmaClient(plasma_socket)
     scheduler_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../build/photon_scheduler")

--- a/src/photon/test/test.py
+++ b/src/photon/test/test.py
@@ -13,6 +13,7 @@ import photon
 import plasma
 
 USE_VALGRIND = False
+PLASMA_STORE_MEMORY = 1000000000
 
 class TestPhotonClient(unittest.TestCase):
 
@@ -23,7 +24,7 @@ class TestPhotonClient(unittest.TestCase):
     # Start Plasma.
     plasma_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../plasma/build/plasma_store")
     plasma_socket = "/tmp/plasma_store{}".format(random.randint(0, 10000))
-    self.p2 = subprocess.Popen([plasma_executable, "-s", plasma_socket, "-m", "1000000000"])
+    self.p2 = subprocess.Popen([plasma_executable, "-s", plasma_socket, "-m", str(PLASMA_STORE_MEMORY)])
     time.sleep(0.1)
     self.plasma_client = plasma.PlasmaClient(plasma_socket)
     scheduler_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../build/photon_scheduler")

--- a/src/plasma/Makefile
+++ b/src/plasma/Makefile
@@ -16,8 +16,8 @@ clean:
 $(BUILD)/manager_tests: test/manager_tests.c plasma.h plasma_client.h plasma_client.c plasma_manager.h plasma_manager.c fling.h fling.c common
 	$(CC) $(CFLAGS) $(TEST_CFLAGS) -o $@ test/manager_tests.c plasma_manager.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a
 
-$(BUILD)/plasma_store: plasma_store.c plasma.h fling.h fling.c malloc.c malloc.h thirdparty/dlmalloc.c common
-	$(CC) $(CFLAGS) plasma_store.c fling.c malloc.c ../common/build/libcommon.a -o $(BUILD)/plasma_store
+$(BUILD)/plasma_store: plasma_store.c plasma.h eviction_policy.c fling.h fling.c malloc.c malloc.h thirdparty/dlmalloc.c common
+	$(CC) $(CFLAGS) plasma_store.c eviction_policy.c fling.c malloc.c ../common/build/libcommon.a -o $(BUILD)/plasma_store
 
 $(BUILD)/plasma_manager: plasma_manager.c plasma.h plasma_client.c fling.h fling.c common
 	$(CC) $(CFLAGS) plasma_manager.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a -o $(BUILD)/plasma_manager

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -1,6 +1,31 @@
 #include "eviction_policy.h"
 
+#include "utlist.h"
+
 void dlfree(void *);
+
+/** An element representing a released object in a doubly-linked list. This is
+ *  used to implement an LRU cache. */
+typedef struct released_object {
+  /** The object_id of the released object. */
+  object_id object_id;
+  /** Needed for the doubly-linked list macros. */
+  struct released_object *prev;
+  /** Needed for the doubly-linked list macros. */
+  struct released_object *next;
+} released_object;
+
+/** This type is used to define a hash table mapping the object ID of a released
+ *  object to its location in the doubly-linked list of released objects. */
+typedef struct {
+  /** Object ID of this object. */
+  object_id object_id;
+  /** A pointer to the corresponding entry for this object in the doubly-linked
+   *  list of released objects. */
+  released_object *released_object;
+  /** Handle for the uthash table. */
+  UT_hash_handle handle;
+} released_object_entry;
 
 /** The part of the Plasma state that is maintained by the eviction policy. */
 struct eviction_state {
@@ -9,9 +34,12 @@ struct eviction_state {
   int64_t memory_capacity;
   /** The amount of memory (in bytes) currently being used. */
   int64_t memory_used;
-  /** An array of the released objects in order from least recently released to
-   *  most recently released. */
-  UT_array *released_objects;
+  /** A doubly-linked list of the released objects in order from least recently
+   *  released to most recently released. */
+  released_object *released_objects;
+  /** A hash table mapping the object ID of a released object to its location in
+   *  the doubly linked list of released objects. */
+  released_object_entry *released_object_table;
 };
 
 /* This is used to define the array of object IDs used to define the
@@ -23,13 +51,63 @@ eviction_state *make_eviction_state(void) {
   /* Find the amount of available memory on the machine. */
   state->memory_capacity = 1000000000;
   state->memory_used = 0;
-  utarray_new(state->released_objects, &released_objects_entry_icd);
+  state->released_objects = NULL;
+  state->released_object_table = NULL;
   return state;
 }
 
 void free_eviction_state(eviction_state *s) {
-  utarray_free(s->released_objects);
+  /* Delete each element in the doubly-linked list. */
+  released_object *element, *temp;
+  DL_FOREACH_SAFE(s->released_objects, element, temp) {
+    DL_DELETE(s->released_objects, element);
+    free(element);
+  }
+  /* Delete each element in the hash table. */
+  released_object_entry *current_entry, *temp_entry;
+  HASH_ITER(handle, s->released_object_table, current_entry, temp_entry) {
+    HASH_DELETE(handle, s->released_object_table, current_entry);
+    free(current_entry);
+  }
+  /* Free the eviction state. */
   free(s);
+}
+
+void add_object_to_lru_cache(eviction_state *eviction_state,
+                             object_id object_id) {
+  /* Add the object ID to the doubly-linked list. */
+  released_object *linked_list_entry = malloc(sizeof(released_object));
+  linked_list_entry->object_id = object_id;
+  DL_APPEND(eviction_state->released_objects, linked_list_entry);
+  /* Check that the object ID is not already in the hash table. */
+  released_object_entry *hash_table_entry;
+  HASH_FIND(handle, eviction_state->released_object_table, &object_id,
+            sizeof(object_id), hash_table_entry);
+  CHECK(hash_table_entry == NULL);
+  /* Add the object ID to the hash table. */
+  hash_table_entry = malloc(sizeof(released_object_entry));
+  hash_table_entry->object_id = object_id;
+  hash_table_entry->released_object = linked_list_entry;
+  HASH_ADD(handle, eviction_state->released_object_table, object_id,
+           sizeof(object_id), hash_table_entry);
+}
+
+void remove_object_from_lru_cache(eviction_state *eviction_state,
+                                  object_id object_id) {
+  /* Check that the object ID is in the hash table. */
+  released_object_entry *hash_table_entry;
+  HASH_FIND(handle, eviction_state->released_object_table, &object_id,
+            sizeof(object_id), hash_table_entry);
+  CHECK(hash_table_entry != NULL);
+  /* Remove the object ID from the doubly-linked list. */
+  DL_DELETE(eviction_state->released_objects,
+            hash_table_entry->released_object);
+            /* Free the entry from the doubly-linked list. */
+  free(hash_table_entry->released_object);
+  /* Remove the object ID from the hash table. */
+  HASH_DELETE(handle, eviction_state->released_object_table, hash_table_entry);
+  /* Free the entry from the hash table. */
+  free(hash_table_entry);
 }
 
 void delete_obj(eviction_state *eviction_state,
@@ -56,27 +134,29 @@ void delete_obj(eviction_state *eviction_state,
 int64_t evict_objects(eviction_state *eviction_state,
                       plasma_store_info *plasma_store_info,
                       int64_t num_bytes_required) {
-  int num_objects_evicted = 0;
   int64_t num_bytes_evicted = 0;
-  for (int i = 0; i < utarray_len(eviction_state->released_objects); ++i) {
+  /* Evict some objects starting with the least recently released object. */
+  released_object *element, *temp;
+  DL_FOREACH_SAFE(eviction_state->released_objects, element, temp) {
     if (num_bytes_evicted >= num_bytes_required) {
       break;
     }
-    object_id *obj_id =
-        (object_id *) utarray_eltptr(eviction_state->released_objects, i);
+    object_id obj_id = element->object_id;
+    /* Find the object table entry for this object. */
     object_table_entry *entry;
-    HASH_FIND(handle, plasma_store_info->open_objects, obj_id, sizeof(object_id),
-              entry);
+    HASH_FIND(handle, plasma_store_info->open_objects, &obj_id,
+              sizeof(object_id), entry);
     if (entry == NULL) {
-      HASH_FIND(handle, plasma_store_info->sealed_objects, obj_id, sizeof(object_id),
-                entry);
+      HASH_FIND(handle, plasma_store_info->sealed_objects, &obj_id,
+                sizeof(object_id), entry);
     }
-    num_objects_evicted += 1;
     num_bytes_evicted += (entry->info.data_size + entry->info.metadata_size);
-    delete_obj(eviction_state, plasma_store_info, *obj_id);
+    /* Delete the object. */
+    delete_obj(eviction_state, plasma_store_info, obj_id);
+    /* Update the LRU cache. */
+    remove_object_from_lru_cache(eviction_state, obj_id);
   }
-  /* Remove the deleted objects from the released objects. */
-  utarray_erase(eviction_state->released_objects, 0, num_objects_evicted);
+  /* Update the number used. */
   eviction_state->memory_used -= num_bytes_evicted;
   return num_bytes_evicted;
 }
@@ -102,32 +182,21 @@ void handle_before_create(eviction_state *eviction_state,
 void handle_add_client(eviction_state *eviction_state,
                        plasma_store_info *plasma_store_info,
                        object_table_entry *entry) {
-  /* If the object was previously unused, remove the object from the list of
-   * released objects. */
-  /* TODO(rkn): This is extremely slow. It can be made more efficient with
-   * better data structures. */
-  if (utarray_len(entry->clients) == 0) {
-    for (int i = 0; i < utarray_len(eviction_state->released_objects); ++i) {
-      object_id *obj_id =
-          (object_id *) utarray_eltptr(eviction_state->released_objects, i);
-      if (memcmp(obj_id, &entry->object_id, sizeof(object_id)) == 0) {
-        utarray_erase(eviction_state->released_objects, i, 1);
-        break;
-      }
-    }
-    /* TODO(rkn): It'd be nice to check that something was actually removed, but
-     * the first time we call add_client_to_object_clients, it won't be in the
-     * list. */
+  /* If the object is in the LRU cache, remove it. */
+  released_object_entry *hash_table_entry;
+  HASH_FIND(handle, eviction_state->released_object_table, &entry->object_id,
+            sizeof(object_id), hash_table_entry);
+  if (hash_table_entry != NULL) {
+    remove_object_from_lru_cache(eviction_state, entry->object_id);
   }
 }
 
 void handle_remove_client(eviction_state *eviction_state,
                           plasma_store_info *plasma_store_info,
                           object_table_entry *entry) {
-  /* If no more clients are using this object, add the object to the list of
-   * released objects. */
+  /* If no more clients are using this object, add it to the LRU cache. */
   if (utarray_len(entry->clients) == 0) {
-    utarray_push_back(eviction_state->released_objects, &entry->object_id);
+    add_object_to_lru_cache(eviction_state, entry->object_id);
   }
 }
 

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -2,8 +2,6 @@
 
 #include "utlist.h"
 
-void dlfree(void *);
-
 /** An element representing a released object in a doubly-linked list. This is
  *  used to implement an LRU cache. */
 typedef struct released_object {
@@ -29,7 +27,7 @@ typedef struct {
 
 /** The part of the Plasma state that is maintained by the eviction policy. */
 struct eviction_state {
-  /** The amount of memory (in bytes) that we allow to be allocated in this
+  /** The amount of memory (in bytes) that we allow to be allocated in the
    *  store. */
   int64_t memory_capacity;
   /** The amount of memory (in bytes) currently being used. */
@@ -92,50 +90,33 @@ void add_object_to_lru_cache(eviction_state *eviction_state,
            sizeof(object_id), hash_table_entry);
 }
 
-void remove_object_from_lru_cache(eviction_state *eviction_state,
-                                  object_id object_id) {
+void remove_object_from_lru_cache_if_present(eviction_state *eviction_state,
+                                             object_id object_id) {
   /* Check that the object ID is in the hash table. */
   released_object_entry *hash_table_entry;
   HASH_FIND(handle, eviction_state->released_object_table, &object_id,
             sizeof(object_id), hash_table_entry);
-  CHECK(hash_table_entry != NULL);
-  /* Remove the object ID from the doubly-linked list. */
-  DL_DELETE(eviction_state->released_objects,
-            hash_table_entry->released_object);
-            /* Free the entry from the doubly-linked list. */
-  free(hash_table_entry->released_object);
-  /* Remove the object ID from the hash table. */
-  HASH_DELETE(handle, eviction_state->released_object_table, hash_table_entry);
-  /* Free the entry from the hash table. */
-  free(hash_table_entry);
+  /* Only remove the object ID if it is in the LRU cache. */
+  if (hash_table_entry != NULL) {
+    /* Remove the object ID from the doubly-linked list. */
+    DL_DELETE(eviction_state->released_objects,
+              hash_table_entry->released_object);
+    /* Free the entry from the doubly-linked list. */
+    free(hash_table_entry->released_object);
+    /* Remove the object ID from the hash table. */
+    HASH_DELETE(handle, eviction_state->released_object_table,
+                hash_table_entry);
+    /* Free the entry from the hash table. */
+    free(hash_table_entry);
+  }
 }
 
-void delete_obj(eviction_state *eviction_state,
-                plasma_store_info *plasma_store_info,
-                object_id object_id) {
-  LOG_DEBUG("deleting object");
-  object_table_entry *entry;
-  HASH_FIND(handle, plasma_store_info->objects, &object_id, sizeof(object_id),
-            entry);
-  /* TODO(rkn): This should probably not fail, but should instead throw an
-   * error. Maybe we should also support deleting objects that have been created
-   * but not sealed. */
-  CHECKM(entry != NULL, "To delete an object it must be in the object table.");
-  CHECKM(entry->state == SEALED,
-         "To delete an object it must have been sealed.")
-  CHECKM(utarray_len(entry->clients) == 0,
-         "To delete an object, there must be no clients currently using it.");
-  uint8_t *pointer = entry->pointer;
-  HASH_DELETE(handle, plasma_store_info->objects, entry);
-  dlfree(pointer);
-  utarray_free(entry->clients);
-  free(entry);
-}
-
-/* Remove the least recently released objects. */
-int64_t evict_objects(eviction_state *eviction_state,
-                      plasma_store_info *plasma_store_info,
-                      int64_t num_bytes_required) {
+int64_t choose_objects_to_evict(eviction_state *eviction_state,
+                                plasma_store_info *plasma_store_info,
+                                int64_t num_bytes_required,
+                                int64_t *num_objects_to_evict,
+                                object_id **objects_to_evict) {
+  int64_t num_objects_evicted = 0;
   int64_t num_bytes_evicted = 0;
   /* Evict some objects starting with the least recently released object. */
   released_object *element, *temp;
@@ -149,57 +130,79 @@ int64_t evict_objects(eviction_state *eviction_state,
     HASH_FIND(handle, plasma_store_info->objects, &obj_id, sizeof(object_id),
               entry);
     num_bytes_evicted += (entry->info.data_size + entry->info.metadata_size);
-    /* Delete the object. */
-    delete_obj(eviction_state, plasma_store_info, obj_id);
-    /* Update the LRU cache. */
-    remove_object_from_lru_cache(eviction_state, obj_id);
+    // /* Update the LRU cache. */
+    // remove_object_from_lru_cache_if_present(eviction_state, obj_id);
+    num_objects_evicted += 1;
   }
+
+  /* Construct the return values. */
+  *num_objects_to_evict = num_objects_evicted;
+  if (num_objects_evicted == 0) {
+    *objects_to_evict = NULL;
+  } else {
+    *objects_to_evict =
+        (object_id *) malloc(num_objects_evicted * sizeof(object_id));
+    int counter = 0;
+    DL_FOREACH_SAFE(eviction_state->released_objects, element, temp) {
+      if (counter >= num_objects_evicted) {
+        break;
+      }
+      (*objects_to_evict)[counter] = element->object_id;
+      /* Update the LRU cache. */
+      remove_object_from_lru_cache_if_present(eviction_state,
+                                              element->object_id);
+      counter += 1;
+    }
+  }
+
   /* Update the number used. */
   eviction_state->memory_used -= num_bytes_evicted;
   return num_bytes_evicted;
 }
 
-void handle_before_create(eviction_state *eviction_state,
-                          plasma_store_info *plasma_store_info,
-                          int64_t size) {
+void require_space(eviction_state *eviction_state,
+                   plasma_store_info *plasma_store_info,
+                   int64_t size,
+                   int64_t *num_objects_to_evict,
+                   object_id **objects_to_evict) {
   /* Check if there is enough space to create the object. */
-  int64_t required_space = eviction_state->memory_used + size -
-                           eviction_state->memory_capacity;
+  int64_t required_space =
+      eviction_state->memory_used + size - eviction_state->memory_capacity;
   if (required_space > 0) {
     /* Try to free up as much free space as we need right now. */
     LOG_DEBUG("not enough space to create this object, so evicting objects");
-    printf("There is not enough space to create this object, so evicting objects.\n");
-    int64_t num_bytes_evicted = evict_objects(eviction_state, plasma_store_info,
-                                              required_space);
+    /* Choose some objects to evict, and update the return pointers. */
+    int64_t num_bytes_evicted = choose_objects_to_evict(
+        eviction_state, plasma_store_info, required_space, num_objects_to_evict,
+        objects_to_evict);
     printf("Evicted %lld bytes.\n", num_bytes_evicted);
+    LOG_INFO(
+        "There is not enough space to create this object, so evicting "
+        "%lld objects to free up %lld bytes.\n",
+        *num_objects_to_evict, num_bytes_evicted);
     CHECK(num_bytes_evicted >= required_space);
   }
   eviction_state->memory_used += size;
 }
 
-void handle_add_client(eviction_state *eviction_state,
-                       plasma_store_info *plasma_store_info,
-                       object_table_entry *entry) {
+void begin_object_access(eviction_state *eviction_state,
+                         plasma_store_info *plasma_store_info,
+                         object_id obj_id,
+                         int64_t *num_objects_to_evict,
+                         object_id **objects_to_evict) {
   /* If the object is in the LRU cache, remove it. */
-  released_object_entry *hash_table_entry;
-  HASH_FIND(handle, eviction_state->released_object_table, &entry->object_id,
-            sizeof(object_id), hash_table_entry);
-  if (hash_table_entry != NULL) {
-    remove_object_from_lru_cache(eviction_state, entry->object_id);
-  }
+  remove_object_from_lru_cache_if_present(eviction_state, obj_id);
+  *num_objects_to_evict = 0;
+  *objects_to_evict = NULL;
 }
 
-void handle_remove_client(eviction_state *eviction_state,
-                          plasma_store_info *plasma_store_info,
-                          object_table_entry *entry) {
-  /* If no more clients are using this object, add it to the LRU cache. */
-  if (utarray_len(entry->clients) == 0) {
-    add_object_to_lru_cache(eviction_state, entry->object_id);
-  }
-}
-
-void handle_delete(eviction_state *eviction_state,
-                   plasma_store_info *plasma_store_info,
-                   object_id object_id) {
-  delete_obj(eviction_state, plasma_store_info, object_id);
+void end_object_access(eviction_state *eviction_state,
+                       plasma_store_info *plasma_store_info,
+                       object_id obj_id,
+                       int64_t *num_objects_to_evict,
+                       object_id **objects_to_evict) {
+  /* Add the object to the LRU cache.*/
+  add_object_to_lru_cache(eviction_state, obj_id);
+  *num_objects_to_evict = 0;
+  *objects_to_evict = NULL;
 }

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -44,10 +44,10 @@ struct eviction_state {
  * released_objects type. */
 UT_icd released_objects_entry_icd = {sizeof(object_id), NULL, NULL, NULL};
 
-eviction_state *make_eviction_state(void) {
+eviction_state *make_eviction_state(int64_t system_memory) {
   eviction_state *state = malloc(sizeof(eviction_state));
   /* Find the amount of available memory on the machine. */
-  state->memory_capacity = 8000000000;
+  state->memory_capacity = system_memory;
   state->memory_used = 0;
   state->released_objects = NULL;
   state->released_object_table = NULL;

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -104,8 +104,7 @@ void remove_object_from_lru_cache(eviction_state *eviction_state,
   /* Free the entry from the doubly-linked list. */
   free(hash_table_entry->released_object);
   /* Remove the object ID from the hash table. */
-  HASH_DELETE(handle, eviction_state->released_object_table,
-              hash_table_entry);
+  HASH_DELETE(handle, eviction_state->released_object_table, hash_table_entry);
   /* Free the entry from the hash table. */
   free(hash_table_entry);
 }

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -1,0 +1,111 @@
+#include "eviction_policy.h"
+
+/** The part of the Plasma state that is maintained by the eviction policy. */
+struct eviction_state {
+  /** The amount of memory (in bytes) that we allow to be allocated in this
+   *  store. */
+  int64_t memory_capacity;
+  /** The amount of memory (in bytes) currently being used. */
+  int64_t memory_used;
+  /** An array of the released objects in order from least recently released to
+   *  most recently released. */
+  UT_array *released_objects;
+};
+
+/* This is used to define the array of object IDs used to define the
+ * released_objects type. */
+UT_icd released_objects_entry_icd = {sizeof(object_id), NULL, NULL, NULL};
+
+eviction_state *make_eviction_state(void) {
+  eviction_state *state = malloc(sizeof(eviction_state));
+  /* Find the amount of available memory on the machine. */
+  state->memory_capacity = 1000000000;
+  state->memory_used = 0;
+  utarray_new(state->released_objects, &released_objects_entry_icd);
+  return state;
+}
+
+void free_eviction_state(eviction_state *s) {
+  utarray_free(s->released_objects);
+  free(s);
+}
+
+/* Remove the least recently released objects. */
+int64_t evict_objects(eviction_state *eviction_state,
+                      plasma_store_info *plasma_store_info,
+                      int64_t num_bytes_required) {
+  int num_objects_evicted = 0;
+  int64_t num_bytes_evicted = 0;
+  for (int i = 0; i < utarray_len(eviction_state->released_objects); ++i) {
+    if (num_bytes_evicted >= num_bytes_required) {
+      break;
+    }
+    object_id *obj_id =
+        (object_id *) utarray_eltptr(eviction_state->released_objects, i);
+    object_table_entry *entry;
+    HASH_FIND(handle, plasma_store_info->open_objects, obj_id, sizeof(object_id),
+              entry);
+    if (entry == NULL) {
+      HASH_FIND(handle, plasma_store_info->sealed_objects, obj_id, sizeof(object_id),
+                entry);
+    }
+    num_objects_evicted += 1;
+    num_bytes_evicted += (entry->info.data_size + entry->info.metadata_size);
+    // TODO: THIS NEEDS TO BE ENABLED.
+    //delete_object(client_context, *obj_id);
+  }
+  /* Remove the deleted objects from the released objects. */
+  utarray_erase(eviction_state->released_objects, 0, num_objects_evicted);
+  eviction_state->memory_used -= num_bytes_evicted;
+  return num_bytes_evicted;
+}
+
+void handle_before_create(eviction_state *eviction_state,
+                          plasma_store_info *plasma_store_info,
+                          int64_t size) {
+  /* Check if there is enough space to create the object. */
+  int64_t required_space = eviction_state->memory_used + size -
+                           eviction_state->memory_capacity;
+  if (required_space > 0) {
+    /* Try to free up as much free space as we need right now. */
+    LOG_DEBUG("not enough space to create this object, so evicting objects");
+    printf("There is not enough space to create this object, so evicting objects.\n");
+    int64_t num_bytes_evicted = evict_objects(eviction_state, plasma_store_info,
+                                              required_space);
+    printf("Evicted %lld bytes.\n", num_bytes_evicted);
+    CHECK(num_bytes_evicted >= required_space);
+  }
+  eviction_state->memory_used += size;
+}
+
+void handle_add_client(eviction_state *eviction_state,
+                       plasma_store_info *plasma_store_info,
+                       object_table_entry *entry) {
+  /* If the object was previously unused, remove the object from the list of
+   * released objects. */
+  /* TODO(rkn): This is extremely slow. It can be made more efficient with
+   * better data structures. */
+  if (utarray_len(entry->clients) == 0) {
+    for (int i = 0; i < utarray_len(eviction_state->released_objects); ++i) {
+      object_id *obj_id =
+          (object_id *) utarray_eltptr(eviction_state->released_objects, i);
+      if (memcmp(obj_id, &entry->object_id, sizeof(object_id)) == 0) {
+        utarray_erase(eviction_state->released_objects, i, 1);
+        break;
+      }
+    }
+    /* TODO(rkn): It'd be nice to check that something was actually removed, but
+     * the first time we call add_client_to_object_clients, it won't be in the
+     * list. */
+  }
+}
+
+void handle_remove_client(eviction_state *eviction_state,
+                          plasma_store_info *plasma_store_info,
+                          object_table_entry *entry) {
+  /* If no more clients are using this object, add the object to the list of
+   * released objects. */
+  if (utarray_len(entry->clients) == 0) {
+    utarray_push_back(eviction_state->released_objects, &entry->object_id);
+  }
+}

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -16,9 +16,11 @@ typedef struct eviction_state eviction_state;
 /**
  * Initialize the eviction policy state.
  *
+ * @param system_memory The amount of memory that can be used by the Plasma
+ *        store.
  * @return The internal state of the eviction policy.
  */
-eviction_state *make_eviction_state(void);
+eviction_state *make_eviction_state(int64_t system_memory);
 
 /**
  * Free the eviction policy state.

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -29,6 +29,21 @@ eviction_state *make_eviction_state(void);
 void free_eviction_state(eviction_state *state);
 
 /**
+ * This method will be called whenever an object is first created in order to
+ * add it to the LRU cache. This is done so that the first time, the Plasma
+ * store calls begin_object_access, we can remove the object from the LRU cache.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param obj_id The object ID of the object that was created.
+ * @return Void.
+ */
+void object_created(eviction_state *eviction_state,
+                    plasma_store_info *plasma_store_info,
+                    object_id obj_id);
+
+/**
  * This method will be called when the Plasma store needs more space, perhaps to
  * create a new object. If the required amount of space cannot be freed up, then
  * a fatal error will be thrown. When this method is called, the eviction policy
@@ -63,7 +78,7 @@ void require_space(eviction_state *eviction_state,
  * @param eviction_state The state managed by the eviction policy.
  * @param plasma_store_info Information about the Plasma store that is exposed
  *        to the eviction policy.
- * @param The object table entry that just had a client added to it.
+ * @param obj_id The ID of the object that is now being used.
  * @param num_objects_to_evict The number of objects that are chosen will be
  *        stored at this address.
  * @param objects_to_evict An array of the object IDs that were chosen will be

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -125,7 +125,6 @@ void end_object_access(eviction_state *eviction_state,
  * @note This method is not part of the API. It is exposed in the header file
  * only for testing.
  *
-
  * @param eviction_state The state managed by the eviction policy.
  * @param plasma_store_info Information about the Plasma store that is exposed
  *        to the eviction policy.

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -1,0 +1,88 @@
+#ifndef EVICTION_POLICY_H
+#define EVICTION_POLICY_H
+
+#include "plasma.h"
+
+/* ==== The eviction policy ====
+ *
+ * This file contains declaration for all functions and data structures that
+ * need to be provided if you want to implement a new eviction algorithm for the
+ * Plasma store.
+ */
+
+/** Internal state of the eviction policy. */
+typedef struct eviction_state eviction_state;
+
+/**
+ * Initialize the eviction policy state.
+ *
+ * @return The internal state of the eviction policy.
+ */
+eviction_state *make_eviction_state(void);
+
+/**
+ * Free the eviction policy state.
+ *
+ * @param state The state managed by the eviction policy.
+ * @return Void.
+ */
+void free_eviction_state(eviction_state *state);
+
+/**
+ * This method will be called before an object is created in the Plasma store.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param size The size in bytes of the new object, including both data and
+ *        metadata.
+ * @return Void.
+ */
+void handle_before_create(eviction_state *eviction_state,
+                          plasma_store_info *plasma_store_info,
+                          int64_t size);
+
+/**
+ * This method will be called whenever remove_client_from_object_clients is
+ * called in the Plasma store.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param The object table entry that just had a client added to it.
+ * @return Void.
+ */
+void handle_add_client(eviction_state *eviction_state,
+                       plasma_store_info *plasma_store_info,
+                       object_table_entry *entry);
+
+/**
+ * This method will be called whenever add_client_to_object_clients is called in
+ * the Plasma store.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param entry The object table entry that just had a client removed from it.
+ * @return Void.
+ */
+void handle_remove_client(eviction_state *eviction_state,
+                          plasma_store_info *plasma_store_info,
+                          object_table_entry *entry);
+
+/**
+ * Remove the least recently released objects to try to free up some space.
+ *
+ * @note This method is not part of the API. It is exposed in the header file
+ * only for testing.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param num_bytes_required The number of bytes of space to try to free up.
+ */
+int64_t evict_objects(eviction_state *eviction_state,
+                      plasma_store_info *plasma_store_info,
+                      int64_t num_bytes_required);
+
+#endif /* EVICTION_POLICY_H */

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -29,73 +29,104 @@ eviction_state *make_eviction_state(void);
 void free_eviction_state(eviction_state *state);
 
 /**
- * This method will be called before an object is created in the Plasma store.
+ * This method will be called when the Plasma store needs more space, perhaps to
+ * create a new object. If the required amount of space cannot be freed up, then
+ * a fatal error will be thrown. When this method is called, the eviction policy
+ * will assume that the objects chosen to be evicted will in fact be evicted
+ * from the Plasma store by the caller.
  *
  * @param eviction_state The state managed by the eviction policy.
  * @param plasma_store_info Information about the Plasma store that is exposed
  *        to the eviction policy.
  * @param size The size in bytes of the new object, including both data and
  *        metadata.
+ * @param num_objects_to_evict The number of objects that are chosen will be
+ *        stored at this address.
+ * @param objects_to_evict An array of the object IDs that were chosen will be
+ *        stored at this address. If the number of objects chosen is greater
+ *        than 0, then the caller needs to free that array. If it equals 0, then
+ *        the array will be NULL.
  * @return Void.
  */
-void handle_before_create(eviction_state *eviction_state,
-                          plasma_store_info *plasma_store_info,
-                          int64_t size);
+void require_space(eviction_state *eviction_state,
+                   plasma_store_info *plasma_store_info,
+                   int64_t size,
+                   int64_t *num_objects_to_evict,
+                   object_id **objects_to_evict);
 
 /**
- * This method will be called whenever remove_client_from_object_clients is
- * called in the Plasma store.
+ * This method will be called whenever an unused object in the Plasma store
+ * starts to be used. When this method is called, the eviction policy will
+ * assume that the objects chosen to be evicted will in fact be evicted from the
+ * Plasma store by the caller.
  *
  * @param eviction_state The state managed by the eviction policy.
  * @param plasma_store_info Information about the Plasma store that is exposed
  *        to the eviction policy.
  * @param The object table entry that just had a client added to it.
+ * @param num_objects_to_evict The number of objects that are chosen will be
+ *        stored at this address.
+ * @param objects_to_evict An array of the object IDs that were chosen will be
+ *        stored at this address. If the number of objects chosen is greater
+ *        than 0, then the caller needs to free that array. If it equals 0, then
+ *        the array will be NULL.
  * @return Void.
  */
-void handle_add_client(eviction_state *eviction_state,
+void begin_object_access(eviction_state *eviction_state,
+                         plasma_store_info *plasma_store_info,
+                         object_id obj_id,
+                         int64_t *num_objects_to_evict,
+                         object_id **objects_to_evict);
+
+/**
+ * This method will be called whenever an object in the Plasma store that was
+ * being used is no longer being used. When this method is called, the eviction
+ * policy will assume that the objects chosen to be evicted will in fact be
+ * evicted from the Plasma store by the caller.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param obj_id The ID of the object that is no longer being used.
+ * @param num_objects_to_evict The number of objects that are chosen will be
+ *        stored at this address.
+ * @param objects_to_evict An array of the object IDs that were chosen will be
+ *        stored at this address. If the number of objects chosen is greater
+ *        than 0, then the caller needs to free that array. If it equals 0, then
+ *        the array will be NULL.
+ * @return Void.
+ */
+void end_object_access(eviction_state *eviction_state,
                        plasma_store_info *plasma_store_info,
-                       object_table_entry *entry);
+                       object_id obj_id,
+                       int64_t *num_objects_to_evict,
+                       object_id **objects_to_evict);
 
 /**
- * This method will be called whenever add_client_to_object_clients is called in
- * the Plasma store.
- *
- * @param eviction_state The state managed by the eviction policy.
- * @param plasma_store_info Information about the Plasma store that is exposed
- *        to the eviction policy.
- * @param entry The object table entry that just had a client removed from it.
- * @return Void.
- */
-void handle_remove_client(eviction_state *eviction_state,
-                          plasma_store_info *plasma_store_info,
-                          object_table_entry *entry);
-
-/**
- * This method will be called whenever delete is called in the Plasma store.
- *
- * @param eviction_state The state managed by the eviction policy.
- * @param plasma_store_info Information about the Plasma store that is exposed
- *        to the eviction policy.
- * @param object_id The object_id of the object to delete.
- * @return Void.
- */
-void handle_delete(eviction_state *eviction_state,
-                   plasma_store_info *plasma_store_info,
-                   object_id object_id);
-
-/**
- * Remove the least recently released objects to try to free up some space.
+ * Choose some objects to evict from the Plasma store. When this method is
+ * called, the eviction policy will assume that the objects chosen to be evicted
+ * will in fact be evicted from the Plasma store by the caller.
  *
  * @note This method is not part of the API. It is exposed in the header file
  * only for testing.
  *
+
  * @param eviction_state The state managed by the eviction policy.
  * @param plasma_store_info Information about the Plasma store that is exposed
  *        to the eviction policy.
  * @param num_bytes_required The number of bytes of space to try to free up.
+ * @param num_objects_to_evict The number of objects that are chosen will be
+ *        stored at this address.
+ * @param objects_to_evict An array of the object IDs that were chosen will be
+ *        stored at this address. If the number of objects chosen is greater
+ *        than 0, then the caller needs to free that array. If it equals 0, then
+ *        the array will be NULL.
+ * @return The total number of bytes of space chosen to be evicted.
  */
-int64_t evict_objects(eviction_state *eviction_state,
-                      plasma_store_info *plasma_store_info,
-                      int64_t num_bytes_required);
+int64_t choose_objects_to_evict(eviction_state *eviction_state,
+                                plasma_store_info *plasma_store_info,
+                                int64_t num_bytes_required,
+                                int64_t *num_objects_to_evict,
+                                object_id **objects_to_evict);
 
 #endif /* EVICTION_POLICY_H */

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -71,6 +71,19 @@ void handle_remove_client(eviction_state *eviction_state,
                           object_table_entry *entry);
 
 /**
+ * This method will be called whenever delete is called in the Plasma store.
+ *
+ * @param eviction_state The state managed by the eviction policy.
+ * @param plasma_store_info Information about the Plasma store that is exposed
+ *        to the eviction policy.
+ * @param object_id The object_id of the object to delete.
+ * @return Void.
+ */
+void handle_delete(eviction_state *eviction_state,
+                   plasma_store_info *plasma_store_info,
+                   object_id object_id);
+
+/**
  * Remove the least recently released objects to try to free up some space.
  *
  * @note This method is not part of the API. It is exposed in the header file

--- a/src/plasma/lib/python/plasma.py
+++ b/src/plasma/lib/python/plasma.py
@@ -90,7 +90,6 @@ class PlasmaClient(object):
     self.client.plasma_contains.restype = None
     self.client.plasma_seal.restype = None
     self.client.plasma_delete.restype = None
-    self.client.plasma_evict.restype = ctypes.c_int64
     self.client.plasma_subscribe.restype = ctypes.c_int
     self.client.plasma_wait.restype = ctypes.c_int
 

--- a/src/plasma/lib/python/plasma.py
+++ b/src/plasma/lib/python/plasma.py
@@ -90,6 +90,7 @@ class PlasmaClient(object):
     self.client.plasma_contains.restype = None
     self.client.plasma_seal.restype = None
     self.client.plasma_delete.restype = None
+    self.client.plasma_evict.restype = ctypes.c_int64
     self.client.plasma_subscribe.restype = ctypes.c_int
     self.client.plasma_wait.restype = ctypes.c_int
 
@@ -204,6 +205,17 @@ class PlasmaClient(object):
       object_id (str): A string used to identify an object.
     """
     self.client.plasma_delete(self.plasma_conn, make_plasma_id(object_id))
+
+  def evict(self, num_bytes):
+    """Evict some objects until to recover some bytes.
+
+    Recover at least num_bytes bytes if possible.
+
+    Args:
+      num_bytes (int): The number of bytes to attempt to recover.
+    """
+    num_bytes_evicted = self.client.plasma_evict(self.plasma_conn, num_bytes)
+    return num_bytes_evicted
 
   def transfer(self, addr, port, object_id):
     """Transfer local object with id object_id to another plasma instance

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -117,23 +117,23 @@ typedef struct {
 /** This type is used by the Plasma store. It is here because it is exposed to
  *  the eviction policy. */
 typedef struct {
-  /* Object id of this object. */
+  /** Object id of this object. */
   object_id object_id;
-  /* Object info like size, creation time and owner. */
+  /** Object info like size, creation time and owner. */
   plasma_object_info info;
-  /* Memory mapped file containing the object. */
+  /** Memory mapped file containing the object. */
   int fd;
-  /* Size of the underlying map. */
+  /** Size of the underlying map. */
   int64_t map_size;
-  /* Offset from the base of the mmap. */
+  /** Offset from the base of the mmap. */
   ptrdiff_t offset;
-  /* Handle for the uthash table. */
+  /** Handle for the uthash table. */
   UT_hash_handle handle;
-  /* Pointer to the object data. Needed to free the object. */
+  /** Pointer to the object data. Needed to free the object. */
   uint8_t *pointer;
   /** An array of the clients that are currently using this object. */
   UT_array *clients;
-  /* The state of the object, e.g., whether it is open or sealed. */
+  /** The state of the object, e.g., whether it is open or sealed. */
   object_state state;
 } object_table_entry;
 

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -139,11 +139,8 @@ typedef struct {
 
 /** The plasma store information that is exposed to the eviction policy. */
 typedef struct {
-  /* Objects that are still being written by their owner process. */
-  object_table_entry *open_objects;
-  /* Objects that have already been sealed by their owner process and
-   * can now be shared with other processes. */
-  object_table_entry *sealed_objects;
+  /** Objects that are in the Plasma store. */
+  object_table_entry *objects;
 } plasma_store_info;
 
 #endif

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -56,6 +56,8 @@ enum plasma_message_type {
   PLASMA_SEAL,
   /** Delete an object. */
   PLASMA_DELETE,
+  /** Evict objects from the store. */
+  PLASMA_EVICT,
   /** Subscribe to notifications about sealed objects. */
   PLASMA_SUBSCRIBE,
   /** Request transfer to another store. */
@@ -83,6 +85,8 @@ typedef struct {
   /** In a transfer request, this is the port of the Plasma Manager to transfer
    *  the object to. */
   int port;
+  /** A number of bytes. This is used for eviction requests. */
+  int64_t num_bytes;
   /** The number of object IDs that will be included in this request. */
   int num_object_ids;
   /** The IDs of the objects that the request is about. */
@@ -97,6 +101,8 @@ typedef struct {
    *  present and 0 otherwise. Used for plasma_contains and
    *  plasma_fetch. */
   int has_object;
+  /** A number of bytes. This is used for replies to eviction requests. */
+  int64_t num_bytes;
   /** Number of object IDs a wait is returning. */
   int num_objects_returned;
   /** The number of object IDs that will be included in this reply. */

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -286,6 +286,18 @@ void plasma_delete(plasma_connection *conn, object_id object_id) {
   plasma_send_request(conn->store_conn, PLASMA_DELETE, &req);
 }
 
+int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes) {
+  /* Send a request to the store to evict objects. */
+  plasma_request req = {.num_bytes = num_bytes};
+  plasma_send_request(conn->store_conn, PLASMA_EVICT, &req);
+  /* Wait for a response with the number of bytes actually evicted. */
+  plasma_reply reply;
+  int r = read(conn->store_conn, &reply, sizeof(plasma_reply));
+  CHECKM(r != -1, "read error");
+  CHECKM(r != 0, "connection disconnected");
+  return reply.num_bytes;
+}
+
 int plasma_subscribe(plasma_connection *conn) {
   int fd[2];
   /* Create a non-blocking socket pair. This will only be used to send

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -178,6 +178,16 @@ void plasma_seal(plasma_connection *conn, object_id object_id);
 void plasma_delete(plasma_connection *conn, object_id object_id);
 
 /**
+ * Delete objects until we have freed up num_bytes bytes or there are no more
+ * released objects that can be deleted.
+ *
+ * @param conn The object containing the connection state.
+ * @param num_bytes The number of bytes to try to free up.
+ * @return The total number of bytes of space retrieved.
+ */
+int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes);
+
+/**
  * Fetch objects from remote plasma stores that have the
  * objects stored.
  *

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -303,24 +303,8 @@ void seal_object(client *client_context, object_id object_id) {
 
 /* Delete an object that has been created in the hash table. */
 void delete_object(client *client_context, object_id object_id) {
-  LOG_DEBUG("deleting object");  // TODO(rkn): add object_id here
-  plasma_store_state *plasma_state = client_context->plasma_state;
-  object_table_entry *entry;
-  HASH_FIND(handle, plasma_state->plasma_store_info->objects, &object_id,
-            sizeof(object_id), entry);
-  /* TODO(rkn): This should probably not fail, but should instead throw an
-   * error. Maybe we should also support deleting objects that have been created
-   * but not sealed. */
-  CHECKM(entry != NULL, "To delete an object it must have been created.");
-  CHECKM(entry->state == SEALED,
-         "To delete an object it must have been sealed.");
-  CHECKM(utarray_len(entry->clients) == 0,
-         "To delete an object, there must be no clients currently using it.");
-  uint8_t *pointer = entry->pointer;
-  HASH_DELETE(handle, plasma_state->plasma_store_info->objects, entry);
-  dlfree(pointer);
-  utarray_free(entry->clients);
-  free(entry);
+  handle_delete(client_context->plasma_state->eviction_state,
+                client_context->plasma_state->plasma_store_info, object_id);
 }
 
 /* Send more notifications to a subscriber. */

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -56,8 +56,7 @@ typedef struct {
   UT_hash_handle handle;
 } object_notify_entry;
 
-/** Contains all information that is associated with a Plasma store client. This
- *  is here because it is exposed to the eviction policy. */
+/** Contains all information that is associated with a Plasma store client. */
 struct client {
   /** The socket used to communicate with the client. */
   int sock;
@@ -329,7 +328,8 @@ void seal_object(client *client_context, object_id object_id) {
   }
 }
 
-/* Delete an object that has been created in the hash table. */
+/* Delete an object that has been created in the hash table. This should only
+ * be called on objects that are returned by the eviction policy to evict. */
 void delete_object(plasma_store_state *plasma_state, object_id object_id) {
   LOG_DEBUG("deleting object");
   object_table_entry *entry;
@@ -464,7 +464,8 @@ void process_message(event_loop *loop,
     seal_object(client_context, req->object_ids[0]);
     break;
   case PLASMA_DELETE:
-    // delete_object(client_context, req->object_ids[0]);
+    /* TODO(rkn): In the future, we can use this method to give hints to the
+     * eviction policy about when an object will no longer be needed. */
     break;
   case PLASMA_EVICT: {
     /* This code path should only be used for testing. */

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -102,13 +102,11 @@ struct plasma_store_state {
 plasma_store_state *init_plasma_store(event_loop *loop) {
   plasma_store_state *state = malloc(sizeof(plasma_store_state));
   state->loop = loop;
-  state->objects = NULL;
   state->objects_notify = NULL;
   state->pending_notifications = NULL;
   /* Initialize the plasma store info. */
   state->plasma_store_info = malloc(sizeof(plasma_store_info));
-  state->plasma_store_info->open_objects = NULL;
-  state->plasma_store_info->sealed_objects = NULL;
+  state->plasma_store_info->objects = NULL;
   /* Initialize the eviction state. */
   state->eviction_state = make_eviction_state();
   return state;

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -187,6 +187,11 @@ void create_object(client *client_context,
   result->metadata_offset = offset + data_size;
   result->data_size = data_size;
   result->metadata_size = metadata_size;
+  /* Notify the eviction policy that this object was created. This must be done
+   * immediately before the call to add_client_to_object_clients so that the
+   * eviction policy does not have an opportunity to evict the object. */
+  object_created(plasma_state->eviction_state, plasma_state->plasma_store_info,
+                 obj_id);
   /* Record that this client is using this object. */
   add_client_to_object_clients(entry, client_context);
 }

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -335,7 +335,7 @@ void delete_object(plasma_store_state *plasma_state, object_id object_id) {
    * but not sealed. */
   CHECKM(entry != NULL, "To delete an object it must be in the object table.");
   CHECKM(entry->state == SEALED,
-         "To delete an object it must have been sealed.")
+         "To delete an object it must have been sealed.");
   CHECKM(utarray_len(entry->clients) == 0,
          "To delete an object, there must be no clients currently using it.");
   uint8_t *pointer = entry->pointer;

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -113,6 +113,14 @@ struct plasma_store_state {
    *  the socket send buffers were full. This is a hash table from client file
    *  descriptor to an array of object_ids to send to that client. */
   notification_queue *pending_notifications;
+  /** The amount of memory (in bytes) that we allow to be allocated in this
+   *  store. */
+  int64_t memory_capacity;
+  /** The amount of memory (in bytes) currently being used. */
+  int64_t memory_used;
+  /** An array of the released objects in order from least recently released
+   *  to most recently released. */
+  UT_array *released_objects;
 };
 
 plasma_store_state *init_plasma_store(event_loop *loop) {
@@ -121,6 +129,10 @@ plasma_store_state *init_plasma_store(event_loop *loop) {
   state->objects = NULL;
   state->objects_notify = NULL;
   state->pending_notifications = NULL;
+  /* Find the amount of available memory on the machine. */
+  state->memory_capacity = 1000000000;
+  state->memory_used = 0;
+  utarray_new(state->released_objects, &object_table_entry_icd);
   return state;
 }
 
@@ -135,6 +147,24 @@ void add_client_to_object_clients(object_table_entry *entry,
       return;
     }
   }
+  /* If the object was previously unused, remove the object from the list of
+   * released objects. */
+  /* TODO(rkn): This is extremely slow. It can be made more efficient with
+   * better data structures. */
+  if (utarray_len(entry->clients) == 0) {
+    plasma_store_state *plasma_state = client_info->plasma_state;
+    for (int i = 0; i < utarray_len(plasma_state->released_objects); ++i) {
+      object_id *obj_id =
+          (object_id *) utarray_eltptr(plasma_state->released_objects, i);
+      if (memcmp(obj_id, &entry->object_id, sizeof(object_id)) == 0) {
+        utarray_erase(plasma_state->released_objects, i, 1);
+        break;
+      }
+    }
+    /* TODO(rkn): It'd be nice to check that something was actually removed, but
+     * the first time we call add_client_to_object_clients, it won't be in the
+     * list. */
+  }
   /* Add the client pointer to the list of clients using this object. */
   utarray_push_back(entry->clients, &client_info);
 }
@@ -147,6 +177,19 @@ void create_object(client *client_context,
                    plasma_object *result) {
   LOG_DEBUG("creating object"); /* TODO(pcm): add object_id here */
   plasma_store_state *plasma_state = client_context->plasma_state;
+
+  /* Check if there is enough space to create the object. */
+  int64_t required_space = plasma_state->memory_used + data_size +
+                           metadata_size - plasma_state->memory_capacity;
+  if (required_space > 0) {
+    /* Try to free up as much free space as we need right now. */
+    LOG_DEBUG("not enough space to create this object, so evicting objects");
+    printf("There is not enough space to create this object, so evicting objects.\n");
+    int64_t num_bytes_evicted = evict_objects(client_context, required_space);
+    printf("Evicted %lld bytes.\n", num_bytes_evicted);
+    CHECK(num_bytes_evicted >= required_space);
+  }
+  plasma_state->memory_used += (data_size + metadata_size);
 
   object_table_entry *entry;
   /* TODO(swang): Return these error to the client instead of exiting. */
@@ -229,6 +272,12 @@ int remove_client_from_object_clients(object_table_entry *entry,
     if (*c == client_info) {
       /* Remove the client from the array. */
       utarray_erase(entry->clients, i, 1);
+      /* If no more clients are using this object, add the object to the list of
+       * released objects. */
+      if (utarray_len(entry->clients) == 0) {
+        plasma_store_state *plasma_state = client_info->plasma_state;
+        utarray_push_back(plasma_state->released_objects, &entry->object_id);
+      }
       /* Return 1 to indicate that the client was removed. */
       return 1;
     }
@@ -322,6 +371,34 @@ void delete_object(client *client_context, object_id object_id) {
   dlfree(pointer);
   utarray_free(entry->clients);
   free(entry);
+}
+
+/* Remove the least recently released objects. */
+int64_t evict_objects(client *client_context, int64_t num_bytes) {
+  int num_objects_evicted = 0;
+  int64_t num_bytes_evicted = 0;
+  plasma_store_state *plasma_state = client_context->plasma_state;
+  for (int i = 0; i < utarray_len(plasma_state->released_objects); ++i) {
+    if (num_bytes_evicted >= num_bytes) {
+      break;
+    }
+    object_id *obj_id =
+        (object_id *) utarray_eltptr(plasma_state->released_objects, i);
+    object_table_entry *entry;
+    HASH_FIND(handle, plasma_state->open_objects, obj_id, sizeof(object_id),
+              entry);
+    if (entry == NULL) {
+      HASH_FIND(handle, plasma_state->sealed_objects, obj_id, sizeof(object_id),
+                entry);
+    }
+    num_objects_evicted += 1;
+    num_bytes_evicted += (entry->info.data_size + entry->info.metadata_size);
+    delete_object(client_context, *obj_id);
+  }
+  /* Remove the deleted objects from the released objects. */
+  utarray_erase(plasma_state->released_objects, 0, num_objects_evicted);
+  plasma_state->memory_used -= num_bytes_evicted;
+  return num_bytes_evicted;
 }
 
 /* Send more notifications to a subscriber. */
@@ -427,6 +504,12 @@ void process_message(event_loop *loop,
   case PLASMA_DELETE:
     delete_object(client_context, req->object_ids[0]);
     break;
+  case PLASMA_EVICT: {
+    int num_bytes_evicted = evict_objects(client_context, req->num_bytes);
+    reply.num_bytes = num_bytes_evicted;
+    plasma_send_reply(client_sock, &reply);
+    break;
+  }
   case PLASMA_SUBSCRIBE:
     subscribe_to_updates(client_context, client_sock);
     break;

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -94,14 +94,4 @@ void send_notifications(event_loop *loop,
                         void *plasma_state,
                         int events);
 
-/**
- * Delete objects until we have freed up num_bytes bytes or there are no more
- * released objects that can be deleted.
- *
- * @param client_context The context of the client making this request.
- * @param num_bytes The number of bytes to try to free up.
- * @return The total number of bytes of space retrieved.
- */
-int64_t evict_objects(client *client_context, int64_t num_bytes);
-
 #endif /* PLASMA_STORE_H */

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -85,4 +85,8 @@ void send_notifications(event_loop *loop,
                         void *plasma_state,
                         int events);
 
+void remove_objects(plasma_store_state *plasma_state,
+                    int64_t num_objects_to_evict,
+                    object_id *objects_to_evict);
+
 #endif /* PLASMA_STORE_H */

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -94,4 +94,14 @@ void send_notifications(event_loop *loop,
                         void *plasma_state,
                         int events);
 
+/**
+ * Delete objects until we have freed up num_bytes bytes or there are no more
+ * released objects that can be deleted.
+ *
+ * @param client_context The context of the client making this request.
+ * @param num_bytes The number of bytes to try to free up.
+ * @return The total number of bytes of space retrieved.
+ */
+int64_t evict_objects(client *client_context, int64_t num_bytes);
+
 #endif /* PLASMA_STORE_H */

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -69,15 +69,6 @@ void seal_object(client *client_context, object_id object_id);
 int contains_object(client *client_context, object_id object_id);
 
 /**
- * Delete an object from the plasma store:
- *
- * @param client_context The context of the client making this request.
- * @param object_id Object ID of the object to be deleted.
- * @return Void.
- */
-void delete_object(client *client_context, object_id object_id);
-
-/**
  * Send notifications about sealed objects to the subscribers. This is called
  * in seal_object. If the socket's send buffer is full, the notification will be
  * buffered, and this will be called again when the send buffer has room.

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -15,6 +15,7 @@ import threading
 import plasma
 
 USE_VALGRIND = False
+PLASMA_STORE_MEMORY = 1000000000
 
 def random_object_id():
   return "".join([chr(random.randint(0, 255)) for _ in range(plasma.PLASMA_ID_SIZE)])
@@ -64,7 +65,7 @@ class TestPlasmaClient(unittest.TestCase):
     # Start Plasma.
     plasma_store_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../build/plasma_store")
     store_name = "/tmp/store{}".format(random.randint(0, 10000))
-    command = [plasma_store_executable, "-s", store_name, "-m", "1000000000"]
+    command = [plasma_store_executable, "-s", store_name, "-m", str(PLASMA_STORE_MEMORY)]
     if USE_VALGRIND:
       self.p = subprocess.Popen(["valgrind", "--track-origins=yes", "--leak-check=full", "--show-leak-kinds=all", "--error-exitcode=1"] + command)
       time.sleep(2.0)
@@ -258,8 +259,8 @@ class TestPlasmaManager(unittest.TestCase):
     store_name2 = "/tmp/store{}".format(random.randint(0, 10000))
     manager_name1 = "/tmp/manager{}".format(random.randint(0, 10000))
     manager_name2 = "/tmp/manager{}".format(random.randint(0, 10000))
-    plasma_store_command1 = [plasma_store_executable, "-s", store_name1, "-m", "1000000000"]
-    plasma_store_command2 = [plasma_store_executable, "-s", store_name2, "-m", "1000000000"]
+    plasma_store_command1 = [plasma_store_executable, "-s", store_name1, "-m", str(PLASMA_STORE_MEMORY)]
+    plasma_store_command2 = [plasma_store_executable, "-s", store_name2, "-m", str(PLASMA_STORE_MEMORY)]
 
     if USE_VALGRIND:
       self.p2 = subprocess.Popen(["valgrind", "--track-origins=yes", "--leak-check=full", "--show-leak-kinds=all", "--error-exitcode=1"] + plasma_store_command1)

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -64,7 +64,7 @@ class TestPlasmaClient(unittest.TestCase):
     # Start Plasma.
     plasma_store_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../build/plasma_store")
     store_name = "/tmp/store{}".format(random.randint(0, 10000))
-    command = [plasma_store_executable, "-s", store_name]
+    command = [plasma_store_executable, "-s", store_name, "-m", "1000000000"]
     if USE_VALGRIND:
       self.p = subprocess.Popen(["valgrind", "--track-origins=yes", "--leak-check=full", "--show-leak-kinds=all", "--error-exitcode=1"] + command)
       time.sleep(2.0)
@@ -258,8 +258,8 @@ class TestPlasmaManager(unittest.TestCase):
     store_name2 = "/tmp/store{}".format(random.randint(0, 10000))
     manager_name1 = "/tmp/manager{}".format(random.randint(0, 10000))
     manager_name2 = "/tmp/manager{}".format(random.randint(0, 10000))
-    plasma_store_command1 = [plasma_store_executable, "-s", store_name1]
-    plasma_store_command2 = [plasma_store_executable, "-s", store_name2]
+    plasma_store_command1 = [plasma_store_executable, "-s", store_name1, "-m", "1000000000"]
+    plasma_store_command2 = [plasma_store_executable, "-s", store_name2, "-m", "1000000000"]
 
     if USE_VALGRIND:
       self.p2 = subprocess.Popen(["valgrind", "--track-origins=yes", "--leak-check=full", "--show-leak-kinds=all", "--error-exitcode=1"] + plasma_store_command1)

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -197,6 +197,44 @@ class TestPlasmaClient(unittest.TestCase):
       memory_buffer[0] = chr(0)
     self.assertRaises(Exception, illegal_assignment)
 
+  def test_evict(self):
+    object_id1 = random_object_id()
+    b1 = self.plasma_client.create(object_id1, 1000)
+    self.plasma_client.seal(object_id1)
+    del b1
+    self.assertEqual(self.plasma_client.evict(1), 1000)
+
+    object_id2 = random_object_id()
+    object_id3 = random_object_id()
+    b2 = self.plasma_client.create(object_id2, 999)
+    b3 = self.plasma_client.create(object_id3, 998)
+    del b3
+    self.plasma_client.seal(object_id3)
+    self.assertEqual(self.plasma_client.evict(1000), 998)
+
+    object_id4 = random_object_id()
+    b4 = self.plasma_client.create(object_id4, 997)
+    self.plasma_client.seal(object_id4)
+    del b4
+    self.plasma_client.seal(object_id2)
+    del b2
+    self.assertEqual(self.plasma_client.evict(1), 997)
+    self.assertEqual(self.plasma_client.evict(1), 999)
+
+    object_id5 = random_object_id()
+    object_id6 = random_object_id()
+    object_id7 = random_object_id()
+    b5 = self.plasma_client.create(object_id5, 996)
+    b6 = self.plasma_client.create(object_id6, 995)
+    b7 = self.plasma_client.create(object_id7, 994)
+    self.plasma_client.seal(object_id5)
+    self.plasma_client.seal(object_id6)
+    self.plasma_client.seal(object_id7)
+    del b5
+    del b6
+    del b7
+    self.assertEqual(self.plasma_client.evict(2000), 996 + 995 + 994)
+
   def test_subscribe(self):
     # Subscribe to notifications from the Plasma Store.
     sock = self.plasma_client.subscribe()


### PR DESCRIPTION
This enables the plasma store to evict objects when there is memory pressure. This also factors out the eviction policy in a separate header file. This eviction policy uses an LRU cache (doubly linked list plus hash table) to track the least recently used objects.