### PR TITLE
Fix bug in serializing arguments of tasks that are more complex objects

### DIFF
--- a/lib/python/ray/serialization.py
+++ b/lib/python/ray/serialization.py
@@ -91,7 +91,7 @@ def serialize(obj):
   """
   class_id = class_identifier(type(obj))
   if class_id not in whitelisted_classes:
-    raise Exception("Ray does not know how to serialize the object {}. To fix this, call 'ray.register_class' on the class of the object.".format(obj))
+    raise Exception("Ray does not know how to serialize objects of type {}. To fix this, call 'ray.register_class' with this class.".format(type(obj)))
   if class_id in classes_to_pickle:
     serialized_obj = {"data": pickling.dumps(obj)}
   elif class_id in custom_serializers.keys():

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -1,14 +1,13 @@
 #include <Python.h>
 #include "node.h"
 
+#include "common.h"
 #include "common_extension.h"
 #include "task.h"
 #include "utarray.h"
 #include "utstring.h"
 
 PyObject *CommonError;
-
-#define MARSHAL_VERSION 2
 
 /* Define the PyObjectID class. */
 
@@ -194,7 +193,9 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   for (size_t i = 0; i < size; ++i) {
     PyObject *arg = PyList_GetItem(arguments, i);
     if (!PyObject_IsInstance(arg, (PyObject *) &PyObjectIDType)) {
-      PyObject *data = PyMarshal_WriteObjectToString(arg, MARSHAL_VERSION);
+      CHECK(pickle_module != NULL);
+      CHECK(pickle_dumps != NULL);
+      PyObject *data = PyObject_CallMethodObjArgs(pickle_module, pickle_dumps, arg, NULL);
       value_data_bytes += PyString_Size(data);
       utarray_push_back(val_repr_ptrs, &data);
     }
@@ -248,10 +249,12 @@ static PyObject *PyTask_arguments(PyObject *self) {
       object_id object_id = task_arg_id(task, i);
       PyList_SetItem(arg_list, i, PyObjectID_make(object_id));
     } else {
-      PyObject *s =
-          PyMarshal_ReadObjectFromString((char *) task_arg_val(task, i),
-                                         (Py_ssize_t) task_arg_length(task, i));
-      PyList_SetItem(arg_list, i, s);
+      CHECK(pickle_module != NULL);
+      CHECK(pickle_loads != NULL);
+      PyObject *str = PyString_FromStringAndSize((char *) task_arg_val(task, i), (Py_ssize_t) task_arg_length(task, i));
+      PyObject *val = PyObject_CallMethodObjArgs(pickle_module, pickle_loads, str, NULL);
+      Py_XDECREF(str);
+      PyList_SetItem(arg_list, i, val);
     }
   }
   return arg_list;
@@ -320,6 +323,10 @@ PyTypeObject PyTaskType = {
     0,                           /* tp_alloc */
     PyType_GenericNew,           /* tp_new */
 };
+
+PyObject *pickle_module = NULL;
+PyObject *pickle_loads = NULL;
+PyObject *pickle_dumps = NULL;
 
 /* Create a PyTask from a C struct. The resulting PyTask takes ownership of the
  * task_spec and will deallocate the task_spec in the PyTask destructor. */

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -9,6 +9,20 @@
 
 PyObject *CommonError;
 
+/* Initialize pickle module. */
+
+PyObject *pickle_module = NULL;
+PyObject *pickle_loads = NULL;
+PyObject *pickle_dumps = NULL;
+
+void init_pickle_module() {
+  /* For Python 3 this needs to be "_pickle" instead of "cPickle". */
+  pickle_module = PyImport_ImportModuleNoBlock("cPickle");
+  pickle_loads = PyString_FromString("loads");
+  pickle_dumps = PyString_FromString("dumps");
+  CHECK(pickle_module != NULL);
+}
+
 /* Define the PyObjectID class. */
 
 int PyObjectToUniqueID(PyObject *object, object_id *objectid) {
@@ -323,10 +337,6 @@ PyTypeObject PyTaskType = {
     0,                           /* tp_alloc */
     PyType_GenericNew,           /* tp_new */
 };
-
-PyObject *pickle_module = NULL;
-PyObject *pickle_loads = NULL;
-PyObject *pickle_dumps = NULL;
 
 /* Create a PyTask from a C struct. The resulting PyTask takes ownership of the
  * task_spec and will deallocate the task_spec in the PyTask destructor. */

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -209,7 +209,8 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
     if (!PyObject_IsInstance(arg, (PyObject *) &PyObjectIDType)) {
       CHECK(pickle_module != NULL);
       CHECK(pickle_dumps != NULL);
-      PyObject *data = PyObject_CallMethodObjArgs(pickle_module, pickle_dumps, arg, NULL);
+      PyObject *data =
+          PyObject_CallMethodObjArgs(pickle_module, pickle_dumps, arg, NULL);
       value_data_bytes += PyString_Size(data);
       utarray_push_back(val_repr_ptrs, &data);
     }
@@ -265,8 +266,11 @@ static PyObject *PyTask_arguments(PyObject *self) {
     } else {
       CHECK(pickle_module != NULL);
       CHECK(pickle_loads != NULL);
-      PyObject *str = PyString_FromStringAndSize((char *) task_arg_val(task, i), (Py_ssize_t) task_arg_length(task, i));
-      PyObject *val = PyObject_CallMethodObjArgs(pickle_module, pickle_loads, str, NULL);
+      PyObject *str =
+          PyString_FromStringAndSize((char *) task_arg_val(task, i),
+                                     (Py_ssize_t) task_arg_length(task, i));
+      PyObject *val =
+          PyObject_CallMethodObjArgs(pickle_module, pickle_loads, str, NULL);
       Py_XDECREF(str);
       PyList_SetItem(arg_list, i, val);
     }

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -15,7 +15,7 @@ PyObject *pickle_module = NULL;
 PyObject *pickle_loads = NULL;
 PyObject *pickle_dumps = NULL;
 
-void init_pickle_module() {
+void init_pickle_module(void) {
   /* For Python 3 this needs to be "_pickle" instead of "cPickle". */
   pickle_module = PyImport_ImportModuleNoBlock("cPickle");
   pickle_loads = PyString_FromString("loads");

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -14,12 +14,14 @@ PyObject *CommonError;
 PyObject *pickle_module = NULL;
 PyObject *pickle_loads = NULL;
 PyObject *pickle_dumps = NULL;
+PyObject *pickle_protocol = NULL;
 
 void init_pickle_module(void) {
   /* For Python 3 this needs to be "_pickle" instead of "cPickle". */
   pickle_module = PyImport_ImportModuleNoBlock("cPickle");
   pickle_loads = PyString_FromString("loads");
   pickle_dumps = PyString_FromString("dumps");
+  pickle_protocol = PyObject_GetAttrString(pickle_module, "HIGHEST_PROTOCOL");
   CHECK(pickle_module != NULL);
 }
 
@@ -209,8 +211,8 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
     if (!PyObject_IsInstance(arg, (PyObject *) &PyObjectIDType)) {
       CHECK(pickle_module != NULL);
       CHECK(pickle_dumps != NULL);
-      PyObject *data =
-          PyObject_CallMethodObjArgs(pickle_module, pickle_dumps, arg, NULL);
+      PyObject *data = PyObject_CallMethodObjArgs(pickle_module, pickle_dumps,
+                                                  arg, pickle_protocol, NULL);
       value_data_bytes += PyString_Size(data);
       utarray_push_back(val_repr_ptrs, &data);
     }

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -26,6 +26,11 @@ extern PyTypeObject PyObjectIDType;
 
 extern PyTypeObject PyTaskType;
 
+/* Python module for pickling. */
+extern PyObject *pickle_module;
+extern PyObject *pickle_dumps;
+extern PyObject *pickle_loads;
+
 int PyObjectToUniqueID(PyObject *object, object_id *objectid);
 
 PyObject *PyObjectID_make(object_id object_id);

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -31,7 +31,7 @@ extern PyObject *pickle_module;
 extern PyObject *pickle_dumps;
 extern PyObject *pickle_loads;
 
-void init_pickle_module();
+void init_pickle_module(void);
 
 int PyObjectToUniqueID(PyObject *object, object_id *objectid);
 

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -31,6 +31,8 @@ extern PyObject *pickle_module;
 extern PyObject *pickle_dumps;
 extern PyObject *pickle_loads;
 
+void init_pickle_module();
+
 int PyObjectToUniqueID(PyObject *object, object_id *objectid);
 
 PyObject *PyObjectID_make(object_id object_id);

--- a/src/common/lib/python/common_module.c
+++ b/src/common/lib/python/common_module.c
@@ -24,6 +24,8 @@ PyMODINIT_FUNC initcommon(void) {
   m = Py_InitModule3("common", common_methods,
                      "A module for common types. This is used for testing.");
 
+  init_pickle_module();
+
   Py_INCREF(&PyTaskType);
   PyModule_AddObject(m, "Task", (PyObject *) &PyTaskType);
 

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -125,6 +125,12 @@ PyMODINIT_FUNC initlibphoton(void) {
   m = Py_InitModule3("libphoton", photon_methods,
                      "A module for the local scheduler.");
 
+  /* For Python 3 this needs to be "_pickle" instead of "cPickle". */
+  pickle_module = PyImport_ImportModuleNoBlock("cPickle");
+  pickle_loads = PyString_FromString("loads");
+  pickle_dumps = PyString_FromString("dumps");
+  assert(pickle_module != NULL);
+
   Py_INCREF(&PyTaskType);
   PyModule_AddObject(m, "Task", (PyObject *) &PyTaskType);
 

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -125,11 +125,7 @@ PyMODINIT_FUNC initlibphoton(void) {
   m = Py_InitModule3("libphoton", photon_methods,
                      "A module for the local scheduler.");
 
-  /* For Python 3 this needs to be "_pickle" instead of "cPickle". */
-  pickle_module = PyImport_ImportModuleNoBlock("cPickle");
-  pickle_loads = PyString_FromString("loads");
-  pickle_dumps = PyString_FromString("dumps");
-  assert(pickle_module != NULL);
+  init_pickle_module();
 
   Py_INCREF(&PyTaskType);
   PyModule_AddObject(m, "Task", (PyObject *) &PyTaskType);


### PR DESCRIPTION
This addresses #70 by using Pickle instead of Marshal to serialize arguments that are added to the task struct.