### PR TITLE
Let the worker know about remote functions that failed to unpickle.

### DIFF
--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -128,8 +128,6 @@ class TaskStatusTest(unittest.TestCase):
     # Check that the error message is in the task info.
     self.assertTrue(b"The initializer failed." in ray.error_info()[b"ReusableVariableImportError"][0][b"message"])
 
-    # Check that if we call the function it fails and does not hang.
-
     ray.worker.cleanup()
 
   def testFailReinitializingVariable(self):


### PR DESCRIPTION
The following example (taken from #154) will currently cause the system to pause for several seconds before throwing an error. The system must then be restarted. This PR fixes that so an error is thrown right away and the system does not need to be restarted.

Define a file `foo.py`, with the following contents.

```python
import ray

def helper():
    return 1

@ray.remote
def f():
    return helper()
```

Then from the same directory as `foo.py`, run the following.

```python
import ray
import sys
import time

ray.init(start_ray_local=True, num_workers=1)

@ray.remote
def remove_foo_from_path():
  sys.path = []

remove_foo_from_path.remote()

time.sleep(1)
import foo # This should cause some error messages.

ray.get(foo.f.remote()) # This hangs.
```