### PR TITLE
Log profiling information from worker.

### DIFF
--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -15,6 +15,6 @@ if hasattr(ctypes, "windll"):
 
 import ray.experimental
 import ray.serialization
-from ray.worker import register_class, error_info, init, connect, disconnect, get, put, wait, remote
+from ray.worker import register_class, error_info, init, connect, disconnect, get, put, wait, remote, log, flush_log
 from ray.worker import Reusable, reusables
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE

--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -15,6 +15,6 @@ if hasattr(ctypes, "windll"):
 
 import ray.experimental
 import ray.serialization
-from ray.worker import register_class, error_info, init, connect, disconnect, get, put, wait, remote, log, flush_log
+from ray.worker import register_class, error_info, init, connect, disconnect, get, put, wait, remote, log_event, log_span, flush_log
 from ray.worker import Reusable, reusables
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -1242,7 +1242,7 @@ def flush_log(worker=global_worker):
   """Send the logged worker events to the global state store."""
   worker_id_hex = repr(worker.worker_id)[9:-1]
   task_id_hex = repr(worker.current_task_id.id())[9:-1]
-  worker.redis_client.rpush("event_log:" + worker_id_hex + ":" + task_id_hex, json.dumps(worker.events))
+  worker.photon_client.log_event("event_log:" + worker_id_hex + ":" + task_id_hex, json.dumps(worker.events))
   worker.events = []
 
 def get(objectid, worker=global_worker):

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -1498,9 +1498,9 @@ def main_loop(worker=global_worker):
     # warning to the user if we are waiting too long to acquire the lock because
     # that may indicate that the system is hanging, and it'd be good to know
     # where the system is hanging.
-    log(event_type="ray:acquire_lock", kind="start", worker=worker)
+    log(event_type="ray:acquire_lock", kind=LOG_SPAN_START, worker=worker)
     with worker.lock:
-      log(event_type="ray:acquire_lock", kind="end", worker=worker)
+      log(event_type="ray:acquire_lock", kind=LOG_SPAN_END, worker=worker)
 
       contents = {"function_name": worker.function_names[function_id.id()],
                   "task_id": task.task_id().hex()}

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -4,7 +4,7 @@ BUILD = build
 
 all: hiredis redis redismodule $(BUILD)/libcommon.a
 
-$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o state/local_scheduler_table.o thirdparty/ae/ae.o thirdparty/sha256.o
+$(BUILD)/libcommon.a: event_loop.o common.o task.o io.o net.o logging.o state/redis.o state/table.o state/object_table.o state/task_table.o state/db_client_table.o state/local_scheduler_table.o thirdparty/ae/ae.o thirdparty/sha256.o
 	ar rcs $@ $^
 
 $(BUILD)/common_tests: test/common_tests.c $(BUILD)/libcommon.a

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -74,6 +74,14 @@ static PyObject *PyObjectID_id(PyObject *self) {
                                    sizeof(s->object_id.id));
 }
 
+static PyObject *PyObjectID_hex(PyObject *self) {
+  PyObjectID *s = (PyObjectID *) self;
+  char hex_id[ID_STRING_SIZE];
+  object_id_to_string(s->object_id, hex_id, ID_STRING_SIZE);
+  PyObject *result = PyUnicode_FromString(hex_id);
+  return result;
+}
+
 static PyObject *PyObjectID_richcompare(PyObjectID *self,
                                         PyObject *other,
                                         int op) {
@@ -140,6 +148,8 @@ static PyObject *PyObjectID___reduce__(PyObjectID *self) {
 static PyMethodDef PyObjectID_methods[] = {
     {"id", (PyCFunction) PyObjectID_id, METH_NOARGS,
      "Return the hash associated with this ObjectID"},
+    {"hex", (PyCFunction) PyObjectID_hex, METH_NOARGS,
+     "Return the object ID as a string in hex."},
     {"__reduce__", (PyCFunction) PyObjectID___reduce__, METH_NOARGS,
      "Say how to pickle this ObjectID. This raises an exception to prevent"
      "object IDs from being serialized."},

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -82,3 +82,16 @@ void ray_log(ray_logger *logger,
   utstring_free(formatted_message);
   utstring_free(timestamp);
 }
+
+void ray_log_event(db_handle *db,
+                   uint8_t *key_name,
+                   int64_t key_name_length,
+                   uint8_t *payload,
+                   int64_t payload_length) {
+  int status =
+      redisAsyncCommand(db->context, NULL, NULL, "RPUSH %b %b", key_name,
+                        key_name_length, payload, payload_length);
+  if ((status == REDIS_ERR) || db->context->err) {
+    LOG_REDIS_DEBUG(db->context, "error while logging message to event log");
+  }
+}

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -84,13 +84,12 @@ void ray_log(ray_logger *logger,
 }
 
 void ray_log_event(db_handle *db,
-                   uint8_t *key_name,
-                   int64_t key_name_length,
-                   uint8_t *payload,
-                   int64_t payload_length) {
-  int status =
-      redisAsyncCommand(db->context, NULL, NULL, "RPUSH %b %b", key_name,
-                        key_name_length, payload, payload_length);
+                   uint8_t *key,
+                   int64_t key_length,
+                   uint8_t *value,
+                   int64_t value_length) {
+  int status = redisAsyncCommand(db->context, NULL, NULL, "RPUSH %b %b", key,
+                                 key_length, value, value_length);
   if ((status == REDIS_ERR) || db->context->err) {
     LOG_REDIS_DEBUG(db->context, "error while logging message to event log");
   }

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -13,6 +13,8 @@
 #define RAY_OBJECT "OBJECT"
 #define RAY_TASK "TASK"
 
+#include "state/db.h"
+
 typedef struct ray_logger_impl ray_logger;
 
 /* Initialize a Ray logger for the given client type and logging level. If the
@@ -36,4 +38,20 @@ void ray_log(ray_logger *logger,
              const char *event_type,
              const char *message);
 
-#endif
+/**
+ * Log an event to the event log.
+ *
+ * @param db The database handle.
+ * @param key_name The key in Redis to append the payload to.
+ * @param key_name_length The length of the key.
+ * @param payload The payload to append to the list in Redis.
+ * @param payload_length The length of the payload.
+ * @return Void.
+ */
+void ray_log_event(db_handle *db,
+                   uint8_t *key_name,
+                   int64_t key_name_length,
+                   uint8_t *payload,
+                   int64_t payload_length);
+
+#endif /* LOGGING_H */

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -42,16 +42,16 @@ void ray_log(ray_logger *logger,
  * Log an event to the event log.
  *
  * @param db The database handle.
- * @param key_name The key in Redis to append the payload to.
- * @param key_name_length The length of the key.
- * @param payload The payload to append to the list in Redis.
- * @param payload_length The length of the payload.
+ * @param key The key in Redis to store the event in.
+ * @param key_length The length of the key.
+ * @param value The value to log.
+ * @param value_length The length of the value.
  * @return Void.
  */
 void ray_log_event(db_handle *db,
-                   uint8_t *key_name,
-                   int64_t key_name_length,
-                   uint8_t *payload,
-                   int64_t payload_length);
+                   uint8_t *key,
+                   int64_t key_length,
+                   uint8_t *value,
+                   int64_t value_length);
 
 #endif /* LOGGING_H */

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -25,6 +25,8 @@ enum photon_message_type {
   EXECUTE_TASK,
   /** Reconstruct a possibly lost object. */
   RECONSTRUCT_OBJECT,
+  /** Log a message to the event table. */
+  EVENT_LOG_MESSAGE,
 };
 
 // clang-format off

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -16,22 +16,22 @@ void photon_disconnect(photon_conn *conn) {
 }
 
 void photon_log_event(photon_conn *conn,
-                      uint8_t *key_name,
-                      int64_t key_name_length,
-                      uint8_t *payload,
-                      int64_t payload_length) {
-  int64_t message_length = sizeof(key_name_length) + sizeof(payload_length) +
-                           key_name_length + payload_length;
+                      uint8_t *key,
+                      int64_t key_length,
+                      uint8_t *value,
+                      int64_t value_length) {
+  int64_t message_length =
+      sizeof(key_length) + sizeof(value_length) + key_length + value_length;
   uint8_t *message = malloc(message_length);
   int64_t offset = 0;
-  memcpy(&message[offset], &key_name_length, sizeof(key_name_length));
-  offset += sizeof(key_name_length);
-  memcpy(&message[offset], &payload_length, sizeof(payload_length));
-  offset += sizeof(payload_length);
-  memcpy(&message[offset], key_name, key_name_length);
-  offset += key_name_length;
-  memcpy(&message[offset], payload, payload_length);
-  offset += payload_length;
+  memcpy(&message[offset], &key_length, sizeof(key_length));
+  offset += sizeof(key_length);
+  memcpy(&message[offset], &value_length, sizeof(value_length));
+  offset += sizeof(value_length);
+  memcpy(&message[offset], key, key_length);
+  offset += key_length;
+  memcpy(&message[offset], value, value_length);
+  offset += value_length;
   CHECK(offset == message_length);
   write_message(conn->conn, EVENT_LOG_MESSAGE, message_length, message);
   free(message);

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -36,6 +36,22 @@ void photon_disconnect(photon_conn *conn);
 void photon_submit(photon_conn *conn, task_spec *task);
 
 /**
+ * Log an event to the event log. This will call RPUSH key_name payload.
+ *
+ * @param conn The connection information.
+ * @param key_name The key to append the payload to.
+ * @param key_name_length The length of the key.
+ * @param payload The payload to append.
+ * @param The length of the payload.
+ * @return Void.
+ */
+void photon_log_event(photon_conn *conn,
+                      uint8_t *key_name,
+                      int64_t key_name_length,
+                      uint8_t *payload,
+                      int64_t payload_length);
+
+/**
  * Get next task for this client. This will block until the scheduler assigns
  * a task to this worker. This allocates and returns a task, and so the task
  * must be freed by the caller.

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -36,20 +36,23 @@ void photon_disconnect(photon_conn *conn);
 void photon_submit(photon_conn *conn, task_spec *task);
 
 /**
- * Log an event to the event log. This will call RPUSH key_name payload.
+ * Log an event to the event log. This will call RPUSH key value. We use RPUSH
+ * instead of SET so that it is possible to flush the log multiple times with
+ * the same key (for example the key might be shared across logging calls in the
+ * same task on a worker).
  *
  * @param conn The connection information.
- * @param key_name The key to append the payload to.
- * @param key_name_length The length of the key.
- * @param payload The payload to append.
- * @param The length of the payload.
+ * @param key The key to store the event in.
+ * @param key_length The length of the key.
+ * @param value The value to store.
+ * @param value_length The length of the value.
  * @return Void.
  */
 void photon_log_event(photon_conn *conn,
-                      uint8_t *key_name,
-                      int64_t key_name_length,
-                      uint8_t *payload,
-                      int64_t payload_length);
+                      uint8_t *key,
+                      int64_t key_length,
+                      uint8_t *value,
+                      int64_t value_length);
 
 /**
  * Get next task for this client. This will block until the scheduler assigns

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -62,6 +62,21 @@ static PyObject *PyPhotonClient_reconstruct_object(PyObject *self,
   Py_RETURN_NONE;
 }
 
+static PyObject *PyPhotonClient_log_event(PyObject *self, PyObject *args) {
+  const char *key_name;
+  int key_name_length;
+  const char *payload;
+  int payload_length;
+  if (!PyArg_ParseTuple(args, "s#s#", &key_name, &key_name_length, &payload,
+                        &payload_length)) {
+    return NULL;
+  }
+  photon_log_event(((PyPhotonClient *) self)->photon_connection,
+                   (uint8_t *) key_name, key_name_length, (uint8_t *) payload,
+                   payload_length);
+  Py_RETURN_NONE;
+}
+
 static PyMethodDef PyPhotonClient_methods[] = {
     {"submit", (PyCFunction) PyPhotonClient_submit, METH_VARARGS,
      "Submit a task to the local scheduler."},
@@ -69,6 +84,8 @@ static PyMethodDef PyPhotonClient_methods[] = {
      "Get a task from the local scheduler."},
     {"reconstruct_object", (PyCFunction) PyPhotonClient_reconstruct_object,
      METH_VARARGS, "Ask the local scheduler to reconstruct an object."},
+    {"log_event", (PyCFunction) PyPhotonClient_log_event, METH_VARARGS,
+     "Log an event to the event log through the local scheduler."},
     {NULL} /* Sentinel */
 };
 

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -63,17 +63,17 @@ static PyObject *PyPhotonClient_reconstruct_object(PyObject *self,
 }
 
 static PyObject *PyPhotonClient_log_event(PyObject *self, PyObject *args) {
-  const char *key_name;
-  int key_name_length;
-  const char *payload;
-  int payload_length;
-  if (!PyArg_ParseTuple(args, "s#s#", &key_name, &key_name_length, &payload,
-                        &payload_length)) {
+  const char *key;
+  int key_length;
+  const char *value;
+  int value_length;
+  if (!PyArg_ParseTuple(args, "s#s#", &key, &key_length, &value,
+                        &value_length)) {
     return NULL;
   }
   photon_log_event(((PyPhotonClient *) self)->photon_connection,
-                   (uint8_t *) key_name, key_name_length, (uint8_t *) payload,
-                   payload_length);
+                   (uint8_t *) key, key_length, (uint8_t *) value,
+                   value_length);
   Py_RETURN_NONE;
 }
 

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -234,28 +234,28 @@ void process_message(event_loop *loop,
   case TASK_DONE: {
   } break;
   case EVENT_LOG_MESSAGE: {
-    /* Parse the message. */
+    /* Parse the message. TODO(rkn): Redo this using flatbuffers to serialize
+     * the message. */
     uint8_t *message = (uint8_t *) utarray_front(state->input_buffer);
     int64_t offset = 0;
-    int64_t key_name_length;
-    memcpy(&key_name_length, &message[offset], sizeof(key_name_length));
-    offset += sizeof(key_name_length);
-    int64_t payload_length;
-    memcpy(&payload_length, &message[offset], sizeof(payload_length));
-    offset += sizeof(payload_length);
-    uint8_t *key_name = malloc(key_name_length);
-    memcpy(key_name, &message[offset], key_name_length);
-    offset += key_name_length;
-    uint8_t *payload = malloc(payload_length);
-    memcpy(payload, &message[offset], payload_length);
-    offset += payload_length;
+    int64_t key_length;
+    memcpy(&key_length, &message[offset], sizeof(key_length));
+    offset += sizeof(key_length);
+    int64_t value_length;
+    memcpy(&value_length, &message[offset], sizeof(value_length));
+    offset += sizeof(value_length);
+    uint8_t *key = malloc(key_length);
+    memcpy(key, &message[offset], key_length);
+    offset += key_length;
+    uint8_t *value = malloc(value_length);
+    memcpy(value, &message[offset], value_length);
+    offset += value_length;
     CHECK(offset == length);
     if (state->db != NULL) {
-      ray_log_event(state->db, key_name, key_name_length, payload,
-                    payload_length);
+      ray_log_event(state->db, key, key_length, value, value_length);
     }
-    free(key_name);
-    free(payload);
+    free(key);
+    free(value);
   } break;
   case GET_TASK: {
     worker_index *wi;


### PR DESCRIPTION
Note: this slows down the simple benchmark below by about 40us.

```python
@ray.remote
def f(x):
  return x

%timeit ray.get(f.remote(3))
```

I think about 5 or so microseconds come just from the additional IPC to photon to log the events (though that call isn't on the critical path, so it's not clear why it slows it down with multiple workers (but it does). The remaining slowdown comes from all of the logging calls. 

For example, a simple logging call like the following takes around 4us, and we do that around 8 times per task, which seems to explain the remaining slowdown.

```python
def g():
  with ray.log_span("event_type1"):
    pass

%timeit g()
```

We'll need to redo the logging code to address this.