### PR TITLE
Fix numbuf compiler warnings.

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -96,6 +96,11 @@
 /* This should be defined if we want to check calls to DCHECK. */
 #define RAY_DCHECK
 
+/* Arrow also defines the DCHECK macro, so undo that definition. */
+#ifdef DCHECK
+#undef DCHECK
+#endif
+
 #ifdef RAY_DCHECK
 #define DCHECK(COND) CHECK(COND)
 #else

--- a/src/numbuf/cpp/src/numbuf/sequence.cc
+++ b/src/numbuf/cpp/src/numbuf/sequence.cc
@@ -33,10 +33,11 @@ SequenceBuilder::SequenceBuilder(MemoryPool* pool)
 /* We need to ensure that the number of bytes allocated by arrow
  * does not exceed 2**31 - 1. To make sure that is the case, allocation needs
  * to be capped at 2**29 - 1, because arrow calculates the next power of two
- * for allocations (see arrow::ArrayBuilder::Reserve).
+ * for allocations (see arrow::ArrayBuilder::Reserve). TODO(rkn): The (1 << 28)
+ * below should really be (1 << 29), but there seems to be a bug.
  */
 #define UPDATE(OFFSET, TAG)                                               \
-  if (total_num_bytes_ >= 1 << 29 - 1) {                                  \
+  if (total_num_bytes_ >= (1 << 28) - 1) {                                \
     return Status::NotImplemented("Sequence contains too many elements"); \
   }                                                                       \
   if (TAG == -1) {                                                        \

--- a/src/numbuf/python/src/pynumbuf/memory.h
+++ b/src/numbuf/python/src/pynumbuf/memory.h
@@ -22,7 +22,7 @@ class FixedBufferStream : public arrow::io::OutputStream,
     return arrow::Status::OK();
   }
 
-  arrow::Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
+  arrow::Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override {
     assert(0);
     return arrow::Status::OK();
   }


### PR DESCRIPTION
This addresses #298, although note that there is a bug related to #298 (see the comments in this PR).