### PR TITLE
fix segfault in photon.Task

### DIFF
--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -323,7 +323,9 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
 }
 
 static void PyTask_dealloc(PyTask *self) {
-  free_task_spec(self->spec);
+  if (self->spec != NULL) {
+    free_task_spec(self->spec);
+  }
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 


### PR DESCRIPTION
Before:
```
In [1]: import photon

In [2]: photon.Task()
Segmentation fault (core dumped)
```

After:
```
In [1]: import photon

In [2]: photon.Task()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-f8e88d989d6f> in <module>()
----> 1 photon.Task()

TypeError: function takes exactly 6 arguments (0 given)
```

The problem was that the first if in PyTask_init returned, which means that `task->spec` is 0. This led to the constructor segfaulting.