### PR TITLE
Fix bug in which we were running out of file descriptors.

### DIFF
--- a/src/plasma/lib/python/plasma.py
+++ b/src/plasma/lib/python/plasma.py
@@ -94,6 +94,9 @@ class PlasmaClient(object):
       size (int): The size in bytes of the created buffer.
       metadata (buffer): An optional buffer encoding whatever metadata the user
         wishes to encode.
+
+    Raises:
+      Exception: An exception is raised if the object could not be created.
     """
     # Turn the metadata into the right type.
     metadata = bytearray("") if metadata is None else metadata

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -196,6 +196,7 @@ bool plasma_create(plasma_connection *conn,
   CHECKM(fd >= 0, "recv not successful");
   if (reply.error_code == PLASMA_OBJECT_ALREADY_EXISTS) {
     LOG_DEBUG("returned from plasma_create with error %d", reply.error_code);
+    close(fd);
     return false;
   }
   plasma_object *object = &reply.object;
@@ -630,6 +631,7 @@ bool plasma_get_local(plasma_connection *conn,
 
     if (!reply.has_object) {
       /* The object is not in our local store. */
+      close(fd);
       return false;
     }
     object = &reply.object;

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -65,9 +65,14 @@ PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
     return NULL;
   }
   uint8_t *data;
-  plasma_create(conn, object_id, size,
-                (uint8_t *) PyByteArray_AsString(metadata),
-                PyByteArray_Size(metadata), &data);
+  bool created = plasma_create(conn, object_id, size,
+                               (uint8_t *) PyByteArray_AsString(metadata),
+                               PyByteArray_Size(metadata), &data);
+  if (!created) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "an object with this ID could not be created");
+    return NULL;
+  }
   return PyBuffer_FromReadWriteMemory((void *) data, (Py_ssize_t) size);
 }
 

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -121,6 +121,18 @@ class TestPlasmaClient(unittest.TestCase):
       for i in range(len(metadata)):
         self.assertEqual(metadata[i], metadata_buffer[i])
 
+  def test_create_existing(self):
+    # This test is partially used to test the code path in which we create an
+    # object with an ID that already exists
+    length = 100
+    for _ in range(1000):
+      object_id = random_object_id()
+      self.plasma_client.create(object_id, length, generate_metadata(length))
+      try:
+        val = self.plasma_client.create(object_id, length, generate_metadata(length))
+      except Exception:
+        pass
+
   def test_contains(self):
     fake_object_ids = [random_object_id() for _ in range(100)]
     real_object_ids = [random_object_id() for _ in range(100)]


### PR DESCRIPTION
The important fix here is to `plasma_client.c`. We were leaking file descriptors in the case where `plasma_create` was called with an object ID that already existed.

The test that I added to `test.py` causes a segfault without the change to `plasma_client.c`.