### PR TITLE
Fix seed bug for generating object ids for put

### DIFF
--- a/.travis/check-git-clang-format-output.sh
+++ b/.travis/check-git-clang-format-output.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -x
+
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
   # Not in a pull request, so compare against parent commit
   base_commit="HEAD^"

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -258,9 +258,9 @@ static PyObject *PyTask_task_id(PyObject *self) {
 }
 
 static PyObject *PyTask_arguments(PyObject *self) {
-  int64_t num_args = task_num_args(((PyTask *) self)->spec);
-  PyObject *arg_list = PyList_New((Py_ssize_t) num_args);
   task_spec *task = ((PyTask *) self)->spec;
+  int64_t num_args = task_num_args(task);
+  PyObject *arg_list = PyList_New((Py_ssize_t) num_args);
   for (int i = 0; i < num_args; ++i) {
     if (task_arg_type(task, i) == ARG_BY_REF) {
       object_id object_id = task_arg_id(task, i);
@@ -281,9 +281,9 @@ static PyObject *PyTask_arguments(PyObject *self) {
 }
 
 static PyObject *PyTask_returns(PyObject *self) {
-  int64_t num_returns = task_num_returns(((PyTask *) self)->spec);
-  PyObject *return_id_list = PyList_New((Py_ssize_t) num_returns);
   task_spec *task = ((PyTask *) self)->spec;
+  int64_t num_returns = task_num_returns(task);
+  PyObject *return_id_list = PyList_New((Py_ssize_t) num_returns);
   for (int i = 0; i < num_returns; ++i) {
     object_id object_id = task_return(task, i);
     PyList_SetItem(return_id_list, i, PyObjectID_make(object_id));
@@ -430,4 +430,14 @@ PyObject *check_simple_value(PyObject *self, PyObject *args) {
     Py_RETURN_TRUE;
   }
   Py_RETURN_FALSE;
+}
+
+PyObject *compute_put_id(PyObject *self, PyObject *args) {
+  int put_index;
+  task_id task_id;
+  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id, &put_index)) {
+    return NULL;
+  }
+  object_id put_id = task_compute_put_id(task_id, put_index);
+  return PyObjectID_make(put_id);
 }

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -435,7 +435,8 @@ PyObject *check_simple_value(PyObject *self, PyObject *args) {
 PyObject *compute_put_id(PyObject *self, PyObject *args) {
   int put_index;
   task_id task_id;
-  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id, &put_index)) {
+  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
+                        &put_index)) {
     return NULL;
   }
   object_id put_id = task_compute_put_id(task_id, put_index);

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -39,6 +39,8 @@ PyObject *PyObjectID_make(object_id object_id);
 
 PyObject *check_simple_value(PyObject *self, PyObject *args);
 
+PyObject *compute_put_id(PyObject *self, PyObject *args);
+
 PyObject *PyTask_make(task_spec *task_spec);
 
 #endif /* COMMON_EXTENSION_H */

--- a/src/common/lib/python/common_module.c
+++ b/src/common/lib/python/common_module.c
@@ -5,6 +5,8 @@
 static PyMethodDef common_methods[] = {
     {"check_simple_value", check_simple_value, METH_VARARGS,
      "Should the object be passed by value?"},
+    {"compute_put_id", compute_put_id, METH_VARARGS,
+     "Return the object ID for a put call within a task."},
     {NULL} /* Sentinel */
 };
 

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -132,7 +132,7 @@ object_id task_compute_put_id(task_id task_id, int64_t put_index) {
   int64_t *first_bytes = (int64_t *) &put_id;
   /* XOR the first bytes of the object ID with the return index. We add one so
    * the first return ID is not the same as the task ID. */
-  *first_bytes = *first_bytes ^ (- put_index - 1);
+  *first_bytes = *first_bytes ^ (-put_index - 1);
   return put_id;
 }
 

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -112,7 +112,10 @@ task_id compute_task_id(task_spec *spec) {
   return task_id;
 }
 
-object_id compute_return_id(task_id task_id, int64_t return_index) {
+object_id task_compute_return_id(task_id task_id, int64_t return_index) {
+  /* Here, return_indices need to be >= 0, so we can use negative
+   * indices for put. */
+  DCHECK(return_index >= 0);
   /* TODO(rkn): This line requires object and task IDs to be the same size. */
   object_id return_id = task_id;
   int64_t *first_bytes = (int64_t *) &return_id;
@@ -120,6 +123,17 @@ object_id compute_return_id(task_id task_id, int64_t return_index) {
    * the first return ID is not the same as the task ID. */
   *first_bytes = *first_bytes ^ (return_index + 1);
   return return_id;
+}
+
+object_id task_compute_put_id(task_id task_id, int64_t put_index) {
+  DCHECK(put_index >= 0);
+  /* TODO(pcm): This line requires object and task IDs to be the same size. */
+  object_id put_id = task_id;
+  int64_t *first_bytes = (int64_t *) &put_id;
+  /* XOR the first bytes of the object ID with the return index. We add one so
+   * the first return ID is not the same as the task ID. */
+  *first_bytes = *first_bytes ^ (- put_index - 1);
+  return put_id;
 }
 
 task_spec *start_construct_task_spec(task_id parent_task_id,
@@ -151,7 +165,7 @@ void finish_construct_task_spec(task_spec *spec) {
   spec->task_id = compute_task_id(spec);
   /* Set the object IDs for the return values. */
   for (int64_t i = 0; i < spec->num_returns; ++i) {
-    *task_return_ptr(spec, i) = compute_return_id(spec->task_id, i);
+    *task_return_ptr(spec, i) = task_compute_return_id(spec->task_id, i);
   }
 }
 

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -221,6 +221,15 @@ int64_t task_args_add_val(task_spec *spec, uint8_t *data, int64_t length);
 object_id task_return(task_spec *spec, int64_t return_index);
 
 /**
+ * Compute the object id associated to a put call.
+ *
+ * @param task_id The task id of the parent task that called the put.
+ * @param put_index The number of put calls in this task so far.
+ * @return The object ID for the object that was put.
+ */
+object_id task_compute_put_id(task_id task_id, int64_t put_index);
+
+/**
  * Free a task_spec.
  *
  * @param The task_spec in question.

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -103,6 +103,8 @@ static PyTypeObject PyPhotonClientType = {
 static PyMethodDef photon_methods[] = {
     {"check_simple_value", check_simple_value, METH_VARARGS,
      "Should the object be passed by value?"},
+    {"compute_put_id", compute_put_id, METH_VARARGS,
+     "Return the object ID for a put call within a task."},
     {NULL} /* Sentinel */
 };
 


### PR DESCRIPTION
Before the PR, this was failing:

```
In [1]: import ray

In [2]: ray.init(start_ray_local=True, num_workers=8)
7349:M 12 Dec 17:55:54.102 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
7349:M 12 Dec 17:55:54.102 # Server started, Redis version 3.9.102
7349:M 12 Dec 17:55:54.102 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
7349:M 12 Dec 17:55:54.103 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
[INFO] (plasma_store.c:616) Allowing the Plasma store to use up to 6.61GB of memory.
Out[2]: 
{'local_scheduler_names': ['/tmp/scheduler81963305'],
 'node_ip_address': '127.0.0.1',
 'object_store_manager_names': ['/tmp/scheduler98992695'],
 'object_store_names': ['/tmp/scheduler48528555'],
 'redis_port': 13126}

In [3]: 

In [3]: import numpy as np

In [4]: np.random.seed(0)

In [5]: ray.put(1)
Out[5]: ObjectID(ac0a7f8c2faac49775a616b7c0cc21d843b34e9a)

In [6]: np.random.seed(0)

In [7]: ray.put(1)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-7-261129042380> in <module>()
----> 1 ray.put(1)

/home/pcmoritz/anaconda/lib/python2.7/site-packages/ray-0.0.1-py2.7.egg/ray/worker.pyc in put(value, worker)
   1000     return value # In PYTHON_MODE, ray.put is the identity operation
   1001   objectid = random_object_id()
-> 1002   worker.put_object(objectid, value)
   1003   return objectid
   1004 

/home/pcmoritz/anaconda/lib/python2.7/site-packages/ray-0.0.1-py2.7.egg/ray/worker.pyc in put_object(self, objectid, value)
    420     schema, size, serialized = numbuf_serialize(value)
    421     size = size + 4096 * 4 + 8 # The last 8 bytes are for the metadata offset. This is temporary.
--> 422     buff = self.plasma_client.create(objectid.id(), size, bytearray(schema))
    423     data = np.frombuffer(buff.buffer, dtype="byte")[8:]
    424     metadata_offset = numbuf.write_to_buffer(serialized, memoryview(data))

/home/pcmoritz/anaconda/lib/python2.7/site-packages/ray-0.0.1-py2.7.egg/plasma/lib/python/plasma.pyc in create(self, object_id, size, metadata)
    105     # Turn the metadata into the right type.
    106     metadata = bytearray("") if metadata is None else metadata
--> 107     buff = libplasma.create(self.conn, object_id, size, metadata)
    108     return PlasmaBuffer(buff, object_id, self)
    109 

RuntimeError: an object with this ID could not be created
```