### PR TITLE
Introduce local scheduler heartbeats which carry load information.

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -4,7 +4,7 @@ BUILD = build
 
 all: hiredis redis redismodule $(BUILD)/libcommon.a
 
-$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o thirdparty/ae/ae.o thirdparty/sha256.o
+$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o state/local_scheduler_table.o thirdparty/ae/ae.o thirdparty/sha256.o
 	ar rcs $@ $^
 
 $(BUILD)/common_tests: test/common_tests.c $(BUILD)/libcommon.a

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -1,0 +1,27 @@
+#include "local_scheduler_table.h"
+#include "redis.h"
+
+void local_scheduler_table_subscribe(
+    db_handle *db_handle,
+    local_scheduler_table_subscribe_callback subscribe_callback,
+    void *subscribe_context,
+    retry_info *retry) {
+  local_scheduler_table_subscribe_data *sub_data =
+      malloc(sizeof(local_scheduler_table_subscribe_data));
+  sub_data->subscribe_callback = subscribe_callback;
+  sub_data->subscribe_context = subscribe_context;
+
+  init_table_callback(db_handle, NIL_ID, __func__, sub_data, retry, NULL,
+                      redis_local_scheduler_table_subscribe, NULL);
+}
+
+void local_scheduler_table_send_info(db_handle *db_handle,
+                                     local_scheduler_info *info,
+                                     retry_info *retry) {
+  local_scheduler_table_send_info_data *data =
+      malloc(sizeof(local_scheduler_table_send_info_data));
+  data->info = *info;
+
+  init_table_callback(db_handle, NIL_ID, __func__, data, retry, NULL,
+                      redis_local_scheduler_table_send_info, NULL);
+}

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -5,7 +5,6 @@
 #include "table.h"
 
 typedef struct {
-  db_client_id db_client_id;
   int task_queue_length;
   int available_workers;
 } local_scheduler_info;

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -1,0 +1,66 @@
+#ifndef LOCAL_SCHEDULER_TABLE_H
+#define LOCAL_SCHEDULER_TABLE_H
+
+#include "db.h"
+#include "table.h"
+
+typedef struct {
+  db_client_id db_client_id;
+  int task_queue_length;
+  int available_workers;
+} local_scheduler_info;
+
+/*
+ *  ==== Subscribing to the local scheduler table ====
+ */
+
+/* Callback for subscribing to the local scheduler table. */
+typedef void (*local_scheduler_table_subscribe_callback)(
+    db_client_id client_id,
+    local_scheduler_info info,
+    void *user_context);
+
+/**
+ * Register a callback for a local scheduler table event.
+ *
+ * @param db_handle Database handle.
+ * @param subscribe_callback Callback that will be called when the local
+ *        scheduler event happens.
+ * @param subscribe_context Context that will be passed into the
+ *        subscribe_callback.
+ * @param retry Information about retrying the request to the database.
+ * @return Void.
+ */
+void local_scheduler_table_subscribe(
+    db_handle *db_handle,
+    local_scheduler_table_subscribe_callback subscribe_callback,
+    void *subscribe_context,
+    retry_info *retry);
+
+/* Data that is needed to register local scheduler table subscribe callbacks
+ * with the state database. */
+typedef struct {
+  local_scheduler_table_subscribe_callback subscribe_callback;
+  void *subscribe_context;
+} local_scheduler_table_subscribe_data;
+
+/**
+ * Send a heartbeat to all subscriers to the local scheduler table. This
+ * heartbeat contains some information about the load on the local scheduler.
+ *
+ * @param db_handle Database handle.
+ * @param info Information about the local scheduler, including the load on the
+ *        local scheduler.
+ * @param retry Information about retrying the request to the database.
+ */
+void local_scheduler_table_send_info(db_handle *db_handle,
+                                     local_scheduler_info *info,
+                                     retry_info *retry);
+
+/* Data that is needed to publish local scheduer heartbeats to the local
+ * scheduler table. */
+typedef struct {
+  local_scheduler_info info;
+} local_scheduler_table_send_info_data;
+
+#endif /* LOCAL_SCHEDULER_TABLE_H */

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1138,7 +1138,7 @@ void redis_local_scheduler_table_send_info_callback(redisAsyncContext *c,
 
   redisReply *reply = r;
   CHECK(reply->type == REDIS_REPLY_INTEGER);
-  LOG_DEBUG("%lld subscribers received this publish.\n", reply->integer);
+  LOG_DEBUG("%" PRId64 " subscribers received this publish.\n", reply->integer);
 
   CHECK(callback_data->done_callback == NULL);
   /* Clean up the timer and callback. */

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1139,7 +1139,6 @@ void redis_local_scheduler_table_send_info_callback(redisAsyncContext *c,
   redisReply *reply = r;
   CHECK(reply->type == REDIS_REPLY_INTEGER);
   LOG_DEBUG("%lld subscribers received this publish.\n", reply->integer);
-  printf("XXX %lld subscribers received this publish.\n", reply->integer);
 
   CHECK(callback_data->done_callback == NULL);
   /* Clean up the timer and callback. */

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -218,6 +218,24 @@ void redis_task_table_subscribe(table_callback_data *callback_data);
  */
 void redis_db_client_table_subscribe(table_callback_data *callback_data);
 
+/**
+ * Subscribe to updates from the local scheduler table.
+ *
+ * @param callback_data Data structure containing redis connection and timeout
+ *        information.
+ * @return Void.
+ */
+void redis_local_scheduler_table_subscribe(table_callback_data *callback_data);
+
+/**
+ * Publish an update to the local scheduler table.
+ *
+ * @param callback_data Data structure containing redis connection and timeout
+ *        information.
+ * @return Void.
+ */
+void redis_local_scheduler_table_send_info(table_callback_data *callback_data);
+
 void redis_object_info_subscribe(table_callback_data *callback_data);
 
 #endif /* REDIS_H */

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -5,6 +5,7 @@
 #include "utlist.h"
 
 #include "state/task_table.h"
+#include "state/local_scheduler_table.h"
 #include "state/object_table.h"
 #include "photon.h"
 #include "photon_scheduler.h"
@@ -88,6 +89,14 @@ void free_scheduling_algorithm_state(
     free(fetch_elt);
   }
   free(algorithm_state);
+}
+
+void provide_scheduler_info(local_scheduler_state *state,
+                            scheduling_algorithm_state *algorithm_state,
+                            local_scheduler_info *info) {
+  task_queue_entry *elt;
+  DL_COUNT(algorithm_state->task_queue, elt, info->task_queue_length);
+  info->available_workers = utarray_len(algorithm_state->available_workers);
 }
 
 /**

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -3,6 +3,7 @@
 
 #include "photon.h"
 #include "common/task.h"
+#include "state/local_scheduler_table.h"
 
 /* The duration that the local scheduler will wait before reinitiating a fetch
  * request for a missing task dependency. TODO(rkn): We may want this to be
@@ -32,6 +33,13 @@ scheduling_algorithm_state *make_scheduling_algorithm_state(void);
  */
 void free_scheduling_algorithm_state(
     scheduling_algorithm_state *algorithm_state);
+
+/**
+ *
+ */
+void provide_scheduler_info(local_scheduler_state *state,
+                            scheduling_algorithm_state *algorithm_state,
+                            local_scheduler_info *info);
 
 /**
  * This function will be called when a new task is submitted by a worker for

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -338,8 +338,10 @@ void start_server(const char *node_ip_address,
   /* Create a timer for publishing information about the load on the local
    * scheduler to the local scheduler table. This message also serves as a
    * heartbeat. */
-  event_loop_add_timer(loop, LOCAL_SCHEDULER_HEARTBEAT_TIMEOUT_MILLISECONDS,
-                       heartbeat_handler, g_state);
+  if (g_state->db != NULL) {
+    event_loop_add_timer(loop, LOCAL_SCHEDULER_HEARTBEAT_TIMEOUT_MILLISECONDS,
+                         heartbeat_handler, g_state);
+  }
   /* Run event loop. */
   event_loop_run(loop);
 }

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -291,6 +291,18 @@ void handle_task_scheduled_callback(task *original_task, void *user_context) {
                         task_task_spec(original_task));
 }
 
+int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
+  local_scheduler_state *state = context;
+  scheduling_algorithm_state *algorithm_state = state->algorithm_state;
+  local_scheduler_info info;
+  /* Ask the scheduling algorithm to fill out the scheduler info struct. */
+  provide_scheduler_info(state, algorithm_state, &info);
+  /* Publish the heartbeat to all subscribers of the local scheduler table. */
+  local_scheduler_table_send_info(state->db, &info, NULL);
+  /* Reset the timer. */
+  return LOCAL_SCHEDULER_HEARTBEAT_TIMEOUT_MILLISECONDS;
+}
+
 void start_server(const char *node_ip_address,
                   const char *socket_name,
                   const char *redis_addr,
@@ -323,6 +335,11 @@ void start_server(const char *node_ip_address,
                          TASK_STATUS_SCHEDULED, handle_task_scheduled_callback,
                          NULL, &retry, NULL, NULL);
   }
+  /* Create a timer for publishing information about the load on the local
+   * scheduler to the local scheduler table. This message also serves as a
+   * heartbeat. */
+  event_loop_add_timer(loop, LOCAL_SCHEDULER_HEARTBEAT_TIMEOUT_MILLISECONDS,
+                       heartbeat_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);
 }

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -4,6 +4,9 @@
 #include "task.h"
 #include "event_loop.h"
 
+/* The duration between local scheduler heartbeats. */
+#define LOCAL_SCHEDULER_HEARTBEAT_TIMEOUT_MILLISECONDS 1000
+
 /**
  * Establish a connection to a new client.
  *


### PR DESCRIPTION
This implements `local_scheduler_table_subscribe`, which is called in `global_scheduler.c` to receive heartbeats from the local schedulers.

This implements `local_scheduler_table_send_info`, which is called on a timer in `photon_scheduler.c` to send heartbeats.

The information being sent is the `local_scheduler_info` struct defined in `local_scheduler_table.h`.