### PR TITLE
Refactor plasma

### DIFF
--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -80,6 +80,7 @@ include_directories("${CMAKE_SOURCE_DIR}/../common/thirdparty/")
 include_directories("${CMAKE_SOURCE_DIR}/../common/lib/python/")
 
 add_library(plasma SHARED
+  plasma.c
   plasma_extension.c
   plasma_client.c
   fling.c)

--- a/src/plasma/Makefile
+++ b/src/plasma/Makefile
@@ -13,23 +13,23 @@ clean:
 	cd ../common; make clean
 	rm -rf $(BUILD)/*
 
-$(BUILD)/manager_tests: test/manager_tests.c plasma.h plasma_client.h plasma_client.c plasma_manager.h plasma_manager.c fling.h fling.c common
-	$(CC) $(CFLAGS) $(TEST_CFLAGS) -o $@ test/manager_tests.c plasma_manager.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a
+$(BUILD)/manager_tests: test/manager_tests.c plasma.h plasma.c plasma_client.h plasma_client.c plasma_manager.h plasma_manager.c fling.h fling.c common
+	$(CC) $(CFLAGS) $(TEST_CFLAGS) -o $@ test/manager_tests.c plasma.c plasma_manager.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a
 
-$(BUILD)/plasma_store: plasma_store.c plasma.h eviction_policy.c fling.h fling.c malloc.c malloc.h thirdparty/dlmalloc.c common
-	$(CC) $(CFLAGS) plasma_store.c eviction_policy.c fling.c malloc.c ../common/build/libcommon.a -o $(BUILD)/plasma_store
+$(BUILD)/plasma_store: plasma_store.c plasma.h plasma.c eviction_policy.c fling.h fling.c malloc.c malloc.h thirdparty/dlmalloc.c common
+	$(CC) $(CFLAGS) plasma_store.c plasma.c eviction_policy.c fling.c malloc.c ../common/build/libcommon.a -o $(BUILD)/plasma_store
 
-$(BUILD)/plasma_manager: plasma_manager.c plasma.h plasma_client.c fling.h fling.c common
-	$(CC) $(CFLAGS) plasma_manager.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a -o $(BUILD)/plasma_manager
+$(BUILD)/plasma_manager: plasma_manager.c plasma.h plasma.c plasma_client.c fling.h fling.c common
+	$(CC) $(CFLAGS) plasma_manager.c plasma.c plasma_client.c fling.c ../common/build/libcommon.a ../common/thirdparty/hiredis/libhiredis.a -o $(BUILD)/plasma_manager
 
-$(BUILD)/plasma_client.so: plasma_client.c fling.h fling.c common
-	$(CC) $(CFLAGS) plasma_client.c fling.c ../common/build/libcommon.a -fPIC -shared -o $(BUILD)/plasma_client.so
+$(BUILD)/plasma_client.so: plasma.h plasma.c plasma_client.c fling.h fling.c common
+	$(CC) $(CFLAGS) plasma.c plasma_client.c fling.c ../common/build/libcommon.a -fPIC -shared -o $(BUILD)/plasma_client.so
 
-$(BUILD)/libplasma_client.a: plasma_client.o fling.o
+$(BUILD)/libplasma_client.a: plasma.o plasma_client.o fling.o
 	ar rcs $@ $^
 
-$(BUILD)/example: plasma_client.c plasma.h example.c fling.h fling.c common
-	$(CC) $(CFLAGS) plasma_client.c example.c fling.c ../common/build/libcommon.a -o $(BUILD)/example
+$(BUILD)/example: plasma_client.c plasma.h plasma.c example.c fling.h fling.c common
+	$(CC) $(CFLAGS) plasma_client.c plasma.c example.c fling.c ../common/build/libcommon.a -o $(BUILD)/example
 
 common: FORCE
 	cd ../common; make

--- a/src/plasma/fling.c
+++ b/src/plasma/fling.c
@@ -17,7 +17,7 @@ void init_msg(struct msghdr *msg,
   msg->msg_namelen = 0;
 }
 
-int send_fd(int conn, int fd, const char *payload, int size) {
+int send_fd(int conn, int fd) {
   struct msghdr msg;
   struct iovec iov;
   char buf[CMSG_SPACE(sizeof(int))];
@@ -31,11 +31,11 @@ int send_fd(int conn, int fd, const char *payload, int size) {
   header->cmsg_len = CMSG_LEN(sizeof(int));
   *(int *) CMSG_DATA(header) = fd;
 
-  /* send file descriptor and payload */
-  return sendmsg(conn, &msg, 0) != -1 && send(conn, payload, size, 0) == -1;
+  /* Send file descriptor. */
+  return sendmsg(conn, &msg, 0);
 }
 
-int recv_fd(int conn, char *payload, int size) {
+int recv_fd(int conn) {
   struct msghdr msg;
   struct iovec iov;
   char buf[CMSG_SPACE(sizeof(int))];
@@ -69,11 +69,6 @@ int recv_fd(int conn, char *payload, int size) {
   if (oh_noes) {
     close(found_fd);
     errno = EBADMSG;
-    return -1;
-  }
-
-  ssize_t len = recv(conn, payload, size, 0);
-  if (len < 0) {
     return -1;
   }
 

--- a/src/plasma/fling.h
+++ b/src/plasma/fling.h
@@ -25,11 +25,19 @@
 
 void init_msg(struct msghdr *msg, struct iovec *iov, char *buf, size_t buf_len);
 
-/* Send a file descriptor "fd" and a payload "payload" of size "size"
- * over the socket "conn". Return 0 on success. */
-int send_fd(int conn, int fd, const char *payload, int size);
+/**
+ * Send a file descriptor over a unix domain socket.
+ *
+ * @param conn Unix domain socket to send the file descriptor over.
+ * @param fd File descriptor to send over.
+ * @return Status code which is < 0 on failure.
+ */
+int send_fd(int conn, int fd);
 
-/* Receive a file descriptor and a payload of size up to "size" from a
- * socket "conn". The payload will be written to "payload" and the file
- * descriptor will be returned. Returns -1 on failure. */
-int recv_fd(int conn, char *payload, int size);
+/**
+ * Receive a file descriptor over a unix domain socket.
+ *
+ * @param conn Unix domain socket to receive the file descriptor from.
+ * @return File descriptor or a value < 0 on failure.
+ */
+int recv_fd(int conn);

--- a/src/plasma/plasma.c
+++ b/src/plasma/plasma.c
@@ -1,0 +1,90 @@
+#include "plasma.h"
+
+#include "io.h"
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+plasma_request plasma_make_request(object_id object_id) {
+  plasma_request request;
+  memset(&request, 0, sizeof(request));
+  request.num_object_ids = 1;
+  request.object_ids[0] = object_id;
+  return request;
+}
+
+plasma_request *plasma_alloc_request(int num_object_ids,
+                                     object_id object_ids[]) {
+  DCHECK(num_object_ids >= 1);
+  int req_size = plasma_request_size(num_object_ids);
+  plasma_request *req = malloc(req_size);
+  memset(req, 0, req_size);
+  req->num_object_ids = num_object_ids;
+  memcpy(&req->object_ids, object_ids, num_object_ids * sizeof(object_ids[0]));
+  return req;
+}
+
+void plasma_free_request(plasma_request *request) {
+  free(request);
+}
+
+int64_t plasma_request_size(int num_object_ids) {
+  int64_t object_ids_size = (num_object_ids - 1) * sizeof(object_id);
+  return sizeof(plasma_request) + object_ids_size;
+}
+
+plasma_reply plasma_make_reply(object_id object_id) {
+  plasma_reply reply;
+  memset(&reply, 0, sizeof(reply));
+  reply.num_object_ids = 1;
+  reply.object_ids[0] = object_id;
+  return reply;
+}
+
+plasma_reply *plasma_alloc_reply(int num_object_ids) {
+  DCHECK(num_object_ids >= 1);
+  int64_t size = plasma_reply_size(num_object_ids);
+  plasma_reply *reply = malloc(size);
+  memset(reply, 0, size);
+  reply->num_object_ids = num_object_ids;
+  return reply;
+}
+
+void plasma_free_reply(plasma_reply *reply) {
+  free(reply);
+}
+
+int64_t plasma_reply_size(int num_object_ids) {
+  DCHECK(num_object_ids >= 1);
+  return sizeof(plasma_reply) + (num_object_ids - 1) * sizeof(object_id);
+}
+
+int plasma_send_reply(int sock, plasma_reply *reply) {
+  DCHECK(reply);
+  int64_t reply_size = plasma_reply_size(reply->num_object_ids);
+  int n = write(sock, (uint8_t *) reply, reply_size);
+  return n == reply_size ? 0 : -1;
+}
+
+int plasma_receive_reply(int sock, int64_t reply_size, plasma_reply *reply) {
+  int r = recv(sock, reply, reply_size, 0);
+  CHECKM(r != -1, "read error");
+  CHECKM(r != 0, "connection disconnected");
+  return r == reply_size ? 0 : -1;
+}
+
+int plasma_send_request(int sock, int64_t type, plasma_request *request) {
+  DCHECK(request);
+  int req_size = plasma_request_size(request->num_object_ids);
+  int error = write_message(sock, type, req_size, (uint8_t *) request);
+  return error ? -1 : 0;
+}
+
+int plasma_receive_request(int sock, int64_t *type, plasma_request **request) {
+  int64_t length;
+  read_message(sock, type, &length, (uint8_t **) request);
+  if (*request == NULL) {
+    return *type == DISCONNECT_CLIENT;
+  }
+  return length == plasma_request_size((*request)->num_object_ids) ? 0 : -1;
+}

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -2,6 +2,7 @@
 #define PLASMA_H
 
 #include <inttypes.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
@@ -144,4 +145,114 @@ typedef struct {
   object_table_entry *objects;
 } plasma_store_info;
 
-#endif
+/**
+ * Create a plasma request with one object ID on the stack.
+ *
+ * @param object_id The object ID to include in the request.
+ * @return The plasma request.
+ */
+plasma_request plasma_make_request(object_id object_id);
+
+/**
+ * Create a plasma request with one or more object IDs on the heap. The caller
+ * must free the returned plasma request pointer with plasma_free_request.
+ *
+ * @param num_object_ids The number of object IDs to include in the request.
+ * @param object_ids The array of object IDs to include in the request. It must
+ *        have length at least equal to num_object_ids.
+ * @return A pointer to the newly created plasma request.
+ */
+plasma_request *plasma_alloc_request(int num_object_ids,
+                                     object_id object_ids[]);
+
+/**
+ * Free a plasma request.
+ *
+ * @param request Pointer to the plasma request to be freed.
+ * @return Void.
+ */
+void plasma_free_request(plasma_request *request);
+
+/**
+ * Size of a request in bytes.
+ *
+ * @param num_object_ids Number of object IDs in the request.
+ * @return The size of the request in bytes.
+ */
+int64_t plasma_request_size(int num_object_ids);
+
+/**
+ * Create a plasma reply with one object ID on the stack.
+ *
+ * @param object_id The object ID to include in the reply.
+ * @return The plasma reply.
+ */
+plasma_reply plasma_make_reply(object_id object_id);
+
+/**
+ * Create a plasma reply with one or more object IDs on the heap. The caller
+ * must free the returned plasma reply pointer with plasma_free_reply.
+ *
+ * @param num_object_ids The number of object IDs to include in the reply.
+ * @return A pointer to the newly created plasma reply.
+ */
+plasma_reply *plasma_alloc_reply(int num_object_ids);
+
+/**
+ * Free a plasma reply.
+ *
+ * @param request Pointer to the plasma reply to be freed.
+ * @return Void.
+ */
+void plasma_free_reply(plasma_reply *request);
+
+/**
+ * Size of a reply in bytes.
+ *
+ * @param num_returns Number of object IDs returned with this reply.
+ * @return The size of the reply in bytes.
+ */
+int64_t plasma_reply_size(int num_returns);
+
+/**
+ * Send a plasma reply.
+ *
+ * @param sock The file descriptor to use to send the request.
+ * @param reply Address of the reply that is sent.
+ * @return Returns a value >= 0 on success.
+ */
+int plasma_send_reply(int sock, plasma_reply *reply);
+
+/**
+ * Receive a plasma reply.
+ *
+ * @param sock The file descriptor to use to get the reply.
+ * @param reply Address of the reply that is received.
+ * @return Returns a value >= 0 on success.
+ */
+int plasma_receive_reply(int sock, int64_t receive_size, plasma_reply *reply);
+
+/**
+ * This is used to send a request to the Plasma Store or
+ * the Plasma Manager.
+ *
+ * @param sock The file descriptor to use to send the request.
+ * @param type The type of request.
+ * @param req The address of the request to send.
+ * @return Returns a value >= 0 on success.
+ */
+int plasma_send_request(int sock, int64_t type, plasma_request *request);
+
+/**
+ * Receive a plasma request. This allocates memory for the request which
+ * needs to be freed by the user.
+ *
+ * @param sock The file descriptor to use to get the reply.
+ * @param type Address where the type of the request is written to.
+ * @param request Address at which the address of the allocated request is
+ *        written.
+ * @return Returns a value >= 0 on success.
+ */
+int plasma_receive_request(int sock, int64_t *type, plasma_request **request);
+
+#endif /* PLASMA_H */

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -10,37 +10,6 @@
 typedef struct plasma_connection plasma_connection;
 
 /**
- * This is used by the Plasma Client to send a request to the Plasma Store or
- * the Plasma Manager.
- *
- * @param conn The file descriptor to use to send the request.
- * @param type The type of request.
- * @param req The address of the request to send.
- * @return Void.
- */
-void plasma_send_request(int fd, int type, plasma_request *req);
-
-/**
- * Create a plasma request to be sent with a single object ID.
- *
- * @param object_id The object ID to include in the request.
- * @return The plasma request.
- */
-plasma_request make_plasma_request(object_id object_id);
-
-/**
- * Create a plasma request to be sent with multiple object ID. Caller must free
- * the returned plasma request pointer.
- *
- * @param num_object_ids The number of object IDs to include in the request.
- * @param object_ids The array of object IDs to include in the request. It must
- *        have length at least equal to num_object_ids.
- * @return A pointer to the newly created plasma request.
- */
-plasma_request *make_plasma_multiple_request(int num_object_ids,
-                                             object_id object_ids[]);
-
-/**
  * Try to connect to the socket several times. If unsuccessful, fail.
  *
  * @param socket_name Name of the Unix domain socket to connect to.


### PR DESCRIPTION
This PR introduces a number of methods to construct, send and receive plasma requests and replies:

- `plasma_make_request` for allocating a request on the stack
- `plasma_alloc_request` for allocating a (possibly variable size) request on the heap
- `plasma_free_request` for freeing a variable size request from the heap
- `plasma_request_size` for getting the size of a request
- `plasma_send_request` for sending a request over a socket
- `plasma_receive_request` for receiving a request over a socket