### PR TITLE
Implement pubsub transfer and transfer subscribe

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -4,7 +4,7 @@ BUILD = build
 
 all: hiredis redis $(BUILD)/libcommon.a
 
-$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o thirdparty/ae/ae.o thirdparty/sha256.o
+$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/pubsub.o state/db_client_table.o thirdparty/ae/ae.o thirdparty/sha256.o
 	ar rcs $@ $^
 
 $(BUILD)/common_tests: test/common_tests.c $(BUILD)/libcommon.a
@@ -25,6 +25,9 @@ $(BUILD)/io_tests: test/io_tests.c $(BUILD)/libcommon.a
 $(BUILD)/task_tests: test/task_tests.c $(BUILD)/libcommon.a
 	$(CC) -o $@ $^ thirdparty/hiredis/libhiredis.a $(CFLAGS)
 
+$(BUILD)/pubsub_tests: test/pubsub_tests.c $(BUILD)/libcommon.a
+	$(CC) -o $@ $^ thirdparty/hiredis/libhiredis.a $(CFLAGS)
+
 $(BUILD)/redis_tests: hiredis test/redis_tests.c $(BUILD)/libcommon.a logging.h
 	$(CC) -o $@ test/redis_tests.c logging.c $(BUILD)/libcommon.a thirdparty/hiredis/libhiredis.a $(CFLAGS)
 
@@ -39,13 +42,14 @@ hiredis:
 	cd thirdparty/hiredis ; make
 
 test: CFLAGS += -DRAY_COMMON_LOG_LEVEL=4
-test: hiredis redis $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests FORCE
+test: hiredis redis $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests $(BUILD)/pubsub_tests FORCE
 	./thirdparty/redis/src/redis-server &
 	sleep 1s
 	./build/common_tests
 	./build/db_tests
 	./build/io_tests
 	./build/task_tests
+	./build/pubsub_tests
 	./build/redis_tests
 	./build/task_table_tests
 	./build/object_table_tests
@@ -58,6 +62,7 @@ valgrind: test
 	valgrind --leak-check=full --error-exitcode=1 ./build/db_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/io_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/task_tests
+	valgrind --leak-check=full --error-exitcode=1 ./build/pubsub_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/redis_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/task_table_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/object_table_tests

--- a/src/common/state/pubsub.c
+++ b/src/common/state/pubsub.c
@@ -1,0 +1,33 @@
+#include "pubsub.h"
+#include "redis.h"
+
+void pubsub_request_transfer(db_handle *db,
+                             object_id object_id,
+                             int source,
+                             int destination,
+                             retry_info *retry,
+                             pubsub_transfer_callback done_callback,
+                             void *user_context) {
+  transfer_data *data = malloc(sizeof(transfer_data));
+  data->object_id = object_id;
+  data->source = source;
+  data->destination = destination;
+  data->subscribe_callback = NULL;
+  init_table_callback(db, object_id, __func__, data, retry, done_callback,
+                      redis_pubsub_request_transfer, user_context);
+}
+
+void pubsub_subscribe_transfer(db_handle *db,
+                               int source,
+                               pubsub_subscribe_transfer_callback subscribe_callback,
+                               retry_info *retry,
+                               pubsub_transfer_callback done_callback,
+                               void *user_context) {
+  transfer_data *data = malloc(sizeof(transfer_data));
+  data->object_id = NIL_OBJECT_ID;
+  data->source = source;
+  data->destination = -1;
+  data->subscribe_callback = subscribe_callback;
+  init_table_callback(db, NIL_OBJECT_ID, __func__, data, retry, done_callback,
+                      redis_pubsub_subscribe_transfer, user_context);
+}

--- a/src/common/state/pubsub.c
+++ b/src/common/state/pubsub.c
@@ -17,12 +17,13 @@ void pubsub_request_transfer(db_handle *db,
                       redis_pubsub_request_transfer, user_context);
 }
 
-void pubsub_subscribe_transfer(db_handle *db,
-                               int source,
-                               pubsub_subscribe_transfer_callback subscribe_callback,
-                               retry_info *retry,
-                               pubsub_transfer_callback done_callback,
-                               void *user_context) {
+void pubsub_subscribe_transfer(
+    db_handle *db,
+    int source,
+    pubsub_subscribe_transfer_callback subscribe_callback,
+    retry_info *retry,
+    pubsub_transfer_callback done_callback,
+    void *user_context) {
   transfer_data *data = malloc(sizeof(transfer_data));
   data->object_id = NIL_OBJECT_ID;
   data->source = source;

--- a/src/common/state/pubsub.h
+++ b/src/common/state/pubsub.h
@@ -1,0 +1,36 @@
+#ifndef TRANSFER_PUBSUB_H
+#define TRANSFER_PUBSUB_H
+
+#include "table.h"
+
+typedef void (*pubsub_transfer_callback)(object_id object_id,
+                                         int source,
+                                         int destination,
+                                         void *user_context);
+
+void pubsub_request_transfer(db_handle *db,
+                             object_id object_id,
+                             int source,
+                             int destionation,
+                             retry_info *retry,
+                             pubsub_transfer_callback done_callback,
+                             void *user_context);
+
+typedef void (*pubsub_subscribe_transfer_callback)(object_id object_id,
+                                                   void *user_context);
+
+void pubsub_subscribe_transfer(db_handle *db,
+                               int source,
+                               pubsub_subscribe_transfer_callback subscribe_callback,
+                               retry_info *retry,
+                               pubsub_transfer_callback done_callback,
+                               void *user_context);
+
+typedef struct {
+  object_id object_id;
+  int source;
+  int destination;
+  pubsub_transfer_callback subscribe_callback;
+} transfer_data;
+
+#endif /* TRANSFER_PUBSUB_H */

--- a/src/common/state/pubsub.h
+++ b/src/common/state/pubsub.h
@@ -19,12 +19,13 @@ void pubsub_request_transfer(db_handle *db,
 typedef void (*pubsub_subscribe_transfer_callback)(object_id object_id,
                                                    void *user_context);
 
-void pubsub_subscribe_transfer(db_handle *db,
-                               int source,
-                               pubsub_subscribe_transfer_callback subscribe_callback,
-                               retry_info *retry,
-                               pubsub_transfer_callback done_callback,
-                               void *user_context);
+void pubsub_subscribe_transfer(
+    db_handle *db,
+    int source,
+    pubsub_subscribe_transfer_callback subscribe_callback,
+    retry_info *retry,
+    pubsub_transfer_callback done_callback,
+    void *user_context);
 
 typedef struct {
   object_id object_id;

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -780,7 +780,8 @@ void redis_pubsub_subscribe_transfer_callback(redisAsyncContext *c,
   CHECK(endptr == payload->str + payload->len);
   transfer_data *data = callback_data->data;
   if (data->subscribe_callback) {
-    data->subscribe_callback(callback_data->id, data->source, destination, callback_data->user_context);
+    data->subscribe_callback(callback_data->id, data->source, destination,
+                             callback_data->user_context);
   }
 }
 
@@ -788,10 +789,10 @@ void redis_pubsub_subscribe_transfer(table_callback_data *callback_data) {
   db_handle *db = callback_data->db_handle;
   transfer_data *data = callback_data->data;
 
-  int status = redisAsyncCommand(
-      db->sub_context, redis_pubsub_subscribe_transfer_callback,
-      (void *) callback_data->timer_id, "PSUBSCRIBE transfer:*:%d",
-      data->source);
+  int status = redisAsyncCommand(db->sub_context,
+                                 redis_pubsub_subscribe_transfer_callback,
+                                 (void *) callback_data->timer_id,
+                                 "PSUBSCRIBE transfer:*:%d", data->source);
   REDIS_CHECK_ERROR(status, db->sub_context);
 }
 

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -183,4 +183,8 @@ void redis_task_table_subscribe(table_callback_data *callback_data);
  */
 void redis_db_client_table_subscribe(table_callback_data *callback_data);
 
+void redis_pubsub_subscribe_transfer(table_callback_data *callback_data);
+
+void redis_pubsub_request_transfer(table_callback_data *callback_data);
+
 #endif /* REDIS_H */

--- a/src/common/test/pubsub_tests.c
+++ b/src/common/test/pubsub_tests.c
@@ -1,0 +1,121 @@
+#include "greatest.h"
+
+#include "test_common.h"
+#include "event_loop.h"
+#include "state/pubsub.h"
+#include "state/redis.h"
+
+SUITE(pubsub_tests);
+
+static event_loop *g_loop;
+
+object_id pubsub_object_id;
+int pubsub_destination = 7;
+int pubsub_transfer_test_success = 0;
+
+int64_t terminate_event_loop_callback(event_loop *loop,
+                                      int64_t timer_id,
+                                      void *context) {
+  event_loop_stop(loop);
+  return EVENT_LOOP_TIMER_DONE;
+}
+
+void pubsub_transfer_test_callback(object_id object_id,
+                                   int source,
+                                   int destination,
+                                   void *user_context) {
+  CHECK(memcmp(&object_id.id, &pubsub_object_id.id, UNIQUE_ID_SIZE));
+  CHECK(destination == pubsub_destination);
+  pubsub_transfer_test_success = 1;
+}
+
+void pubsub_subscribe_done_callback(object_id object_id,
+                                    int source,
+                                    int destination,
+                                    void *user_context) {
+  db_handle *db = user_context;
+  retry_info retry = {
+      .num_retries = 0, .timeout = 100, .fail_callback = NULL
+  };
+  pubsub_request_transfer(db, pubsub_object_id, source, pubsub_destination,
+                          &retry, NULL, NULL);
+}
+
+/* This test makes sure that the subscriber of a transfer gets notified
+ * if a transfer is requested from that source. */
+TEST pubsub_transfer_test(void) {
+  pubsub_object_id = globally_unique_id();
+  g_loop = event_loop_create();
+  db_handle *db =
+      db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 11236);
+  db_attach(db, g_loop);
+  retry_info retry = {
+      .num_retries = 0, .timeout = 100, .fail_callback = NULL
+  };
+  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback,
+                            &retry, pubsub_subscribe_done_callback, db);
+
+  event_loop_add_timer(g_loop, 750,
+                       (event_loop_timer_handler) terminate_event_loop_callback,
+                       NULL);
+  event_loop_run(g_loop);
+  db_disconnect(db);
+  destroy_outstanding_callbacks(g_loop);
+  event_loop_destroy(g_loop);
+  ASSERT(pubsub_transfer_test_success == 1);
+  PASS();
+}
+
+void pubsub_transfer_test_callback2(object_id object_id,
+                                    int source,
+                                    int destination,
+                                    void *user_context) {
+  CHECK(0);
+}
+
+void pubsub_subscribe_done_callback2(object_id object_id,
+                                     int source,
+                                     int destination,
+                                     void *user_context) {
+  db_handle *db = user_context;
+  retry_info retry = {
+      .num_retries = 0, .timeout = 100, .fail_callback = NULL
+  };
+  pubsub_request_transfer(db, NIL_ID, 1, pubsub_destination,
+                          &retry, NULL, NULL);
+}
+
+/* This test makes sure that the subscriber of a transfer doesn't get notified
+ * if a transfer is requested from a different source */
+TEST pubsub_transfer_test2(void) {
+  g_loop = event_loop_create();
+  db_handle *db =
+    db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 11236);
+  db_attach(db, g_loop);
+  retry_info retry = {
+      .num_retries = 0, .timeout = 100, .fail_callback = NULL
+  };
+  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback2,
+                            &retry, pubsub_subscribe_done_callback2, db);
+  event_loop_add_timer(g_loop, 750,
+                       (event_loop_timer_handler) terminate_event_loop_callback,
+                       NULL);
+  event_loop_run(g_loop);
+  db_disconnect(db);
+  destroy_outstanding_callbacks(g_loop);
+  event_loop_destroy(g_loop);
+  PASS();
+}
+
+SUITE(pubsub_tests) {
+  RUN_REDIS_TEST(pubsub_transfer_test);
+  RUN_REDIS_TEST(pubsub_transfer_test2);
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char **argv) {
+  GREATEST_MAIN_BEGIN();
+  RUN_SUITE(pubsub_tests);
+  GREATEST_MAIN_END();
+}

--- a/src/common/test/pubsub_tests.c
+++ b/src/common/test/pubsub_tests.c
@@ -34,9 +34,7 @@ void pubsub_subscribe_done_callback(object_id object_id,
                                     int destination,
                                     void *user_context) {
   db_handle *db = user_context;
-  retry_info retry = {
-      .num_retries = 0, .timeout = 100, .fail_callback = NULL
-  };
+  retry_info retry = {.num_retries = 0, .timeout = 100, .fail_callback = NULL};
   pubsub_request_transfer(db, pubsub_object_id, source, pubsub_destination,
                           &retry, NULL, NULL);
 }
@@ -49,11 +47,9 @@ TEST pubsub_transfer_test(void) {
   db_handle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 11236);
   db_attach(db, g_loop);
-  retry_info retry = {
-      .num_retries = 0, .timeout = 100, .fail_callback = NULL
-  };
-  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback,
-                            &retry, pubsub_subscribe_done_callback, db);
+  retry_info retry = {.num_retries = 0, .timeout = 100, .fail_callback = NULL};
+  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback, &retry,
+                            pubsub_subscribe_done_callback, db);
 
   event_loop_add_timer(g_loop, 750,
                        (event_loop_timer_handler) terminate_event_loop_callback,
@@ -78,11 +74,9 @@ void pubsub_subscribe_done_callback2(object_id object_id,
                                      int destination,
                                      void *user_context) {
   db_handle *db = user_context;
-  retry_info retry = {
-      .num_retries = 0, .timeout = 100, .fail_callback = NULL
-  };
-  pubsub_request_transfer(db, NIL_ID, 1, pubsub_destination,
-                          &retry, NULL, NULL);
+  retry_info retry = {.num_retries = 0, .timeout = 100, .fail_callback = NULL};
+  pubsub_request_transfer(db, NIL_ID, 1, pubsub_destination, &retry, NULL,
+                          NULL);
 }
 
 /* This test makes sure that the subscriber of a transfer doesn't get notified
@@ -90,13 +84,11 @@ void pubsub_subscribe_done_callback2(object_id object_id,
 TEST pubsub_transfer_test2(void) {
   g_loop = event_loop_create();
   db_handle *db =
-    db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 11236);
+      db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 11236);
   db_attach(db, g_loop);
-  retry_info retry = {
-      .num_retries = 0, .timeout = 100, .fail_callback = NULL
-  };
-  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback2,
-                            &retry, pubsub_subscribe_done_callback2, db);
+  retry_info retry = {.num_retries = 0, .timeout = 100, .fail_callback = NULL};
+  pubsub_subscribe_transfer(db, 0, pubsub_transfer_test_callback2, &retry,
+                            pubsub_subscribe_done_callback2, db);
   event_loop_add_timer(g_loop, 750,
                        (event_loop_timer_handler) terminate_event_loop_callback,
                        NULL);


### PR DESCRIPTION
This PR implements a publish and subscribe facility for the global state store, which can be used by the global scheduler to inform plasma managers to ship objects.