### PR TITLE
Throw Python exception if plasma store cannot create new object.

### DIFF
--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -63,9 +63,9 @@ void object_created(eviction_state *eviction_state,
  *        stored at this address. If the number of objects chosen is greater
  *        than 0, then the caller needs to free that array. If it equals 0, then
  *        the array will be NULL.
- * @return Void.
+ * @return True if enough space can be freed and false otherwise.
  */
-void require_space(eviction_state *eviction_state,
+bool require_space(eviction_state *eviction_state,
                    plasma_store_info *plasma_store_info,
                    int64_t size,
                    int64_t *num_objects_to_evict,

--- a/src/plasma/format/plasma.fbs
+++ b/src/plasma/format/plasma.fbs
@@ -51,7 +51,9 @@ enum PlasmaError:int {
   // Trying to create an object that already exists.
   ObjectExists,
   // Trying to access an object that doesn't exist.
-  ObjectNonexistent
+  ObjectNonexistent,
+  // Trying to create an object but there isn't enough space in the store.
+  OutOfMemory
 }
 
 // Plasma store messages

--- a/src/plasma/plasma/plasma.py
+++ b/src/plasma/plasma/plasma.py
@@ -9,6 +9,8 @@ import sys
 import time
 
 from . import libplasma
+from .libplasma import plasma_object_exists_error
+from .libplasma import plasma_out_of_memory_error
 
 PLASMA_ID_SIZE = 20
 PLASMA_WAIT_TIMEOUT = 2 ** 30
@@ -128,7 +130,12 @@ class PlasmaClient(object):
         wishes to encode.
 
     Raises:
-      Exception: An exception is raised if the object could not be created.
+      plasma_object_exists_error: This exception is raised if the object could
+        not be created because there already is an object with the same ID in
+        the plasma store.
+      plasma_out_of_memory_error: This exception is raised if the object could
+        not be created because the plasma store is unable to evict enough
+        objects to create room for it.
     """
     # Turn the metadata into the right type.
     metadata = bytearray(b"") if metadata is None else metadata

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -80,15 +80,21 @@ int plasma_manager_connect(const char *addr, int port);
  * @param metadata_size The size in bytes of the metadata. If there is no
           metadata, this should be 0.
  * @param data The address of the newly created object will be written here.
- * @return True, if object was created, false, otherwise (e.g., if object has
- *         been already created).
+ * @return One of the following error codes:
+ *         - PlasmaError_OK, if the object was created successfully.
+ *         - PlasmaError_ObjectExists, if an object with this ID is already
+ *           present in the store. In this case, the client should not call
+ *           plasma_release.
+ *         - PlasmaError_OutOfMemory, if the store is out of memory and cannot
+ *           create the object. In this case, the client should not call
+ *           plasma_release.
  */
-bool plasma_create(plasma_connection *conn,
-                   object_id object_id,
-                   int64_t size,
-                   uint8_t *metadata,
-                   int64_t metadata_size,
-                   uint8_t **data);
+int plasma_create(plasma_connection *conn,
+                  object_id object_id,
+                  int64_t size,
+                  uint8_t *metadata,
+                  int64_t metadata_size,
+                  uint8_t **data);
 
 /**
  * Get an object from the Plasma Store. This function will block until the

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -7,6 +7,9 @@
 #include "plasma_client.h"
 #include "object_info.h"
 
+PyObject *PlasmaOutOfMemoryError;
+PyObject *PlasmaObjectExistsError;
+
 static int PyObjectToPlasmaConnection(PyObject *object,
                                       plasma_connection **conn) {
   if (PyCapsule_IsValid(object, "plasma")) {
@@ -73,13 +76,13 @@ PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
                                  (uint8_t *) PyByteArray_AsString(metadata),
                                  PyByteArray_Size(metadata), &data);
   if (error_code == PlasmaError_ObjectExists) {
-    PyErr_SetString(PyExc_RuntimeError,
+    PyErr_SetString(PlasmaObjectExistsError,
                     "An object with this ID already exists in the plasma "
                     "store.");
     return NULL;
   }
   if (error_code == PlasmaError_OutOfMemory) {
-    PyErr_SetString(PyExc_RuntimeError,
+    PyErr_SetString(PlasmaOutOfMemoryError,
                     "The plasma store ran out of memory and could not create "
                     "this object.");
     return NULL;
@@ -429,6 +432,19 @@ MOD_INIT(libplasma) {
   PyObject *m = Py_InitModule3("libplasma", plasma_methods,
                                "A Python client library for plasma.");
 #endif
+
+  /* Create a custom exception for when an object ID is reused. */
+  char plasma_object_exists_error[] = "plasma_object_exists.error";
+  PlasmaObjectExistsError =
+      PyErr_NewException(plasma_object_exists_error, NULL, NULL);
+  Py_INCREF(PlasmaObjectExistsError);
+  PyModule_AddObject(m, "plasma_object_exists_error", PlasmaObjectExistsError);
+  /* Create a custom exception for when the plasma store is out of memory. */
+  char plasma_out_of_memory_error[] = "plasma_out_of_memory.error";
+  PlasmaOutOfMemoryError =
+      PyErr_NewException(plasma_out_of_memory_error, NULL, NULL);
+  Py_INCREF(PlasmaOutOfMemoryError);
+  PyModule_AddObject(m, "plasma_out_of_memory_error", PlasmaOutOfMemoryError);
 
 #if PY_MAJOR_VERSION >= 3
   return m;

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -15,13 +15,20 @@ typedef struct plasma_store_state plasma_store_state;
  * @param object_id Object ID of the object to be created.
  * @param data_size Size in bytes of the object to be created.
  * @param metadata_size Size in bytes of the object metadata.
- * @return False if the object already exists, otherwise true.
+ * @return One of the following error codes:
+ *         - PlasmaError_OK, if the object was created successfully.
+ *         - PlasmaError_ObjectExists, if an object with this ID is already
+ *           present in the store. In this case, the client should not call
+ *           plasma_release.
+ *         - PlasmaError_OutOfMemory, if the store is out of memory and cannot
+ *           create the object. In this case, the client should not call
+ *           plasma_release.
  */
-bool create_object(client *client_context,
-                   object_id object_id,
-                   int64_t data_size,
-                   int64_t metadata_size,
-                   plasma_object *result);
+int create_object(client *client_context,
+                  object_id object_id,
+                  int64_t data_size,
+                  int64_t metadata_size,
+                  plasma_object *result);
 
 /**
  * Get an object. This method assumes that we currently have or will eventually

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -107,8 +107,78 @@ class TestPlasmaClient(unittest.TestCase):
       self.plasma_client.create(object_id, length, generate_metadata(length))
       try:
         val = self.plasma_client.create(object_id, length, generate_metadata(length))
-      except Exception:
-        pass
+      except Exception as e:
+        self.assertEqual(e.args, ("An object with this ID already exists in the plasma store.",))
+      else:
+        self.assertTrue(False)
+
+  def test_store_full(self):
+    # The store is started with 1GB, so make sure that create throws an
+    # exception when it is full.
+    def assert_create_raises_plasma_full(unit_test, size):
+      partial_size = np.random.randint(size)
+      try:
+        _, memory_buffer, _ = create_object(unit_test.plasma_client, partial_size, size - partial_size)
+      except Exception as e:
+        unit_test.assertEqual(e.args, ("The plasma store ran out of memory and could not create this object.",))
+      else:
+        # For some reason the above didn't throw an exception, so fail.
+        unit_test.assertTrue(False)
+
+    # Create a list to keep some of the buffers in scope.
+    memory_buffers = []
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 8, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 8. Make sure that we can't create an object of
+    # size 10 ** 8 + 1, but we can create one of size 10 ** 8.
+    assert_create_raises_plasma_full(self, 10 ** 8 + 1)
+    _, memory_buffer, _ = create_object(self.plasma_client, 10 ** 8, 0)
+    del memory_buffer
+    _, memory_buffer, _ = create_object(self.plasma_client, 10 ** 8, 0)
+    del memory_buffer
+    assert_create_raises_plasma_full(self, 10 ** 8 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 7, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 7.
+    assert_create_raises_plasma_full(self, 10 ** 7 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 6, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 6.
+    assert_create_raises_plasma_full(self, 10 ** 6 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 5, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 5.
+    assert_create_raises_plasma_full(self, 10 ** 5 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 4, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 4.
+    assert_create_raises_plasma_full(self, 10 ** 4 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 3, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 3.
+    assert_create_raises_plasma_full(self, 10 ** 3 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 2, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 2.
+    assert_create_raises_plasma_full(self, 10 ** 2 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 1, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 1.
+    assert_create_raises_plasma_full(self, 10 ** 1 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 9 * 10 ** 0, 0)
+    memory_buffers.append(memory_buffer)
+    # Remaining space is 10 ** 0.
+    assert_create_raises_plasma_full(self, 10 ** 0 + 1)
+
+    _, memory_buffer, _ = create_object(self.plasma_client, 1, 0)
 
   def test_contains(self):
     fake_object_ids = [random_object_id() for _ in range(100)]

--- a/src/plasma/test/test.py
+++ b/src/plasma/test/test.py
@@ -107,8 +107,8 @@ class TestPlasmaClient(unittest.TestCase):
       self.plasma_client.create(object_id, length, generate_metadata(length))
       try:
         val = self.plasma_client.create(object_id, length, generate_metadata(length))
-      except Exception as e:
-        self.assertEqual(e.args, ("An object with this ID already exists in the plasma store.",))
+      except plasma.plasma_object_exists_error as e:
+        pass
       else:
         self.assertTrue(False)
 
@@ -119,8 +119,8 @@ class TestPlasmaClient(unittest.TestCase):
       partial_size = np.random.randint(size)
       try:
         _, memory_buffer, _ = create_object(unit_test.plasma_client, partial_size, size - partial_size)
-      except Exception as e:
-        unit_test.assertEqual(e.args, ("The plasma store ran out of memory and could not create this object.",))
+      except plasma.plasma_out_of_memory_error as e:
+        pass
       else:
         # For some reason the above didn't throw an exception, so fail.
         unit_test.assertTrue(False)


### PR DESCRIPTION
There are two reasons why the store might not be able to create a new object.
1. There is no space.
2. There is already an object with the given ID.

This propagates these two errors from the store to the client and raises different Python exceptions based on which one we see.