### PR TITLE
Print helpful error message when libgcc error occurs.

### DIFF
--- a/numbuf/numbuf/__init__.py
+++ b/numbuf/numbuf/__init__.py
@@ -2,4 +2,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from numbuf.libnumbuf import *
+# See https://github.com/ray-project/ray/issues/131.
+helpful_message = """
+
+If you are using Anaconda, try fixing this problem by running:
+
+  conda install libgcc
+"""
+
+try:
+  from numbuf.libnumbuf import *
+except ImportError as e:
+  if not hasattr(e, "msg") or not isinstance(e.msg, str) or not "GLIBCXX" in e.msg:
+    raise
+  e.msg += helpful_message
+  raise


### PR DESCRIPTION
This addresses #131.