### PR TITLE
Improve formatting of error messages.

### DIFF
--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -1274,19 +1274,22 @@ def main_loop(worker=global_worker):
     After the task executes, the worker resets any reusable variables that were
     accessed by the task.
     """
-    worker.current_task_id = task.task_id()
-    worker.task_index = 0
-    worker.put_index = 0
-    function_id = task.function_id()
-    args = task.arguments()
-    return_object_ids = task.returns()
-    function_name = worker.function_names[function_id.id()]
     try:
-      arguments = get_arguments_for_execution(worker.functions[function_id.id()], args, worker) # get args from objstore
-      outputs = worker.functions[function_id.id()].executor(arguments) # execute the function
+      worker.current_task_id = task.task_id()
+      worker.task_index = 0
+      worker.put_index = 0
+      function_id = task.function_id()
+      args = task.arguments()
+      return_object_ids = task.returns()
+      function_name = worker.function_names[function_id.id()]
+      # Get task arguments from the object store.
+      arguments = get_arguments_for_execution(worker.functions[function_id.id()], args, worker)
+      # Execute the task.
+      outputs = worker.functions[function_id.id()].executor(arguments)
+      # Store the outputs in the local object store.
       if len(return_object_ids) == 1:
         outputs = (outputs,)
-      store_outputs_in_objstore(return_object_ids, outputs, worker) # store output in local object store
+      store_outputs_in_objstore(return_object_ids, outputs, worker)
     except Exception as e:
       # We determine whether the exception was caused by the call to
       # get_arguments_for_execution or by the execution of the remote function

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -858,6 +858,10 @@ def print_error_messages(worker):
   This runs in a separate thread on the driver and prints error messages in the
   background.
   """
+  # TODO(rkn): All error messages should have a "component" field indicating
+  # which process the error came from (e.g., a worker or a plasma store).
+  # Currently all error messages come from workers.
+
   helpful_message = """
 You can inspect errors by running
 


### PR DESCRIPTION
The following will currently cause the system to hang (after this PR, the user should get an error message).

Define a file `foo.py`, with the following contents.

```python
import ray

def helper():
    return 1

@ray.remote
def f():
    return helper()
```

Then from the same directory as `foo.py`, run the following.

```python
import ray
import sys
import time

ray.init(start_ray_local=True, num_workers=1)

@ray.remote
def remove_foo_from_path():
  sys.path = []

remove_foo_from_path.remote()

time.sleep(1)
import foo # This should cause some error messages.

ray.get(foo.f.remote()) # This hangs.
```