### PR TITLE
Start and clean up workers from the local scheduler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ install:
   - ./.travis/install-dependencies.sh
   - ./.travis/install-ray.sh
 
+  - if [[ "$PYTHON" == "3.5" ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi
+
   - cd python/core
   - bash ../../src/common/test/run_tests.sh
   - bash ../../src/plasma/test/run_tests.sh

--- a/python/photon/photon_services.py
+++ b/python/photon/photon_services.py
@@ -11,11 +11,17 @@ import time
 def random_name():
   return str(random.randint(0, 99999999))
 
-def start_local_scheduler(plasma_store_name, plasma_manager_name=None,
-                          worker_path=None, plasma_address=None,
-                          node_ip_address="127.0.0.1", redis_address=None,
-                          use_valgrind=False, use_profiler=False,
-                          redirect_output=False, static_resource_list=None):
+def start_local_scheduler(plasma_store_name,
+                          plasma_manager_name=None,
+                          worker_path=None,
+                          plasma_address=None,
+                          node_ip_address="127.0.0.1",
+                          redis_address=None,
+                          use_valgrind=False,
+                          use_profiler=False,
+                          redirect_output=False,
+                          static_resource_list=None,
+                          num_workers=0):
   """Start a local scheduler process.
 
   Args:
@@ -41,6 +47,8 @@ def start_local_scheduler(plasma_store_name, plasma_manager_name=None,
     static_resource_list (list): A list of integers specifying the local
       scheduler's resource capacities. The resources should appear in an order
       matching the order defined in task.h.
+    num_workers (int): The number of workers that the local scheduler should
+      start.
 
   Return:
     A tuple of the name of the local scheduler socket and the process ID of the
@@ -52,7 +60,12 @@ def start_local_scheduler(plasma_store_name, plasma_manager_name=None,
     raise Exception("Cannot use valgrind and profiler at the same time.")
   local_scheduler_executable = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../core/src/photon/photon_scheduler")
   local_scheduler_name = "/tmp/scheduler{}".format(random_name())
-  command = [local_scheduler_executable, "-s", local_scheduler_name, "-p", plasma_store_name, "-h", node_ip_address]
+  command = [local_scheduler_executable,
+             "-s", local_scheduler_name,
+             "-p", plasma_store_name,
+             "-h", node_ip_address,
+             "-n", str(num_workers),
+             ]
   if plasma_manager_name is not None:
     command += ["-m", plasma_manager_name]
   if worker_path is not None:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -735,9 +735,15 @@ def get_address_info_from_redis(redis_address, node_ip_address, num_retries=5):
       time.sleep(1)
     counter += 1
 
-def _init(address_info=None, start_ray_local=False, object_id_seed=None,
-          num_workers=None, num_local_schedulers=None,
-          driver_mode=SCRIPT_MODE, num_cpus=None, num_gpus=None):
+def _init(address_info=None,
+          start_ray_local=False,
+          object_id_seed=None,
+          num_workers=None,
+          num_local_schedulers=None,
+          driver_mode=SCRIPT_MODE,
+          start_workers_from_local_scheduler=True,
+          num_cpus=None,
+          num_gpus=None):
   """Helper method to connect to an existing Ray cluster or start a new one.
 
   This method handles two cases. Either a Ray cluster already exists and we
@@ -764,6 +770,9 @@ def _init(address_info=None, start_ray_local=False, object_id_seed=None,
       only provided if start_ray_local is True.
     driver_mode (bool): The mode in which to start the driver. This should be
       one of ray.SCRIPT_MODE, ray.PYTHON_MODE, and ray.SILENT_MODE.
+    start_workers_from_local_scheduler (bool): If this flag is True, then start
+      the initial workers from the local scheduler. Else, start them from
+      Python. The latter case is for debugging purposes only.
     num_cpus: A list containing the number of CPUs the local schedulers should
       be configured with.
     num_gpus: A list containing the number of GPUs the local schedulers should
@@ -815,7 +824,9 @@ def _init(address_info=None, start_ray_local=False, object_id_seed=None,
                                            node_ip_address=node_ip_address,
                                            num_workers=num_workers,
                                            num_local_schedulers=num_local_schedulers,
-                                           num_cpus=num_cpus, num_gpus=num_gpus)
+                                           start_workers_from_local_scheduler=start_workers_from_local_scheduler,
+                                           num_cpus=num_cpus,
+                                           num_gpus=num_gpus)
   else:
     if redis_address is None:
       raise Exception("If start_ray_local=False, then redis_address must be provided.")

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -27,20 +27,14 @@ enum photon_message_type {
   RECONSTRUCT_OBJECT,
   /** Log a message to the event table. */
   EVENT_LOG_MESSAGE,
+  /** Register a worker's process ID with the local scheduler. */
+  REGISTER_PID,
 };
-
-// clang-format off
-/** Contains all information that is associated to a worker. */
-typedef struct {
-  int sock;
-  /** A pointer to a task object, to update the task table. */
-  task *task_in_progress;
-} worker;
-// clang-format on
 
 /* These are needed to define the UT_arrays. */
 UT_icd task_ptr_icd;
-UT_icd worker_icd;
+UT_icd workers_icd;
+UT_icd pid_t_icd;
 
 /** Internal state of the scheduling algorithm. */
 typedef struct scheduling_algorithm_state scheduling_algorithm_state;
@@ -50,7 +44,7 @@ typedef struct scheduling_algorithm_state scheduling_algorithm_state;
  *  scheduler. */
 typedef struct {
   /** The script to use when starting a new worker. */
-  char *start_worker_command;
+  const char **start_worker_command;
   /** Whether there is a global scheduler. */
   bool global_scheduler_exists;
 } local_scheduler_config;
@@ -65,6 +59,9 @@ typedef struct {
    *  structs when we free the scheduler state and also to access the worker
    *  structs in the tests. */
   UT_array *workers;
+  /** List of the process IDs for child processes (workers) started by the
+   *  local scheduler that have not sent a REGISTER_PID message yet. */
+  UT_array *child_pids;
   /** The handle to the database. */
   db_handle *db;
   /** The Plasma client. */
@@ -90,6 +87,11 @@ typedef struct {
    *  no task is running on the worker, this will be NULL. This is used to
    *  update the task table. */
   task *task_in_progress;
+  /** The process ID of the client. If this is set to zero, the client has not
+   *  yet registered a process ID. */
+  pid_t pid;
+  /** Whether the client is a child process of the local scheduler. */
+  bool is_child;
   /** A pointer to the local scheduler state. */
   local_scheduler_state *local_scheduler_state;
 } local_scheduler_client;

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -7,6 +7,11 @@
 photon_conn *photon_connect(const char *photon_socket) {
   photon_conn *result = malloc(sizeof(photon_conn));
   result->conn = connect_ipc_sock(photon_socket);
+  /* If this is a worker, register the process ID with the local scheduler. */
+  pid_t my_pid = getpid();
+  int success = write_message(result->conn, REGISTER_PID, sizeof(my_pid),
+                              (uint8_t *) &my_pid);
+  CHECKM(success == 0, "Unable to register worker with local scheduler");
   return result;
 }
 

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -20,6 +20,7 @@ static int PyPhotonClient_init(PyPhotonClient *self,
   if (!PyArg_ParseTuple(args, "s", &socket_name)) {
     return -1;
   }
+  /* Connect to the Photon scheduler. */
   self->photon_connection = photon_connect(socket_name);
   return 0;
 }

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -79,8 +79,9 @@ local_scheduler_state *init_local_scheduler(
     const char *plasma_store_socket_name,
     const char *plasma_manager_address,
     bool global_scheduler_exists,
+    const double static_resource_vector[],
     const char *worker_path,
-    const double static_resource_vector[]);
+    int num_workers);
 
 void free_local_scheduler(local_scheduler_state *state);
 
@@ -90,6 +91,10 @@ void process_message(event_loop *loop,
                      int client_sock,
                      void *context,
                      int events);
+
+void kill_worker(local_scheduler_client *worker, bool wait);
+
+void start_worker(local_scheduler_state *state);
 #endif
 
 #endif /* PHOTON_SCHEDULER_H */

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -41,17 +41,22 @@ typedef struct {
   local_scheduler_state *photon_state;
   /** Photon's event loop. */
   event_loop *loop;
-  /** A Photon client connection. */
-  photon_conn *conn;
+  /** Number of Photon client connections, or mock workers. */
+  int num_photon_conns;
+  /** Photon client connections. */
+  photon_conn **conns;
 } photon_mock;
 
-photon_mock *init_photon_mock(bool connect_to_redis) {
+photon_mock *init_photon_mock(bool connect_to_redis,
+                              int num_workers,
+                              int num_mock_workers) {
+  const char *node_ip_address = "127.0.0.1";
   const char *redis_addr = NULL;
   int redis_port = -1;
   const double static_resource_conf[MAX_RESOURCE_INDEX] = {DEFAULT_NUM_CPUS,
                                                            DEFAULT_NUM_GPUS};
   if (connect_to_redis) {
-    redis_addr = "127.0.0.1";
+    redis_addr = node_ip_address;
     redis_port = 6379;
   }
 
@@ -67,23 +72,44 @@ photon_mock *init_photon_mock(bool connect_to_redis) {
   UT_string *photon_socket_name =
       bind_ipc_sock_retry(photon_socket_name_format, &mock->photon_fd);
   CHECK(mock->plasma_fd >= 0 && mock->photon_fd >= 0);
+
+  UT_string *worker_command;
+  utstring_new(worker_command);
+  utstring_printf(worker_command,
+                  "python ../../python/ray/workers/default_worker.py "
+                  "--node-ip-address=%s --object-store-name=%s "
+                  "--object-store-manager-name=%s --local-scheduler-name=%s "
+                  "--redis-address=%s:%d",
+                  node_ip_address, plasma_store_socket_name,
+                  utstring_body(plasma_manager_socket_name),
+                  utstring_body(photon_socket_name), redis_addr, redis_port);
+
   mock->photon_state = init_local_scheduler(
       "127.0.0.1", mock->loop, redis_addr, redis_port,
       utstring_body(photon_socket_name), plasma_store_socket_name,
-      utstring_body(plasma_manager_socket_name), NULL, false, NULL,
-      static_resource_conf);
+      utstring_body(plasma_manager_socket_name), NULL, false,
+      static_resource_conf, utstring_body(worker_command), num_workers);
+
   /* Connect a Photon client. */
-  mock->conn = photon_connect(utstring_body(photon_socket_name));
-  new_client_connection(mock->loop, mock->photon_fd,
-                        (void *) mock->photon_state, 0);
+  mock->num_photon_conns = num_mock_workers;
+  mock->conns = malloc(sizeof(photon_conn *) * num_mock_workers);
+  for (int i = 0; i < num_mock_workers; ++i) {
+    mock->conns[i] = photon_connect(utstring_body(photon_socket_name));
+    new_client_connection(mock->loop, mock->photon_fd,
+                          (void *) mock->photon_state, 0);
+  }
+
+  utstring_free(worker_command);
   utstring_free(plasma_manager_socket_name);
   utstring_free(photon_socket_name);
   return mock;
 }
 
 void destroy_photon_mock(photon_mock *mock) {
-  photon_disconnect(mock->conn);
-  close(mock->photon_fd);
+  for (int i = 0; i < mock->num_photon_conns; ++i) {
+    photon_disconnect(mock->conns[i]);
+  }
+  free(mock->conns);
   close(mock->plasma_fd);
   /* This also frees mock->loop. */
   free_local_scheduler(mock->photon_state);
@@ -103,7 +129,9 @@ void reset_worker(photon_mock *mock, local_scheduler_client *worker) {
  * value, the task should get assigned to a worker again.
  */
 TEST object_reconstruction_test(void) {
-  photon_mock *photon = init_photon_mock(true);
+  photon_mock *photon = init_photon_mock(true, 0, 1);
+  photon_conn *worker = photon->conns[0];
+
   /* Create a task with zero dependencies and one return value. */
   task_spec *spec = example_task_spec(0, 1);
   object_id return_id = task_return(spec, 0);
@@ -125,10 +153,10 @@ TEST object_reconstruction_test(void) {
   if (pid == 0) {
     /* Make sure we receive the task twice. First from the initial submission,
      * and second from the reconstruct request. */
-    photon_submit(photon->conn, spec);
-    task_spec *task_assigned = photon_get_task(photon->conn);
+    photon_submit(worker, spec);
+    task_spec *task_assigned = photon_get_task(worker);
     ASSERT_EQ(memcmp(task_assigned, spec, task_spec_size(spec)), 0);
-    task_spec *reconstruct_task = photon_get_task(photon->conn);
+    task_spec *reconstruct_task = photon_get_task(worker);
     ASSERT_EQ(memcmp(reconstruct_task, spec, task_spec_size(spec)), 0);
     /* Clean up. */
     free_task_spec(reconstruct_task);
@@ -150,7 +178,7 @@ TEST object_reconstruction_test(void) {
                         (retry_info *) &photon_retry, NULL, NULL);
     /* Trigger reconstruction, and run the event loop again. */
     object_id return_id = task_return(spec, 0);
-    photon_reconstruct_object(photon->conn, return_id);
+    photon_reconstruct_object(worker, return_id);
     event_loop_add_timer(photon->loop, 500,
                          (event_loop_timer_handler) timeout_handler, NULL);
     event_loop_run(photon->loop);
@@ -171,7 +199,8 @@ TEST object_reconstruction_test(void) {
  * should trigger reconstruction of all previous tasks in the lineage.
  */
 TEST object_reconstruction_recursive_test(void) {
-  photon_mock *photon = init_photon_mock(true);
+  photon_mock *photon = init_photon_mock(true, 0, 1);
+  photon_conn *worker = photon->conns[0];
   /* Create a chain of tasks, each one dependent on the one before it. Mark
    * each object as available so that tasks will run immediately. */
   const int NUM_TASKS = 10;
@@ -204,11 +233,11 @@ TEST object_reconstruction_recursive_test(void) {
   if (pid == 0) {
     /* Submit the tasks, and make sure each one gets assigned to a worker. */
     for (int i = 0; i < NUM_TASKS; ++i) {
-      photon_submit(photon->conn, specs[i]);
+      photon_submit(worker, specs[i]);
     }
     /* Make sure we receive each task from the initial submission. */
     for (int i = 0; i < NUM_TASKS; ++i) {
-      task_spec *task_assigned = photon_get_task(photon->conn);
+      task_spec *task_assigned = photon_get_task(worker);
       ASSERT_EQ(memcmp(task_assigned, specs[i], task_spec_size(task_assigned)),
                 0);
       free_task_spec(task_assigned);
@@ -216,7 +245,7 @@ TEST object_reconstruction_recursive_test(void) {
     /* Check that the workers receive all tasks in the final return object's
      * lineage during reconstruction. */
     for (int i = 0; i < NUM_TASKS; ++i) {
-      task_spec *task_assigned = photon_get_task(photon->conn);
+      task_spec *task_assigned = photon_get_task(worker);
       bool found = false;
       for (int j = 0; j < NUM_TASKS; ++j) {
         if (specs[j] == NULL) {
@@ -249,7 +278,7 @@ TEST object_reconstruction_recursive_test(void) {
     /* Trigger reconstruction for the last object, and run the event loop
      * again. */
     object_id return_id = task_return(specs[NUM_TASKS - 1], 0);
-    photon_reconstruct_object(photon->conn, return_id);
+    photon_reconstruct_object(worker, return_id);
     event_loop_add_timer(photon->loop, 500,
                          (event_loop_timer_handler) timeout_handler, NULL);
     event_loop_run(photon->loop);
@@ -275,25 +304,27 @@ task_spec *object_reconstruction_suppression_spec;
 void object_reconstruction_suppression_callback(object_id object_id,
                                                 void *user_context) {
   /* Submit the task after adding the object to the object table. */
-  photon_mock *photon = user_context;
-  photon_submit(photon->conn, object_reconstruction_suppression_spec);
+  photon_conn *worker = user_context;
+  photon_submit(worker, object_reconstruction_suppression_spec);
 }
 
 TEST object_reconstruction_suppression_test(void) {
-  photon_mock *photon = init_photon_mock(true);
+  photon_mock *photon = init_photon_mock(true, 0, 1);
+  photon_conn *worker = photon->conns[0];
+
   object_reconstruction_suppression_spec = example_task_spec(0, 1);
   object_id return_id = task_return(object_reconstruction_suppression_spec, 0);
   pid_t pid = fork();
   if (pid == 0) {
     /* Make sure we receive the task once. This will block until the
      * object_table_add callback completes. */
-    task_spec *task_assigned = photon_get_task(photon->conn);
+    task_spec *task_assigned = photon_get_task(worker);
     ASSERT_EQ(memcmp(task_assigned, object_reconstruction_suppression_spec,
                      task_spec_size(object_reconstruction_suppression_spec)),
               0);
     /* Trigger a reconstruction. We will check that no tasks get queued as a
      * result of this line in the event loop process. */
-    photon_reconstruct_object(photon->conn, return_id);
+    photon_reconstruct_object(worker, return_id);
     /* Clean up. */
     free_task_spec(task_assigned);
     free_task_spec(object_reconstruction_suppression_spec);
@@ -309,7 +340,7 @@ TEST object_reconstruction_suppression_test(void) {
     object_table_add(db, return_id, 1, (unsigned char *) NIL_DIGEST,
                      (retry_info *) &photon_retry,
                      object_reconstruction_suppression_callback,
-                     (void *) photon);
+                     (void *) worker);
     /* Run the event loop. NOTE: OSX appears to require the parent process to
      * listen for events on the open file descriptors. */
     event_loop_add_timer(photon->loop, 1000,
@@ -328,7 +359,7 @@ TEST object_reconstruction_suppression_test(void) {
 }
 
 TEST task_dependency_test(void) {
-  photon_mock *photon = init_photon_mock(false);
+  photon_mock *photon = init_photon_mock(false, 0, 1);
   local_scheduler_state *state = photon->photon_state;
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
@@ -403,7 +434,7 @@ TEST task_dependency_test(void) {
 }
 
 TEST task_multi_dependency_test(void) {
-  photon_mock *photon = init_photon_mock(false);
+  photon_mock *photon = init_photon_mock(false, 0, 1);
   local_scheduler_state *state = photon->photon_state;
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
@@ -476,12 +507,73 @@ TEST task_multi_dependency_test(void) {
   PASS();
 }
 
+TEST start_kill_workers_test(void) {
+  /* Start some workers. */
+  int num_workers = 4;
+  photon_mock *photon = init_photon_mock(true, num_workers, 0);
+  /* We start off with num_workers children processes, but no workers
+   * registered yet. */
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), num_workers);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), 0);
+
+  /* Make sure that each worker connects to the photon scheduler. This for loop
+   * will hang if one of the workers does not connect. */
+  for (int i = 0; i < num_workers; ++i) {
+    new_client_connection(photon->loop, photon->photon_fd,
+                          (void *) photon->photon_state, 0);
+  }
+
+  /* After handling each worker's initial connection, we should now have all
+   * workers accounted for, but we haven't yet matched up process IDs with our
+   * children processes. */
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), num_workers);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
+
+  /* Each worker should register its process ID. */
+  for (int i = 0; i < utarray_len(photon->photon_state->workers); ++i) {
+    local_scheduler_client *worker =
+        *(local_scheduler_client **) utarray_eltptr(
+            photon->photon_state->workers, i);
+    process_message(photon->photon_state->loop, worker->sock, worker, 0);
+  }
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
+
+  /* After killing a worker, its state is cleaned up. */
+  local_scheduler_client *worker = *(local_scheduler_client **) utarray_eltptr(
+      photon->photon_state->workers, 0);
+  kill_worker(worker, true);
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers - 1);
+
+  /* Start a worker after the local scheduler has been initialized. */
+  start_worker(photon->photon_state);
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 1);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers - 1);
+  /* Make sure the new worker connects to the photon scheduler. */
+  new_client_connection(photon->loop, photon->photon_fd,
+                        (void *) photon->photon_state, 0);
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 1);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
+  /* Make sure that the new worker registers its process ID. */
+  worker = *(local_scheduler_client **) utarray_eltptr(
+      photon->photon_state->workers, num_workers - 1);
+  process_message(photon->photon_state->loop, worker->sock, worker, 0);
+  ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);
+  ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
+
+  /* Clean up. */
+  destroy_photon_mock(photon);
+  PASS();
+}
+
 SUITE(photon_tests) {
   RUN_REDIS_TEST(object_reconstruction_test);
   RUN_REDIS_TEST(object_reconstruction_recursive_test);
   RUN_REDIS_TEST(object_reconstruction_suppression_test);
   RUN_TEST(task_dependency_test);
   RUN_TEST(task_multi_dependency_test);
+  RUN_TEST(start_kill_workers_test);
 }
 
 GREATEST_MAIN_DEFS();

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -16,7 +16,10 @@ class ComponentFailureTest(unittest.TestCase):
     def f():
       ray.worker.global_worker.plasma_client.get(obj_id)
 
-    ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
+    ray.worker._init(num_workers=1,
+                     driver_mode=ray.SILENT_MODE,
+                     start_workers_from_local_scheduler=False,
+                     start_ray_local=True)
 
     # Have the worker wait in a get call.
     f.remote()
@@ -44,7 +47,10 @@ class ComponentFailureTest(unittest.TestCase):
     def f():
       ray.worker.global_worker.plasma_client.wait([obj_id])
 
-    ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
+    ray.worker._init(num_workers=1,
+                     driver_mode=ray.SILENT_MODE,
+                     start_workers_from_local_scheduler=False,
+                     start_ray_local=True)
 
     # Have the worker wait in a get call.
     f.remote()

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -183,6 +183,22 @@ class SerializationTest(unittest.TestCase):
 
 class WorkerTest(unittest.TestCase):
 
+  def testPythonWorkers(self):
+    # Test the codepath for starting workers from the Python script, instead of
+    # the local scheduler. This codepath is for debugging purposes only.
+    num_workers = 4
+    ray.worker._init(num_workers=num_workers,
+                     start_workers_from_local_scheduler=False,
+                     start_ray_local=True)
+
+    @ray.remote
+    def f(x):
+      return x
+
+    values = ray.get([f.remote(1) for i in range(num_workers * 2)])
+    self.assertEqual(values, [1] * (num_workers * 2))
+    ray.worker.cleanup()
+
   def testPutGet(self):
     ray.init(num_workers=0)
 


### PR DESCRIPTION
Workers can be started from either the local scheduler or the Python script, as before. Workers send their process IDs to the local scheduler upon initial connection, so that the local scheduler can clean up worker child processes.