### PR TITLE
Test object notifications from Plasma store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
         - make valgrind
         - cd ../..
 
+        - cd src/photon
+        - make valgrind
+        - cd ../..
+
         - ./.travis/install-ray.sh
       script:
         - python src/plasma/test/test.py valgrind

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -363,6 +363,7 @@ void handle_object_removed(local_scheduler_state *state, object_id object_id) {
             sizeof(object_id), entry);
   if (entry != NULL) {
     HASH_DELETE(handle, algorithm_state->local_objects, entry);
+    free(entry);
   }
 }
 

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -85,12 +85,22 @@ void free_local_scheduler(local_scheduler_state *state) {
     db_disconnect(state->db);
   }
   plasma_disconnect(state->plasma_conn);
+
   worker_index *current_worker_index, *temp_worker_index;
   HASH_ITER(hh, state->worker_index, current_worker_index, temp_worker_index) {
     HASH_DEL(state->worker_index, current_worker_index);
     free(current_worker_index);
   }
+
+  worker *w;
+  for (w = (worker *) utarray_front(state->workers); w != NULL;
+       w = (worker *) utarray_next(state->workers, w)) {
+    if (w->task_in_progress) {
+      free_task(w->task_in_progress);
+    }
+  }
   utarray_free(state->workers);
+
   free_scheduling_algorithm_state(state->algorithm_state);
   utarray_free(state->input_buffer);
   event_loop_destroy(state->loop);

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -261,4 +261,14 @@ event_loop *get_event_loop(plasma_manager_state *state);
  */
 int get_client_sock(client_connection *conn);
 
+/**
+ * Return whether or not the object is local.
+ *
+ * @param state The state of the plasma manager.
+ * @param object_id The ID of the object we want to find.
+ * @return A bool that is true if the requested object is local and false
+ *         otherwise.
+ */
+bool is_object_local(plasma_manager_state *state, object_id object_id);
+
 #endif /* PLASMA_MANAGER_H */


### PR DESCRIPTION
Test the object notification handlers for the Plasma manager and the Photon scheduler. This also turns on Valgrind testing for Photon.