### PR TITLE
Allow fatal errors to produce core dumps.

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -63,7 +63,7 @@
     void *buffer[255];                                                        \
     const int calls = backtrace(buffer, sizeof(buffer) / sizeof(void *));     \
     backtrace_symbols_fd(buffer, calls, 1);                                   \
-    exit(-1);                                                                 \
+    abort();                                                                  \
   } while (0)
 #else
 #define LOG_FATAL(M, ...)                                                     \


### PR DESCRIPTION
To produce a core dump, before starting Ray, run

```
ulimit -c unlimited
```

Then when there is a crash, cd to `/cores` and inspect the core dump (e.g., on Mac) with `lldb -c path/to/core`.