### PR TITLE
Wait until kill operation was successful

### DIFF
--- a/src/plasma/test/run_tests.sh
+++ b/src/plasma/test/run_tests.sh
@@ -32,3 +32,4 @@ kill $plasma3_pid
 kill $plasma2_pid
 kill $plasma1_pid
 kill $redis_pid
+wait $redis_pid


### PR DESCRIPTION
This should fix the problem that can be reproduced locally if you run the following in ray/python/core

```
bash ../../src/plasma/test/run_tests.sh ; bash ../../src/common/test/run_tests.sh
```