### PR TITLE
Let actors use GPUs.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -17,5 +17,6 @@ import ray.experimental
 import ray.serialization
 from ray.worker import register_class, error_info, init, connect, disconnect, get, put, wait, remote, log_event, log_span, flush_log
 from ray.actor import actor
+from ray.actor import get_gpu_ids
 from ray.worker import EnvironmentVariable, env
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -97,6 +97,8 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus, worker
     local_scheduler_id = random.choice(local_schedulers)[b"ray_client_id"]
     gpu_ids = []
   else:
+    # All of this logic is for finding a local scheduler that has enough
+    # available GPUs.
     local_scheduler_id = None
     for local_scheduler in local_schedulers:
       local_scheduler_total_gpus = int(float(local_scheduler[b"num_gpus"].decode("ascii")))

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import ray.worker
-
-def get_local_schedulers():
+def get_local_schedulers(worker):
   local_schedulers = []
-  for client in ray.worker.global_worker.redis_client.keys("CL:*"):
-    client_type, ray_client_id = ray.worker.global_worker.redis_client.hmget(client, "client_type", "ray_client_id")
-    if client_type == b"photon":
-      local_schedulers.append(ray_client_id)
+  local_schedulers = []
+  for client in worker.redis_client.keys("CL:*"):
+    client_info = worker.redis_client.hgetall(client)
+    if client_info[b"client_type"] == b"photon":
+      local_schedulers.append(client_info)
   return local_schedulers

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 def get_local_schedulers(worker):
   local_schedulers = []
-  local_schedulers = []
   for client in worker.redis_client.keys("CL:*"):
     client_info = worker.redis_client.hgetall(client)
     if client_info[b"client_type"] == b"photon":

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -303,21 +303,38 @@ local_scheduler_state *init_local_scheduler(
   if (redis_addr != NULL) {
     int num_args;
     const char **db_connect_args = NULL;
+    /* Use UT_string to convert the resource value into a string. */
+    UT_string *num_cpus;
+    UT_string *num_gpus;
+    utstring_new(num_cpus);
+    utstring_new(num_gpus);
+    utstring_printf(num_cpus, "%f", static_resource_conf[0]);
+    utstring_printf(num_gpus, "%f", static_resource_conf[1]);
     if (plasma_manager_address != NULL) {
-      num_args = 4;
+      num_args = 8;
       db_connect_args = malloc(sizeof(char *) * num_args);
       db_connect_args[0] = "local_scheduler_socket_name";
       db_connect_args[1] = local_scheduler_socket_name;
-      db_connect_args[2] = "aux_address";
-      db_connect_args[3] = plasma_manager_address;
+      db_connect_args[2] = "num_cpus";
+      db_connect_args[3] = utstring_body(num_cpus);
+      db_connect_args[4] = "num_gpus";
+      db_connect_args[5] = utstring_body(num_gpus);
+      db_connect_args[6] = "aux_address";
+      db_connect_args[7] = plasma_manager_address;
     } else {
-      num_args = 2;
+      num_args = 6;
       db_connect_args = malloc(sizeof(char *) * num_args);
       db_connect_args[0] = "local_scheduler_socket_name";
       db_connect_args[1] = local_scheduler_socket_name;
+      db_connect_args[2] = "num_cpus";
+      db_connect_args[3] = utstring_body(num_cpus);
+      db_connect_args[4] = "num_gpus";
+      db_connect_args[5] = utstring_body(num_gpus);
     }
     state->db = db_connect(redis_addr, redis_port, "photon", node_ip_address,
                            num_args, db_connect_args);
+    utstring_free(num_cpus);
+    utstring_free(num_gpus);
     free(db_connect_args);
     db_attach(state->db, loop, false);
   } else {

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -132,6 +132,50 @@ class ActorAPI(unittest.TestCase):
   #   # TODO(rkn): Implement this.
   #   pass
 
+  def testDecoratorArgs(self):
+    ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
+
+    # This is an invalid way of using the actor decorator.
+    with self.assertRaises(Exception):
+      @ray.actor()
+      class Actor(object):
+        def __init__(self):
+          pass
+
+    # This is an invalid way of using the actor decorator.
+    with self.assertRaises(Exception):
+      @ray.actor(invalid_kwarg=0)
+      class Actor(object):
+        def __init__(self):
+          pass
+
+    # This is an invalid way of using the actor decorator.
+    with self.assertRaises(Exception):
+      @ray.actor(num_cpus=0, invalid_kwarg=0)
+      class Actor(object):
+        def __init__(self):
+          pass
+
+    # This is a valid way of using the decorator.
+    @ray.actor(num_cpus=1)
+    class Actor(object):
+      def __init__(self):
+        pass
+
+    # This is a valid way of using the decorator.
+    @ray.actor(num_gpus=1)
+    class Actor(object):
+      def __init__(self):
+        pass
+
+    # This is a valid way of using the decorator.
+    @ray.actor(num_cpus=1, num_gpus=1)
+    class Actor(object):
+      def __init__(self):
+        pass
+
+    ray.worker.cleanup()
+
 class ActorMethods(unittest.TestCase):
 
   def testDefineActor(self):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -523,5 +523,94 @@ class ActorsOnMultipleNodes(unittest.TestCase):
 
     ray.worker.cleanup()
 
+class ActorsWithGPUs(unittest.TestCase):
+
+  def testActorGPUs(self):
+    num_local_schedulers = 3
+    num_gpus_per_scheduler = 4
+    ray.worker._init(start_ray_local=True, num_workers=0,
+                     num_local_schedulers=num_local_schedulers,
+                     num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
+
+    @ray.actor(num_gpus=1)
+    class Actor1(object):
+      def __init__(self):
+        self.gpu_ids = ray.get_gpu_ids()
+      def get_location_and_ids(self):
+        return ray.worker.global_worker.plasma_client.store_socket_name, tuple(self.gpu_ids)
+
+    # Create one actor per GPU.
+    actors = [Actor1() for _ in range(num_local_schedulers * num_gpus_per_scheduler)]
+    # Make sure that no two actors are assigned to the same GPU.
+    locations_and_ids = ray.get([actor.get_location_and_ids() for actor in actors])
+    node_names = set([location for location, gpu_id in locations_and_ids])
+    self.assertEqual(len(node_names), num_local_schedulers)
+    location_actor_combinations = []
+    for node_name in node_names:
+      for gpu_id in range(num_gpus_per_scheduler):
+        location_actor_combinations.append((node_name, (gpu_id,)))
+    self.assertEqual(set(locations_and_ids), set(location_actor_combinations))
+
+    # Creating a new actor should fail because all of the GPUs are being used.
+    with self.assertRaises(Exception):
+      a = Actor1()
+
+    ray.worker.cleanup()
+
+  def testActorMultipleGPUs(self):
+    num_local_schedulers = 3
+    num_gpus_per_scheduler = 5
+    ray.worker._init(start_ray_local=True, num_workers=0,
+                     num_local_schedulers=num_local_schedulers,
+                     num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
+
+    @ray.actor(num_gpus=2)
+    class Actor1(object):
+      def __init__(self):
+        self.gpu_ids = ray.get_gpu_ids()
+      def get_location_and_ids(self):
+        return ray.worker.global_worker.plasma_client.store_socket_name, tuple(self.gpu_ids)
+
+    # Create some actors.
+    actors = [Actor1() for _ in range(num_local_schedulers * 2)]
+    # Make sure that no two actors are assigned to the same GPU.
+    locations_and_ids = ray.get([actor.get_location_and_ids() for actor in actors])
+    node_names = set([location for location, gpu_id in locations_and_ids])
+    self.assertEqual(len(node_names), num_local_schedulers)
+    location_actor_combinations = []
+    for node_name in node_names:
+      location_actor_combinations.append((node_name, (0, 1)))
+      location_actor_combinations.append((node_name, (2, 3)))
+    self.assertEqual(set(locations_and_ids), set(location_actor_combinations))
+
+    # Creating a new actor should fail because all of the GPUs are being used.
+    with self.assertRaises(Exception):
+      a = Actor1()
+
+    # We should be able to create more actors that use only a single GPU.
+    @ray.actor(num_gpus=1)
+    class Actor2(object):
+      def __init__(self):
+        self.gpu_ids = ray.get_gpu_ids()
+      def get_location_and_ids(self):
+        return ray.worker.global_worker.plasma_client.store_socket_name, tuple(self.gpu_ids)
+
+    # Create some actors.
+    actors = [Actor2() for _ in range(num_local_schedulers)]
+    # Make sure that no two actors are assigned to the same GPU.
+    locations_and_ids = ray.get([actor.get_location_and_ids() for actor in actors])
+    node_names = set([location for location, gpu_id in locations_and_ids])
+    self.assertEqual(len(node_names), num_local_schedulers)
+    location_actor_combinations = []
+    for node_name in node_names:
+      location_actor_combinations.append((node_name, (4,)))
+    self.assertEqual(set(locations_and_ids), set(location_actor_combinations))
+
+    # Creating a new actor should fail because all of the GPUs are being used.
+    with self.assertRaises(Exception):
+      a = Actor2()
+
+    ray.worker.cleanup()
+
 if __name__ == "__main__":
   unittest.main(verbosity=2)


### PR DESCRIPTION
This is a quick hack to allow actors to use GPUs so we can figure out what the right API here is.

In this PR:

- When creating an actor, the decorator can take a number of GPUs (and CPUs, although that field is currently not used for anything), e.g., via `ray.actor(num_gpus=2)`.
- Actor methods can call `ray.get_gpu_ids()` to get a list of the GPU IDs that the actor is allowed to use. The idea is that this could be used in the constructor of an actor (which defines a neural net) via something like
```
os.environ["CUDA_VISIBLE_DEVICES"] = ",".join([str(i) for i in ray.get_gpu_ids()])
```
- **GPU management here is done entirely outside of the local scheduler.** The worker or driver that creates the actor will interact with Redis to see how many available GPUs each local scheduler has, will take some of them for the newly created actor, and will mark them as used. If there aren't enough available GPUs, it will raise an exception. **TODO:** this needs to be unified with how resource management is done in the rest of the system.
- **GPUs are never freed once an actor consumes them.** More generally, actors are never garbage collected. **TODO:** this needs to change.