### PR TITLE
Move common C tests into shell script and properly cleanup the redis …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,14 +30,12 @@ PYTHON_GLOBAL_SCHEDULER_DIR="$PYTHON_DIR/global_scheduler"
 pushd "$COMMON_DIR"
   make clean
   make
-  make test
 popd
 cp "$COMMON_DIR/thirdparty/redis-3.2.3/src/redis-server" "$PYTHON_COMMON_DIR/thirdparty/redis-3.2.3/src/"
 
 pushd "$PLASMA_DIR"
   make clean
   make
-  make test
   pushd "$PLASMA_DIR/build"
     cmake ..
     make install

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+
+pushd "$ROOT_DIR/src/common/test"
+  ./run_tests.sh
+popd
+
+pushd "$ROOT_DIR/src/plasma"
+  make test
+popd

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -g -Wall -Wno-typedef-redefinition --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -fPIC -I. -Ithirdparty -Ithirdparty/ae
 BUILD = build
 
-all: hiredis $(BUILD)/libcommon.a
+all: hiredis redis $(BUILD)/libcommon.a $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests
 
 $(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o thirdparty/ae/ae.o thirdparty/sha256.o
 	ar rcs $@ $^
@@ -39,24 +39,11 @@ hiredis:
 	cd thirdparty/hiredis ; make
 
 test: CFLAGS += -DRAY_COMMON_LOG_LEVEL=4
-test: hiredis redis $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests FORCE
-	./thirdparty/redis-3.2.3/src/redis-server &
-	sleep 1s
-	./build/common_tests
-	./build/db_tests
-	./build/io_tests
-	./build/task_tests
-	./build/redis_tests
-	./build/task_table_tests
-	./build/object_table_tests
+test: FORCE
+	./test/run_tests.sh
 
-valgrind: test
-	valgrind --leak-check=full --error-exitcode=1 ./build/common_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/db_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/io_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/task_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/redis_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/task_table_tests
-	valgrind --leak-check=full --error-exitcode=1 ./build/object_table_tests
+valgrind: CFLAGS += -DRAY_COMMON_LOG_LEVEL=4
+valgrind: FORCE
+	./test/run_tests.sh valgrind
 
 FORCE:

--- a/src/common/test/run-tests.sh
+++ b/src/common/test/run-tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+
+pushd "$ROOT_DIR/.."
+  # This assumes the default port is not already being used.
+  ./thirdparty/redis-3.2.3/src/redis-server &
+  REDIS_SERVER_PID=$!
+  sleep 1s
+  if [[ "$1" == "valgrind" ]]; then
+    valgrind --leak-check=full --error-exitcode=1 ./build/common_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/db_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/io_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/task_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/redis_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/task_table_tests
+    valgrind --leak-check=full --error-exitcode=1 ./build/object_table_tests
+  else
+    ./build/common_tests
+    ./build/db_tests
+    ./build/io_tests
+    ./build/task_tests
+    ./build/redis_tests
+    ./build/task_table_tests
+    ./build/object_table_tests
+  fi
+  kill $REDIS_SERVER_PID
+popd


### PR DESCRIPTION
…server started by the tests.

Before this PR, pip install would hang, e.g., if you run
```
pip install --user --upgrade --verbose "git+git://github.com/ray-project/ray.git#egg=ray&subdirectory=lib/python"
```
Then it almost finishes but seems to freeze.

It looks like the reason is that during the testing that happens during installation, we start up a redis server and never kill it, and that prevents the pip install from finishing.

This should be fixed now. Try pip installing from this branch, e.g.,
```
pip install --user --upgrade --verbose "git+git://github.com/ray-project/ray.git@install#egg=ray&subdirectory=lib/python"
```
