### PR TITLE
Fix global scheduler test failure.

### DIFF
--- a/python/common/redis_module/runtest.py
+++ b/python/common/redis_module/runtest.py
@@ -54,7 +54,7 @@ def get_next_message(pubsub_client, timeout_seconds=10):
 class TestGlobalStateStore(unittest.TestCase):
 
   def setUp(self):
-    redis_port = ray.services.start_redis()
+    redis_port, _ = ray.services.start_redis()
     self.redis = redis.StrictRedis(host="localhost", port=redis_port, db=0)
 
   def tearDown(self):

--- a/python/plasma/test/test.py
+++ b/python/plasma/test/test.py
@@ -493,7 +493,7 @@ class TestPlasmaManager(unittest.TestCase):
     store_name1, self.p2 = plasma.start_plasma_store(use_valgrind=USE_VALGRIND)
     store_name2, self.p3 = plasma.start_plasma_store(use_valgrind=USE_VALGRIND)
     # Start a Redis server.
-    redis_address = services.address("127.0.0.1", services.start_redis())
+    redis_address = services.address("127.0.0.1", services.start_redis()[0])
     # Start two PlasmaManagers.
     manager_name1, self.p4, self.port1 = plasma.start_plasma_manager(store_name1, redis_address, use_valgrind=USE_VALGRIND)
     manager_name2, self.p5, self.port2 = plasma.start_plasma_manager(store_name2, redis_address, use_valgrind=USE_VALGRIND)
@@ -794,7 +794,7 @@ class TestPlasmaManagerRecovery(unittest.TestCase):
     # Start a Plasma store.
     self.store_name, self.p2 = plasma.start_plasma_store(use_valgrind=USE_VALGRIND)
     # Start a Redis server.
-    self.redis_address = services.address("127.0.0.1", services.start_redis())
+    self.redis_address = services.address("127.0.0.1", services.start_redis()[0])
     # Start a PlasmaManagers.
     manager_name, self.p3, self.port1 = plasma.start_plasma_manager(
         self.store_name,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -211,8 +211,8 @@ def start_redis(port=None, num_retries=20, stdout_file=None, stderr_file=None,
       that imported services exits.
 
   Returns:
-    The port used by Redis. If a port is passed in, then the same value is
-      returned.
+    A tuple of the port used by Redis and a handle to the process that was
+      started. If a port is passed in, then the returned port value is the same.
 
   Raises:
     Exception: An exception is raised if Redis could not be started.
@@ -259,7 +259,7 @@ def start_redis(port=None, num_retries=20, stdout_file=None, stderr_file=None,
   redis_client.config_set("protected-mode", "no")
   # Put a time stamp in Redis to indicate when it was started.
   redis_client.set("redis_start_time", time.time())
-  return port
+  return port, p
 
 def start_global_scheduler(redis_address, stdout_file=None, stderr_file=None,
                            cleanup=True):
@@ -622,9 +622,9 @@ def start_ray_processes(address_info=None,
     redis_stdout_file, redis_stderr_file = new_log_files("redis", redirect_output)
     if redis_address is None:
       # Start a Redis server. The start_redis method will choose a random port.
-      redis_port = start_redis(stdout_file=redis_stdout_file,
-                               stderr_file=redis_stderr_file,
-                               cleanup=cleanup)
+      redis_port, _ = start_redis(stdout_file=redis_stdout_file,
+                                  stderr_file=redis_stderr_file,
+                                  cleanup=cleanup)
       redis_address = address(node_ip_address, redis_port)
       address_info["redis_address"] = redis_address
       time.sleep(0.1)
@@ -634,11 +634,11 @@ def start_ray_processes(address_info=None,
       # machine that this method is running on.
       redis_ip_address = get_ip_address(redis_address)
       redis_port = get_port(redis_address)
-      new_redis_port = start_redis(port=int(redis_port),
-                                   num_retries=1,
-                                   stdout_file=redis_stdout_file,
-                                   stderr_file=redis_stderr_file,
-                                   cleanup=cleanup)
+      new_redis_port, _ = start_redis(port=int(redis_port),
+                                      num_retries=1,
+                                      stdout_file=redis_stdout_file,
+                                      stderr_file=redis_stderr_file,
+                                      cleanup=cleanup)
       assert redis_port == new_redis_port
   else:
     if redis_address is None:


### PR DESCRIPTION
Note that the change in the way we kill the processes in `tearDown` actually seems to make a difference. On my laptop the previous way does not actually kill the processes.