### PR TITLE
Change fetch requests in plasma manager to use a single timer.

### DIFF
--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -185,7 +185,7 @@ struct plasma_request_buffer {
  * Call the request_transfer method, which well attempt to get an object from
  * a remote Plasma manager. If it is unable to get it from another Plasma
  * manager, it will cycle through a list of Plasma managers that have the
- * object.
+ * object. This method is only called from the tests.
  *
  * @param object_id The object ID of the object to transfer.
  * @param manager_count The number of managers that have the object.
@@ -197,6 +197,14 @@ void call_request_transfer(object_id object_id,
                            int manager_count,
                            const char *manager_vector[],
                            void *context);
+
+/*
+ * This runs periodically (every MANAGER_TIMEOUT milliseconds) and reissues
+ * transfer requests for all outstanding fetch requests. This is only exposed so
+ * that it can be called from the tests.
+ *
+ */
+int fetch_timeout_handler(event_loop *loop, timer_id id, void *context);
 
 /**
  * Clean up and free an active object context. Deregister it from the

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -177,6 +177,11 @@ TEST request_transfer_retry_test(void) {
   free(manager_vector);
   event_loop_add_timer(local_mock->loop, MANAGER_TIMEOUT * 2, test_done_handler,
                        local_mock->state);
+  /* Register the fetch timeout handler. This is normally done when the plasma
+   * manager is started. It is needed here so that retries will happen when
+   * fetch requests time out. */
+  event_loop_add_timer(local_mock->loop, MANAGER_TIMEOUT, fetch_timeout_handler,
+                       local_mock->state);
   event_loop_run(local_mock->loop);
 
   int read_fd = get_client_sock(remote_mock2->read_conn);


### PR DESCRIPTION
Currently, on multiple nodes, the following appears to hang.

```python
import ray
ray.init(redis_address="...")

@ray.remote
def f(x):
  return x

ray.get([f.remote(3) for _ in range(10000)])
```

Nothing is crashing, but the plasma manager is using 100% CPU and no other processes are doing anything. The manager appears to have way too many timers in its event loop, which are using up all its cycles. There is currently one timer for every object that is being fetched.

@stephanie-wang pointed out that this problem was introduced in #212 because it changed from fetching and getting objects serially to fetching and getting them in batches.

This change switches to using a single timer for all fetch requests instead of one timer per fetch request. This is similar to one of the changes made in the local scheduler in #219.