### PR TITLE
Replace direct calls to recv with read_bytes.

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#include "io.c"
+#include "io.h"
 
 /* This is used to define the array of object IDs. */
 const UT_icd object_id_icd = {sizeof(object_id), NULL, NULL, NULL};

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -6,6 +6,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "io.c"
+
 /* This is used to define the array of object IDs. */
 const UT_icd object_id_icd = {sizeof(object_id), NULL, NULL, NULL};
 
@@ -20,7 +22,7 @@ unique_id globally_unique_id(void) {
     LOG_ERROR("Could not generate random number");
   }
   unique_id result;
-  read(fd, &result.id[0], UNIQUE_ID_SIZE);
+  CHECK(read_bytes(fd, &result.id[0], UNIQUE_ID_SIZE) >= 0);
   close(fd);
   return result;
 }

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -133,7 +133,14 @@ void process_plasma_notification(event_loop *loop,
   local_scheduler_state *s = context;
   /* Read the notification from Plasma. */
   object_id obj_id;
-  recv(client_sock, (char *) &obj_id, sizeof(obj_id), 0);
+  int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
+  if (error == -1) {
+    /* The store has closed the socket. */
+    LOG_DEBUG("The plasma store has closed the object notification socket.");
+    event_loop_remove_file(loop, client_sock);
+    close(client_sock);
+    return;
+  }
   handle_object_available(s->scheduler_info, s->scheduler_state, obj_id);
 }
 

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -136,8 +136,9 @@ void process_plasma_notification(event_loop *loop,
   int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
   if (error < 0) {
     /* The store has closed the socket. */
-    LOG_DEBUG("The plasma store has closed the object notification socket, or "
-              "some other error has occurred.");
+    LOG_DEBUG(
+        "The plasma store has closed the object notification socket, or some "
+        "other error has occurred.");
     event_loop_remove_file(loop, client_sock);
     close(client_sock);
     return;

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -134,9 +134,10 @@ void process_plasma_notification(event_loop *loop,
   /* Read the notification from Plasma. */
   object_id obj_id;
   int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
-  if (error == -1) {
+  if (error < 0) {
     /* The store has closed the socket. */
-    LOG_DEBUG("The plasma store has closed the object notification socket.");
+    LOG_DEBUG("The plasma store has closed the object notification socket, or "
+              "some other error has occurred.");
     event_loop_remove_file(loop, client_sock);
     close(client_sock);
     return;

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -1303,15 +1303,14 @@ void process_object_notification(event_loop *loop,
   plasma_manager_state *state = context;
   object_id obj_id;
   /* Read the notification from Plasma. */
-  int n = recv(client_sock, (char *) &obj_id, sizeof(object_id), MSG_WAITALL);
-  if (n == 0) {
+  int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
+  if (error == -1) {
     /* The store has closed the socket. */
     LOG_DEBUG("The plasma store has closed the object notification socket.");
     event_loop_remove_file(loop, client_sock);
     close(client_sock);
     return;
   }
-  CHECK(n == sizeof(object_id));
   /* Add object to locally available object. */
   /* TODO(pcm): Where is this deallocated? */
   available_object *entry =

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -1306,8 +1306,9 @@ void process_object_notification(event_loop *loop,
   int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
   if (error < 0) {
     /* The store has closed the socket. */
-    LOG_DEBUG("The plasma store has closed the object notification socket, or "
-              "some other error has occurred.");
+    LOG_DEBUG(
+        "The plasma store has closed the object notification socket, or some "
+        "other error has occurred.");
     event_loop_remove_file(loop, client_sock);
     close(client_sock);
     return;

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -1304,9 +1304,10 @@ void process_object_notification(event_loop *loop,
   object_id obj_id;
   /* Read the notification from Plasma. */
   int error = read_bytes(client_sock, (uint8_t *) &obj_id, sizeof(obj_id));
-  if (error == -1) {
+  if (error < 0) {
     /* The store has closed the socket. */
-    LOG_DEBUG("The plasma store has closed the object notification socket.");
+    LOG_DEBUG("The plasma store has closed the object notification socket, or "
+              "some other error has occurred.");
     event_loop_remove_file(loop, client_sock);
     close(client_sock);
     return;


### PR DESCRIPTION
There were a couple other instances of direct calls to `read` or `write` or `send` or `recv`.

1. In `read_object_chunk` in `plasma_manager.c` (but there the logic seems to be pretty lenient with errors returned by `read`). https://github.com/ray-project/ray/blob/master/src/plasma/plasma_manager.c#L506
2. In `send_notifications` in `plasma_store.c`. There the logic is a bit more complicated since we want a non-blocking send. We essentially want `send` to either successfully write the full amount or not write anything (how do we do this?). If it successfully writes some of the bytes we currently fail. We can revisit this if it's a problem. https://github.com/ray-project/ray/blob/master/src/plasma/plasma_store.c#L403

There may be other instances as well.