### PR TITLE
Delay releasing a maximum number of bytes in the plasma client.

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -44,7 +44,7 @@ redismodule:
 
 test: CFLAGS += -DRAY_COMMON_LOG_LEVEL=4
 test: hiredis redis redismodule $(BUILD)/common_tests $(BUILD)/task_table_tests $(BUILD)/object_table_tests $(BUILD)/db_tests $(BUILD)/io_tests $(BUILD)/task_tests $(BUILD)/redis_tests FORCE
-	./thirdparty/redis/src/redis-server --loadmodule ./redis_module/ray_redis_module.so &
+	./thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./redis_module/ray_redis_module.so &
 	sleep 1s
 	./build/common_tests
 	./build/db_tests
@@ -57,7 +57,7 @@ test: hiredis redis redismodule $(BUILD)/common_tests $(BUILD)/task_table_tests 
 	python ./redis_module/runtest.py
 
 valgrind: test
-	./thirdparty/redis/src/redis-server --loadmodule redis_module/ray_redis_module.so &
+	./thirdparty/redis/src/redis-server --loglevel warning --loadmodule redis_module/ray_redis_module.so &
 	sleep 1s
 	valgrind --leak-check=full --error-exitcode=1 ./build/common_tests
 	valgrind --leak-check=full --error-exitcode=1 ./build/db_tests

--- a/src/photon/Makefile
+++ b/src/photon/Makefile
@@ -26,10 +26,18 @@ clean:
 test: CFLAGS += -DRAY_TIMEOUT=50 -DRAY_COMMON_LOG_LEVEL=4
 test: $(BUILD)/photon_tests FORCE
 	../common/thirdparty/redis/src/redis-server --loadmodule ../common/redis_module/ray_redis_module.so &
-	sleep 0.5s && ./build/photon_tests && ../common/thirdparty/redis/src/redis-cli shutdown
+	../plasma/build/plasma_store -s /tmp/s1 -m 100000000 &
+	sleep 0.5s
+	./build/photon_tests
+	../common/thirdparty/redis/src/redis-cli shutdown
+	killall plasma_store
 
 valgrind: test
 	../common/thirdparty/redis/src/redis-server --loadmodule ../common/redis_module/ray_redis_module.so &
-	sleep 0.5s && valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/photon_tests && ../common/thirdparty/redis/src/redis-cli shutdown
+	../plasma/build/plasma_store -s /tmp/s1 -m 100000000 &
+	sleep 0.5s
+	valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/photon_tests
+	../common/thirdparty/redis/src/redis-cli shutdown
+	killall plasma_store
 
 FORCE:

--- a/src/photon/Makefile
+++ b/src/photon/Makefile
@@ -25,16 +25,16 @@ clean:
 # Set the request timeout low and logging level at FATAL for testing purposes.
 test: CFLAGS += -DRAY_TIMEOUT=50 -DRAY_COMMON_LOG_LEVEL=4
 test: $(BUILD)/photon_tests FORCE
-	../common/thirdparty/redis/src/redis-server --loadmodule ../common/redis_module/ray_redis_module.so &
-	../plasma/build/plasma_store -s /tmp/s1 -m 100000000 &
+	../common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ../common/redis_module/ray_redis_module.so &
+	../plasma/build/plasma_store -s /tmp/plasma_store_socket_1 -m 100000000 &
 	sleep 0.5s
 	./build/photon_tests
 	../common/thirdparty/redis/src/redis-cli shutdown
 	killall plasma_store
 
 valgrind: test
-	../common/thirdparty/redis/src/redis-server --loadmodule ../common/redis_module/ray_redis_module.so &
-	../plasma/build/plasma_store -s /tmp/s1 -m 100000000 &
+	../common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ../common/redis_module/ray_redis_module.so &
+	../plasma/build/plasma_store -s /tmp/plasma_store_socket_1 -m 100000000 &
 	sleep 0.5s
 	valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/photon_tests
 	../common/thirdparty/redis/src/redis-cli shutdown

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -63,8 +63,7 @@ local_scheduler_state *init_local_scheduler(
   } else {
     state->db = NULL;
   }
-  /* Connect to Plasma. This method will retry if Plasma hasn't started yet.
-   * Pass in a NULL manager address and port. */
+  /* Connect to Plasma. This method will retry if Plasma hasn't started yet. */
   state->plasma_conn =
       plasma_connect(plasma_store_socket_name, plasma_manager_socket_name,
                      PLASMA_DEFAULT_RELEASE_DELAY);

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -22,8 +22,8 @@
 
 SUITE(photon_tests);
 
-const char *plasma_store_socket_name = "/tmp/s1";
-const char *plasma_socket_name_format = "/tmp/plasma_socket_%d";
+const char *plasma_store_socket_name = "/tmp/plasma_store_socket_1";
+const char *plasma_manager_socket_name_format = "/tmp/plasma_manager_socket_%d";
 const char *photon_socket_name_format = "/tmp/photon_socket_%d";
 
 int64_t timeout_handler(event_loop *loop, int64_t id, void *context) {
@@ -54,7 +54,7 @@ photon_mock *init_photon_mock() {
   /* TODO(rkn): Why are we reusing mock->plasma_fd for both the store and the
    * manager? */
   UT_string *plasma_manager_socket_name =
-      bind_ipc_sock_retry(plasma_socket_name_format, &mock->plasma_fd);
+      bind_ipc_sock_retry(plasma_manager_socket_name_format, &mock->plasma_fd);
   mock->plasma_fd = socket_connect_retry(plasma_store_socket_name, 5, 100);
   UT_string *photon_socket_name =
       bind_ipc_sock_retry(photon_socket_name_format, &mock->photon_fd);

--- a/src/plasma/Makefile
+++ b/src/plasma/Makefile
@@ -46,7 +46,7 @@ common: FORCE
 test: CFLAGS += -DRAY_TIMEOUT=50 -DRAY_COMMON_LOG_LEVEL=4
 # First, build and run all the unit tests.
 test: $(BUILD)/manager_tests $(BUILD)/client_tests $(BUILD)/serialization_tests FORCE
-	./build/plasma_store -s /tmp/s1 -m 0 &
+	./build/plasma_store -s /tmp/plasma_store_socket_1 -m 0 &
 	sleep 1
 	./build/manager_tests
 	killall plasma_store
@@ -57,7 +57,7 @@ test: $(BUILD)/manager_tests $(BUILD)/client_tests $(BUILD)/serialization_tests 
 test: all
 
 valgrind: test
-	./build/plasma_store -s /tmp/s1 -m 0 &
+	./build/plasma_store -s /tmp/plasma_store_socket_1 -m 0 &
 	sleep 1
 	valgrind --leak-check=full --error-exitcode=1 ./build/manager_tests
 	killall plasma_store

--- a/src/plasma/Makefile
+++ b/src/plasma/Makefile
@@ -46,7 +46,10 @@ common: FORCE
 test: CFLAGS += -DRAY_TIMEOUT=50 -DRAY_COMMON_LOG_LEVEL=4
 # First, build and run all the unit tests.
 test: $(BUILD)/manager_tests $(BUILD)/client_tests $(BUILD)/serialization_tests FORCE
+	./build/plasma_store -s /tmp/s1 -m 0 &
+	sleep 1
 	./build/manager_tests
+	killall plasma_store
 	./build/serialization_tests
 	./test/run_client_tests.sh
 	cd ../common; make redis
@@ -54,7 +57,10 @@ test: $(BUILD)/manager_tests $(BUILD)/client_tests $(BUILD)/serialization_tests 
 test: all
 
 valgrind: test
+	./build/plasma_store -s /tmp/s1 -m 0 &
+	sleep 1
 	valgrind --leak-check=full --error-exitcode=1 ./build/manager_tests
+	killall plasma_store
 	valgrind --leak-check=full --error-exitcode=1 ./build/serialization_tests
 
 FORCE:

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -165,7 +165,7 @@ void require_space(eviction_state *eviction_state,
   if (required_space > 0) {
     /* Try to free up at least as much space as we need right now but ideally
      * up to 20% of the total capacity. */
-    int64_t space_to_free = MAX(size, eviction_state->memory_capacity / 5);
+    int64_t space_to_free = MAX(size, plasma_store_info->memory_capacity / 5);
     LOG_DEBUG("not enough space to create this object, so evicting objects");
     /* Choose some objects to evict, and update the return pointers. */
     int64_t num_bytes_evicted = choose_objects_to_evict(

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -27,9 +27,6 @@ typedef struct {
 
 /** The part of the Plasma state that is maintained by the eviction policy. */
 struct eviction_state {
-  /** The amount of memory (in bytes) that we allow to be allocated in the
-   *  store. */
-  int64_t memory_capacity;
   /** The amount of memory (in bytes) currently being used. */
   int64_t memory_used;
   /** A doubly-linked list of the released objects in order from least recently
@@ -44,10 +41,8 @@ struct eviction_state {
  * released_objects type. */
 UT_icd released_objects_entry_icd = {sizeof(object_id), NULL, NULL, NULL};
 
-eviction_state *make_eviction_state(int64_t system_memory) {
+eviction_state *make_eviction_state(void) {
   eviction_state *state = malloc(sizeof(eviction_state));
-  /* Find the amount of available memory on the machine. */
-  state->memory_capacity = system_memory;
   state->memory_used = 0;
   state->released_objects = NULL;
   state->released_object_table = NULL;
@@ -166,7 +161,7 @@ void require_space(eviction_state *eviction_state,
                    object_id **objects_to_evict) {
   /* Check if there is enough space to create the object. */
   int64_t required_space =
-      eviction_state->memory_used + size - eviction_state->memory_capacity;
+      eviction_state->memory_used + size - plasma_store_info->memory_capacity;
   if (required_space > 0) {
     /* Try to free up at least as much space as we need right now but ideally
      * up to 20% of the total capacity. */

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -20,7 +20,7 @@ typedef struct eviction_state eviction_state;
  *        store.
  * @return The internal state of the eviction policy.
  */
-eviction_state *make_eviction_state(int64_t system_memory);
+eviction_state *make_eviction_state(void);
 
 /**
  * Free the eviction policy state.

--- a/src/plasma/format/plasma.fbs
+++ b/src/plasma/format/plasma.fbs
@@ -25,6 +25,9 @@ enum MessageType:int {
   // See if the store contains an object (will be deprecated).
   PlasmaContainsRequest,
   PlasmaContainsReply,
+  // Get information for a newly connecting client.
+  PlasmaConnectRequest,
+  PlasmaConnectReply,
   // Make room for new objects in the plasma store.
   PlasmaEvictRequest,
   PlasmaEvictReply,
@@ -195,6 +198,18 @@ table PlasmaContainsReply {
   object_id: string;
   // 1 if the object is in the store and 0 otherwise.
   has_object: int;
+}
+
+// PlasmaConnect is used by a plasma client the first time it connects with the
+// store. This is not really necessary, but is used to get some information
+// about the store such as its memory capacity.
+
+table PlasmaConnectRequest {
+}
+
+table PlasmaConnectReply {
+  // The memory capacity of the store.
+  memory_capacity: long;
 }
 
 table PlasmaEvictRequest {

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -112,6 +112,9 @@ typedef struct {
 typedef struct {
   /** Objects that are in the Plasma store. */
   object_table_entry *objects;
+  /** The amount of memory (in bytes) that we allow to be allocated in the
+   *  store. */
+  int64_t memory_capacity;
 } plasma_store_info;
 
 typedef struct {

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -387,7 +387,7 @@ void plasma_release(plasma_connection *conn, object_id obj_id) {
    * that conn->release_history_first_entry != NULL may be relying on an
    * implementation detail that may or may not work as expected. */
   while ((conn->in_use_object_bytes >
-              MIN(L3_CACHE_SIZE_BYTES, conn->store_capacity / 1000) ||
+              MIN(L3_CACHE_SIZE_BYTES, conn->store_capacity / 100) ||
           conn->release_history_length > conn->config.release_delay) &&
          conn->release_history_length > 0) {
     DCHECK(conn->release_history_first_entry != NULL);

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -27,7 +27,7 @@
 #include "plasma_client.h"
 #include "fling.h"
 #include "uthash.h"
-#include "utringbuffer.h"
+#include "utlist.h"
 #include "sha256.h"
 
 #define XXH_STATIC_LINKING_ONLY
@@ -83,6 +83,17 @@ typedef struct {
   int release_delay;
 } plasma_client_config;
 
+/** An element representing a pending release call in a doubly-linked list. This
+ *  is used to implement the delayed release mechanism. */
+typedef struct pending_release {
+  /** The object_id of the released object. */
+  object_id object_id;
+  /** Needed for the doubly-linked list macros. */
+  struct pending_release *prev;
+  /** Needed for the doubly-linked list macros. */
+  struct pending_release *next;
+} pending_release;
+
 /** Information about a connection between a Plasma Client and Plasma Store.
  *  This is used to avoid mapping the same files into memory multiple times. */
 struct plasma_connection {
@@ -103,14 +114,21 @@ struct plasma_connection {
   /** A hash table of the object IDs that are currently being used by this
    * client. */
   object_in_use_entry *objects_in_use;
-  /** Object IDs of the last few release calls. This is used to delay releasing
-   *  objects to see if they can be reused by subsequent tasks so we do not
-   *  unneccessarily invalidate cpu caches. TODO(pcm): replace this with a
-   *  proper lru cache of size sizeof(L3 cache). */
-  UT_ringbuffer *release_history;
+  /** Object IDs of the last few release calls. This is a doubly-linked list and
+   *  is used to delay releasing objects to see if they can be reused by
+   *  subsequent tasks so we do not unneccessarily invalidate cpu caches.
+   *  TODO(pcm): replace this with a proper lru cache using the size of the L3
+   *  cache. */
+  pending_release *release_history;
+  /** This is the first element in the release_history doubly-linked list. It is
+   *  an implementation detail used so we can pop from the front of the list. */
+  pending_release *release_history_first_entry;
+  /** The length of the release_history doubly-linked list. This is an
+   *  implementation detail. */
+  int release_history_length;
   /** The number of bytes in the combined objects that are held in the release
-   *  history ring buffer. If this is too large then the client starts releasing
-   *  objects. */
+   *  history doubly-linked list. If this is too large then the client starts
+   *  releasing objects. */
   int64_t cached_object_bytes;
   /** Configuration options for the plasma client. */
   plasma_client_config config;
@@ -185,6 +203,9 @@ void increment_object_count(plasma_connection *conn,
     HASH_FIND_INT(conn->mmap_table, &object->handle.store_fd, entry);
     CHECK(entry != NULL);
     CHECK(entry->count >= 0);
+    /* Update the cached_object_bytes. */
+    conn->cached_object_bytes +=
+        (object_entry->object.data_size + object_entry->object.metadata_size);
     entry->count += 1;
   } else {
     CHECK(object_entry->count > 0);
@@ -236,6 +257,11 @@ bool plasma_create(plasma_connection *conn,
   /* Increment the count of the number of instances of this object that this
    * client is using. A call to plasma_release is required to decrement this
    * count. Cache the reference to the object. */
+  increment_object_count(conn, obj_id, &object, false);
+  /* We increment the count a second time (and the corresponding decrement will
+   * happen in a plasma_release call in plasma_seal) so even if the buffer
+   * returned by plasma_create goes out of scope, the object does not get
+   * released before the call to plasma_seal happens. */
   increment_object_count(conn, obj_id, &object, false);
   return true;
 }
@@ -291,6 +317,17 @@ void plasma_get(plasma_connection *conn,
   increment_object_count(conn, obj_id, object, true);
 }
 
+/**
+ * This is a helper method for implementing plasma_release. We maintain a buffer
+ * of release calls and only perform them once the buffer becomes full (as
+ * judged by the aggregate sizes of the objects). There may be multiple release
+ * calls for the same object ID in the buffer. In this case, the first release
+ * calls will not do anything. The client will only send a message to the store
+ * releasing the object when the client is truly done with the object.
+ *
+ * @param conn The plasma connection.
+ * @param object_id The object ID to attempt to release.
+ */
 void plasma_perform_release(plasma_connection *conn, object_id object_id) {
   /* Decrement the count of the number of instances of this object that are
    * being used by this client. The corresponding increment should have happened
@@ -322,54 +359,51 @@ void plasma_perform_release(plasma_connection *conn, object_id object_id) {
     /* Tell the store that the client no longer needs the object. */
     CHECK(plasma_send_ReleaseRequest(conn->store_conn, conn->builder,
                                      object_id) >= 0);
+    /* Update the cached_object_bytes. */
+    conn->cached_object_bytes -=
+        (object_entry->object.data_size + object_entry->object.metadata_size);
+    DCHECK(conn->cached_object_bytes >= 0);
     /* Remove the entry from the hash table of objects currently in use. */
     HASH_DELETE(hh, conn->objects_in_use, object_entry);
     free(object_entry);
   }
 }
 
-/**
- * Return the size in bytes (data plus meteadata) of an object that is currently
- * in use by this client.
- *
- * @param conn The plasma connection.
- * @param obj_id The object ID in question.
- * @return The total size in bytes of the object.
- */
-int64_t object_size(plasma_connection *conn, object_id obj_id) {
-  object_in_use_entry *object_entry;
-  HASH_FIND(hh, conn->objects_in_use, &obj_id, sizeof(obj_id), object_entry);
-  CHECK(object_entry != NULL);
-  return object_entry->object.data_size + object_entry->object.metadata_size;
-}
-
 void plasma_release(plasma_connection *conn, object_id obj_id) {
-  /* If no ringbuffer is used, don't delay the release. */
-  if (conn->config.release_delay == 0) {
-    plasma_perform_release(conn, obj_id);
-  } else {
-    /* The ring buffer is full, so release an object and update the cached
-     * object bytes. */
-    if (utringbuffer_full(conn->release_history)) {
-      object_id object_id_to_release =
-          *(object_id *) utringbuffer_front(conn->release_history);
-      conn->cached_object_bytes -= object_size(conn, object_id_to_release);
-      plasma_perform_release(conn, object_id_to_release);
-    }
-    /* Add the new object to the ring buffer and update the cached object bytes.
-     */
-    utringbuffer_push_back(conn->release_history, &obj_id);
-    conn->cached_object_bytes += object_size(conn, obj_id);
-    /* If there are too many bytes held in the objects in the ring buffer,
-     * release objects until that is no longer the case. */
-    while (conn->cached_object_bytes > MIN(L3_CACHE_SIZE_BYTES,
-                                           conn->store_capacity)) {
-      DCHECK(!utringbuffer_empty(conn->release_history));
-      object_id object_id_to_release =
-          *(object_id *) utringbuffer_front(conn->release_history);
-      conn->cached_object_bytes -= object_size(conn, object_id_to_release);
-      plasma_perform_release(conn, object_id_to_release);
-    }
+  /* Add the new object to the release history. The corresponding call to free
+   * will occur in plasma_perform_release or in plasma_disconnect. */
+  pending_release *pending_release_entry = malloc(sizeof(pending_release));
+  pending_release_entry->object_id = obj_id;
+  DL_APPEND(conn->release_history, pending_release_entry);
+  conn->release_history_length += 1;
+  /* If the doubly-linked list was previously empty, update the pointer to the
+   * first element of the doubly-linked list. */
+  if (conn->release_history_first_entry == NULL) {
+    conn->release_history_first_entry = pending_release_entry;
+  }
+  /* If there are too many bytes in use by the client or if there are too many
+   * pending release calls, and there are at least some pending release calls in
+   * the release_history list, then release some objects. TODO(rkn): Checking
+   * that conn->release_history_first_entry != NULL may be relying on an
+   * implementation detail that may or may not work as expected. */
+  while ((conn->cached_object_bytes >
+              MIN(L3_CACHE_SIZE_BYTES, conn->store_capacity / 1000) ||
+          conn->release_history_length > conn->config.release_delay) &&
+         conn->release_history_length > 0) {
+    DCHECK(conn->release_history_first_entry != NULL);
+    /* Perform a release for the object ID for the first pending release. */
+    plasma_perform_release(conn, conn->release_history_first_entry->object_id);
+    /* Remove the first entry from the doubly-linked list. */
+    pending_release *new_first_entry = conn->release_history_first_entry->next;
+    DL_DELETE(conn->release_history, conn->release_history_first_entry);
+    free(conn->release_history_first_entry);
+    /* Update the first element in the doubly linked list. */
+    conn->release_history_first_entry = new_first_entry;
+    conn->release_history_length -= 1;
+    DCHECK(conn->release_history_length >= 0);
+  }
+  if (conn->release_history_length == 0) {
+    DCHECK(conn->release_history_first_entry == NULL);
   }
 }
 
@@ -438,6 +472,11 @@ void plasma_seal(plasma_connection *conn, object_id object_id) {
   CHECK(plasma_compute_object_hash(conn, object_id, &digest[0]));
   CHECK(plasma_send_SealRequest(conn->store_conn, conn->builder, object_id,
                                 &digest[0]) >= 0);
+  /* We call plasma_release to decrement the number of instances of this object
+   * that are currently being used by this client. The corresponding increment
+   * happened in plasma_create and was used to ensure that the object was not
+   * released before the call to plasma_seal. */
+  plasma_release(conn, object_id);
 }
 
 void plasma_delete(plasma_connection *conn, object_id object_id) {
@@ -518,7 +557,11 @@ plasma_connection *plasma_connect(const char *store_socket_name,
   result->mmap_table = NULL;
   result->objects_in_use = NULL;
   result->config.release_delay = release_delay;
-  utringbuffer_new(result->release_history, release_delay, &object_id_icd);
+  /* Initialize the release history doubly-linked list to NULL and also
+   * initialize other implementation details of the release history. */
+  result->release_history = NULL;
+  result->release_history_first_entry = NULL;
+  result->release_history_length = 0;
   result->cached_object_bytes = 0;
   /* Send a ConnectRequest to the store to get its memory capacity. */
   plasma_send_ConnectRequest(result->store_conn, result->builder);
@@ -530,12 +573,32 @@ plasma_connection *plasma_connect(const char *store_socket_name,
 }
 
 void plasma_disconnect(plasma_connection *conn) {
-  object_id *id = NULL;
-  while ((id = (object_id *) utringbuffer_next(conn->release_history, id))) {
-    plasma_perform_release(conn, *id);
+  /* Perform the pending release calls to flush out the queue so that the counts
+   * in the objects_in_use table are accurate. */
+  pending_release *element, *temp;
+  DL_FOREACH_SAFE(conn->release_history, element, temp) {
+    plasma_perform_release(conn, element->object_id);
+    DL_DELETE(conn->release_history, element);
+    free(element);
   }
+  /* Loop over the objects in use table and release all remaining objects. */
+  object_in_use_entry *current_entry, *temp_entry;
+  HASH_ITER(hh, conn->objects_in_use, current_entry, temp_entry) {
+    object_id object_id_to_release = current_entry->object_id;
+    int count = current_entry->count;
+    for (int i = 0; i < count; ++i) {
+      plasma_release(conn, object_id_to_release);
+    }
+  }
+  /* Perform all pending releases again to flush out the queue again. */
+  DL_FOREACH_SAFE(conn->release_history, element, temp) {
+    plasma_perform_release(conn, element->object_id);
+    DL_DELETE(conn->release_history, element);
+    free(element);
+  }
+  /* Check that we've successfully released everything. */
+  CHECK(conn->cached_object_bytes == 0);
   free_protocol_builder(conn->builder);
-  utringbuffer_free(conn->release_history);
   close(conn->store_conn);
   if (conn->manager_conn >= 0) {
     close(conn->manager_conn);

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -7,6 +7,8 @@
 #include "plasma.h"
 
 #define PLASMA_DEFAULT_RELEASE_DELAY 64
+/* Use 100MB as an overestimate of the L3 cache size. */
+#define L3_CACHE_SIZE_BYTES 100000000
 
 typedef struct plasma_connection plasma_connection;
 

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -741,7 +741,7 @@ void process_transfer_request(event_loop *loop,
       LOG_WARN("Blocking in the plasma manager.");
     }
     counter += 1;
-  } while(!has_obj);
+  } while (!has_obj);
   plasma_get(conn->manager_state->plasma_conn, object_id, &data_size, &data,
              &metadata_size, &metadata);
   assert(metadata == data + data_size);

--- a/src/plasma/plasma_protocol.c
+++ b/src/plasma/plasma_protocol.c
@@ -341,6 +341,34 @@ void plasma_read_ContainsReply(uint8_t *data,
   *has_object = PlasmaContainsReply_has_object(rep);
 }
 
+/* Plasma connect message. */
+
+int plasma_send_ConnectRequest(int sock, protocol_builder *B) {
+  PlasmaConnectRequest_start_as_root(B);
+  PlasmaConnectRequest_end_as_root(B);
+  return finalize_buffer_and_send(B, sock, MessageType_PlasmaConnectRequest);
+}
+
+void plasma_read_ConnectRequest(uint8_t *data) {
+  DCHECK(data);
+  PlasmaConnectRequest_table_t req = PlasmaConnectRequest_as_root(data);
+}
+
+int plasma_send_ConnectReply(int sock,
+                             protocol_builder *B,
+                             int64_t memory_capacity) {
+  PlasmaConnectReply_start_as_root(B);
+  PlasmaConnectReply_memory_capacity_add(B, memory_capacity);
+  PlasmaConnectReply_end_as_root(B);
+  return finalize_buffer_and_send(B, sock, MessageType_PlasmaConnectReply);
+}
+
+void plasma_read_ConnectReply(uint8_t *data, int64_t *memory_capacity) {
+  DCHECK(data);
+  PlasmaConnectReply_table_t rep = PlasmaConnectReply_as_root(data);
+  *memory_capacity = PlasmaConnectReply_memory_capacity(rep);
+}
+
 /* Plasma evict message. */
 
 int plasma_send_EvictRequest(int sock, protocol_builder *B, int64_t num_bytes) {

--- a/src/plasma/plasma_protocol.h
+++ b/src/plasma/plasma_protocol.h
@@ -187,6 +187,18 @@ void plasma_read_ContainsReply(uint8_t *data,
                                object_id *object_id,
                                int *has_object);
 
+/* Plasma Connect message functions. */
+
+int plasma_send_ConnectRequest(int sock, protocol_builder *B);
+
+void plasma_read_ConnectRequest(uint8_t *data);
+
+int plasma_send_ConnectReply(int sock,
+                             protocol_builder *B,
+                             int64_t memory_capacity);
+
+void plasma_read_ConnectReply(uint8_t *data, int64_t *memory_capacity);
+
 /* Plasma Evict message functions (no reply so far). */
 
 int plasma_send_EvictRequest(int sock, protocol_builder *B, int64_t num_bytes);

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -100,8 +100,9 @@ plasma_store_state *init_plasma_store(event_loop *loop, int64_t system_memory) {
   /* Initialize the plasma store info. */
   state->plasma_store_info = malloc(sizeof(plasma_store_info));
   state->plasma_store_info->objects = NULL;
+  state->plasma_store_info->memory_capacity = system_memory;
   /* Initialize the eviction state. */
-  state->eviction_state = make_eviction_state(system_memory);
+  state->eviction_state = make_eviction_state();
   utarray_new(state->input_buffer, &byte_icd);
   state->builder = make_protocol_builder();
   return state;
@@ -576,6 +577,11 @@ void process_message(event_loop *loop,
   } break;
   case MessageType_PlasmaSubscribeRequest:
     subscribe_to_updates(client_context, client_sock);
+    break;
+  case MessageType_PlasmaConnectRequest:
+    CHECK(plasma_send_ConnectReply(client_sock, state->builder,
+                                   state->plasma_store_info->memory_capacity) >=
+          0);
     break;
   case DISCONNECT_CLIENT: {
     LOG_DEBUG("Disconnecting client on fd %d", client_sock);

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -19,8 +19,8 @@
 
 SUITE(plasma_manager_tests);
 
-const char *plasma_store_socket_name = "/tmp/s1";
-const char *plasma_socket_name_format = "/tmp/plasma_socket_%d";
+const char *plasma_store_socket_name = "/tmp/plasma_store_socket_1";
+const char *plasma_manager_socket_name_format = "/tmp/plasma_manager_socket_%d";
 const char *manager_addr = "127.0.0.1";
 object_id oid;
 
@@ -61,8 +61,8 @@ plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
   /* Start listening on all the ports and initiate the local plasma manager. */
   mock->port = bind_inet_sock_retry(&mock->manager_remote_fd);
   mock->local_store = socket_connect_retry(plasma_store_socket_name, 5, 100);
-  UT_string *manager_socket_name =
-      bind_ipc_sock_retry(plasma_socket_name_format, &mock->manager_local_fd);
+  UT_string *manager_socket_name = bind_ipc_sock_retry(
+      plasma_manager_socket_name_format, &mock->manager_local_fd);
 
   CHECK(mock->manager_local_fd >= 0 && mock->local_store >= 0);
 

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -19,6 +19,7 @@
 
 SUITE(plasma_manager_tests);
 
+const char *plasma_store_socket_name = "/tmp/s1";
 const char *plasma_socket_name_format = "/tmp/plasma_socket_%d";
 const char *manager_addr = "127.0.0.1";
 object_id oid;
@@ -59,14 +60,13 @@ plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
   plasma_mock *mock = malloc(sizeof(plasma_mock));
   /* Start listening on all the ports and initiate the local plasma manager. */
   mock->port = bind_inet_sock_retry(&mock->manager_remote_fd);
-  UT_string *store_socket_name =
-      bind_ipc_sock_retry(plasma_socket_name_format, &mock->local_store);
+  mock->local_store = socket_connect_retry(plasma_store_socket_name, 5, 100);
   UT_string *manager_socket_name =
       bind_ipc_sock_retry(plasma_socket_name_format, &mock->manager_local_fd);
 
   CHECK(mock->manager_local_fd >= 0 && mock->local_store >= 0);
 
-  mock->state = init_plasma_manager_state(utstring_body(store_socket_name),
+  mock->state = init_plasma_manager_state(plasma_store_socket_name,
                                           utstring_body(manager_socket_name),
                                           manager_addr, mock->port, NULL, 0);
   mock->loop = get_event_loop(mock->state);
@@ -84,12 +84,11 @@ plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
   }
   /* Connect a new client to the local plasma manager and mock a request to an
    * object. */
-  mock->plasma_conn = plasma_connect(utstring_body(store_socket_name),
+  mock->plasma_conn = plasma_connect(plasma_store_socket_name,
                                      utstring_body(manager_socket_name), 0);
   wait_for_pollin(mock->manager_local_fd);
   mock->client_conn =
       new_client_connection(mock->loop, mock->manager_local_fd, mock->state, 0);
-  utstring_free(store_socket_name);
   utstring_free(manager_socket_name);
   return mock;
 }

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -22,13 +22,22 @@ USE_VALGRIND = False
 PLASMA_STORE_MEMORY = 1000000000
 
 def assert_get_object_equal(unit_test, client1, client2, object_id, memory_buffer=None, metadata=None):
+  client1_buff = client1.get(object_id)
+  client2_buff = client2.get(object_id)
+  client1_metadata = client1.get_metadata(object_id)
+  client2_metadata = client2.get_metadata(object_id)
+  unit_test.assertEqual(len(client1_buff), len(client2_buff))
+  unit_test.assertEqual(len(client1_metadata), len(client2_metadata))
+  # Check that the buffers from the two clients are the same.
+  unit_test.assertTrue(plasma.buffers_equal(client1_buff, client2_buff))
+  # Check that the metadata buffers from the two clients are the same.
+  unit_test.assertTrue(plasma.buffers_equal(client1_metadata, client2_metadata))
+  # If a reference buffer was provided, check that it is the same as well.
   if memory_buffer is not None:
-    unit_test.assertEqual(memory_buffer[:], client2.get(object_id)[:])
+    unit_test.assertTrue(plasma.buffers_equal(memory_buffer, client1_buff))
+  # If reference metadata was provided, check that it is the same as well.
   if metadata is not None:
-    unit_test.assertEqual(metadata[:], client2.get_metadata(object_id)[:])
-  unit_test.assertEqual(client1.get(object_id)[:], client2.get(object_id)[:])
-  unit_test.assertEqual(client1.get_metadata(object_id)[:],
-                        client2.get_metadata(object_id)[:])
+    unit_test.assertTrue(plasma.buffers_equal(metadata, client1_metadata))
 
 class TestPlasmaClient(unittest.TestCase):
 


### PR DESCRIPTION
This changes things so that the plasma client starts releasing objects when either the number of pending release calls is greater than `conn->config.release_delay` (64 by default) (note this includes many redundant release calls for the same objects) or when the total number of bytes of cached objects exceeds `MIN(L3_CACHE_SIZE_BYTES, conn->store_capacity / 1000)`, where the L3 cache size is currently set to 100MB.

This fixes a problem in which very large objects are created by a client (e.g., 1/10th the size of the store capacity) and then never released by the client because the release calls are buffered in the release_history ring buffer), this prevents the store from evicting those objects and causes it to run out of memory.

This PR also replaces the ring buffer with a doubly linked list because now it can have a more variable length.

This PR also makes sure to release all objects that are still in use when a client calls `plasma_disconnect`.

This PR also introduces an additional call to `increment_object_count` in `plasma_create` and a corresponding call to `plasma_release` in `plasma_seal`. The point of this is so that the object does not get released before the object gets sealed. For example, in the code below, the object could get released when the buffer returned by `create` goes out of scope, which can happen before it the call to `seal`.

```python
c = plasma.PlasmaClient("/tmp/s1")
def f():
  objid = np.random.bytes(20)
  c.create(objid, 100)
  c.seal(objid)

f()
```