### PR TITLE
Quick workaround for ray.wait bug.

### DIFF
--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -1006,7 +1006,7 @@ def wait(object_ids, num_returns=1, timeout=None, worker=global_worker):
   """
   check_connected(worker)
   object_id_strs = [object_id.id() for object_id in object_ids]
-  timeout = timeout if timeout is not None else 2 ** 36
+  timeout = timeout if timeout is not None else 2 ** 30
   ready_ids, remaining_ids = worker.plasma_client.wait(object_id_strs, timeout, num_returns)
   ready_ids = [photon.ObjectID(object_id) for object_id in ready_ids]
   remaining_ids = [photon.ObjectID(object_id) for object_id in remaining_ids]

--- a/src/plasma/lib/python/plasma.py
+++ b/src/plasma/lib/python/plasma.py
@@ -6,7 +6,7 @@ import time
 import libplasma
 
 PLASMA_ID_SIZE = 20
-PLASMA_WAIT_TIMEOUT = 2 ** 36
+PLASMA_WAIT_TIMEOUT = 2 ** 30
 
 class PlasmaBuffer(object):
   """This is the type of objects returned by calls to get with a PlasmaClient.

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -189,6 +189,12 @@ PyObject *PyPlasma_wait(PyObject *self, PyObject *args) {
         "The argument num_returns cannot be greater than len(object_ids)");
     return NULL;
   }
+  int64_t threshold = 1 << 30;
+  if (timeout > threshold) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "The argument timeout cannot be greater than 2 ** 30.");
+    return NULL;
+  }
 
   object_id *object_ids = malloc(sizeof(object_id) * n);
   for (int i = 0; i < n; ++i) {


### PR DESCRIPTION
Without this fix, you can reproduce the bug as follows (on Mac OS X).

```python
import ray
ray.init(start_ray_local=True, num_workers=1)

@ray.remote
def f():
  return 1

ray.wait([f.remote()], timeout=(2 ** 60))
```

The last line just hangs.

I've looked through the code, and the timeout is properly passed around as a 64 bit int (all the way to where the timer is added to the event loop). The hanging occurs because when the result of the task `f` is written to the object store, it calls `seal_object` in the plasma store (like it's supposed to), which calls `send_notifications` to notify the plasma manager (like it is supposed to), but the corresponding callback in the plasma manager (process_object_notification) never gets called (and that's the part that should cause wait to return).