### PR TITLE
Put object store memory on /dev/shm on linux

### DIFF
--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -147,7 +147,13 @@ def start_objstore(node_ip_address, redis_address, cleanup=True):
   """
   # Compute a fraction of the system memory for the Plasma store to use.
   system_memory = psutil.virtual_memory().total
-  plasma_store_memory = int(system_memory * 0.4)
+  if sys.platform == "linux" or sys.platform == "linux2":
+    # On linux we use /dev/shm, its size is half the size of the physical
+    # memory. To not overflow it, we set the plasma memory limit to 0.4 times
+    # the size of the physical memory.
+    plasma_store_memory = int(system_memory * 0.4)
+  else:
+    plasma_store_memory = int(system_memory * 0.75)
   # Start the Plasma store.
   plasma_store_name, p1 = plasma.start_plasma_store(plasma_store_memory=plasma_store_memory, use_profiler=RUN_PLASMA_STORE_PROFILER)
   # Start the plasma manager.

--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -147,7 +147,7 @@ def start_objstore(node_ip_address, redis_address, cleanup=True):
   """
   # Compute a fraction of the system memory for the Plasma store to use.
   system_memory = psutil.virtual_memory().total
-  plasma_store_memory = int(system_memory * 0.75)
+  plasma_store_memory = int(system_memory * 0.4)
   # Start the Plasma store.
   plasma_store_name, p1 = plasma.start_plasma_store(plasma_store_memory=plasma_store_memory, use_profiler=RUN_PLASMA_STORE_PROFILER)
   # Start the plasma manager.

--- a/src/plasma/malloc.c
+++ b/src/plasma/malloc.c
@@ -69,7 +69,11 @@ int create_buffer(int64_t size) {
     fd = -1;
   }
 #else
-  static char template[] = "/tmp/plasmaXXXXXX";
+#ifdef __linux__
+  static char template[] = "/dev/shm/plasmaXXXXXX";
+#else
+  static char template [] = "/tmp/plasmaXXXXXX";
+#endif
   char file_name[32];
   strncpy(file_name, template, 32);
   fd = mkstemp(file_name);

--- a/src/plasma/malloc.c
+++ b/src/plasma/malloc.c
@@ -72,7 +72,7 @@ int create_buffer(int64_t size) {
 #ifdef __linux__
   static char template[] = "/dev/shm/plasmaXXXXXX";
 #else
-  static char template [] = "/tmp/plasmaXXXXXX";
+  static char template[] = "/tmp/plasmaXXXXXX";
 #endif
   char file_name[32];
   strncpy(file_name, template, 32);


### PR DESCRIPTION
On linux, /tmp is synchronized with the disk and if the disk is too small, the object store will get a sigbus error. The shared memory file system /dev/shm is not backed by disk as far as I am aware.

By default, /dev/shm is limited to half the size of the available RAM, so we set the plasma store limit to 0.4 * size of available RAM for now. Making /dev/shm larger is possible, but there seems to be some concern that the OOM killer cannot operate well if it is too large.