### PR TITLE
Enable pushing error messages from C code.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(common STATIC
   state/object_table.c
   state/task_table.c
   state/db_client_table.c
+  state/error_table.c
   state/local_scheduler_table.c
   thirdparty/ae/ae.c
   thirdparty/sha256.c)

--- a/src/common/state/error_table.c
+++ b/src/common/state/error_table.c
@@ -1,0 +1,54 @@
+#include "error_table.h"
+#include "redis.h"
+
+void push_error_hmset(db_handle *db_handle,
+                      unique_id driver_id,
+                      unique_id error_id,
+                      char *error_type,
+                      char *error_message,
+                      error_table_push_error_hmset_callback done_callback,
+                      retry_info *retry) {
+  error_table_push_error_hmset_data *data =
+      malloc(sizeof(error_table_push_error_hmset_data) - 1 +
+             strlen(error_type) + strlen(error_message));
+  data->driver_id = driver_id;
+  data->error_id = error_id;
+  data->error_type_len = strlen(error_type);
+  data->error_message_len = strlen(error_message);
+  memcpy(&data->error_type_and_message[0], error_type, data->error_type_len);
+  memcpy(&data->error_type_and_message[data->error_type_len], error_message,
+         data->error_message_len);
+
+  init_table_callback(db_handle, NIL_ID, __func__, data, retry, done_callback,
+                      redis_error_table_push_error_hmset, NULL);
+}
+
+void push_error_rpush(db_handle *db_handle,
+                      unique_id driver_id,
+                      unique_id error_id,
+                      retry_info *retry) {
+  error_table_push_error_rpush_data *data =
+      malloc(sizeof(error_table_push_error_rpush_data));
+  data->error_id = error_id;
+  data->driver_id = driver_id;
+
+  init_table_callback(db_handle, NIL_ID, __func__, data, retry, NULL,
+                      redis_error_table_push_error_rpush, NULL);
+}
+
+void hmset_error_done_callback(db_handle *db_handle,
+                               unique_id driver_id,
+                               unique_id error_id) {
+  push_error_rpush(db_handle, driver_id, error_id, NULL);
+}
+
+void push_error(db_handle *db_handle,
+                unique_id driver_id,
+                char *error_type,
+                char *error_message,
+                retry_info *retry) {
+  /* TODO(rkn): The method globally_unique_id needs to be more efficient. */
+  unique_id error_id = globally_unique_id();
+  push_error_hmset(db_handle, driver_id, error_id, error_type, error_message,
+                   hmset_error_done_callback, retry);
+}

--- a/src/common/state/error_table.h
+++ b/src/common/state/error_table.h
@@ -1,0 +1,60 @@
+#ifndef ERROR_TABLE_H
+#define ERROR_TABLE_H
+
+#include "db.h"
+#include "table.h"
+
+/* Data structures that are needed for pushing error messages to Redis. These
+ * data structures are only used internally. */
+
+typedef struct {
+  /* The ID of the driver that the error should be pushed to. */
+  unique_id driver_id;
+  /* The string used as an identifier for this error message. */
+  unique_id error_id;
+  /* The length of the error type. */
+  int64_t error_type_len;
+  /* The length of the error message. */
+  int64_t error_message_len;
+  /* The concatenation of the error type and error message. The size of this
+   * array will actually be strlen(error_type) + strlen(error_message). The
+   * error type will come first, followed by the error message. The substrings
+   * in this array are not null-terminated. */
+  uint8_t error_type_and_message[1];
+} error_table_push_error_hmset_data;
+
+/* Data that is needed to publish local scheduer heartbeats to the local
+ * scheduler table. */
+typedef struct {
+  /* The ID used to identify the driver involved. */
+  unique_id driver_id;
+  /* The ID used to identify the error. */
+  unique_id error_id;
+} error_table_push_error_rpush_data;
+
+/* Callback used internally for pushing an error to Redis. This is only used
+ * internally. */
+typedef void (*error_table_push_error_hmset_callback)(db_handle *db,
+                                                      unique_id driver_id,
+                                                      unique_id error_id);
+
+/**
+ * Send an error message to a driver process. This will be printed in the
+ * background for the driver process.
+ *
+ * @param db_handle Database handle.
+ * @param driver_id The ID of the driver or job process.
+ * @param error_type A null-terminated string indicating the type of error being
+ *        pushed.
+ * @param error_message A null-terminated string indicating the error message to
+ *        send to the driver.
+ * @param retry Information about retrying the request to the database.
+ * @return Void.
+ */
+void push_error(db_handle *db_handle,
+                unique_id driver_id,
+                char *error_type,
+                char *error_message,
+                retry_info *retry);
+
+#endif /* ERROR_TABLE_H */

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -247,4 +247,22 @@ void redis_local_scheduler_table_send_info(table_callback_data *callback_data);
 
 void redis_object_info_subscribe(table_callback_data *callback_data);
 
+/**
+ * Put an error message to Redis.
+ *
+ * @param callback_data Data structure containing redis connection and timeout
+ *        information.
+ * @return Void.
+ */
+void redis_error_table_push_error_hmset(table_callback_data *callback_data);
+
+/**
+ * Put an error message identifier in Redis.
+ *
+ * @param callback_data Data structure containing redis connection and timeout
+ *        information.
+ * @return Void.
+ */
+void redis_error_table_push_error_rpush(table_callback_data *callback_data);
+
 #endif /* REDIS_H */


### PR DESCRIPTION
This can be used from C via something like

```c
#include "state/error_table.h"

task_spec *spec = ...

push_error(db, task_spec_driver_id(spec), "impossible resource request error",
           "This task requires more resources than are available in the system and cannot currently be run.");
```

TODO:
- There are currently no tests. What is a good test for this?

Notes:
- The motivation for this is that if a task requests 10 GPUs and there aren't any GPUs, the global scheduler will determine that the request cannot be fulfilled, and so the global scheduler can push an error message to the driver process that submitted the task. On the other hand, I can't think of other use cases for this at the moment.
- This is a special case of a much more general feature that we need, which is the ability to do LOGGING from C processes (to an "event log" in Redis).
- This should be implemented more cleanly with a Redis module command.