### PR TITLE
Change all table calls to use default retry behavior.

### DIFF
--- a/src/common/state/table.c
+++ b/src/common/state/table.c
@@ -80,8 +80,8 @@ int64_t table_timeout_handler(event_loop *loop,
 
   CHECK(callback_data->retry.num_retries >= 0 ||
         callback_data->retry.num_retries == -1);
-  LOG_DEBUG("retrying operation, retry_count = %d",
-            callback_data->retry.num_retries);
+  LOG_WARN("retrying operation, retry_count = %d",
+           callback_data->retry.num_retries);
 
   if (callback_data->retry.num_retries == 0) {
     /* We didn't get a response from the database after exhausting all retries;

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -29,10 +29,14 @@ typedef void (*table_fail_callback)(unique_id id,
 typedef void (*table_retry_callback)(table_callback_data *callback_data);
 
 /**
- * Data structure consolidating the retry related varaibles.
+ * Data structure consolidating the retry related variables. If a NULL
+ * retry_info struct is used, the default behavior will be to retry infinitely
+ * many times.
  */
 typedef struct {
-  /** Number of retries left. */
+  /** Number of retries. This field will be decremented every time a retry
+   *  occurs (unless the value is -1). If this value is -1, then there will be
+   *  infinitely many retries. */
   int num_retries;
   /** Timeout, in milliseconds. */
   uint64_t timeout;

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -8,13 +8,6 @@
 #include "utarray.h"
 #include "uthash.h"
 
-/* Retry values for state table operations. For now, only try each command once
- * and give it one second to succeed. */
-/* TODO(swang): We should set retry values in a config file somewhere. */
-static const retry_info photon_retry = {.num_retries = 0,
-                                        .timeout = 1000,
-                                        .fail_callback = NULL};
-
 enum photon_message_type {
   /** Notify the local scheduler that a task has finished. */
   TASK_DONE = 64,

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -365,13 +365,11 @@ void add_task_to_actor_queue(local_scheduler_state *state,
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
        * the task table, so just update the entry. */
-      task_table_update(state->db, task, (retry_info *) &photon_retry, NULL,
-                        NULL);
+      task_table_update(state->db, task, NULL, NULL, NULL);
     } else {
       /* Otherwise, this is the first time the task has been seen in the system
        * (unless it's a resubmission of a previous task), so add the entry. */
-      task_table_add_task(state->db, task, (retry_info *) &photon_retry, NULL,
-                          NULL);
+      task_table_add_task(state->db, task, NULL, NULL, NULL);
     }
   }
 }
@@ -663,13 +661,11 @@ task_queue_entry *queue_task(local_scheduler_state *state,
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
        * the task table, so just update the entry. */
-      task_table_update(state->db, task, (retry_info *) &photon_retry, NULL,
-                        NULL);
+      task_table_update(state->db, task, NULL, NULL, NULL);
     } else {
       /* Otherwise, this is the first time the task has been seen in the system
        * (unless it's a resubmission of a previous task), so add the entry. */
-      task_table_add_task(state->db, task, (retry_info *) &photon_retry, NULL,
-                          NULL);
+      task_table_add_task(state->db, task, NULL, NULL, NULL);
     }
   }
 
@@ -767,8 +763,7 @@ void give_task_to_local_scheduler(local_scheduler_state *state,
   /* Assign the task to the relevant local scheduler. */
   DCHECK(state->config.global_scheduler_exists);
   task *task = alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
-  task_table_add_task(state->db, task, (retry_info *) &photon_retry, NULL,
-                      NULL);
+  task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
 
 /**
@@ -791,8 +786,7 @@ void give_task_to_global_scheduler(local_scheduler_state *state,
   DCHECK(state->config.global_scheduler_exists);
   task *task = alloc_task(spec, TASK_STATUS_WAITING, NIL_ID);
   DCHECK(state->db != NULL);
-  task_table_add_task(state->db, task, (retry_info *) &photon_retry, NULL,
-                      NULL);
+  task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
 
 bool resource_constraints_satisfied(local_scheduler_state *state,
@@ -822,8 +816,7 @@ void update_result_table(local_scheduler_state *state, task_spec *spec) {
     task_id task_id = task_spec_id(spec);
     for (int64_t i = 0; i < task_num_returns(spec); ++i) {
       object_id return_id = task_return(spec, i);
-      result_table_add(state->db, return_id, task_id,
-                       (retry_info *) &photon_retry, NULL, NULL);
+      result_table_add(state->db, return_id, task_id, NULL, NULL, NULL);
     }
   }
 }

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -183,8 +183,7 @@ TEST object_reconstruction_test(void) {
      * that would suppress object reconstruction. */
     task *task = alloc_task(spec, TASK_STATUS_DONE,
                             get_db_client_id(photon->photon_state->db));
-    task_table_add_task(photon->photon_state->db, task,
-                        (retry_info *) &photon_retry, NULL, NULL);
+    task_table_add_task(photon->photon_state->db, task, NULL, NULL, NULL);
     /* Trigger reconstruction, and run the event loop again. */
     object_id return_id = task_return(spec, 0);
     photon_reconstruct_object(worker, return_id);
@@ -282,8 +281,7 @@ TEST object_reconstruction_recursive_test(void) {
      * condition that would suppress object reconstruction. */
     task *last_task = alloc_task(specs[NUM_TASKS - 1], TASK_STATUS_DONE,
                                  get_db_client_id(photon->photon_state->db));
-    task_table_add_task(photon->photon_state->db, last_task,
-                        (retry_info *) &photon_retry, NULL, NULL);
+    task_table_add_task(photon->photon_state->db, last_task, NULL, NULL, NULL);
     /* Trigger reconstruction for the last object, and run the event loop
      * again. */
     object_id return_id = task_return(specs[NUM_TASKS - 1], 0);
@@ -346,8 +344,7 @@ TEST object_reconstruction_suppression_test(void) {
                                2, db_connect_args);
     db_attach(db, photon->loop, false);
     /* Add the object to the object table. */
-    object_table_add(db, return_id, 1, (unsigned char *) NIL_DIGEST,
-                     (retry_info *) &photon_retry,
+    object_table_add(db, return_id, 1, (unsigned char *) NIL_DIGEST, NULL,
                      object_reconstruction_suppression_callback,
                      (void *) worker);
     /* Run the event loop. NOTE: OSX appears to require the parent process to


### PR DESCRIPTION
This also changes the default retry behavior to retry infinitely many times (every 10 seconds).

This is a temporary fix for #115 and for other failures we've been seeing where we try to do too many calls to Redis and the calls start timing out.

However, the entire retry mechanism needs to be rethought.