### PR TITLE
Split local scheduler task queue

### DIFF
--- a/src/common/task.h
+++ b/src/common/task.h
@@ -252,10 +252,16 @@ void print_task(task_spec *spec, UT_string *output);
 /** The scheduling_state can be used as a flag when we are listening
  *  for an event, for example TASK_WAITING | TASK_SCHEDULED. */
 typedef enum {
+  /** The task is waiting to be scheduled. */
   TASK_STATUS_WAITING = 1,
+  /** The task has been scheduled to a node, but has not been queued yet. */
   TASK_STATUS_SCHEDULED = 2,
+  /** The task has been queued on a node, where it will wait for its
+   *  dependencies to become ready and a worker to become available. */
   TASK_STATUS_QUEUED = 4,
+  /** The task is running on a worker. */
   TASK_STATUS_RUNNING = 8,
+  /** The task is done executing. */
   TASK_STATUS_DONE = 16
 } scheduling_state;
 

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -244,9 +244,9 @@ void print_task(task_spec *spec, UT_string *output);
 
 /**
  * ==== Task ====
- * Contains information about a scheduled task: The task specification, the task
- * schedulign state (WAITING, SCHEDULED, RUNNING, DONE), and which local
- * scheduler the task is scheduled on.
+ * Contains information about a scheduled task: The task specification, the
+ * task scheduling state (WAITING, SCHEDULED, QUEUED, RUNNING, DONE), and which
+ * local scheduler the task is scheduled on.
  */
 
 /** The scheduling_state can be used as a flag when we are listening
@@ -254,8 +254,9 @@ void print_task(task_spec *spec, UT_string *output);
 typedef enum {
   TASK_STATUS_WAITING = 1,
   TASK_STATUS_SCHEDULED = 2,
-  TASK_STATUS_RUNNING = 4,
-  TASK_STATUS_DONE = 8
+  TASK_STATUS_QUEUED = 4,
+  TASK_STATUS_RUNNING = 8,
+  TASK_STATUS_DONE = 16
 } scheduling_state;
 
 /** A task is an execution of a task specification.  It has a state of execution

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -205,6 +205,8 @@ void dispatch_tasks(local_scheduler_state *state,
     assign_task_to_worker(state, dispatched_task->spec, *worker_index);
     /* Remove the available worker from the queue and free the struct. */
     utarray_pop_back(algorithm_state->available_workers);
+    free_task_spec(dispatched_task->spec);
+    free(dispatched_task);
   }
 }
 

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -215,7 +215,10 @@ void dispatch_tasks(local_scheduler_state *state,
  * A helper function to allocate a queue entry for a task specification and
  * push it onto a generic queue.
  *
- * @param task_queue A pointer to a task queue.
+ * @param task_queue A pointer to a task queue. NOTE: Because we are using
+ *        utlist.h, we must pass in a pointer to the queue we want to append
+ *        to. If we passed in the queue itself and the queue was empty, this
+ *        would append the task to a queue that we don't have a reference to.
  * @param spec The task specification to queue.
  * @return Void.
  */

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -43,8 +43,17 @@ void provide_scheduler_info(local_scheduler_state *state,
 
 /**
  * This function will be called when a new task is submitted by a worker for
- * execution.
+ * execution. The task will either be:
+ * 1. Put into the waiting queue, where it will wait for its dependencies to
+ *    become available.
+ * 2. Put into the dispatch queue, where it will wait for an available worker.
+ * 3. Given to the global scheduler to be scheduled.
  *
+ * Currently, the local scheduler policy is to keep the task if its
+ * dependencies are ready and there is an available worker.
+ *
+ * @param state The state of the local scheduler.
+ * @param algorithm_state State maintained by the scheduling algorithm.
  * @param task Task that is submitted by the worker.
  * @return Void.
  */

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -102,12 +102,21 @@ void handle_worker_available(local_scheduler_state *state,
 /** The following methods are for testing purposes only. */
 #ifdef PHOTON_TEST
 /**
- * Get the number of tasks currently queued locally.
+ * Get the number of tasks currently waiting for object dependencies to become
+ * available locally.
  *
  * @param algorithm_state State maintained by the scheduling algorithm.
- * @return The number of tasks queued locally.
+ * @return The number of tasks queued.
  */
-int num_tasks_in_queue(scheduling_algorithm_state *algorithm_state);
+int num_waiting_tasks(scheduling_algorithm_state *algorithm_state);
+
+/**
+ * Get the number of tasks currently waiting for a worker to become available.
+ *
+ * @param algorithm_state State maintained by the scheduling algorithm.
+ * @return The number of tasks queued.
+ */
+int num_dispatch_tasks(scheduling_algorithm_state *algorithm_state);
 #endif
 
 #endif /* PHOTON_ALGORITHM_H */

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -110,8 +110,7 @@ void free_local_scheduler(local_scheduler_state *state) {
 
 void assign_task_to_worker(local_scheduler_state *state,
                            task_spec *spec,
-                           int worker_index,
-                           bool from_global_scheduler) {
+                           int worker_index) {
   CHECK(worker_index < utarray_len(state->workers));
   worker *w = (worker *) utarray_eltptr(state->workers, worker_index);
   write_message(w->sock, EXECUTE_TASK, task_spec_size(spec), (uint8_t *) spec);
@@ -119,13 +118,8 @@ void assign_task_to_worker(local_scheduler_state *state,
   if (state->db != NULL) {
     task *task =
         alloc_task(spec, TASK_STATUS_RUNNING, get_db_client_id(state->db));
-    if (from_global_scheduler) {
-      task_table_update(state->db, task, (retry_info *) &photon_retry, NULL,
-                        NULL);
-    } else {
-      task_table_add_task(state->db, task, (retry_info *) &photon_retry, NULL,
-                          NULL);
-    }
+    task_table_update(state->db, task, (retry_info *) &photon_retry, NULL,
+                      NULL);
     /* Record which task this worker is executing. This will be freed in
      * process_message when the worker sends a GET_TASK message to the local
      * scheduler. */

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -160,15 +160,13 @@ void reconstruct_object_task_lookup_callback(object_id reconstruct_object_id,
   CHECKM(task != NULL,
          "No task information found for object during reconstruction");
   local_scheduler_state *state = user_context;
-  /* If the task's scheduling state is WAITING or SCHEDULED, assume that
+  /* If the task's scheduling state is pending completion, assume that
    * reconstruction is already being taken care of and cancel this
    * reconstruction operation. NOTE: This codepath is not responsible for
    * detecting failure of the other reconstruction, or updating the
    * scheduling_state accordingly. */
   scheduling_state task_status = task_state(task);
-  if (task_status == TASK_STATUS_WAITING ||
-      task_status == TASK_STATUS_SCHEDULED ||
-      task_status == TASK_STATUS_RUNNING) {
+  if (task_status < TASK_STATUS_DONE) {
     LOG_DEBUG("Task to reconstruct had scheduling state %d", task_status);
     return;
   }

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -166,7 +166,7 @@ void reconstruct_object_task_lookup_callback(object_id reconstruct_object_id,
    * detecting failure of the other reconstruction, or updating the
    * scheduling_state accordingly. */
   scheduling_state task_status = task_state(task);
-  if (task_status < TASK_STATUS_DONE) {
+  if (task_status != TASK_STATUS_DONE) {
     LOG_DEBUG("Task to reconstruct had scheduling state %d", task_status);
     return;
   }

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -35,8 +35,7 @@ void new_client_connection(event_loop *loop,
  */
 void assign_task_to_worker(local_scheduler_state *state,
                            task_spec *task,
-                           int worker_index,
-                           bool from_global_scheduler);
+                           int worker_index);
 
 /**
  * This is the callback that is used to process a notification from the Plasma

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -138,7 +138,8 @@ TEST object_reconstruction_test(void) {
      * left in the local scheduler's task queue. Then, clean up. */
     wait(NULL);
     free_task_spec(spec);
-    ASSERT_EQ(num_tasks_in_queue(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_waiting_tasks(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_dispatch_tasks(photon->photon_state->algorithm_state), 0);
     destroy_photon_mock(photon);
     PASS();
   }
@@ -217,7 +218,8 @@ TEST object_reconstruction_recursive_test(void) {
     /* Wait for the child process to exit and check that there are no tasks
      * left in the local scheduler's task queue. Then, clean up. */
     wait(NULL);
-    ASSERT_EQ(num_tasks_in_queue(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_waiting_tasks(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_dispatch_tasks(photon->photon_state->algorithm_state), 0);
     for (int i = 0; i < NUM_TASKS; ++i) {
       free_task_spec(specs[i]);
     }
@@ -278,7 +280,8 @@ TEST object_reconstruction_suppression_test(void) {
     /* Wait for the child process to exit and check that there are no tasks
      * left in the local scheduler's task queue. Then, clean up. */
     wait(NULL);
-    ASSERT_EQ(num_tasks_in_queue(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_waiting_tasks(photon->photon_state->algorithm_state), 0);
+    ASSERT_EQ(num_dispatch_tasks(photon->photon_state->algorithm_state), 0);
     free_task_spec(object_reconstruction_suppression_spec);
     db_disconnect(db);
     destroy_photon_mock(photon);
@@ -294,35 +297,41 @@ TEST object_notifications_test(void) {
   task_spec *spec = example_task_spec(1, 1);
   object_id oid = task_arg_id(spec, 0);
 
-  /* Check that the task gets queued if the task is submitted and a worker is
-   * available, but the input is not. Once the input is available, the task
-   * gets assigned. */
+  /* Check that the task gets queued in the waiting queue if the task is
+   * submitted and a worker is available, but the input is not. */
   handle_task_submitted(state, algorithm_state, spec);
   handle_worker_available(state, algorithm_state, worker_index);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 1);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 1);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 0);
+  /* Once the input is available, the task gets assigned. */
   handle_object_available(state, algorithm_state, oid);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 0);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 0);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 0);
   reset_worker(photon, worker_index);
 
-  /* Check that the task gets queued if the task is submitted and the input is
-   * available, but no worker is available yet. Once a worker is available, the
-   * task gets assigned. */
+  /* Check that the task gets queued in the dispatch queue if the task is
+   * submitted and the input is available, but no worker is available yet. */
   handle_task_submitted(state, algorithm_state, spec);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 1);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 0);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 1);
+  /* Once a worker is available, the task gets assigned. */
   handle_worker_available(state, algorithm_state, worker_index);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 0);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 0);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 0);
   reset_worker(photon, worker_index);
 
   /* If an object gets removed, check the first scenario again, where the task
-   * gets queued if the task is submitted and a worker is available, but the
-   * input is not. Once the input is made available again, the task gets
-   * assigned. */
+   * gets queued in the waiting task if the task is submitted and a worker is
+   * available, but the input is not. */
   handle_object_removed(state, oid);
   handle_task_submitted(state, algorithm_state, spec);
   handle_worker_available(state, algorithm_state, worker_index);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 1);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 1);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 0);
+  /*  Once the input is made available again, the task gets assigned. */
   handle_object_available(state, algorithm_state, oid);
-  ASSERT_EQ(num_tasks_in_queue(algorithm_state), 0);
+  ASSERT_EQ(num_waiting_tasks(algorithm_state), 0);
+  ASSERT_EQ(num_dispatch_tasks(algorithm_state), 0);
 
   free_task_spec(spec);
   destroy_photon_mock(photon);


### PR DESCRIPTION
This refactor splits the local scheduler's task queue into two queues. `waiting_task_queue` is for tasks that are waiting for object dependencies to become available. `dispatch_task_queue` is used for tasks whose dependencies are available but that are waiting on an available worker.

Once this is merged, we will be able to optimize moving tasks from the waiting queue to the dispatch queue.