### PR TITLE
[WIP] Reconstruction for puts

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1347,7 +1347,8 @@ def put(value, worker=global_worker):
     if worker.mode == PYTHON_MODE:
       # In PYTHON_MODE, ray.put is the identity operation
       return value
-    object_id = photon.compute_put_id(worker.current_task_id, worker.put_index)
+
+    object_id = worker.photon_client.compute_put_id(worker.current_task_id, worker.put_index)
     worker.put_object(object_id, value)
     worker.put_index += 1
     return object_id

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -522,14 +522,3 @@ PyObject *check_simple_value(PyObject *self, PyObject *args) {
   }
   Py_RETURN_FALSE;
 }
-
-PyObject *compute_put_id(PyObject *self, PyObject *args) {
-  int put_index;
-  task_id task_id;
-  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
-                        &put_index)) {
-    return NULL;
-  }
-  object_id put_id = task_compute_put_id(task_id, put_index);
-  return PyObjectID_make(put_id);
-}

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -44,8 +44,6 @@ PyObject *check_simple_value(PyObject *self, PyObject *args);
 PyObject *PyTask_to_string(PyObject *, PyObject *args);
 PyObject *PyTask_from_string(PyObject *, PyObject *args);
 
-PyObject *compute_put_id(PyObject *self, PyObject *args);
-
 PyObject *PyTask_make(task_spec *task_spec);
 
 #endif /* COMMON_EXTENSION_H */

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -27,6 +27,8 @@ enum photon_message_type {
   RECONSTRUCT_OBJECT,
   /** Log a message to the event table. */
   EVENT_LOG_MESSAGE,
+  /** Add a result table entry for an object put. */
+  PUT_OBJECT,
 };
 
 // clang-format off

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -68,3 +68,12 @@ void photon_reconstruct_object(photon_conn *conn, object_id object_id) {
 void photon_log_message(photon_conn *conn) {
   write_message(conn->conn, LOG_MESSAGE, 0, NULL);
 }
+
+void photon_put_object(photon_conn *conn,
+                       task_id task_id,
+                       object_id object_id) {
+  DCHECK(sizeof(unique_id) == sizeof(task_id));
+  DCHECK(sizeof(unique_id) == sizeof(object_id));
+  unique_id put_ids[2] = {task_id, object_id};
+  write_message(conn->conn, PUT_OBJECT, sizeof(put_ids), (uint8_t *) put_ids);
+}

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -91,4 +91,14 @@ void photon_reconstruct_object(photon_conn *conn, object_id object_id);
  */
 void photon_log_message(photon_conn *conn);
 
+/**
+ * Record the mapping from object ID to task ID for put events.
+ *
+ * @param conn The connection information.
+ * @param task_id The ID of the task that called put.
+ * @param object_id The ID of the object being stored.
+ * @return Void.
+ */
+void photon_put_object(photon_conn *conn, task_id task_id, object_id object_id);
+
 #endif

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -77,6 +77,19 @@ static PyObject *PyPhotonClient_log_event(PyObject *self, PyObject *args) {
   Py_RETURN_NONE;
 }
 
+static PyObject *PyPhotonClient_compute_put_id(PyObject *self, PyObject *args) {
+  int put_index;
+  task_id task_id;
+  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
+                        &put_index)) {
+    return NULL;
+  }
+  object_id put_id = task_compute_put_id(task_id, put_index);
+  photon_put_object(((PyPhotonClient *) self)->photon_connection, task_id,
+                    put_id);
+  return PyObjectID_make(put_id);
+}
+
 static PyMethodDef PyPhotonClient_methods[] = {
     {"submit", (PyCFunction) PyPhotonClient_submit, METH_VARARGS,
      "Submit a task to the local scheduler."},
@@ -86,6 +99,8 @@ static PyMethodDef PyPhotonClient_methods[] = {
      METH_VARARGS, "Ask the local scheduler to reconstruct an object."},
     {"log_event", (PyCFunction) PyPhotonClient_log_event, METH_VARARGS,
      "Log an event to the event log through the local scheduler."},
+    {"compute_put_id", (PyCFunction) PyPhotonClient_compute_put_id,
+     METH_VARARGS, "Return the object ID for a put call within a task."},
     {NULL} /* Sentinel */
 };
 
@@ -133,8 +148,6 @@ static PyTypeObject PyPhotonClientType = {
 static PyMethodDef photon_methods[] = {
     {"check_simple_value", check_simple_value, METH_VARARGS,
      "Should the object be passed by value?"},
-    {"compute_put_id", compute_put_id, METH_VARARGS,
-     "Return the object ID for a put call within a task."},
     {"task_from_string", PyTask_from_string, METH_VARARGS,
      "Creates a Python PyTask object from a string representation of "
      "task_spec."},

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -317,6 +317,13 @@ void process_message(event_loop *loop,
   } break;
   case LOG_MESSAGE: {
   } break;
+  case PUT_OBJECT: {
+    unique_id *put_ids = (unique_id *) utarray_front(state->input_buffer);
+    task_id result_task_id = (task_id) put_ids[0];
+    object_id return_id = (object_id) put_ids[1];
+    result_table_add(state->db, return_id, result_task_id,
+                     (retry_info *) &photon_retry, NULL, NULL);
+  } break;
   default:
     /* This code should be unreachable. */
     CHECK(0);

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -133,9 +133,11 @@ class ReconstructionTests(unittest.TestCase):
         "object_store_addresses": plasma_addresses,
         }
 
-    # Start the rest of the services in the Ray cluster.
+    # Start the rest of the services in the Ray cluster. NOTE(swang): We need
+    # to use two workers per local scheduler to prevent deadlock for testPut.
     ray.worker._init(address_info=address_info, start_ray_local=True,
-                     num_workers=self.num_local_schedulers, num_local_schedulers=self.num_local_schedulers)
+                     num_workers=self.num_local_schedulers * 2,
+                     num_local_schedulers=self.num_local_schedulers)
 
   def tearDown(self):
     self.assertTrue(ray.services.all_processes_alive())
@@ -275,10 +277,143 @@ class ReconstructionTests(unittest.TestCase):
       value = ray.get(args[i])
       self.assertEqual(value[0], i)
 
+  def testPut(self):
+    # Define the size of one task's return argument so that the combined sum of
+    # all objects' sizes is at least twice the plasma stores' combined allotted
+    # memory.
+    num_objects = 1000
+    size = self.plasma_store_memory * 2 // (num_objects * 8)
+
+    # This task puts an array of size `size`, with the first index equal to
+    # `i`, into the object store and returns the resulting object ID.
+    @ray.remote
+    def put_task(i, size):
+      array = np.zeros(size)
+      array[0] = i
+      put_id = ray.put(array)
+      return [put_id]
+
+    # This task copies the given array, updates its first index with `i`, and
+    # returns it.
+    @ray.remote
+    def put_arg_task(i, arg):
+      arg = np.copy(arg)
+      arg[0] = i
+      return arg
+
+    # This task submits a remote task with a large numpy array as the argument.
+    # Ray internally puts the large array into the object store. The task
+    # returns the result of the remote task, which is the same array with the
+    # first index updated.
+    @ray.remote
+    def put_args_task(i, size):
+      array = np.zeros(size)
+      return ray.get(put_arg_task.remote(i, array))
+
+    # Test direct calls to ray.put. Launch num_objects instances of the remote
+    # task that does a put.
+    args = []
+    for i in range(num_objects):
+      arg = put_task.remote(i, size)
+      args.append(arg)
+
+    # Get the result of each put to force each task to finish. After some
+    # number of gets, old values should be evicted.
+    for i in range(num_objects):
+      value = ray.get(args[i])
+      value = ray.get(value[0])
+      self.assertEqual(value[0], i)
+    # Get each value again to force reconstruction.
+    for i in range(num_objects):
+      value = ray.get(args[i])
+      value = ray.get(value[0])
+      self.assertEqual(value[0], i)
+    # Get 10 values randomly.
+    for _ in range(10):
+      i  = np.random.randint(num_objects)
+      value = ray.get(args[i])
+      value = ray.get(value[0])
+      self.assertEqual(value[0], i)
+
+    # Test puts of remote task arguments. Launch num_objects instances of the
+    # remote task that calls a remote task with a large argument.
+    args = []
+    for i in range(num_objects):
+      arg = put_args_task.remote(i, size)
+      # TODO(swang): We get each value as we submit to prevent deadlock, since
+      # each of these tasks submits and then blocks on a remote task.
+      value = ray.get(arg)
+      self.assertEqual(value[0], i)
+      args.append(arg)
+    # Get each value again to force reconstruction.
+    for i in range(num_objects):
+      value = ray.get(args[i])
+      self.assertEqual(value[0], i)
+    # Get 10 values randomly.
+    for _ in range(10):
+      i  = np.random.randint(num_objects)
+      value = ray.get(args[i])
+      self.assertEqual(value[0], i)
+
+
+  # TODO(swang): The following test case is a gnarly example of deadlock due to
+  # ray.put! The root_task function does a ray.put to store the initial
+  # argument. Then, it launches a chain of dependencies, where each remote task
+  # is dependent on the one before it. By the time the last task has finished,
+  # the initial argument will have been evicted. To reconstruct the initial
+  # argument, root_task needs to be run again. Even if the job manages to
+  # return, it will continue to eat up workers, as each instance of root_task
+  # will resubmit another instance of root_task to reconstruct the initial
+  # argument.
+  #def testPut(self):
+  #  # Define the size of one task's return argument so that the combined sum of
+  #  # all objects' sizes is at least twice the plasma stores' combined allotted
+  #  # memory.
+  #  num_objects = 1000
+  #  size = self.plasma_store_memory * 2 // (num_objects * 8)
+
+  #  # Define a task with a single dependency, which returns its one argument.
+  #  @ray.remote
+  #  def single_dependency(i, arg):
+  #    arg = np.copy(arg)
+  #    arg[0] = i
+  #    return arg
+
+  #  @ray.remote
+  #  def root_task(size):
+  #    array = np.zeros(size)
+  #    arg = ray.put(array)
+
+  #    # Launch num_objects instances of the remote task, each dependent on the
+  #    # one before it.
+  #    args = []
+  #    for i in range(num_objects):
+  #      arg = single_dependency.remote(i, arg)
+  #      args.append(arg)
+
+  #    # Get each value to force each task to finish. After some number of gets,
+  #    # old values should be evicted.
+  #    for i in range(num_objects):
+  #      value = ray.get(args[i])
+  #      self.assertEqual(value[0], i)
+  #    # Get each value again to force reconstruction.
+  #    for i in range(num_objects):
+  #      value = ray.get(args[i])
+  #      self.assertEqual(value[0], i)
+  #    # Get 10 values randomly.
+  #    for _ in range(10):
+  #      i  = np.random.randint(num_objects)
+  #      value = ray.get(args[i])
+  #      self.assertEqual(value[0], i)
+
+  #    return True
+
+  #  ray.get(root_task.remote(size))
+
 class ReconstructionTestsMultinode(ReconstructionTests):
 
   # Run the same tests as the single-node suite, but with 4 local schedulers,
-  # one worker each.
+  # two workers each.
   num_local_schedulers = 4
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reconstruction for objects that were created through `ray.put` (including arguments of a remote task that were stored in the object store). This excludes `ray.put` calls by the driver.