### PR TITLE
Make numpy arrays immutable

### DIFF
--- a/numbuf/python/src/pynumbuf/adapters/numpy.cc
+++ b/numbuf/python/src/pynumbuf/adapters/numpy.cc
@@ -27,8 +27,8 @@ namespace numbuf {
         num_dims, dim.data(), NPY_##TYPE, reinterpret_cast<void*>(data));         \
     if (base != Py_None) { PyArray_SetBaseObject((PyArrayObject*)*out, base); }   \
     Py_XINCREF(base);                                                             \
-  }                                                                               \
-    return Status::OK();
+    break;                                                                        \
+  }
 
 Status DeserializeArray(
     std::shared_ptr<Array> array, int32_t offset, PyObject* base, PyObject** out) {
@@ -57,6 +57,11 @@ Status DeserializeArray(
     default:
       DCHECK(false) << "arrow type not recognized: " << content->value_type()->type;
   }
+  /* Mark the array as immutable. */
+  PyObject* flags = PyObject_GetAttrString(*out, "flags");
+  DCHECK(flags != NULL) << "Could not mark Numpy array immutable";
+  int flag_set = PyObject_SetAttrString(flags, "writeable", Py_False);
+  DCHECK(flag_set == 0) << "Could not mark Numpy array immutable";
   return Status::OK();
 }
 

--- a/numbuf/python/src/pynumbuf/adapters/numpy.cc
+++ b/numbuf/python/src/pynumbuf/adapters/numpy.cc
@@ -27,8 +27,7 @@ namespace numbuf {
         num_dims, dim.data(), NPY_##TYPE, reinterpret_cast<void*>(data));         \
     if (base != Py_None) { PyArray_SetBaseObject((PyArrayObject*)*out, base); }   \
     Py_XINCREF(base);                                                             \
-    break;                                                                        \
-  }
+  } break;
 
 Status DeserializeArray(
     std::shared_ptr<Array> array, int32_t offset, PyObject* base, PyObject** out) {

--- a/numbuf/python/test/runtest.py
+++ b/numbuf/python/test/runtest.py
@@ -120,13 +120,8 @@ class SerializationTests(unittest.TestCase):
 
   def testObjectArrayImmutable(self):
     obj = np.zeros([10])
-    obj.flags.writeable = False
-    schema, size, batch = numbuf.serialize_list([obj])
-    size = size + 4096 # INITIAL_METADATA_SIZE in arrow
-    buff = np.zeros(size, dtype="uint8")
-    metadata_offset = numbuf.write_to_buffer(batch, memoryview(buff))
-    array = numbuf.read_from_buffer(memoryview(buff), memoryview(schema), metadata_offset)
-    result = numbuf.deserialize_list(array)
+    schema, size, serialized = numbuf.serialize_list([obj])
+    result = numbuf.deserialize_list(serialized)
     assert_equal(result[0], obj)
     try:
       result[0][0] = 1

--- a/numbuf/python/test/runtest.py
+++ b/numbuf/python/test/runtest.py
@@ -123,11 +123,8 @@ class SerializationTests(unittest.TestCase):
     schema, size, serialized = numbuf.serialize_list([obj])
     result = numbuf.deserialize_list(serialized)
     assert_equal(result[0], obj)
-    try:
+    with self.assertRaises(ValueError):
       result[0][0] = 1
-      self.assertTrue(False)
-    except ValueError:
-      pass
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Set a flag when deserializing numpy arrays to make them immutable.