### PR TITLE
Fix test_illegal_put failure in plasma test.

### DIFF
--- a/python/plasma/test/test.py
+++ b/python/plasma/test/test.py
@@ -762,7 +762,8 @@ class TestPlasmaManager(unittest.TestCase):
       time.sleep(0.1)
 
     print("Time waiting for plasma manager to fail = {:.2}".format(100 - time_left))
-    self.assertNotEqual([self.p5.poll(), self.p4.poll()], [None, None])
+    # Check that exactly one of the plasma managers has died.
+    self.assertEqual([self.p5.poll(), self.p4.poll()].count(None), 1)
 
   def test_illegal_functionality(self):
     # Create an object id string.

--- a/python/plasma/test/test.py
+++ b/python/plasma/test/test.py
@@ -747,18 +747,22 @@ class TestPlasmaManager(unittest.TestCase):
         j += 1
       memory_buffer2[i] = chr(j % 256)
     self.client2.seal(object_id)
-    # Give the second manager some time to complete the seal, then make sure it
-    # exited.
+    # Make sure that one of the plasma managers exited (the second one to call
+    # RAY.OBJECT_TABLE_ADD should have exited). In the vast majority of cases,
+    # this should be p5. However, on Travis, it is frequently p4.
     time_left = 100
     while time_left > 0:
       if self.p5.poll() != None:
         self.processes_to_kill.remove(self.p5)
         break
+      if self.p4.poll() != None:
+        self.processes_to_kill.remove(self.p4)
+        break
       time_left -= 0.1
       time.sleep(0.1)
 
     print("Time waiting for plasma manager to fail = {:.2}".format(100 - time_left))
-    self.assertNotEqual(self.p5.poll(), None)
+    self.assertNotEqual([self.p5.poll(), self.p4.poll()], [None, None])
 
   def test_illegal_functionality(self):
     # Create an object id string.


### PR DESCRIPTION
In this test, `client1` and `client2` are connected to `manager1` and `manager2` respectively. We call `client1` calls `create` and `seal` on an object. Then `client2` calls `create` and `seal` on a slightly different object with the same object ID. This should cause a hash mismatch followed by a fatal error. We then check that the plasma manager died. However, in many instances on Travis, this check failed even though we could see the fatal error in the logs.

I think the issue is that `manager1` was actually the one dying in a bunch of cases, meaning that the timing was such that the `RAY.OBJECT_TABLE_ADD` command for the second manager arrived at Redis first. This seems pretty unlikely, but I guess it can happen.