### PR TITLE
Install python package dependencies through setup.py.

### DIFF
--- a/doc/install-on-macosx.md
+++ b/doc/install-on-macosx.md
@@ -1,47 +1,42 @@
 # Installation on Mac OS X
 
-Ray must currently be built from source. We have tested Ray on OS X 10.11.
-
-## Clone the Ray repository
-
-```
-git clone https://github.com/ray-project/ray.git
-```
+Ray should work with Python 2 and Python 3. We have tested Ray on OS X 10.11.
 
 ## Dependencies
 
-First install the dependencies using brew. We currently do not support Python 3.
-If you have trouble installing the Python packages, you may find it easier to
-install [Anaconda](https://www.continuum.io/downloads).
+To install Ray, first install the following dependencies. We recommend using
+[Anaconda](https://www.continuum.io/downloads).
 
 ```
 brew update
-brew install git cmake automake autoconf libtool boost
+brew install cmake automake autoconf libtool boost
 sudo easy_install pip
-sudo pip install numpy funcsigs colorama --ignore-installed six
+
+sudo pip install numpy funcsigs colorama psutil redis --ignore-installed six
 sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
+sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
 ```
 
-## Build
+# Install Ray
 
-Then run the setup scripts.
+Ray can be installed with pip as follows.
 
 ```
-cd ray
-./setup.sh # Build all necessary third party libraries (e.g., gRPC and Apache Arrow). This may take about 10 minutes.
-./build.sh # Build Ray.
-source setup-env.sh # Add Ray to your Python path.
+sudo pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
-For convenience, you may also want to add the line `source
-"$RAY_ROOT/setup-env.sh"` to the bottom of your `~/.bashrc` file manually, where
-`$RAY_ROOT` is the Ray directory (e.g., `/home/ubuntu/ray`).
+Alternatively, Ray can be built from source as follows.
+
+```
+git clone https://github.com/ray-project/ray.git
+cd lib/python
+sudo python setup.py install
+```
 
 ## Test if the installation succeeded
-
-To test if the installation was successful, try running some tests.
+To test if the installation was successful, try running some tests (from the
+`ray` directory).
 
 ```
-python test/runtest.py # This tests basic functionality.
-python test/array_test.py # This tests some array libraries.
+python test/runtest.py
 ```

--- a/doc/install-on-macosx.md
+++ b/doc/install-on-macosx.md
@@ -34,8 +34,8 @@ python setup.py install
 ```
 
 ## Test if the installation succeeded
-To test if the installation was successful, try running some tests (from the
-`ray` directory).
+To test if the installation was successful, try running some tests. This assumes
+that you've cloned the git repository.
 
 ```
 python test/runtest.py

--- a/doc/install-on-macosx.md
+++ b/doc/install-on-macosx.md
@@ -10,11 +10,11 @@ To install Ray, first install the following dependencies. We recommend using
 ```
 brew update
 brew install cmake automake autoconf libtool boost
-sudo easy_install pip
+sudo easy_install pip  # If you're using Anaconda, then this is unnecessary.
 
-sudo pip install numpy funcsigs colorama psutil redis --ignore-installed six
-sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
-sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
+pip install numpy funcsigs colorama psutil redis --ignore-installed six
+pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
+pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
 ```
 
 # Install Ray
@@ -22,7 +22,7 @@ sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git
 Ray can be installed with pip as follows.
 
 ```
-sudo pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
+pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
 Alternatively, Ray can be built from source as follows.
@@ -30,7 +30,7 @@ Alternatively, Ray can be built from source as follows.
 ```
 git clone https://github.com/ray-project/ray.git
 cd lib/python
-sudo python setup.py install
+python setup.py install
 ```
 
 ## Test if the installation succeeded

--- a/doc/install-on-macosx.md
+++ b/doc/install-on-macosx.md
@@ -25,7 +25,7 @@ Ray can be installed with pip as follows.
 pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
-Alternatively, Ray can be built from source as follows.
+Alternatively, Ray can be built from the repository as follows.
 
 ```
 git clone https://github.com/ray-project/ray.git

--- a/doc/install-on-ubuntu.md
+++ b/doc/install-on-ubuntu.md
@@ -1,44 +1,43 @@
 # Installation on Ubuntu
 
-Ray must currently be built from source. We have tested Ray on Ubuntu 14.04.
-
-## Clone the Ray repository
-
-```
-git clone https://github.com/ray-project/ray.git
-```
+Ray should work with Python 2 and Python 3. We have tested Ray on Ubuntu 14.04
+and Ubuntu 16.04
 
 ## Dependencies
 
-First install the dependencies. We currently do not support Python 3.
+To install Ray, first install the following dependencies. We recommend using
+[Anaconda](https://www.continuum.io/downloads).
 
 ```
 sudo apt-get update
-sudo apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
-sudo pip install funcsigs colorama
+sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
+
+sudo pip install funcsigs colorama psutil redis
 sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
+sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
 ```
 
-## Build
+# Install Ray
 
-Then run the setup scripts.
+Ray can be installed with pip as follows.
 
 ```
-cd ray
-./setup.sh # Build all necessary third party libraries (e.g., gRPC and Apache Arrow). This may take about 10 minutes.
-./build.sh # Build Ray.
-source setup-env.sh # Add Ray to your Python path.
+sudo pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
-For convenience, you may also want to add the line `source
-"$RAY_ROOT/setup-env.sh"` to the bottom of your `~/.bashrc` file manually, where
-`$RAY_ROOT` is the Ray directory (e.g., `/home/ubuntu/ray`).
+Alternatively, Ray can be built from source as follows.
+
+```
+git clone https://github.com/ray-project/ray.git
+cd lib/python
+sudo python setup.py install
+```
 
 ## Test if the installation succeeded
 
-To test if the installation was successful, try running some tests.
+To test if the installation was successful, try running some tests (from the
+`ray` directory).
 
 ```
-python test/runtest.py # This tests basic functionality.
-python test/array_test.py # This tests some array libraries.
+python test/runtest.py
 ```

--- a/doc/install-on-ubuntu.md
+++ b/doc/install-on-ubuntu.md
@@ -35,8 +35,8 @@ python setup.py install
 
 ## Test if the installation succeeded
 
-To test if the installation was successful, try running some tests (from the
-`ray` directory).
+To test if the installation was successful, try running some tests. This assumes
+that you've cloned the git repository.
 
 ```
 python test/runtest.py

--- a/doc/install-on-ubuntu.md
+++ b/doc/install-on-ubuntu.md
@@ -10,11 +10,11 @@ To install Ray, first install the following dependencies. We recommend using
 
 ```
 sudo apt-get update
-sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
+sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-pip libboost-all-dev unzip  # If you're using Anaconda, then python-dev and python-pip are unnecessary.
 
-sudo pip install funcsigs colorama psutil redis
-sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
-sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
+pip install numpy funcsigs colorama psutil redis
+pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
+pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff
 ```
 
 # Install Ray
@@ -22,7 +22,7 @@ sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git
 Ray can be installed with pip as follows.
 
 ```
-sudo pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
+pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
 Alternatively, Ray can be built from source as follows.
@@ -30,7 +30,7 @@ Alternatively, Ray can be built from source as follows.
 ```
 git clone https://github.com/ray-project/ray.git
 cd lib/python
-sudo python setup.py install
+python setup.py install
 ```
 
 ## Test if the installation succeeded

--- a/doc/install-on-ubuntu.md
+++ b/doc/install-on-ubuntu.md
@@ -25,7 +25,7 @@ Ray can be installed with pip as follows.
 pip install --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
 ```
 
-Alternatively, Ray can be built from source as follows.
+Alternatively, Ray can be built from the repository as follows.
 
 ```
 git clone https://github.com/ray-project/ray.git

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -15,7 +15,12 @@ else
   exit 1
 fi
 
-if [[ $platform == "macosx" ]]; then
+if [[ $platform == "linux" ]]; then
+  # These commands must be kept in sync with the installation instructions.
+  sudo apt-get update
+  sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
+  sudo pip install funcsigs colorama psutil redis
+elif [[ $platform == "macosx" ]]; then
   # check that brew is installed
   which -s brew
   if [[ $? != 0 ]]; then
@@ -25,20 +30,11 @@ if [[ $platform == "macosx" ]]; then
     echo "Updating brew."
     brew update
   fi
-fi
-
-if [[ $platform == "linux" ]]; then
   # These commands must be kept in sync with the installation instructions.
-  sudo apt-get update
-  sudo apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
-  sudo pip install funcsigs colorama psutil redis
-  sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
-elif [[ $platform == "macosx" ]]; then
-  # These commands must be kept in sync with the installation instructions.
-  brew install git cmake automake autoconf libtool boost
+  brew install cmake automake autoconf libtool boost
   sudo easy_install pip
   sudo pip install numpy funcsigs colorama psutil redis --ignore-installed six
-  sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
 fi
 
+sudo pip install --upgrade git+git://github.com/cloudpipe/cloudpickle.git@0d225a4695f1f65ae1cbb2e0bbc145e10167cce4  # We use the latest version of cloudpickle because it can serialize named tuples.
 sudo pip install --upgrade --verbose git+git://github.com/ray-project/numbuf.git@d1974afbab9f0f1bcf8af15a8c476d868ad31aff

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import subprocess
 
 from setuptools import setup, find_packages
@@ -21,5 +23,13 @@ setup(name="ray",
                     "photon": ["build/photon_scheduler",
                                "libphoton.so"]},
       cmdclass={"install": install},
+      install_requires=["numpy",
+                        "funcsigs",
+                        "colorama",
+                        "psutil",
+                        "redis",
+                        "cloudpickle",
+                        "numbuf==0.0.1"],
       include_package_data=True,
-      zip_safe=False)
+      zip_safe=False,
+      license="Apache 2.0")


### PR DESCRIPTION
Ideally, we would only need to pip install ray, and we wouldn't need to pip install the other Python packages. However, the following problems were encountered.

1. It is difficult to tell `setup.py` to install a specific commit of cloudpickle. This seems to be against the spirit of setuptools. This is why we have people install cloudpickle by hand. Hopefully the cloudpickle package will eventually be updated on PyPI and we can just require a sufficiently recent version.
2. giving `setup.py` the URL of the numbuf repository with something like
    ```python
    setup(
      dependency_links=["https://github.com/ray-project/numbuf/tarball/d1974afbab9f0f1bcf8af15a8c476d868ad31aff#egg=numbuf"]
    )
    ```
    doesn't seem to work reliably.
3. In numbuf's `setup.py`, we can set `setup_requires=["numpy"]`, and this attempts to install numpy, but it doesn't appear to succeed.
4. Including `funcsigs` in `install_requires` in `setup.py` fails on Travis with the error
    ```
    Processing funcsigs-1.0.2.tar.gz
    Writing /tmp/easy_install-7EOPah/funcsigs-1.0.2/setup.cfg
    Running funcsigs-1.0.2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-7EOPah/funcsigs-1.0.2/egg-dist-tmp-q5IF8e
    error: Installed distribution setuptools 1.1.6 conflicts with requirement setuptools>=17.1
    ```