### PR TITLE
Remove Redis version from Linux scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /src/plasma/build
 /src/photon/build
 /src/common/build
-/src/common/thirdparty/redis-3.2.3
+/src/common/thirdparty/redis
 
 # Python byte code files
 *.pyc

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ pushd "$COMMON_DIR"
   make clean
   make
 popd
-cp "$COMMON_DIR/thirdparty/redis-3.2.3/src/redis-server" "$PYTHON_COMMON_DIR/thirdparty/redis-3.2.3/src/"
+cp "$COMMON_DIR/thirdparty/redis/src/redis-server" "$PYTHON_COMMON_DIR/thirdparty/redis/src/"
 
 pushd "$PLASMA_DIR"
   make clean

--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -81,7 +81,7 @@ def start_redis(num_retries=20, cleanup=True):
   Raises:
     Exception: An exception is raised if Redis could not be started.
   """
-  redis_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../common/thirdparty/redis-3.2.3/src/redis-server")
+  redis_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../common/thirdparty/redis/src/redis-server")
   counter = 0
   while counter < num_retries:
     if counter > 0:

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -21,7 +21,7 @@ class install(_install.install):
 setup(name="ray",
       version="0.0.1",
       packages=find_packages(),
-      package_data={"common": ["thirdparty/redis-3.2.3/src/redis-server"],
+      package_data={"common": ["thirdparty/redis/src/redis-server"],
                     "plasma": ["build/plasma_store",
                                "build/plasma_manager",
                                "lib/python/libplasma.so"],

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -40,7 +40,7 @@ hiredis:
 
 test: CFLAGS += -DRAY_COMMON_LOG_LEVEL=4
 test: hiredis redis $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests FORCE
-	./thirdparty/redis-3.2.3/src/redis-server &
+	./thirdparty/redis/src/redis-server &
 	sleep 1s
 	./build/common_tests
 	./build/db_tests

--- a/src/common/thirdparty/build-redis.sh
+++ b/src/common/thirdparty/build-redis.sh
@@ -3,9 +3,11 @@
 # Cause the script to exit if a single command fails.
 set -e
 
-if [ ! -f redis-3.2.3/src/redis-server ]; then
-  wget http://download.redis.io/releases/redis-3.2.3.tar.gz
-  tar xvfz redis-3.2.3.tar.gz
-  cd redis-3.2.3
+if [ ! -f redis/src/redis-server ]; then
+  redis_vname="redis-3.2.3"
+  if [ ! -f redis/utils/whatisdoing.sh ]; then
+    mkdir -p "./redis" && wget -O- "http://download.redis.io/releases/$redis_vname.tar.gz" | tar xvz --strip-components=1 -C "./redis"
+  fi
+  cd redis
   make
 fi

--- a/src/common/thirdparty/build-redis.sh
+++ b/src/common/thirdparty/build-redis.sh
@@ -5,6 +5,9 @@ set -e
 
 if [ ! -f redis/src/redis-server ]; then
   redis_vname="redis-3.2.3"
+  # This check is to make sure the tarball has been fully extracted. The only
+  # relevant bit about redis/utils/whatisdoing.sh is that it is one of the last
+  # files in the tarball.
   if [ ! -f redis/utils/whatisdoing.sh ]; then
     mkdir -p "./redis" && wget -O- "http://download.redis.io/releases/$redis_vname.tar.gz" | tar xvz --strip-components=1 -C "./redis"
   fi

--- a/src/global_scheduler/test/test.py
+++ b/src/global_scheduler/test/test.py
@@ -41,7 +41,7 @@ class TestGlobalScheduler(unittest.TestCase):
 
   def setUp(self):
     # Start a Redis server.
-    redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis-3.2.3/src/redis-server")
+    redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis/src/redis-server")
     node_ip_address = "127.0.0.1"
     redis_port = new_port()
     redis_address = "{}:{}".format(node_ip_address, redis_port)

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -56,7 +56,7 @@ def assert_get_object_equal(unit_test, client1, client2, object_id, memory_buffe
                         client2.get_metadata(object_id)[:])
 
 # Check if the redis-server binary is present.
-redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis-3.2.3/src/redis-server")
+redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis/src/redis-server")
 if not os.path.exists(redis_path):
   raise Exception("You do not have the redis-server binary. Run `make test` in the plasma directory to get it.")
 
@@ -254,7 +254,7 @@ class TestPlasmaManager(unittest.TestCase):
     store_name1, self.p2 = plasma.start_plasma_store(use_valgrind=USE_VALGRIND)
     store_name2, self.p3 = plasma.start_plasma_store(use_valgrind=USE_VALGRIND)
     # Start a Redis server.
-    redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis-3.2.3/src/redis-server")
+    redis_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../common/thirdparty/redis/src/redis-server")
     redis_port = 6379
     with open(os.devnull, "w") as FNULL:
       self.redis_process = subprocess.Popen([redis_path,


### PR DESCRIPTION
Not required per se, but version numbers aren't necessary at all (and shouldn't need to be sprinkled across multiple scripts).