### PR TITLE
Enable more warnings and fix usleep() issue

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -g -Wall -Wno-typedef-redefinition --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -fPIC -I. -Ithirdparty -Ithirdparty/ae
+CFLAGS = -g -Wall -Wextra -Werror=implicit-function-declaration -Wno-typedef-redefinition -Wno-sign-compare -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -fPIC -I. -Ithirdparty -Ithirdparty/ae
 BUILD = build
 
 all: hiredis redis $(BUILD)/libcommon.a

--- a/src/global_scheduler/Makefile
+++ b/src/global_scheduler/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -g -Wall --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I. -I../common -I../common/thirdparty -I../common/state
+CFLAGS = -g -Wall -Wextra -Werror=implicit-function-declaration -Wno-sign-compare -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I. -I../common -I../common/thirdparty -I../common/state
 BUILD = build
 
 all: $(BUILD)/global_scheduler

--- a/src/photon/Makefile
+++ b/src/photon/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -g -Wall --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I.. -I../common -I../common/thirdparty -fPIC
+CFLAGS = -g -Wall -Wextra -Werror=implicit-function-declaration -Wno-sign-compare -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I.. -I../common -I../common/thirdparty -fPIC
 BUILD = build
 
 all: $(BUILD)/photon_scheduler $(BUILD)/photon_client.a

--- a/src/plasma/Makefile
+++ b/src/plasma/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -g -Wall --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I. -I../common -I../common/thirdparty
+CFLAGS = -g -Wall -Wextra -Werror=implicit-function-declaration -Wno-sign-compare -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -I. -I../common -I../common/thirdparty
 TEST_CFLAGS = -DPLASMA_TEST=1 -I.
 BUILD = build
 

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -25,6 +25,11 @@
 #define NUM_CONNECT_ATTEMPTS 50
 #define CONNECT_TIMEOUT 100
 
+#ifndef _WIN32
+/* This function is actually not declared in standard POSIX, so declare it */
+extern int usleep(useconds_t usec);
+#endif
+
 typedef struct {
   /** Key that uniquely identifies the  memory mapped file. In practice, we
    *  take the numerical value of the file descriptor in the object store. */

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -26,7 +26,7 @@
 #define CONNECT_TIMEOUT 100
 
 #ifndef _WIN32
-/* This function is actually not declared in standard POSIX, so declare it */
+/* This function is actually not declared in standard POSIX, so declare it. */
 extern int usleep(useconds_t usec);
 #endif
 

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -16,7 +16,7 @@
 #include "plasma_manager.h"
 
 #ifndef _WIN32
-/* This function is actually not declared in standard POSIX, so declare it */
+/* This function is actually not declared in standard POSIX, so declare it. */
 extern int usleep(useconds_t usec);
 #endif
 

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -15,6 +15,11 @@
 #include "plasma_client.h"
 #include "plasma_manager.h"
 
+#ifndef _WIN32
+/* This function is actually not declared in standard POSIX, so declare it */
+extern int usleep(useconds_t usec);
+#endif
+
 SUITE(plasma_manager_tests);
 
 const char *manager_addr = "127.0.0.1";


### PR DESCRIPTION
Seems like we were getting "lucky" with the `usleep` call... it seemed to be undeclared on Ubuntu.