### PR TITLE
fix docker build bug

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -4,9 +4,7 @@
 FROM ubuntu:xenial
 RUN apt-get update \
     && apt-get install -y vim git wget \
-    && apt-get install -y cmake build-essential autoconf curl libtool libboost-all-dev unzip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y cmake build-essential autoconf curl libtool libboost-all-dev unzip
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
     && wget --quiet 'https://repo.continuum.io/archive/Anaconda2-4.2.0-Linux-x86_64.sh' -O /tmp/anaconda.sh \
     && /bin/bash /tmp/anaconda.sh -b -p /opt/conda \

--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -2,5 +2,5 @@
 
 FROM ray-project/deploy
 RUN conda install -y -c conda-forge tensorflow
-RUN apt-get install zlib1g-dev
+RUN apt-get install -y zlib1g-dev
 RUN pip install gym[atari]


### PR DESCRIPTION
Fix error that occurs when building examples Docker image. Rather than clean up fully after apt-get runs in base-deps we leave the catalog in place for use by other images. The difference in image size is minimal.