### PR TITLE
Only download arrow if not already present.

### DIFF
--- a/numbuf/thirdparty/download_thirdparty.sh
+++ b/numbuf/thirdparty/download_thirdparty.sh
@@ -7,6 +7,8 @@ set -e
 
 TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
-git clone https://github.com/pcmoritz/arrow.git "$TP_DIR/arrow"
+if [ ! -d $TP_DIR/arrow ]; then
+  git clone https://github.com/pcmoritz/arrow.git "$TP_DIR/arrow"
+fi
 cd "$TP_DIR/arrow"
 git checkout c88bd70c13cf16c07b840623cb466aa98d535be0


### PR DESCRIPTION
Previously, if you did `cd numbuf; python setup.py install` twice in a row, it would fail the second time when it tried to clone Arrow to a location that already existed.