### PR TITLE
Add include for usleep.

### DIFF
--- a/src/common/test/test_common.h
+++ b/src/common/test/test_common.h
@@ -1,6 +1,8 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
+#include <unistd.h>
+
 #include "io.h"
 #include "hiredis/hiredis.h"
 #include "utstring.h"


### PR DESCRIPTION
After #65, `make test` in `src/common` (on OS X) would fail with

```
gcc -o build/task_table_tests test/task_table_tests.c build/libcommon.a thirdparty/hiredis/libhiredis.a -g -Wall -Wextra -Werror=implicit-function-declaration -Wno-typedef-redefinition -Wno-sign-compare -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers --std=c99 -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L -fPIC -I. -Ithirdparty -Ithirdparty/ae -DRAY_COMMON_LOG_LEVEL=4
In file included from test/task_table_tests.c:9:
/usr/include/unistd.h:604:6: error: cannot apply asm label to function after its first use
int      usleep(useconds_t) __DARWIN_ALIAS_C(usleep);
```

This fixes that.