### PR TITLE
[WIP] Allow start_ray.sh to take a object manager port.

### DIFF
--- a/python/plasma/plasma.py
+++ b/python/plasma/plasma.py
@@ -325,7 +325,10 @@ def start_plasma_store(plasma_store_memory=DEFAULT_PLASMA_STORE_MEMORY, use_valg
       time.sleep(0.1)
   return plasma_store_name, pid
 
-def start_plasma_manager(store_name, redis_address, node_ip_address="127.0.0.1", num_retries=20, use_valgrind=False, run_profiler=False, redirect_output=False):
+def new_port():
+  return random.randint(10000, 65535)
+
+def start_plasma_manager(store_name, redis_address, plasma_manager_port=None, node_ip_address="127.0.0.1", num_retries=20, use_valgrind=False, run_profiler=False, redirect_output=False):
   """Start a plasma manager and return the ports it listens on.
 
   Args:
@@ -346,13 +349,16 @@ def start_plasma_manager(store_name, redis_address, node_ip_address="127.0.0.1",
   """
   plasma_manager_executable = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../core/src/plasma/plasma_manager")
   plasma_manager_name = "/tmp/plasma_manager{}".format(random_name())
-  port = None
+  if plasma_manager_port is not None:
+    assert num_retries == 1
+    port = plasma_manager_port
+  else:
+    port = new_port()
   process = None
   counter = 0
   while counter < num_retries:
     if counter > 0:
       print("Plasma manager failed to start, retrying now.")
-    port = random.randint(10000, 65535)
     command = [plasma_manager_executable,
                "-s", store_name,
                "-m", plasma_manager_name,
@@ -374,5 +380,7 @@ def start_plasma_manager(store_name, redis_address, node_ip_address="127.0.0.1",
     # See if the process has terminated
     if process.poll() == None:
       return plasma_manager_name, process, port
+    # Generate a new port and try again.
+    port = new_port()
     counter += 1
   raise Exception("Couldn't start plasma manager.")

--- a/scripts/start_ray.py
+++ b/scripts/start_ray.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser(description="Parse addresses for the worker to 
 parser.add_argument("--node-ip-address", required=False, type=str, help="the IP address of the worker's node")
 parser.add_argument("--redis-address", required=False, type=str, help="the address to use for connecting to Redis")
 parser.add_argument("--redis-port", required=False, type=str, help="the port to use for starting Redis")
+parser.add_argument("--object-manager-port", required=False, type=int, help="the port to use for starting the object manager")
 parser.add_argument("--num-workers", default=10, required=False, type=int, help="the number of workers to start on this node")
 parser.add_argument("--head", action="store_true", help="provide this argument for the head node")
 
@@ -50,10 +51,13 @@ if __name__ == "__main__":
       node_ip_address = args.node_ip_address
     print("Using IP address {} for this node.".format(node_ip_address))
 
+    address_info = {}
     if args.redis_port is not None:
-      address_info = {"redis_address": "{}:{}".format(node_ip_address,
-                                                      args.redis_port)}
-    else:
+      address_info["redis_address"] = "{}:{}".format(node_ip_address,
+                                                     args.redis_port)
+    if args.object_manager_port is not None:
+      address_info["object_manager_port"] = args.object_manager_port
+    if address_info == {}:
       address_info = None
 
     address_info = services.start_ray_head(address_info=address_info,
@@ -99,6 +103,7 @@ if __name__ == "__main__":
     check_no_existing_redis_clients(node_ip_address, args.redis_address)
     address_info = services.start_ray_node(node_ip_address=node_ip_address,
                                            redis_address=args.redis_address,
+                                           object_manager_port=args.object_manager_port,
                                            num_workers=args.num_workers,
                                            cleanup=False,
                                            redirect_output=True)


### PR DESCRIPTION
I need to clean this up before merging, but this should allow us to specify the port for the object manager to use when we call `start_ray.sh` by passing in a flag like `--object-manager-port=12345`.