### PR TITLE
handling partial/interrupted I/O

### DIFF
--- a/src/common/io.c
+++ b/src/common/io.c
@@ -239,25 +239,23 @@ int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
  */
 int read_bytes(int fd, uint8_t *cursor, size_t length) {
   ssize_t nbytes = 0;
-  /* termination condition: EOF or read 'length' bytes total
-   *
-   */
+  /* Termination condition: EOF or read 'length' bytes total. */
   size_t bytesleft = length;
   size_t offset = 0;
   while (bytesleft > 0) {
-	  nbytes = read(fd, cursor+offset, bytesleft);
-	  if (nbytes < 0) {
-		  if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
-			  continue;
-		  }
-		  return -1;
-	  } else if (0 == nbytes) {
-		  /* encountered early EOF */
-		  return -1;
-	  }
-	  CHECK(nbytes > 0);
-	  bytesleft -= nbytes;
-	  offset += nbytes;
+    nbytes = read(fd, cursor + offset, bytesleft);
+    if (nbytes < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        continue;
+      }
+      return -1;
+    } else if (0 == nbytes) {
+      /* Encountered early EOF. */
+      return -1;
+    }
+    CHECK(nbytes > 0);
+    bytesleft -= nbytes;
+    offset += nbytes;
   }
 
   return 0;

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -32,5 +32,7 @@ int64_t read_buffer(int fd, int64_t *type, UT_array *buffer);
 void write_log_message(int fd, char *message);
 void write_formatted_log_message(int fd, const char *format, ...);
 char *read_log_message(int fd);
+int read_bytes(int fd, uint8_t *cursor, size_t length);
+int write_bytes(int fd, uint8_t *cursor, size_t length);
 
 #endif /* IO_H */

--- a/src/plasma/plasma.c
+++ b/src/plasma/plasma.c
@@ -62,15 +62,11 @@ int64_t plasma_reply_size(int num_object_ids) {
 int plasma_send_reply(int sock, plasma_reply *reply) {
   DCHECK(reply);
   int64_t reply_size = plasma_reply_size(reply->num_object_ids);
-  int n = write(sock, (uint8_t *) reply, reply_size);
-  return n == reply_size ? 0 : -1;
+  return write_bytes(sock, (uint8_t *) reply, reply_size);
 }
 
 int plasma_receive_reply(int sock, int64_t reply_size, plasma_reply *reply) {
-  int r = recv(sock, reply, reply_size, 0);
-  CHECKM(r != -1, "read error");
-  CHECKM(r != 0, "connection disconnected");
-  return r == reply_size ? 0 : -1;
+  return read_bytes(sock, (uint8_t *) reply, reply_size);
 }
 
 int plasma_send_request(int sock, int64_t type, plasma_request *request) {


### PR DESCRIPTION
Updated read_bytes and write_bytes to handle EINTR and changed the flow a bit.

EINTR is induced when a process is interrupted by a signal while doing I/O. It is not uncommon in asynchronous, event-driven code with callbacks. Different *Nix systems may handle EINTR differently, some automatically restart the syscall, some don't. It is best to handle it in all cases and manually restart the syscall, while accounting for the partial read/write.

Plasma send/receive were updated to support partial fd reads/writes, in lieu of treating them as failed I/O.