### PR TITLE
Change type naming convention.

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -9,31 +9,31 @@
 #include "io.h"
 
 /* This is used to define the array of object IDs. */
-const UT_icd object_id_icd = {sizeof(object_id), NULL, NULL, NULL};
+const UT_icd object_id_icd = {sizeof(ObjectID), NULL, NULL, NULL};
 
-const unique_id NIL_ID = {{255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+const UniqueID NIL_ID = {{255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
                            255, 255, 255, 255, 255, 255, 255, 255, 255, 255}};
 
 const unsigned char NIL_DIGEST[DIGEST_SIZE] = {0};
 
-unique_id globally_unique_id(void) {
+UniqueID globally_unique_id(void) {
   /* Use /dev/urandom for "real" randomness. */
   int fd;
   int const flags = 0 /* for Windows compatibility */;
   if ((fd = open("/dev/urandom", O_RDONLY, flags)) == -1) {
     LOG_ERROR("Could not generate random number");
   }
-  unique_id result;
+  UniqueID result;
   CHECK(read_bytes(fd, &result.id[0], UNIQUE_ID_SIZE) >= 0);
   close(fd);
   return result;
 }
 
-bool object_ids_equal(object_id first_id, object_id second_id) {
+bool object_ids_equal(ObjectID first_id, ObjectID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-bool object_id_is_nil(object_id id) {
+bool object_id_is_nil(ObjectID id) {
   return object_ids_equal(id, NIL_OBJECT_ID);
 }
 
@@ -41,7 +41,7 @@ bool db_client_ids_equal(db_client_id first_id, db_client_id second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-char *object_id_to_string(object_id obj_id, char *id_string, int id_length) {
+char *object_id_to_string(ObjectID obj_id, char *id_string, int id_length) {
   CHECK(id_length >= ID_STRING_SIZE);
   static const char hex[] = "0123456789abcdef";
   char *buf = id_string;

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -29,19 +29,19 @@ UniqueID globally_unique_id(void) {
   return result;
 }
 
-bool object_ids_equal(ObjectID first_id, ObjectID second_id) {
+bool ObjectID_equal(ObjectID first_id, ObjectID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-bool object_id_is_nil(ObjectID id) {
-  return object_ids_equal(id, NIL_OBJECT_ID);
+bool ObjectID_is_nil(ObjectID id) {
+  return ObjectID_equal(id, NIL_OBJECT_ID);
 }
 
-bool db_client_ids_equal(DBClientID first_id, DBClientID second_id) {
+bool DBClientID_equal(DBClientID first_id, DBClientID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-char *object_id_to_string(ObjectID obj_id, char *id_string, int id_length) {
+char *ObjectID_to_string(ObjectID obj_id, char *id_string, int id_length) {
   CHECK(id_length >= ID_STRING_SIZE);
   static const char hex[] = "0123456789abcdef";
   char *buf = id_string;

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -12,7 +12,7 @@
 const UT_icd object_id_icd = {sizeof(ObjectID), NULL, NULL, NULL};
 
 const UniqueID NIL_ID = {{255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-                           255, 255, 255, 255, 255, 255, 255, 255, 255, 255}};
+                          255, 255, 255, 255, 255, 255, 255, 255, 255, 255}};
 
 const unsigned char NIL_DIGEST[DIGEST_SIZE] = {0};
 

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -37,7 +37,7 @@ bool object_id_is_nil(ObjectID id) {
   return object_ids_equal(id, NIL_OBJECT_ID);
 }
 
-bool db_client_ids_equal(db_client_id first_id, db_client_id second_id) {
+bool db_client_ids_equal(DBClientID first_id, DBClientID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -166,7 +166,7 @@ bool object_ids_equal(ObjectID first_id, ObjectID second_id);
  */
 bool object_id_is_nil(ObjectID id);
 
-typedef UniqueID db_client_id;
+typedef UniqueID DBClientID;
 
 /**
  * Compare two db client IDs.
@@ -175,7 +175,7 @@ typedef UniqueID db_client_id;
  * @param second_id The first db client ID to compare.
  * @return True if the db client IDs are the same and false otherwise.
  */
-bool db_client_ids_equal(db_client_id first_id, db_client_id second_id);
+bool db_client_ids_equal(DBClientID first_id, DBClientID second_id);
 
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 #define MIN(x, y) ((x) <= (y) ? (x) : (y))

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -147,7 +147,7 @@ typedef UniqueID ObjectID;
  *        string.
  * @param id_length The length of the id_string buffer.
  */
-char *object_id_to_string(ObjectID obj_id, char *id_string, int id_length);
+char *ObjectID_to_string(ObjectID obj_id, char *id_string, int id_length);
 
 /**
  * Compare two object IDs.
@@ -156,7 +156,7 @@ char *object_id_to_string(ObjectID obj_id, char *id_string, int id_length);
  * @param second_id The first object ID to compare.
  * @return True if the object IDs are the same and false otherwise.
  */
-bool object_ids_equal(ObjectID first_id, ObjectID second_id);
+bool ObjectID_equal(ObjectID first_id, ObjectID second_id);
 
 /**
  * Compare a object ID to the nil ID.
@@ -164,7 +164,7 @@ bool object_ids_equal(ObjectID first_id, ObjectID second_id);
  * @param id The object ID to compare to nil.
  * @return True if the object ID is equal to nil.
  */
-bool object_id_is_nil(ObjectID id);
+bool ObjectID_is_nil(ObjectID id);
 
 typedef UniqueID DBClientID;
 
@@ -175,7 +175,7 @@ typedef UniqueID DBClientID;
  * @param second_id The first db client ID to compare.
  * @return True if the db client IDs are the same and false otherwise.
  */
-bool db_client_ids_equal(DBClientID first_id, DBClientID second_id);
+bool DBClientID_equal(DBClientID first_id, DBClientID second_id);
 
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 #define MIN(x, y) ((x) <= (y) ? (x) : (y))

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -121,18 +121,18 @@
 
 #define IS_NIL_ID(id) UNIQUE_ID_EQ(id, NIL_ID)
 
-typedef struct { unsigned char id[UNIQUE_ID_SIZE]; } unique_id;
+typedef struct { unsigned char id[UNIQUE_ID_SIZE]; } UniqueID;
 
 extern const UT_icd object_id_icd;
 
-extern const unique_id NIL_ID;
+extern const UniqueID NIL_ID;
 
 /* Generate a globally unique ID. */
-unique_id globally_unique_id(void);
+UniqueID globally_unique_id(void);
 
 #define NIL_OBJECT_ID NIL_ID
 
-typedef unique_id object_id;
+typedef UniqueID ObjectID;
 
 #define ID_STRING_SIZE (2 * UNIQUE_ID_SIZE + 1)
 
@@ -147,7 +147,7 @@ typedef unique_id object_id;
  *        string.
  * @param id_length The length of the id_string buffer.
  */
-char *object_id_to_string(object_id obj_id, char *id_string, int id_length);
+char *object_id_to_string(ObjectID obj_id, char *id_string, int id_length);
 
 /**
  * Compare two object IDs.
@@ -156,7 +156,7 @@ char *object_id_to_string(object_id obj_id, char *id_string, int id_length);
  * @param second_id The first object ID to compare.
  * @return True if the object IDs are the same and false otherwise.
  */
-bool object_ids_equal(object_id first_id, object_id second_id);
+bool object_ids_equal(ObjectID first_id, ObjectID second_id);
 
 /**
  * Compare a object ID to the nil ID.
@@ -164,9 +164,9 @@ bool object_ids_equal(object_id first_id, object_id second_id);
  * @param id The object ID to compare to nil.
  * @return True if the object ID is equal to nil.
  */
-bool object_id_is_nil(object_id id);
+bool object_id_is_nil(ObjectID id);
 
-typedef unique_id db_client_id;
+typedef UniqueID db_client_id;
 
 /**
  * Compare two db client IDs.

--- a/src/common/io.c
+++ b/src/common/io.c
@@ -37,7 +37,7 @@ int bind_inet_sock(const int port, bool shall_listen) {
     close(socket_fd);
     return -1;
   }
-  int *const pon = (int *const) &on;
+  int *const pon = (int *const) & on;
   if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, pon, sizeof(on)) < 0) {
     LOG_ERROR("setsockopt failed for port %d", port);
     close(socket_fd);

--- a/src/common/io.c
+++ b/src/common/io.c
@@ -37,7 +37,7 @@ int bind_inet_sock(const int port, bool shall_listen) {
     close(socket_fd);
     return -1;
   }
-  int *const pon = (char const *) &on;
+  int *const pon = (int *const) &on;
   if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, pon, sizeof(on)) < 0) {
     LOG_ERROR("setsockopt failed for port %d", port);
     close(socket_fd);
@@ -302,7 +302,7 @@ void read_message(int fd, int64_t *type, int64_t *length, uint8_t **bytes) {
   if (closed) {
     goto disconnected;
   }
-  *bytes = malloc(*length * sizeof(uint8_t));
+  *bytes = (uint8_t *) malloc(*length * sizeof(uint8_t));
   closed = read_bytes(fd, *bytes, *length);
   if (closed) {
     free(*bytes);

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -423,7 +423,7 @@ static PyMethodDef PyTask_methods[] = {
      "Return the actor ID for this task."},
     {"driver_id", (PyCFunction) PyTask_driver_id, METH_NOARGS,
      "Return the driver ID for this task."},
-    {"TaskID", (PyCFunction) PyTask_task_id, METH_NOARGS,
+    {"task_id", (PyCFunction) PyTask_task_id, METH_NOARGS,
      "Return the task ID for this task."},
     {"arguments", (PyCFunction) PyTask_arguments, METH_NOARGS,
      "Return the arguments for the task."},

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -270,7 +270,7 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   /* How many tasks have been launched on the actor so far? */
   int actor_counter = 0;
   /* ID of the function this task executes. */
-  function_id function_id;
+  FunctionID function_id;
   /* Arguments of the task (can be PyObjectIDs or Python values). */
   PyObject *arguments;
   /* Array of pointers to string representations of pass-by-value args. */
@@ -278,7 +278,7 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   utarray_new(val_repr_ptrs, &ut_ptr_icd);
   int num_returns;
   /* The ID of the task that called this task. */
-  task_id parent_task_id;
+  TaskID parent_task_id;
   /* The number of tasks that the parent task has called prior to this one. */
   int parent_counter;
   /* Resource vector of the required resources to execute this task. */
@@ -353,12 +353,12 @@ static void PyTask_dealloc(PyTask *self) {
 }
 
 static PyObject *PyTask_function_id(PyObject *self) {
-  function_id function_id = task_function(((PyTask *) self)->spec);
+  FunctionID function_id = task_function(((PyTask *) self)->spec);
   return PyObjectID_make(function_id);
 }
 
 static PyObject *PyTask_actor_id(PyObject *self) {
-  actor_id actor_id = task_spec_actor_id(((PyTask *) self)->spec);
+  ActorID actor_id = task_spec_actor_id(((PyTask *) self)->spec);
   return PyObjectID_make(actor_id);
 }
 
@@ -368,7 +368,7 @@ static PyObject *PyTask_driver_id(PyObject *self) {
 }
 
 static PyObject *PyTask_task_id(PyObject *self) {
-  task_id task_id = task_spec_id(((PyTask *) self)->spec);
+  TaskID task_id = task_spec_id(((PyTask *) self)->spec);
   return PyObjectID_make(task_id);
 }
 
@@ -423,7 +423,7 @@ static PyMethodDef PyTask_methods[] = {
      "Return the actor ID for this task."},
     {"driver_id", (PyCFunction) PyTask_driver_id, METH_NOARGS,
      "Return the driver ID for this task."},
-    {"task_id", (PyCFunction) PyTask_task_id, METH_NOARGS,
+    {"TaskID", (PyCFunction) PyTask_task_id, METH_NOARGS,
      "Return the task ID for this task."},
     {"arguments", (PyCFunction) PyTask_arguments, METH_NOARGS,
      "Return the arguments for the task."},
@@ -569,7 +569,7 @@ PyObject *check_simple_value(PyObject *self, PyObject *args) {
 
 PyObject *compute_put_id(PyObject *self, PyObject *args) {
   int put_index;
-  task_id task_id;
+  TaskID task_id;
   if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
                         &put_index)) {
     return NULL;

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -35,7 +35,7 @@ void init_pickle_module(void) {
 
 /* Define the PyObjectID class. */
 
-int PyStringToUniqueID(PyObject *object, object_id *object_id) {
+int PyStringToUniqueID(PyObject *object, ObjectID *object_id) {
   if (PyBytes_Check(object)) {
     memcpy(&object_id->id[0], PyBytes_AsString(object), UNIQUE_ID_SIZE);
     return 1;
@@ -45,7 +45,7 @@ int PyStringToUniqueID(PyObject *object, object_id *object_id) {
   }
 }
 
-int PyObjectToUniqueID(PyObject *object, object_id *objectid) {
+int PyObjectToUniqueID(PyObject *object, ObjectID *objectid) {
   if (PyObject_IsInstance(object, (PyObject *) &PyObjectIDType)) {
     *objectid = ((PyObjectID *) object)->object_id;
     return 1;
@@ -61,7 +61,7 @@ static int PyObjectID_init(PyObjectID *self, PyObject *args, PyObject *kwds) {
   if (!PyArg_ParseTuple(args, "s#", &data, &size)) {
     return -1;
   }
-  if (size != sizeof(object_id)) {
+  if (size != sizeof(ObjectID)) {
     PyErr_SetString(CommonError,
                     "ObjectID: object id string needs to have length 20");
     return -1;
@@ -71,7 +71,7 @@ static int PyObjectID_init(PyObjectID *self, PyObject *args, PyObject *kwds) {
 }
 
 /* Create a PyObjectID from C. */
-PyObject *PyObjectID_make(object_id object_id) {
+PyObject *PyObjectID_make(ObjectID object_id) {
   PyObjectID *result = PyObject_New(PyObjectID, &PyObjectIDType);
   result = (PyObjectID *) PyObject_Init((PyObject *) result, &PyObjectIDType);
   result->object_id = object_id;
@@ -264,9 +264,9 @@ PyTypeObject PyObjectIDType = {
 
 static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   /* ID of the driver that this task originates from. */
-  unique_id driver_id;
+  UniqueID driver_id;
   /* ID of the actor this task should run on. */
-  unique_id actor_id = NIL_ACTOR_ID;
+  UniqueID actor_id = NIL_ACTOR_ID;
   /* How many tasks have been launched on the actor so far? */
   int actor_counter = 0;
   /* ID of the function this task executes. */
@@ -363,7 +363,7 @@ static PyObject *PyTask_actor_id(PyObject *self) {
 }
 
 static PyObject *PyTask_driver_id(PyObject *self) {
-  unique_id driver_id = task_spec_driver_id(((PyTask *) self)->spec);
+  UniqueID driver_id = task_spec_driver_id(((PyTask *) self)->spec);
   return PyObjectID_make(driver_id);
 }
 
@@ -378,7 +378,7 @@ static PyObject *PyTask_arguments(PyObject *self) {
   PyObject *arg_list = PyList_New((Py_ssize_t) num_args);
   for (int i = 0; i < num_args; ++i) {
     if (task_arg_type(task, i) == ARG_BY_REF) {
-      object_id object_id = task_arg_id(task, i);
+      ObjectID object_id = task_arg_id(task, i);
       PyList_SetItem(arg_list, i, PyObjectID_make(object_id));
     } else {
       CHECK(pickle_module != NULL);
@@ -410,7 +410,7 @@ static PyObject *PyTask_returns(PyObject *self) {
   int64_t num_returns = task_num_returns(task);
   PyObject *return_id_list = PyList_New((Py_ssize_t) num_returns);
   for (int i = 0; i < num_returns; ++i) {
-    object_id object_id = task_return(task, i);
+    ObjectID object_id = task_return(task, i);
     PyList_SetItem(return_id_list, i, PyObjectID_make(object_id));
   }
   return return_id_list;
@@ -574,6 +574,6 @@ PyObject *compute_put_id(PyObject *self, PyObject *args) {
                         &put_index)) {
     return NULL;
   }
-  object_id put_id = task_compute_put_id(task_id, put_index);
+  ObjectID put_id = task_compute_put_id(task_id, put_index);
   return PyObjectID_make(put_id);
 }

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -157,14 +157,12 @@ static PyObject *PyObjectID_richcompare(PyObjectID *self,
       result = Py_NotImplemented;
       break;
     case Py_EQ:
-      result = ObjectID_equal(self->object_id, other_id->object_id)
-                   ? Py_True
-                   : Py_False;
+      result = ObjectID_equal(self->object_id, other_id->object_id) ? Py_True
+                                                                    : Py_False;
       break;
     case Py_NE:
-      result = !ObjectID_equal(self->object_id, other_id->object_id)
-                   ? Py_True
-                   : Py_False;
+      result = !ObjectID_equal(self->object_id, other_id->object_id) ? Py_True
+                                                                     : Py_False;
       break;
     case Py_GT:
       result = Py_NotImplemented;

--- a/src/common/lib/python/common_extension.c
+++ b/src/common/lib/python/common_extension.c
@@ -136,7 +136,7 @@ static PyObject *PyObjectID_id(PyObject *self) {
 static PyObject *PyObjectID_hex(PyObject *self) {
   PyObjectID *s = (PyObjectID *) self;
   char hex_id[ID_STRING_SIZE];
-  object_id_to_string(s->object_id, hex_id, ID_STRING_SIZE);
+  ObjectID_to_string(s->object_id, hex_id, ID_STRING_SIZE);
   PyObject *result = PyUnicode_FromString(hex_id);
   return result;
 }
@@ -157,12 +157,12 @@ static PyObject *PyObjectID_richcompare(PyObjectID *self,
       result = Py_NotImplemented;
       break;
     case Py_EQ:
-      result = object_ids_equal(self->object_id, other_id->object_id)
+      result = ObjectID_equal(self->object_id, other_id->object_id)
                    ? Py_True
                    : Py_False;
       break;
     case Py_NE:
-      result = !object_ids_equal(self->object_id, other_id->object_id)
+      result = !ObjectID_equal(self->object_id, other_id->object_id)
                    ? Py_True
                    : Py_False;
       break;
@@ -190,7 +190,7 @@ static long PyObjectID_hash(PyObjectID *self) {
 
 static PyObject *PyObjectID_repr(PyObjectID *self) {
   char hex_id[ID_STRING_SIZE];
-  object_id_to_string(self->object_id, hex_id, ID_STRING_SIZE);
+  ObjectID_to_string(self->object_id, hex_id, ID_STRING_SIZE);
   UT_string *repr;
   utstring_new(repr);
   utstring_printf(repr, "ObjectID(%s)", hex_id);

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -13,7 +13,7 @@ extern PyObject *CommonError;
 // clang-format off
 typedef struct {
   PyObject_HEAD
-  object_id object_id;
+  ObjectID object_id;
 } PyObjectID;
 
 typedef struct {
@@ -33,11 +33,11 @@ extern PyObject *pickle_loads;
 
 void init_pickle_module(void);
 
-int PyStringToUniqueID(PyObject *object, object_id *object_id);
+int PyStringToUniqueID(PyObject *object, ObjectID *object_id);
 
-int PyObjectToUniqueID(PyObject *object, object_id *objectid);
+int PyObjectToUniqueID(PyObject *object, ObjectID *objectid);
 
-PyObject *PyObjectID_make(object_id object_id);
+PyObject *PyObjectID_make(ObjectID object_id);
 
 PyObject *check_simple_value(PyObject *self, PyObject *args);
 

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -65,7 +65,7 @@ void RayLogger_log(RayLogger *logger,
                   log_levels[log_level], event_type, message,
                   utstring_body(timestamp));
   if (logger->is_direct) {
-    db_handle *db = (db_handle *) logger->conn;
+    DBHandle *db = (DBHandle *) logger->conn;
     /* Fill in the client ID and send the message to Redis. */
     int status = redisAsyncCommand(
         db->context, NULL, NULL, utstring_body(formatted_message),
@@ -83,7 +83,7 @@ void RayLogger_log(RayLogger *logger,
   utstring_free(timestamp);
 }
 
-void RayLogger_log_event(db_handle *db,
+void RayLogger_log_event(DBHandle *db,
                          uint8_t *key,
                          int64_t key_length,
                          uint8_t *value,

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -30,7 +30,7 @@ RayLogger *RayLogger_init(const char *client_type,
                           int log_level,
                           int is_direct,
                           void *conn) {
-  RayLogger *logger = malloc(sizeof(RayLogger));
+  RayLogger *logger = (RayLogger *) malloc(sizeof(RayLogger));
   logger->client_type = client_type;
   logger->log_level = log_level;
   logger->is_direct = is_direct;

--- a/src/common/logging.c
+++ b/src/common/logging.c
@@ -14,7 +14,7 @@ static const char *log_levels[5] = {"DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
 static const char *log_fmt =
     "HMSET log:%s:%s log_level %s event_type %s message %s timestamp %s";
 
-struct ray_logger_impl {
+struct RayLoggerImpl {
   /* String that identifies this client type. */
   const char *client_type;
   /* Suppress all log messages below this level. */
@@ -26,11 +26,11 @@ struct ray_logger_impl {
   void *conn;
 };
 
-ray_logger *init_ray_logger(const char *client_type,
-                            int log_level,
-                            int is_direct,
-                            void *conn) {
-  ray_logger *logger = malloc(sizeof(ray_logger));
+RayLogger *RayLogger_init(const char *client_type,
+                          int log_level,
+                          int is_direct,
+                          void *conn) {
+  RayLogger *logger = malloc(sizeof(RayLogger));
   logger->client_type = client_type;
   logger->log_level = log_level;
   logger->is_direct = is_direct;
@@ -38,14 +38,14 @@ ray_logger *init_ray_logger(const char *client_type,
   return logger;
 }
 
-void free_ray_logger(ray_logger *logger) {
+void RayLogger_free(RayLogger *logger) {
   free(logger);
 }
 
-void ray_log(ray_logger *logger,
-             int log_level,
-             const char *event_type,
-             const char *message) {
+void RayLogger_log(RayLogger *logger,
+                   int log_level,
+                   const char *event_type,
+                   const char *message) {
   if (log_level < logger->log_level) {
     return;
   }
@@ -83,11 +83,11 @@ void ray_log(ray_logger *logger,
   utstring_free(timestamp);
 }
 
-void ray_log_event(db_handle *db,
-                   uint8_t *key,
-                   int64_t key_length,
-                   uint8_t *value,
-                   int64_t value_length) {
+void RayLogger_log_event(db_handle *db,
+                         uint8_t *key,
+                         int64_t key_length,
+                         uint8_t *value,
+                         int64_t value_length) {
   int status = redisAsyncCommand(db->context, NULL, NULL, "RPUSH %b %b", key,
                                  key_length, value, value_length);
   if ((status == REDIS_ERR) || db->context->err) {

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -48,7 +48,7 @@ void RayLogger_log(RayLogger *logger,
  * @param value_length The length of the value.
  * @return Void.
  */
-void RayLogger_log_event(db_handle *db,
+void RayLogger_log_event(DBHandle *db,
                          uint8_t *key,
                          int64_t key_length,
                          uint8_t *value,

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -15,28 +15,28 @@
 
 #include "state/db.h"
 
-typedef struct ray_logger_impl ray_logger;
+typedef struct RayLoggerImpl RayLogger;
 
 /* Initialize a Ray logger for the given client type and logging level. If the
  * is_direct flag is set, the logger will treat the given connection as a
  * direct connection to the log. Otherwise, it will treat it as a socket to
  * another process with a connection to the log.
  * NOTE: User is responsible for freeing the returned logger. */
-ray_logger *init_ray_logger(const char *client_type,
-                            int log_level,
-                            int is_direct,
-                            void *conn);
+RayLogger *RayLogger_init(const char *client_type,
+                          int log_level,
+                          int is_direct,
+                          void *conn);
 
 /* Free the logger. This does not free the connection to the log. */
-void free_ray_logger(ray_logger *logger);
+void RayLogger_free(RayLogger *logger);
 
 /* Log an event at the given log level with the given event_type.
  * NOTE: message cannot contain spaces! JSON format is recommended.
  * TODO: Support spaces in messages. */
-void ray_log(ray_logger *logger,
-             int log_level,
-             const char *event_type,
-             const char *message);
+void RayLogger_log(RayLogger *logger,
+                   int log_level,
+                   const char *event_type,
+                   const char *message);
 
 /**
  * Log an event to the event log.
@@ -48,10 +48,10 @@ void ray_log(ray_logger *logger,
  * @param value_length The length of the value.
  * @return Void.
  */
-void ray_log_event(db_handle *db,
-                   uint8_t *key,
-                   int64_t key_length,
-                   uint8_t *value,
-                   int64_t value_length);
+void RayLogger_log_event(db_handle *db,
+                         uint8_t *key,
+                         int64_t key_length,
+                         uint8_t *value,
+                         int64_t value_length);
 
 #endif /* LOGGING_H */

--- a/src/common/object_info.h
+++ b/src/common/object_info.h
@@ -16,6 +16,6 @@ typedef struct {
   int64_t construct_duration;
   unsigned char digest[DIGEST_SIZE];
   bool is_deletion;
-} object_info;
+} ObjectInfo;
 
 #endif

--- a/src/common/object_info.h
+++ b/src/common/object_info.h
@@ -9,7 +9,7 @@
  * Object information data structure.
  */
 typedef struct {
-  object_id obj_id;
+  ObjectID obj_id;
   int64_t data_size;
   int64_t metadata_size;
   int64_t create_time;

--- a/src/common/state/actor_notification_table.c
+++ b/src/common/state/actor_notification_table.c
@@ -2,7 +2,7 @@
 #include "redis.h"
 
 void actor_notification_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     actor_notification_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry) {

--- a/src/common/state/actor_notification_table.c
+++ b/src/common/state/actor_notification_table.c
@@ -5,7 +5,7 @@ void actor_notification_table_subscribe(
     DBHandle *db_handle,
     actor_notification_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry) {
+    RetryInfo *retry) {
   actor_notification_table_subscribe_data *sub_data =
       malloc(sizeof(actor_notification_table_subscribe_data));
   sub_data->subscribe_callback = subscribe_callback;

--- a/src/common/state/actor_notification_table.c
+++ b/src/common/state/actor_notification_table.c
@@ -6,8 +6,8 @@ void actor_notification_table_subscribe(
     actor_notification_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     RetryInfo *retry) {
-  actor_notification_table_subscribe_data *sub_data =
-      malloc(sizeof(actor_notification_table_subscribe_data));
+  ActorNotificationTableSubscribeData *sub_data =
+      malloc(sizeof(ActorNotificationTableSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -7,7 +7,7 @@
 
 typedef struct {
   /** The ID of the actor. */
-  actor_id actor_id;
+  ActorID actor_id;
   /** The ID of the local scheduler that is responsible for the actor. */
   db_client_id local_scheduler_id;
 } actor_info;

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -35,7 +35,7 @@ void actor_notification_table_subscribe(
     DBHandle *db_handle,
     actor_notification_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry);
+    RetryInfo *retry);
 
 /* Data that is needed to register local scheduler table subscribe callbacks
  * with the state database. */

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -10,14 +10,14 @@ typedef struct {
   ActorID actor_id;
   /** The ID of the local scheduler that is responsible for the actor. */
   DBClientID local_scheduler_id;
-} actor_info;
+} ActorInfo;
 
 /*
  *  ==== Subscribing to the actor notification table ====
  */
 
 /* Callback for subscribing to the local scheduler table. */
-typedef void (*actor_notification_table_subscribe_callback)(actor_info info,
+typedef void (*actor_notification_table_subscribe_callback)(ActorInfo info,
                                                             void *user_context);
 
 /**

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -9,7 +9,7 @@ typedef struct {
   /** The ID of the actor. */
   ActorID actor_id;
   /** The ID of the local scheduler that is responsible for the actor. */
-  db_client_id local_scheduler_id;
+  DBClientID local_scheduler_id;
 } actor_info;
 
 /*

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -32,7 +32,7 @@ typedef void (*actor_notification_table_subscribe_callback)(actor_info info,
  * @return Void.
  */
 void actor_notification_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     actor_notification_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry);

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -42,6 +42,6 @@ void actor_notification_table_subscribe(
 typedef struct {
   actor_notification_table_subscribe_callback subscribe_callback;
   void *subscribe_context;
-} actor_notification_table_subscribe_data;
+} ActorNotificationTableSubscribeData;
 
 #endif /* ACTOR_NOTIFICATION_TABLE_H */

--- a/src/common/state/db.h
+++ b/src/common/state/db.h
@@ -4,7 +4,7 @@
 #include "common.h"
 #include "event_loop.h"
 
-typedef struct db_handle db_handle;
+typedef struct DBHandle DBHandle;
 
 /**
  * Connect to the global system store.
@@ -21,7 +21,7 @@ typedef struct db_handle db_handle;
  * @return This returns a handle to the database, which must be freed with
  *         db_disconnect after use.
  */
-db_handle *db_connect(const char *db_address,
+DBHandle *db_connect(const char *db_address,
                       int db_port,
                       const char *client_type,
                       const char *node_ip_address,
@@ -38,7 +38,7 @@ db_handle *db_connect(const char *db_address,
  *        reattached to the loop.
  * @return Void.
  */
-void db_attach(db_handle *db, event_loop *loop, bool reattach);
+void db_attach(DBHandle *db, event_loop *loop, bool reattach);
 
 /**
  * Disconnect from the global system store.
@@ -46,7 +46,7 @@ void db_attach(db_handle *db, event_loop *loop, bool reattach);
  * @param db The database connection to close and clean up.
  * @return Void.
  */
-void db_disconnect(db_handle *db);
+void db_disconnect(DBHandle *db);
 
 /**
  * Returns the db client ID.
@@ -54,6 +54,6 @@ void db_disconnect(db_handle *db);
  * @param db The handle to the database.
  * @returns int The db client ID for this connection to the database.
  */
-db_client_id get_db_client_id(db_handle *db);
+db_client_id get_db_client_id(DBHandle *db);
 
 #endif

--- a/src/common/state/db.h
+++ b/src/common/state/db.h
@@ -54,6 +54,6 @@ void db_disconnect(DBHandle *db);
  * @param db The handle to the database.
  * @returns int The db client ID for this connection to the database.
  */
-db_client_id get_db_client_id(DBHandle *db);
+DBClientID get_db_client_id(DBHandle *db);
 
 #endif

--- a/src/common/state/db.h
+++ b/src/common/state/db.h
@@ -22,11 +22,11 @@ typedef struct DBHandle DBHandle;
  *         db_disconnect after use.
  */
 DBHandle *db_connect(const char *db_address,
-                      int db_port,
-                      const char *client_type,
-                      const char *node_ip_address,
-                      int num_args,
-                      const char **args);
+                     int db_port,
+                     const char *client_type,
+                     const char *node_ip_address,
+                     int num_args,
+                     const char **args);
 
 /**
  * Attach global system store connection to an event loop. Callbacks from

--- a/src/common/state/db_client_table.c
+++ b/src/common/state/db_client_table.c
@@ -2,7 +2,7 @@
 #include "redis.h"
 
 void db_client_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     db_client_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry,

--- a/src/common/state/db_client_table.c
+++ b/src/common/state/db_client_table.c
@@ -5,7 +5,7 @@ void db_client_table_subscribe(
     DBHandle *db_handle,
     db_client_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry,
+    RetryInfo *retry,
     db_client_table_done_callback done_callback,
     void *user_context) {
   db_client_table_subscribe_data *sub_data =

--- a/src/common/state/db_client_table.c
+++ b/src/common/state/db_client_table.c
@@ -8,8 +8,8 @@ void db_client_table_subscribe(
     RetryInfo *retry,
     db_client_table_done_callback done_callback,
     void *user_context) {
-  db_client_table_subscribe_data *sub_data =
-      malloc(sizeof(db_client_table_subscribe_data));
+  DBClientTableSubscribeData *sub_data =
+      malloc(sizeof(DBClientTableSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -35,7 +35,7 @@ void db_client_table_subscribe(
     DBHandle *db_handle,
     db_client_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry,
+    RetryInfo *retry,
     db_client_table_done_callback done_callback,
     void *user_context);
 

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -44,6 +44,6 @@ void db_client_table_subscribe(
 typedef struct {
   db_client_table_subscribe_callback subscribe_callback;
   void *subscribe_context;
-} db_client_table_subscribe_data;
+} DBClientTableSubscribeData;
 
 #endif /* DB_CLIENT_TABLE_H */

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -4,7 +4,7 @@
 #include "db.h"
 #include "table.h"
 
-typedef void (*db_client_table_done_callback)(db_client_id db_client_id,
+typedef void (*db_client_table_done_callback)(DBClientID db_client_id,
                                               void *user_context);
 
 /*
@@ -12,7 +12,7 @@ typedef void (*db_client_table_done_callback)(db_client_id db_client_id,
  */
 
 /* Callback for subscribing to the db client table. */
-typedef void (*db_client_table_subscribe_callback)(db_client_id db_client_id,
+typedef void (*db_client_table_subscribe_callback)(DBClientID db_client_id,
                                                    const char *client_type,
                                                    const char *aux_address,
                                                    void *user_context);

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -32,7 +32,7 @@ typedef void (*db_client_table_subscribe_callback)(db_client_id db_client_id,
  * @return Void.
  */
 void db_client_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     db_client_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry,

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -16,7 +16,7 @@ void local_scheduler_table_subscribe(
 }
 
 void local_scheduler_table_send_info(DBHandle *db_handle,
-                                     local_scheduler_info *info,
+                                     LocalSchedulerInfo *info,
                                      retry_info *retry) {
   local_scheduler_table_send_info_data *data =
       malloc(sizeof(local_scheduler_table_send_info_data));

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -5,7 +5,7 @@ void local_scheduler_table_subscribe(
     DBHandle *db_handle,
     local_scheduler_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry) {
+    RetryInfo *retry) {
   local_scheduler_table_subscribe_data *sub_data =
       malloc(sizeof(local_scheduler_table_subscribe_data));
   sub_data->subscribe_callback = subscribe_callback;
@@ -17,7 +17,7 @@ void local_scheduler_table_subscribe(
 
 void local_scheduler_table_send_info(DBHandle *db_handle,
                                      LocalSchedulerInfo *info,
-                                     retry_info *retry) {
+                                     RetryInfo *retry) {
   local_scheduler_table_send_info_data *data =
       malloc(sizeof(local_scheduler_table_send_info_data));
   data->info = *info;

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -2,7 +2,7 @@
 #include "redis.h"
 
 void local_scheduler_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     local_scheduler_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry) {
@@ -15,7 +15,7 @@ void local_scheduler_table_subscribe(
                       redis_local_scheduler_table_subscribe, NULL);
 }
 
-void local_scheduler_table_send_info(db_handle *db_handle,
+void local_scheduler_table_send_info(DBHandle *db_handle,
                                      local_scheduler_info *info,
                                      retry_info *retry) {
   local_scheduler_table_send_info_data *data =

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -18,8 +18,8 @@ void local_scheduler_table_subscribe(
 void local_scheduler_table_send_info(DBHandle *db_handle,
                                      LocalSchedulerInfo *info,
                                      RetryInfo *retry) {
-  local_scheduler_table_send_info_data *data =
-      malloc(sizeof(local_scheduler_table_send_info_data));
+  LocalSchedulerTableSendInfoData *data =
+      malloc(sizeof(LocalSchedulerTableSendInfoData));
   data->info = *info;
 
   init_table_callback(db_handle, NIL_ID, __func__, data, retry, NULL,

--- a/src/common/state/local_scheduler_table.c
+++ b/src/common/state/local_scheduler_table.c
@@ -6,8 +6,8 @@ void local_scheduler_table_subscribe(
     local_scheduler_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     RetryInfo *retry) {
-  local_scheduler_table_subscribe_data *sub_data =
-      malloc(sizeof(local_scheduler_table_subscribe_data));
+  LocalSchedulerTableSubscribeData *sub_data =
+      malloc(sizeof(LocalSchedulerTableSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -55,7 +55,7 @@ void local_scheduler_table_subscribe(
 typedef struct {
   local_scheduler_table_subscribe_callback subscribe_callback;
   void *subscribe_context;
-} local_scheduler_table_subscribe_data;
+} LocalSchedulerTableSubscribeData;
 
 /**
  * Send a heartbeat to all subscriers to the local scheduler table. This

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -74,6 +74,6 @@ void local_scheduler_table_send_info(DBHandle *db_handle,
  * scheduler table. */
 typedef struct {
   LocalSchedulerInfo info;
-} local_scheduler_table_send_info_data;
+} LocalSchedulerTableSendInfoData;
 
 #endif /* LOCAL_SCHEDULER_TABLE_H */

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -48,7 +48,7 @@ void local_scheduler_table_subscribe(
     DBHandle *db_handle,
     local_scheduler_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
-    retry_info *retry);
+    RetryInfo *retry);
 
 /* Data that is needed to register local scheduler table subscribe callbacks
  * with the state database. */
@@ -68,7 +68,7 @@ typedef struct {
  */
 void local_scheduler_table_send_info(DBHandle *db_handle,
                                      LocalSchedulerInfo *info,
-                                     retry_info *retry);
+                                     RetryInfo *retry);
 
 /* Data that is needed to publish local scheduler heartbeats to the local
  * scheduler table. */

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -21,7 +21,7 @@ typedef struct {
   /** The resource vector of resources currently available to this local
    *  scheduler. */
   double dynamic_resources[MAX_RESOURCE_INDEX];
-} local_scheduler_info;
+} LocalSchedulerInfo;
 
 /*
  *  ==== Subscribing to the local scheduler table ====
@@ -30,7 +30,7 @@ typedef struct {
 /* Callback for subscribing to the local scheduler table. */
 typedef void (*local_scheduler_table_subscribe_callback)(
     DBClientID client_id,
-    local_scheduler_info info,
+    LocalSchedulerInfo info,
     void *user_context);
 
 /**
@@ -67,13 +67,13 @@ typedef struct {
  * @param retry Information about retrying the request to the database.
  */
 void local_scheduler_table_send_info(DBHandle *db_handle,
-                                     local_scheduler_info *info,
+                                     LocalSchedulerInfo *info,
                                      retry_info *retry);
 
 /* Data that is needed to publish local scheduler heartbeats to the local
  * scheduler table. */
 typedef struct {
-  local_scheduler_info info;
+  LocalSchedulerInfo info;
 } local_scheduler_table_send_info_data;
 
 #endif /* LOCAL_SCHEDULER_TABLE_H */

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -73,6 +73,7 @@ void local_scheduler_table_send_info(DBHandle *db_handle,
 /* Data that is needed to publish local scheduler heartbeats to the local
  * scheduler table. */
 typedef struct {
+  /* The information to be sent. */
   LocalSchedulerInfo info;
 } LocalSchedulerTableSendInfoData;
 

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -45,7 +45,7 @@ typedef void (*local_scheduler_table_subscribe_callback)(
  * @return Void.
  */
 void local_scheduler_table_subscribe(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     local_scheduler_table_subscribe_callback subscribe_callback,
     void *subscribe_context,
     retry_info *retry);
@@ -66,7 +66,7 @@ typedef struct {
  *        local scheduler.
  * @param retry Information about retrying the request to the database.
  */
-void local_scheduler_table_send_info(db_handle *db_handle,
+void local_scheduler_table_send_info(DBHandle *db_handle,
                                      local_scheduler_info *info,
                                      retry_info *retry);
 

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -29,7 +29,7 @@ typedef struct {
 
 /* Callback for subscribing to the local scheduler table. */
 typedef void (*local_scheduler_table_subscribe_callback)(
-    db_client_id client_id,
+    DBClientID client_id,
     local_scheduler_info info,
     void *user_context);
 

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -30,15 +30,15 @@ void object_table_add(DBHandle *db_handle,
 
 void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
-                         db_client_id *client_id,
+                         DBClientID *client_id,
                          retry_info *retry,
                          object_table_done_callback done_callback,
                          void *user_context) {
   CHECK(db_handle != NULL);
   /* Copy the client ID, if one was provided. */
-  db_client_id *client_id_copy = NULL;
+  DBClientID *client_id_copy = NULL;
   if (client_id != NULL) {
-    client_id_copy = malloc(sizeof(db_client_id));
+    client_id_copy = malloc(sizeof(DBClientID));
     *client_id_copy = *client_id;
   }
   init_table_callback(db_handle, object_id, __func__, client_id_copy, retry,

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -2,7 +2,7 @@
 #include "redis.h"
 #include "object_info.h"
 
-void object_table_lookup(db_handle *db_handle,
+void object_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
                          retry_info *retry,
                          object_table_lookup_done_callback done_callback,
@@ -12,7 +12,7 @@ void object_table_lookup(db_handle *db_handle,
                       done_callback, redis_object_table_lookup, user_context);
 }
 
-void object_table_add(db_handle *db_handle,
+void object_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
@@ -28,7 +28,7 @@ void object_table_add(db_handle *db_handle,
                       done_callback, redis_object_table_add, user_context);
 }
 
-void object_table_remove(db_handle *db_handle,
+void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
                          db_client_id *client_id,
                          retry_info *retry,
@@ -46,7 +46,7 @@ void object_table_remove(db_handle *db_handle,
 }
 
 void object_table_subscribe_to_notifications(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     bool subscribe_all,
     object_table_object_available_callback object_available_callback,
     void *subscribe_context,
@@ -65,7 +65,7 @@ void object_table_subscribe_to_notifications(
       redis_object_table_subscribe_to_notifications, user_context);
 }
 
-void object_table_request_notifications(db_handle *db_handle,
+void object_table_request_notifications(DBHandle *db_handle,
                                         int num_object_ids,
                                         ObjectID object_ids[],
                                         retry_info *retry) {
@@ -81,7 +81,7 @@ void object_table_request_notifications(db_handle *db_handle,
                       redis_object_table_request_notifications, NULL);
 }
 
-void object_info_subscribe(db_handle *db_handle,
+void object_info_subscribe(DBHandle *db_handle,
                            object_info_subscribe_callback subscribe_callback,
                            void *subscribe_context,
                            retry_info *retry,
@@ -96,7 +96,7 @@ void object_info_subscribe(db_handle *db_handle,
                       done_callback, redis_object_info_subscribe, user_context);
 }
 
-void result_table_add(db_handle *db_handle,
+void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       TaskID task_id_arg,
                       retry_info *retry,
@@ -108,7 +108,7 @@ void result_table_add(db_handle *db_handle,
                       done_callback, redis_result_table_add, user_context);
 }
 
-void result_table_lookup(db_handle *db_handle,
+void result_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
                          retry_info *retry,
                          result_table_lookup_callback done_callback,

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -87,8 +87,8 @@ void object_info_subscribe(DBHandle *db_handle,
                            RetryInfo *retry,
                            object_info_done_callback done_callback,
                            void *user_context) {
-  object_info_subscribe_data *sub_data =
-      malloc(sizeof(object_info_subscribe_data));
+  ObjectInfoSubscribeData *sub_data =
+      malloc(sizeof(ObjectInfoSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -54,8 +54,7 @@ void object_table_subscribe_to_notifications(
     object_table_lookup_done_callback done_callback,
     void *user_context) {
   CHECK(db_handle != NULL);
-  ObjectTableSubscribeData *sub_data =
-      malloc(sizeof(ObjectTableSubscribeData));
+  ObjectTableSubscribeData *sub_data = malloc(sizeof(ObjectTableSubscribeData));
   sub_data->object_available_callback = object_available_callback;
   sub_data->subscribe_context = subscribe_context;
   sub_data->subscribe_all = subscribe_all;
@@ -87,8 +86,7 @@ void object_info_subscribe(DBHandle *db_handle,
                            RetryInfo *retry,
                            object_info_done_callback done_callback,
                            void *user_context) {
-  ObjectInfoSubscribeData *sub_data =
-      malloc(sizeof(ObjectInfoSubscribeData));
+  ObjectInfoSubscribeData *sub_data = malloc(sizeof(ObjectInfoSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -4,7 +4,7 @@
 
 void object_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          object_table_lookup_done_callback done_callback,
                          void *user_context) {
   CHECK(db_handle != NULL);
@@ -16,7 +16,7 @@ void object_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
-                      retry_info *retry,
+                      RetryInfo *retry,
                       object_table_done_callback done_callback,
                       void *user_context) {
   CHECK(db_handle != NULL);
@@ -31,7 +31,7 @@ void object_table_add(DBHandle *db_handle,
 void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
                          DBClientID *client_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          object_table_done_callback done_callback,
                          void *user_context) {
   CHECK(db_handle != NULL);
@@ -50,7 +50,7 @@ void object_table_subscribe_to_notifications(
     bool subscribe_all,
     object_table_object_available_callback object_available_callback,
     void *subscribe_context,
-    retry_info *retry,
+    RetryInfo *retry,
     object_table_lookup_done_callback done_callback,
     void *user_context) {
   CHECK(db_handle != NULL);
@@ -68,7 +68,7 @@ void object_table_subscribe_to_notifications(
 void object_table_request_notifications(DBHandle *db_handle,
                                         int num_object_ids,
                                         ObjectID object_ids[],
-                                        retry_info *retry) {
+                                        RetryInfo *retry) {
   CHECK(db_handle != NULL);
   CHECK(num_object_ids > 0);
   object_table_request_notifications_data *data =
@@ -84,7 +84,7 @@ void object_table_request_notifications(DBHandle *db_handle,
 void object_info_subscribe(DBHandle *db_handle,
                            object_info_subscribe_callback subscribe_callback,
                            void *subscribe_context,
-                           retry_info *retry,
+                           RetryInfo *retry,
                            object_info_done_callback done_callback,
                            void *user_context) {
   object_info_subscribe_data *sub_data =
@@ -99,7 +99,7 @@ void object_info_subscribe(DBHandle *db_handle,
 void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       TaskID task_id_arg,
-                      retry_info *retry,
+                      RetryInfo *retry,
                       result_table_done_callback done_callback,
                       void *user_context) {
   TaskID *task_id_copy = malloc(sizeof(TaskID));
@@ -110,7 +110,7 @@ void result_table_add(DBHandle *db_handle,
 
 void result_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          result_table_lookup_callback done_callback,
                          void *user_context) {
   init_table_callback(db_handle, object_id, __func__, NULL, retry,

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -3,7 +3,7 @@
 #include "object_info.h"
 
 void object_table_lookup(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          retry_info *retry,
                          object_table_lookup_done_callback done_callback,
                          void *user_context) {
@@ -13,7 +13,7 @@ void object_table_lookup(db_handle *db_handle,
 }
 
 void object_table_add(db_handle *db_handle,
-                      object_id object_id,
+                      ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
                       retry_info *retry,
@@ -29,7 +29,7 @@ void object_table_add(db_handle *db_handle,
 }
 
 void object_table_remove(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          db_client_id *client_id,
                          retry_info *retry,
                          object_table_done_callback done_callback,
@@ -67,15 +67,15 @@ void object_table_subscribe_to_notifications(
 
 void object_table_request_notifications(db_handle *db_handle,
                                         int num_object_ids,
-                                        object_id object_ids[],
+                                        ObjectID object_ids[],
                                         retry_info *retry) {
   CHECK(db_handle != NULL);
   CHECK(num_object_ids > 0);
   object_table_request_notifications_data *data =
       malloc(sizeof(object_table_request_notifications_data) +
-             num_object_ids * sizeof(object_id));
+             num_object_ids * sizeof(ObjectID));
   data->num_object_ids = num_object_ids;
-  memcpy(data->object_ids, object_ids, num_object_ids * sizeof(object_id));
+  memcpy(data->object_ids, object_ids, num_object_ids * sizeof(ObjectID));
 
   init_table_callback(db_handle, NIL_OBJECT_ID, __func__, data, retry, NULL,
                       redis_object_table_request_notifications, NULL);
@@ -97,7 +97,7 @@ void object_info_subscribe(db_handle *db_handle,
 }
 
 void result_table_add(db_handle *db_handle,
-                      object_id object_id,
+                      ObjectID object_id,
                       task_id task_id_arg,
                       retry_info *retry,
                       result_table_done_callback done_callback,
@@ -109,7 +109,7 @@ void result_table_add(db_handle *db_handle,
 }
 
 void result_table_lookup(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          retry_info *retry,
                          result_table_lookup_callback done_callback,
                          void *user_context) {

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -21,7 +21,7 @@ void object_table_add(DBHandle *db_handle,
                       void *user_context) {
   CHECK(db_handle != NULL);
 
-  object_table_add_data *info = malloc(sizeof(object_table_add_data));
+  ObjectTableAddData *info = malloc(sizeof(ObjectTableAddData));
   info->object_size = object_size;
   memcpy(&info->digest[0], digest, DIGEST_SIZE);
   init_table_callback(db_handle, object_id, __func__, info, retry,
@@ -54,8 +54,8 @@ void object_table_subscribe_to_notifications(
     object_table_lookup_done_callback done_callback,
     void *user_context) {
   CHECK(db_handle != NULL);
-  object_table_subscribe_data *sub_data =
-      malloc(sizeof(object_table_subscribe_data));
+  ObjectTableSubscribeData *sub_data =
+      malloc(sizeof(ObjectTableSubscribeData));
   sub_data->object_available_callback = object_available_callback;
   sub_data->subscribe_context = subscribe_context;
   sub_data->subscribe_all = subscribe_all;
@@ -71,8 +71,8 @@ void object_table_request_notifications(DBHandle *db_handle,
                                         RetryInfo *retry) {
   CHECK(db_handle != NULL);
   CHECK(num_object_ids > 0);
-  object_table_request_notifications_data *data =
-      malloc(sizeof(object_table_request_notifications_data) +
+  ObjectTableRequestNotificationsData *data =
+      malloc(sizeof(ObjectTableRequestNotificationsData) +
              num_object_ids * sizeof(ObjectID));
   data->num_object_ids = num_object_ids;
   memcpy(data->object_ids, object_ids, num_object_ids * sizeof(ObjectID));

--- a/src/common/state/object_table.c
+++ b/src/common/state/object_table.c
@@ -98,11 +98,11 @@ void object_info_subscribe(db_handle *db_handle,
 
 void result_table_add(db_handle *db_handle,
                       ObjectID object_id,
-                      task_id task_id_arg,
+                      TaskID task_id_arg,
                       retry_info *retry,
                       result_table_done_callback done_callback,
                       void *user_context) {
-  task_id *task_id_copy = malloc(sizeof(task_id));
+  TaskID *task_id_copy = malloc(sizeof(TaskID));
   memcpy(task_id_copy, task_id_arg.id, sizeof(*task_id_copy));
   init_table_callback(db_handle, object_id, __func__, task_id_copy, retry,
                       done_callback, redis_result_table_add, user_context);

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -202,7 +202,7 @@ void object_info_subscribe(DBHandle *db_handle,
 typedef struct {
   object_info_subscribe_callback subscribe_callback;
   void *subscribe_context;
-} object_info_subscribe_data;
+} ObjectInfoSubscribeData;
 
 /*
  *  ==== Result table ====

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -98,7 +98,7 @@ typedef struct {
  */
 void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
-                         db_client_id *client_id,
+                         DBClientID *client_id,
                          retry_info *retry,
                          object_table_done_callback done_callback,
                          void *user_context);

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -39,7 +39,7 @@ typedef void (*object_table_object_available_callback)(
  *  @param user_context Context passed by the caller.
  *  @return Void.
  */
-void object_table_lookup(db_handle *db_handle,
+void object_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
                          retry_info *retry,
                          object_table_lookup_done_callback done_callback,
@@ -65,7 +65,7 @@ typedef void (*object_table_done_callback)(ObjectID object_id,
  * @param user_context User context to be passed in the callbacks.
  * @return Void.
  */
-void object_table_add(db_handle *db_handle,
+void object_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
@@ -96,7 +96,7 @@ typedef struct {
  * @param user_context User context to be passed in the callbacks.
  * @return Void.
  */
-void object_table_remove(db_handle *db_handle,
+void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
                          db_client_id *client_id,
                          retry_info *retry,
@@ -125,7 +125,7 @@ void object_table_remove(db_handle *db_handle,
  * @return Void.
  */
 void object_table_subscribe_to_notifications(
-    db_handle *db_handle,
+    DBHandle *db_handle,
     bool subscribe_all,
     object_table_object_available_callback object_available_callback,
     void *subscribe_context,
@@ -144,7 +144,7 @@ void object_table_subscribe_to_notifications(
  * @param retry Information about retrying the request to the database.
  * @return Void.
  */
-void object_table_request_notifications(db_handle *db,
+void object_table_request_notifications(DBHandle *db,
                                         int num_object_ids,
                                         ObjectID object_ids[],
                                         retry_info *retry);
@@ -190,7 +190,7 @@ typedef void (*object_info_subscribe_callback)(ObjectID object_id,
  *        callbacks.
  * @return Void.
  */
-void object_info_subscribe(db_handle *db_handle,
+void object_info_subscribe(DBHandle *db_handle,
                            object_info_subscribe_callback subscribe_callback,
                            void *subscribe_context,
                            retry_info *retry,
@@ -227,7 +227,7 @@ typedef void (*result_table_done_callback)(ObjectID object_id,
  * @param user_context Context passed by the caller.
  * @return Void.
  */
-void result_table_add(db_handle *db_handle,
+void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       TaskID task_id,
                       retry_info *retry,
@@ -250,7 +250,7 @@ typedef void (*result_table_lookup_callback)(ObjectID object_id,
  * @param user_context Context passed by the caller.
  * @return Void.
  */
-void result_table_lookup(db_handle *db_handle,
+void result_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
                          retry_info *retry,
                          result_table_lookup_callback done_callback,

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -77,7 +77,7 @@ void object_table_add(DBHandle *db_handle,
 typedef struct {
   int64_t object_size;
   unsigned char digest[DIGEST_SIZE];
-} object_table_add_data;
+} ObjectTableAddData;
 
 /*
  *  ==== Remove object call and callback ====
@@ -155,7 +155,7 @@ typedef struct {
   int num_object_ids;
   /** This field is used to store a variable number of object IDs. */
   ObjectID object_ids[0];
-} object_table_request_notifications_data;
+} ObjectTableRequestNotificationsData;
 
 /** Data that is needed to register new object available callbacks with the
  *  state database. */
@@ -163,7 +163,7 @@ typedef struct {
   bool subscribe_all;
   object_table_object_available_callback object_available_callback;
   void *subscribe_context;
-} object_table_subscribe_data;
+} ObjectTableSubscribeData;
 
 /*
  * ==== Object info table, contains size of the object ====

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -41,7 +41,7 @@ typedef void (*object_table_object_available_callback)(
  */
 void object_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          object_table_lookup_done_callback done_callback,
                          void *user_context);
 
@@ -69,7 +69,7 @@ void object_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
-                      retry_info *retry,
+                      RetryInfo *retry,
                       object_table_done_callback done_callback,
                       void *user_context);
 
@@ -99,7 +99,7 @@ typedef struct {
 void object_table_remove(DBHandle *db_handle,
                          ObjectID object_id,
                          DBClientID *client_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          object_table_done_callback done_callback,
                          void *user_context);
 
@@ -129,7 +129,7 @@ void object_table_subscribe_to_notifications(
     bool subscribe_all,
     object_table_object_available_callback object_available_callback,
     void *subscribe_context,
-    retry_info *retry,
+    RetryInfo *retry,
     object_table_lookup_done_callback done_callback,
     void *user_context);
 
@@ -147,7 +147,7 @@ void object_table_subscribe_to_notifications(
 void object_table_request_notifications(DBHandle *db,
                                         int num_object_ids,
                                         ObjectID object_ids[],
-                                        retry_info *retry);
+                                        RetryInfo *retry);
 
 /** Data that is needed to run object_request_notifications requests. */
 typedef struct {
@@ -193,7 +193,7 @@ typedef void (*object_info_subscribe_callback)(ObjectID object_id,
 void object_info_subscribe(DBHandle *db_handle,
                            object_info_subscribe_callback subscribe_callback,
                            void *subscribe_context,
-                           retry_info *retry,
+                           RetryInfo *retry,
                            object_info_done_callback done_callback,
                            void *user_context);
 
@@ -230,7 +230,7 @@ typedef void (*result_table_done_callback)(ObjectID object_id,
 void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       TaskID task_id,
-                      retry_info *retry,
+                      RetryInfo *retry,
                       result_table_done_callback done_callback,
                       void *user_context);
 
@@ -252,7 +252,7 @@ typedef void (*result_table_lookup_callback)(ObjectID object_id,
  */
 void result_table_lookup(DBHandle *db_handle,
                          ObjectID object_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          result_table_lookup_callback done_callback,
                          void *user_context);
 

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -16,14 +16,14 @@
  * before), then manager_count will be -1.
  */
 typedef void (*object_table_lookup_done_callback)(
-    object_id object_id,
+    ObjectID object_id,
     int manager_count,
     OWNER const char *manager_vector[],
     void *user_context);
 
-/* Callback called when object object_id is available. */
+/* Callback called when object ObjectID is available. */
 typedef void (*object_table_object_available_callback)(
-    object_id object_id,
+    ObjectID object_id,
     int64_t data_size,
     int manager_count,
     OWNER const char *manager_vector[],
@@ -40,7 +40,7 @@ typedef void (*object_table_object_available_callback)(
  *  @return Void.
  */
 void object_table_lookup(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          retry_info *retry,
                          object_table_lookup_done_callback done_callback,
                          void *user_context);
@@ -50,7 +50,7 @@ void object_table_lookup(db_handle *db_handle,
  */
 
 /* Callback called when the object add/remove operation completes. */
-typedef void (*object_table_done_callback)(object_id object_id,
+typedef void (*object_table_done_callback)(ObjectID object_id,
                                            void *user_context);
 
 /**
@@ -66,7 +66,7 @@ typedef void (*object_table_done_callback)(object_id object_id,
  * @return Void.
  */
 void object_table_add(db_handle *db_handle,
-                      object_id object_id,
+                      ObjectID object_id,
                       int64_t object_size,
                       unsigned char digest[],
                       retry_info *retry,
@@ -97,7 +97,7 @@ typedef struct {
  * @return Void.
  */
 void object_table_remove(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          db_client_id *client_id,
                          retry_info *retry,
                          object_table_done_callback done_callback,
@@ -146,7 +146,7 @@ void object_table_subscribe_to_notifications(
  */
 void object_table_request_notifications(db_handle *db,
                                         int num_object_ids,
-                                        object_id object_ids[],
+                                        ObjectID object_ids[],
                                         retry_info *retry);
 
 /** Data that is needed to run object_request_notifications requests. */
@@ -154,7 +154,7 @@ typedef struct {
   /** The number of object IDs. */
   int num_object_ids;
   /** This field is used to store a variable number of object IDs. */
-  object_id object_ids[0];
+  ObjectID object_ids[0];
 } object_table_request_notifications_data;
 
 /** Data that is needed to register new object available callbacks with the
@@ -169,10 +169,10 @@ typedef struct {
  * ==== Object info table, contains size of the object ====
  */
 
-typedef void (*object_info_done_callback)(object_id object_id,
+typedef void (*object_info_done_callback)(ObjectID object_id,
                                           void *user_context);
 
-typedef void (*object_info_subscribe_callback)(object_id object_id,
+typedef void (*object_info_subscribe_callback)(ObjectID object_id,
                                                int64_t object_size,
                                                void *user_context);
 
@@ -211,7 +211,7 @@ typedef struct {
 /**
  * Callback called when the add/remove operation for a result table entry
  * completes. */
-typedef void (*result_table_done_callback)(object_id object_id,
+typedef void (*result_table_done_callback)(ObjectID object_id,
                                            void *user_context);
 
 /**
@@ -228,14 +228,14 @@ typedef void (*result_table_done_callback)(object_id object_id,
  * @return Void.
  */
 void result_table_add(db_handle *db_handle,
-                      object_id object_id,
+                      ObjectID object_id,
                       task_id task_id,
                       retry_info *retry,
                       result_table_done_callback done_callback,
                       void *user_context);
 
 /** Callback called when the result table lookup completes. */
-typedef void (*result_table_lookup_callback)(object_id object_id,
+typedef void (*result_table_lookup_callback)(ObjectID object_id,
                                              task_id task_id,
                                              void *user_context);
 
@@ -251,7 +251,7 @@ typedef void (*result_table_lookup_callback)(object_id object_id,
  * @return Void.
  */
 void result_table_lookup(db_handle *db_handle,
-                         object_id object_id,
+                         ObjectID object_id,
                          retry_info *retry,
                          result_table_lookup_callback done_callback,
                          void *user_context);

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -229,14 +229,14 @@ typedef void (*result_table_done_callback)(ObjectID object_id,
  */
 void result_table_add(db_handle *db_handle,
                       ObjectID object_id,
-                      task_id task_id,
+                      TaskID task_id,
                       retry_info *retry,
                       result_table_done_callback done_callback,
                       void *user_context);
 
 /** Callback called when the result table lookup completes. */
 typedef void (*result_table_lookup_callback)(ObjectID object_id,
-                                             task_id task_id,
+                                             TaskID task_id,
                                              void *user_context);
 
 /**

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -363,8 +363,8 @@ void redis_result_table_add(table_callback_data *callback_data) {
 /* This allocates a task which must be freed by the caller, unless the returned
  * task is NULL. This is used by both redis_result_table_lookup_callback and
  * redis_task_table_get_task_callback. */
-task *parse_and_construct_task_from_redis_reply(redisReply *reply) {
-  task *task;
+Task *parse_and_construct_task_from_redis_reply(redisReply *reply) {
+  Task *task;
   if (reply->type == REDIS_REPLY_NIL) {
     /* There is no task in the reply, so return NULL. */
     task = NULL;
@@ -737,7 +737,7 @@ void redis_task_table_get_task_callback(redisAsyncContext *c,
   REDIS_CALLBACK_HEADER(db, callback_data, r);
   redisReply *reply = r;
   /* Parse the task from the reply. */
-  task *task = parse_and_construct_task_from_redis_reply(reply);
+  Task *task = parse_and_construct_task_from_redis_reply(reply);
   /* Call the done callback if there is one. */
   task_table_get_callback done_callback = callback_data->done_callback;
   if (done_callback != NULL) {
@@ -783,7 +783,7 @@ void redis_task_table_add_task_callback(redisAsyncContext *c,
 
 void redis_task_table_add_task(table_callback_data *callback_data) {
   DBHandle *db = callback_data->db_handle;
-  task *task = callback_data->data;
+  Task *task = callback_data->data;
   TaskID task_id = task_task_id(task);
   DBClientID local_scheduler_id = task_local_scheduler(task);
   int state = task_state(task);
@@ -819,7 +819,7 @@ void redis_task_table_update_callback(redisAsyncContext *c,
 
 void redis_task_table_update(table_callback_data *callback_data) {
   DBHandle *db = callback_data->db_handle;
-  task *task = callback_data->data;
+  Task *task = callback_data->data;
   TaskID task_id = task_task_id(task);
   DBClientID local_scheduler_id = task_local_scheduler(task);
   int state = task_state(task);
@@ -841,7 +841,7 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
   REDIS_CALLBACK_HEADER(db, callback_data, r);
   redisReply *reply = r;
   /* Parse the task from the reply. */
-  task *task = parse_and_construct_task_from_redis_reply(reply);
+  Task *task = parse_and_construct_task_from_redis_reply(reply);
   /* Call the done callback if there is one. */
   task_table_get_callback done_callback = callback_data->done_callback;
   if (done_callback != NULL) {
@@ -939,7 +939,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
     task_spec *spec;
     parse_task_table_subscribe_callback(payload->str, payload->len, &task_id,
                                         &state, &local_scheduler_id, &spec);
-    task *task = alloc_task(spec, state, local_scheduler_id);
+    Task *task = alloc_task(spec, state, local_scheduler_id);
     free(spec);
     /* Call the subscribe callback if there is one. */
     if (data->subscribe_callback != NULL) {

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1189,7 +1189,7 @@ void redis_object_info_subscribe_callback(redisAsyncContext *c,
     return;
   }
   /* Otherwise, parse the payload and call the callback. */
-  object_info_subscribe_data *data = (object_info_subscribe_data *) callback_data->data;
+  ObjectInfoSubscribeData *data = (ObjectInfoSubscribeData *) callback_data->data;
   ObjectID object_id;
   memcpy(object_id.id, payload->str, sizeof(object_id.id));
   /* payload->str should have the format: "ObjectID:object_size_int" */

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -349,7 +349,7 @@ void redis_result_table_add(table_callback_data *callback_data) {
   CHECK(callback_data);
   db_handle *db = callback_data->db_handle;
   ObjectID id = callback_data->id;
-  task_id *result_task_id = (task_id *) callback_data->data;
+  TaskID *result_task_id = (TaskID *) callback_data->data;
   /* Add the result entry to the result table. */
   int status = redisAsyncCommand(
       db->context, redis_result_table_add_callback,
@@ -406,7 +406,7 @@ void redis_result_table_lookup_callback(redisAsyncContext *c,
          "Unexpected reply type %d in redis_result_table_lookup_callback",
          reply->type);
   /* Parse the task from the reply. */
-  task_id result_id = NIL_TASK_ID;
+  TaskID result_id = NIL_TASK_ID;
   if (reply->type == REDIS_REPLY_STRING) {
     CHECK(reply->len == sizeof(result_id));
     memcpy(&result_id, reply->str, reply->len);
@@ -753,7 +753,7 @@ void redis_task_table_get_task_callback(redisAsyncContext *c,
 void redis_task_table_get_task(table_callback_data *callback_data) {
   db_handle *db = callback_data->db_handle;
   CHECK(callback_data->data == NULL);
-  task_id task_id = callback_data->id;
+  TaskID task_id = callback_data->id;
 
   int status = redisAsyncCommand(
       db->context, redis_task_table_get_task_callback,
@@ -784,7 +784,7 @@ void redis_task_table_add_task_callback(redisAsyncContext *c,
 void redis_task_table_add_task(table_callback_data *callback_data) {
   db_handle *db = callback_data->db_handle;
   task *task = callback_data->data;
-  task_id task_id = task_task_id(task);
+  TaskID task_id = task_task_id(task);
   db_client_id local_scheduler_id = task_local_scheduler(task);
   int state = task_state(task);
   task_spec *spec = task_task_spec(task);
@@ -820,7 +820,7 @@ void redis_task_table_update_callback(redisAsyncContext *c,
 void redis_task_table_update(table_callback_data *callback_data) {
   db_handle *db = callback_data->db_handle;
   task *task = callback_data->data;
-  task_id task_id = task_task_id(task);
+  TaskID task_id = task_task_id(task);
   db_client_id local_scheduler_id = task_local_scheduler(task);
   int state = task_state(task);
 
@@ -857,7 +857,7 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
 
 void redis_task_table_test_and_update(table_callback_data *callback_data) {
   db_handle *db = callback_data->db_handle;
-  task_id task_id = callback_data->id;
+  TaskID task_id = callback_data->id;
   task_table_test_and_update_data *update_data = callback_data->data;
 
   int status = redisAsyncCommand(
@@ -877,7 +877,7 @@ void redis_task_table_test_and_update(table_callback_data *callback_data) {
  * Make this code nicer. */
 void parse_task_table_subscribe_callback(char *payload,
                                          int length,
-                                         task_id *task_id,
+                                         TaskID *task_id,
                                          int *state,
                                          db_client_id *local_scheduler_id,
                                          task_spec **spec) {
@@ -933,7 +933,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
     /* Handle a task table event. Parse the payload and call the callback. */
     task_table_subscribe_data *data = callback_data->data;
     /* Read out the information from the payload. */
-    task_id task_id;
+    TaskID task_id;
     int state;
     db_client_id local_scheduler_id;
     task_spec *spec;

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1051,7 +1051,7 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
     /* Handle a local scheduler heartbeat. Parse the payload and call the
      * subscribe callback. */
     redisReply *payload = reply->element[2];
-    local_scheduler_table_subscribe_data *data = (local_scheduler_table_subscribe_data *) callback_data->data;
+    LocalSchedulerTableSubscribeData *data = (LocalSchedulerTableSubscribeData *) callback_data->data;
     DBClientID client_id;
     LocalSchedulerInfo info;
     /* The payload should be the concatenation of these two structs. */

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1127,8 +1127,8 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     /* Handle an actor notification message. Parse the payload and call the
      * subscribe callback. */
     redisReply *payload = reply->element[2];
-    actor_notification_table_subscribe_data *data =
-        (actor_notification_table_subscribe_data *) callback_data->data;
+    ActorNotificationTableSubscribeData *data =
+        (ActorNotificationTableSubscribeData *) callback_data->data;
     ActorInfo info;
     /* The payload should be the concatenation of these two structs. */
     CHECK(sizeof(info.actor_id) + sizeof(info.local_scheduler_id) ==

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1073,7 +1073,7 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
     redisReply *payload = reply->element[2];
     local_scheduler_table_subscribe_data *data = (local_scheduler_table_subscribe_data *) callback_data->data;
     DBClientID client_id;
-    local_scheduler_info info;
+    LocalSchedulerInfo info;
     /* The payload should be the concatenation of these two structs. */
     CHECK(sizeof(client_id) + sizeof(info) == payload->len);
     memcpy(&client_id, payload->str, sizeof(client_id));

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -225,7 +225,8 @@ void redis_object_table_add_callback(redisAsyncContext *c,
   CHECK(strcmp(reply->str, "OK") == 0);
   /* Call the done callback if there is one. */
   if (callback_data->done_callback != NULL) {
-    object_table_done_callback done_callback = (object_table_done_callback) callback_data->done_callback;
+    object_table_done_callback done_callback =
+        (object_table_done_callback) callback_data->done_callback;
     done_callback(callback_data->id, callback_data->user_context);
   }
   /* Clean up the timer and callback. */
@@ -235,7 +236,7 @@ void redis_object_table_add_callback(redisAsyncContext *c,
 void redis_object_table_add(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
 
-  object_table_add_data *info = (object_table_add_data *) callback_data->data;
+  ObjectTableAddData *info = (ObjectTableAddData *) callback_data->data;
   ObjectID obj_id = callback_data->id;
   int64_t object_size = info->object_size;
   unsigned char *digest = info->digest;
@@ -601,7 +602,8 @@ void object_table_redis_subscribe_to_notifications_callback(
         db, reply->element[2]->str, reply->element[2]->len, &data_size,
         &manager_count, &manager_vector);
     /* Call the subscribe callback. */
-    object_table_subscribe_data *data = (object_table_subscribe_data *) callback_data->data;
+    ObjectTableSubscribeData *data =
+        (ObjectTableSubscribeData *) callback_data->data;
     if (data->object_available_callback) {
       data->object_available_callback(obj_id, data_size, manager_count,
                                       manager_vector, data->subscribe_context);
@@ -639,7 +641,7 @@ void redis_object_table_subscribe_to_notifications(
    * The channel name should probably be the client ID with some prefix. */
   CHECKM(callback_data->data != NULL,
          "Object table subscribe data passed as NULL.");
-  if (((object_table_subscribe_data *) (callback_data->data))->subscribe_all) {
+  if (((ObjectTableSubscribeData *) (callback_data->data))->subscribe_all) {
     /* Subscribe to the object broadcast channel. */
     status = redisAsyncCommand(
         db->sub_context, object_table_redis_subscribe_to_notifications_callback,
@@ -675,7 +677,8 @@ void redis_object_table_request_notifications(
     TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
 
-  object_table_request_notifications_data *request_data = (object_table_request_notifications_data *) callback_data->data;
+  ObjectTableRequestNotificationsData *request_data =
+      (ObjectTableRequestNotificationsData *) callback_data->data;
   int num_object_ids = request_data->num_object_ids;
   ObjectID *object_ids = request_data->object_ids;
 
@@ -838,7 +841,7 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
 void redis_task_table_test_and_update(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   TaskID task_id = callback_data->id;
-  task_table_test_and_update_data *update_data = (task_table_test_and_update_data *) callback_data->data;
+  TaskTableTestAndUpdateData *update_data = (TaskTableTestAndUpdateData *) callback_data->data;
 
   int status = redisAsyncCommand(
       db->context, redis_task_table_test_and_update_callback,
@@ -911,7 +914,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
   if (strcmp(message_type->str, "message") == 0 ||
       strcmp(message_type->str, "pmessage") == 0) {
     /* Handle a task table event. Parse the payload and call the callback. */
-    task_table_subscribe_data *data = (task_table_subscribe_data *) callback_data->data;
+    TaskTableSubscribeData *data = (TaskTableSubscribeData *) callback_data->data;
     /* Read out the information from the payload. */
     TaskID task_id;
     int state;
@@ -946,7 +949,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
 
 void redis_task_table_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
-  task_table_subscribe_data *data = (task_table_subscribe_data *) callback_data->data;
+  TaskTableSubscribeData *data = (TaskTableSubscribeData *) callback_data->data;
   /* TASK_CHANNEL_PREFIX is defined in ray_redis_module.c and must be kept in
    * sync with that file. */
   const char *TASK_CHANNEL_PREFIX = "TT:";
@@ -1000,7 +1003,7 @@ void redis_db_client_table_subscribe_callback(redisAsyncContext *c,
     return;
   }
   /* Otherwise, parse the payload and call the callback. */
-  db_client_table_subscribe_data *data = (db_client_table_subscribe_data *) callback_data->data;
+  DBClientTableSubscribeData *data = (DBClientTableSubscribeData *) callback_data->data;
   DBClientID client;
   memcpy(client.id, payload->str, sizeof(client.id));
   /* We subtract 1 + sizeof(client.id) to compute the length of the

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1127,8 +1127,9 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     /* Handle an actor notification message. Parse the payload and call the
      * subscribe callback. */
     redisReply *payload = reply->element[2];
-    actor_notification_table_subscribe_data *data = (actor_notification_table_subscribe_data *) callback_data->data;
-    actor_info info;
+    actor_notification_table_subscribe_data *data =
+        (actor_notification_table_subscribe_data *) callback_data->data;
+    ActorInfo info;
     /* The payload should be the concatenation of these two structs. */
     CHECK(sizeof(info.actor_id) + sizeof(info.local_scheduler_id) ==
           payload->len);

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -59,7 +59,7 @@ extern int usleep(useconds_t usec);
     return;                                           \
   }                                                   \
   DBHandle *DB = (DBHandle *) c->data;                \
-  table_callback_data *CB_DATA =                      \
+  TableCallbackData *CB_DATA =                      \
       outstanding_callbacks_find((int64_t) privdata); \
   if (CB_DATA == NULL) {                              \
     /* the callback data structure has been           \
@@ -232,7 +232,7 @@ void redis_object_table_add_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_object_table_add(table_callback_data *callback_data) {
+void redis_object_table_add(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
 
   object_table_add_data *info = (object_table_add_data *) callback_data->data;
@@ -274,7 +274,7 @@ void redis_object_table_remove_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_object_table_remove(table_callback_data *callback_data) {
+void redis_object_table_remove(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
 
   ObjectID obj_id = callback_data->id;
@@ -294,7 +294,7 @@ void redis_object_table_remove(table_callback_data *callback_data) {
   }
 }
 
-void redis_object_table_lookup(table_callback_data *callback_data) {
+void redis_object_table_lookup(TableCallbackData *callback_data) {
   CHECK(callback_data);
   DBHandle *db = callback_data->db_handle;
 
@@ -325,7 +325,7 @@ void redis_result_table_add_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_result_table_add(table_callback_data *callback_data) {
+void redis_result_table_add(TableCallbackData *callback_data) {
   CHECK(callback_data);
   DBHandle *db = callback_data->db_handle;
   ObjectID id = callback_data->id;
@@ -401,7 +401,7 @@ void redis_result_table_lookup_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_result_table_lookup(table_callback_data *callback_data) {
+void redis_result_table_lookup(TableCallbackData *callback_data) {
   CHECK(callback_data);
   DBHandle *db = callback_data->db_handle;
   ObjectID id = callback_data->id;
@@ -627,7 +627,7 @@ void object_table_redis_subscribe_to_notifications_callback(
 }
 
 void redis_object_table_subscribe_to_notifications(
-    table_callback_data *callback_data) {
+    TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   /* The object channel prefix must match the value defined in
    * src/common/redismodule/ray_redis_module.c. */
@@ -672,7 +672,7 @@ void redis_object_table_request_notifications_callback(redisAsyncContext *c,
 }
 
 void redis_object_table_request_notifications(
-    table_callback_data *callback_data) {
+    TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
 
   object_table_request_notifications_data *request_data = (object_table_request_notifications_data *) callback_data->data;
@@ -730,7 +730,7 @@ void redis_task_table_get_task_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_task_table_get_task(table_callback_data *callback_data) {
+void redis_task_table_get_task(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   CHECK(callback_data->data == NULL);
   TaskID task_id = callback_data->id;
@@ -761,7 +761,7 @@ void redis_task_table_add_task_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_task_table_add_task(table_callback_data *callback_data) {
+void redis_task_table_add_task(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   Task *task = (Task *) callback_data->data;
   TaskID task_id = Task_task_id(task);
@@ -797,7 +797,7 @@ void redis_task_table_update_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_task_table_update(table_callback_data *callback_data) {
+void redis_task_table_update(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   Task *task = (Task *) callback_data->data;
   TaskID task_id = Task_task_id(task);
@@ -835,7 +835,7 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_task_table_test_and_update(table_callback_data *callback_data) {
+void redis_task_table_test_and_update(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   TaskID task_id = callback_data->id;
   task_table_test_and_update_data *update_data = (task_table_test_and_update_data *) callback_data->data;
@@ -944,7 +944,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
   }
 }
 
-void redis_task_table_subscribe(table_callback_data *callback_data) {
+void redis_task_table_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   task_table_subscribe_data *data = (task_table_subscribe_data *) callback_data->data;
   /* TASK_CHANNEL_PREFIX is defined in ray_redis_module.c and must be kept in
@@ -1024,7 +1024,7 @@ void redis_db_client_table_subscribe_callback(redisAsyncContext *c,
   free(aux_address);
 }
 
-void redis_db_client_table_subscribe(table_callback_data *callback_data) {
+void redis_db_client_table_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   int status = redisAsyncCommand(
       db->sub_context, redis_db_client_table_subscribe_callback,
@@ -1073,7 +1073,7 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
   }
 }
 
-void redis_local_scheduler_table_subscribe(table_callback_data *callback_data) {
+void redis_local_scheduler_table_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   int status = redisAsyncCommand(
       db->sub_context, redis_local_scheduler_table_subscribe_callback,
@@ -1098,7 +1098,7 @@ void redis_local_scheduler_table_send_info_callback(redisAsyncContext *c,
   destroy_timer_callback(db->loop, callback_data);
 }
 
-void redis_local_scheduler_table_send_info(table_callback_data *callback_data) {
+void redis_local_scheduler_table_send_info(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   LocalSchedulerTableSendInfoData *data = (LocalSchedulerTableSendInfoData *) callback_data->data;
   int status = redisAsyncCommand(
@@ -1152,7 +1152,7 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
 }
 
 void redis_actor_notification_table_subscribe(
-    table_callback_data *callback_data) {
+    TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   int status = redisAsyncCommand(
       db->sub_context, redis_actor_notification_table_subscribe_callback,
@@ -1201,7 +1201,7 @@ void redis_object_info_subscribe_callback(redisAsyncContext *c,
   }
 }
 
-void redis_object_info_subscribe(table_callback_data *callback_data) {
+void redis_object_info_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   int status = redisAsyncCommand(
       db->sub_context, redis_object_info_subscribe_callback,

--- a/src/common/state/redis.c
+++ b/src/common/state/redis.c
@@ -1100,7 +1100,7 @@ void redis_local_scheduler_table_send_info_callback(redisAsyncContext *c,
 
 void redis_local_scheduler_table_send_info(table_callback_data *callback_data) {
   DBHandle *db = callback_data->db_handle;
-  local_scheduler_table_send_info_data *data = (local_scheduler_table_send_info_data *) callback_data->data;
+  LocalSchedulerTableSendInfoData *data = (LocalSchedulerTableSendInfoData *) callback_data->data;
   int status = redisAsyncCommand(
       db->context, redis_local_scheduler_table_send_info_callback,
       (void *) callback_data->timer_id, "PUBLISH local_schedulers %b%b",

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -108,8 +108,7 @@ void redis_object_table_subscribe_to_notifications(
  *        information.
  * @return Void.
  */
-void redis_object_table_request_notifications(
-    TableCallbackData *callback_data);
+void redis_object_table_request_notifications(TableCallbackData *callback_data);
 
 /**
  * Add a new object to the object table in redis.
@@ -252,8 +251,7 @@ void redis_local_scheduler_table_send_info(TableCallbackData *callback_data);
  *        information.
  * @return Void.
  */
-void redis_actor_notification_table_subscribe(
-    TableCallbackData *callback_data);
+void redis_actor_notification_table_subscribe(TableCallbackData *callback_data);
 
 void redis_object_info_subscribe(TableCallbackData *callback_data);
 

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -22,7 +22,7 @@
 
 typedef struct {
   /** Unique ID for this db client. */
-  db_client_id db_client_id;
+  DBClientID db_client_id;
   /** IP address and port of this db client. */
   char *addr;
   /** Handle for the uthash table. */
@@ -33,7 +33,7 @@ struct DBHandle {
   /** String that identifies this client type. */
   char *client_type;
   /** Unique ID for this client. */
-  db_client_id client;
+  DBClientID client;
   /** Redis context for all non-subscribe connections. */
   redisAsyncContext *context;
   /** Redis context for "subscribe" communication. Yes, we need a separate one

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -70,7 +70,7 @@ void object_table_lookup_callback(redisAsyncContext *c,
  *        information.
  * @return Void.
  */
-void redis_object_table_lookup(table_callback_data *callback_data);
+void redis_object_table_lookup(TableCallbackData *callback_data);
 
 /**
  * Add a location entry to the object table in redis.
@@ -79,7 +79,7 @@ void redis_object_table_lookup(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_object_table_add(table_callback_data *callback_data);
+void redis_object_table_add(TableCallbackData *callback_data);
 
 /**
  * Remove a location entry from the object table in redis.
@@ -88,7 +88,7 @@ void redis_object_table_add(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_object_table_remove(table_callback_data *callback_data);
+void redis_object_table_remove(TableCallbackData *callback_data);
 
 /**
  * Create a client-specific channel for receiving notifications from the object
@@ -99,7 +99,7 @@ void redis_object_table_remove(table_callback_data *callback_data);
  * @return Void.
  */
 void redis_object_table_subscribe_to_notifications(
-    table_callback_data *callback_data);
+    TableCallbackData *callback_data);
 
 /**
  * Request notifications about when certain objects become available.
@@ -109,7 +109,7 @@ void redis_object_table_subscribe_to_notifications(
  * @return Void.
  */
 void redis_object_table_request_notifications(
-    table_callback_data *callback_data);
+    TableCallbackData *callback_data);
 
 /**
  * Add a new object to the object table in redis.
@@ -118,7 +118,7 @@ void redis_object_table_request_notifications(
  *        information.
  * @return Void.
  */
-void redis_result_table_add(table_callback_data *callback_data);
+void redis_result_table_add(TableCallbackData *callback_data);
 
 /**
  * Lookup the task that created the object in redis. The result is the task ID.
@@ -127,7 +127,7 @@ void redis_result_table_add(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_result_table_lookup(table_callback_data *callback_data);
+void redis_result_table_lookup(TableCallbackData *callback_data);
 
 /**
  * Callback invoked when the reply from the object table lookup command is
@@ -154,7 +154,7 @@ void redis_object_table_lookup_callback(redisAsyncContext *c,
  *        information.
  * @return Void.
  */
-void redis_task_table_get_task(table_callback_data *callback_data);
+void redis_task_table_get_task(TableCallbackData *callback_data);
 
 /**
  * Add a task table entry with a new task spec and the task's scheduling
@@ -164,7 +164,7 @@ void redis_task_table_get_task(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_task_table_add_task(table_callback_data *callback_data);
+void redis_task_table_add_task(TableCallbackData *callback_data);
 
 /**
  * Update a task table entry with the task's scheduling information.
@@ -173,7 +173,7 @@ void redis_task_table_add_task(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_task_table_update(table_callback_data *callback_data);
+void redis_task_table_update(TableCallbackData *callback_data);
 
 /**
  * Update a task table entry with the task's scheduling information, if the
@@ -183,7 +183,7 @@ void redis_task_table_update(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_task_table_test_and_update(table_callback_data *callback_data);
+void redis_task_table_test_and_update(TableCallbackData *callback_data);
 
 /**
  * Callback invoked when the reply from the task push command is received.
@@ -216,7 +216,7 @@ void redis_task_table_publish_publish_callback(redisAsyncContext *c,
  *        information.
  * @return Void.
  */
-void redis_task_table_subscribe(table_callback_data *callback_data);
+void redis_task_table_subscribe(TableCallbackData *callback_data);
 
 /**
  * Subscribe to updates from the db client table.
@@ -225,7 +225,7 @@ void redis_task_table_subscribe(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_db_client_table_subscribe(table_callback_data *callback_data);
+void redis_db_client_table_subscribe(TableCallbackData *callback_data);
 
 /**
  * Subscribe to updates from the local scheduler table.
@@ -234,7 +234,7 @@ void redis_db_client_table_subscribe(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_local_scheduler_table_subscribe(table_callback_data *callback_data);
+void redis_local_scheduler_table_subscribe(TableCallbackData *callback_data);
 
 /**
  * Publish an update to the local scheduler table.
@@ -243,7 +243,7 @@ void redis_local_scheduler_table_subscribe(table_callback_data *callback_data);
  *        information.
  * @return Void.
  */
-void redis_local_scheduler_table_send_info(table_callback_data *callback_data);
+void redis_local_scheduler_table_send_info(TableCallbackData *callback_data);
 
 /**
  * Subscribe to updates about newly created actors.
@@ -253,8 +253,8 @@ void redis_local_scheduler_table_send_info(table_callback_data *callback_data);
  * @return Void.
  */
 void redis_actor_notification_table_subscribe(
-    table_callback_data *callback_data);
+    TableCallbackData *callback_data);
 
-void redis_object_info_subscribe(table_callback_data *callback_data);
+void redis_object_info_subscribe(TableCallbackData *callback_data);
 
 #endif /* REDIS_H */

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -29,7 +29,7 @@ typedef struct {
   UT_hash_handle hh;
 } db_client_cache_entry;
 
-struct db_handle {
+struct DBHandle {
   /** String that identifies this client type. */
   char *client_type;
   /** Unique ID for this client. */

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -27,7 +27,7 @@ typedef struct {
   char *addr;
   /** Handle for the uthash table. */
   UT_hash_handle hh;
-} db_client_cache_entry;
+} DBClientCacheEntry;
 
 struct DBHandle {
   /** String that identifies this client type. */
@@ -45,7 +45,7 @@ struct DBHandle {
   int64_t db_index;
   /** Cache for the IP addresses of db clients. This is a hash table mapping
    *  client IDs to addresses. */
-  db_client_cache_entry *db_client_cache;
+  DBClientCacheEntry *db_client_cache;
   /** Redis context for synchronous connections. This should only be used very
    *  rarely, it is not asynchronous. */
   redisContext *sync_context;

--- a/src/common/state/table.c
+++ b/src/common/state/table.c
@@ -8,7 +8,7 @@ static const retry_info default_retry = {.num_retries = -1,
                                          .timeout = 10000,
                                          .fail_callback = NULL};
 
-table_callback_data *init_table_callback(db_handle *db_handle,
+table_callback_data *init_table_callback(DBHandle *db_handle,
                                          UniqueID id,
                                          const char *label,
                                          OWNER void *data,

--- a/src/common/state/table.c
+++ b/src/common/state/table.c
@@ -4,7 +4,7 @@
 #include "redis.h"
 
 /* The default behavior is to retry every ten seconds forever. */
-static const retry_info default_retry = {.num_retries = -1,
+static const RetryInfo default_retry = {.num_retries = -1,
                                          .timeout = 10000,
                                          .fail_callback = NULL};
 
@@ -12,7 +12,7 @@ table_callback_data *init_table_callback(DBHandle *db_handle,
                                          UniqueID id,
                                          const char *label,
                                          OWNER void *data,
-                                         retry_info *retry,
+                                         RetryInfo *retry,
                                          table_done_callback done_callback,
                                          table_retry_callback retry_callback,
                                          void *user_context) {
@@ -20,7 +20,7 @@ table_callback_data *init_table_callback(DBHandle *db_handle,
   CHECK(db_handle->loop);
   /* If no retry info is provided, use the default retry info. */
   if (retry == NULL) {
-    retry = (retry_info *) &default_retry;
+    retry = (RetryInfo *) &default_retry;
   }
   CHECK(retry);
   /* Allocate and initialize callback data structure for object table */

--- a/src/common/state/table.c
+++ b/src/common/state/table.c
@@ -5,17 +5,17 @@
 
 /* The default behavior is to retry every ten seconds forever. */
 static const RetryInfo default_retry = {.num_retries = -1,
-                                         .timeout = 10000,
-                                         .fail_callback = NULL};
+                                        .timeout = 10000,
+                                        .fail_callback = NULL};
 
 TableCallbackData *init_table_callback(DBHandle *db_handle,
-                                         UniqueID id,
-                                         const char *label,
-                                         OWNER void *data,
-                                         RetryInfo *retry,
-                                         table_done_callback done_callback,
-                                         table_retry_callback retry_callback,
-                                         void *user_context) {
+                                       UniqueID id,
+                                       const char *label,
+                                       OWNER void *data,
+                                       RetryInfo *retry,
+                                       table_done_callback done_callback,
+                                       table_retry_callback retry_callback,
+                                       void *user_context) {
   CHECK(db_handle);
   CHECK(db_handle->loop);
   /* If no retry info is provided, use the default retry info. */

--- a/src/common/state/table.c
+++ b/src/common/state/table.c
@@ -9,7 +9,7 @@ static const retry_info default_retry = {.num_retries = -1,
                                          .fail_callback = NULL};
 
 table_callback_data *init_table_callback(db_handle *db_handle,
-                                         unique_id id,
+                                         UniqueID id,
                                          const char *label,
                                          OWNER void *data,
                                          retry_info *retry,

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -68,7 +68,7 @@ struct table_callback_data {
   /** User context. */
   void *user_context;
   /** Handle to db. */
-  db_handle *db_handle;
+  DBHandle *db_handle;
   /** Handle to timer. */
   int64_t timer_id;
   UT_hash_handle hh; /* makes this structure hashable */
@@ -104,7 +104,7 @@ int64_t table_timeout_handler(event_loop *loop,
  *        passed on to the various callbacks.
  * @return New table callback data struct.
  */
-table_callback_data *init_table_callback(db_handle *db_handle,
+table_callback_data *init_table_callback(DBHandle *db_handle,
                                          UniqueID id,
                                          const char *label,
                                          OWNER void *data,

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -22,7 +22,7 @@ typedef void *table_done_callback;
  *        data field in table_callback_data. The user is responsible for
  *        freeing user_data.
  */
-typedef void (*table_fail_callback)(unique_id id,
+typedef void (*table_fail_callback)(UniqueID id,
                                     void *user_context,
                                     void *user_data);
 
@@ -47,7 +47,7 @@ typedef struct {
 struct table_callback_data {
   /** ID of the entry in the table that we are going to look up, remove or add.
    */
-  unique_id id;
+  UniqueID id;
   /** A label to identify the original request for logging purposes. */
   const char *label;
   /** The callback that will be called when results is returned. */
@@ -105,7 +105,7 @@ int64_t table_timeout_handler(event_loop *loop,
  * @return New table callback data struct.
  */
 table_callback_data *init_table_callback(db_handle *db_handle,
-                                         unique_id id,
+                                         UniqueID id,
                                          const char *label,
                                          OWNER void *data,
                                          retry_info *retry,

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -30,7 +30,7 @@ typedef void (*table_retry_callback)(table_callback_data *callback_data);
 
 /**
  * Data structure consolidating the retry related variables. If a NULL
- * retry_info struct is used, the default behavior will be to retry infinitely
+ * RetryInfo struct is used, the default behavior will be to retry infinitely
  * many times.
  */
 typedef struct {
@@ -42,7 +42,7 @@ typedef struct {
   uint64_t timeout;
   /** The callback that will be called if there are no more retries left. */
   table_fail_callback fail_callback;
-} retry_info;
+} RetryInfo;
 
 struct table_callback_data {
   /** ID of the entry in the table that we are going to look up, remove or add.
@@ -57,7 +57,7 @@ struct table_callback_data {
   /** Retry information containing the remaining number of retries, the timeout
    *  before the next retry, and a pointer to the failure callback.
    */
-  retry_info retry;
+  RetryInfo retry;
   /** Pointer to the data that is entered into the table. This can be used to
    *  pass the result of the call to the callback. The callback takes ownership
    *  over this data and will free it. */
@@ -108,7 +108,7 @@ table_callback_data *init_table_callback(DBHandle *db_handle,
                                          UniqueID id,
                                          const char *label,
                                          OWNER void *data,
-                                         retry_info *retry,
+                                         RetryInfo *retry,
                                          table_done_callback done_callback,
                                          table_retry_callback retry_callback,
                                          void *user_context);

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -105,13 +105,13 @@ int64_t table_timeout_handler(event_loop *loop,
  * @return New table callback data struct.
  */
 TableCallbackData *init_table_callback(DBHandle *db_handle,
-                                         UniqueID id,
-                                         const char *label,
-                                         OWNER void *data,
-                                         RetryInfo *retry,
-                                         table_done_callback done_callback,
-                                         table_retry_callback retry_callback,
-                                         void *user_context);
+                                       UniqueID id,
+                                       const char *label,
+                                       OWNER void *data,
+                                       RetryInfo *retry,
+                                       table_done_callback done_callback,
+                                       table_retry_callback retry_callback,
+                                       void *user_context);
 
 /**
  * Destroy any state associated with the callback data. This removes all
@@ -132,8 +132,7 @@ void destroy_table_callback(TableCallbackData *callback_data);
  *        want to remove.
  * @return Void.
  */
-void destroy_timer_callback(event_loop *loop,
-                            TableCallbackData *callback_data);
+void destroy_timer_callback(event_loop *loop, TableCallbackData *callback_data);
 
 /**
  * Add an outstanding callback entry.

--- a/src/common/state/table.h
+++ b/src/common/state/table.h
@@ -7,7 +7,7 @@
 #include "common.h"
 #include "db.h"
 
-typedef struct table_callback_data table_callback_data;
+typedef struct TableCallbackData TableCallbackData;
 
 typedef void *table_done_callback;
 
@@ -17,16 +17,16 @@ typedef void *table_done_callback;
  * @param id The unique ID that identifies this callback. Examples include an
  *        object ID or task ID.
  * @param user_context The state context for the callback. This is equivalent
- *        to the user_context field in table_callback_data.
+ *        to the user_context field in TableCallbackData.
  * @param user_data A data argument for the callback. This is equivalent to the
- *        data field in table_callback_data. The user is responsible for
+ *        data field in TableCallbackData. The user is responsible for
  *        freeing user_data.
  */
 typedef void (*table_fail_callback)(UniqueID id,
                                     void *user_context,
                                     void *user_data);
 
-typedef void (*table_retry_callback)(table_callback_data *callback_data);
+typedef void (*table_retry_callback)(TableCallbackData *callback_data);
 
 /**
  * Data structure consolidating the retry related variables. If a NULL
@@ -44,7 +44,7 @@ typedef struct {
   table_fail_callback fail_callback;
 } RetryInfo;
 
-struct table_callback_data {
+struct TableCallbackData {
   /** ID of the entry in the table that we are going to look up, remove or add.
    */
   UniqueID id;
@@ -104,7 +104,7 @@ int64_t table_timeout_handler(event_loop *loop,
  *        passed on to the various callbacks.
  * @return New table callback data struct.
  */
-table_callback_data *init_table_callback(DBHandle *db_handle,
+TableCallbackData *init_table_callback(DBHandle *db_handle,
                                          UniqueID id,
                                          const char *label,
                                          OWNER void *data,
@@ -122,7 +122,7 @@ table_callback_data *init_table_callback(DBHandle *db_handle,
  *        want to remove.
  * @return Void.
  */
-void destroy_table_callback(table_callback_data *callback_data);
+void destroy_table_callback(TableCallbackData *callback_data);
 
 /**
  * Destroy all state events associated with the callback data, including memory
@@ -133,7 +133,7 @@ void destroy_table_callback(table_callback_data *callback_data);
  * @return Void.
  */
 void destroy_timer_callback(event_loop *loop,
-                            table_callback_data *callback_data);
+                            TableCallbackData *callback_data);
 
 /**
  * Add an outstanding callback entry.
@@ -142,7 +142,7 @@ void destroy_timer_callback(event_loop *loop,
  *        want to insert.
  * @return None.
  */
-void outstanding_callbacks_add(table_callback_data *callback_data);
+void outstanding_callbacks_add(TableCallbackData *callback_data);
 
 /**
  * Find an outstanding callback entry.
@@ -151,7 +151,7 @@ void outstanding_callbacks_add(table_callback_data *callback_data);
  *        timer ID assigned by the Redis ae event loop.
  * @return Returns the callback data if found, NULL otherwise.
  */
-table_callback_data *outstanding_callbacks_find(int64_t key);
+TableCallbackData *outstanding_callbacks_find(int64_t key);
 
 /**
  * Remove an outstanding callback entry. This only removes the callback entry
@@ -162,7 +162,7 @@ table_callback_data *outstanding_callbacks_find(int64_t key);
  *        want to remove.
  * @return Void.
  */
-void outstanding_callbacks_remove(table_callback_data *callback_data);
+void outstanding_callbacks_remove(TableCallbackData *callback_data);
 
 /**
  * Destroy all outstanding callbacks and remove their associated timer events

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -3,7 +3,7 @@
 
 #define NUM_DB_REQUESTS 2
 
-void task_table_get_task(db_handle *db_handle,
+void task_table_get_task(DBHandle *db_handle,
                          TaskID task_id,
                          retry_info *retry,
                          task_table_get_callback done_callback,
@@ -12,7 +12,7 @@ void task_table_get_task(db_handle *db_handle,
                       redis_task_table_get_task, user_context);
 }
 
-void task_table_add_task(db_handle *db_handle,
+void task_table_add_task(DBHandle *db_handle,
                          OWNER task *task,
                          retry_info *retry,
                          task_table_done_callback done_callback,
@@ -21,7 +21,7 @@ void task_table_add_task(db_handle *db_handle,
                       done_callback, redis_task_table_add_task, user_context);
 }
 
-void task_table_update(db_handle *db_handle,
+void task_table_update(DBHandle *db_handle,
                        OWNER task *task,
                        retry_info *retry,
                        task_table_done_callback done_callback,
@@ -30,7 +30,7 @@ void task_table_update(db_handle *db_handle,
                       done_callback, redis_task_table_update, user_context);
 }
 
-void task_table_test_and_update(db_handle *db_handle,
+void task_table_test_and_update(DBHandle *db_handle,
                                 TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
@@ -49,7 +49,7 @@ void task_table_test_and_update(db_handle *db_handle,
 }
 
 /* TODO(swang): A corresponding task_table_unsubscribe. */
-void task_table_subscribe(db_handle *db_handle,
+void task_table_subscribe(DBHandle *db_handle,
                           db_client_id local_scheduler_id,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -57,8 +57,7 @@ void task_table_subscribe(DBHandle *db_handle,
                           RetryInfo *retry,
                           task_table_done_callback done_callback,
                           void *user_context) {
-  TaskTableSubscribeData *sub_data =
-      malloc(sizeof(TaskTableSubscribeData));
+  TaskTableSubscribeData *sub_data = malloc(sizeof(TaskTableSubscribeData));
   sub_data->local_scheduler_id = local_scheduler_id;
   sub_data->state_filter = state_filter;
   sub_data->subscribe_callback = subscribe_callback;

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -37,8 +37,8 @@ void task_table_test_and_update(DBHandle *db_handle,
                                 RetryInfo *retry,
                                 task_table_get_callback done_callback,
                                 void *user_context) {
-  task_table_test_and_update_data *update_data =
-      malloc(sizeof(task_table_test_and_update_data));
+  TaskTableTestAndUpdateData *update_data =
+      malloc(sizeof(TaskTableTestAndUpdateData));
   update_data->test_state_bitmask = test_state_bitmask;
   update_data->update_state = update_state;
   /* Update the task entry's local scheduler with this client's ID. */
@@ -57,8 +57,8 @@ void task_table_subscribe(DBHandle *db_handle,
                           RetryInfo *retry,
                           task_table_done_callback done_callback,
                           void *user_context) {
-  task_table_subscribe_data *sub_data =
-      malloc(sizeof(task_table_subscribe_data));
+  TaskTableSubscribeData *sub_data =
+      malloc(sizeof(TaskTableSubscribeData));
   sub_data->local_scheduler_id = local_scheduler_id;
   sub_data->state_filter = state_filter;
   sub_data->subscribe_callback = subscribe_callback;

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -5,7 +5,7 @@
 
 void task_table_get_task(DBHandle *db_handle,
                          TaskID task_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          task_table_get_callback done_callback,
                          void *user_context) {
   init_table_callback(db_handle, task_id, __func__, NULL, retry, done_callback,
@@ -14,7 +14,7 @@ void task_table_get_task(DBHandle *db_handle,
 
 void task_table_add_task(DBHandle *db_handle,
                          OWNER Task *task,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          task_table_done_callback done_callback,
                          void *user_context) {
   init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
@@ -23,7 +23,7 @@ void task_table_add_task(DBHandle *db_handle,
 
 void task_table_update(DBHandle *db_handle,
                        OWNER Task *task,
-                       retry_info *retry,
+                       RetryInfo *retry,
                        task_table_done_callback done_callback,
                        void *user_context) {
   init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
@@ -34,7 +34,7 @@ void task_table_test_and_update(DBHandle *db_handle,
                                 TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
-                                retry_info *retry,
+                                RetryInfo *retry,
                                 task_table_get_callback done_callback,
                                 void *user_context) {
   task_table_test_and_update_data *update_data =
@@ -54,7 +54,7 @@ void task_table_subscribe(DBHandle *db_handle,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,
                           void *subscribe_context,
-                          retry_info *retry,
+                          RetryInfo *retry,
                           task_table_done_callback done_callback,
                           void *user_context) {
   task_table_subscribe_data *sub_data =

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -17,7 +17,7 @@ void task_table_add_task(DBHandle *db_handle,
                          retry_info *retry,
                          task_table_done_callback done_callback,
                          void *user_context) {
-  init_table_callback(db_handle, task_task_id(task), __func__, task, retry,
+  init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
                       done_callback, redis_task_table_add_task, user_context);
 }
 
@@ -26,7 +26,7 @@ void task_table_update(DBHandle *db_handle,
                        retry_info *retry,
                        task_table_done_callback done_callback,
                        void *user_context) {
-  init_table_callback(db_handle, task_task_id(task), __func__, task, retry,
+  init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
                       done_callback, redis_task_table_update, user_context);
 }
 

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -50,7 +50,7 @@ void task_table_test_and_update(DBHandle *db_handle,
 
 /* TODO(swang): A corresponding task_table_unsubscribe. */
 void task_table_subscribe(DBHandle *db_handle,
-                          db_client_id local_scheduler_id,
+                          DBClientID local_scheduler_id,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,
                           void *subscribe_context,

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -4,7 +4,7 @@
 #define NUM_DB_REQUESTS 2
 
 void task_table_get_task(db_handle *db_handle,
-                         task_id task_id,
+                         TaskID task_id,
                          retry_info *retry,
                          task_table_get_callback done_callback,
                          void *user_context) {
@@ -31,7 +31,7 @@ void task_table_update(db_handle *db_handle,
 }
 
 void task_table_test_and_update(db_handle *db_handle,
-                                task_id task_id,
+                                TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
                                 retry_info *retry,

--- a/src/common/state/task_table.c
+++ b/src/common/state/task_table.c
@@ -13,7 +13,7 @@ void task_table_get_task(DBHandle *db_handle,
 }
 
 void task_table_add_task(DBHandle *db_handle,
-                         OWNER task *task,
+                         OWNER Task *task,
                          retry_info *retry,
                          task_table_done_callback done_callback,
                          void *user_context) {
@@ -22,7 +22,7 @@ void task_table_add_task(DBHandle *db_handle,
 }
 
 void task_table_update(DBHandle *db_handle,
-                       OWNER task *task,
+                       OWNER Task *task,
                        retry_info *retry,
                        task_table_done_callback done_callback,
                        void *user_context) {

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -26,7 +26,7 @@ typedef void (*task_table_done_callback)(TaskID task_id, void *user_context);
 
 /* Callback called when a task table read operation completes. If the task ID
  * was not in the task table, then the task pointer will be NULL. */
-typedef void (*task_table_get_callback)(task *task, void *user_context);
+typedef void (*task_table_get_callback)(Task *task, void *user_context);
 
 /**
  * Get a task's entry from the task table.
@@ -59,7 +59,7 @@ void task_table_get_task(DBHandle *db,
  * @return Void.
  */
 void task_table_add_task(DBHandle *db_handle,
-                         OWNER task *task,
+                         OWNER Task *task,
                          retry_info *retry,
                          task_table_done_callback done_callback,
                          void *user_context);
@@ -82,7 +82,7 @@ void task_table_add_task(DBHandle *db_handle,
  * @return Void.
  */
 void task_table_update(DBHandle *db_handle,
-                       OWNER task *task,
+                       OWNER Task *task,
                        retry_info *retry,
                        task_table_done_callback done_callback,
                        void *user_context);
@@ -127,7 +127,7 @@ typedef struct {
  */
 
 /* Callback for subscribing to the task table. */
-typedef void (*task_table_subscribe_callback)(task *task, void *user_context);
+typedef void (*task_table_subscribe_callback)(Task *task, void *user_context);
 
 /**
  * Register a callback for a task event. An event is any update of a task in

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -119,7 +119,7 @@ void task_table_test_and_update(DBHandle *db_handle,
 typedef struct {
   int test_state_bitmask;
   int update_state;
-  db_client_id local_scheduler_id;
+  DBClientID local_scheduler_id;
 } task_table_test_and_update_data;
 
 /*
@@ -153,7 +153,7 @@ typedef void (*task_table_subscribe_callback)(task *task, void *user_context);
  * @return Void.
  */
 void task_table_subscribe(DBHandle *db_handle,
-                          db_client_id local_scheduler_id,
+                          DBClientID local_scheduler_id,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,
                           void *subscribe_context,
@@ -164,7 +164,7 @@ void task_table_subscribe(DBHandle *db_handle,
 /* Data that is needed to register task table subscribe callbacks with the state
  * database. */
 typedef struct {
-  db_client_id local_scheduler_id;
+  DBClientID local_scheduler_id;
   int state_filter;
   task_table_subscribe_callback subscribe_callback;
   void *subscribe_context;

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -41,7 +41,7 @@ typedef void (*task_table_get_callback)(Task *task, void *user_context);
  */
 void task_table_get_task(DBHandle *db,
                          TaskID task_id,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          task_table_get_callback done_callback,
                          void *user_context);
 
@@ -60,7 +60,7 @@ void task_table_get_task(DBHandle *db,
  */
 void task_table_add_task(DBHandle *db_handle,
                          OWNER Task *task,
-                         retry_info *retry,
+                         RetryInfo *retry,
                          task_table_done_callback done_callback,
                          void *user_context);
 
@@ -83,7 +83,7 @@ void task_table_add_task(DBHandle *db_handle,
  */
 void task_table_update(DBHandle *db_handle,
                        OWNER Task *task,
-                       retry_info *retry,
+                       RetryInfo *retry,
                        task_table_done_callback done_callback,
                        void *user_context);
 
@@ -111,7 +111,7 @@ void task_table_test_and_update(DBHandle *db_handle,
                                 TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
-                                retry_info *retry,
+                                RetryInfo *retry,
                                 task_table_get_callback done_callback,
                                 void *user_context);
 
@@ -157,7 +157,7 @@ void task_table_subscribe(DBHandle *db_handle,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,
                           void *subscribe_context,
-                          retry_info *retry,
+                          RetryInfo *retry,
                           task_table_done_callback done_callback,
                           void *user_context);
 

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -22,7 +22,7 @@
  */
 
 /* Callback called when a task table write operation completes. */
-typedef void (*task_table_done_callback)(task_id task_id, void *user_context);
+typedef void (*task_table_done_callback)(TaskID task_id, void *user_context);
 
 /* Callback called when a task table read operation completes. If the task ID
  * was not in the task table, then the task pointer will be NULL. */
@@ -40,7 +40,7 @@ typedef void (*task_table_get_callback)(task *task, void *user_context);
  * @return Void.
  */
 void task_table_get_task(db_handle *db,
-                         task_id task_id,
+                         TaskID task_id,
                          retry_info *retry,
                          task_table_get_callback done_callback,
                          void *user_context);
@@ -108,7 +108,7 @@ void task_table_update(db_handle *db_handle,
  * @return Void.
  */
 void task_table_test_and_update(db_handle *db_handle,
-                                task_id task_id,
+                                TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
                                 retry_info *retry,

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -39,7 +39,7 @@ typedef void (*task_table_get_callback)(task *task, void *user_context);
  *        fail_callback.
  * @return Void.
  */
-void task_table_get_task(db_handle *db,
+void task_table_get_task(DBHandle *db,
                          TaskID task_id,
                          retry_info *retry,
                          task_table_get_callback done_callback,
@@ -58,7 +58,7 @@ void task_table_get_task(db_handle *db,
  *        fail_callback.
  * @return Void.
  */
-void task_table_add_task(db_handle *db_handle,
+void task_table_add_task(DBHandle *db_handle,
                          OWNER task *task,
                          retry_info *retry,
                          task_table_done_callback done_callback,
@@ -81,7 +81,7 @@ void task_table_add_task(db_handle *db_handle,
  *        fail_callback.
  * @return Void.
  */
-void task_table_update(db_handle *db_handle,
+void task_table_update(DBHandle *db_handle,
                        OWNER task *task,
                        retry_info *retry,
                        task_table_done_callback done_callback,
@@ -107,7 +107,7 @@ void task_table_update(db_handle *db_handle,
  *        fail_callback.
  * @return Void.
  */
-void task_table_test_and_update(db_handle *db_handle,
+void task_table_test_and_update(DBHandle *db_handle,
                                 TaskID task_id,
                                 int test_state_bitmask,
                                 int update_state,
@@ -152,7 +152,7 @@ typedef void (*task_table_subscribe_callback)(task *task, void *user_context);
  *        fail_callback.
  * @return Void.
  */
-void task_table_subscribe(db_handle *db_handle,
+void task_table_subscribe(DBHandle *db_handle,
                           db_client_id local_scheduler_id,
                           int state_filter,
                           task_table_subscribe_callback subscribe_callback,

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -120,7 +120,7 @@ typedef struct {
   int test_state_bitmask;
   int update_state;
   DBClientID local_scheduler_id;
-} task_table_test_and_update_data;
+} TaskTableTestAndUpdateData;
 
 /*
  *  ==== Subscribing to the task table ====
@@ -168,6 +168,6 @@ typedef struct {
   int state_filter;
   task_table_subscribe_callback subscribe_callback;
   void *subscribe_context;
-} task_table_subscribe_data;
+} TaskTableSubscribeData;
 
 #endif /* task_table_H */

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -340,7 +340,7 @@ void print_task(task_spec *spec, UT_string *output) {
 
 /* TASK INSTANCES */
 
-struct task_impl {
+struct TaskImpl {
   /** The scheduling state of the task. */
   int state;
   /** The ID of the local scheduler involved. */
@@ -349,7 +349,7 @@ struct task_impl {
   task_spec spec;
 };
 
-Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
+Task *Task_alloc(task_spec *spec, int state, DBClientID local_scheduler_id) {
   int64_t size = sizeof(Task) - sizeof(task_spec) + task_spec_size(spec);
   Task *result = (Task *) malloc(size);
   memset(result, 0, size);
@@ -359,43 +359,43 @@ Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
   return result;
 }
 
-Task *copy_task(Task *other) {
-  int64_t size = task_size(other);
+Task *Task_copy(Task *other) {
+  int64_t size = Task_size(other);
   Task *copy = (Task *) malloc(size);
   CHECK(copy != NULL);
   memcpy(copy, other, size);
   return copy;
 }
 
-int64_t task_size(Task *task_arg) {
+int64_t Task_size(Task *task_arg) {
   return sizeof(Task) - sizeof(task_spec) + task_spec_size(&task_arg->spec);
 }
 
-int task_state(Task *task) {
+int Task_state(Task *task) {
   return task->state;
 }
 
-void task_set_state(Task *task, int state) {
+void Task_set_state(Task *task, int state) {
   task->state = state;
 }
 
-DBClientID task_local_scheduler(Task *task) {
+DBClientID Task_local_scheduler_id(Task *task) {
   return task->local_scheduler_id;
 }
 
-void task_set_local_scheduler(Task *task, DBClientID local_scheduler_id) {
+void Task_set_local_scheduler_id(Task *task, DBClientID local_scheduler_id) {
   task->local_scheduler_id = local_scheduler_id;
 }
 
-task_spec *task_task_spec(Task *task) {
+task_spec *Task_task_spec(Task *task) {
   return &task->spec;
 }
 
-TaskID task_task_id(Task *task) {
-  task_spec *spec = task_task_spec(task);
+TaskID Task_task_id(Task *task) {
+  task_spec *spec = Task_task_spec(task);
   return task_spec_id(spec);
 }
 
-void free_task(Task *task) {
+void Task_free(Task *task) {
   free(task);
 }

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -24,7 +24,7 @@ typedef struct {
   /* Either ARG_BY_REF or ARG_BY_VAL. */
   int8_t type;
   union {
-    object_id obj_id;
+    ObjectID obj_id;
     struct {
       /* Offset where the data associated to this arg is located relative
        * to &task_spec.args_and_returns[0]. */
@@ -36,7 +36,7 @@ typedef struct {
 
 struct task_spec_impl {
   /** ID of the driver that created this task. */
-  unique_id driver_id;
+  UniqueID driver_id;
   /** Task ID of the task. */
   task_id task_id;
   /** Task ID of the parent task. */
@@ -129,12 +129,12 @@ task_id compute_task_id(task_spec *spec) {
   return task_id;
 }
 
-object_id task_compute_return_id(task_id task_id, int64_t return_index) {
+ObjectID task_compute_return_id(task_id task_id, int64_t return_index) {
   /* Here, return_indices need to be >= 0, so we can use negative
    * indices for put. */
   DCHECK(return_index >= 0);
   /* TODO(rkn): This line requires object and task IDs to be the same size. */
-  object_id return_id = task_id;
+  ObjectID return_id = task_id;
   int64_t *first_bytes = (int64_t *) &return_id;
   /* XOR the first bytes of the object ID with the return index. We add one so
    * the first return ID is not the same as the task ID. */
@@ -142,10 +142,10 @@ object_id task_compute_return_id(task_id task_id, int64_t return_index) {
   return return_id;
 }
 
-object_id task_compute_put_id(task_id task_id, int64_t put_index) {
+ObjectID task_compute_put_id(task_id task_id, int64_t put_index) {
   DCHECK(put_index >= 0);
   /* TODO(pcm): This line requires object and task IDs to be the same size. */
-  object_id put_id = task_id;
+  ObjectID put_id = task_id;
   int64_t *first_bytes = (int64_t *) &put_id;
   /* XOR the first bytes of the object ID with the return index. We add one so
    * the first return ID is not the same as the task ID. */
@@ -153,7 +153,7 @@ object_id task_compute_put_id(task_id task_id, int64_t put_index) {
   return put_id;
 }
 
-task_spec *start_construct_task_spec(unique_id driver_id,
+task_spec *start_construct_task_spec(UniqueID driver_id,
                                      task_id parent_task_id,
                                      int64_t parent_counter,
                                      actor_id actor_id,
@@ -215,7 +215,7 @@ int64_t task_spec_actor_counter(task_spec *spec) {
   return spec->actor_counter;
 }
 
-unique_id task_spec_driver_id(task_spec *spec) {
+UniqueID task_spec_driver_id(task_spec *spec) {
   /* Check that the task has been constructed. */
   DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
   return spec->driver_id;
@@ -240,7 +240,7 @@ int8_t task_arg_type(task_spec *spec, int64_t arg_index) {
   return spec->args_and_returns[arg_index].type;
 }
 
-object_id task_arg_id(task_spec *spec, int64_t arg_index) {
+ObjectID task_arg_id(task_spec *spec, int64_t arg_index) {
   /* Check that the task has been constructed. */
   DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
   DCHECK(0 <= arg_index && arg_index < spec->num_args);
@@ -265,7 +265,7 @@ int64_t task_arg_length(task_spec *spec, int64_t arg_index) {
   return arg->value.length;
 }
 
-int64_t task_args_add_ref(task_spec *spec, object_id obj_id) {
+int64_t task_args_add_ref(task_spec *spec, ObjectID obj_id) {
   /* Check that the task is still under construction. */
   DCHECK(task_ids_equal(spec->task_id, NIL_TASK_ID));
   task_arg *arg = &spec->args_and_returns[spec->arg_index];
@@ -296,7 +296,7 @@ void task_spec_set_required_resource(task_spec *spec,
   spec->required_resources[resource_index] = value;
 }
 
-object_id task_return(task_spec *spec, int64_t return_index) {
+ObjectID task_return(task_spec *spec, int64_t return_index) {
   /* Check that the task has been constructed. */
   DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
   DCHECK(0 <= return_index && return_index < spec->num_returns);
@@ -322,17 +322,17 @@ void print_task(task_spec *spec, UT_string *output) {
    * of bytes compared to the id (+ 1 byte for '\0'). */
   static char hex[ID_STRING_SIZE];
   /* Print function id. */
-  object_id_to_string((object_id) task_function(spec), &hex[0], ID_STRING_SIZE);
+  object_id_to_string((ObjectID) task_function(spec), &hex[0], ID_STRING_SIZE);
   utstring_printf(output, "fun %s ", &hex[0]);
   /* Print arguments. */
   for (int i = 0; i < task_num_args(spec); ++i) {
-    object_id_to_string((object_id) task_arg_id(spec, i), &hex[0],
+    object_id_to_string((ObjectID) task_arg_id(spec, i), &hex[0],
                         ID_STRING_SIZE);
     utstring_printf(output, " id:%d %s", i, &hex[0]);
   }
   /* Print return ids. */
   for (int i = 0; i < task_num_returns(spec); ++i) {
-    object_id obj_id = task_return(spec, i);
+    ObjectID obj_id = task_return(spec, i);
     object_id_to_string(obj_id, &hex[0], ID_STRING_SIZE);
     utstring_printf(output, " ret:%d %s", i, &hex[0]);
   }

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -344,12 +344,12 @@ struct task_impl {
   /** The scheduling state of the task. */
   int state;
   /** The ID of the local scheduler involved. */
-  db_client_id local_scheduler_id;
+  DBClientID local_scheduler_id;
   /** The task specification for this task. */
   task_spec spec;
 };
 
-task *alloc_task(task_spec *spec, int state, db_client_id local_scheduler_id) {
+task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
   int64_t size = sizeof(task) - sizeof(task_spec) + task_spec_size(spec);
   task *result = malloc(size);
   memset(result, 0, size);
@@ -379,11 +379,11 @@ void task_set_state(task *task, int state) {
   task->state = state;
 }
 
-db_client_id task_local_scheduler(task *task) {
+DBClientID task_local_scheduler(task *task) {
   return task->local_scheduler_id;
 }
 
-void task_set_local_scheduler(task *task, db_client_id local_scheduler_id) {
+void task_set_local_scheduler(task *task, DBClientID local_scheduler_id) {
   task->local_scheduler_id = local_scheduler_id;
 }
 

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -163,7 +163,7 @@ task_spec *start_construct_task_spec(UniqueID driver_id,
                                      int64_t num_returns,
                                      int64_t args_value_size) {
   int64_t size = TASK_SPEC_SIZE(num_args, num_returns, args_value_size);
-  task_spec *task = malloc(size);
+  task_spec *task = (task_spec *) malloc(size);
   memset(task, 0, size);
   task->driver_id = driver_id;
   task->task_id = NIL_TASK_ID;
@@ -351,7 +351,7 @@ struct task_impl {
 
 Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
   int64_t size = sizeof(Task) - sizeof(task_spec) + task_spec_size(spec);
-  Task *result = malloc(size);
+  Task *result = (Task *) malloc(size);
   memset(result, 0, size);
   result->state = state;
   result->local_scheduler_id = local_scheduler_id;
@@ -361,7 +361,7 @@ Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
 
 Task *copy_task(Task *other) {
   int64_t size = task_size(other);
-  Task *copy = malloc(size);
+  Task *copy = (Task *) malloc(size);
   CHECK(copy != NULL);
   memcpy(copy, other, size);
   return copy;

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -349,9 +349,9 @@ struct task_impl {
   task_spec spec;
 };
 
-task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
-  int64_t size = sizeof(task) - sizeof(task_spec) + task_spec_size(spec);
-  task *result = malloc(size);
+Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
+  int64_t size = sizeof(Task) - sizeof(task_spec) + task_spec_size(spec);
+  Task *result = malloc(size);
   memset(result, 0, size);
   result->state = state;
   result->local_scheduler_id = local_scheduler_id;
@@ -359,43 +359,43 @@ task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id) {
   return result;
 }
 
-task *copy_task(task *other) {
+Task *copy_task(Task *other) {
   int64_t size = task_size(other);
-  task *copy = malloc(size);
+  Task *copy = malloc(size);
   CHECK(copy != NULL);
   memcpy(copy, other, size);
   return copy;
 }
 
-int64_t task_size(task *task_arg) {
-  return sizeof(task) - sizeof(task_spec) + task_spec_size(&task_arg->spec);
+int64_t task_size(Task *task_arg) {
+  return sizeof(Task) - sizeof(task_spec) + task_spec_size(&task_arg->spec);
 }
 
-int task_state(task *task) {
+int task_state(Task *task) {
   return task->state;
 }
 
-void task_set_state(task *task, int state) {
+void task_set_state(Task *task, int state) {
   task->state = state;
 }
 
-DBClientID task_local_scheduler(task *task) {
+DBClientID task_local_scheduler(Task *task) {
   return task->local_scheduler_id;
 }
 
-void task_set_local_scheduler(task *task, DBClientID local_scheduler_id) {
+void task_set_local_scheduler(Task *task, DBClientID local_scheduler_id) {
   task->local_scheduler_id = local_scheduler_id;
 }
 
-task_spec *task_task_spec(task *task) {
+task_spec *task_task_spec(Task *task) {
   return &task->spec;
 }
 
-TaskID task_task_id(task *task) {
+TaskID task_task_id(Task *task) {
   task_spec *spec = task_task_spec(task);
   return task_spec_id(spec);
 }
 
-void free_task(task *task) {
+void free_task(Task *task) {
   free(task);
 }

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -327,7 +327,7 @@ void print_task(task_spec *spec, UT_string *output) {
   /* Print arguments. */
   for (int i = 0; i < task_num_args(spec); ++i) {
     ObjectID_to_string((ObjectID) task_arg_id(spec, i), &hex[0],
-                        ID_STRING_SIZE);
+                       ID_STRING_SIZE);
     utstring_printf(output, " id:%d %s", i, &hex[0]);
   }
   /* Print return ids. */

--- a/src/common/task.c
+++ b/src/common/task.c
@@ -78,24 +78,24 @@ struct task_spec_impl {
   (sizeof(task_spec) + ((NUM_ARGS) + (NUM_RETURNS)) * sizeof(task_arg) + \
    (ARGS_VALUE_SIZE))
 
-bool task_ids_equal(TaskID first_id, TaskID second_id) {
+bool TaskID_equal(TaskID first_id, TaskID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-bool task_id_is_nil(TaskID id) {
-  return task_ids_equal(id, NIL_TASK_ID);
+bool TaskID_is_nil(TaskID id) {
+  return TaskID_equal(id, NIL_TASK_ID);
 }
 
-bool actor_ids_equal(ActorID first_id, ActorID second_id) {
+bool ActorID_equal(ActorID first_id, ActorID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-bool function_ids_equal(FunctionID first_id, FunctionID second_id) {
+bool FunctionID_equal(FunctionID first_id, FunctionID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
-bool function_id_is_nil(FunctionID id) {
-  return function_ids_equal(id, NIL_FUNCTION_ID);
+bool FunctionID_is_nil(FunctionID id) {
+  return FunctionID_equal(id, NIL_FUNCTION_ID);
 }
 
 TaskID *task_return_ptr(task_spec *spec, int64_t return_index) {
@@ -112,9 +112,9 @@ TaskID *task_return_ptr(task_spec *spec, int64_t return_index) {
 TaskID compute_task_id(task_spec *spec) {
   /* Check that the task ID and return ID fields of the task_spec are
    * uninitialized. */
-  DCHECK(task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(TaskID_equal(spec->task_id, NIL_TASK_ID));
   for (int i = 0; i < spec->num_returns; ++i) {
-    DCHECK(object_ids_equal(*task_return_ptr(spec, i), NIL_ID));
+    DCHECK(ObjectID_equal(*task_return_ptr(spec, i), NIL_ID));
   }
   /* Compute a SHA256 hash of the task_spec. */
   SHA256_CTX ctx;
@@ -199,31 +199,31 @@ int64_t task_spec_size(task_spec *spec) {
 
 FunctionID task_function(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   return spec->function_id;
 }
 
 ActorID task_spec_actor_id(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   return spec->actor_id;
 }
 
 int64_t task_spec_actor_counter(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   return spec->actor_counter;
 }
 
 UniqueID task_spec_driver_id(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   return spec->driver_id;
 }
 
 TaskID task_spec_id(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   return spec->task_id;
 }
 
@@ -242,7 +242,7 @@ int8_t task_arg_type(task_spec *spec, int64_t arg_index) {
 
 ObjectID task_arg_id(task_spec *spec, int64_t arg_index) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   DCHECK(0 <= arg_index && arg_index < spec->num_args);
   task_arg *arg = &spec->args_and_returns[arg_index];
   DCHECK(arg->type == ARG_BY_REF)
@@ -267,7 +267,7 @@ int64_t task_arg_length(task_spec *spec, int64_t arg_index) {
 
 int64_t task_args_add_ref(task_spec *spec, ObjectID obj_id) {
   /* Check that the task is still under construction. */
-  DCHECK(task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(TaskID_equal(spec->task_id, NIL_TASK_ID));
   task_arg *arg = &spec->args_and_returns[spec->arg_index];
   arg->type = ARG_BY_REF;
   arg->obj_id = obj_id;
@@ -276,7 +276,7 @@ int64_t task_args_add_ref(task_spec *spec, ObjectID obj_id) {
 
 int64_t task_args_add_val(task_spec *spec, uint8_t *data, int64_t length) {
   /* Check that the task is still under construction. */
-  DCHECK(task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(TaskID_equal(spec->task_id, NIL_TASK_ID));
   task_arg *arg = &spec->args_and_returns[spec->arg_index];
   arg->type = ARG_BY_VAL;
   arg->value.offset = spec->args_value_offset;
@@ -298,7 +298,7 @@ void task_spec_set_required_resource(task_spec *spec,
 
 ObjectID task_return(task_spec *spec, int64_t return_index) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   DCHECK(0 <= return_index && return_index < spec->num_returns);
   task_arg *ret = &spec->args_and_returns[spec->num_args + return_index];
   DCHECK(ret->type == ARG_BY_REF);
@@ -312,7 +312,7 @@ double task_spec_get_required_resource(const task_spec *spec,
 
 void free_task_spec(task_spec *spec) {
   /* Check that the task has been constructed. */
-  DCHECK(!task_ids_equal(spec->task_id, NIL_TASK_ID));
+  DCHECK(!TaskID_equal(spec->task_id, NIL_TASK_ID));
   DCHECK(spec->arg_index == spec->num_args);
   free(spec);
 }
@@ -322,18 +322,18 @@ void print_task(task_spec *spec, UT_string *output) {
    * of bytes compared to the id (+ 1 byte for '\0'). */
   static char hex[ID_STRING_SIZE];
   /* Print function id. */
-  object_id_to_string((ObjectID) task_function(spec), &hex[0], ID_STRING_SIZE);
+  ObjectID_to_string((ObjectID) task_function(spec), &hex[0], ID_STRING_SIZE);
   utstring_printf(output, "fun %s ", &hex[0]);
   /* Print arguments. */
   for (int i = 0; i < task_num_args(spec); ++i) {
-    object_id_to_string((ObjectID) task_arg_id(spec, i), &hex[0],
+    ObjectID_to_string((ObjectID) task_arg_id(spec, i), &hex[0],
                         ID_STRING_SIZE);
     utstring_printf(output, " id:%d %s", i, &hex[0]);
   }
   /* Print return ids. */
   for (int i = 0; i < task_num_returns(spec); ++i) {
     ObjectID obj_id = task_return(spec, i);
-    object_id_to_string(obj_id, &hex[0], ID_STRING_SIZE);
+    ObjectID_to_string(obj_id, &hex[0], ID_STRING_SIZE);
     utstring_printf(output, " ret:%d %s", i, &hex[0]);
   }
 }

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -46,7 +46,7 @@ enum arg_type { ARG_BY_REF, ARG_BY_VAL };
  * @param second_id The first task ID to compare.
  * @return True if the task IDs are the same and false otherwise.
  */
-bool task_ids_equal(TaskID first_id, TaskID second_id);
+bool TaskID_equal(TaskID first_id, TaskID second_id);
 
 /**
  * Compare a task ID to the nil ID.
@@ -54,7 +54,7 @@ bool task_ids_equal(TaskID first_id, TaskID second_id);
  * @param id The task ID to compare to nil.
  * @return True if the task ID is equal to nil.
  */
-bool task_id_is_nil(TaskID id);
+bool TaskID_is_nil(TaskID id);
 
 /**
  * Compare two actor IDs.
@@ -63,7 +63,7 @@ bool task_id_is_nil(TaskID id);
  * @param second_id The first actor ID to compare.
  * @return True if the actor IDs are the same and false otherwise.
  */
-bool actor_ids_equal(ActorID first_id, ActorID second_id);
+bool ActorID_equal(ActorID first_id, ActorID second_id);
 
 /**
  * Compare two function IDs.
@@ -72,7 +72,7 @@ bool actor_ids_equal(ActorID first_id, ActorID second_id);
  * @param second_id The first function ID to compare.
  * @return True if the function IDs are the same and false otherwise.
  */
-bool function_ids_equal(FunctionID first_id, FunctionID second_id);
+bool FunctionID_equal(FunctionID first_id, FunctionID second_id);
 
 /**
  * Compare a function ID to the nil ID.
@@ -80,7 +80,7 @@ bool function_ids_equal(FunctionID first_id, FunctionID second_id);
  * @param id The function ID to compare to nil.
  * @return True if the function ID is equal to nil.
  */
-bool function_id_is_nil(FunctionID id);
+bool FunctionID_is_nil(FunctionID id);
 
 /* Construct and modify task specifications. */
 

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -18,19 +18,15 @@
 #define NIL_ACTOR_ID NIL_ID
 #define NIL_FUNCTION_ID NIL_ID
 
-typedef UniqueID function_id;
+typedef UniqueID FunctionID;
 
 /** The task ID is a deterministic hash of the function ID that the task
  *  executes and the argument IDs or argument values. */
-typedef UniqueID task_id;
+typedef UniqueID TaskID;
 
 /** The actor ID is the ID of the actor that a task must run on. If the task is
  *  not run on an actor, then NIL_ACTOR_ID should be used. */
-typedef UniqueID actor_id;
-
-/** The task instance ID is a globally unique ID generated which identifies this
- *  particular execution of the task. */
-typedef UniqueID task_iid;
+typedef UniqueID ActorID;
 
 /**
  * ==== Task specifications ====
@@ -50,7 +46,7 @@ enum arg_type { ARG_BY_REF, ARG_BY_VAL };
  * @param second_id The first task ID to compare.
  * @return True if the task IDs are the same and false otherwise.
  */
-bool task_ids_equal(task_id first_id, task_id second_id);
+bool task_ids_equal(TaskID first_id, TaskID second_id);
 
 /**
  * Compare a task ID to the nil ID.
@@ -58,7 +54,7 @@ bool task_ids_equal(task_id first_id, task_id second_id);
  * @param id The task ID to compare to nil.
  * @return True if the task ID is equal to nil.
  */
-bool task_id_is_nil(task_id id);
+bool task_id_is_nil(TaskID id);
 
 /**
  * Compare two actor IDs.
@@ -67,7 +63,7 @@ bool task_id_is_nil(task_id id);
  * @param second_id The first actor ID to compare.
  * @return True if the actor IDs are the same and false otherwise.
  */
-bool actor_ids_equal(actor_id first_id, actor_id second_id);
+bool actor_ids_equal(ActorID first_id, ActorID second_id);
 
 /**
  * Compare two function IDs.
@@ -76,7 +72,7 @@ bool actor_ids_equal(actor_id first_id, actor_id second_id);
  * @param second_id The first function ID to compare.
  * @return True if the function IDs are the same and false otherwise.
  */
-bool function_ids_equal(function_id first_id, function_id second_id);
+bool function_ids_equal(FunctionID first_id, FunctionID second_id);
 
 /**
  * Compare a function ID to the nil ID.
@@ -84,7 +80,7 @@ bool function_ids_equal(function_id first_id, function_id second_id);
  * @param id The function ID to compare to nil.
  * @return True if the function ID is equal to nil.
  */
-bool function_id_is_nil(function_id id);
+bool function_id_is_nil(FunctionID id);
 
 /* Construct and modify task specifications. */
 
@@ -107,11 +103,11 @@ bool function_id_is_nil(function_id id);
  * @return The partially constructed task_spec.
  */
 task_spec *start_construct_task_spec(UniqueID driver_id,
-                                     task_id parent_task_id,
+                                     TaskID parent_task_id,
                                      int64_t parent_counter,
                                      UniqueID actor_id,
                                      int64_t actor_counter,
-                                     function_id function_id,
+                                     FunctionID function_id,
                                      int64_t num_args,
                                      int64_t num_returns,
                                      int64_t args_value_size);
@@ -140,7 +136,7 @@ int64_t task_spec_size(task_spec *spec);
  * @param spec The task_spec in question.
  * @return The function ID of the function to execute in this task.
  */
-function_id task_function(task_spec *spec);
+FunctionID task_function(task_spec *spec);
 
 /**
  * Return the actor ID of the task.
@@ -173,7 +169,7 @@ UniqueID task_spec_driver_id(task_spec *spec);
  * @param spec The task_spec in question.
  * @return The task ID of the task.
  */
-task_id task_spec_id(task_spec *spec);
+TaskID task_spec_id(task_spec *spec);
 
 /**
  * Get the number of arguments to this task.
@@ -308,7 +304,7 @@ double task_spec_get_required_resource(const task_spec *spec,
  * @param put_index The number of put calls in this task so far.
  * @return The object ID for the object that was put.
  */
-ObjectID task_compute_put_id(task_id task_id, int64_t put_index);
+ObjectID task_compute_put_id(TaskID task_id, int64_t put_index);
 
 /**
  * Free a task_spec.
@@ -396,7 +392,7 @@ void task_set_local_scheduler(task *task, db_client_id local_scheduler_id);
 task_spec *task_task_spec(task *task);
 
 /** Task ID of this task. */
-task_id task_task_id(task *task);
+TaskID task_task_id(task *task);
 
 /** Free this task datastructure. */
 void free_task(task *task);

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -18,19 +18,19 @@
 #define NIL_ACTOR_ID NIL_ID
 #define NIL_FUNCTION_ID NIL_ID
 
-typedef unique_id function_id;
+typedef UniqueID function_id;
 
 /** The task ID is a deterministic hash of the function ID that the task
  *  executes and the argument IDs or argument values. */
-typedef unique_id task_id;
+typedef UniqueID task_id;
 
 /** The actor ID is the ID of the actor that a task must run on. If the task is
  *  not run on an actor, then NIL_ACTOR_ID should be used. */
-typedef unique_id actor_id;
+typedef UniqueID actor_id;
 
 /** The task instance ID is a globally unique ID generated which identifies this
  *  particular execution of the task. */
-typedef unique_id task_iid;
+typedef UniqueID task_iid;
 
 /**
  * ==== Task specifications ====
@@ -106,10 +106,10 @@ bool function_id_is_nil(function_id id);
           ignoring object ID arguments.
  * @return The partially constructed task_spec.
  */
-task_spec *start_construct_task_spec(unique_id driver_id,
+task_spec *start_construct_task_spec(UniqueID driver_id,
                                      task_id parent_task_id,
                                      int64_t parent_counter,
-                                     unique_id actor_id,
+                                     UniqueID actor_id,
                                      int64_t actor_counter,
                                      function_id function_id,
                                      int64_t num_args,
@@ -148,7 +148,7 @@ function_id task_function(task_spec *spec);
  * @param spec The task_spec in question.
  * @return The actor ID of the actor the task is part of.
  */
-unique_id task_spec_actor_id(task_spec *spec);
+UniqueID task_spec_actor_id(task_spec *spec);
 
 /**
  * Return the actor counter of the task. This starts at 0 and increments by 1
@@ -165,7 +165,7 @@ int64_t task_spec_actor_counter(task_spec *spec);
  * @param spec The task_spec in question.
  * @return The driver ID of the task.
  */
-unique_id task_spec_driver_id(task_spec *spec);
+UniqueID task_spec_driver_id(task_spec *spec);
 
 /**
  * Return the task ID of the task.
@@ -209,7 +209,7 @@ int8_t task_arg_type(task_spec *spec, int64_t arg_index);
  * @param arg_index The index of the argument in question.
  * @return The argument at that index.
  */
-object_id task_arg_id(task_spec *spec, int64_t arg_index);
+ObjectID task_arg_id(task_spec *spec, int64_t arg_index);
 
 /**
  * Get a particular argument to this task. This assumes the argument is a value.
@@ -239,7 +239,7 @@ int64_t task_arg_length(task_spec *spec, int64_t arg_index);
  * @return The number of task arguments that have been set before this one. This
  *         is only used for testing.
  */
-int64_t task_args_add_ref(task_spec *spec, object_id obj_id);
+int64_t task_args_add_ref(task_spec *spec, ObjectID obj_id);
 
 /**
  * Set the next task argument. Note that this API only allows you to set the
@@ -260,7 +260,7 @@ int64_t task_args_add_val(task_spec *spec, uint8_t *data, int64_t length);
  * @param return_index The index of the return object ID in question.
  * @return The relevant return object ID.
  */
-object_id task_return(task_spec *spec, int64_t return_index);
+ObjectID task_return(task_spec *spec, int64_t return_index);
 
 /**
  * Indices into resource vectors.
@@ -308,7 +308,7 @@ double task_spec_get_required_resource(const task_spec *spec,
  * @param put_index The number of put calls in this task so far.
  * @return The object ID for the object that was put.
  */
-object_id task_compute_put_id(task_id task_id, int64_t put_index);
+ObjectID task_compute_put_id(task_id task_id, int64_t put_index);
 
 /**
  * Free a task_spec.

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -353,7 +353,7 @@ typedef enum {
 /** A task is an execution of a task specification.  It has a state of execution
  * (see scheduling_state) and the ID of the local scheduler it is scheduled on
  * or running on. */
-typedef struct task_impl Task;
+typedef struct TaskImpl Task;
 
 /**
  * Allocate a new task. Must be freed with free_task after use.
@@ -363,7 +363,7 @@ typedef struct task_impl Task;
  * @param local_scheduler_id The ID of the local scheduler that the task is
  *        scheduled on, if any.
  */
-Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
+Task *Task_alloc(task_spec *spec, int state, DBClientID local_scheduler_id);
 
 /**
  * Create a copy of the task. Must be freed with free_task after use.
@@ -371,30 +371,30 @@ Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
  * @param other The task that will be copied.
  * @returns Pointer to the copy of the task.
  */
-Task *copy_task(Task *other);
+Task *Task_copy(Task *other);
 
 /** Size of task structure in bytes. */
-int64_t task_size(Task *task);
+int64_t Task_size(Task *task);
 
 /** The scheduling state of the task. */
-int task_state(Task *task);
+int Task_state(Task *task);
 
 /** Update the schedule state of the task. */
-void task_set_state(Task *task, int state);
+void Task_set_state(Task *task, int state);
 
 /** Local scheduler this task has been assigned to or is running on. */
-DBClientID task_local_scheduler(Task *task);
+DBClientID Task_local_scheduler_id(Task *task);
 
 /** Set the local scheduler ID for this task. */
-void task_set_local_scheduler(Task *task, DBClientID local_scheduler_id);
+void Task_set_local_scheduler_id(Task *task, DBClientID local_scheduler_id);
 
 /** Task specification of this task. */
-task_spec *task_task_spec(Task *task);
+task_spec *Task_task_spec(Task *task);
 
 /** Task ID of this task. */
-TaskID task_task_id(Task *task);
+TaskID Task_task_id(Task *task);
 
 /** Free this task datastructure. */
-void free_task(Task *task);
+void Task_free(Task *task);
 
 #endif

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -353,7 +353,7 @@ typedef enum {
 /** A task is an execution of a task specification.  It has a state of execution
  * (see scheduling_state) and the ID of the local scheduler it is scheduled on
  * or running on. */
-typedef struct task_impl task;
+typedef struct task_impl Task;
 
 /**
  * Allocate a new task. Must be freed with free_task after use.
@@ -363,7 +363,7 @@ typedef struct task_impl task;
  * @param local_scheduler_id The ID of the local scheduler that the task is
  *        scheduled on, if any.
  */
-task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
+Task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
 
 /**
  * Create a copy of the task. Must be freed with free_task after use.
@@ -371,30 +371,30 @@ task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
  * @param other The task that will be copied.
  * @returns Pointer to the copy of the task.
  */
-task *copy_task(task *other);
+Task *copy_task(Task *other);
 
 /** Size of task structure in bytes. */
-int64_t task_size(task *task);
+int64_t task_size(Task *task);
 
 /** The scheduling state of the task. */
-int task_state(task *task);
+int task_state(Task *task);
 
 /** Update the schedule state of the task. */
-void task_set_state(task *task, int state);
+void task_set_state(Task *task, int state);
 
 /** Local scheduler this task has been assigned to or is running on. */
-DBClientID task_local_scheduler(task *task);
+DBClientID task_local_scheduler(Task *task);
 
 /** Set the local scheduler ID for this task. */
-void task_set_local_scheduler(task *task, DBClientID local_scheduler_id);
+void task_set_local_scheduler(Task *task, DBClientID local_scheduler_id);
 
 /** Task specification of this task. */
-task_spec *task_task_spec(task *task);
+task_spec *task_task_spec(Task *task);
 
 /** Task ID of this task. */
-TaskID task_task_id(task *task);
+TaskID task_task_id(Task *task);
 
 /** Free this task datastructure. */
-void free_task(task *task);
+void free_task(Task *task);
 
 #endif

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -363,7 +363,7 @@ typedef struct task_impl task;
  * @param local_scheduler_id The ID of the local scheduler that the task is
  *        scheduled on, if any.
  */
-task *alloc_task(task_spec *spec, int state, db_client_id local_scheduler_id);
+task *alloc_task(task_spec *spec, int state, DBClientID local_scheduler_id);
 
 /**
  * Create a copy of the task. Must be freed with free_task after use.
@@ -383,10 +383,10 @@ int task_state(task *task);
 void task_set_state(task *task, int state);
 
 /** Local scheduler this task has been assigned to or is running on. */
-db_client_id task_local_scheduler(task *task);
+DBClientID task_local_scheduler(task *task);
 
 /** Set the local scheduler ID for this task. */
-void task_set_local_scheduler(task *task, db_client_id local_scheduler_id);
+void task_set_local_scheduler(task *task, DBClientID local_scheduler_id);
 
 /** Task specification of this task. */
 task_spec *task_task_spec(task *task);

--- a/src/common/test/common_tests.c
+++ b/src/common/test/common_tests.c
@@ -6,8 +6,8 @@ SUITE(common_tests);
 
 TEST sha1_test(void) {
   static char hex[ID_STRING_SIZE];
-  unique_id uid = globally_unique_id();
-  object_id_to_string((object_id) uid, &hex[0], ID_STRING_SIZE);
+  UniqueID uid = globally_unique_id();
+  object_id_to_string((ObjectID) uid, &hex[0], ID_STRING_SIZE);
   PASS();
 }
 

--- a/src/common/test/common_tests.c
+++ b/src/common/test/common_tests.c
@@ -7,7 +7,7 @@ SUITE(common_tests);
 TEST sha1_test(void) {
   static char hex[ID_STRING_SIZE];
   UniqueID uid = globally_unique_id();
-  object_id_to_string((ObjectID) uid, &hex[0], ID_STRING_SIZE);
+  ObjectID_to_string((ObjectID) uid, &hex[0], ID_STRING_SIZE);
   PASS();
 }
 

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -221,7 +221,7 @@ TEST unique_client_id_test(void) {
   }
   for (int i = 0; i < num_conns; ++i) {
     for (int j = 0; j < i; ++j) {
-      ASSERT(!db_client_ids_equal(ids[i], ids[j]));
+      ASSERT(!DBClientID_equal(ids[i], ids[j]));
     }
   }
   PASS();

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -78,7 +78,7 @@ TEST object_table_lookup_test(void) {
   db_attach(db1, loop, false);
   db_attach(db2, loop, false);
   UniqueID id = globally_unique_id();
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = NUM_RETRIES,
       .timeout = TIMEOUT,
       .fail_callback = timeout_callback,
@@ -122,7 +122,7 @@ int64_t task_table_delayed_add_task(event_loop *loop,
                                     int64_t id,
                                     void *context) {
   DBHandle *db = context;
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = NUM_RETRIES,
       .timeout = TIMEOUT,
       .fail_callback = task_table_test_fail_callback,
@@ -153,7 +153,7 @@ TEST task_table_test(void) {
   task_table_test_task =
       Task_alloc(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
   free_task_spec(spec);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = NUM_RETRIES,
       .timeout = TIMEOUT,
       .fail_callback = task_table_test_fail_callback,
@@ -187,7 +187,7 @@ TEST task_table_all_test(void) {
   /* Schedule two tasks on different local local schedulers. */
   Task *task1 = Task_alloc(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
   Task *task2 = Task_alloc(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = NUM_RETRIES, .timeout = TIMEOUT, .fail_callback = NULL,
   };
   task_table_subscribe(db, NIL_ID, TASK_STATUS_SCHEDULED,

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -148,7 +148,7 @@ TEST task_table_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "local_scheduler", "127.0.0.1", 0, NULL);
   db_attach(db, loop, false);
-  db_client_id local_scheduler_id = globally_unique_id();
+  DBClientID local_scheduler_id = globally_unique_id();
   task_spec *spec = example_task_spec(1, 1);
   task_table_test_task =
       alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
@@ -212,7 +212,7 @@ TEST task_table_all_test(void) {
 TEST unique_client_id_test(void) {
   enum { num_conns = 100 };
 
-  db_client_id ids[num_conns];
+  DBClientID ids[num_conns];
   DBHandle *db;
   for (int i = 0; i < num_conns; ++i) {
     db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -69,11 +69,11 @@ TEST object_table_lookup_test(void) {
   event_loop *loop = event_loop_create();
   /* This uses manager_port1. */
   const char *db_connect_args1[] = {"address", "127.0.0.1:12345"};
-  db_handle *db1 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
+  DBHandle *db1 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
                               2, db_connect_args1);
   /* This uses manager_port2. */
   const char *db_connect_args2[] = {"address", "127.0.0.1:12346"};
-  db_handle *db2 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
+  DBHandle *db2 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
                               2, db_connect_args2);
   db_attach(db1, loop, false);
   db_attach(db2, loop, false);
@@ -121,7 +121,7 @@ void task_table_test_fail_callback(UniqueID id,
 int64_t task_table_delayed_add_task(event_loop *loop,
                                     int64_t id,
                                     void *context) {
-  db_handle *db = context;
+  DBHandle *db = context;
   retry_info retry = {
       .num_retries = NUM_RETRIES,
       .timeout = TIMEOUT,
@@ -145,7 +145,7 @@ void task_table_test_callback(task *callback_task, void *user_data) {
 TEST task_table_test(void) {
   task_table_test_callback_called = 0;
   event_loop *loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "local_scheduler", "127.0.0.1", 0, NULL);
   db_attach(db, loop, false);
   db_client_id local_scheduler_id = globally_unique_id();
@@ -180,7 +180,7 @@ void task_table_all_test_callback(task *task, void *user_data) {
 
 TEST task_table_all_test(void) {
   event_loop *loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "local_scheduler", "127.0.0.1", 0, NULL);
   db_attach(db, loop, false);
   task_spec *spec = example_task_spec(1, 1);
@@ -213,7 +213,7 @@ TEST unique_client_id_test(void) {
   enum { num_conns = 100 };
 
   db_client_id ids[num_conns];
-  db_handle *db;
+  DBHandle *db;
   for (int i = 0; i < num_conns; ++i) {
     db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
     ids[i] = get_db_client_id(db);

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -127,16 +127,16 @@ int64_t task_table_delayed_add_task(event_loop *loop,
       .timeout = TIMEOUT,
       .fail_callback = task_table_test_fail_callback,
   };
-  task_table_add_task(db, copy_task(task_table_test_task), &retry, NULL,
+  task_table_add_task(db, Task_copy(task_table_test_task), &retry, NULL,
                       (void *) loop);
   return EVENT_LOOP_TIMER_DONE;
 }
 
 void task_table_test_callback(Task *callback_task, void *user_data) {
   task_table_test_callback_called = 1;
-  CHECK(task_state(callback_task) == TASK_STATUS_SCHEDULED);
-  CHECK(task_size(callback_task) == task_size(task_table_test_task));
-  CHECK(memcmp(callback_task, task_table_test_task, task_size(callback_task)) ==
+  CHECK(Task_state(callback_task) == TASK_STATUS_SCHEDULED);
+  CHECK(Task_size(callback_task) == Task_size(task_table_test_task));
+  CHECK(memcmp(callback_task, task_table_test_task, Task_size(callback_task)) ==
         0);
   event_loop *loop = user_data;
   event_loop_stop(loop);
@@ -151,7 +151,7 @@ TEST task_table_test(void) {
   DBClientID local_scheduler_id = globally_unique_id();
   task_spec *spec = example_task_spec(1, 1);
   task_table_test_task =
-      alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
+      Task_alloc(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
   free_task_spec(spec);
   retry_info retry = {
       .num_retries = NUM_RETRIES,
@@ -164,7 +164,7 @@ TEST task_table_test(void) {
   event_loop_add_timer(
       loop, 200, (event_loop_timer_handler) task_table_delayed_add_task, db);
   event_loop_run(loop);
-  free_task(task_table_test_task);
+  Task_free(task_table_test_task);
   db_disconnect(db);
   destroy_outstanding_callbacks(loop);
   event_loop_destroy(loop);
@@ -185,8 +185,8 @@ TEST task_table_all_test(void) {
   db_attach(db, loop, false);
   task_spec *spec = example_task_spec(1, 1);
   /* Schedule two tasks on different local local schedulers. */
-  Task *task1 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
-  Task *task2 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
+  Task *task1 = Task_alloc(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
+  Task *task2 = Task_alloc(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
   retry_info retry = {
       .num_retries = NUM_RETRIES, .timeout = TIMEOUT, .fail_callback = NULL,
   };

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -70,11 +70,11 @@ TEST object_table_lookup_test(void) {
   /* This uses manager_port1. */
   const char *db_connect_args1[] = {"address", "127.0.0.1:12345"};
   DBHandle *db1 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
-                              2, db_connect_args1);
+                             2, db_connect_args1);
   /* This uses manager_port2. */
   const char *db_connect_args2[] = {"address", "127.0.0.1:12346"};
   DBHandle *db2 = db_connect("127.0.0.1", 6379, "plasma_manager", manager_addr,
-                              2, db_connect_args2);
+                             2, db_connect_args2);
   db_attach(db1, loop, false);
   db_attach(db2, loop, false);
   UniqueID id = globally_unique_id();

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -34,7 +34,7 @@ const int TEST_NUMBER = 10;
 
 /* Test if entries have been written to the database. */
 
-void lookup_done_callback(object_id object_id,
+void lookup_done_callback(ObjectID object_id,
                           int manager_count,
                           const char *manager_vector[],
                           void *user_context) {
@@ -52,10 +52,10 @@ void lookup_done_callback(object_id object_id,
 }
 
 /* Entry added to database successfully. */
-void add_done_callback(object_id object_id, void *user_context) {}
+void add_done_callback(ObjectID object_id, void *user_context) {}
 
 /* Test if we got a timeout callback if we couldn't connect database. */
-void timeout_callback(object_id object_id, void *context, void *user_data) {
+void timeout_callback(ObjectID object_id, void *context, void *user_data) {
   user_context *uc = (user_context *) context;
   CHECK(uc->test_number == TEST_NUMBER)
 }
@@ -77,7 +77,7 @@ TEST object_table_lookup_test(void) {
                               2, db_connect_args2);
   db_attach(db1, loop, false);
   db_attach(db2, loop, false);
-  unique_id id = globally_unique_id();
+  UniqueID id = globally_unique_id();
   retry_info retry = {
       .num_retries = NUM_RETRIES,
       .timeout = TIMEOUT,
@@ -111,7 +111,7 @@ TEST object_table_lookup_test(void) {
 int task_table_test_callback_called = 0;
 task *task_table_test_task;
 
-void task_table_test_fail_callback(unique_id id,
+void task_table_test_fail_callback(UniqueID id,
                                    void *context,
                                    void *user_data) {
   event_loop *loop = user_data;

--- a/src/common/test/db_tests.c
+++ b/src/common/test/db_tests.c
@@ -109,7 +109,7 @@ TEST object_table_lookup_test(void) {
 }
 
 int task_table_test_callback_called = 0;
-task *task_table_test_task;
+Task *task_table_test_task;
 
 void task_table_test_fail_callback(UniqueID id,
                                    void *context,
@@ -132,7 +132,7 @@ int64_t task_table_delayed_add_task(event_loop *loop,
   return EVENT_LOOP_TIMER_DONE;
 }
 
-void task_table_test_callback(task *callback_task, void *user_data) {
+void task_table_test_callback(Task *callback_task, void *user_data) {
   task_table_test_callback_called = 1;
   CHECK(task_state(callback_task) == TASK_STATUS_SCHEDULED);
   CHECK(task_size(callback_task) == task_size(task_table_test_task));
@@ -174,7 +174,7 @@ TEST task_table_test(void) {
 
 int num_test_callback_called = 0;
 
-void task_table_all_test_callback(task *task, void *user_data) {
+void task_table_all_test_callback(Task *task, void *user_data) {
   num_test_callback_called += 1;
 }
 
@@ -185,8 +185,8 @@ TEST task_table_all_test(void) {
   db_attach(db, loop, false);
   task_spec *spec = example_task_spec(1, 1);
   /* Schedule two tasks on different local local schedulers. */
-  task *task1 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
-  task *task2 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
+  Task *task1 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
+  Task *task2 = alloc_task(spec, TASK_STATUS_SCHEDULED, globally_unique_id());
   retry_info retry = {
       .num_retries = NUM_RETRIES, .timeout = TIMEOUT, .fail_callback = NULL,
   };

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -34,13 +34,13 @@ void new_object_done_callback(ObjectID object_id,
                               TaskID task_id,
                               void *user_context) {
   new_object_succeeded = 1;
-  CHECK(object_ids_equal(object_id, new_object_id));
-  CHECK(task_ids_equal(task_id, new_object_task_id));
+  CHECK(ObjectID_equal(object_id, new_object_id));
+  CHECK(TaskID_equal(task_id, new_object_task_id));
   event_loop_stop(g_loop);
 }
 
 void new_object_lookup_callback(ObjectID object_id, void *user_context) {
-  CHECK(object_ids_equal(object_id, new_object_id));
+  CHECK(ObjectID_equal(object_id, new_object_id));
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -592,7 +592,7 @@ void subscribe_success_object_available_callback(ObjectID object_id,
                                                  const char *manager_vector[],
                                                  void *user_context) {
   CHECK(user_context == (void *) subscribe_success_context);
-  CHECK(object_ids_equal(object_id, subscribe_id));
+  CHECK(ObjectID_equal(object_id, subscribe_id));
   CHECK(manager_count == 1);
   subscribe_success_succeeded = 1;
 }

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -214,9 +214,7 @@ void subscribe_done_callback(ObjectID object_id,
   CHECK(0);
 }
 
-void subscribe_fail_callback(UniqueID id,
-                             void *user_context,
-                             void *user_data) {
+void subscribe_fail_callback(UniqueID id, void *user_context, void *user_data) {
   subscribe_failed = 1;
   event_loop_stop(g_loop);
 }
@@ -321,8 +319,8 @@ TEST add_lookup_test(void) {
   lookup_retry_succeeded = 0;
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11235"};
-  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                             2, db_connect_args);
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 2,
+                            db_connect_args);
   db_attach(db, g_loop, true);
   RetryInfo retry = {
       .num_retries = 5,
@@ -602,8 +600,8 @@ TEST subscribe_success_test(void) {
 
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                             2, db_connect_args);
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 2,
+                            db_connect_args);
   db_attach(db, g_loop, false);
   subscribe_id = globally_unique_id();
 
@@ -671,8 +669,8 @@ TEST subscribe_object_present_test(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                             2, db_connect_args);
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 2,
+                            db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {
@@ -786,8 +784,8 @@ TEST subscribe_object_available_later_test(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                             2, db_connect_args);
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 2,
+                            db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {
@@ -839,8 +837,8 @@ TEST subscribe_object_available_subscribe_all(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                             2, db_connect_args);
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 2,
+                            db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -41,7 +41,7 @@ void new_object_done_callback(ObjectID object_id,
 
 void new_object_lookup_callback(ObjectID object_id, void *user_context) {
   CHECK(ObjectID_equal(object_id, new_object_id));
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
@@ -52,7 +52,7 @@ void new_object_lookup_callback(ObjectID object_id, void *user_context) {
 }
 
 void new_object_task_callback(TaskID task_id, void *user_context) {
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
@@ -73,7 +73,7 @@ TEST new_object_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
@@ -108,7 +108,7 @@ TEST new_object_no_task_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
@@ -150,7 +150,7 @@ TEST lookup_timeout_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = lookup_fail_callback,
   };
   object_table_lookup(db, NIL_ID, &retry, lookup_done_callback,
@@ -186,7 +186,7 @@ TEST add_timeout_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = add_fail_callback,
   };
   object_table_add(db, NIL_ID, 0, (unsigned char *) NIL_DIGEST, &retry,
@@ -226,7 +226,7 @@ TEST subscribe_timeout_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = subscribe_fail_callback,
@@ -307,7 +307,7 @@ void add_lookup_done_callback(ObjectID object_id,
 
 void add_lookup_callback(ObjectID object_id, void *user_context) {
   DBHandle *db = user_context;
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = lookup_retry_fail_callback,
@@ -324,7 +324,7 @@ TEST add_lookup_test(void) {
   DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, true);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = lookup_retry_fail_callback,
@@ -355,7 +355,7 @@ void add_remove_lookup_done_callback(ObjectID object_id,
 
 void add_remove_lookup_callback(ObjectID object_id, void *user_context) {
   DBHandle *db = user_context;
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = lookup_retry_fail_callback,
@@ -366,7 +366,7 @@ void add_remove_lookup_callback(ObjectID object_id, void *user_context) {
 
 void add_remove_callback(ObjectID object_id, void *user_context) {
   DBHandle *db = user_context;
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = lookup_retry_fail_callback,
@@ -381,7 +381,7 @@ TEST add_remove_lookup_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, true);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = lookup_retry_fail_callback,
@@ -450,7 +450,7 @@ TEST lookup_late_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0,
       .timeout = 0,
       .fail_callback = lookup_late_fail_callback,
@@ -492,7 +492,7 @@ TEST add_late_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 0, .fail_callback = add_late_fail_callback,
   };
   object_table_add(db, NIL_ID, 0, (unsigned char *) NIL_DIGEST, &retry,
@@ -537,7 +537,7 @@ TEST subscribe_late_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0,
       .timeout = 0,
       .fail_callback = subscribe_late_fail_callback,
@@ -578,7 +578,7 @@ void subscribe_success_done_callback(ObjectID object_id,
                                      int manager_count,
                                      const char *manager_vector[],
                                      void *user_context) {
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 750, .fail_callback = NULL,
   };
   object_table_add((DBHandle *) user_context, subscribe_id, 0,
@@ -607,7 +607,7 @@ TEST subscribe_success_test(void) {
   db_attach(db, g_loop, false);
   subscribe_id = globally_unique_id();
 
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0,
       .timeout = 100,
       .fail_callback = subscribe_success_fail_callback,
@@ -675,7 +675,7 @@ TEST subscribe_object_present_test(void) {
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = fatal_fail_callback,
   };
   object_table_add(db, id, data_size, (unsigned char *) NIL_DIGEST, &retry,
@@ -727,7 +727,7 @@ TEST subscribe_object_not_present_test(void) {
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };
   object_table_subscribe_to_notifications(
@@ -790,7 +790,7 @@ TEST subscribe_object_available_later_test(void) {
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };
   object_table_subscribe_to_notifications(
@@ -843,7 +843,7 @@ TEST subscribe_object_available_subscribe_all(void) {
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };
   object_table_subscribe_to_notifications(

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -67,7 +67,7 @@ TEST new_object_test(void) {
   new_object_succeeded = 0;
   new_object_id = globally_unique_id();
   new_object_task = example_task(1, 1, TASK_STATUS_WAITING);
-  new_object_task_spec = task_task_spec(new_object_task);
+  new_object_task_spec = Task_task_spec(new_object_task);
   new_object_task_id = task_spec_id(new_object_task_spec);
   g_loop = event_loop_create();
   DBHandle *db =
@@ -78,7 +78,7 @@ TEST new_object_test(void) {
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
   };
-  task_table_add_task(db, copy_task(new_object_task), &retry,
+  task_table_add_task(db, Task_copy(new_object_task), &retry,
                       new_object_task_callback, db);
   event_loop_run(g_loop);
   db_disconnect(db);

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -46,7 +46,7 @@ void new_object_lookup_callback(ObjectID object_id, void *user_context) {
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
   };
-  db_handle *db = user_context;
+  DBHandle *db = user_context;
   result_table_lookup(db, new_object_id, &retry, new_object_done_callback,
                       NULL);
 }
@@ -57,7 +57,7 @@ void new_object_task_callback(TaskID task_id, void *user_context) {
       .timeout = 100,
       .fail_callback = new_object_fail_callback,
   };
-  db_handle *db = user_context;
+  DBHandle *db = user_context;
   result_table_add(db, new_object_id, new_object_task_id, &retry,
                    new_object_lookup_callback, (void *) db);
 }
@@ -70,7 +70,7 @@ TEST new_object_test(void) {
   new_object_task_spec = task_task_spec(new_object_task);
   new_object_task_id = task_spec_id(new_object_task_spec);
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -105,7 +105,7 @@ TEST new_object_no_task_test(void) {
   new_object_id = globally_unique_id();
   new_object_task_id = globally_unique_id();
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -147,7 +147,7 @@ void lookup_fail_callback(UniqueID id, void *user_context, void *user_data) {
 
 TEST lookup_timeout_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -183,7 +183,7 @@ void add_fail_callback(UniqueID id, void *user_context, void *user_data) {
 
 TEST add_timeout_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -223,7 +223,7 @@ void subscribe_fail_callback(UniqueID id,
 
 TEST subscribe_timeout_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -248,7 +248,7 @@ TEST subscribe_timeout_test(void) {
 int64_t reconnect_context_callback(event_loop *loop,
                                    int64_t timer_id,
                                    void *context) {
-  db_handle *db = context;
+  DBHandle *db = context;
   /* Reconnect to redis. This is not reconnecting the pub/sub channel. */
   redisAsyncFree(db->context);
   redisFree(db->sync_context);
@@ -306,7 +306,7 @@ void add_lookup_done_callback(ObjectID object_id,
 }
 
 void add_lookup_callback(ObjectID object_id, void *user_context) {
-  db_handle *db = user_context;
+  DBHandle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -321,7 +321,7 @@ TEST add_lookup_test(void) {
   lookup_retry_succeeded = 0;
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11235"};
-  db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, true);
   retry_info retry = {
@@ -354,7 +354,7 @@ void add_remove_lookup_done_callback(ObjectID object_id,
 }
 
 void add_remove_lookup_callback(ObjectID object_id, void *user_context) {
-  db_handle *db = user_context;
+  DBHandle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -365,7 +365,7 @@ void add_remove_lookup_callback(ObjectID object_id, void *user_context) {
 }
 
 void add_remove_callback(ObjectID object_id, void *user_context) {
-  db_handle *db = user_context;
+  DBHandle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -378,7 +378,7 @@ void add_remove_callback(ObjectID object_id, void *user_context) {
 TEST add_remove_lookup_test(void) {
   g_loop = event_loop_create();
   lookup_retry_succeeded = 0;
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, true);
   retry_info retry = {
@@ -408,7 +408,7 @@ int subscribe_retry_succeeded = 0;
 int64_t reconnect_sub_context_callback(event_loop *loop,
                                        int64_t timer_id,
                                        void *context) {
-  db_handle *db = context;
+  DBHandle *db = context;
   /* Reconnect to redis. This is not reconnecting the pub/sub channel. */
   redisAsyncFree(db->sub_context);
   redisAsyncFree(db->context);
@@ -447,7 +447,7 @@ void lookup_late_done_callback(ObjectID object_id,
 
 TEST lookup_late_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -489,7 +489,7 @@ void add_late_done_callback(ObjectID object_id, void *user_context) {
 
 TEST add_late_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -534,7 +534,7 @@ void subscribe_late_done_callback(ObjectID object_id,
 
 TEST subscribe_late_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -581,7 +581,7 @@ void subscribe_success_done_callback(ObjectID object_id,
   retry_info retry = {
       .num_retries = 0, .timeout = 750, .fail_callback = NULL,
   };
-  object_table_add((db_handle *) user_context, subscribe_id, 0,
+  object_table_add((DBHandle *) user_context, subscribe_id, 0,
                    (unsigned char *) NIL_DIGEST, &retry, NULL, NULL);
   subscribe_success_done = 1;
 }
@@ -602,7 +602,7 @@ TEST subscribe_success_test(void) {
 
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   subscribe_id = globally_unique_id();
@@ -671,7 +671,7 @@ TEST subscribe_object_present_test(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
@@ -723,7 +723,7 @@ void subscribe_object_not_present_object_available_callback(
 
 TEST subscribe_object_not_present_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
@@ -786,7 +786,7 @@ TEST subscribe_object_available_later_test(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
@@ -839,7 +839,7 @@ TEST subscribe_object_available_subscribe_all(void) {
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
   const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
-  db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+  DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -19,7 +19,7 @@ int new_object_succeeded = 0;
 ObjectID new_object_id;
 task *new_object_task;
 task_spec *new_object_task_spec;
-task_id new_object_task_id;
+TaskID new_object_task_id;
 
 void new_object_fail_callback(UniqueID id,
                               void *user_context,
@@ -31,7 +31,7 @@ void new_object_fail_callback(UniqueID id,
 /* === Test adding an object with an associated task === */
 
 void new_object_done_callback(ObjectID object_id,
-                              task_id task_id,
+                              TaskID task_id,
                               void *user_context) {
   new_object_succeeded = 1;
   CHECK(object_ids_equal(object_id, new_object_id));
@@ -51,7 +51,7 @@ void new_object_lookup_callback(ObjectID object_id, void *user_context) {
                       NULL);
 }
 
-void new_object_task_callback(task_id task_id, void *user_context) {
+void new_object_task_callback(TaskID task_id, void *user_context) {
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -92,7 +92,7 @@ TEST new_object_test(void) {
 /* === Test adding an object without an associated task === */
 
 void new_object_no_task_callback(ObjectID object_id,
-                                 task_id task_id,
+                                 TaskID task_id,
                                  void *user_context) {
   new_object_succeeded = 1;
   CHECK(IS_NIL_ID(task_id));

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -17,7 +17,7 @@ static event_loop *g_loop;
 int new_object_failed = 0;
 int new_object_succeeded = 0;
 ObjectID new_object_id;
-task *new_object_task;
+Task *new_object_task;
 task_spec *new_object_task_spec;
 TaskID new_object_task_id;
 

--- a/src/common/test/object_table_tests.c
+++ b/src/common/test/object_table_tests.c
@@ -16,12 +16,12 @@ static event_loop *g_loop;
 
 int new_object_failed = 0;
 int new_object_succeeded = 0;
-object_id new_object_id;
+ObjectID new_object_id;
 task *new_object_task;
 task_spec *new_object_task_spec;
 task_id new_object_task_id;
 
-void new_object_fail_callback(unique_id id,
+void new_object_fail_callback(UniqueID id,
                               void *user_context,
                               void *user_data) {
   new_object_failed = 1;
@@ -30,7 +30,7 @@ void new_object_fail_callback(unique_id id,
 
 /* === Test adding an object with an associated task === */
 
-void new_object_done_callback(object_id object_id,
+void new_object_done_callback(ObjectID object_id,
                               task_id task_id,
                               void *user_context) {
   new_object_succeeded = 1;
@@ -39,7 +39,7 @@ void new_object_done_callback(object_id object_id,
   event_loop_stop(g_loop);
 }
 
-void new_object_lookup_callback(object_id object_id, void *user_context) {
+void new_object_lookup_callback(ObjectID object_id, void *user_context) {
   CHECK(object_ids_equal(object_id, new_object_id));
   retry_info retry = {
       .num_retries = 5,
@@ -91,7 +91,7 @@ TEST new_object_test(void) {
 
 /* === Test adding an object without an associated task === */
 
-void new_object_no_task_callback(object_id object_id,
+void new_object_no_task_callback(ObjectID object_id,
                                  task_id task_id,
                                  void *user_context) {
   new_object_succeeded = 1;
@@ -131,7 +131,7 @@ TEST new_object_no_task_test(void) {
 const char *lookup_timeout_context = "lookup_timeout";
 int lookup_failed = 0;
 
-void lookup_done_callback(object_id object_id,
+void lookup_done_callback(ObjectID object_id,
                           int manager_count,
                           const char *manager_vector[],
                           void *context) {
@@ -139,7 +139,7 @@ void lookup_done_callback(object_id object_id,
   CHECK(0);
 }
 
-void lookup_fail_callback(unique_id id, void *user_context, void *user_data) {
+void lookup_fail_callback(UniqueID id, void *user_context, void *user_data) {
   lookup_failed = 1;
   CHECK(user_context == (void *) lookup_timeout_context);
   event_loop_stop(g_loop);
@@ -170,12 +170,12 @@ TEST lookup_timeout_test(void) {
 const char *add_timeout_context = "add_timeout";
 int add_failed = 0;
 
-void add_done_callback(object_id object_id, void *user_context) {
+void add_done_callback(ObjectID object_id, void *user_context) {
   /* The done callback should not be called. */
   CHECK(0);
 }
 
-void add_fail_callback(unique_id id, void *user_context, void *user_data) {
+void add_fail_callback(UniqueID id, void *user_context, void *user_data) {
   add_failed = 1;
   CHECK(user_context == (void *) add_timeout_context);
   event_loop_stop(g_loop);
@@ -205,7 +205,7 @@ TEST add_timeout_test(void) {
 
 int subscribe_failed = 0;
 
-void subscribe_done_callback(object_id object_id,
+void subscribe_done_callback(ObjectID object_id,
                              int64_t data_size,
                              int manager_count,
                              const char *manager_vector[],
@@ -214,7 +214,7 @@ void subscribe_done_callback(object_id object_id,
   CHECK(0);
 }
 
-void subscribe_fail_callback(unique_id id,
+void subscribe_fail_callback(UniqueID id,
                              void *user_context,
                              void *user_data) {
   subscribe_failed = 1;
@@ -273,7 +273,7 @@ int64_t terminate_event_loop_callback(event_loop *loop,
 const char *lookup_retry_context = "lookup_retry";
 int lookup_retry_succeeded = 0;
 
-void lookup_retry_done_callback(object_id object_id,
+void lookup_retry_done_callback(ObjectID object_id,
                                 int manager_count,
                                 const char *manager_vector[],
                                 void *context) {
@@ -281,7 +281,7 @@ void lookup_retry_done_callback(object_id object_id,
   lookup_retry_succeeded = 1;
 }
 
-void lookup_retry_fail_callback(unique_id id,
+void lookup_retry_fail_callback(UniqueID id,
                                 void *user_context,
                                 void *user_data) {
   /* The fail callback should not be called. */
@@ -295,7 +295,7 @@ int add_retry_succeeded = 0;
 
 /* === Test add then lookup retry === */
 
-void add_lookup_done_callback(object_id object_id,
+void add_lookup_done_callback(ObjectID object_id,
                               int manager_count,
                               const char *manager_vector[],
                               void *context) {
@@ -305,7 +305,7 @@ void add_lookup_done_callback(object_id object_id,
   lookup_retry_succeeded = 1;
 }
 
-void add_lookup_callback(object_id object_id, void *user_context) {
+void add_lookup_callback(ObjectID object_id, void *user_context) {
   db_handle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
@@ -344,7 +344,7 @@ TEST add_lookup_test(void) {
 }
 
 /* === Test add, remove, then lookup === */
-void add_remove_lookup_done_callback(object_id object_id,
+void add_remove_lookup_done_callback(ObjectID object_id,
                                      int manager_count,
                                      const char *manager_vector[],
                                      void *context) {
@@ -353,7 +353,7 @@ void add_remove_lookup_done_callback(object_id object_id,
   lookup_retry_succeeded = 1;
 }
 
-void add_remove_lookup_callback(object_id object_id, void *user_context) {
+void add_remove_lookup_callback(ObjectID object_id, void *user_context) {
   db_handle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
@@ -364,7 +364,7 @@ void add_remove_lookup_callback(object_id object_id, void *user_context) {
                       (void *) lookup_retry_context);
 }
 
-void add_remove_callback(object_id object_id, void *user_context) {
+void add_remove_callback(ObjectID object_id, void *user_context) {
   db_handle *db = user_context;
   retry_info retry = {
       .num_retries = 5,
@@ -430,14 +430,14 @@ int64_t reconnect_sub_context_callback(event_loop *loop,
 const char *lookup_late_context = "lookup_late";
 int lookup_late_failed = 0;
 
-void lookup_late_fail_callback(unique_id id,
+void lookup_late_fail_callback(UniqueID id,
                                void *user_context,
                                void *user_data) {
   CHECK(user_context == (void *) lookup_late_context);
   lookup_late_failed = 1;
 }
 
-void lookup_late_done_callback(object_id object_id,
+void lookup_late_done_callback(ObjectID object_id,
                                int manager_count,
                                const char *manager_vector[],
                                void *context) {
@@ -477,12 +477,12 @@ TEST lookup_late_test(void) {
 const char *add_late_context = "add_late";
 int add_late_failed = 0;
 
-void add_late_fail_callback(unique_id id, void *user_context, void *user_data) {
+void add_late_fail_callback(UniqueID id, void *user_context, void *user_data) {
   CHECK(user_context == (void *) add_late_context);
   add_late_failed = 1;
 }
 
-void add_late_done_callback(object_id object_id, void *user_context) {
+void add_late_done_callback(ObjectID object_id, void *user_context) {
   /* This function should never be called. */
   CHECK(0);
 }
@@ -517,14 +517,14 @@ TEST add_late_test(void) {
 const char *subscribe_late_context = "subscribe_late";
 int subscribe_late_failed = 0;
 
-void subscribe_late_fail_callback(unique_id id,
+void subscribe_late_fail_callback(UniqueID id,
                                   void *user_context,
                                   void *user_data) {
   CHECK(user_context == (void *) subscribe_late_context);
   subscribe_late_failed = 1;
 }
 
-void subscribe_late_done_callback(object_id object_id,
+void subscribe_late_done_callback(ObjectID object_id,
                                   int manager_count,
                                   const char *manager_vector[],
                                   void *user_context) {
@@ -565,16 +565,16 @@ TEST subscribe_late_test(void) {
 const char *subscribe_success_context = "subscribe_success";
 int subscribe_success_done = 0;
 int subscribe_success_succeeded = 0;
-object_id subscribe_id;
+ObjectID subscribe_id;
 
-void subscribe_success_fail_callback(unique_id id,
+void subscribe_success_fail_callback(UniqueID id,
                                      void *user_context,
                                      void *user_data) {
   /* This function should never be called. */
   CHECK(0);
 }
 
-void subscribe_success_done_callback(object_id object_id,
+void subscribe_success_done_callback(ObjectID object_id,
                                      int manager_count,
                                      const char *manager_vector[],
                                      void *user_context) {
@@ -586,7 +586,7 @@ void subscribe_success_done_callback(object_id object_id,
   subscribe_success_done = 1;
 }
 
-void subscribe_success_object_available_callback(object_id object_id,
+void subscribe_success_object_available_callback(ObjectID object_id,
                                                  int64_t data_size,
                                                  int manager_count,
                                                  const char *manager_vector[],
@@ -617,7 +617,7 @@ TEST subscribe_success_test(void) {
       (void *) subscribe_success_context, &retry,
       subscribe_success_done_callback, (void *) db);
 
-  object_id object_ids[1] = {subscribe_id};
+  ObjectID object_ids[1] = {subscribe_id};
   object_table_request_notifications(db, 1, object_ids, &retry);
 
   /* Install handler for terminating the event loop. */
@@ -645,7 +645,7 @@ const char *subscribe_object_present_str = "subscribe_object_present";
 int subscribe_object_present_succeeded = 0;
 
 void subscribe_object_present_object_available_callback(
-    object_id object_id,
+    ObjectID object_id,
     int64_t data_size,
     int manager_count,
     const char *manager_vector[],
@@ -658,7 +658,7 @@ void subscribe_object_present_object_available_callback(
   CHECK(manager_count == 1);
 }
 
-void fatal_fail_callback(unique_id id, void *user_context, void *user_data) {
+void fatal_fail_callback(UniqueID id, void *user_context, void *user_data) {
   /* This function should never be called. */
   CHECK(0);
 }
@@ -674,7 +674,7 @@ TEST subscribe_object_present_test(void) {
   db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
-  unique_id id = globally_unique_id();
+  UniqueID id = globally_unique_id();
   retry_info retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = fatal_fail_callback,
   };
@@ -690,7 +690,7 @@ TEST subscribe_object_present_test(void) {
   /* Run the event loop to create do the add and subscribe. */
   event_loop_run(g_loop);
 
-  object_id object_ids[1] = {id};
+  ObjectID object_ids[1] = {id};
   object_table_request_notifications(db, 1, object_ids, &retry);
   /* Install handler for terminating the event loop. */
   event_loop_add_timer(g_loop, 750,
@@ -712,7 +712,7 @@ const char *subscribe_object_not_present_context =
     "subscribe_object_not_present";
 
 void subscribe_object_not_present_object_available_callback(
-    object_id object_id,
+    ObjectID object_id,
     int64_t data_size,
     int manager_count,
     const char *manager_vector[],
@@ -726,7 +726,7 @@ TEST subscribe_object_not_present_test(void) {
   db_handle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  unique_id id = globally_unique_id();
+  UniqueID id = globally_unique_id();
   retry_info retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };
@@ -740,7 +740,7 @@ TEST subscribe_object_not_present_test(void) {
   /* Run the event loop to do the subscribe. */
   event_loop_run(g_loop);
 
-  object_id object_ids[1] = {id};
+  ObjectID object_ids[1] = {id};
   object_table_request_notifications(db, 1, object_ids, &retry);
   /* Install handler for terminating the event loop. */
   event_loop_add_timer(g_loop, 750,
@@ -762,7 +762,7 @@ const char *subscribe_object_available_later_context =
 int subscribe_object_available_later_succeeded = 0;
 
 void subscribe_object_available_later_object_available_callback(
-    object_id object_id,
+    ObjectID object_id,
     int64_t data_size,
     int manager_count,
     const char *manager_vector[],
@@ -789,7 +789,7 @@ TEST subscribe_object_available_later_test(void) {
   db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
-  unique_id id = globally_unique_id();
+  UniqueID id = globally_unique_id();
   retry_info retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };
@@ -803,7 +803,7 @@ TEST subscribe_object_available_later_test(void) {
   /* Run the event loop to do the subscribe. */
   event_loop_run(g_loop);
 
-  object_id object_ids[1] = {id};
+  ObjectID object_ids[1] = {id};
   object_table_request_notifications(db, 1, object_ids, &retry);
   /* Install handler for terminating the event loop. */
   event_loop_add_timer(g_loop, 750,
@@ -842,7 +842,7 @@ TEST subscribe_object_available_subscribe_all(void) {
   db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                              2, db_connect_args);
   db_attach(db, g_loop, false);
-  unique_id id = globally_unique_id();
+  UniqueID id = globally_unique_id();
   retry_info retry = {
       .num_retries = 0, .timeout = 100, .fail_callback = NULL,
   };

--- a/src/common/test/redis_tests.c
+++ b/src/common/test/redis_tests.c
@@ -69,7 +69,7 @@ TEST redis_socket_test(void) {
 }
 
 void redis_read_callback(event_loop *loop, int fd, void *context, int events) {
-  db_handle *db = context;
+  DBHandle *db = context;
   char *cmd = read_log_message(fd);
   redisAsyncCommand(db->context, async_redis_socket_test_callback, NULL, cmd);
   free(cmd);
@@ -102,7 +102,7 @@ TEST async_redis_socket_test(void) {
   utarray_push_back(connections, &socket_fd);
 
   /* Start connection to Redis. */
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "test_process", "127.0.0.1", 0, NULL);
   db_attach(db, loop, false);
 
@@ -148,7 +148,7 @@ void logging_read_callback(event_loop *loop,
                            int fd,
                            void *context,
                            int events) {
-  db_handle *conn = context;
+  DBHandle *conn = context;
   char *cmd = read_log_message(fd);
   redisAsyncCommand(conn->context, logging_test_callback, NULL, cmd,
                     (char *) conn->client.id, sizeof(conn->client.id));
@@ -177,7 +177,7 @@ TEST logging_test(void) {
   utarray_push_back(connections, &socket_fd);
 
   /* Start connection to Redis. */
-  db_handle *conn =
+  DBHandle *conn =
       db_connect("127.0.0.1", 6379, "test_process", "127.0.0.1", 0, NULL);
   db_attach(conn, loop, false);
 

--- a/src/common/test/redis_tests.c
+++ b/src/common/test/redis_tests.c
@@ -185,8 +185,8 @@ TEST logging_test(void) {
   int client_fd = connect_ipc_sock(socket_pathname);
   ASSERT(client_fd >= 0);
   utarray_push_back(connections, &client_fd);
-  ray_logger *logger = init_ray_logger("worker", RAY_INFO, 0, &client_fd);
-  ray_log(logger, RAY_INFO, "TEST", "Message");
+  RayLogger *logger = RayLogger_init("worker", RAY_INFO, 0, &client_fd);
+  RayLogger_log(logger, RAY_INFO, "TEST", "Message");
 
   event_loop_add_file(loop, socket_fd, EVENT_LOOP_READ, logging_accept_callback,
                       conn);
@@ -197,7 +197,7 @@ TEST logging_test(void) {
 
   ASSERT(logging_test_callback_called);
 
-  free_ray_logger(logger);
+  RayLogger_free(logger);
   db_disconnect(conn);
   event_loop_destroy(loop);
   for (int *p = (int *) utarray_front(connections); p != NULL;

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -126,9 +126,7 @@ void subscribe_done_callback(TaskID task_id, void *user_context) {
   CHECK(0);
 }
 
-void subscribe_fail_callback(UniqueID id,
-                             void *user_context,
-                             void *user_data) {
+void subscribe_fail_callback(UniqueID id, void *user_context, void *user_data) {
   subscribe_failed = 1;
   CHECK(user_context == (void *) subscribe_timeout_context);
   event_loop_stop(g_loop);

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -73,13 +73,13 @@ void add_lookup_fail_callback(UniqueID id,
 
 void lookup_success_callback(Task *task, void *context) {
   lookup_success = 1;
-  CHECK(memcmp(task, add_lookup_task, task_size(task)) == 0);
+  CHECK(memcmp(task, add_lookup_task, Task_size(task)) == 0);
   event_loop_stop(g_loop);
 }
 
 void add_success_callback(TaskID task_id, void *context) {
   add_success = 1;
-  CHECK(TaskID_equal(task_id, task_task_id(add_lookup_task)));
+  CHECK(TaskID_equal(task_id, Task_task_id(add_lookup_task)));
 
   DBHandle *db = context;
   retry_info retry = {
@@ -102,7 +102,7 @@ TEST add_lookup_test(void) {
       .timeout = 1000,
       .fail_callback = add_lookup_fail_callback,
   };
-  task_table_add_task(db, copy_task(add_lookup_task), &retry,
+  task_table_add_task(db, Task_copy(add_lookup_task), &retry,
                       add_success_callback, (void *) db);
   /* Disconnect the database to see if the lookup times out. */
   event_loop_run(g_loop);

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -79,7 +79,7 @@ void lookup_success_callback(Task *task, void *context) {
 
 void add_success_callback(TaskID task_id, void *context) {
   add_success = 1;
-  CHECK(task_ids_equal(task_id, task_task_id(add_lookup_task)));
+  CHECK(TaskID_equal(task_id, task_task_id(add_lookup_task)));
 
   DBHandle *db = context;
   retry_info retry = {

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -21,7 +21,7 @@ task_id lookup_nil_id;
 int lookup_nil_success = 0;
 const char *lookup_nil_context = "lookup_nil";
 
-void lookup_nil_fail_callback(unique_id id,
+void lookup_nil_fail_callback(UniqueID id,
                               void *user_context,
                               void *user_data) {
   /* The fail callback should not be called. */
@@ -64,7 +64,7 @@ int lookup_success = 0;
 task *add_lookup_task;
 const char *add_lookup_context = "add_lookup";
 
-void add_lookup_fail_callback(unique_id id,
+void add_lookup_fail_callback(UniqueID id,
                               void *user_context,
                               void *user_data) {
   /* The fail callback should not be called. */
@@ -126,7 +126,7 @@ void subscribe_done_callback(task_id task_id, void *user_context) {
   CHECK(0);
 }
 
-void subscribe_fail_callback(unique_id id,
+void subscribe_fail_callback(UniqueID id,
                              void *user_context,
                              void *user_data) {
   subscribe_failed = 1;
@@ -169,7 +169,7 @@ void publish_done_callback(task_id task_id, void *user_context) {
   CHECK(0);
 }
 
-void publish_fail_callback(unique_id id, void *user_context, void *user_data) {
+void publish_fail_callback(UniqueID id, void *user_context, void *user_data) {
   publish_failed = 1;
   CHECK(user_context == (void *) publish_timeout_context);
   event_loop_stop(g_loop);
@@ -225,12 +225,12 @@ const char *subscribe_retry_context = "subscribe_retry";
 const int subscribe_retry_test_number = 273;
 int subscribe_retry_succeeded = 0;
 
-void subscribe_retry_done_callback(object_id object_id, void *user_context) {
+void subscribe_retry_done_callback(ObjectID object_id, void *user_context) {
   CHECK(user_context == (void *) subscribe_retry_context);
   subscribe_retry_succeeded = 1;
 }
 
-void subscribe_retry_fail_callback(unique_id id,
+void subscribe_retry_fail_callback(UniqueID id,
                                    void *user_context,
                                    void *user_data) {
   /* The fail callback should not be called. */
@@ -272,12 +272,12 @@ TEST subscribe_retry_test(void) {
 const char *publish_retry_context = "publish_retry";
 int publish_retry_succeeded = 0;
 
-void publish_retry_done_callback(object_id object_id, void *user_context) {
+void publish_retry_done_callback(ObjectID object_id, void *user_context) {
   CHECK(user_context == (void *) publish_retry_context);
   publish_retry_succeeded = 1;
 }
 
-void publish_retry_fail_callback(unique_id id,
+void publish_retry_fail_callback(UniqueID id,
                                  void *user_context,
                                  void *user_data) {
   /* The fail callback should not be called. */
@@ -321,7 +321,7 @@ TEST publish_retry_test(void) {
 const char *subscribe_late_context = "subscribe_late";
 int subscribe_late_failed = 0;
 
-void subscribe_late_fail_callback(unique_id id,
+void subscribe_late_fail_callback(UniqueID id,
                                   void *user_context,
                                   void *user_data) {
   CHECK(user_context == (void *) subscribe_late_context);
@@ -366,7 +366,7 @@ TEST subscribe_late_test(void) {
 const char *publish_late_context = "publish_late";
 int publish_late_failed = 0;
 
-void publish_late_fail_callback(unique_id id,
+void publish_late_fail_callback(UniqueID id,
                                 void *user_context,
                                 void *user_data) {
   CHECK(user_context == (void *) publish_late_context);

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -17,7 +17,7 @@ event_loop *g_loop;
 
 /* === A lookup of a task not in the table === */
 
-task_id lookup_nil_id;
+TaskID lookup_nil_id;
 int lookup_nil_success = 0;
 const char *lookup_nil_context = "lookup_nil";
 
@@ -77,7 +77,7 @@ void lookup_success_callback(task *task, void *context) {
   event_loop_stop(g_loop);
 }
 
-void add_success_callback(task_id task_id, void *context) {
+void add_success_callback(TaskID task_id, void *context) {
   add_success = 1;
   CHECK(task_ids_equal(task_id, task_task_id(add_lookup_task)));
 
@@ -121,7 +121,7 @@ TEST add_lookup_test(void) {
 const char *subscribe_timeout_context = "subscribe_timeout";
 int subscribe_failed = 0;
 
-void subscribe_done_callback(task_id task_id, void *user_context) {
+void subscribe_done_callback(TaskID task_id, void *user_context) {
   /* The done callback should not be called. */
   CHECK(0);
 }
@@ -164,7 +164,7 @@ const char *publish_timeout_context = "publish_timeout";
 const int publish_test_number = 272;
 int publish_failed = 0;
 
-void publish_done_callback(task_id task_id, void *user_context) {
+void publish_done_callback(TaskID task_id, void *user_context) {
   /* The done callback should not be called. */
   CHECK(0);
 }
@@ -328,7 +328,7 @@ void subscribe_late_fail_callback(UniqueID id,
   subscribe_late_failed = 1;
 }
 
-void subscribe_late_done_callback(task_id task_id, void *user_context) {
+void subscribe_late_done_callback(TaskID task_id, void *user_context) {
   /* This function should never be called. */
   CHECK(0);
 }
@@ -373,7 +373,7 @@ void publish_late_fail_callback(UniqueID id,
   publish_late_failed = 1;
 }
 
-void publish_late_done_callback(task_id task_id, void *user_context) {
+void publish_late_done_callback(TaskID task_id, void *user_context) {
   /* This function should never be called. */
   CHECK(0);
 }

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -38,7 +38,7 @@ void lookup_nil_success_callback(task *task, void *context) {
 TEST lookup_nil_test(void) {
   lookup_nil_id = globally_unique_id();
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -81,7 +81,7 @@ void add_success_callback(TaskID task_id, void *context) {
   add_success = 1;
   CHECK(task_ids_equal(task_id, task_task_id(add_lookup_task)));
 
-  db_handle *db = context;
+  DBHandle *db = context;
   retry_info retry = {
       .num_retries = 5,
       .timeout = 1000,
@@ -94,7 +94,7 @@ void add_success_callback(TaskID task_id, void *context) {
 TEST add_lookup_test(void) {
   add_lookup_task = example_task(1, 1, TASK_STATUS_WAITING);
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -136,7 +136,7 @@ void subscribe_fail_callback(UniqueID id,
 
 TEST subscribe_timeout_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -177,7 +177,7 @@ void publish_fail_callback(UniqueID id, void *user_context, void *user_data) {
 
 TEST publish_timeout_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   task *task = example_task(1, 1, TASK_STATUS_WAITING);
@@ -202,7 +202,7 @@ TEST publish_timeout_test(void) {
 int64_t reconnect_db_callback(event_loop *loop,
                               int64_t timer_id,
                               void *context) {
-  db_handle *db = context;
+  DBHandle *db = context;
   /* Reconnect to redis. */
   redisAsyncFree(db->sub_context);
   db->sub_context = redisAsyncConnect("127.0.0.1", 6379);
@@ -239,7 +239,7 @@ void subscribe_retry_fail_callback(UniqueID id,
 
 TEST subscribe_retry_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -286,7 +286,7 @@ void publish_retry_fail_callback(UniqueID id,
 
 TEST publish_retry_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   task *task = example_task(1, 1, TASK_STATUS_WAITING);
@@ -335,7 +335,7 @@ void subscribe_late_done_callback(TaskID task_id, void *user_context) {
 
 TEST subscribe_late_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   retry_info retry = {
@@ -380,7 +380,7 @@ void publish_late_done_callback(TaskID task_id, void *user_context) {
 
 TEST publish_late_test(void) {
   g_loop = event_loop_create();
-  db_handle *db =
+  DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   task *task = example_task(1, 1, TASK_STATUS_WAITING);

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -28,7 +28,7 @@ void lookup_nil_fail_callback(UniqueID id,
   CHECK(0);
 }
 
-void lookup_nil_success_callback(task *task, void *context) {
+void lookup_nil_success_callback(Task *task, void *context) {
   lookup_nil_success = 1;
   CHECK(task == NULL);
   CHECK(context == (void *) lookup_nil_context);
@@ -61,7 +61,7 @@ TEST lookup_nil_test(void) {
 
 int add_success = 0;
 int lookup_success = 0;
-task *add_lookup_task;
+Task *add_lookup_task;
 const char *add_lookup_context = "add_lookup";
 
 void add_lookup_fail_callback(UniqueID id,
@@ -71,7 +71,7 @@ void add_lookup_fail_callback(UniqueID id,
   CHECK(0);
 }
 
-void lookup_success_callback(task *task, void *context) {
+void lookup_success_callback(Task *task, void *context) {
   lookup_success = 1;
   CHECK(memcmp(task, add_lookup_task, task_size(task)) == 0);
   event_loop_stop(g_loop);
@@ -180,7 +180,7 @@ TEST publish_timeout_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  task *task = example_task(1, 1, TASK_STATUS_WAITING);
+  Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   retry_info retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = publish_fail_callback,
   };
@@ -289,7 +289,7 @@ TEST publish_retry_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  task *task = example_task(1, 1, TASK_STATUS_WAITING);
+  Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   retry_info retry = {
       .num_retries = 5,
       .timeout = 100,
@@ -383,7 +383,7 @@ TEST publish_late_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  task *task = example_task(1, 1, TASK_STATUS_WAITING);
+  Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   retry_info retry = {
       .num_retries = 0,
       .timeout = 0,

--- a/src/common/test/task_table_tests.c
+++ b/src/common/test/task_table_tests.c
@@ -41,7 +41,7 @@ TEST lookup_nil_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 1000,
       .fail_callback = lookup_nil_fail_callback,
@@ -82,7 +82,7 @@ void add_success_callback(TaskID task_id, void *context) {
   CHECK(TaskID_equal(task_id, Task_task_id(add_lookup_task)));
 
   DBHandle *db = context;
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 1000,
       .fail_callback = add_lookup_fail_callback,
@@ -97,7 +97,7 @@ TEST add_lookup_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 1000,
       .fail_callback = add_lookup_fail_callback,
@@ -139,7 +139,7 @@ TEST subscribe_timeout_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = subscribe_fail_callback,
@@ -181,7 +181,7 @@ TEST publish_timeout_test(void) {
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = publish_fail_callback,
   };
   task_table_add_task(db, task, &retry, publish_done_callback,
@@ -242,7 +242,7 @@ TEST subscribe_retry_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = subscribe_retry_fail_callback,
@@ -290,7 +290,7 @@ TEST publish_retry_test(void) {
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 5,
       .timeout = 100,
       .fail_callback = publish_retry_fail_callback,
@@ -338,7 +338,7 @@ TEST subscribe_late_test(void) {
   DBHandle *db =
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0,
       .timeout = 0,
       .fail_callback = subscribe_late_fail_callback,
@@ -384,7 +384,7 @@ TEST publish_late_test(void) {
       db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1", 0, NULL);
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
-  retry_info retry = {
+  RetryInfo retry = {
       .num_retries = 0,
       .timeout = 0,
       .fail_callback = publish_late_fail_callback,

--- a/src/common/test/task_tests.c
+++ b/src/common/test/task_tests.c
@@ -19,10 +19,10 @@ TEST task_test(void) {
   ASSERT(task_num_args(spec) == 4);
   ASSERT(task_num_returns(spec) == 2);
 
-  unique_id arg1 = globally_unique_id();
+  UniqueID arg1 = globally_unique_id();
   ASSERT(task_args_add_ref(spec, arg1) == 0);
   ASSERT(task_args_add_val(spec, (uint8_t *) "hello", 5) == 1);
-  unique_id arg2 = globally_unique_id();
+  UniqueID arg2 = globally_unique_id();
   ASSERT(task_args_add_ref(spec, arg2) == 2);
   ASSERT(task_args_add_val(spec, (uint8_t *) "world", 5) == 3);
   /* Finish constructing the spec. This constructs the task ID and the
@@ -48,7 +48,7 @@ TEST deterministic_ids_test(void) {
   /* Define the inputs to the task construction. */
   task_id parent_task_id = globally_unique_id();
   function_id func_id = globally_unique_id();
-  unique_id arg1 = globally_unique_id();
+  UniqueID arg1 = globally_unique_id();
   uint8_t *arg2 = (uint8_t *) "hello world";
 
   /* Construct a first task. */

--- a/src/common/test/task_tests.c
+++ b/src/common/test/task_tests.c
@@ -12,8 +12,8 @@
 SUITE(task_tests);
 
 TEST task_test(void) {
-  task_id parent_task_id = globally_unique_id();
-  function_id func_id = globally_unique_id();
+  TaskID parent_task_id = globally_unique_id();
+  FunctionID func_id = globally_unique_id();
   task_spec *spec = start_construct_task_spec(
       NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0, func_id, 4, 2, 10);
   ASSERT(task_num_args(spec) == 4);
@@ -46,8 +46,8 @@ TEST task_test(void) {
 
 TEST deterministic_ids_test(void) {
   /* Define the inputs to the task construction. */
-  task_id parent_task_id = globally_unique_id();
-  function_id func_id = globally_unique_id();
+  TaskID parent_task_id = globally_unique_id();
+  FunctionID func_id = globally_unique_id();
   UniqueID arg1 = globally_unique_id();
   uint8_t *arg2 = (uint8_t *) "hello world";
 
@@ -147,8 +147,8 @@ TEST deterministic_ids_test(void) {
 }
 
 TEST send_task(void) {
-  task_id parent_task_id = globally_unique_id();
-  function_id func_id = globally_unique_id();
+  TaskID parent_task_id = globally_unique_id();
+  FunctionID func_id = globally_unique_id();
   task_spec *spec = start_construct_task_spec(
       NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0, func_id, 4, 2, 10);
   task_args_add_ref(spec, globally_unique_id());

--- a/src/common/test/task_tests.c
+++ b/src/common/test/task_tests.c
@@ -32,11 +32,11 @@ TEST task_test(void) {
   /* Check that the spec was constructed as expected. */
   ASSERT(task_num_args(spec) == 4);
   ASSERT(task_num_returns(spec) == 2);
-  ASSERT(function_ids_equal(task_function(spec), func_id));
-  ASSERT(object_ids_equal(task_arg_id(spec, 0), arg1));
+  ASSERT(FunctionID_equal(task_function(spec), func_id));
+  ASSERT(ObjectID_equal(task_arg_id(spec, 0), arg1));
   ASSERT(memcmp(task_arg_val(spec, 1), (uint8_t *) "hello",
                 task_arg_length(spec, 1)) == 0);
-  ASSERT(object_ids_equal(task_arg_id(spec, 2), arg2));
+  ASSERT(ObjectID_equal(task_arg_id(spec, 2), arg2));
   ASSERT(memcmp(task_arg_val(spec, 3), (uint8_t *) "world",
                 task_arg_length(spec, 3)) == 0);
 
@@ -66,14 +66,14 @@ TEST deterministic_ids_test(void) {
   finish_construct_task_spec(spec2);
 
   /* Check that these tasks have the same task IDs and the same return IDs.*/
-  ASSERT(task_ids_equal(task_spec_id(spec1), task_spec_id(spec2)));
-  ASSERT(object_ids_equal(task_return(spec1, 0), task_return(spec2, 0)));
-  ASSERT(object_ids_equal(task_return(spec1, 1), task_return(spec2, 1)));
-  ASSERT(object_ids_equal(task_return(spec1, 2), task_return(spec2, 2)));
+  ASSERT(TaskID_equal(task_spec_id(spec1), task_spec_id(spec2)));
+  ASSERT(ObjectID_equal(task_return(spec1, 0), task_return(spec2, 0)));
+  ASSERT(ObjectID_equal(task_return(spec1, 1), task_return(spec2, 1)));
+  ASSERT(ObjectID_equal(task_return(spec1, 2), task_return(spec2, 2)));
   /* Check that the return IDs are all distinct. */
-  ASSERT(!object_ids_equal(task_return(spec1, 0), task_return(spec2, 1)));
-  ASSERT(!object_ids_equal(task_return(spec1, 0), task_return(spec2, 2)));
-  ASSERT(!object_ids_equal(task_return(spec1, 1), task_return(spec2, 2)));
+  ASSERT(!ObjectID_equal(task_return(spec1, 0), task_return(spec2, 1)));
+  ASSERT(!ObjectID_equal(task_return(spec1, 0), task_return(spec2, 2)));
+  ASSERT(!ObjectID_equal(task_return(spec1, 1), task_return(spec2, 2)));
 
   /* Create more tasks that are only mildly different. */
 
@@ -114,11 +114,11 @@ TEST deterministic_ids_test(void) {
   finish_construct_task_spec(spec7);
 
   /* Check that the task IDs are all distinct from the original. */
-  ASSERT(!task_ids_equal(task_spec_id(spec1), task_spec_id(spec3)));
-  ASSERT(!task_ids_equal(task_spec_id(spec1), task_spec_id(spec4)));
-  ASSERT(!task_ids_equal(task_spec_id(spec1), task_spec_id(spec5)));
-  ASSERT(!task_ids_equal(task_spec_id(spec1), task_spec_id(spec6)));
-  ASSERT(!task_ids_equal(task_spec_id(spec1), task_spec_id(spec7)));
+  ASSERT(!TaskID_equal(task_spec_id(spec1), task_spec_id(spec3)));
+  ASSERT(!TaskID_equal(task_spec_id(spec1), task_spec_id(spec4)));
+  ASSERT(!TaskID_equal(task_spec_id(spec1), task_spec_id(spec5)));
+  ASSERT(!TaskID_equal(task_spec_id(spec1), task_spec_id(spec6)));
+  ASSERT(!TaskID_equal(task_spec_id(spec1), task_spec_id(spec7)));
 
   /* Check that the return object IDs are distinct from the originals. */
   task_spec *specs[6] = {spec1, spec3, spec4, spec5, spec6, spec7};
@@ -127,7 +127,7 @@ TEST deterministic_ids_test(void) {
       for (int task_index2 = 0; task_index2 < 6; ++task_index2) {
         for (int return_index2 = 0; return_index2 < 3; ++return_index2) {
           if (task_index1 != task_index2 && return_index1 != return_index2) {
-            ASSERT(!object_ids_equal(
+            ASSERT(!ObjectID_equal(
                 task_return(specs[task_index1], return_index1),
                 task_return(specs[task_index2], return_index2)));
           }

--- a/src/common/test/test_common.h
+++ b/src/common/test/test_common.h
@@ -19,8 +19,8 @@ const int64_t arg_value_size = 1000;
 static inline task_spec *example_task_spec_with_args(int64_t num_args,
                                                      int64_t num_returns,
                                                      ObjectID arg_ids[]) {
-  task_id parent_task_id = globally_unique_id();
-  function_id func_id = globally_unique_id();
+  TaskID parent_task_id = globally_unique_id();
+  FunctionID func_id = globally_unique_id();
   task_spec *task =
       start_construct_task_spec(NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
                                 func_id, num_args, num_returns, arg_value_size);

--- a/src/common/test/test_common.h
+++ b/src/common/test/test_common.h
@@ -42,21 +42,21 @@ static inline task_spec *example_task_spec(int64_t num_args,
   return example_task_spec_with_args(num_args, num_returns, NULL);
 }
 
-static inline task *example_task_with_args(int64_t num_args,
+static inline Task *example_task_with_args(int64_t num_args,
                                            int64_t num_returns,
                                            int task_state,
                                            ObjectID arg_ids[]) {
   task_spec *spec = example_task_spec_with_args(num_args, num_returns, arg_ids);
-  task *instance = alloc_task(spec, task_state, NIL_ID);
+  Task *instance = alloc_task(spec, task_state, NIL_ID);
   free_task_spec(spec);
   return instance;
 }
 
-static inline task *example_task(int64_t num_args,
+static inline Task *example_task(int64_t num_args,
                                  int64_t num_returns,
                                  int task_state) {
   task_spec *spec = example_task_spec(num_args, num_returns);
-  task *instance = alloc_task(spec, task_state, NIL_ID);
+  Task *instance = alloc_task(spec, task_state, NIL_ID);
   free_task_spec(spec);
   return instance;
 }

--- a/src/common/test/test_common.h
+++ b/src/common/test/test_common.h
@@ -44,19 +44,19 @@ static inline task_spec *example_task_spec(int64_t num_args,
 
 static inline Task *example_task_with_args(int64_t num_args,
                                            int64_t num_returns,
-                                           int task_state,
+                                           int Task_state,
                                            ObjectID arg_ids[]) {
   task_spec *spec = example_task_spec_with_args(num_args, num_returns, arg_ids);
-  Task *instance = alloc_task(spec, task_state, NIL_ID);
+  Task *instance = Task_alloc(spec, Task_state, NIL_ID);
   free_task_spec(spec);
   return instance;
 }
 
 static inline Task *example_task(int64_t num_args,
                                  int64_t num_returns,
-                                 int task_state) {
+                                 int Task_state) {
   task_spec *spec = example_task_spec(num_args, num_returns);
-  Task *instance = alloc_task(spec, task_state, NIL_ID);
+  Task *instance = Task_alloc(spec, Task_state, NIL_ID);
   free_task_spec(spec);
   return instance;
 }

--- a/src/common/test/test_common.h
+++ b/src/common/test/test_common.h
@@ -18,14 +18,14 @@ const int64_t arg_value_size = 1000;
 
 static inline task_spec *example_task_spec_with_args(int64_t num_args,
                                                      int64_t num_returns,
-                                                     object_id arg_ids[]) {
+                                                     ObjectID arg_ids[]) {
   task_id parent_task_id = globally_unique_id();
   function_id func_id = globally_unique_id();
   task_spec *task =
       start_construct_task_spec(NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
                                 func_id, num_args, num_returns, arg_value_size);
   for (int64_t i = 0; i < num_args; ++i) {
-    object_id arg_id;
+    ObjectID arg_id;
     if (arg_ids == NULL) {
       arg_id = globally_unique_id();
     } else {
@@ -45,7 +45,7 @@ static inline task_spec *example_task_spec(int64_t num_args,
 static inline task *example_task_with_args(int64_t num_args,
                                            int64_t num_returns,
                                            int task_state,
-                                           object_id arg_ids[]) {
+                                           ObjectID arg_ids[]) {
   task_spec *spec = example_task_spec_with_args(num_args, num_returns, arg_ids);
   task *instance = alloc_task(spec, task_state, NIL_ID);
   free_task_spec(spec);

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -99,7 +99,7 @@ void free_global_scheduler(global_scheduler_state *state) {
   }
 
   /* Free the scheduler object info table. */
-  scheduler_object_info *object_entry, *tmp_entry;
+  SchedulerObjectInfo *object_entry, *tmp_entry;
   HASH_ITER(hh, state->scheduler_object_info_table, object_entry, tmp_entry) {
     HASH_DELETE(hh, state->scheduler_object_info_table, object_entry);
     utarray_free(object_entry->object_locations);
@@ -250,15 +250,15 @@ void object_table_subscribe_callback(ObjectID object_id,
   for (int i = 0; i < manager_count; i++) {
     LOG_DEBUG("\t\t%s", manager_vector[i]);
   }
-  scheduler_object_info *obj_info_entry = NULL;
+  SchedulerObjectInfo *obj_info_entry = NULL;
 
   HASH_FIND(hh, state->scheduler_object_info_table, &object_id,
             sizeof(object_id), obj_info_entry);
 
   if (obj_info_entry == NULL) {
     /* Construct a new object info hash table entry. */
-    obj_info_entry = malloc(sizeof(scheduler_object_info));
-    memset(obj_info_entry, 0, sizeof(scheduler_object_info));
+    obj_info_entry = malloc(sizeof(SchedulerObjectInfo));
+    memset(obj_info_entry, 0, sizeof(obj_info_entry));
 
     obj_info_entry->object_id = object_id;
     obj_info_entry->data_size = data_size;

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -78,7 +78,7 @@ GlobalSchedulerState *GlobalSchedulerState_init(event_loop *loop,
 }
 
 void GlobalSchedulerState_free(GlobalSchedulerState *state) {
-  aux_address_entry *entry, *tmp;
+  AuxAddressEntry *entry, *tmp;
 
   db_disconnect(state->db);
   utarray_free(state->local_schedulers);
@@ -179,8 +179,8 @@ void process_new_db_client(DBClientID db_client_id,
   if (strncmp(client_type, "photon", strlen("photon")) == 0) {
     /* Add plasma_manager ip:port -> photon_db_client_id association to state.
      */
-    aux_address_entry *plasma_photon_entry =
-        calloc(1, sizeof(aux_address_entry));
+    AuxAddressEntry *plasma_photon_entry =
+        calloc(1, sizeof(AuxAddressEntry));
     plasma_photon_entry->aux_address = strdup(aux_address);
     plasma_photon_entry->photon_db_client_id = db_client_id;
     HASH_ADD_KEYPTR(plasma_photon_hh, state->plasma_photon_map,
@@ -197,7 +197,7 @@ void process_new_db_client(DBClientID db_client_id,
 #if (RAY_COMMON_LOG_LEVEL <= RAY_COMMON_DEBUG)
     {
       /* Print the photon to plasma association map so far. */
-      aux_address_entry *entry, *tmp;
+      AuxAddressEntry *entry, *tmp;
       LOG_DEBUG("Photon to Plasma hash map so far:");
       HASH_ITER(plasma_photon_hh, state->plasma_photon_map, entry, tmp) {
         LOG_DEBUG("%s -> %s", entry->aux_address,

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -179,8 +179,7 @@ void process_new_db_client(DBClientID db_client_id,
   if (strncmp(client_type, "photon", strlen("photon")) == 0) {
     /* Add plasma_manager ip:port -> photon_db_client_id association to state.
      */
-    AuxAddressEntry *plasma_photon_entry =
-        calloc(1, sizeof(AuxAddressEntry));
+    AuxAddressEntry *plasma_photon_entry = calloc(1, sizeof(AuxAddressEntry));
     plasma_photon_entry->aux_address = strdup(aux_address);
     plasma_photon_entry->photon_db_client_id = db_client_id;
     HASH_ADD_KEYPTR(plasma_photon_hh, state->plasma_photon_map,
@@ -202,7 +201,7 @@ void process_new_db_client(DBClientID db_client_id,
       HASH_ITER(plasma_photon_hh, state->plasma_photon_map, entry, tmp) {
         LOG_DEBUG("%s -> %s", entry->aux_address,
                   ObjectID_to_string(entry->photon_db_client_id, id_string,
-                                      ID_STRING_SIZE));
+                                     ID_STRING_SIZE));
       }
     }
 #endif

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -235,7 +235,7 @@ void process_new_db_client(db_client_id db_client_id,
  * @param user_context The user context.
  * @return Void.
  */
-void object_table_subscribe_callback(object_id object_id,
+void object_table_subscribe_callback(ObjectID object_id,
                                      int64_t data_size,
                                      int manager_count,
                                      const char *manager_vector[],
@@ -294,7 +294,7 @@ void local_scheduler_table_handler(db_client_id client_id,
   char id_string[ID_STRING_SIZE];
   LOG_DEBUG(
       "Local scheduler heartbeat from db_client_id %s",
-      object_id_to_string((object_id) client_id, id_string, ID_STRING_SIZE));
+      object_id_to_string((ObjectID) client_id, id_string, ID_STRING_SIZE));
   UNUSED(id_string);
   LOG_DEBUG(
       "total workers = %d, task queue length = %d, available workers = %d",

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -32,7 +32,7 @@ UT_icd pending_tasks_icd = {sizeof(task *), NULL, NULL, NULL};
  */
 void assign_task_to_local_scheduler(global_scheduler_state *state,
                                     task *task,
-                                    db_client_id local_scheduler_id) {
+                                    DBClientID local_scheduler_id) {
   char id_string[ID_STRING_SIZE];
   task_spec *spec = task_task_spec(task);
   LOG_DEBUG("assigning task to local_scheduler_id = %s",
@@ -135,7 +135,7 @@ void signal_handler(int signal) {
 /* End of the cleanup code. */
 
 local_scheduler *get_local_scheduler(global_scheduler_state *state,
-                                     db_client_id photon_id) {
+                                     DBClientID photon_id) {
   local_scheduler *local_scheduler_ptr;
   for (int i = 0; i < utarray_len(state->local_schedulers); ++i) {
     local_scheduler_ptr =
@@ -167,7 +167,7 @@ void process_task_waiting(task *waiting_task, void *user_context) {
  * @param aux_address: an ip:port pair for the plasma manager associated with
  * this db client.
  */
-void process_new_db_client(db_client_id db_client_id,
+void process_new_db_client(DBClientID db_client_id,
                            const char *client_type,
                            const char *aux_address,
                            void *user_context) {
@@ -285,7 +285,7 @@ void object_table_subscribe_callback(ObjectID object_id,
   }
 }
 
-void local_scheduler_table_handler(db_client_id client_id,
+void local_scheduler_table_handler(DBClientID client_id,
                                    local_scheduler_info info,
                                    void *user_context) {
   /* Extract global scheduler state from the callback context. */

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -287,7 +287,7 @@ void object_table_subscribe_callback(ObjectID object_id,
 }
 
 void local_scheduler_table_handler(DBClientID client_id,
-                                   local_scheduler_info info,
+                                   LocalSchedulerInfo info,
                                    void *user_context) {
   /* Extract global scheduler state from the callback context. */
   global_scheduler_state *state = (global_scheduler_state *) user_context;

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -36,11 +36,11 @@ void assign_task_to_local_scheduler(GlobalSchedulerState *state,
   char id_string[ID_STRING_SIZE];
   task_spec *spec = task_task_spec(task);
   LOG_DEBUG("assigning task to local_scheduler_id = %s",
-            object_id_to_string(local_scheduler_id, id_string, ID_STRING_SIZE));
+            ObjectID_to_string(local_scheduler_id, id_string, ID_STRING_SIZE));
   task_set_state(task, TASK_STATUS_SCHEDULED);
   task_set_local_scheduler(task, local_scheduler_id);
   LOG_DEBUG("Issuing a task table update for task = %s",
-            object_id_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
+            ObjectID_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
   UNUSED(id_string);
   task_table_update(state->db, copy_task(task), NULL, NULL, NULL);
 
@@ -140,7 +140,7 @@ LocalScheduler *get_local_scheduler(GlobalSchedulerState *state,
   for (int i = 0; i < utarray_len(state->local_schedulers); ++i) {
     local_scheduler_ptr =
         (LocalScheduler *) utarray_eltptr(state->local_schedulers, i);
-    if (db_client_ids_equal(local_scheduler_ptr->id, photon_id)) {
+    if (DBClientID_equal(local_scheduler_ptr->id, photon_id)) {
       LOG_DEBUG("photon_id matched cached local scheduler entry.");
       return local_scheduler_ptr;
     }
@@ -174,7 +174,7 @@ void process_new_db_client(DBClientID db_client_id,
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
   char id_string[ID_STRING_SIZE];
   LOG_DEBUG("db client table callback for db client = %s",
-            object_id_to_string(db_client_id, id_string, ID_STRING_SIZE));
+            ObjectID_to_string(db_client_id, id_string, ID_STRING_SIZE));
   UNUSED(id_string);
   if (strncmp(client_type, "photon", strlen("photon")) == 0) {
     /* Add plasma_manager ip:port -> photon_db_client_id association to state.
@@ -201,7 +201,7 @@ void process_new_db_client(DBClientID db_client_id,
       LOG_DEBUG("Photon to Plasma hash map so far:");
       HASH_ITER(plasma_photon_hh, state->plasma_photon_map, entry, tmp) {
         LOG_DEBUG("%s -> %s", entry->aux_address,
-                  object_id_to_string(entry->photon_db_client_id, id_string,
+                  ObjectID_to_string(entry->photon_db_client_id, id_string,
                                       ID_STRING_SIZE));
       }
     }
@@ -244,7 +244,7 @@ void object_table_subscribe_callback(ObjectID object_id,
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
   char id_string[ID_STRING_SIZE];
   LOG_DEBUG("object table subscribe callback for OBJECT = %s",
-            object_id_to_string(object_id, id_string, ID_STRING_SIZE));
+            ObjectID_to_string(object_id, id_string, ID_STRING_SIZE));
   UNUSED(id_string);
   LOG_DEBUG("\tManagers<%d>:", manager_count);
   for (int i = 0; i < manager_count; i++) {
@@ -267,7 +267,7 @@ void object_table_subscribe_callback(ObjectID object_id,
     HASH_ADD(hh, state->scheduler_object_info_table, object_id,
              sizeof(obj_info_entry->object_id), obj_info_entry);
     LOG_DEBUG("New object added to object_info_table with id = %s",
-              object_id_to_string(object_id, id_string, ID_STRING_SIZE));
+              ObjectID_to_string(object_id, id_string, ID_STRING_SIZE));
     LOG_DEBUG("\tmanager locations:");
     for (int i = 0; i < manager_count; i++) {
       LOG_DEBUG("\t\t%s", manager_vector[i]);
@@ -295,7 +295,7 @@ void local_scheduler_table_handler(DBClientID client_id,
   char id_string[ID_STRING_SIZE];
   LOG_DEBUG(
       "Local scheduler heartbeat from db_client_id %s",
-      object_id_to_string((ObjectID) client_id, id_string, ID_STRING_SIZE));
+      ObjectID_to_string((ObjectID) client_id, id_string, ID_STRING_SIZE));
   UNUSED(id_string);
   LOG_DEBUG(
       "total workers = %d, task queue length = %d, available workers = %d",

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -71,7 +71,7 @@ GlobalSchedulerState *GlobalSchedulerState_init(event_loop *loop,
       db_connect(redis_addr, redis_port, "global_scheduler", ":", 0, NULL);
   db_attach(state->db, loop, false);
   utarray_new(state->local_schedulers, &local_scheduler_icd);
-  state->policy_state = init_global_scheduler_policy();
+  state->policy_state = GlobalSchedulerPolicyState_init();
   /* Initialize the array of tasks that have not been scheduled yet. */
   utarray_new(state->pending_tasks, &pending_tasks_icd);
   return state;
@@ -82,7 +82,7 @@ void GlobalSchedulerState_free(GlobalSchedulerState *state) {
 
   db_disconnect(state->db);
   utarray_free(state->local_schedulers);
-  destroy_global_scheduler_policy(state->policy_state);
+  GlobalSchedulerPolicyState_free(state->policy_state);
   /* Delete the plasma to photon association map. */
   HASH_ITER(plasma_photon_hh, state->plasma_photon_map, entry, tmp) {
     HASH_DELETE(plasma_photon_hh, state->plasma_photon_map, entry);

--- a/src/global_scheduler/global_scheduler.c
+++ b/src/global_scheduler/global_scheduler.c
@@ -34,15 +34,15 @@ void assign_task_to_local_scheduler(GlobalSchedulerState *state,
                                     Task *task,
                                     DBClientID local_scheduler_id) {
   char id_string[ID_STRING_SIZE];
-  task_spec *spec = task_task_spec(task);
+  task_spec *spec = Task_task_spec(task);
   LOG_DEBUG("assigning task to local_scheduler_id = %s",
             ObjectID_to_string(local_scheduler_id, id_string, ID_STRING_SIZE));
-  task_set_state(task, TASK_STATUS_SCHEDULED);
-  task_set_local_scheduler(task, local_scheduler_id);
+  Task_set_state(task, TASK_STATUS_SCHEDULED);
+  Task_set_local_scheduler_id(task, local_scheduler_id);
   LOG_DEBUG("Issuing a task table update for task = %s",
-            ObjectID_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
+            ObjectID_to_string(Task_task_id(task), id_string, ID_STRING_SIZE));
   UNUSED(id_string);
-  task_table_update(state->db, copy_task(task), NULL, NULL, NULL);
+  task_table_update(state->db, Task_copy(task), NULL, NULL, NULL);
 
   /* TODO(rkn): We should probably pass around local_scheduler struct pointers
    * instead of db_client_id objects. */
@@ -114,7 +114,7 @@ void GlobalSchedulerState_free(GlobalSchedulerState *state) {
   }
   for (int i = 0; i < num_pending_tasks; ++i) {
     Task **pending_task = (Task **) utarray_eltptr(state->pending_tasks, i);
-    free_task(*pending_task);
+    Task_free(*pending_task);
   }
   utarray_free(state->pending_tasks);
   /* Free the global scheduler state. */
@@ -157,7 +157,7 @@ void process_task_waiting(Task *waiting_task, void *user_context) {
    * task to the array of pending tasks. The global scheduler will periodically
    * resubmit the tasks in this array. */
   if (!successfully_assigned) {
-    Task *task_copy = copy_task(waiting_task);
+    Task *task_copy = Task_copy(waiting_task);
     utarray_push_back(state->pending_tasks, &task_copy);
   }
 }

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -41,7 +41,7 @@ typedef struct {
   UT_array *object_locations;
   /** Handle for the uthash table. */
   UT_hash_handle hh;
-} scheduler_object_info;
+} SchedulerObjectInfo;
 
 /**
  * A struct used for caching Photon to Plasma association.
@@ -76,7 +76,7 @@ typedef struct {
   /** The photon_db_client_id -> plasma_manager ip:port association. */
   aux_address_entry *photon_plasma_map;
   /** Objects cached by this global scheduler instance. */
-  scheduler_object_info *scheduler_object_info_table;
+  SchedulerObjectInfo *scheduler_object_info_table;
   /** An array of tasks that haven't been scheduled yet. */
   UT_array *pending_tasks;
 } global_scheduler_state;

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -64,7 +64,7 @@ typedef struct {
   /** The global scheduler event loop. */
   event_loop *loop;
   /** The global state store database. */
-  db_handle *db;
+  DBHandle *db;
   /** The local schedulers that are connected to Redis. TODO(rkn): This probably
    *  needs to be a hashtable since we often look up the local_scheduler struct
    *  based on its db_client_id. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -27,7 +27,7 @@ typedef struct {
   LocalSchedulerInfo info;
 } LocalScheduler;
 
-typedef struct global_scheduler_policy_state global_scheduler_policy_state;
+typedef struct GlobalSchedulerPolicyState GlobalSchedulerPolicyState;
 
 /**
  * This defines a hash table used to cache information about different objects.
@@ -70,7 +70,7 @@ typedef struct {
    *  based on its db_client_id. */
   UT_array *local_schedulers;
   /** The state managed by the scheduling policy. */
-  global_scheduler_policy_state *policy_state;
+  GlobalSchedulerPolicyState *policy_state;
   /** The plasma_manager ip:port -> photon_db_client_id association. */
   aux_address_entry *plasma_photon_map;
   /** The photon_db_client_id -> plasma_manager ip:port association. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -25,7 +25,7 @@ typedef struct {
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
   local_scheduler_info info;
-} local_scheduler;
+} LocalScheduler;
 
 typedef struct global_scheduler_policy_state global_scheduler_policy_state;
 
@@ -90,8 +90,8 @@ typedef struct {
  * @return The corresponding local scheduler struct. If the global scheduler is
  *         not aware of the local scheduler, then this will be NULL.
  */
-local_scheduler *get_local_scheduler(global_scheduler_state *state,
-                                     DBClientID photon_id);
+LocalScheduler *get_local_scheduler(global_scheduler_state *state,
+                                    DBClientID photon_id);
 
 /**
  * Assign the given task to the local scheduler, update Redis and scheduler data

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -15,7 +15,7 @@
 /** Contains all information that is associated with a local scheduler. */
 typedef struct {
   /** The ID of the local scheduler in Redis. */
-  db_client_id id;
+  DBClientID id;
   /** The number of tasks sent from the global scheduler to this local
    *  scheduler. */
   int64_t num_tasks_sent;
@@ -50,7 +50,7 @@ typedef struct {
   /** IP:port string for the plasma_manager. */
   char *aux_address;
   /** Photon db client id. */
-  db_client_id photon_db_client_id;
+  DBClientID photon_db_client_id;
   /** Plasma_manager ip:port -> photon_db_client_id. */
   UT_hash_handle plasma_photon_hh;
   /** Photon_db_client_id -> plasma_manager ip:port. */
@@ -91,7 +91,7 @@ typedef struct {
  *         not aware of the local scheduler, then this will be NULL.
  */
 local_scheduler *get_local_scheduler(global_scheduler_state *state,
-                                     db_client_id photon_id);
+                                     DBClientID photon_id);
 
 /**
  * Assign the given task to the local scheduler, update Redis and scheduler data
@@ -104,6 +104,6 @@ local_scheduler *get_local_scheduler(global_scheduler_state *state,
  */
 void assign_task_to_local_scheduler(global_scheduler_state *state,
                                     task *task,
-                                    db_client_id local_scheduler_id);
+                                    DBClientID local_scheduler_id);
 
 #endif /* GLOBAL_SCHEDULER_H */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -34,7 +34,7 @@ typedef struct global_scheduler_policy_state global_scheduler_policy_state;
  */
 typedef struct {
   /** The object ID in question. */
-  object_id object_id;
+  ObjectID object_id;
   /** The size in bytes of the object. */
   int64_t data_size;
   /** An array of object locations for this object. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -24,7 +24,7 @@ typedef struct {
   int64_t num_recent_tasks_sent;
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
-  local_scheduler_info info;
+  LocalSchedulerInfo info;
 } LocalScheduler;
 
 typedef struct global_scheduler_policy_state global_scheduler_policy_state;

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -55,7 +55,7 @@ typedef struct {
   UT_hash_handle plasma_photon_hh;
   /** Photon_db_client_id -> plasma_manager ip:port. */
   UT_hash_handle photon_plasma_hh;
-} aux_address_entry;
+} AuxAddressEntry;
 
 /**
  * Global scheduler state structure.
@@ -72,9 +72,9 @@ typedef struct {
   /** The state managed by the scheduling policy. */
   GlobalSchedulerPolicyState *policy_state;
   /** The plasma_manager ip:port -> photon_db_client_id association. */
-  aux_address_entry *plasma_photon_map;
+  AuxAddressEntry *plasma_photon_map;
   /** The photon_db_client_id -> plasma_manager ip:port association. */
-  aux_address_entry *photon_plasma_map;
+  AuxAddressEntry *photon_plasma_map;
   /** Objects cached by this global scheduler instance. */
   SchedulerObjectInfo *scheduler_object_info_table;
   /** An array of tasks that haven't been scheduled yet. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -79,7 +79,7 @@ typedef struct {
   SchedulerObjectInfo *scheduler_object_info_table;
   /** An array of tasks that haven't been scheduled yet. */
   UT_array *pending_tasks;
-} global_scheduler_state;
+} GlobalSchedulerState;
 
 /**
  * This is a helper method to look up the local scheduler struct that
@@ -90,7 +90,7 @@ typedef struct {
  * @return The corresponding local scheduler struct. If the global scheduler is
  *         not aware of the local scheduler, then this will be NULL.
  */
-LocalScheduler *get_local_scheduler(global_scheduler_state *state,
+LocalScheduler *get_local_scheduler(GlobalSchedulerState *state,
                                     DBClientID photon_id);
 
 /**
@@ -102,7 +102,7 @@ LocalScheduler *get_local_scheduler(global_scheduler_state *state,
  * @param local_scheduler_id DB client ID for the local scheduler.
  * @return Void.
  */
-void assign_task_to_local_scheduler(global_scheduler_state *state,
+void assign_task_to_local_scheduler(GlobalSchedulerState *state,
                                     Task *task,
                                     DBClientID local_scheduler_id);
 

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -103,7 +103,7 @@ local_scheduler *get_local_scheduler(global_scheduler_state *state,
  * @return Void.
  */
 void assign_task_to_local_scheduler(global_scheduler_state *state,
-                                    task *task,
+                                    Task *task,
                                     DBClientID local_scheduler_id);
 
 #endif /* GLOBAL_SCHEDULER_H */

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -119,7 +119,7 @@ ObjectSizeEntry *create_object_size_hashmap(GlobalSchedulerState *state,
     char **p = NULL;
     char id_string[ID_STRING_SIZE];
     LOG_DEBUG("locations for an arg_by_ref obj_id = %s",
-              object_id_to_string(obj_id, id_string, ID_STRING_SIZE));
+              ObjectID_to_string(obj_id, id_string, ID_STRING_SIZE));
     UNUSED(id_string);
     for (p = (char **) utarray_front(obj_info_entry->object_locations);
          p != NULL;
@@ -177,7 +177,7 @@ DBClientID get_photon_id(GlobalSchedulerState *state,
 
   char id_string[ID_STRING_SIZE];
   LOG_DEBUG("photon ID found = %s",
-            object_id_to_string(photon_id, id_string, ID_STRING_SIZE));
+            ObjectID_to_string(photon_id, id_string, ID_STRING_SIZE));
   UNUSED(id_string);
 
   if (IS_NIL_ID(photon_id)) {
@@ -313,7 +313,7 @@ bool handle_task_waiting(GlobalSchedulerState *state,
     char id_string[ID_STRING_SIZE];
     LOG_ERROR(
         "Infeasible task. No nodes satisfy hard constraints for task = %s",
-        object_id_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
+        ObjectID_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
     /* TODO(atumanov): propagate this error to the task's driver and/or
      * cache the task in case new local schedulers satisfy it in the future. */
     return false;

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -51,7 +51,7 @@ bool constraints_satisfied_hard(const LocalScheduler *scheduler,
  * This is a helper method that assigns a task to the next local scheduler in a
  * round robin fashion.
  */
-void handle_task_round_robin(global_scheduler_state *state,
+void handle_task_round_robin(GlobalSchedulerState *state,
                              global_scheduler_policy_state *policy_state,
                              Task *task) {
   CHECKM(utarray_len(state->local_schedulers) > 0,
@@ -83,7 +83,7 @@ void handle_task_round_robin(global_scheduler_state *state,
   }
 }
 
-object_size_entry *create_object_size_hashmap(global_scheduler_state *state,
+object_size_entry *create_object_size_hashmap(GlobalSchedulerState *state,
                                               task_spec *task_spec,
                                               bool *has_args_by_ref,
                                               int64_t *task_data_size) {
@@ -155,7 +155,7 @@ void free_object_size_hashmap(object_size_entry *object_size_table) {
   }
 }
 
-DBClientID get_photon_id(global_scheduler_state *state,
+DBClientID get_photon_id(GlobalSchedulerState *state,
                            const char *plasma_location) {
   aux_address_entry *aux_entry = NULL;
   DBClientID photon_id = NIL_ID;
@@ -201,7 +201,7 @@ double inner_product(double a[], double b[], int size) {
   return result;
 }
 
-double calculate_object_size_fraction(global_scheduler_state *state,
+double calculate_object_size_fraction(GlobalSchedulerState *state,
                                       LocalScheduler *scheduler,
                                       object_size_entry *object_size_table,
                                       int64_t total_task_object_size) {
@@ -235,7 +235,7 @@ double calculate_object_size_fraction(global_scheduler_state *state,
   return object_size_fraction;
 }
 
-double calculate_score_dynvec_normalized(global_scheduler_state *state,
+double calculate_score_dynvec_normalized(GlobalSchedulerState *state,
                                          LocalScheduler *scheduler,
                                          const task_spec *task_spec,
                                          double object_size_fraction) {
@@ -261,13 +261,13 @@ double calculate_score_dynvec_normalized(global_scheduler_state *state,
   return score;
 }
 
-double calculate_cost_pending(const global_scheduler_state *state,
+double calculate_cost_pending(const GlobalSchedulerState *state,
                               const LocalScheduler *scheduler) {
   /* TODO: make sure that num_recent_tasks_sent is reset on each heartbeat. */
   return scheduler->num_recent_tasks_sent + scheduler->info.task_queue_length;
 }
 
-bool handle_task_waiting(global_scheduler_state *state,
+bool handle_task_waiting(GlobalSchedulerState *state,
                          global_scheduler_policy_state *policy_state,
                          Task *task) {
   task_spec *task_spec = task_task_spec(task);
@@ -325,13 +325,13 @@ bool handle_task_waiting(global_scheduler_state *state,
   return true;
 }
 
-void handle_object_available(global_scheduler_state *state,
+void handle_object_available(GlobalSchedulerState *state,
                              global_scheduler_policy_state *policy_state,
                              ObjectID object_id) {
   /* Do nothing for now. */
 }
 
-void handle_new_local_scheduler(global_scheduler_state *state,
+void handle_new_local_scheduler(GlobalSchedulerState *state,
                                 global_scheduler_policy_state *policy_state,
                                 DBClientID db_client_id) {
   /* Do nothing for now. */

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -23,8 +23,7 @@ GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void) {
   return policy_state;
 }
 
-void GlobalSchedulerPolicyState_free(
-    GlobalSchedulerPolicyState *policy_state) {
+void GlobalSchedulerPolicyState_free(GlobalSchedulerPolicyState *policy_state) {
   free(policy_state);
 }
 
@@ -156,7 +155,7 @@ void free_object_size_hashmap(ObjectSizeEntry *object_size_table) {
 }
 
 DBClientID get_photon_id(GlobalSchedulerState *state,
-                           const char *plasma_location) {
+                         const char *plasma_location) {
   AuxAddressEntry *aux_entry = NULL;
   DBClientID photon_id = NIL_ID;
   if (plasma_location != NULL) {

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -6,9 +6,9 @@
 
 #include "global_scheduler_algorithm.h"
 
-global_scheduler_policy_state *init_global_scheduler_policy(void) {
-  global_scheduler_policy_state *policy_state =
-      malloc(sizeof(global_scheduler_policy_state));
+GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void) {
+  GlobalSchedulerPolicyState *policy_state =
+      malloc(sizeof(GlobalSchedulerPolicyState));
   policy_state->round_robin_index = 0;
 
   int num_weight_elem =
@@ -23,8 +23,8 @@ global_scheduler_policy_state *init_global_scheduler_policy(void) {
   return policy_state;
 }
 
-void destroy_global_scheduler_policy(
-    global_scheduler_policy_state *policy_state) {
+void GlobalSchedulerPolicyState_free(
+    GlobalSchedulerPolicyState *policy_state) {
   free(policy_state);
 }
 
@@ -52,7 +52,7 @@ bool constraints_satisfied_hard(const LocalScheduler *scheduler,
  * round robin fashion.
  */
 void handle_task_round_robin(GlobalSchedulerState *state,
-                             global_scheduler_policy_state *policy_state,
+                             GlobalSchedulerPolicyState *policy_state,
                              Task *task) {
   CHECKM(utarray_len(state->local_schedulers) > 0,
          "No local schedulers. We currently don't handle this case.");
@@ -268,7 +268,7 @@ double calculate_cost_pending(const GlobalSchedulerState *state,
 }
 
 bool handle_task_waiting(GlobalSchedulerState *state,
-                         global_scheduler_policy_state *policy_state,
+                         GlobalSchedulerPolicyState *policy_state,
                          Task *task) {
   task_spec *task_spec = task_task_spec(task);
 
@@ -326,13 +326,13 @@ bool handle_task_waiting(GlobalSchedulerState *state,
 }
 
 void handle_object_available(GlobalSchedulerState *state,
-                             global_scheduler_policy_state *policy_state,
+                             GlobalSchedulerPolicyState *policy_state,
                              ObjectID object_id) {
   /* Do nothing for now. */
 }
 
 void handle_new_local_scheduler(GlobalSchedulerState *state,
-                                global_scheduler_policy_state *policy_state,
+                                GlobalSchedulerPolicyState *policy_state,
                                 DBClientID db_client_id) {
   /* Do nothing for now. */
 }

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -53,7 +53,7 @@ bool constraints_satisfied_hard(const local_scheduler *scheduler,
  */
 void handle_task_round_robin(global_scheduler_state *state,
                              global_scheduler_policy_state *policy_state,
-                             task *task) {
+                             Task *task) {
   CHECKM(utarray_len(state->local_schedulers) > 0,
          "No local schedulers. We currently don't handle this case.");
   local_scheduler *scheduler = NULL;
@@ -269,7 +269,7 @@ double calculate_cost_pending(const global_scheduler_state *state,
 
 bool handle_task_waiting(global_scheduler_state *state,
                          global_scheduler_policy_state *policy_state,
-                         task *task) {
+                         Task *task) {
   task_spec *task_spec = task_task_spec(task);
 
   CHECKM(task_spec != NULL,

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -157,7 +157,7 @@ void free_object_size_hashmap(ObjectSizeEntry *object_size_table) {
 
 DBClientID get_photon_id(GlobalSchedulerState *state,
                            const char *plasma_location) {
-  aux_address_entry *aux_entry = NULL;
+  AuxAddressEntry *aux_entry = NULL;
   DBClientID photon_id = NIL_ID;
   if (plasma_location != NULL) {
     LOG_DEBUG("max object size location found : %s", plasma_location);
@@ -215,7 +215,7 @@ double calculate_object_size_fraction(GlobalSchedulerState *state,
      * which is used as the key for object_size_table.
      * This uses the plasma aux address to locate the object_size this node
      * contributes. */
-    aux_address_entry *photon_plasma_pair = NULL;
+    AuxAddressEntry *photon_plasma_pair = NULL;
     HASH_FIND(photon_plasma_hh, state->photon_plasma_map, &(scheduler->id),
               sizeof(scheduler->id), photon_plasma_pair);
     if (photon_plasma_pair != NULL) {

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -57,7 +57,7 @@ void handle_task_round_robin(GlobalSchedulerState *state,
   CHECKM(utarray_len(state->local_schedulers) > 0,
          "No local schedulers. We currently don't handle this case.");
   LocalScheduler *scheduler = NULL;
-  task_spec *task_spec = task_task_spec(task);
+  task_spec *task_spec = Task_task_spec(task);
   int i;
   int num_retries = 1;
   bool task_satisfied = false;
@@ -270,7 +270,7 @@ double calculate_cost_pending(const GlobalSchedulerState *state,
 bool handle_task_waiting(GlobalSchedulerState *state,
                          GlobalSchedulerPolicyState *policy_state,
                          Task *task) {
-  task_spec *task_spec = task_task_spec(task);
+  task_spec *task_spec = Task_task_spec(task);
 
   CHECKM(task_spec != NULL,
          "task wait handler encounted a task with NULL spec");
@@ -313,7 +313,7 @@ bool handle_task_waiting(GlobalSchedulerState *state,
     char id_string[ID_STRING_SIZE];
     LOG_ERROR(
         "Infeasible task. No nodes satisfy hard constraints for task = %s",
-        ObjectID_to_string(task_task_id(task), id_string, ID_STRING_SIZE));
+        ObjectID_to_string(Task_task_id(task), id_string, ID_STRING_SIZE));
     /* TODO(atumanov): propagate this error to the task's driver and/or
      * cache the task in case new local schedulers satisfy it in the future. */
     return false;

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -155,10 +155,10 @@ void free_object_size_hashmap(object_size_entry *object_size_table) {
   }
 }
 
-db_client_id get_photon_id(global_scheduler_state *state,
+DBClientID get_photon_id(global_scheduler_state *state,
                            const char *plasma_location) {
   aux_address_entry *aux_entry = NULL;
-  db_client_id photon_id = NIL_ID;
+  DBClientID photon_id = NIL_ID;
   if (plasma_location != NULL) {
     LOG_DEBUG("max object size location found : %s", plasma_location);
     /* Lookup association of plasma location to photon. */
@@ -289,7 +289,7 @@ bool handle_task_waiting(global_scheduler_state *state,
   local_scheduler *scheduler = NULL;
   double best_photon_score = INT32_MIN;
   CHECKM(best_photon_score < 0, "We might have a floating point underflow");
-  db_client_id best_photon_id = NIL_ID; /* best node to send this task */
+  DBClientID best_photon_id = NIL_ID; /* best node to send this task */
   for (scheduler = (local_scheduler *) utarray_front(state->local_schedulers);
        scheduler != NULL; scheduler = (local_scheduler *) utarray_next(
                               state->local_schedulers, scheduler)) {
@@ -333,6 +333,6 @@ void handle_object_available(global_scheduler_state *state,
 
 void handle_new_local_scheduler(global_scheduler_state *state,
                                 global_scheduler_policy_state *policy_state,
-                                db_client_id db_client_id) {
+                                DBClientID db_client_id) {
   /* Do nothing for now. */
 }

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -99,7 +99,7 @@ object_size_entry *create_object_size_hashmap(global_scheduler_state *state,
       continue;
     }
     *has_args_by_ref = true;
-    object_id obj_id = task_arg_id(task_spec, i);
+    ObjectID obj_id = task_arg_id(task_spec, i);
     /* Look up this object ID in the global scheduler object cache. */
     scheduler_object_info *obj_info_entry = NULL;
     HASH_FIND(hh, state->scheduler_object_info_table, &obj_id, sizeof(obj_id),
@@ -327,7 +327,7 @@ bool handle_task_waiting(global_scheduler_state *state,
 
 void handle_object_available(global_scheduler_state *state,
                              global_scheduler_policy_state *policy_state,
-                             object_id object_id) {
+                             ObjectID object_id) {
   /* Do nothing for now. */
 }
 

--- a/src/global_scheduler/global_scheduler_algorithm.c
+++ b/src/global_scheduler/global_scheduler_algorithm.c
@@ -101,7 +101,7 @@ object_size_entry *create_object_size_hashmap(global_scheduler_state *state,
     *has_args_by_ref = true;
     ObjectID obj_id = task_arg_id(task_spec, i);
     /* Look up this object ID in the global scheduler object cache. */
-    scheduler_object_info *obj_info_entry = NULL;
+    SchedulerObjectInfo *obj_info_entry = NULL;
     HASH_FIND(hh, state->scheduler_object_info_table, &obj_id, sizeof(obj_id),
               obj_info_entry);
     if (obj_info_entry == NULL) {

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -58,7 +58,7 @@ void destroy_global_scheduler_policy(
  * @return True if the task was assigned to a local scheduler and false
  *         otherwise.
  */
-bool handle_task_waiting(global_scheduler_state *state,
+bool handle_task_waiting(GlobalSchedulerState *state,
                          global_scheduler_policy_state *policy_state,
                          Task *task);
 
@@ -70,7 +70,7 @@ bool handle_task_waiting(global_scheduler_state *state,
  * @param object_id The ID of the object that is now available.
  * @return Void.
  */
-void handle_object_available(global_scheduler_state *state,
+void handle_object_available(GlobalSchedulerState *state,
                              global_scheduler_policy_state *policy_state,
                              ObjectID object_id);
 
@@ -83,7 +83,7 @@ void handle_object_available(global_scheduler_state *state,
  * @return Void.
  */
 void handle_local_scheduler_heartbeat(
-    global_scheduler_state *state,
+    GlobalSchedulerState *state,
     global_scheduler_policy_state *policy_state);
 
 /**
@@ -95,7 +95,7 @@ void handle_local_scheduler_heartbeat(
  * @param The db client ID of the new local scheduler.
  * @return Void.
  */
-void handle_new_local_scheduler(global_scheduler_state *state,
+void handle_new_local_scheduler(GlobalSchedulerState *state,
                                 global_scheduler_policy_state *policy_state,
                                 DBClientID db_client_id);
 

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -20,7 +20,7 @@ typedef enum {
 } global_scheduler_algorithm;
 
 /** The state managed by the global scheduling policy. */
-struct global_scheduler_policy_state {
+struct GlobalSchedulerPolicyState {
   /** The index of the next local scheduler to assign a task to. */
   int64_t round_robin_index;
   double resource_attribute_weight[MAX_RESOURCE_INDEX + 1];
@@ -38,7 +38,7 @@ typedef struct {
  *
  * @return The state of the scheduling policy.
  */
-global_scheduler_policy_state *init_global_scheduler_policy(void);
+GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void);
 
 /**
  * Free the global scheduler policy state.
@@ -46,8 +46,8 @@ global_scheduler_policy_state *init_global_scheduler_policy(void);
  * @param policy_state The policy state to free.
  * @return Void.
  */
-void destroy_global_scheduler_policy(
-    global_scheduler_policy_state *policy_state);
+void GlobalSchedulerPolicyState_free(
+    GlobalSchedulerPolicyState *policy_state);
 
 /**
  * Main new task handling function in the global scheduler.
@@ -59,7 +59,7 @@ void destroy_global_scheduler_policy(
  *         otherwise.
  */
 bool handle_task_waiting(GlobalSchedulerState *state,
-                         global_scheduler_policy_state *policy_state,
+                         GlobalSchedulerPolicyState *policy_state,
                          Task *task);
 
 /**
@@ -71,7 +71,7 @@ bool handle_task_waiting(GlobalSchedulerState *state,
  * @return Void.
  */
 void handle_object_available(GlobalSchedulerState *state,
-                             global_scheduler_policy_state *policy_state,
+                             GlobalSchedulerPolicyState *policy_state,
                              ObjectID object_id);
 
 /**
@@ -84,7 +84,7 @@ void handle_object_available(GlobalSchedulerState *state,
  */
 void handle_local_scheduler_heartbeat(
     GlobalSchedulerState *state,
-    global_scheduler_policy_state *policy_state);
+    GlobalSchedulerPolicyState *policy_state);
 
 /**
  * Handle the presence of a new local scheduler. Currently, this just adds the
@@ -96,7 +96,7 @@ void handle_local_scheduler_heartbeat(
  * @return Void.
  */
 void handle_new_local_scheduler(GlobalSchedulerState *state,
-                                global_scheduler_policy_state *policy_state,
+                                GlobalSchedulerPolicyState *policy_state,
                                 DBClientID db_client_id);
 
 #endif /* GLOBAL_SCHEDULER_ALGORITHM_H */

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -97,6 +97,6 @@ void handle_local_scheduler_heartbeat(
  */
 void handle_new_local_scheduler(global_scheduler_state *state,
                                 global_scheduler_policy_state *policy_state,
-                                db_client_id db_client_id);
+                                DBClientID db_client_id);
 
 #endif /* GLOBAL_SCHEDULER_ALGORITHM_H */

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -60,7 +60,7 @@ void destroy_global_scheduler_policy(
  */
 bool handle_task_waiting(global_scheduler_state *state,
                          global_scheduler_policy_state *policy_state,
-                         task *task);
+                         Task *task);
 
 /**
  * Handle the fact that a new object is available.

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -72,7 +72,7 @@ bool handle_task_waiting(global_scheduler_state *state,
  */
 void handle_object_available(global_scheduler_state *state,
                              global_scheduler_policy_state *policy_state,
-                             object_id object_id);
+                             ObjectID object_id);
 
 /**
  * Handle a heartbeat message from a local scheduler. TODO(rkn): this is a

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -46,8 +46,7 @@ GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void);
  * @param policy_state The policy state to free.
  * @return Void.
  */
-void GlobalSchedulerPolicyState_free(
-    GlobalSchedulerPolicyState *policy_state);
+void GlobalSchedulerPolicyState_free(GlobalSchedulerPolicyState *policy_state);
 
 /**
  * Main new task handling function in the global scheduler.
@@ -82,9 +81,8 @@ void handle_object_available(GlobalSchedulerState *state,
  * @param policy_state The state managed by the scheduling policy.
  * @return Void.
  */
-void handle_local_scheduler_heartbeat(
-    GlobalSchedulerState *state,
-    GlobalSchedulerPolicyState *policy_state);
+void handle_local_scheduler_heartbeat(GlobalSchedulerState *state,
+                                      GlobalSchedulerPolicyState *policy_state);
 
 /**
  * Handle the presence of a new local scheduler. Currently, this just adds the

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -30,7 +30,7 @@ typedef struct {
   const char *object_location;
   int64_t total_object_size;
   UT_hash_handle hh;
-} object_size_entry;
+} ObjectSizeEntry;
 
 /**
  * Create the state of the global scheduler policy. This state must be freed by

--- a/src/numbuf/python/src/pynumbuf/numbuf.cc
+++ b/src/numbuf/python/src/pynumbuf/numbuf.cc
@@ -208,7 +208,7 @@ static PyObject* register_callbacks(PyObject* self, PyObject* args) {
  * @return Void.
  */
 static void BufferCapsule_Destructor(PyObject* capsule) {
-  object_id* id = reinterpret_cast<object_id*>(PyCapsule_GetPointer(capsule, "buffer"));
+  ObjectID* id = reinterpret_cast<ObjectID*>(PyCapsule_GetPointer(capsule, "buffer"));
   auto context = reinterpret_cast<PyObject*>(PyCapsule_GetContext(capsule));
   /* We use the context of the connection capsule to indicate if the connection
    * is still active (if the context is NULL) or if it is closed (if the context
@@ -236,7 +236,7 @@ static void BufferCapsule_Destructor(PyObject* capsule) {
  * @return None.
  */
 static PyObject* store_list(PyObject* self, PyObject* args) {
-  object_id obj_id;
+  ObjectID obj_id;
   plasma_connection* conn;
   PyObject* value;
   if (!PyArg_ParseTuple(args, "O&O&O", PyStringToUniqueID, &obj_id,
@@ -320,7 +320,7 @@ static PyObject* retrieve_list(PyObject* self, PyObject* args) {
   if (!PyObjectToPlasmaConnection(plasma_conn, &conn)) { return NULL; }
 
   Py_ssize_t num_object_ids = PyList_Size(object_id_list);
-  object_id* object_ids = new object_id[num_object_ids];
+  ObjectID* object_ids = new ObjectID[num_object_ids];
   object_buffer* object_buffers = new object_buffer[num_object_ids];
 
   for (int i = 0; i < num_object_ids; ++i) {
@@ -340,7 +340,7 @@ static PyObject* retrieve_list(PyObject* self, PyObject* args) {
 
     if (object_buffers[i].data_size != -1) {
       /* The object was retrieved, so return the object. */
-      object_id* buffer_obj_id = new object_id(object_ids[i]);
+      ObjectID* buffer_obj_id = new ObjectID(object_ids[i]);
       /* This keeps a Plasma buffer in scope as long as an object that is backed by that
        * buffer is in scope. This prevents memory in the object store from getting
        * released while it is still being used to back a Python object. */

--- a/src/numbuf/python/src/pynumbuf/numbuf.cc
+++ b/src/numbuf/python/src/pynumbuf/numbuf.cc
@@ -215,7 +215,7 @@ static void BufferCapsule_Destructor(PyObject* capsule) {
    * is (void*) 0x1). This is neccessary because the primary pointer of the
    * capsule cannot be NULL. */
   if (PyCapsule_GetContext(context) == NULL) {
-    plasma_connection* conn;
+    PlasmaConnection* conn;
     CHECK(PyObjectToPlasmaConnection(context, &conn));
     plasma_release(conn, *id);
   }
@@ -237,7 +237,7 @@ static void BufferCapsule_Destructor(PyObject* capsule) {
  */
 static PyObject* store_list(PyObject* self, PyObject* args) {
   ObjectID obj_id;
-  plasma_connection* conn;
+  PlasmaConnection* conn;
   PyObject* value;
   if (!PyArg_ParseTuple(args, "O&O&O", PyStringToUniqueID, &obj_id,
           PyObjectToPlasmaConnection, &conn, &value)) {
@@ -316,7 +316,7 @@ static PyObject* retrieve_list(PyObject* self, PyObject* args) {
   if (!PyArg_ParseTuple(args, "OOL", &object_id_list, &plasma_conn, &timeout_ms)) {
     return NULL;
   }
-  plasma_connection* conn;
+  PlasmaConnection* conn;
   if (!PyObjectToPlasmaConnection(plasma_conn, &conn)) { return NULL; }
 
   Py_ssize_t num_object_ids = PyList_Size(object_id_list);

--- a/src/numbuf/python/src/pynumbuf/numbuf.cc
+++ b/src/numbuf/python/src/pynumbuf/numbuf.cc
@@ -321,7 +321,7 @@ static PyObject* retrieve_list(PyObject* self, PyObject* args) {
 
   Py_ssize_t num_object_ids = PyList_Size(object_id_list);
   ObjectID* object_ids = new ObjectID[num_object_ids];
-  object_buffer* object_buffers = new object_buffer[num_object_ids];
+  ObjectBuffer* object_buffers = new ObjectBuffer[num_object_ids];
 
   for (int i = 0; i < num_object_ids; ++i) {
     PyStringToUniqueID(PyList_GetItem(object_id_list, i), &object_ids[i]);

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -86,7 +86,7 @@ typedef struct {
   /** The handle to the database. */
   DBHandle *db;
   /** The Plasma client. */
-  plasma_connection *plasma_conn;
+  PlasmaConnection *plasma_conn;
   /** State for the scheduling algorithm. */
   SchedulingAlgorithmState *algorithm_state;
   /** Input buffer, used for reading input in process_message to avoid

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -84,7 +84,7 @@ typedef struct {
    *  that is responsible for the actor. */
   actor_map_entry *actor_mapping;
   /** The handle to the database. */
-  db_handle *db;
+  DBHandle *db;
   /** The Plasma client. */
   plasma_connection *plasma_conn;
   /** State for the scheduling algorithm. */

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -49,7 +49,7 @@ typedef struct {
   /** The ID of the actor. This is used as a key in the hash table. */
   ActorID actor_id;
   /** The ID of the local scheduler that is responsible for the actor. */
-  db_client_id local_scheduler_id;
+  DBClientID local_scheduler_id;
   /** Handle fo the hash table. */
   UT_hash_handle hh;
 } actor_map_entry;

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -98,7 +98,7 @@ typedef struct {
   /** Vector of dynamic attributes associated with the node owned by this local
    *  scheduler. */
   double dynamic_resources[MAX_RESOURCE_INDEX];
-} local_scheduler_state;
+} LocalSchedulerState;
 
 /** Contains all information associated with a local scheduler client. */
 typedef struct {
@@ -120,7 +120,7 @@ typedef struct {
    *  worker, this should be NIL_ACTOR_ID. */
   ActorID actor_id;
   /** A pointer to the local scheduler state. */
-  local_scheduler_state *local_scheduler_state;
+  LocalSchedulerState *local_scheduler_state;
 } local_scheduler_client;
 
 #endif /* PHOTON_H */

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -55,7 +55,7 @@ typedef struct {
 } actor_map_entry;
 
 /** Internal state of the scheduling algorithm. */
-typedef struct scheduling_algorithm_state scheduling_algorithm_state;
+typedef struct SchedulingAlgorithmState SchedulingAlgorithmState;
 
 /** A struct storing the configuration state of the local scheduler. This should
  *  consist of values that don't change over the lifetime of the local
@@ -88,7 +88,7 @@ typedef struct {
   /** The Plasma client. */
   plasma_connection *plasma_conn;
   /** State for the scheduling algorithm. */
-  scheduling_algorithm_state *algorithm_state;
+  SchedulingAlgorithmState *algorithm_state;
   /** Input buffer, used for reading input in process_message to avoid
    *  allocation for each call to process_message. */
   UT_array *input_buffer;

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -121,6 +121,6 @@ typedef struct {
   ActorID actor_id;
   /** A pointer to the local scheduler state. */
   LocalSchedulerState *local_scheduler_state;
-} local_scheduler_client;
+} LocalSchedulerClient;
 
 #endif /* PHOTON_H */

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -38,7 +38,7 @@ UT_icd pid_t_icd;
 typedef struct {
   /** The ID of the actor. This is NIL_ACTOR_ID if the worker is not an actor.
    */
-  actor_id actor_id;
+  ActorID actor_id;
   /** The process ID of this worker. */
   pid_t worker_pid;
 } register_worker_info;
@@ -47,7 +47,7 @@ typedef struct {
  *  local scheduler that is responsible for the actor. */
 typedef struct {
   /** The ID of the actor. This is used as a key in the hash table. */
-  actor_id actor_id;
+  ActorID actor_id;
   /** The ID of the local scheduler that is responsible for the actor. */
   db_client_id local_scheduler_id;
   /** Handle fo the hash table. */
@@ -118,7 +118,7 @@ typedef struct {
   bool is_child;
   /** The ID of the actor on this worker. If there is no actor running on this
    *  worker, this should be NIL_ACTOR_ID. */
-  actor_id actor_id;
+  ActorID actor_id;
   /** A pointer to the local scheduler state. */
   local_scheduler_state *local_scheduler_state;
 } local_scheduler_client;

--- a/src/photon/photon.h
+++ b/src/photon/photon.h
@@ -107,7 +107,7 @@ typedef struct {
   /** A pointer to the task object that is currently running on this client. If
    *  no task is running on the worker, this will be NULL. This is used to
    *  update the task table. */
-  task *task_in_progress;
+  Task *task_in_progress;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -12,8 +12,7 @@
 #include "common/task.h"
 
 /* Declared for convenience. */
-void remove_actor(SchedulingAlgorithmState *algorithm_state,
-                  ActorID actor_id);
+void remove_actor(SchedulingAlgorithmState *algorithm_state, ActorID actor_id);
 
 typedef struct task_queue_entry {
   /** The task that is queued. */
@@ -127,8 +126,7 @@ SchedulingAlgorithmState *SchedulingAlgorithmState_init(void) {
   return algorithm_state;
 }
 
-void SchedulingAlgorithmState_free(
-    SchedulingAlgorithmState *algorithm_state) {
+void SchedulingAlgorithmState_free(SchedulingAlgorithmState *algorithm_state) {
   /* Free all of the tasks in the waiting queue. */
   task_queue_entry *elt, *tmp1;
   DL_FOREACH_SAFE(algorithm_state->waiting_task_queue, elt, tmp1) {
@@ -238,8 +236,7 @@ void create_actor(SchedulingAlgorithmState *algorithm_state,
   UNUSED(id_string);
 }
 
-void remove_actor(SchedulingAlgorithmState *algorithm_state,
-                  ActorID actor_id) {
+void remove_actor(SchedulingAlgorithmState *algorithm_state, ActorID actor_id) {
   LocalActorInfo *entry;
   HASH_FIND(hh, algorithm_state->local_actor_infos, &actor_id, sizeof(actor_id),
             entry);
@@ -392,7 +389,7 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   HASH_FIND(hh, state->actor_mapping, &actor_id, sizeof(actor_id), actor_entry);
   CHECK(actor_entry != NULL);
   CHECK(DBClientID_equal(actor_entry->local_scheduler_id,
-                            get_db_client_id(state->db)));
+                         get_db_client_id(state->db)));
 
   /* Get the local actor entry for this actor. */
   LocalActorInfo *entry;
@@ -847,7 +844,7 @@ void handle_actor_task_submitted(LocalSchedulerState *state,
   }
 
   if (DBClientID_equal(entry->local_scheduler_id,
-                          get_db_client_id(state->db))) {
+                       get_db_client_id(state->db))) {
     /* This local scheduler is responsible for the actor, so handle the task
      * locally. */
     add_task_to_actor_queue(state, algorithm_state, spec, false);
@@ -914,7 +911,7 @@ void handle_actor_task_scheduled(LocalSchedulerState *state,
      * creation. This may be possible though should be very uncommon. If it does
      * happen, it's ok. */
     DCHECK(DBClientID_equal(entry->local_scheduler_id,
-                               get_db_client_id(state->db)));
+                            get_db_client_id(state->db)));
   } else {
     LOG_INFO(
         "handle_actor_task_scheduled called on local scheduler but the "
@@ -1041,9 +1038,8 @@ void handle_worker_blocked(LocalSchedulerState *state,
       utarray_erase(algorithm_state->executing_workers, i, 1);
 
       /* Check that the worker isn't in the list of blocked workers. */
-      for (LocalSchedulerClient **q =
-               (LocalSchedulerClient **) utarray_front(
-                   algorithm_state->blocked_workers);
+      for (LocalSchedulerClient **q = (LocalSchedulerClient **) utarray_front(
+               algorithm_state->blocked_workers);
            q != NULL; q = (LocalSchedulerClient **) utarray_next(
                           algorithm_state->blocked_workers, q)) {
         DCHECK(*q != worker);
@@ -1080,9 +1076,8 @@ void handle_worker_unblocked(LocalSchedulerState *state,
       utarray_erase(algorithm_state->blocked_workers, i, 1);
 
       /* Check that the worker isn't in the list of executing workers. */
-      for (LocalSchedulerClient **q =
-               (LocalSchedulerClient **) utarray_front(
-                   algorithm_state->executing_workers);
+      for (LocalSchedulerClient **q = (LocalSchedulerClient **) utarray_front(
+               algorithm_state->executing_workers);
            q != NULL; q = (LocalSchedulerClient **) utarray_next(
                           algorithm_state->executing_workers, q)) {
         DCHECK(*q != worker);

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -361,7 +361,7 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
   /* Update the task table. */
   if (state->db != NULL) {
     Task *task =
-        alloc_task(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
+        Task_alloc(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
        * the task table, so just update the entry. */
@@ -657,7 +657,7 @@ task_queue_entry *queue_task(LocalSchedulerState *state,
    * task table to notify others that we have queued it. */
   if (state->db != NULL) {
     Task *task =
-        alloc_task(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
+        Task_alloc(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
        * the task table, so just update the entry. */
@@ -762,7 +762,7 @@ void give_task_to_local_scheduler(LocalSchedulerState *state,
   CHECK(state->db != NULL);
   /* Assign the task to the relevant local scheduler. */
   DCHECK(state->config.global_scheduler_exists);
-  Task *task = alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
+  Task *task = Task_alloc(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
   task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
 
@@ -784,7 +784,7 @@ void give_task_to_global_scheduler(LocalSchedulerState *state,
   }
   /* Pass on the task to the global scheduler. */
   DCHECK(state->config.global_scheduler_exists);
-  Task *task = alloc_task(spec, TASK_STATUS_WAITING, NIL_ID);
+  Task *task = Task_alloc(spec, TASK_STATUS_WAITING, NIL_ID);
   DCHECK(state->db != NULL);
   task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
@@ -1051,7 +1051,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
 
       /* Return the resources that the blocked worker was using. */
       CHECK(worker->task_in_progress != NULL);
-      task_spec *spec = task_task_spec(worker->task_in_progress);
+      task_spec *spec = Task_task_spec(worker->task_in_progress);
       update_dynamic_resources(state, spec, true);
       /* Add the worker to the list of blocked workers. */
       worker->is_blocked = true;
@@ -1094,7 +1094,7 @@ void handle_worker_unblocked(LocalSchedulerState *state,
        * fixed by having blocked workers explicitly yield and wait to be given
        * back resources before continuing execution. */
       CHECK(worker->task_in_progress != NULL);
-      task_spec *spec = task_task_spec(worker->task_in_progress);
+      task_spec *spec = Task_task_spec(worker->task_in_progress);
       update_dynamic_resources(state, spec, false);
       /* Add the worker to the list of executing workers. */
       worker->is_blocked = false;

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -182,7 +182,7 @@ void SchedulingAlgorithmState_free(
 
 void provide_scheduler_info(LocalSchedulerState *state,
                             SchedulingAlgorithmState *algorithm_state,
-                            local_scheduler_info *info) {
+                            LocalSchedulerInfo *info) {
   task_queue_entry *elt;
   info->total_num_workers = utarray_len(state->workers);
   /* TODO(swang): Provide separate counts for tasks that are waiting for

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -360,7 +360,7 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
 
   /* Update the task table. */
   if (state->db != NULL) {
-    task *task =
+    Task *task =
         alloc_task(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
@@ -656,7 +656,7 @@ task_queue_entry *queue_task(LocalSchedulerState *state,
   /* The task has been added to a local scheduler queue. Write the entry in the
    * task table to notify others that we have queued it. */
   if (state->db != NULL) {
-    task *task =
+    Task *task =
         alloc_task(spec, TASK_STATUS_QUEUED, get_db_client_id(state->db));
     if (from_global_scheduler) {
       /* If the task is from the global scheduler, it's already been added to
@@ -762,7 +762,7 @@ void give_task_to_local_scheduler(LocalSchedulerState *state,
   CHECK(state->db != NULL);
   /* Assign the task to the relevant local scheduler. */
   DCHECK(state->config.global_scheduler_exists);
-  task *task = alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
+  Task *task = alloc_task(spec, TASK_STATUS_SCHEDULED, local_scheduler_id);
   task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
 
@@ -784,7 +784,7 @@ void give_task_to_global_scheduler(LocalSchedulerState *state,
   }
   /* Pass on the task to the global scheduler. */
   DCHECK(state->config.global_scheduler_exists);
-  task *task = alloc_task(spec, TASK_STATUS_WAITING, NIL_ID);
+  Task *task = alloc_task(spec, TASK_STATUS_WAITING, NIL_ID);
   DCHECK(state->db != NULL);
   task_table_add_task(state->db, task, NULL, NULL, NULL);
 }

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -969,7 +969,7 @@ void handle_worker_available(LocalSchedulerState *state,
 }
 
 void handle_worker_removed(LocalSchedulerState *state,
-                           scheduling_algorithm_state *algorithm_state,
+                           SchedulingAlgorithmState *algorithm_state,
                            local_scheduler_client *worker) {
   /* Make sure that we remove the worker at most once. */
   bool removed = false;

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -13,7 +13,7 @@
 
 /* Declared for convenience. */
 void remove_actor(scheduling_algorithm_state *algorithm_state,
-                  actor_id actor_id);
+                  ActorID actor_id);
 
 typedef struct task_queue_entry {
   /** The task that is queued. */
@@ -48,7 +48,7 @@ UT_icd worker_icd = {sizeof(local_scheduler_client *), NULL, NULL, NULL};
  *  used inside of a hash table. */
 typedef struct {
   /** The ID of the actor. This is used as a key in the hash table. */
-  actor_id actor_id;
+  ActorID actor_id;
   /** The number of tasks that have been executed on this actor so far. This is
    *  used to guarantee the in-order execution of tasks on actors (in the order
    *  that the tasks were submitted). This is currently meaningful because we
@@ -218,7 +218,7 @@ void provide_scheduler_info(local_scheduler_state *state,
  * @return Void.
  */
 void create_actor(scheduling_algorithm_state *algorithm_state,
-                  actor_id actor_id,
+                  ActorID actor_id,
                   local_scheduler_client *worker) {
   /* This will be freed when the actor is removed in remove_actor. */
   local_actor_info *entry = malloc(sizeof(local_actor_info));
@@ -239,7 +239,7 @@ void create_actor(scheduling_algorithm_state *algorithm_state,
 }
 
 void remove_actor(scheduling_algorithm_state *algorithm_state,
-                  actor_id actor_id) {
+                  ActorID actor_id) {
   local_actor_info *entry;
   HASH_FIND(hh, algorithm_state->local_actor_infos, &actor_id, sizeof(actor_id),
             entry);
@@ -271,7 +271,7 @@ void remove_actor(scheduling_algorithm_state *algorithm_state,
 
 void handle_actor_worker_connect(local_scheduler_state *state,
                                  scheduling_algorithm_state *algorithm_state,
-                                 actor_id actor_id,
+                                 ActorID actor_id,
                                  local_scheduler_client *worker) {
   local_actor_info *entry;
   HASH_FIND(hh, algorithm_state->local_actor_infos, &actor_id, sizeof(actor_id),
@@ -288,7 +288,7 @@ void handle_actor_worker_connect(local_scheduler_state *state,
 
 void handle_actor_worker_disconnect(local_scheduler_state *state,
                                     scheduling_algorithm_state *algorithm_state,
-                                    actor_id actor_id) {
+                                    ActorID actor_id) {
   remove_actor(algorithm_state, actor_id);
 }
 
@@ -314,7 +314,7 @@ void add_task_to_actor_queue(local_scheduler_state *state,
                              scheduling_algorithm_state *algorithm_state,
                              task_spec *spec,
                              bool from_global_scheduler) {
-  actor_id actor_id = task_spec_actor_id(spec);
+  ActorID actor_id = task_spec_actor_id(spec);
   char tmp[ID_STRING_SIZE];
   object_id_to_string(actor_id, tmp, ID_STRING_SIZE);
   DCHECK(!actor_ids_equal(actor_id, NIL_ACTOR_ID));
@@ -384,7 +384,7 @@ void add_task_to_actor_queue(local_scheduler_state *state,
  */
 bool dispatch_actor_task(local_scheduler_state *state,
                          scheduling_algorithm_state *algorithm_state,
-                         actor_id actor_id) {
+                         ActorID actor_id) {
   /* Make sure this worker actually is an actor. */
   CHECK(!actor_ids_equal(actor_id, NIL_ACTOR_ID));
   /* Make sure this actor belongs to this local scheduler. */
@@ -830,7 +830,7 @@ void handle_task_submitted(local_scheduler_state *state,
 void handle_actor_task_submitted(local_scheduler_state *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  task_spec *spec) {
-  actor_id actor_id = task_spec_actor_id(spec);
+  ActorID actor_id = task_spec_actor_id(spec);
   CHECK(!actor_ids_equal(actor_id, NIL_ACTOR_ID));
 
   /* Find the local scheduler responsible for this actor. */
@@ -864,7 +864,7 @@ void handle_actor_task_submitted(local_scheduler_state *state,
 void handle_actor_creation_notification(
     local_scheduler_state *state,
     scheduling_algorithm_state *algorithm_state,
-    actor_id actor_id) {
+    ActorID actor_id) {
   int num_cached_actor_tasks =
       utarray_len(algorithm_state->cached_submitted_actor_tasks);
   for (int i = 0; i < num_cached_actor_tasks; ++i) {
@@ -903,7 +903,7 @@ void handle_actor_task_scheduled(local_scheduler_state *state,
   DCHECK(state->config.global_scheduler_exists);
   /* Check that the task is meant to run on an actor that this local scheduler
    * is responsible for. */
-  actor_id actor_id = task_spec_actor_id(spec);
+  ActorID actor_id = task_spec_actor_id(spec);
   DCHECK(!actor_ids_equal(actor_id, NIL_ACTOR_ID));
   actor_map_entry *entry;
   HASH_FIND(hh, state->actor_mapping, &actor_id, sizeof(actor_id), entry);
@@ -1015,7 +1015,7 @@ void handle_worker_removed(local_scheduler_state *state,
 void handle_actor_worker_available(local_scheduler_state *state,
                                    scheduling_algorithm_state *algorithm_state,
                                    local_scheduler_client *worker) {
-  actor_id actor_id = worker->actor_id;
+  ActorID actor_id = worker->actor_id;
   CHECK(!actor_ids_equal(actor_id, NIL_ACTOR_ID));
   /* Get the actor info for this worker. */
   local_actor_info *entry;

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -755,7 +755,7 @@ void queue_task_locally(LocalSchedulerState *state,
 void give_task_to_local_scheduler(LocalSchedulerState *state,
                                   scheduling_algorithm_state *algorithm_state,
                                   task_spec *spec,
-                                  db_client_id local_scheduler_id) {
+                                  DBClientID local_scheduler_id) {
   if (db_client_ids_equal(local_scheduler_id, get_db_client_id(state->db))) {
     LOG_WARN("Local scheduler is trying to assign a task to itself.");
   }

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -26,7 +26,7 @@ typedef struct task_queue_entry {
  *  which objects are being actively fetched. */
 typedef struct {
   /** Object id of this object. */
-  object_id object_id;
+  ObjectID object_id;
   /** An array of the tasks dependent on this object. */
   UT_array *dependent_tasks;
   /** Handle for the uthash table. NOTE: This handle is used for both the
@@ -444,7 +444,7 @@ bool dispatch_actor_task(local_scheduler_state *state,
 void fetch_missing_dependency(local_scheduler_state *state,
                               scheduling_algorithm_state *algorithm_state,
                               task_queue_entry *task_entry,
-                              object_id obj_id) {
+                              ObjectID obj_id) {
   object_entry *entry;
   HASH_FIND(hh, algorithm_state->remote_objects, &obj_id, sizeof(obj_id),
             entry);
@@ -486,7 +486,7 @@ void fetch_missing_dependencies(local_scheduler_state *state,
   int num_missing_dependencies = 0;
   for (int i = 0; i < num_args; ++i) {
     if (task_arg_type(task, i) == ARG_BY_REF) {
-      object_id obj_id = task_arg_id(task, i);
+      ObjectID obj_id = task_arg_id(task, i);
       object_entry *entry;
       HASH_FIND(hh, algorithm_state->local_objects, &obj_id, sizeof(obj_id),
                 entry);
@@ -514,7 +514,7 @@ bool can_run(scheduling_algorithm_state *algorithm_state, task_spec *task) {
   int64_t num_args = task_num_args(task);
   for (int i = 0; i < num_args; ++i) {
     if (task_arg_type(task, i) == ARG_BY_REF) {
-      object_id obj_id = task_arg_id(task, i);
+      ObjectID obj_id = task_arg_id(task, i);
       object_entry *entry;
       HASH_FIND(hh, algorithm_state->local_objects, &obj_id, sizeof(obj_id),
                 entry);
@@ -540,7 +540,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
 
   /* Allocate a buffer to hold all the object IDs for active fetch requests. */
   int num_object_ids = HASH_COUNT(state->algorithm_state->remote_objects);
-  object_id *object_ids = malloc(num_object_ids * sizeof(object_id));
+  ObjectID *object_ids = malloc(num_object_ids * sizeof(ObjectID));
 
   /* Fill out the request with the object IDs for active fetches. */
   object_entry *fetch_request, *tmp;
@@ -1113,7 +1113,7 @@ void handle_worker_unblocked(local_scheduler_state *state,
 
 void handle_object_available(local_scheduler_state *state,
                              scheduling_algorithm_state *algorithm_state,
-                             object_id object_id) {
+                             ObjectID object_id) {
   /* Get the entry for this object from the active fetch request, or allocate
    * one if needed. */
   object_entry *entry;
@@ -1158,7 +1158,7 @@ void handle_object_available(local_scheduler_state *state,
 }
 
 void handle_object_removed(local_scheduler_state *state,
-                           object_id removed_object_id) {
+                           ObjectID removed_object_id) {
   /* Remove the object from the set of locally available objects. */
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   object_entry *entry;
@@ -1180,7 +1180,7 @@ void handle_object_removed(local_scheduler_state *state,
     int64_t num_args = task_num_args(task);
     for (int i = 0; i < num_args; ++i) {
       if (task_arg_type(task, i) == ARG_BY_REF) {
-        object_id arg_id = task_arg_id(task, i);
+        ObjectID arg_id = task_arg_id(task, i);
         if (object_ids_equal(arg_id, removed_object_id)) {
           fetch_missing_dependency(state, algorithm_state, elt,
                                    removed_object_id);
@@ -1195,7 +1195,7 @@ void handle_object_removed(local_scheduler_state *state,
     int64_t num_args = task_num_args(task);
     for (int i = 0; i < num_args; ++i) {
       if (task_arg_type(task, i) == ARG_BY_REF) {
-        object_id arg_id = task_arg_id(task, i);
+        ObjectID arg_id = task_arg_id(task, i);
         if (object_ids_equal(arg_id, removed_object_id)) {
           LOG_DEBUG("Moved task from dispatch queue back to waiting queue");
           DL_DELETE(algorithm_state->dispatch_task_queue, elt);

--- a/src/photon/photon_algorithm.c
+++ b/src/photon/photon_algorithm.c
@@ -180,7 +180,7 @@ void free_scheduling_algorithm_state(
   free(algorithm_state);
 }
 
-void provide_scheduler_info(local_scheduler_state *state,
+void provide_scheduler_info(LocalSchedulerState *state,
                             scheduling_algorithm_state *algorithm_state,
                             local_scheduler_info *info) {
   task_queue_entry *elt;
@@ -269,7 +269,7 @@ void remove_actor(scheduling_algorithm_state *algorithm_state,
   free(entry);
 }
 
-void handle_actor_worker_connect(local_scheduler_state *state,
+void handle_actor_worker_connect(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  ActorID actor_id,
                                  local_scheduler_client *worker) {
@@ -286,7 +286,7 @@ void handle_actor_worker_connect(local_scheduler_state *state,
   }
 }
 
-void handle_actor_worker_disconnect(local_scheduler_state *state,
+void handle_actor_worker_disconnect(LocalSchedulerState *state,
                                     scheduling_algorithm_state *algorithm_state,
                                     ActorID actor_id) {
   remove_actor(algorithm_state, actor_id);
@@ -310,7 +310,7 @@ void handle_actor_worker_disconnect(local_scheduler_state *state,
  *        locally by a worker.
  * @return Void.
  */
-void add_task_to_actor_queue(local_scheduler_state *state,
+void add_task_to_actor_queue(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              task_spec *spec,
                              bool from_global_scheduler) {
@@ -382,7 +382,7 @@ void add_task_to_actor_queue(local_scheduler_state *state,
  * @param actor_id The ID of the actor corresponding to the worker.
  * @return True if a task was dispatched to the actor and false otherwise.
  */
-bool dispatch_actor_task(local_scheduler_state *state,
+bool dispatch_actor_task(LocalSchedulerState *state,
                          scheduling_algorithm_state *algorithm_state,
                          ActorID actor_id) {
   /* Make sure this worker actually is an actor. */
@@ -441,7 +441,7 @@ bool dispatch_actor_task(local_scheduler_state *state,
  * @param obj_id The ID of the object that the task is dependent on.
  * @returns Void.
  */
-void fetch_missing_dependency(local_scheduler_state *state,
+void fetch_missing_dependency(LocalSchedulerState *state,
                               scheduling_algorithm_state *algorithm_state,
                               task_queue_entry *task_entry,
                               ObjectID obj_id) {
@@ -478,7 +478,7 @@ void fetch_missing_dependency(local_scheduler_state *state,
  * @param task_entry The task's queue entry.
  * @returns Void.
  */
-void fetch_missing_dependencies(local_scheduler_state *state,
+void fetch_missing_dependencies(LocalSchedulerState *state,
                                 scheduling_algorithm_state *algorithm_state,
                                 task_queue_entry *task_entry) {
   task_spec *task = task_entry->spec;
@@ -531,7 +531,7 @@ bool can_run(scheduling_algorithm_state *algorithm_state, task_spec *task) {
 /* TODO(rkn): This method will need to be changed to call reconstruct. */
 /* TODO(swang): This method is not covered by any valgrind tests. */
 int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
-  local_scheduler_state *state = context;
+  LocalSchedulerState *state = context;
   /* Only try the fetches if we are connected to the object store manager. */
   if (!plasma_manager_is_connected(state->plasma_conn)) {
     LOG_INFO("Local scheduler is not connected to a object store manager");
@@ -564,7 +564,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
  * @param algorithm_state The scheduling algorithm state.
  * @return Void.
  */
-void dispatch_tasks(local_scheduler_state *state,
+void dispatch_tasks(LocalSchedulerState *state,
                     scheduling_algorithm_state *algorithm_state) {
   task_queue_entry *elt, *tmp;
 
@@ -642,7 +642,7 @@ void dispatch_tasks(local_scheduler_state *state,
  *        scheduler. If false, the task was submitted by a worker.
  * @return Void.
  */
-task_queue_entry *queue_task(local_scheduler_state *state,
+task_queue_entry *queue_task(LocalSchedulerState *state,
                              task_queue_entry **task_queue,
                              task_spec *spec,
                              bool from_global_scheduler) {
@@ -685,7 +685,7 @@ task_queue_entry *queue_task(local_scheduler_state *state,
  *        scheduler. If false, the task was submitted by a worker.
  * @return Void.
  */
-void queue_waiting_task(local_scheduler_state *state,
+void queue_waiting_task(LocalSchedulerState *state,
                         scheduling_algorithm_state *algorithm_state,
                         task_spec *spec,
                         bool from_global_scheduler) {
@@ -708,7 +708,7 @@ void queue_waiting_task(local_scheduler_state *state,
  *        scheduler. If false, the task was submitted by a worker.
  * @return Void.
  */
-void queue_dispatch_task(local_scheduler_state *state,
+void queue_dispatch_task(LocalSchedulerState *state,
                          scheduling_algorithm_state *algorithm_state,
                          task_spec *spec,
                          bool from_global_scheduler) {
@@ -729,7 +729,7 @@ void queue_dispatch_task(local_scheduler_state *state,
  *        scheduler. If false, the task was submitted by a worker.
  * @return Void.
  */
-void queue_task_locally(local_scheduler_state *state,
+void queue_task_locally(LocalSchedulerState *state,
                         scheduling_algorithm_state *algorithm_state,
                         task_spec *spec,
                         bool from_global_scheduler) {
@@ -752,7 +752,7 @@ void queue_task_locally(local_scheduler_state *state,
  * @param local_scheduler_id The ID of the local scheduler to give the task to.
  * @return Void.
  */
-void give_task_to_local_scheduler(local_scheduler_state *state,
+void give_task_to_local_scheduler(LocalSchedulerState *state,
                                   scheduling_algorithm_state *algorithm_state,
                                   task_spec *spec,
                                   db_client_id local_scheduler_id) {
@@ -774,7 +774,7 @@ void give_task_to_local_scheduler(local_scheduler_state *state,
  * @param spec The task specification to schedule.
  * @return Void.
  */
-void give_task_to_global_scheduler(local_scheduler_state *state,
+void give_task_to_global_scheduler(LocalSchedulerState *state,
                                    scheduling_algorithm_state *algorithm_state,
                                    task_spec *spec) {
   if (state->db == NULL || !state->config.global_scheduler_exists) {
@@ -789,7 +789,7 @@ void give_task_to_global_scheduler(local_scheduler_state *state,
   task_table_add_task(state->db, task, NULL, NULL, NULL);
 }
 
-bool resource_constraints_satisfied(local_scheduler_state *state,
+bool resource_constraints_satisfied(LocalSchedulerState *state,
                                     task_spec *spec) {
   /* At the local scheduler, if required resource vector exceeds either static
    * or dynamic resource vector, the resource constraint is not satisfied. */
@@ -803,7 +803,7 @@ bool resource_constraints_satisfied(local_scheduler_state *state,
   return true;
 }
 
-void handle_task_submitted(local_scheduler_state *state,
+void handle_task_submitted(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            task_spec *spec) {
   /* TODO(atumanov): if static is satisfied and local objects ready, but dynamic
@@ -827,7 +827,7 @@ void handle_task_submitted(local_scheduler_state *state,
   dispatch_tasks(state, algorithm_state);
 }
 
-void handle_actor_task_submitted(local_scheduler_state *state,
+void handle_actor_task_submitted(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  task_spec *spec) {
   ActorID actor_id = task_spec_actor_id(spec);
@@ -862,7 +862,7 @@ void handle_actor_task_submitted(local_scheduler_state *state,
 }
 
 void handle_actor_creation_notification(
-    local_scheduler_state *state,
+    LocalSchedulerState *state,
     scheduling_algorithm_state *algorithm_state,
     ActorID actor_id) {
   int num_cached_actor_tasks =
@@ -880,7 +880,7 @@ void handle_actor_creation_notification(
                 num_cached_actor_tasks);
 }
 
-void handle_task_scheduled(local_scheduler_state *state,
+void handle_task_scheduled(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            task_spec *spec) {
   /* This callback handles tasks that were assigned to this local scheduler by
@@ -893,7 +893,7 @@ void handle_task_scheduled(local_scheduler_state *state,
   dispatch_tasks(state, algorithm_state);
 }
 
-void handle_actor_task_scheduled(local_scheduler_state *state,
+void handle_actor_task_scheduled(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  task_spec *spec) {
   /* This callback handles tasks that were assigned to this local scheduler by
@@ -925,7 +925,7 @@ void handle_actor_task_scheduled(local_scheduler_state *state,
   dispatch_actor_task(state, algorithm_state, actor_id);
 }
 
-void handle_worker_available(local_scheduler_state *state,
+void handle_worker_available(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              local_scheduler_client *worker) {
   CHECK(worker->task_in_progress == NULL);
@@ -968,7 +968,7 @@ void handle_worker_available(local_scheduler_state *state,
   dispatch_tasks(state, algorithm_state);
 }
 
-void handle_worker_removed(local_scheduler_state *state,
+void handle_worker_removed(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            local_scheduler_client *worker) {
   /* Make sure that we remove the worker at most once. */
@@ -1012,7 +1012,7 @@ void handle_worker_removed(local_scheduler_state *state,
   }
 }
 
-void handle_actor_worker_available(local_scheduler_state *state,
+void handle_actor_worker_available(LocalSchedulerState *state,
                                    scheduling_algorithm_state *algorithm_state,
                                    local_scheduler_client *worker) {
   ActorID actor_id = worker->actor_id;
@@ -1029,7 +1029,7 @@ void handle_actor_worker_available(local_scheduler_state *state,
   dispatch_actor_task(state, algorithm_state, actor_id);
 }
 
-void handle_worker_blocked(local_scheduler_state *state,
+void handle_worker_blocked(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            local_scheduler_client *worker) {
   /* Find the worker in the list of executing workers. */
@@ -1068,7 +1068,7 @@ void handle_worker_blocked(local_scheduler_state *state,
       "workers.");
 }
 
-void handle_worker_unblocked(local_scheduler_state *state,
+void handle_worker_unblocked(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              local_scheduler_client *worker) {
   /* Find the worker in the list of blocked workers. */
@@ -1111,7 +1111,7 @@ void handle_worker_unblocked(local_scheduler_state *state,
       "workers.");
 }
 
-void handle_object_available(local_scheduler_state *state,
+void handle_object_available(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              ObjectID object_id) {
   /* Get the entry for this object from the active fetch request, or allocate
@@ -1157,7 +1157,7 @@ void handle_object_available(local_scheduler_state *state,
   }
 }
 
-void handle_object_removed(local_scheduler_state *state,
+void handle_object_removed(LocalSchedulerState *state,
                            ObjectID removed_object_id) {
   /* Remove the object from the set of locally available objects. */
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -37,7 +37,7 @@ void free_scheduling_algorithm_state(
 /**
  *
  */
-void provide_scheduler_info(local_scheduler_state *state,
+void provide_scheduler_info(LocalSchedulerState *state,
                             scheduling_algorithm_state *algorithm_state,
                             local_scheduler_info *info);
 
@@ -57,7 +57,7 @@ void provide_scheduler_info(local_scheduler_state *state,
  * @param task Task that is submitted by the worker.
  * @return Void.
  */
-void handle_task_submitted(local_scheduler_state *state,
+void handle_task_submitted(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            task_spec *spec);
 
@@ -70,7 +70,7 @@ void handle_task_submitted(local_scheduler_state *state,
  * @param task Task that is submitted by the worker.
  * @return Void.
  */
-void handle_actor_task_submitted(local_scheduler_state *state,
+void handle_actor_task_submitted(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  task_spec *spec);
 
@@ -85,7 +85,7 @@ void handle_actor_task_submitted(local_scheduler_state *state,
  * @return Void.
  */
 void handle_actor_creation_notification(
-    local_scheduler_state *state,
+    LocalSchedulerState *state,
     scheduling_algorithm_state *algorithm_state,
     ActorID actor_id);
 
@@ -98,7 +98,7 @@ void handle_actor_creation_notification(
  * @param task Task that is assigned by the global scheduler.
  * @return Void.
  */
-void handle_task_scheduled(local_scheduler_state *state,
+void handle_task_scheduled(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            task_spec *spec);
 
@@ -112,7 +112,7 @@ void handle_task_scheduled(local_scheduler_state *state,
  * @param task Task that is assigned by the global scheduler.
  * @return Void.
  */
-void handle_actor_task_scheduled(local_scheduler_state *state,
+void handle_actor_task_scheduled(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  task_spec *spec);
 
@@ -125,7 +125,7 @@ void handle_actor_task_scheduled(local_scheduler_state *state,
  * @param object_id ID of the object that became available.
  * @return Void.
  */
-void handle_object_available(local_scheduler_state *state,
+void handle_object_available(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              ObjectID object_id);
 
@@ -136,7 +136,7 @@ void handle_object_available(local_scheduler_state *state,
  * @param object_id ID of the object that was removed.
  * @return Void.
  */
-void handle_object_removed(local_scheduler_state *state, ObjectID object_id);
+void handle_object_removed(LocalSchedulerState *state, ObjectID object_id);
 
 /**
  * This function is called when a new worker becomes available.
@@ -146,7 +146,7 @@ void handle_object_removed(local_scheduler_state *state, ObjectID object_id);
  * @param worker The worker that is available.
  * @return Void.
  */
-void handle_worker_available(local_scheduler_state *state,
+void handle_worker_available(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              local_scheduler_client *worker);
 
@@ -171,7 +171,7 @@ void handle_worker_removed(local_scheduler_state *state,
  * @param wi Information about the worker that is available.
  * @return Void.
  */
-void handle_actor_worker_available(local_scheduler_state *state,
+void handle_actor_worker_available(LocalSchedulerState *state,
                                    scheduling_algorithm_state *algorithm_state,
                                    local_scheduler_client *worker);
 
@@ -184,7 +184,7 @@ void handle_actor_worker_available(local_scheduler_state *state,
  * @param worker The worker that was connected.
  * @return Void.
  */
-void handle_actor_worker_connect(local_scheduler_state *state,
+void handle_actor_worker_connect(LocalSchedulerState *state,
                                  scheduling_algorithm_state *algorithm_state,
                                  ActorID actor_id,
                                  local_scheduler_client *worker);
@@ -197,7 +197,7 @@ void handle_actor_worker_connect(local_scheduler_state *state,
  * @param actor_id The ID of the actor running on the worker.
  * @return Void.
  */
-void handle_actor_worker_disconnect(local_scheduler_state *state,
+void handle_actor_worker_disconnect(LocalSchedulerState *state,
                                     scheduling_algorithm_state *algorithm_state,
                                     ActorID actor_id);
 
@@ -210,7 +210,7 @@ void handle_actor_worker_disconnect(local_scheduler_state *state,
  * @param worker The worker that is blocked.
  * @return Void.
  */
-void handle_worker_blocked(local_scheduler_state *state,
+void handle_worker_blocked(LocalSchedulerState *state,
                            scheduling_algorithm_state *algorithm_state,
                            local_scheduler_client *worker);
 
@@ -223,7 +223,7 @@ void handle_worker_blocked(local_scheduler_state *state,
  * @param worker The worker that is now unblocked.
  * @return Void.
  */
-void handle_worker_unblocked(local_scheduler_state *state,
+void handle_worker_unblocked(LocalSchedulerState *state,
                              scheduling_algorithm_state *algorithm_state,
                              local_scheduler_client *worker);
 

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -31,8 +31,7 @@ SchedulingAlgorithmState *SchedulingAlgorithmState_init(void);
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @return Void.
  */
-void SchedulingAlgorithmState_free(
-    SchedulingAlgorithmState *algorithm_state);
+void SchedulingAlgorithmState_free(SchedulingAlgorithmState *algorithm_state);
 
 /**
  *

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -158,8 +158,8 @@ void handle_worker_available(LocalSchedulerState *state,
  * @param worker The worker that is removed.
  * @return Void.
  */
-void handle_worker_removed(local_scheduler_state *state,
-                           scheduling_algorithm_state *algorithm_state,
+void handle_worker_removed(LocalSchedulerState *state,
+                           SchedulingAlgorithmState *algorithm_state,
                            local_scheduler_client *worker);
 
 /**

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -39,7 +39,7 @@ void SchedulingAlgorithmState_free(
  */
 void provide_scheduler_info(LocalSchedulerState *state,
                             SchedulingAlgorithmState *algorithm_state,
-                            local_scheduler_info *info);
+                            LocalSchedulerInfo *info);
 
 /**
  * This function will be called when a new task is submitted by a worker for

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -148,7 +148,7 @@ void handle_object_removed(LocalSchedulerState *state, ObjectID object_id);
  */
 void handle_worker_available(LocalSchedulerState *state,
                              SchedulingAlgorithmState *algorithm_state,
-                             local_scheduler_client *worker);
+                             LocalSchedulerClient *worker);
 
 /**
  * This function is called when a worker is removed.
@@ -160,7 +160,7 @@ void handle_worker_available(LocalSchedulerState *state,
  */
 void handle_worker_removed(LocalSchedulerState *state,
                            SchedulingAlgorithmState *algorithm_state,
-                           local_scheduler_client *worker);
+                           LocalSchedulerClient *worker);
 
 /**
  * This version of handle_worker_available is called whenever the worker that is
@@ -173,7 +173,7 @@ void handle_worker_removed(LocalSchedulerState *state,
  */
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
-                                   local_scheduler_client *worker);
+                                   LocalSchedulerClient *worker);
 
 /**
  * Handle the fact that a new worker is available for running an actor.
@@ -187,7 +187,7 @@ void handle_actor_worker_available(LocalSchedulerState *state,
 void handle_actor_worker_connect(LocalSchedulerState *state,
                                  SchedulingAlgorithmState *algorithm_state,
                                  ActorID actor_id,
-                                 local_scheduler_client *worker);
+                                 LocalSchedulerClient *worker);
 
 /**
  * Handle the fact that a worker running an actor has disconnected.
@@ -212,7 +212,7 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
  */
 void handle_worker_blocked(LocalSchedulerState *state,
                            SchedulingAlgorithmState *algorithm_state,
-                           local_scheduler_client *worker);
+                           LocalSchedulerClient *worker);
 
 /**
  * This function is called when a worker that was blocked on an object that
@@ -225,7 +225,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
  */
 void handle_worker_unblocked(LocalSchedulerState *state,
                              SchedulingAlgorithmState *algorithm_state,
-                             local_scheduler_client *worker);
+                             LocalSchedulerClient *worker);
 
 /**
  * This function fetches queued task's missing object dependencies. It is

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -23,7 +23,7 @@
  *
  * @return State managed by the scheduling algorithm.
  */
-scheduling_algorithm_state *make_scheduling_algorithm_state(void);
+SchedulingAlgorithmState *SchedulingAlgorithmState_init(void);
 
 /**
  * Free the scheduler state.
@@ -31,14 +31,14 @@ scheduling_algorithm_state *make_scheduling_algorithm_state(void);
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @return Void.
  */
-void free_scheduling_algorithm_state(
-    scheduling_algorithm_state *algorithm_state);
+void SchedulingAlgorithmState_free(
+    SchedulingAlgorithmState *algorithm_state);
 
 /**
  *
  */
 void provide_scheduler_info(LocalSchedulerState *state,
-                            scheduling_algorithm_state *algorithm_state,
+                            SchedulingAlgorithmState *algorithm_state,
                             local_scheduler_info *info);
 
 /**
@@ -58,7 +58,7 @@ void provide_scheduler_info(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_task_submitted(LocalSchedulerState *state,
-                           scheduling_algorithm_state *algorithm_state,
+                           SchedulingAlgorithmState *algorithm_state,
                            task_spec *spec);
 
 /**
@@ -71,7 +71,7 @@ void handle_task_submitted(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_actor_task_submitted(LocalSchedulerState *state,
-                                 scheduling_algorithm_state *algorithm_state,
+                                 SchedulingAlgorithmState *algorithm_state,
                                  task_spec *spec);
 
 /**
@@ -86,7 +86,7 @@ void handle_actor_task_submitted(LocalSchedulerState *state,
  */
 void handle_actor_creation_notification(
     LocalSchedulerState *state,
-    scheduling_algorithm_state *algorithm_state,
+    SchedulingAlgorithmState *algorithm_state,
     ActorID actor_id);
 
 /**
@@ -99,7 +99,7 @@ void handle_actor_creation_notification(
  * @return Void.
  */
 void handle_task_scheduled(LocalSchedulerState *state,
-                           scheduling_algorithm_state *algorithm_state,
+                           SchedulingAlgorithmState *algorithm_state,
                            task_spec *spec);
 
 /**
@@ -113,7 +113,7 @@ void handle_task_scheduled(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_actor_task_scheduled(LocalSchedulerState *state,
-                                 scheduling_algorithm_state *algorithm_state,
+                                 SchedulingAlgorithmState *algorithm_state,
                                  task_spec *spec);
 
 /**
@@ -126,7 +126,7 @@ void handle_actor_task_scheduled(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_object_available(LocalSchedulerState *state,
-                             scheduling_algorithm_state *algorithm_state,
+                             SchedulingAlgorithmState *algorithm_state,
                              ObjectID object_id);
 
 /**
@@ -147,7 +147,7 @@ void handle_object_removed(LocalSchedulerState *state, ObjectID object_id);
  * @return Void.
  */
 void handle_worker_available(LocalSchedulerState *state,
-                             scheduling_algorithm_state *algorithm_state,
+                             SchedulingAlgorithmState *algorithm_state,
                              local_scheduler_client *worker);
 
 /**
@@ -172,7 +172,7 @@ void handle_worker_removed(local_scheduler_state *state,
  * @return Void.
  */
 void handle_actor_worker_available(LocalSchedulerState *state,
-                                   scheduling_algorithm_state *algorithm_state,
+                                   SchedulingAlgorithmState *algorithm_state,
                                    local_scheduler_client *worker);
 
 /**
@@ -185,7 +185,7 @@ void handle_actor_worker_available(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_actor_worker_connect(LocalSchedulerState *state,
-                                 scheduling_algorithm_state *algorithm_state,
+                                 SchedulingAlgorithmState *algorithm_state,
                                  ActorID actor_id,
                                  local_scheduler_client *worker);
 
@@ -198,7 +198,7 @@ void handle_actor_worker_connect(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_actor_worker_disconnect(LocalSchedulerState *state,
-                                    scheduling_algorithm_state *algorithm_state,
+                                    SchedulingAlgorithmState *algorithm_state,
                                     ActorID actor_id);
 
 /**
@@ -211,7 +211,7 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_worker_blocked(LocalSchedulerState *state,
-                           scheduling_algorithm_state *algorithm_state,
+                           SchedulingAlgorithmState *algorithm_state,
                            local_scheduler_client *worker);
 
 /**
@@ -224,7 +224,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
  * @return Void.
  */
 void handle_worker_unblocked(LocalSchedulerState *state,
-                             scheduling_algorithm_state *algorithm_state,
+                             SchedulingAlgorithmState *algorithm_state,
                              local_scheduler_client *worker);
 
 /**
@@ -248,7 +248,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context);
  * @return Void.
  */
 void print_worker_info(const char *message,
-                       scheduling_algorithm_state *algorithm_state);
+                       SchedulingAlgorithmState *algorithm_state);
 
 /** The following methods are for testing purposes only. */
 #ifdef PHOTON_TEST
@@ -259,7 +259,7 @@ void print_worker_info(const char *message,
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @return The number of tasks queued.
  */
-int num_waiting_tasks(scheduling_algorithm_state *algorithm_state);
+int num_waiting_tasks(SchedulingAlgorithmState *algorithm_state);
 
 /**
  * Get the number of tasks currently waiting for a worker to become available.
@@ -267,7 +267,7 @@ int num_waiting_tasks(scheduling_algorithm_state *algorithm_state);
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @return The number of tasks queued.
  */
-int num_dispatch_tasks(scheduling_algorithm_state *algorithm_state);
+int num_dispatch_tasks(SchedulingAlgorithmState *algorithm_state);
 #endif
 
 #endif /* PHOTON_ALGORITHM_H */

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -127,7 +127,7 @@ void handle_actor_task_scheduled(local_scheduler_state *state,
  */
 void handle_object_available(local_scheduler_state *state,
                              scheduling_algorithm_state *algorithm_state,
-                             object_id object_id);
+                             ObjectID object_id);
 
 /**
  * This function is called if an object is removed from the local plasma store.
@@ -136,7 +136,7 @@ void handle_object_available(local_scheduler_state *state,
  * @param object_id ID of the object that was removed.
  * @return Void.
  */
-void handle_object_removed(local_scheduler_state *state, object_id object_id);
+void handle_object_removed(local_scheduler_state *state, ObjectID object_id);
 
 /**
  * This function is called when a new worker becomes available.

--- a/src/photon/photon_algorithm.h
+++ b/src/photon/photon_algorithm.h
@@ -87,7 +87,7 @@ void handle_actor_task_submitted(local_scheduler_state *state,
 void handle_actor_creation_notification(
     local_scheduler_state *state,
     scheduling_algorithm_state *algorithm_state,
-    actor_id actor_id);
+    ActorID actor_id);
 
 /**
  * This function will be called when a task is assigned by the global scheduler
@@ -186,7 +186,7 @@ void handle_actor_worker_available(local_scheduler_state *state,
  */
 void handle_actor_worker_connect(local_scheduler_state *state,
                                  scheduling_algorithm_state *algorithm_state,
-                                 actor_id actor_id,
+                                 ActorID actor_id,
                                  local_scheduler_client *worker);
 
 /**
@@ -199,7 +199,7 @@ void handle_actor_worker_connect(local_scheduler_state *state,
  */
 void handle_actor_worker_disconnect(local_scheduler_state *state,
                                     scheduling_algorithm_state *algorithm_state,
-                                    actor_id actor_id);
+                                    ActorID actor_id);
 
 /**
  * This function is called when a worker that was executing a task becomes

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -4,8 +4,10 @@
 #include "common/task.h"
 #include <stdlib.h>
 
-photon_conn *photon_connect(const char *photon_socket, ActorID actor_id) {
-  photon_conn *result = (photon_conn *) malloc(sizeof(photon_conn));
+PhotonConnection *PhotonConnection_init(const char *photon_socket,
+                                        ActorID actor_id) {
+  PhotonConnection *result =
+      (PhotonConnection *) malloc(sizeof(PhotonConnection));
   result->conn = connect_ipc_sock_retry(photon_socket, -1, -1);
   register_worker_info info;
   memset(&info, 0, sizeof(info));
@@ -18,12 +20,12 @@ photon_conn *photon_connect(const char *photon_socket, ActorID actor_id) {
   return result;
 }
 
-void photon_disconnect(photon_conn *conn) {
+void PhotonConnection_free(PhotonConnection *conn) {
   close(conn->conn);
   free(conn);
 }
 
-void photon_log_event(photon_conn *conn,
+void photon_log_event(PhotonConnection *conn,
                       uint8_t *key,
                       int64_t key_length,
                       uint8_t *value,
@@ -45,12 +47,12 @@ void photon_log_event(photon_conn *conn,
   free(message);
 }
 
-void photon_submit(photon_conn *conn, task_spec *task) {
+void photon_submit(PhotonConnection *conn, task_spec *task) {
   write_message(conn->conn, SUBMIT_TASK, task_spec_size(task),
                 (uint8_t *) task);
 }
 
-task_spec *photon_get_task(photon_conn *conn) {
+task_spec *photon_get_task(PhotonConnection *conn) {
   write_message(conn->conn, GET_TASK, 0, NULL);
   int64_t type;
   int64_t length;
@@ -64,19 +66,19 @@ task_spec *photon_get_task(photon_conn *conn) {
   return task;
 }
 
-void photon_task_done(photon_conn *conn) {
+void photon_task_done(PhotonConnection *conn) {
   write_message(conn->conn, TASK_DONE, 0, NULL);
 }
 
-void photon_reconstruct_object(photon_conn *conn, ObjectID object_id) {
+void photon_reconstruct_object(PhotonConnection *conn, ObjectID object_id) {
   write_message(conn->conn, RECONSTRUCT_OBJECT, sizeof(object_id),
                 (uint8_t *) &object_id);
 }
 
-void photon_log_message(photon_conn *conn) {
+void photon_log_message(PhotonConnection *conn) {
   write_message(conn->conn, LOG_MESSAGE, 0, NULL);
 }
 
-void photon_notify_unblocked(photon_conn *conn) {
+void photon_notify_unblocked(PhotonConnection *conn) {
   write_message(conn->conn, NOTIFY_UNBLOCKED, 0, NULL);
 }

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -4,7 +4,7 @@
 #include "common/task.h"
 #include <stdlib.h>
 
-photon_conn *photon_connect(const char *photon_socket, actor_id actor_id) {
+photon_conn *photon_connect(const char *photon_socket, ActorID actor_id) {
   photon_conn *result = malloc(sizeof(photon_conn));
   result->conn = connect_ipc_sock_retry(photon_socket, -1, -1);
   register_worker_info info;

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 photon_conn *photon_connect(const char *photon_socket, ActorID actor_id) {
-  photon_conn *result = malloc(sizeof(photon_conn));
+  photon_conn *result = (photon_conn *) malloc(sizeof(photon_conn));
   result->conn = connect_ipc_sock_retry(photon_socket, -1, -1);
   register_worker_info info;
   memset(&info, 0, sizeof(info));
@@ -30,7 +30,7 @@ void photon_log_event(photon_conn *conn,
                       int64_t value_length) {
   int64_t message_length =
       sizeof(key_length) + sizeof(value_length) + key_length + value_length;
-  uint8_t *message = malloc(message_length);
+  uint8_t *message = (uint8_t *) malloc(message_length);
   int64_t offset = 0;
   memcpy(&message[offset], &key_length, sizeof(key_length));
   offset += sizeof(key_length);

--- a/src/photon/photon_client.c
+++ b/src/photon/photon_client.c
@@ -68,7 +68,7 @@ void photon_task_done(photon_conn *conn) {
   write_message(conn->conn, TASK_DONE, 0, NULL);
 }
 
-void photon_reconstruct_object(photon_conn *conn, object_id object_id) {
+void photon_reconstruct_object(photon_conn *conn, ObjectID object_id) {
   write_message(conn->conn, RECONSTRUCT_OBJECT, sizeof(object_id),
                 (uint8_t *) &object_id);
 }

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -7,7 +7,7 @@
 typedef struct {
   /* File descriptor of the Unix domain socket that connects to photon. */
   int conn;
-} photon_conn;
+} PhotonConnection;
 
 /**
  * Connect to the local scheduler.
@@ -18,15 +18,16 @@ typedef struct {
  *        running on this actor, this should be NIL_ACTOR_ID.
  * @return The connection information.
  */
-photon_conn *photon_connect(const char *photon_socket, ActorID actor_id);
+PhotonConnection *PhotonConnection_init(const char *photon_socket,
+                                        ActorID actor_id);
 
 /**
  * Disconnect from the local scheduler.
  *
- * @param conn Photon connection information returned by photon_connect.
+ * @param conn Photon connection information returned by PhotonConnection_init.
  * @return Void.
  */
-void photon_disconnect(photon_conn *conn);
+void PhotonConnection_free(PhotonConnection *conn);
 
 /**
  * Submit a task to the local scheduler.
@@ -35,7 +36,7 @@ void photon_disconnect(photon_conn *conn);
  * @param task The address of the task to submit.
  * @return Void.
  */
-void photon_submit(photon_conn *conn, task_spec *task);
+void photon_submit(PhotonConnection *conn, task_spec *task);
 
 /**
  * Log an event to the event log. This will call RPUSH key value. We use RPUSH
@@ -50,7 +51,7 @@ void photon_submit(photon_conn *conn, task_spec *task);
  * @param value_length The length of the value.
  * @return Void.
  */
-void photon_log_event(photon_conn *conn,
+void photon_log_event(PhotonConnection *conn,
                       uint8_t *key,
                       int64_t key_length,
                       uint8_t *value,
@@ -66,7 +67,7 @@ void photon_log_event(photon_conn *conn,
  * @param conn The connection information.
  * @return The address of the assigned task.
  */
-task_spec *photon_get_task(photon_conn *conn);
+task_spec *photon_get_task(PhotonConnection *conn);
 
 /**
  * Tell the local scheduler that the client has finished executing a task.
@@ -74,7 +75,7 @@ task_spec *photon_get_task(photon_conn *conn);
  * @param conn The connection information.
  * @return Void.
  */
-void photon_task_done(photon_conn *conn);
+void photon_task_done(PhotonConnection *conn);
 
 /**
  * Tell the local scheduler to reconstruct an object.
@@ -83,7 +84,7 @@ void photon_task_done(photon_conn *conn);
  * @param object_id The ID of the object to reconstruct.
  * @return Void.
  */
-void photon_reconstruct_object(photon_conn *conn, ObjectID object_id);
+void photon_reconstruct_object(PhotonConnection *conn, ObjectID object_id);
 
 /**
  * Send a log message to the local scheduler.
@@ -91,7 +92,7 @@ void photon_reconstruct_object(photon_conn *conn, ObjectID object_id);
  * @param conn The connection information.
  * @return Void.
  */
-void photon_log_message(photon_conn *conn);
+void photon_log_message(PhotonConnection *conn);
 
 /**
  * Notify the local scheduler that this client (worker) is no longer blocked.
@@ -99,6 +100,6 @@ void photon_log_message(photon_conn *conn);
  * @param conn The connection information.
  * @return Void.
  */
-void photon_notify_unblocked(photon_conn *conn);
+void photon_notify_unblocked(PhotonConnection *conn);
 
 #endif

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -18,7 +18,7 @@ typedef struct {
  *        running on this actor, this should be NIL_ACTOR_ID.
  * @return The connection information.
  */
-photon_conn *photon_connect(const char *photon_socket, actor_id actor_id);
+photon_conn *photon_connect(const char *photon_socket, ActorID actor_id);
 
 /**
  * Disconnect from the local scheduler.

--- a/src/photon/photon_client.h
+++ b/src/photon/photon_client.h
@@ -83,7 +83,7 @@ void photon_task_done(photon_conn *conn);
  * @param object_id The ID of the object to reconstruct.
  * @return Void.
  */
-void photon_reconstruct_object(photon_conn *conn, object_id object_id);
+void photon_reconstruct_object(photon_conn *conn, ObjectID object_id);
 
 /**
  * Send a log message to the local scheduler.

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -17,7 +17,7 @@ static int PyPhotonClient_init(PyPhotonClient *self,
                                PyObject *args,
                                PyObject *kwds) {
   char *socket_name;
-  actor_id actor_id;
+  ActorID actor_id;
   if (!PyArg_ParseTuple(args, "sO&", &socket_name, PyStringToUniqueID,
                         &actor_id)) {
     return -1;

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -9,7 +9,7 @@ PyObject *PhotonError;
 // clang-format off
 typedef struct {
   PyObject_HEAD
-  photon_conn *photon_connection;
+  PhotonConnection *photon_connection;
 } PyPhotonClient;
 // clang-format on
 
@@ -23,12 +23,12 @@ static int PyPhotonClient_init(PyPhotonClient *self,
     return -1;
   }
   /* Connect to the Photon scheduler. */
-  self->photon_connection = photon_connect(socket_name, actor_id);
+  self->photon_connection = PhotonConnection_init(socket_name, actor_id);
   return 0;
 }
 
 static void PyPhotonClient_dealloc(PyPhotonClient *self) {
-  photon_disconnect(((PyPhotonClient *) self)->photon_connection);
+  PhotonConnection_free(((PyPhotonClient *) self)->photon_connection);
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 

--- a/src/photon/photon_extension.c
+++ b/src/photon/photon_extension.c
@@ -56,7 +56,7 @@ static PyObject *PyPhotonClient_get_task(PyObject *self) {
 
 static PyObject *PyPhotonClient_reconstruct_object(PyObject *self,
                                                    PyObject *args) {
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&", PyStringToUniqueID, &object_id)) {
     return NULL;
   }

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -201,7 +201,7 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   }
 
   /* Free the algorithm state. */
-  free_scheduling_algorithm_state(state->algorithm_state);
+  SchedulingAlgorithmState_free(state->algorithm_state);
   state->algorithm_state = NULL;
   /* Free the input buffer. */
   utarray_free(state->input_buffer);
@@ -380,7 +380,7 @@ LocalSchedulerState *LocalSchedulerState_init(
   event_loop_add_file(loop, plasma_fd, EVENT_LOOP_READ,
                       process_plasma_notification, state);
   /* Add scheduler state. */
-  state->algorithm_state = make_scheduling_algorithm_state();
+  state->algorithm_state = SchedulingAlgorithmState_init();
   /* Add the input buffer. This is used to read in messages from clients without
    * having to reallocate a new buffer every time. */
   utarray_new(state->input_buffer, &byte_icd);
@@ -847,7 +847,7 @@ void handle_actor_creation_callback(actor_info info, void *context) {
 
 int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerState *state = context;
-  scheduling_algorithm_state *algorithm_state = state->algorithm_state;
+  SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   local_scheduler_info info;
   /* Ask the scheduling algorithm to fill out the scheduler info struct. */
   provide_scheduler_info(state, algorithm_state, &info);

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -504,13 +504,13 @@ void reconstruct_task_update_callback(task *task, void *user_context) {
   /* Recursively reconstruct the task's inputs, if necessary. */
   for (int64_t i = 0; i < task_num_args(spec); ++i) {
     if (task_arg_type(spec, i) == ARG_BY_REF) {
-      object_id arg_id = task_arg_id(spec, i);
+      ObjectID arg_id = task_arg_id(spec, i);
       reconstruct_object(state, arg_id);
     }
   }
 }
 
-void reconstruct_evicted_result_lookup_callback(object_id reconstruct_object_id,
+void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
                                                 task_id task_id,
                                                 void *user_context) {
   /* TODO(swang): The following check will fail if an object was created by a
@@ -549,7 +549,7 @@ void reconstruct_failed_result_lookup_callback(object_id reconstruct_object_id,
                              reconstruct_task_update_callback, state);
 }
 
-void reconstruct_object_lookup_callback(object_id reconstruct_object_id,
+void reconstruct_object_lookup_callback(ObjectID reconstruct_object_id,
                                         int manager_count,
                                         const char *manager_vector[],
                                         void *user_context) {
@@ -575,7 +575,7 @@ void reconstruct_object_lookup_callback(object_id reconstruct_object_id,
 }
 
 void reconstruct_object(local_scheduler_state *state,
-                        object_id reconstruct_object_id) {
+                        ObjectID reconstruct_object_id) {
   LOG_DEBUG("Starting reconstruction");
   /* TODO(swang): Track task lineage for puts. */
   CHECK(state->db != NULL);
@@ -726,7 +726,7 @@ void process_message(event_loop *loop,
         print_worker_info("Reconstructing", state->algorithm_state);
       }
     }
-    object_id *obj_id = (object_id *) utarray_front(state->input_buffer);
+    ObjectID *obj_id = (ObjectID *) utarray_front(state->input_buffer);
     reconstruct_object(state, *obj_id);
   } break;
   case DISCONNECT_CLIENT: {

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -36,7 +36,7 @@ UT_icd byte_icd = {sizeof(uint8_t), NULL, NULL, NULL};
  * @param spec Task specification object.
  * @return Void.
  */
-void print_resource_info(const local_scheduler_state *state,
+void print_resource_info(const LocalSchedulerState *state,
                          const task_spec *spec) {
 #if RAY_COMMON_LOG_LEVEL <= RAY_COMMON_DEBUG
   /* Print information about available and requested resources. */
@@ -78,7 +78,7 @@ int force_kill_worker(event_loop *loop, timer_id id, void *context) {
  */
 void kill_worker(local_scheduler_client *worker, bool cleanup) {
   /* Erase the local scheduler's reference to the worker. */
-  local_scheduler_state *state = worker->local_scheduler_state;
+  LocalSchedulerState *state = worker->local_scheduler_state;
   int num_workers = utarray_len(state->workers);
   for (int i = 0; i < utarray_len(state->workers); ++i) {
     local_scheduler_client *active_worker =
@@ -144,7 +144,7 @@ void kill_worker(local_scheduler_client *worker, bool cleanup) {
   }
 }
 
-void free_local_scheduler(local_scheduler_state *state) {
+void LocalSchedulerState_free(LocalSchedulerState *state) {
   /* Free the command for starting new workers. */
   if (state->config.start_worker_command != NULL) {
     int i = 0;
@@ -219,7 +219,7 @@ void free_local_scheduler(local_scheduler_state *state) {
  * @param state The state of the local scheduler.
  * @return Void.
  */
-void start_worker(local_scheduler_state *state, ActorID actor_id) {
+void start_worker(LocalSchedulerState *state, ActorID actor_id) {
   /* We can't start a worker if we don't have the path to the worker script. */
   if (state->config.start_worker_command == NULL) {
     LOG_WARN("No valid command to start worker provided. Cannot start worker.");
@@ -251,7 +251,7 @@ void start_worker(local_scheduler_state *state, ActorID actor_id) {
   execvp(start_actor_worker_command[0],
          (char *const *) start_actor_worker_command);
   free(start_actor_worker_command);
-  free_local_scheduler(state);
+  LocalSchedulerState_free(state);
   LOG_FATAL("Failed to start worker");
 }
 
@@ -296,7 +296,7 @@ const char **parse_command(const char *command) {
   return command_args;
 }
 
-local_scheduler_state *init_local_scheduler(
+LocalSchedulerState *LocalSchedulerState_init(
     const char *node_ip_address,
     event_loop *loop,
     const char *redis_addr,
@@ -309,7 +309,7 @@ local_scheduler_state *init_local_scheduler(
     const double static_resource_conf[],
     const char *start_worker_command,
     int num_workers) {
-  local_scheduler_state *state = malloc(sizeof(local_scheduler_state));
+  LocalSchedulerState *state = malloc(sizeof(LocalSchedulerState));
   /* Set the configuration struct for the local scheduler. */
   if (start_worker_command != NULL) {
     state->config.start_worker_command = parse_command(start_worker_command);
@@ -402,7 +402,7 @@ local_scheduler_state *init_local_scheduler(
   return state;
 }
 
-void update_dynamic_resources(local_scheduler_state *state,
+void update_dynamic_resources(LocalSchedulerState *state,
                               task_spec *spec,
                               bool return_resources) {
   for (int i = 0; i < MAX_RESOURCE_INDEX; ++i) {
@@ -425,7 +425,7 @@ void update_dynamic_resources(local_scheduler_state *state,
   print_resource_info(state, spec);
 }
 
-void assign_task_to_worker(local_scheduler_state *state,
+void assign_task_to_worker(LocalSchedulerState *state,
                            task_spec *spec,
                            local_scheduler_client *worker) {
   if (write_message(worker->sock, EXECUTE_TASK, task_spec_size(spec),
@@ -463,7 +463,7 @@ void process_plasma_notification(event_loop *loop,
                                  int client_sock,
                                  void *context,
                                  int events) {
-  local_scheduler_state *state = context;
+  LocalSchedulerState *state = context;
   /* Read the notification from Plasma. */
   object_info object_info;
   int error =
@@ -494,7 +494,7 @@ void reconstruct_task_update_callback(task *task, void *user_context) {
   }
   /* Otherwise, the test-and-set succeeded, so resubmit the task for execution
    * to ensure that reconstruction will happen. */
-  local_scheduler_state *state = user_context;
+  LocalSchedulerState *state = user_context;
   task_spec *spec = task_task_spec(task);
   /* If the task is an actor task, then we currently do not reconstruct it.
    * TODO(rkn): Handle this better. */
@@ -517,7 +517,7 @@ void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
    * put. */
   CHECKM(!IS_NIL_ID(task_id),
          "No task information found for object during reconstruction");
-  local_scheduler_state *state = user_context;
+  LocalSchedulerState *state = user_context;
   /* If there are no other instances of the task running, it's safe for us to
    * claim responsibility for reconstruction. */
   task_table_test_and_update(state->db, task_id,
@@ -526,8 +526,8 @@ void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
                              reconstruct_task_update_callback, state);
 }
 
-void reconstruct_failed_result_lookup_callback(object_id reconstruct_object_id,
-                                               task_id task_id,
+void reconstruct_failed_result_lookup_callback(ObjectID reconstruct_object_id,
+                                               TaskID task_id,
                                                void *user_context) {
   /* TODO(swang): The following check will fail if an object was created by a
    * put. */
@@ -557,7 +557,7 @@ void reconstruct_object_lookup_callback(ObjectID reconstruct_object_id,
   /* Only continue reconstruction if we find that the object doesn't exist on
    * any nodes. NOTE: This codepath is not responsible for checking if the
    * object table entry is up-to-date. */
-  local_scheduler_state *state = user_context;
+  LocalSchedulerState *state = user_context;
   /* Look up the task that created the object in the result table. */
   if (manager_count == 0) {
     /* If the object was created and later evicted, we reconstruct the object
@@ -574,7 +574,7 @@ void reconstruct_object_lookup_callback(ObjectID reconstruct_object_id,
   }
 }
 
-void reconstruct_object(local_scheduler_state *state,
+void reconstruct_object(LocalSchedulerState *state,
                         ObjectID reconstruct_object_id) {
   LOG_DEBUG("Starting reconstruction");
   /* TODO(swang): Track task lineage for puts. */
@@ -590,7 +590,7 @@ void process_message(event_loop *loop,
                      void *context,
                      int events) {
   local_scheduler_client *worker = context;
-  local_scheduler_state *state = worker->local_scheduler_state;
+  LocalSchedulerState *state = worker->local_scheduler_state;
 
   int64_t type;
   int64_t length = read_buffer(client_sock, &type, state->input_buffer);
@@ -762,7 +762,7 @@ void new_client_connection(event_loop *loop,
                            int listener_sock,
                            void *context,
                            int events) {
-  local_scheduler_state *state = context;
+  LocalSchedulerState *state = context;
   int new_socket = accept_client(listener_sock);
   /* Create a struct for this worker. This will be freed when we free the local
    * scheduler state. */
@@ -782,12 +782,12 @@ void new_client_connection(event_loop *loop,
 
 /* We need this code so we can clean up when we get a SIGTERM signal. */
 
-local_scheduler_state *g_state;
+LocalSchedulerState *g_state;
 
 void signal_handler(int signal) {
   LOG_DEBUG("Signal was %d", signal);
   if (signal == SIGTERM) {
-    free_local_scheduler(g_state);
+    LocalSchedulerState_free(g_state);
     exit(0);
   }
 }
@@ -820,7 +820,7 @@ void handle_task_scheduled_callback(task *original_task, void *user_context) {
 void handle_actor_creation_callback(actor_info info, void *context) {
   ActorID actor_id = info.actor_id;
   db_client_id local_scheduler_id = info.local_scheduler_id;
-  local_scheduler_state *state = context;
+  LocalSchedulerState *state = context;
   /* Make sure the actor entry is not already present in the actor map table.
    * TODO(rkn): We will need to remove this check to handle the case where the
    * corresponding publish is retried and the case in which a task that creates
@@ -846,7 +846,7 @@ void handle_actor_creation_callback(actor_info info, void *context) {
 }
 
 int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
-  local_scheduler_state *state = context;
+  LocalSchedulerState *state = context;
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   local_scheduler_info info;
   /* Ask the scheduling algorithm to fill out the scheduler info struct. */
@@ -873,7 +873,7 @@ void start_server(const char *node_ip_address,
   signal(SIGPIPE, SIG_IGN);
   int fd = bind_ipc_sock(socket_name, true);
   event_loop *loop = event_loop_create();
-  g_state = init_local_scheduler(
+  g_state = LocalSchedulerState_init(
       node_ip_address, loop, redis_addr, redis_port, socket_name,
       plasma_store_socket_name, plasma_manager_socket_name,
       plasma_manager_address, global_scheduler_exists, static_resource_conf,

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -657,7 +657,7 @@ void process_message(event_loop *loop,
                 sizeof(info->actor_id), entry);
       CHECK(entry != NULL);
       CHECK(DBClientID_equal(entry->local_scheduler_id,
-                                get_db_client_id(state->db)));
+                             get_db_client_id(state->db)));
       /* Update the worker struct with this actor ID. */
       CHECK(ActorID_equal(worker->actor_id, NIL_ACTOR_ID));
       worker->actor_id = info->actor_id;

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -639,7 +639,7 @@ void process_message(event_loop *loop,
     offset += value_length;
     CHECK(offset == length);
     if (state->db != NULL) {
-      ray_log_event(state->db, key, key_length, value, value_length);
+      RayLogger_log_event(state->db, key, key_length, value, value_length);
     }
     free(key);
     free(value);

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -22,7 +22,7 @@
 #include "utarray.h"
 #include "uthash.h"
 
-UT_icd task_ptr_icd = {sizeof(task *), NULL, NULL, NULL};
+UT_icd task_ptr_icd = {sizeof(Task *), NULL, NULL, NULL};
 UT_icd workers_icd = {sizeof(local_scheduler_client *), NULL, NULL, NULL};
 
 UT_icd pid_t_icd = {sizeof(pid_t), NULL, NULL, NULL};
@@ -445,7 +445,7 @@ void assign_task_to_worker(LocalSchedulerState *state,
   /* Resource accounting:
    * Update dynamic resource vector in the local scheduler state. */
   update_dynamic_resources(state, spec, false);
-  task *task = alloc_task(spec, TASK_STATUS_RUNNING,
+  Task *task = alloc_task(spec, TASK_STATUS_RUNNING,
                           state->db ? get_db_client_id(state->db) : NIL_ID);
   /* Record which task this worker is executing. This will be freed in
    * process_message when the worker sends a GET_TASK message to the local
@@ -485,7 +485,7 @@ void process_plasma_notification(event_loop *loop,
   }
 }
 
-void reconstruct_task_update_callback(task *task, void *user_context) {
+void reconstruct_task_update_callback(Task *task, void *user_context) {
   if (task == NULL) {
     /* The test-and-set of the task's scheduling state failed, so the task was
      * either not finished yet, or it was already being reconstructed.
@@ -794,7 +794,7 @@ void signal_handler(int signal) {
 
 /* End of the cleanup code. */
 
-void handle_task_scheduled_callback(task *original_task, void *user_context) {
+void handle_task_scheduled_callback(Task *original_task, void *user_context) {
   task_spec *spec = task_task_spec(original_task);
   if (actor_ids_equal(task_spec_actor_id(spec), NIL_ACTOR_ID)) {
     /* This task does not involve an actor. Handle it normally. */

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -817,7 +817,7 @@ void handle_task_scheduled_callback(Task *original_task, void *user_context) {
  *        for creating the actor.
  * @return Void.
  */
-void handle_actor_creation_callback(actor_info info, void *context) {
+void handle_actor_creation_callback(ActorInfo info, void *context) {
   ActorID actor_id = info.actor_id;
   DBClientID local_scheduler_id = info.local_scheduler_id;
   LocalSchedulerState *state = context;

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -465,7 +465,7 @@ void process_plasma_notification(event_loop *loop,
                                  int events) {
   LocalSchedulerState *state = context;
   /* Read the notification from Plasma. */
-  object_info object_info;
+  ObjectInfo object_info;
   int error =
       read_bytes(client_sock, (uint8_t *) &object_info, sizeof(object_info));
   if (error < 0) {

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -848,7 +848,7 @@ void handle_actor_creation_callback(actor_info info, void *context) {
 int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerState *state = context;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
-  local_scheduler_info info;
+  LocalSchedulerInfo info;
   /* Ask the scheduling algorithm to fill out the scheduler info struct. */
   provide_scheduler_info(state, algorithm_state, &info);
   /* Publish the heartbeat to all subscribers of the local scheduler table. */

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -541,7 +541,7 @@ void reconstruct_failed_result_lookup_callback(ObjectID reconstruct_object_id,
         "entry yet)");
     return;
   }
-  local_scheduler_state *state = user_context;
+  LocalSchedulerState *state = user_context;
   /* If the task failed to finish, it's safe for us to claim responsibility for
    * reconstruction. */
   task_table_test_and_update(state->db, task_id, TASK_STATUS_LOST,
@@ -603,9 +603,9 @@ void process_message(event_loop *loop,
     /* Update the result table, which holds mappings of object ID -> ID of the
      * task that created it. */
     if (state->db != NULL) {
-      task_id task_id = task_spec_id(spec);
+      TaskID task_id = task_spec_id(spec);
       for (int64_t i = 0; i < task_num_returns(spec); ++i) {
-        object_id return_id = task_return(spec, i);
+        ObjectID return_id = task_return(spec, i);
         result_table_add(state->db, return_id, task_id, NULL, NULL, NULL);
       }
     }

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -219,7 +219,7 @@ void free_local_scheduler(local_scheduler_state *state) {
  * @param state The state of the local scheduler.
  * @return Void.
  */
-void start_worker(local_scheduler_state *state, actor_id actor_id) {
+void start_worker(local_scheduler_state *state, ActorID actor_id) {
   /* We can't start a worker if we don't have the path to the worker script. */
   if (state->config.start_worker_command == NULL) {
     LOG_WARN("No valid command to start worker provided. Cannot start worker.");
@@ -511,7 +511,7 @@ void reconstruct_task_update_callback(task *task, void *user_context) {
 }
 
 void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
-                                                task_id task_id,
+                                                TaskID task_id,
                                                 void *user_context) {
   /* TODO(swang): The following check will fail if an object was created by a
    * put. */
@@ -818,7 +818,7 @@ void handle_task_scheduled_callback(task *original_task, void *user_context) {
  * @return Void.
  */
 void handle_actor_creation_callback(actor_info info, void *context) {
-  actor_id actor_id = info.actor_id;
+  ActorID actor_id = info.actor_id;
   db_client_id local_scheduler_id = info.local_scheduler_id;
   local_scheduler_state *state = context;
   /* Make sure the actor entry is not already present in the actor map table.

--- a/src/photon/photon_scheduler.c
+++ b/src/photon/photon_scheduler.c
@@ -819,7 +819,7 @@ void handle_task_scheduled_callback(task *original_task, void *user_context) {
  */
 void handle_actor_creation_callback(actor_info info, void *context) {
   ActorID actor_id = info.actor_id;
-  db_client_id local_scheduler_id = info.local_scheduler_id;
+  DBClientID local_scheduler_id = info.local_scheduler_id;
   LocalSchedulerState *state = context;
   /* Make sure the actor entry is not already present in the actor map table.
    * TODO(rkn): We will need to remove this check to handle the case where the

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -40,7 +40,7 @@ void new_client_connection(event_loop *loop,
  */
 void assign_task_to_worker(LocalSchedulerState *state,
                            task_spec *task,
-                           local_scheduler_client *worker);
+                           LocalSchedulerClient *worker);
 
 /**
  * This is the callback that is used to process a notification from the Plasma
@@ -79,7 +79,7 @@ void print_resource_info(const LocalSchedulerState *s, const task_spec *spec);
  *        exit.
  * @param Void.
  */
-void kill_worker(local_scheduler_client *worker, bool wait);
+void kill_worker(LocalSchedulerClient *worker, bool wait);
 
 /**
  * Start a worker. This forks a new worker process that can be added to the

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -127,7 +127,7 @@ LocalSchedulerState *LocalSchedulerState_init(
 
 void LocalSchedulerState_free(LocalSchedulerState *state);
 
-scheduling_algorithm_state *get_algorithm_state(LocalSchedulerState *state);
+SchedulingAlgorithmState *get_algorithm_state(LocalSchedulerState *state);
 
 void process_message(event_loop *loop,
                      int client_sock,

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -91,7 +91,7 @@ void kill_worker(local_scheduler_client *worker, bool wait);
  *        actor, then NIL_ACTOR_ID should be used.
  * @param Void.
  */
-void start_worker(local_scheduler_state *state, actor_id actor_id);
+void start_worker(local_scheduler_state *state, ActorID actor_id);
 
 /**
  * Update our accounting for the current resources being used, according to

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -38,7 +38,7 @@ void new_client_connection(event_loop *loop,
  * @param worker The worker to assign the task to.
  * @return Void.
  */
-void assign_task_to_worker(local_scheduler_state *state,
+void assign_task_to_worker(LocalSchedulerState *state,
                            task_spec *task,
                            local_scheduler_client *worker);
 
@@ -67,9 +67,9 @@ void process_plasma_notification(event_loop *loop,
  * @param object_id The ID of the object to reconstruct.
  * @return Void.
  */
-void reconstruct_object(local_scheduler_state *state, ObjectID object_id);
+void reconstruct_object(LocalSchedulerState *state, ObjectID object_id);
 
-void print_resource_info(const local_scheduler_state *s, const task_spec *spec);
+void print_resource_info(const LocalSchedulerState *s, const task_spec *spec);
 
 /**
  * Kill a worker.
@@ -91,7 +91,7 @@ void kill_worker(local_scheduler_client *worker, bool wait);
  *        actor, then NIL_ACTOR_ID should be used.
  * @param Void.
  */
-void start_worker(local_scheduler_state *state, ActorID actor_id);
+void start_worker(LocalSchedulerState *state, ActorID actor_id);
 
 /**
  * Update our accounting for the current resources being used, according to
@@ -105,13 +105,13 @@ void start_worker(local_scheduler_state *state, ActorID actor_id);
  *        available. Else, it will take from the dynamic resources available.
  * @return Void.
  */
-void update_dynamic_resources(local_scheduler_state *state,
+void update_dynamic_resources(LocalSchedulerState *state,
                               task_spec *spec,
                               bool return_resources);
 
 /** The following methods are for testing purposes only. */
 #ifdef PHOTON_TEST
-local_scheduler_state *init_local_scheduler(
+LocalSchedulerState *LocalSchedulerState_init(
     const char *node_ip_address,
     event_loop *loop,
     const char *redis_addr,
@@ -125,9 +125,9 @@ local_scheduler_state *init_local_scheduler(
     const char *worker_path,
     int num_workers);
 
-void free_local_scheduler(local_scheduler_state *state);
+void LocalSchedulerState_free(LocalSchedulerState *state);
 
-scheduling_algorithm_state *get_algorithm_state(local_scheduler_state *state);
+scheduling_algorithm_state *get_algorithm_state(LocalSchedulerState *state);
 
 void process_message(event_loop *loop,
                      int client_sock,

--- a/src/photon/photon_scheduler.h
+++ b/src/photon/photon_scheduler.h
@@ -67,7 +67,7 @@ void process_plasma_notification(event_loop *loop,
  * @param object_id The ID of the object to reconstruct.
  * @return Void.
  */
-void reconstruct_object(local_scheduler_state *state, object_id object_id);
+void reconstruct_object(local_scheduler_state *state, ObjectID object_id);
 
 void print_resource_info(const local_scheduler_state *s, const task_spec *spec);
 

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -41,7 +41,7 @@ typedef struct {
   /** Photon's socket for IPC requests. */
   int photon_fd;
   /** Photon's local scheduler state. */
-  local_scheduler_state *photon_state;
+  LocalSchedulerState *photon_state;
   /** Photon's event loop. */
   event_loop *loop;
   /** Number of Photon client connections, or mock workers. */
@@ -79,7 +79,7 @@ photon_mock *init_photon_mock(int num_workers, int num_mock_workers) {
                   utstring_body(plasma_manager_socket_name),
                   utstring_body(photon_socket_name), redis_addr, redis_port);
 
-  mock->photon_state = init_local_scheduler(
+  mock->photon_state = LocalSchedulerState_init(
       "127.0.0.1", mock->loop, redis_addr, redis_port,
       utstring_body(photon_socket_name), plasma_store_socket_name,
       utstring_body(plasma_manager_socket_name), NULL, false,
@@ -127,7 +127,7 @@ void destroy_photon_mock(photon_mock *mock) {
   event_loop_run(mock->loop);
 
   /* This also frees mock->loop. */
-  free_local_scheduler(mock->photon_state);
+  LocalSchedulerState_free(mock->photon_state);
   close(mock->plasma_store_fd);
   close(mock->plasma_manager_fd);
   free(mock);
@@ -374,7 +374,7 @@ TEST object_reconstruction_suppression_test(void) {
 
 TEST task_dependency_test(void) {
   photon_mock *photon = init_photon_mock(0, 1);
-  local_scheduler_state *state = photon->photon_state;
+  LocalSchedulerState *state = photon->photon_state;
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
   local_scheduler_client *worker =
@@ -449,7 +449,7 @@ TEST task_dependency_test(void) {
 
 TEST task_multi_dependency_test(void) {
   photon_mock *photon = init_photon_mock(0, 1);
-  local_scheduler_state *state = photon->photon_state;
+  LocalSchedulerState *state = photon->photon_state;
   scheduling_algorithm_state *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
   local_scheduler_client *worker =

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -189,7 +189,7 @@ TEST object_reconstruction_test(void) {
     event_loop_run(photon->loop);
     /* Set the task's status to TASK_STATUS_DONE to prevent the race condition
      * that would suppress object reconstruction. */
-    task *task = alloc_task(spec, TASK_STATUS_DONE,
+    Task *task = alloc_task(spec, TASK_STATUS_DONE,
                             get_db_client_id(photon->photon_state->db));
     task_table_add_task(photon->photon_state->db, task, NULL, NULL, NULL);
     /* Trigger reconstruction, and run the event loop again. */
@@ -287,7 +287,7 @@ TEST object_reconstruction_recursive_test(void) {
     event_loop_run(photon->loop);
     /* Set the final task's status to TASK_STATUS_DONE to prevent the race
      * condition that would suppress object reconstruction. */
-    task *last_task = alloc_task(specs[NUM_TASKS - 1], TASK_STATUS_DONE,
+    Task *last_task = alloc_task(specs[NUM_TASKS - 1], TASK_STATUS_DONE,
                                  get_db_client_id(photon->photon_state->db));
     task_table_add_task(photon->photon_state->db, last_task, NULL, NULL, NULL);
     /* Trigger reconstruction for the last object, and run the event loop

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -115,8 +115,8 @@ void PhotonMock_free(PhotonMock *mock) {
 
   /* Kill all the workers and run the event loop again so that the task table
    * updates propagate and the tasks in progress are freed. */
-  LocalSchedulerClient **worker = (LocalSchedulerClient **) utarray_eltptr(
-      mock->photon_state->workers, 0);
+  LocalSchedulerClient **worker =
+      (LocalSchedulerClient **) utarray_eltptr(mock->photon_state->workers, 0);
   while (worker != NULL) {
     kill_worker(*worker, true);
     worker = (LocalSchedulerClient **) utarray_eltptr(
@@ -349,7 +349,7 @@ TEST object_reconstruction_suppression_test(void) {
     /* Connect a plasma manager client so we can call object_table_add. */
     const char *db_connect_args[] = {"address", "127.0.0.1:12346"};
     DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
-                               2, db_connect_args);
+                              2, db_connect_args);
     db_attach(db, photon->loop, false);
     /* Add the object to the object table. */
     object_table_add(db, return_id, 1, (unsigned char *) NIL_DIGEST, NULL,
@@ -545,9 +545,8 @@ TEST start_kill_workers_test(void) {
 
   /* Each worker should register its process ID. */
   for (int i = 0; i < utarray_len(photon->photon_state->workers); ++i) {
-    LocalSchedulerClient *worker =
-        *(LocalSchedulerClient **) utarray_eltptr(
-            photon->photon_state->workers, i);
+    LocalSchedulerClient *worker = *(LocalSchedulerClient **) utarray_eltptr(
+        photon->photon_state->workers, i);
     process_message(photon->photon_state->loop, worker->sock, worker, 0);
   }
   ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -375,7 +375,7 @@ TEST object_reconstruction_suppression_test(void) {
 TEST task_dependency_test(void) {
   photon_mock *photon = init_photon_mock(0, 1);
   LocalSchedulerState *state = photon->photon_state;
-  scheduling_algorithm_state *algorithm_state = state->algorithm_state;
+  SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
   local_scheduler_client *worker =
       *((local_scheduler_client **) utarray_eltptr(state->workers, 0));
@@ -450,7 +450,7 @@ TEST task_dependency_test(void) {
 TEST task_multi_dependency_test(void) {
   photon_mock *photon = init_photon_mock(0, 1);
   LocalSchedulerState *state = photon->photon_state;
-  scheduling_algorithm_state *algorithm_state = state->algorithm_state;
+  SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
   local_scheduler_client *worker =
       *((local_scheduler_client **) utarray_eltptr(state->workers, 0));

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -115,11 +115,11 @@ void destroy_photon_mock(photon_mock *mock) {
 
   /* Kill all the workers and run the event loop again so that the task table
    * updates propagate and the tasks in progress are freed. */
-  local_scheduler_client **worker = (local_scheduler_client **) utarray_eltptr(
+  LocalSchedulerClient **worker = (LocalSchedulerClient **) utarray_eltptr(
       mock->photon_state->workers, 0);
   while (worker != NULL) {
     kill_worker(*worker, true);
-    worker = (local_scheduler_client **) utarray_eltptr(
+    worker = (LocalSchedulerClient **) utarray_eltptr(
         mock->photon_state->workers, 0);
   }
   event_loop_add_timer(mock->loop, 500,
@@ -133,7 +133,7 @@ void destroy_photon_mock(photon_mock *mock) {
   free(mock);
 }
 
-void reset_worker(photon_mock *mock, local_scheduler_client *worker) {
+void reset_worker(photon_mock *mock, LocalSchedulerClient *worker) {
   if (worker->task_in_progress) {
     free_task(worker->task_in_progress);
     worker->task_in_progress = NULL;
@@ -377,8 +377,8 @@ TEST task_dependency_test(void) {
   LocalSchedulerState *state = photon->photon_state;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
-  local_scheduler_client *worker =
-      *((local_scheduler_client **) utarray_eltptr(state->workers, 0));
+  LocalSchedulerClient *worker =
+      *((LocalSchedulerClient **) utarray_eltptr(state->workers, 0));
   task_spec *spec = example_task_spec(1, 1);
   ObjectID oid = task_arg_id(spec, 0);
 
@@ -452,8 +452,8 @@ TEST task_multi_dependency_test(void) {
   LocalSchedulerState *state = photon->photon_state;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
-  local_scheduler_client *worker =
-      *((local_scheduler_client **) utarray_eltptr(state->workers, 0));
+  LocalSchedulerClient *worker =
+      *((LocalSchedulerClient **) utarray_eltptr(state->workers, 0));
   task_spec *spec = example_task_spec(2, 1);
   ObjectID oid1 = task_arg_id(spec, 0);
   ObjectID oid2 = task_arg_id(spec, 1);
@@ -545,8 +545,8 @@ TEST start_kill_workers_test(void) {
 
   /* Each worker should register its process ID. */
   for (int i = 0; i < utarray_len(photon->photon_state->workers); ++i) {
-    local_scheduler_client *worker =
-        *(local_scheduler_client **) utarray_eltptr(
+    LocalSchedulerClient *worker =
+        *(LocalSchedulerClient **) utarray_eltptr(
             photon->photon_state->workers, i);
     process_message(photon->photon_state->loop, worker->sock, worker, 0);
   }
@@ -554,7 +554,7 @@ TEST start_kill_workers_test(void) {
   ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
 
   /* After killing a worker, its state is cleaned up. */
-  local_scheduler_client *worker = *(local_scheduler_client **) utarray_eltptr(
+  LocalSchedulerClient *worker = *(LocalSchedulerClient **) utarray_eltptr(
       photon->photon_state->workers, 0);
   kill_worker(worker, false);
   ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);
@@ -573,7 +573,7 @@ TEST start_kill_workers_test(void) {
   ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 1);
   ASSERT_EQ(utarray_len(photon->photon_state->workers), num_workers);
   /* Make sure that the new worker registers its process ID. */
-  worker = *(local_scheduler_client **) utarray_eltptr(
+  worker = *(LocalSchedulerClient **) utarray_eltptr(
       photon->photon_state->workers, num_workers - 1);
   process_message(photon->photon_state->loop, worker->sock, worker, 0);
   ASSERT_EQ(utarray_len(photon->photon_state->child_pids), 0);

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -135,7 +135,7 @@ void destroy_photon_mock(photon_mock *mock) {
 
 void reset_worker(photon_mock *mock, LocalSchedulerClient *worker) {
   if (worker->task_in_progress) {
-    free_task(worker->task_in_progress);
+    Task_free(worker->task_in_progress);
     worker->task_in_progress = NULL;
   }
 }
@@ -189,7 +189,7 @@ TEST object_reconstruction_test(void) {
     event_loop_run(photon->loop);
     /* Set the task's status to TASK_STATUS_DONE to prevent the race condition
      * that would suppress object reconstruction. */
-    Task *task = alloc_task(spec, TASK_STATUS_DONE,
+    Task *task = Task_alloc(spec, TASK_STATUS_DONE,
                             get_db_client_id(photon->photon_state->db));
     task_table_add_task(photon->photon_state->db, task, NULL, NULL, NULL);
     /* Trigger reconstruction, and run the event loop again. */
@@ -287,7 +287,7 @@ TEST object_reconstruction_recursive_test(void) {
     event_loop_run(photon->loop);
     /* Set the final task's status to TASK_STATUS_DONE to prevent the race
      * condition that would suppress object reconstruction. */
-    Task *last_task = alloc_task(specs[NUM_TASKS - 1], TASK_STATUS_DONE,
+    Task *last_task = Task_alloc(specs[NUM_TASKS - 1], TASK_STATUS_DONE,
                                  get_db_client_id(photon->photon_state->db));
     task_table_add_task(photon->photon_state->db, last_task, NULL, NULL, NULL);
     /* Trigger reconstruction for the last object, and run the event loop

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -348,7 +348,7 @@ TEST object_reconstruction_suppression_test(void) {
   } else {
     /* Connect a plasma manager client so we can call object_table_add. */
     const char *db_connect_args[] = {"address", "127.0.0.1:12346"};
-    db_handle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
+    DBHandle *db = db_connect("127.0.0.1", 6379, "plasma_manager", "127.0.0.1",
                                2, db_connect_args);
     db_attach(db, photon->loop, false);
     /* Add the object to the object table. */

--- a/src/photon/test/photon_tests.c
+++ b/src/photon/test/photon_tests.c
@@ -151,7 +151,7 @@ TEST object_reconstruction_test(void) {
 
   /* Create a task with zero dependencies and one return value. */
   task_spec *spec = example_task_spec(0, 1);
-  object_id return_id = task_return(spec, 0);
+  ObjectID return_id = task_return(spec, 0);
 
   /* Add an empty object table entry for the object we want to reconstruct, to
    * simulate it having been created and evicted. */
@@ -193,7 +193,7 @@ TEST object_reconstruction_test(void) {
                             get_db_client_id(photon->photon_state->db));
     task_table_add_task(photon->photon_state->db, task, NULL, NULL, NULL);
     /* Trigger reconstruction, and run the event loop again. */
-    object_id return_id = task_return(spec, 0);
+    ObjectID return_id = task_return(spec, 0);
     photon_reconstruct_object(worker, return_id);
     event_loop_add_timer(photon->loop, 500,
                          (event_loop_timer_handler) timeout_handler, NULL);
@@ -223,7 +223,7 @@ TEST object_reconstruction_recursive_test(void) {
   task_spec *specs[NUM_TASKS];
   specs[0] = example_task_spec(0, 1);
   for (int i = 1; i < NUM_TASKS; ++i) {
-    object_id arg_id = task_return(specs[i - 1], 0);
+    ObjectID arg_id = task_return(specs[i - 1], 0);
     handle_object_available(photon->photon_state,
                             photon->photon_state->algorithm_state, arg_id);
     specs[i] = example_task_spec_with_args(1, 1, &arg_id);
@@ -234,7 +234,7 @@ TEST object_reconstruction_recursive_test(void) {
   const char *client_id = "clientid";
   redisContext *context = redisConnect("127.0.0.1", 6379);
   for (int i = 0; i < NUM_TASKS; ++i) {
-    object_id return_id = task_return(specs[i], 0);
+    ObjectID return_id = task_return(specs[i], 0);
     redisReply *reply = redisCommand(
         context, "RAY.OBJECT_TABLE_ADD %b %ld %b %s", return_id.id,
         sizeof(return_id.id), 1, NIL_DIGEST, (size_t) DIGEST_SIZE, client_id);
@@ -292,7 +292,7 @@ TEST object_reconstruction_recursive_test(void) {
     task_table_add_task(photon->photon_state->db, last_task, NULL, NULL, NULL);
     /* Trigger reconstruction for the last object, and run the event loop
      * again. */
-    object_id return_id = task_return(specs[NUM_TASKS - 1], 0);
+    ObjectID return_id = task_return(specs[NUM_TASKS - 1], 0);
     photon_reconstruct_object(worker, return_id);
     event_loop_add_timer(photon->loop, 500,
                          (event_loop_timer_handler) timeout_handler, NULL);
@@ -316,7 +316,7 @@ TEST object_reconstruction_recursive_test(void) {
  */
 task_spec *object_reconstruction_suppression_spec;
 
-void object_reconstruction_suppression_callback(object_id object_id,
+void object_reconstruction_suppression_callback(ObjectID object_id,
                                                 void *user_context) {
   /* Submit the task after adding the object to the object table. */
   photon_conn *worker = user_context;
@@ -328,7 +328,7 @@ TEST object_reconstruction_suppression_test(void) {
   photon_conn *worker = photon->conns[0];
 
   object_reconstruction_suppression_spec = example_task_spec(0, 1);
-  object_id return_id = task_return(object_reconstruction_suppression_spec, 0);
+  ObjectID return_id = task_return(object_reconstruction_suppression_spec, 0);
   pid_t pid = fork();
   if (pid == 0) {
     /* Make sure we receive the task once. This will block until the
@@ -380,7 +380,7 @@ TEST task_dependency_test(void) {
   local_scheduler_client *worker =
       *((local_scheduler_client **) utarray_eltptr(state->workers, 0));
   task_spec *spec = example_task_spec(1, 1);
-  object_id oid = task_arg_id(spec, 0);
+  ObjectID oid = task_arg_id(spec, 0);
 
   /* Check that the task gets queued in the waiting queue if the task is
    * submitted, but the input and workers are not available. */
@@ -455,8 +455,8 @@ TEST task_multi_dependency_test(void) {
   local_scheduler_client *worker =
       *((local_scheduler_client **) utarray_eltptr(state->workers, 0));
   task_spec *spec = example_task_spec(2, 1);
-  object_id oid1 = task_arg_id(spec, 0);
-  object_id oid2 = task_arg_id(spec, 1);
+  ObjectID oid1 = task_arg_id(spec, 0);
+  ObjectID oid2 = task_arg_id(spec, 1);
 
   /* Check that the task gets queued in the waiting queue if the task is
    * submitted, but the inputs and workers are not available. */

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -6,7 +6,7 @@
  *  used to implement an LRU cache. */
 typedef struct released_object {
   /** The object_id of the released object. */
-  object_id object_id;
+  ObjectID object_id;
   /** Needed for the doubly-linked list macros. */
   struct released_object *prev;
   /** Needed for the doubly-linked list macros. */
@@ -17,7 +17,7 @@ typedef struct released_object {
  *  object to its location in the doubly-linked list of released objects. */
 typedef struct {
   /** Object ID of this object. */
-  object_id object_id;
+  ObjectID object_id;
   /** A pointer to the corresponding entry for this object in the doubly-linked
    *  list of released objects. */
   released_object *released_object;
@@ -39,7 +39,7 @@ struct eviction_state {
 
 /* This is used to define the array of object IDs used to define the
  * released_objects type. */
-UT_icd released_objects_entry_icd = {sizeof(object_id), NULL, NULL, NULL};
+UT_icd released_objects_entry_icd = {sizeof(ObjectID), NULL, NULL, NULL};
 
 eviction_state *make_eviction_state(void) {
   eviction_state *state = malloc(sizeof(eviction_state));
@@ -67,7 +67,7 @@ void free_eviction_state(eviction_state *s) {
 }
 
 void add_object_to_lru_cache(eviction_state *eviction_state,
-                             object_id object_id) {
+                             ObjectID object_id) {
   /* Add the object ID to the doubly-linked list. */
   released_object *linked_list_entry = malloc(sizeof(released_object));
   linked_list_entry->object_id = object_id;
@@ -86,7 +86,7 @@ void add_object_to_lru_cache(eviction_state *eviction_state,
 }
 
 void remove_object_from_lru_cache(eviction_state *eviction_state,
-                                  object_id object_id) {
+                                  ObjectID object_id) {
   /* Check that the object ID is in the hash table. */
   released_object_entry *hash_table_entry;
   HASH_FIND(handle, eviction_state->released_object_table, &object_id,
@@ -108,7 +108,7 @@ int64_t choose_objects_to_evict(eviction_state *eviction_state,
                                 plasma_store_info *plasma_store_info,
                                 int64_t num_bytes_required,
                                 int64_t *num_objects_to_evict,
-                                object_id **objects_to_evict) {
+                                ObjectID **objects_to_evict) {
   int64_t num_objects = 0;
   int64_t num_bytes = 0;
   /* Figure out how many objects need to be evicted in order to recover a
@@ -131,7 +131,7 @@ int64_t choose_objects_to_evict(eviction_state *eviction_state,
   if (num_objects == 0) {
     *objects_to_evict = NULL;
   } else {
-    *objects_to_evict = (object_id *) malloc(num_objects * sizeof(object_id));
+    *objects_to_evict = (ObjectID *) malloc(num_objects * sizeof(ObjectID));
     int counter = 0;
     DL_FOREACH_SAFE(eviction_state->released_objects, element, temp) {
       if (counter == num_objects) {
@@ -150,7 +150,7 @@ int64_t choose_objects_to_evict(eviction_state *eviction_state,
 
 void object_created(eviction_state *eviction_state,
                     plasma_store_info *plasma_store_info,
-                    object_id obj_id) {
+                    ObjectID obj_id) {
   add_object_to_lru_cache(eviction_state, obj_id);
 }
 
@@ -158,7 +158,7 @@ bool require_space(eviction_state *eviction_state,
                    plasma_store_info *plasma_store_info,
                    int64_t size,
                    int64_t *num_objects_to_evict,
-                   object_id **objects_to_evict) {
+                   ObjectID **objects_to_evict) {
   /* Check if there is enough space to create the object. */
   int64_t required_space =
       eviction_state->memory_used + size - plasma_store_info->memory_capacity;
@@ -191,9 +191,9 @@ bool require_space(eviction_state *eviction_state,
 
 void begin_object_access(eviction_state *eviction_state,
                          plasma_store_info *plasma_store_info,
-                         object_id obj_id,
+                         ObjectID obj_id,
                          int64_t *num_objects_to_evict,
-                         object_id **objects_to_evict) {
+                         ObjectID **objects_to_evict) {
   /* If the object is in the LRU cache, remove it. */
   remove_object_from_lru_cache(eviction_state, obj_id);
   *num_objects_to_evict = 0;
@@ -202,9 +202,9 @@ void begin_object_access(eviction_state *eviction_state,
 
 void end_object_access(eviction_state *eviction_state,
                        plasma_store_info *plasma_store_info,
-                       object_id obj_id,
+                       ObjectID obj_id,
                        int64_t *num_objects_to_evict,
-                       object_id **objects_to_evict) {
+                       ObjectID **objects_to_evict) {
   /* Add the object to the LRU cache.*/
   add_object_to_lru_cache(eviction_state, obj_id);
   *num_objects_to_evict = 0;

--- a/src/plasma/eviction_policy.c
+++ b/src/plasma/eviction_policy.c
@@ -105,7 +105,7 @@ void remove_object_from_lru_cache(eviction_state *eviction_state,
 }
 
 int64_t choose_objects_to_evict(eviction_state *eviction_state,
-                                plasma_store_info *plasma_store_info,
+                                PlasmaStoreInfo *plasma_store_info,
                                 int64_t num_bytes_required,
                                 int64_t *num_objects_to_evict,
                                 ObjectID **objects_to_evict) {
@@ -149,13 +149,13 @@ int64_t choose_objects_to_evict(eviction_state *eviction_state,
 }
 
 void object_created(eviction_state *eviction_state,
-                    plasma_store_info *plasma_store_info,
+                    PlasmaStoreInfo *plasma_store_info,
                     ObjectID obj_id) {
   add_object_to_lru_cache(eviction_state, obj_id);
 }
 
 bool require_space(eviction_state *eviction_state,
-                   plasma_store_info *plasma_store_info,
+                   PlasmaStoreInfo *plasma_store_info,
                    int64_t size,
                    int64_t *num_objects_to_evict,
                    ObjectID **objects_to_evict) {
@@ -190,7 +190,7 @@ bool require_space(eviction_state *eviction_state,
 }
 
 void begin_object_access(eviction_state *eviction_state,
-                         plasma_store_info *plasma_store_info,
+                         PlasmaStoreInfo *plasma_store_info,
                          ObjectID obj_id,
                          int64_t *num_objects_to_evict,
                          ObjectID **objects_to_evict) {
@@ -201,7 +201,7 @@ void begin_object_access(eviction_state *eviction_state,
 }
 
 void end_object_access(eviction_state *eviction_state,
-                       plasma_store_info *plasma_store_info,
+                       PlasmaStoreInfo *plasma_store_info,
                        ObjectID obj_id,
                        int64_t *num_objects_to_evict,
                        ObjectID **objects_to_evict) {

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -42,7 +42,7 @@ void free_eviction_state(eviction_state *state);
  * @return Void.
  */
 void object_created(eviction_state *eviction_state,
-                    plasma_store_info *plasma_store_info,
+                    PlasmaStoreInfo *plasma_store_info,
                     ObjectID obj_id);
 
 /**
@@ -66,7 +66,7 @@ void object_created(eviction_state *eviction_state,
  * @return True if enough space can be freed and false otherwise.
  */
 bool require_space(eviction_state *eviction_state,
-                   plasma_store_info *plasma_store_info,
+                   PlasmaStoreInfo *plasma_store_info,
                    int64_t size,
                    int64_t *num_objects_to_evict,
                    ObjectID **objects_to_evict);
@@ -90,7 +90,7 @@ bool require_space(eviction_state *eviction_state,
  * @return Void.
  */
 void begin_object_access(eviction_state *eviction_state,
-                         plasma_store_info *plasma_store_info,
+                         PlasmaStoreInfo *plasma_store_info,
                          ObjectID obj_id,
                          int64_t *num_objects_to_evict,
                          ObjectID **objects_to_evict);
@@ -114,7 +114,7 @@ void begin_object_access(eviction_state *eviction_state,
  * @return Void.
  */
 void end_object_access(eviction_state *eviction_state,
-                       plasma_store_info *plasma_store_info,
+                       PlasmaStoreInfo *plasma_store_info,
                        ObjectID obj_id,
                        int64_t *num_objects_to_evict,
                        ObjectID **objects_to_evict);
@@ -140,7 +140,7 @@ void end_object_access(eviction_state *eviction_state,
  * @return The total number of bytes of space chosen to be evicted.
  */
 int64_t choose_objects_to_evict(eviction_state *eviction_state,
-                                plasma_store_info *plasma_store_info,
+                                PlasmaStoreInfo *plasma_store_info,
                                 int64_t num_bytes_required,
                                 int64_t *num_objects_to_evict,
                                 ObjectID **objects_to_evict);

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -11,7 +11,7 @@
  */
 
 /** Internal state of the eviction policy. */
-typedef struct eviction_state eviction_state;
+typedef struct EvictionState EvictionState;
 
 /**
  * Initialize the eviction policy state.
@@ -20,7 +20,7 @@ typedef struct eviction_state eviction_state;
  *        store.
  * @return The internal state of the eviction policy.
  */
-eviction_state *make_eviction_state(void);
+EvictionState *EvictionState_init(void);
 
 /**
  * Free the eviction policy state.
@@ -28,7 +28,7 @@ eviction_state *make_eviction_state(void);
  * @param state The state managed by the eviction policy.
  * @return Void.
  */
-void free_eviction_state(eviction_state *state);
+void EvictionState_free(EvictionState *state);
 
 /**
  * This method will be called whenever an object is first created in order to
@@ -41,9 +41,9 @@ void free_eviction_state(eviction_state *state);
  * @param obj_id The object ID of the object that was created.
  * @return Void.
  */
-void object_created(eviction_state *eviction_state,
-                    PlasmaStoreInfo *plasma_store_info,
-                    ObjectID obj_id);
+void EvictionState_object_created(EvictionState *eviction_state,
+                                  PlasmaStoreInfo *plasma_store_info,
+                                  ObjectID obj_id);
 
 /**
  * This method will be called when the Plasma store needs more space, perhaps to
@@ -65,11 +65,11 @@ void object_created(eviction_state *eviction_state,
  *        the array will be NULL.
  * @return True if enough space can be freed and false otherwise.
  */
-bool require_space(eviction_state *eviction_state,
-                   PlasmaStoreInfo *plasma_store_info,
-                   int64_t size,
-                   int64_t *num_objects_to_evict,
-                   ObjectID **objects_to_evict);
+bool EvictionState_require_space(EvictionState *eviction_state,
+                                 PlasmaStoreInfo *plasma_store_info,
+                                 int64_t size,
+                                 int64_t *num_objects_to_evict,
+                                 ObjectID **objects_to_evict);
 
 /**
  * This method will be called whenever an unused object in the Plasma store
@@ -89,11 +89,11 @@ bool require_space(eviction_state *eviction_state,
  *        the array will be NULL.
  * @return Void.
  */
-void begin_object_access(eviction_state *eviction_state,
-                         PlasmaStoreInfo *plasma_store_info,
-                         ObjectID obj_id,
-                         int64_t *num_objects_to_evict,
-                         ObjectID **objects_to_evict);
+void EvictionState_begin_object_access(EvictionState *eviction_state,
+                                       PlasmaStoreInfo *plasma_store_info,
+                                       ObjectID obj_id,
+                                       int64_t *num_objects_to_evict,
+                                       ObjectID **objects_to_evict);
 
 /**
  * This method will be called whenever an object in the Plasma store that was
@@ -113,11 +113,11 @@ void begin_object_access(eviction_state *eviction_state,
  *        the array will be NULL.
  * @return Void.
  */
-void end_object_access(eviction_state *eviction_state,
-                       PlasmaStoreInfo *plasma_store_info,
-                       ObjectID obj_id,
-                       int64_t *num_objects_to_evict,
-                       ObjectID **objects_to_evict);
+void EvictionState_end_object_access(EvictionState *eviction_state,
+                                     PlasmaStoreInfo *plasma_store_info,
+                                     ObjectID obj_id,
+                                     int64_t *num_objects_to_evict,
+                                     ObjectID **objects_to_evict);
 
 /**
  * Choose some objects to evict from the Plasma store. When this method is
@@ -139,10 +139,11 @@ void end_object_access(eviction_state *eviction_state,
  *        the array will be NULL.
  * @return The total number of bytes of space chosen to be evicted.
  */
-int64_t choose_objects_to_evict(eviction_state *eviction_state,
-                                PlasmaStoreInfo *plasma_store_info,
-                                int64_t num_bytes_required,
-                                int64_t *num_objects_to_evict,
-                                ObjectID **objects_to_evict);
+int64_t EvictionState_choose_objects_to_evict(
+    EvictionState *eviction_state,
+    PlasmaStoreInfo *plasma_store_info,
+    int64_t num_bytes_required,
+    int64_t *num_objects_to_evict,
+    ObjectID **objects_to_evict);
 
 #endif /* EVICTION_POLICY_H */

--- a/src/plasma/eviction_policy.h
+++ b/src/plasma/eviction_policy.h
@@ -43,7 +43,7 @@ void free_eviction_state(eviction_state *state);
  */
 void object_created(eviction_state *eviction_state,
                     plasma_store_info *plasma_store_info,
-                    object_id obj_id);
+                    ObjectID obj_id);
 
 /**
  * This method will be called when the Plasma store needs more space, perhaps to
@@ -69,7 +69,7 @@ bool require_space(eviction_state *eviction_state,
                    plasma_store_info *plasma_store_info,
                    int64_t size,
                    int64_t *num_objects_to_evict,
-                   object_id **objects_to_evict);
+                   ObjectID **objects_to_evict);
 
 /**
  * This method will be called whenever an unused object in the Plasma store
@@ -91,9 +91,9 @@ bool require_space(eviction_state *eviction_state,
  */
 void begin_object_access(eviction_state *eviction_state,
                          plasma_store_info *plasma_store_info,
-                         object_id obj_id,
+                         ObjectID obj_id,
                          int64_t *num_objects_to_evict,
-                         object_id **objects_to_evict);
+                         ObjectID **objects_to_evict);
 
 /**
  * This method will be called whenever an object in the Plasma store that was
@@ -115,9 +115,9 @@ void begin_object_access(eviction_state *eviction_state,
  */
 void end_object_access(eviction_state *eviction_state,
                        plasma_store_info *plasma_store_info,
-                       object_id obj_id,
+                       ObjectID obj_id,
                        int64_t *num_objects_to_evict,
-                       object_id **objects_to_evict);
+                       ObjectID **objects_to_evict);
 
 /**
  * Choose some objects to evict from the Plasma store. When this method is
@@ -143,6 +143,6 @@ int64_t choose_objects_to_evict(eviction_state *eviction_state,
                                 plasma_store_info *plasma_store_info,
                                 int64_t num_bytes_required,
                                 int64_t *num_objects_to_evict,
-                                object_id **objects_to_evict);
+                                ObjectID **objects_to_evict);
 
 #endif /* EVICTION_POLICY_H */

--- a/src/plasma/format/plasma.fbs
+++ b/src/plasma/format/plasma.fbs
@@ -55,7 +55,7 @@ enum PlasmaError:int {
 
 // Plasma store messages
 
-struct PlasmaObject {
+struct PlasmaObjectSpec {
   // Index of the memory segment (= memory mapped file) that
   // this object is allocated in.
   segment_index: int;
@@ -84,7 +84,7 @@ table PlasmaCreateReply {
   // ID of the object that was created.
   object_id: string;
   // The object that is returned with this reply.
-  plasma_object: PlasmaObject;
+  plasma_object: PlasmaObjectSpec;
   // Error that occurred for this call.
   error: PlasmaError;
 }
@@ -117,7 +117,7 @@ table PlasmaGetReply {
   // in the local Plasma store.
   object_ids: [string];
   // Plasma object information, in the same order as their IDs.
-  plasma_objects: [PlasmaObject];
+  plasma_objects: [PlasmaObjectSpec];
   // The number of elements in both object_ids and plasma_objects arrays must agree.
 }
 

--- a/src/plasma/plasma.c
+++ b/src/plasma/plasma.c
@@ -7,17 +7,6 @@
 
 #include "plasma_protocol.h"
 
-bool plasma_object_ids_distinct(int num_object_ids, ObjectID object_ids[]) {
-  for (int i = 0; i < num_object_ids; ++i) {
-    for (int j = 0; j < i; ++j) {
-      if (object_ids_equal(object_ids[i], object_ids[j])) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 void warn_if_sigpipe(int status, int client_sock) {
   if (status >= 0) {
     return;

--- a/src/plasma/plasma.c
+++ b/src/plasma/plasma.c
@@ -7,7 +7,7 @@
 
 #include "plasma_protocol.h"
 
-bool plasma_object_ids_distinct(int num_object_ids, object_id object_ids[]) {
+bool plasma_object_ids_distinct(int num_object_ids, ObjectID object_ids[]) {
   for (int i = 0; i < num_object_ids; ++i) {
     for (int j = 0; j < i; ++j) {
       if (object_ids_equal(object_ids[i], object_ids[j])) {

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -89,7 +89,7 @@ typedef struct {
   /** Object id of this object. */
   ObjectID object_id;
   /** Object info like size, creation time and owner. */
-  object_info info;
+  ObjectInfo info;
   /** Memory mapped file containing the object. */
   int fd;
   /** Size of the underlying map. */

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -60,7 +60,7 @@ typedef struct {
   int64_t data_size;
   /** The size in bytes of the metadata. */
   int64_t metadata_size;
-} plasma_object;
+} PlasmaObject;
 
 typedef enum {
   /** Object was created but not sealed in the local Plasma Store. */

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -115,25 +115,7 @@ typedef struct {
   /** The amount of memory (in bytes) that we allow to be allocated in the
    *  store. */
   int64_t memory_capacity;
-} plasma_store_info;
-
-typedef struct {
-  /** The ID of the object. */
-  ObjectID obj_id;
-  /** The size of the object. */
-  int64_t object_size;
-  /** The digest of the object used, used to see if two objects are the same. */
-  unsigned char digest[DIGEST_SIZE];
-} object_id_notification;
-
-/**
- * Check if a collection of object IDs contains any duplicates.
- *
- * @param num_object_ids The number of object IDs.
- * @param object_ids[] The list of object IDs to check.
- * @return True if the object IDs are all distinct and false otherwise.
- */
-bool plasma_object_ids_distinct(int num_object_ids, ObjectID object_ids[]);
+} PlasmaStoreInfo;
 
 /**
  * Print a warning if the status is less than zero. This should be used to check

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -22,7 +22,7 @@
  */
 typedef struct {
   /** The ID of the requested object. If ID_NIL request any object. */
-  object_id object_id;
+  ObjectID object_id;
   /** Request associated to the object. It can take one of the following values:
    *  - PLASMA_QUERY_LOCAL: return if or when the object is available in the
    *    local Plasma Store.
@@ -87,7 +87,7 @@ typedef enum {
  *  the eviction policy. */
 typedef struct {
   /** Object id of this object. */
-  object_id object_id;
+  ObjectID object_id;
   /** Object info like size, creation time and owner. */
   object_info info;
   /** Memory mapped file containing the object. */
@@ -119,7 +119,7 @@ typedef struct {
 
 typedef struct {
   /** The ID of the object. */
-  object_id obj_id;
+  ObjectID obj_id;
   /** The size of the object. */
   int64_t object_size;
   /** The digest of the object used, used to see if two objects are the same. */
@@ -133,7 +133,7 @@ typedef struct {
  * @param object_ids[] The list of object IDs to check.
  * @return True if the object IDs are all distinct and false otherwise.
  */
-bool plasma_object_ids_distinct(int num_object_ids, object_id object_ids[]);
+bool plasma_object_ids_distinct(int num_object_ids, ObjectID object_ids[]);
 
 /**
  * Print a warning if the status is less than zero. This should be used to check

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -37,7 +37,7 @@ typedef struct {
    *  - PLASMA_CLIENT_IN_TRANSFER, if the object is currently being scheduled
    *    for being transferred or it is transferring. */
   int status;
-} object_request;
+} ObjectRequest;
 
 /* Handle to access memory mapped file and map it into client address space. */
 typedef struct {

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -443,9 +443,7 @@ void plasma_release(PlasmaConnection *conn, ObjectID obj_id) {
 }
 
 /* This method is used to query whether the plasma store contains an object. */
-void plasma_contains(PlasmaConnection *conn,
-                     ObjectID obj_id,
-                     int *has_object) {
+void plasma_contains(PlasmaConnection *conn, ObjectID obj_id, int *has_object) {
   /* Check if we already have a reference to the object. */
   object_in_use_entry *object_entry;
   HASH_FIND(hh, conn->objects_in_use, &obj_id, sizeof(obj_id), object_entry);
@@ -556,8 +554,8 @@ int plasma_subscribe(PlasmaConnection *conn) {
 }
 
 PlasmaConnection *plasma_connect(const char *store_socket_name,
-                                  const char *manager_socket_name,
-                                  int release_delay) {
+                                 const char *manager_socket_name,
+                                 int release_delay) {
   /* Initialize the store connection struct */
   PlasmaConnection *result = malloc(sizeof(PlasmaConnection));
   result->store_conn = connect_ipc_sock_retry(store_socket_name, -1, -1);

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -655,7 +655,7 @@ int plasma_status(plasma_connection *conn, ObjectID object_id) {
 
 int plasma_wait(plasma_connection *conn,
                 int num_object_requests,
-                object_request object_requests[],
+                ObjectRequest object_requests[],
                 int num_ready_objects,
                 uint64_t timeout_ms) {
   CHECK(conn != NULL);

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -314,7 +314,7 @@ void plasma_get(PlasmaConnection *conn,
   free(reply_data);
 
   for (int i = 0; i < num_objects; ++i) {
-    DCHECK(object_ids_equal(received_obj_ids[i], object_ids[i]));
+    DCHECK(ObjectID_equal(received_obj_ids[i], object_ids[i]));
     object = &object_data[i];
     if (object_buffers[i].data_size != -1) {
       /* If the object was already in use by the client, then the store should

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -59,7 +59,7 @@ typedef struct {
    *  and decrement a count in the relevant client_mmap_table_entry. */
   int count;
   /** Cached information to read the object. */
-  plasma_object object;
+  PlasmaObject object;
   /** A flag representing whether the object has been sealed. */
   bool is_sealed;
   /** Handle for the uthash table. */
@@ -167,7 +167,7 @@ uint8_t *lookup_mmapped_file(plasma_connection *conn, int store_fd_val) {
 
 void increment_object_count(plasma_connection *conn,
                             ObjectID object_id,
-                            plasma_object *object,
+                            PlasmaObject *object,
                             bool is_sealed) {
   /* Increment the count of the object to track the fact that it is being used.
    * The corresponding decrement should happen in plasma_release. */
@@ -219,7 +219,7 @@ int plasma_create(plasma_connection *conn,
       plasma_receive(conn->store_conn, MessageType_PlasmaCreateReply);
   int error;
   ObjectID id;
-  plasma_object object;
+  PlasmaObject object;
   plasma_read_CreateReply(reply_data, &id, &object, &error);
   free(reply_data);
   if (error != PlasmaError_OK) {
@@ -277,8 +277,8 @@ void plasma_get(plasma_connection *conn,
       object_buffers[i].data_size = -1;
     } else {
       /*  */
-      plasma_object object_data;
-      plasma_object *object;
+      PlasmaObject object_data;
+      PlasmaObject *object;
       /* NOTE: If the object is still unsealed, we will deadlock, since we must
        * have been the one who created it. */
       CHECKM(object_entry->is_sealed,
@@ -308,8 +308,8 @@ void plasma_get(plasma_connection *conn,
   uint8_t *reply_data =
       plasma_receive(conn->store_conn, MessageType_PlasmaGetReply);
   ObjectID *received_obj_ids = malloc(num_objects * sizeof(ObjectID));
-  plasma_object *object_data = malloc(num_objects * sizeof(plasma_object));
-  plasma_object *object;
+  PlasmaObject *object_data = malloc(num_objects * sizeof(PlasmaObject));
+  PlasmaObject *object;
   plasma_read_GetReply(reply_data, received_obj_ids, object_data, num_objects);
   free(reply_data);
 

--- a/src/plasma/plasma_client.c
+++ b/src/plasma/plasma_client.c
@@ -262,7 +262,7 @@ void plasma_get(PlasmaConnection *conn,
                 ObjectID object_ids[],
                 int64_t num_objects,
                 int64_t timeout_ms,
-                object_buffer object_buffers[]) {
+                ObjectBuffer object_buffers[]) {
   /* Fill out the info for the objects that are already in use locally. */
   bool all_present = true;
   for (int i = 0; i < num_objects; ++i) {
@@ -468,7 +468,7 @@ bool plasma_compute_object_hash(PlasmaConnection *conn,
                                 unsigned char *digest) {
   /* Get the plasma object data. We pass in a timeout of 0 to indicate that
    * the operation should timeout immediately. */
-  object_buffer obj_buffer;
+  ObjectBuffer obj_buffer;
   ObjectID obj_id_array[1] = {obj_id};
   plasma_get(conn, obj_id_array, 1, 0, &obj_buffer);
   /* If the object was not retrieved, return false. */

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -328,7 +328,7 @@ int plasma_info(plasma_connection *conn,
  */
 int plasma_wait(plasma_connection *conn,
                 int num_object_requests,
-                object_request object_requests[],
+                ObjectRequest object_requests[],
                 int num_ready_objects,
                 uint64_t timeout_ms);
 

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -10,7 +10,7 @@
 /* Use 100MB as an overestimate of the L3 cache size. */
 #define L3_CACHE_SIZE_BYTES 100000000
 
-typedef struct plasma_connection plasma_connection;
+typedef struct PlasmaConnection PlasmaConnection;
 
 /**
  * Try to connect to the socket several times. If unsuccessful, fail.
@@ -35,9 +35,9 @@ int socket_connect_retry(const char *socket_name,
  *        function will not connect to a manager.
  * @return The object containing the connection state.
  */
-plasma_connection *plasma_connect(const char *store_socket_name,
-                                  const char *manager_socket_name,
-                                  int release_delay);
+PlasmaConnection *plasma_connect(const char *store_socket_name,
+                                 const char *manager_socket_name,
+                                 int release_delay);
 
 /**
  * Disconnect from the local plasma instance, including the local store and
@@ -46,7 +46,7 @@ plasma_connection *plasma_connect(const char *store_socket_name,
  * @param conn The connection to the local plasma store and plasma manager.
  * @return Void.
  */
-void plasma_disconnect(plasma_connection *conn);
+void plasma_disconnect(PlasmaConnection *conn);
 
 /**
  * Return true if the plasma manager is connected.
@@ -54,7 +54,7 @@ void plasma_disconnect(plasma_connection *conn);
  * @param conn The connection to the local plasma store and plasma manager.
  * @return True if the plasma manager is connected and false otherwise.
  */
-bool plasma_manager_is_connected(plasma_connection *conn);
+bool plasma_manager_is_connected(PlasmaConnection *conn);
 
 /**
  * Try to connect to a possibly remote Plasma Manager.
@@ -89,7 +89,7 @@ int plasma_manager_connect(const char *addr, int port);
  *           create the object. In this case, the client should not call
  *           plasma_release.
  */
-int plasma_create(plasma_connection *conn,
+int plasma_create(PlasmaConnection *conn,
                   ObjectID object_id,
                   int64_t size,
                   uint8_t *metadata,
@@ -125,7 +125,7 @@ typedef struct {
  *        size field is -1, then the object was not retrieved.
  * @return Void.
  */
-void plasma_get(plasma_connection *conn,
+void plasma_get(PlasmaConnection *conn,
                 ObjectID object_ids[],
                 int64_t num_objects,
                 int64_t timeout_ms,
@@ -141,7 +141,7 @@ void plasma_get(plasma_connection *conn,
  * @param object_id The ID of the object that is no longer needed.
  * @return Void.
  */
-void plasma_release(plasma_connection *conn, ObjectID object_id);
+void plasma_release(PlasmaConnection *conn, ObjectID object_id);
 
 /**
  * Check if the object store contains a particular object and the object has
@@ -155,7 +155,7 @@ void plasma_release(plasma_connection *conn, ObjectID object_id);
  *        present and 0 if it is not present.
  * @return Void.
  */
-void plasma_contains(plasma_connection *conn,
+void plasma_contains(PlasmaConnection *conn,
                      ObjectID object_id,
                      int *has_object);
 
@@ -168,7 +168,7 @@ void plasma_contains(plasma_connection *conn,
  *        The pointer must have at least DIGEST_SIZE bytes allocated.
  * @return A boolean representing whether the hash operation succeeded.
  */
-bool plasma_compute_object_hash(plasma_connection *conn,
+bool plasma_compute_object_hash(PlasmaConnection *conn,
                                 ObjectID object_id,
                                 unsigned char *digest);
 
@@ -180,7 +180,7 @@ bool plasma_compute_object_hash(plasma_connection *conn,
  * @param object_id The ID of the object to seal.
  * @return Void.
  */
-void plasma_seal(plasma_connection *conn, ObjectID object_id);
+void plasma_seal(PlasmaConnection *conn, ObjectID object_id);
 
 /**
  * Delete an object from the object store. This currently assumes that the
@@ -193,7 +193,7 @@ void plasma_seal(plasma_connection *conn, ObjectID object_id);
  * @param object_id The ID of the object to delete.
  * @return Void.
  */
-void plasma_delete(plasma_connection *conn, ObjectID object_id);
+void plasma_delete(PlasmaConnection *conn, ObjectID object_id);
 
 /**
  * Delete objects until we have freed up num_bytes bytes or there are no more
@@ -203,7 +203,7 @@ void plasma_delete(plasma_connection *conn, ObjectID object_id);
  * @param num_bytes The number of bytes to try to free up.
  * @return The total number of bytes of space retrieved.
  */
-int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes);
+int64_t plasma_evict(PlasmaConnection *conn, int64_t num_bytes);
 
 /**
  * Attempt to initiate the transfer of some objects from remote Plasma Stores.
@@ -226,7 +226,7 @@ int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes);
  * @param object_ids The IDs of the objects that fetch is being called on.
  * @return Void.
  */
-void plasma_fetch(plasma_connection *conn,
+void plasma_fetch(PlasmaConnection *conn,
                   int num_object_ids,
                   ObjectID object_ids[]);
 
@@ -240,7 +240,7 @@ void plasma_fetch(plasma_connection *conn,
  *
  * @return Void.
  */
-void plasma_transfer(plasma_connection *conn,
+void plasma_transfer(PlasmaConnection *conn,
                      const char *addr,
                      int port,
                      ObjectID object_id);
@@ -254,7 +254,7 @@ void plasma_transfer(plasma_connection *conn,
  * @return The file descriptor that the client should use to read notifications
            from the object store about sealed objects.
  */
-int plasma_subscribe(plasma_connection *conn);
+int plasma_subscribe(PlasmaConnection *conn);
 
 /**
  * Get the file descriptor for the socket connection to the plasma manager.
@@ -263,7 +263,7 @@ int plasma_subscribe(plasma_connection *conn);
  * @return The file descriptor for the manager connection. If there is no
  *         connection to the manager, this is -1.
  */
-int get_manager_fd(plasma_connection *conn);
+int get_manager_fd(PlasmaConnection *conn);
 
 /**
  * Return the status of a given object. This method may query the object table.
@@ -281,7 +281,7 @@ int get_manager_fd(plasma_connection *conn);
  *         - PLASMA_CLIENT_DOES_NOT_EXIST, if the object doesn’t exist in the
  *           system.
  */
-int plasma_status(plasma_connection *conn, ObjectID object_id);
+int plasma_status(PlasmaConnection *conn, ObjectID object_id);
 
 /**
  * Return the information associated to a given object.
@@ -293,7 +293,7 @@ int plasma_status(plasma_connection *conn, ObjectID object_id);
  *         PLASMA_CLIENT_NOT_LOCAL, if not. In this case, the caller needs to
  *         ignore data, metadata_size, and metadata fields.
  */
-int plasma_info(plasma_connection *conn,
+int plasma_info(PlasmaConnection *conn,
                 ObjectID object_id,
                 object_info *object_info);
 
@@ -326,7 +326,7 @@ int plasma_info(plasma_connection *conn,
  *         returned number is less than min_num_ready_objects this means that
  *         timeout expired.
  */
-int plasma_wait(plasma_connection *conn,
+int plasma_wait(PlasmaConnection *conn,
                 int num_object_requests,
                 ObjectRequest object_requests[],
                 int num_ready_objects,

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -295,7 +295,7 @@ int plasma_status(PlasmaConnection *conn, ObjectID object_id);
  */
 int plasma_info(PlasmaConnection *conn,
                 ObjectID object_id,
-                object_info *object_info);
+                ObjectInfo *object_info);
 
 /**
  * Wait for (1) a specified number of objects to be available (sealed) in the

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -108,7 +108,7 @@ typedef struct {
   int64_t metadata_size;
   /** The address of the metadata. */
   uint8_t *metadata;
-} object_buffer;
+} ObjectBuffer;
 
 /**
  * Get some objects from the Plasma Store. This function will block until the
@@ -129,7 +129,7 @@ void plasma_get(PlasmaConnection *conn,
                 ObjectID object_ids[],
                 int64_t num_objects,
                 int64_t timeout_ms,
-                object_buffer object_buffers[]);
+                ObjectBuffer object_buffers[]);
 
 /**
  * Tell Plasma that the client no longer needs the object. This should be called

--- a/src/plasma/plasma_client.h
+++ b/src/plasma/plasma_client.h
@@ -90,7 +90,7 @@ int plasma_manager_connect(const char *addr, int port);
  *           plasma_release.
  */
 int plasma_create(plasma_connection *conn,
-                  object_id object_id,
+                  ObjectID object_id,
                   int64_t size,
                   uint8_t *metadata,
                   int64_t metadata_size,
@@ -126,7 +126,7 @@ typedef struct {
  * @return Void.
  */
 void plasma_get(plasma_connection *conn,
-                object_id object_ids[],
+                ObjectID object_ids[],
                 int64_t num_objects,
                 int64_t timeout_ms,
                 object_buffer object_buffers[]);
@@ -141,7 +141,7 @@ void plasma_get(plasma_connection *conn,
  * @param object_id The ID of the object that is no longer needed.
  * @return Void.
  */
-void plasma_release(plasma_connection *conn, object_id object_id);
+void plasma_release(plasma_connection *conn, ObjectID object_id);
 
 /**
  * Check if the object store contains a particular object and the object has
@@ -156,7 +156,7 @@ void plasma_release(plasma_connection *conn, object_id object_id);
  * @return Void.
  */
 void plasma_contains(plasma_connection *conn,
-                     object_id object_id,
+                     ObjectID object_id,
                      int *has_object);
 
 /**
@@ -169,7 +169,7 @@ void plasma_contains(plasma_connection *conn,
  * @return A boolean representing whether the hash operation succeeded.
  */
 bool plasma_compute_object_hash(plasma_connection *conn,
-                                object_id object_id,
+                                ObjectID object_id,
                                 unsigned char *digest);
 
 /**
@@ -180,7 +180,7 @@ bool plasma_compute_object_hash(plasma_connection *conn,
  * @param object_id The ID of the object to seal.
  * @return Void.
  */
-void plasma_seal(plasma_connection *conn, object_id object_id);
+void plasma_seal(plasma_connection *conn, ObjectID object_id);
 
 /**
  * Delete an object from the object store. This currently assumes that the
@@ -193,7 +193,7 @@ void plasma_seal(plasma_connection *conn, object_id object_id);
  * @param object_id The ID of the object to delete.
  * @return Void.
  */
-void plasma_delete(plasma_connection *conn, object_id object_id);
+void plasma_delete(plasma_connection *conn, ObjectID object_id);
 
 /**
  * Delete objects until we have freed up num_bytes bytes or there are no more
@@ -228,7 +228,7 @@ int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes);
  */
 void plasma_fetch(plasma_connection *conn,
                   int num_object_ids,
-                  object_id object_ids[]);
+                  ObjectID object_ids[]);
 
 /**
  * Transfer local object to a different plasma manager.
@@ -243,7 +243,7 @@ void plasma_fetch(plasma_connection *conn,
 void plasma_transfer(plasma_connection *conn,
                      const char *addr,
                      int port,
-                     object_id object_id);
+                     ObjectID object_id);
 
 /**
  * Subscribe to notifications when objects are sealed in the object store.
@@ -281,7 +281,7 @@ int get_manager_fd(plasma_connection *conn);
  *         - PLASMA_CLIENT_DOES_NOT_EXIST, if the object doesn’t exist in the
  *           system.
  */
-int plasma_status(plasma_connection *conn, object_id object_id);
+int plasma_status(plasma_connection *conn, ObjectID object_id);
 
 /**
  * Return the information associated to a given object.
@@ -294,7 +294,7 @@ int plasma_status(plasma_connection *conn, object_id object_id);
  *         ignore data, metadata_size, and metadata fields.
  */
 int plasma_info(plasma_connection *conn,
-                object_id object_id,
+                ObjectID object_id,
                 object_info *object_info);
 
 /**

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -21,7 +21,7 @@ PyObject *PyPlasma_connect(PyObject *self, PyObject *args) {
                         &release_delay)) {
     return NULL;
   }
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   if (strlen(manager_socket_name) == 0) {
     conn = plasma_connect(store_socket_name, NULL, release_delay);
   } else {
@@ -33,7 +33,7 @@ PyObject *PyPlasma_connect(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_disconnect(PyObject *self, PyObject *args) {
   PyObject *conn_capsule;
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   if (!PyArg_ParseTuple(args, "O", &conn_capsule)) {
     return NULL;
   }
@@ -48,7 +48,7 @@ PyObject *PyPlasma_disconnect(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   long long size;
   PyObject *metadata;
@@ -86,7 +86,7 @@ PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_hash(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
@@ -104,7 +104,7 @@ PyObject *PyPlasma_hash(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_seal(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
@@ -115,7 +115,7 @@ PyObject *PyPlasma_seal(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_release(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
@@ -126,7 +126,7 @@ PyObject *PyPlasma_release(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_get(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   PyObject *object_id_list;
   long long timeout_ms;
   if (!PyArg_ParseTuple(args, "O&OL", PyObjectToPlasmaConnection, &conn,
@@ -180,7 +180,7 @@ PyObject *PyPlasma_get(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_contains(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
@@ -196,7 +196,7 @@ PyObject *PyPlasma_contains(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_fetch(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   PyObject *object_id_list;
   if (!PyArg_ParseTuple(args, "O&O", PyObjectToPlasmaConnection, &conn,
                         &object_id_list)) {
@@ -217,7 +217,7 @@ PyObject *PyPlasma_fetch(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_wait(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   PyObject *object_id_list;
   long long timeout;
   int num_returns;
@@ -292,7 +292,7 @@ PyObject *PyPlasma_wait(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_evict(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   long long num_bytes;
   if (!PyArg_ParseTuple(args, "O&L", PyObjectToPlasmaConnection, &conn,
                         &num_bytes)) {
@@ -303,7 +303,7 @@ PyObject *PyPlasma_evict(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_delete(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
@@ -314,7 +314,7 @@ PyObject *PyPlasma_delete(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_transfer(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   ObjectID object_id;
   const char *addr;
   int port;
@@ -333,7 +333,7 @@ PyObject *PyPlasma_transfer(PyObject *self, PyObject *args) {
 }
 
 PyObject *PyPlasma_subscribe(PyObject *self, PyObject *args) {
-  plasma_connection *conn;
+  PlasmaConnection *conn;
   if (!PyArg_ParseTuple(args, "O&", PyObjectToPlasmaConnection, &conn)) {
     return NULL;
   }

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -136,7 +136,7 @@ PyObject *PyPlasma_get(PyObject *self, PyObject *args) {
 
   Py_ssize_t num_object_ids = PyList_Size(object_id_list);
   ObjectID object_ids[num_object_ids];
-  object_buffer object_buffers[num_object_ids];
+  ObjectBuffer object_buffers[num_object_ids];
 
   for (int i = 0; i < num_object_ids; ++i) {
     PyStringToUniqueID(PyList_GetItem(object_id_list, i), &object_ids[i]);

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -344,7 +344,7 @@ PyObject *PyPlasma_subscribe(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_receive_notification(PyObject *self, PyObject *args) {
   int plasma_sock;
-  object_info object_info;
+  ObjectInfo object_info;
 
   if (!PyArg_ParseTuple(args, "i", &plasma_sock)) {
     return NULL;

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -249,7 +249,7 @@ PyObject *PyPlasma_wait(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  object_request *object_requests = malloc(sizeof(object_request) * n);
+  ObjectRequest *object_requests = malloc(sizeof(ObjectRequest) * n);
   for (int i = 0; i < n; ++i) {
     CHECK(PyStringToUniqueID(PyList_GetItem(object_id_list, i),
                              &object_requests[i].object_id) == 1);

--- a/src/plasma/plasma_extension.c
+++ b/src/plasma/plasma_extension.c
@@ -49,7 +49,7 @@ PyObject *PyPlasma_disconnect(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   long long size;
   PyObject *metadata;
   if (!PyArg_ParseTuple(args, "O&O&LO", PyObjectToPlasmaConnection, &conn,
@@ -87,7 +87,7 @@ PyObject *PyPlasma_create(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_hash(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
     return NULL;
@@ -105,7 +105,7 @@ PyObject *PyPlasma_hash(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_seal(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
     return NULL;
@@ -116,7 +116,7 @@ PyObject *PyPlasma_seal(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_release(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
     return NULL;
@@ -135,7 +135,7 @@ PyObject *PyPlasma_get(PyObject *self, PyObject *args) {
   }
 
   Py_ssize_t num_object_ids = PyList_Size(object_id_list);
-  object_id object_ids[num_object_ids];
+  ObjectID object_ids[num_object_ids];
   object_buffer object_buffers[num_object_ids];
 
   for (int i = 0; i < num_object_ids; ++i) {
@@ -181,7 +181,7 @@ PyObject *PyPlasma_get(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_contains(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
     return NULL;
@@ -207,7 +207,7 @@ PyObject *PyPlasma_fetch(PyObject *self, PyObject *args) {
     return NULL;
   }
   Py_ssize_t n = PyList_Size(object_id_list);
-  object_id *object_ids = malloc(sizeof(object_id) * n);
+  ObjectID *object_ids = malloc(sizeof(ObjectID) * n);
   for (int i = 0; i < n; ++i) {
     PyStringToUniqueID(PyList_GetItem(object_id_list, i), &object_ids[i]);
   }
@@ -304,7 +304,7 @@ PyObject *PyPlasma_evict(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_delete(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   if (!PyArg_ParseTuple(args, "O&O&", PyObjectToPlasmaConnection, &conn,
                         PyStringToUniqueID, &object_id)) {
     return NULL;
@@ -315,7 +315,7 @@ PyObject *PyPlasma_delete(PyObject *self, PyObject *args) {
 
 PyObject *PyPlasma_transfer(PyObject *self, PyObject *args) {
   plasma_connection *conn;
-  object_id object_id;
+  ObjectID object_id;
   const char *addr;
   int port;
   if (!PyArg_ParseTuple(args, "O&O&si", PyObjectToPlasmaConnection, &conn,
@@ -350,7 +350,7 @@ PyObject *PyPlasma_receive_notification(PyObject *self, PyObject *args) {
     return NULL;
   }
   /* Receive object notification from the plasma connection socket. If the
-   * object was added, return a tuple of its fields: object_id, data_size,
+   * object was added, return a tuple of its fields: ObjectID, data_size,
    * metadata_size. If the object was deleted, data_size and metadata_size will
    * be set to -1. */
   int nbytes =

--- a/src/plasma/plasma_extension.h
+++ b/src/plasma/plasma_extension.h
@@ -2,9 +2,9 @@
 #define PLASMA_EXTENSION_H
 
 static int PyObjectToPlasmaConnection(PyObject *object,
-                                      plasma_connection **conn) {
+                                      PlasmaConnection **conn) {
   if (PyCapsule_IsValid(object, "plasma")) {
-    *conn = (plasma_connection *) PyCapsule_GetPointer(object, "plasma");
+    *conn = (PlasmaConnection *) PyCapsule_GetPointer(object, "plasma");
     return 1;
   } else {
     PyErr_SetString(PyExc_TypeError, "must be a 'plasma' capsule");

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -1227,7 +1227,7 @@ void process_status_request(ClientConnection *client_conn,
 }
 
 void process_delete_object_notification(plasma_manager_state *state,
-                                        object_info object_info) {
+                                        ObjectInfo object_info) {
   ObjectID obj_id = object_info.obj_id;
   available_object *entry;
   HASH_FIND(hh, state->local_available_objects, &obj_id, sizeof(obj_id), entry);
@@ -1248,7 +1248,7 @@ void process_delete_object_notification(plasma_manager_state *state,
 }
 
 void process_add_object_notification(plasma_manager_state *state,
-                                     object_info object_info) {
+                                     ObjectInfo object_info) {
   ObjectID obj_id = object_info.obj_id;
   available_object *entry =
       (available_object *) malloc(sizeof(available_object));
@@ -1285,7 +1285,7 @@ void process_object_notification(event_loop *loop,
                                  void *context,
                                  int events) {
   plasma_manager_state *state = context;
-  object_info object_info;
+  ObjectInfo object_info;
   /* Read the notification from Plasma. */
   int error =
       read_bytes(client_sock, (uint8_t *) &object_info, sizeof(object_info));

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -43,8 +43,7 @@
  * @param object_id ID of the object for which we process this request.
  * @return Void.
  */
-void process_status_request(ClientConnection *client_conn,
-                            ObjectID object_id);
+void process_status_request(ClientConnection *client_conn, ObjectID object_id);
 
 /**
  * Request the transfer from a remote node or get the status of
@@ -1200,8 +1199,7 @@ void object_table_lookup_fail_callback(ObjectID object_id,
   CHECK(0);
 }
 
-void process_status_request(ClientConnection *client_conn,
-                            ObjectID object_id) {
+void process_status_request(ClientConnection *client_conn, ObjectID object_id) {
   /* Return success immediately if we already have this object. */
   if (is_object_local(client_conn->manager_state, object_id)) {
     int status = ObjectStatus_Local;

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -760,7 +760,7 @@ void process_transfer_request(event_loop *loop,
    * do a non-blocking get call on the store, and if the object isn't there then
    * perhaps the manager should initiate the transfer when it receives a
    * notification from the store that the object is present. */
-  object_buffer obj_buffer;
+  ObjectBuffer obj_buffer;
   int counter = 0;
   do {
     /* We pass in 0 to indicate that the command should return immediately. */

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -186,7 +186,7 @@ struct plasma_manager_state {
    *  other plasma managers. These are used for writing data to
    *  other plasma stores. */
   client_connection *manager_connections;
-  db_handle *db;
+  DBHandle *db;
   /** Our address. */
   const char *addr;
   /** Our port. */

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -181,7 +181,7 @@ struct plasma_manager_state {
   /** Event loop. */
   event_loop *loop;
   /** Connection to the local plasma store for reading or writing data. */
-  plasma_connection *plasma_conn;
+  PlasmaConnection *plasma_conn;
   /** Hash table of all contexts for active connections to
    *  other plasma managers. These are used for writing data to
    *  other plasma stores. */

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -44,7 +44,7 @@
  * @return Void.
  */
 void process_status_request(client_connection *client_conn,
-                            object_id object_id);
+                            ObjectID object_id);
 
 /**
  * Request the transfer from a remote node or get the status of
@@ -58,7 +58,7 @@ void process_status_request(client_connection *client_conn,
  * @param context Client connection.
  * @return Status of object_id as defined in plasma.h
  */
-int request_status(object_id object_id,
+int request_status(ObjectID object_id,
                    int manager_count,
                    const char *manager_vector[],
                    void *context);
@@ -75,7 +75,7 @@ int request_status(object_id object_id,
  * @param conn The client connection object.
  */
 void process_transfer_request(event_loop *loop,
-                              object_id object_id,
+                              ObjectID object_id,
                               const char *addr,
                               int port,
                               client_connection *conn);
@@ -94,7 +94,7 @@ void process_transfer_request(event_loop *loop,
  */
 void process_data_request(event_loop *loop,
                           int client_sock,
-                          object_id object_id,
+                          ObjectID object_id,
                           int64_t data_size,
                           int64_t metadata_size,
                           client_connection *conn);
@@ -102,14 +102,14 @@ void process_data_request(event_loop *loop,
 /** Entry of the hashtable of objects that are available locally. */
 typedef struct {
   /** Object id of this object. */
-  object_id object_id;
+  ObjectID object_id;
   /** Handle for the uthash table. */
   UT_hash_handle hh;
 } available_object;
 
 typedef struct {
   /** The ID of the object we are fetching or waiting for. */
-  object_id object_id;
+  ObjectID object_id;
   /** Pointer to the array containing the manager locations of this object. This
    *  struct owns and must free each entry. */
   char **manager_vector;
@@ -169,7 +169,7 @@ UT_icd wait_request_icd = {sizeof(wait_request *), NULL, NULL, NULL};
 
 typedef struct {
   /** The ID of the object. This is used as a key in a hash table. */
-  object_id object_id;
+  ObjectID object_id;
   /** An array of the wait requests involving this object ID. */
   UT_array *wait_requests;
   /** Handle for the uthash table in the manager state that keeps track of the
@@ -211,7 +211,7 @@ plasma_manager_state *g_manager_state = NULL;
 /* The context for fetch and wait requests. These are per client, per object. */
 struct client_object_request {
   /** The ID of the object we are fetching or waiting for. */
-  object_id object_id;
+  ObjectID object_id;
   /** The client connection context, shared between other
    *  client_object_requests for the same client. */
   client_connection *client_conn;
@@ -288,7 +288,7 @@ object_wait_requests **object_wait_requests_table_ptr_from_type(
 }
 
 void add_wait_request_for_object(plasma_manager_state *manager_state,
-                                 object_id object_id,
+                                 ObjectID object_id,
                                  int type,
                                  wait_request *wait_req) {
   object_wait_requests **object_wait_requests_table_ptr =
@@ -312,7 +312,7 @@ void add_wait_request_for_object(plasma_manager_state *manager_state,
 }
 
 void remove_wait_request_for_object(plasma_manager_state *manager_state,
-                                    object_id object_id,
+                                    ObjectID object_id,
                                     int type,
                                     wait_request *wait_req) {
   object_wait_requests **object_wait_requests_table_ptr =
@@ -368,7 +368,7 @@ void return_from_wait(plasma_manager_state *manager_state,
 }
 
 void update_object_wait_requests(plasma_manager_state *manager_state,
-                                 object_id obj_id,
+                                 ObjectID obj_id,
                                  int type,
                                  int status) {
   object_wait_requests **object_wait_requests_table_ptr =
@@ -423,7 +423,7 @@ void update_object_wait_requests(plasma_manager_state *manager_state,
 }
 
 fetch_request *create_fetch_request(plasma_manager_state *manager_state,
-                                    object_id object_id) {
+                                    ObjectID object_id) {
   fetch_request *fetch_req = malloc(sizeof(fetch_request));
   fetch_req->object_id = object_id;
   fetch_req->manager_count = 0;
@@ -722,7 +722,7 @@ client_connection *get_manager_connection(plasma_manager_state *state,
 }
 
 void process_transfer_request(event_loop *loop,
-                              object_id obj_id,
+                              ObjectID obj_id,
                               const char *addr,
                               int port,
                               client_connection *conn) {
@@ -764,7 +764,7 @@ void process_transfer_request(event_loop *loop,
   int counter = 0;
   do {
     /* We pass in 0 to indicate that the command should return immediately. */
-    object_id obj_id_array[1] = {obj_id};
+    ObjectID obj_id_array[1] = {obj_id};
     plasma_get(conn->manager_state->plasma_conn, obj_id_array, 1, 0,
                &obj_buffer);
     if (counter > 0) {
@@ -800,7 +800,7 @@ void process_transfer_request(event_loop *loop,
  */
 void process_data_request(event_loop *loop,
                           int client_sock,
-                          object_id object_id,
+                          ObjectID object_id,
                           int64_t data_size,
                           int64_t metadata_size,
                           client_connection *conn) {
@@ -842,7 +842,7 @@ void process_data_request(event_loop *loop,
 }
 
 void request_transfer_from(plasma_manager_state *manager_state,
-                           object_id object_id) {
+                           ObjectID object_id) {
   fetch_request *fetch_req;
   HASH_FIND(hh, manager_state->fetch_requests, &object_id, sizeof(object_id),
             fetch_req);
@@ -901,14 +901,14 @@ int fetch_timeout_handler(event_loop *loop, timer_id id, void *context) {
   return MANAGER_TIMEOUT;
 }
 
-bool is_object_local(plasma_manager_state *state, object_id object_id) {
+bool is_object_local(plasma_manager_state *state, ObjectID object_id) {
   available_object *entry;
   HASH_FIND(hh, state->local_available_objects, &object_id, sizeof(object_id),
             entry);
   return entry != NULL;
 }
 
-void request_transfer(object_id object_id,
+void request_transfer(ObjectID object_id,
                       int manager_count,
                       const char *manager_vector[],
                       void *context) {
@@ -958,7 +958,7 @@ void request_transfer(object_id object_id,
 }
 
 /* This method is only called from the tests. */
-void call_request_transfer(object_id object_id,
+void call_request_transfer(ObjectID object_id,
                            int manager_count,
                            const char *manager_vector[],
                            void *context) {
@@ -975,11 +975,11 @@ void call_request_transfer(object_id object_id,
   request_transfer(object_id, manager_count, manager_vector, context);
 }
 
-void fatal_table_callback(object_id id, void *user_context, void *user_data) {
+void fatal_table_callback(ObjectID id, void *user_context, void *user_data) {
   CHECK(0);
 }
 
-void object_present_callback(object_id object_id,
+void object_present_callback(ObjectID object_id,
                              int manager_count,
                              const char *manager_vector[],
                              void *context) {
@@ -995,7 +995,7 @@ void object_present_callback(object_id object_id,
 
 /* This callback is used by both fetch and wait. Therefore, it may have to
  * handle outstanding fetch and wait requests. */
-void object_table_subscribe_callback(object_id object_id,
+void object_table_subscribe_callback(ObjectID object_id,
                                      int64_t data_size,
                                      int manager_count,
                                      const char *manager_vector[],
@@ -1014,16 +1014,16 @@ void object_table_subscribe_callback(object_id object_id,
 
 void process_fetch_requests(client_connection *client_conn,
                             int num_object_ids,
-                            object_id object_ids[]) {
+                            ObjectID object_ids[]) {
   plasma_manager_state *manager_state = client_conn->manager_state;
 
   int num_object_ids_to_request = 0;
   /* This is allocating more space than necessary, but we do not know the exact
    * number of object IDs to request notifications for yet. */
-  object_id *object_ids_to_request = malloc(num_object_ids * sizeof(object_id));
+  ObjectID *object_ids_to_request = malloc(num_object_ids * sizeof(ObjectID));
 
   for (int i = 0; i < num_object_ids; ++i) {
-    object_id obj_id = object_ids[i];
+    ObjectID obj_id = object_ids[i];
 
     /* Check if this object is already present locally. If so, do nothing. */
     if (is_object_local(manager_state, obj_id)) {
@@ -1093,11 +1093,11 @@ void process_wait_request(client_connection *client_conn,
   int num_object_ids_to_request = 0;
   /* This is allocating more space than necessary, but we do not know the exact
    * number of object IDs to request notifications for yet. */
-  object_id *object_ids_to_request =
-      malloc(num_object_requests * sizeof(object_id));
+  ObjectID *object_ids_to_request =
+      malloc(num_object_requests * sizeof(ObjectID));
 
   for (int i = 0; i < num_object_requests; ++i) {
-    object_id obj_id = object_requests[i].object_id;
+    ObjectID obj_id = object_requests[i].object_id;
 
     /* Check if this object is already present locally. If so, mark the object
      * as present. */
@@ -1162,7 +1162,7 @@ void process_wait_request(client_connection *client_conn,
  * @param context Client connection.
  * @return Void.
  */
-void request_status_done(object_id object_id,
+void request_status_done(ObjectID object_id,
                          int manager_count,
                          const char *manager_vector[],
                          void *context) {
@@ -1175,7 +1175,7 @@ void request_status_done(object_id object_id,
                   client_conn->fd);
 }
 
-int request_status(object_id object_id,
+int request_status(ObjectID object_id,
                    int manager_count,
                    const char *manager_vector[],
                    void *context) {
@@ -1192,7 +1192,7 @@ int request_status(object_id object_id,
   return (manager_count > 0 ? ObjectStatus_Remote : ObjectStatus_Nonexistent);
 }
 
-void object_table_lookup_fail_callback(object_id object_id,
+void object_table_lookup_fail_callback(ObjectID object_id,
                                        void *user_context,
                                        void *user_data) {
   /* Fail for now. Later, we may want to send a ObjectStatus_Nonexistent to the
@@ -1201,7 +1201,7 @@ void object_table_lookup_fail_callback(object_id object_id,
 }
 
 void process_status_request(client_connection *client_conn,
-                            object_id object_id) {
+                            ObjectID object_id) {
   /* Return success immediately if we already have this object. */
   if (is_object_local(client_conn->manager_state, object_id)) {
     int status = ObjectStatus_Local;
@@ -1228,7 +1228,7 @@ void process_status_request(client_connection *client_conn,
 
 void process_delete_object_notification(plasma_manager_state *state,
                                         object_info object_info) {
-  object_id obj_id = object_info.obj_id;
+  ObjectID obj_id = object_info.obj_id;
   available_object *entry;
   HASH_FIND(hh, state->local_available_objects, &obj_id, sizeof(obj_id), entry);
   if (entry != NULL) {
@@ -1249,11 +1249,11 @@ void process_delete_object_notification(plasma_manager_state *state,
 
 void process_add_object_notification(plasma_manager_state *state,
                                      object_info object_info) {
-  object_id obj_id = object_info.obj_id;
+  ObjectID obj_id = object_info.obj_id;
   available_object *entry =
       (available_object *) malloc(sizeof(available_object));
   entry->object_id = obj_id;
-  HASH_ADD(hh, state->local_available_objects, object_id, sizeof(object_id),
+  HASH_ADD(hh, state->local_available_objects, object_id, sizeof(ObjectID),
            entry);
 
   /* Add this object to the (redis) object table. */
@@ -1320,7 +1320,7 @@ void process_message(event_loop *loop,
   switch (type) {
   case MessageType_PlasmaDataRequest: {
     LOG_DEBUG("Processing data request");
-    object_id object_id;
+    ObjectID object_id;
     char *address;
     int port;
     plasma_read_DataRequest(data, &object_id, &address, &port);
@@ -1329,7 +1329,7 @@ void process_message(event_loop *loop,
   } break;
   case MessageType_PlasmaDataReply: {
     LOG_DEBUG("Processing data reply");
-    object_id object_id;
+    ObjectID object_id;
     int64_t object_size;
     int64_t metadata_size;
     plasma_read_DataReply(data, &object_id, &object_size, &metadata_size);
@@ -1339,7 +1339,7 @@ void process_message(event_loop *loop,
   case MessageType_PlasmaFetchRequest: {
     LOG_DEBUG("Processing fetch remote");
     int64_t num_objects = plasma_read_FetchRequest_num_objects(data);
-    object_id *object_ids_to_fetch = malloc(num_objects * sizeof(object_id));
+    ObjectID *object_ids_to_fetch = malloc(num_objects * sizeof(ObjectID));
     /* TODO(pcm): process_fetch_requests allocates an array of num_objects
      * object_ids too so these should be shared in the future. */
     plasma_read_FetchRequest(data, object_ids_to_fetch, num_objects);
@@ -1363,7 +1363,7 @@ void process_message(event_loop *loop,
   } break;
   case MessageType_PlasmaStatusRequest: {
     LOG_DEBUG("Processing status");
-    object_id object_id;
+    ObjectID object_id;
     int64_t num_objects = plasma_read_StatusRequest_num_objects(data);
     CHECK(num_objects == 1);
     plasma_read_StatusRequest(data, &object_id, 1);

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -394,7 +394,7 @@ void update_object_wait_requests(plasma_manager_state *manager_state,
       /* Mark the object as present in the wait request. */
       int j = 0;
       for (; j < wait_req->num_object_requests; ++j) {
-        if (object_ids_equal(wait_req->object_requests[j].object_id, obj_id)) {
+        if (ObjectID_equal(wait_req->object_requests[j].object_id, obj_id)) {
           /* Check that this object is currently nonexistent. */
           CHECK(wait_req->object_requests[j].status ==
                 ObjectStatus_Nonexistent);
@@ -733,7 +733,7 @@ void process_transfer_request(event_loop *loop,
    * ID, do not add the transfer request. */
   plasma_request_buffer *pending;
   LL_FOREACH(manager_conn->transfer_queue, pending) {
-    if (object_ids_equal(pending->object_id, obj_id) &&
+    if (ObjectID_equal(pending->object_id, obj_id) &&
         (pending->type == MessageType_PlasmaDataReply)) {
       return;
     }

--- a/src/plasma/plasma_manager.c
+++ b/src/plasma/plasma_manager.c
@@ -155,7 +155,7 @@ typedef struct {
   /** The object requests for this wait request. Each object request has a
    *  status field which is either PLASMA_QUERY_LOCAL or PLASMA_QUERY_ANYWHERE.
    */
-  object_request *object_requests;
+  ObjectRequest *object_requests;
   /** The minimum number of objects to wait for in this request. */
   int64_t num_objects_to_wait_for;
   /** The number of object requests in this wait request that are already
@@ -1068,7 +1068,7 @@ int wait_timeout_handler(event_loop *loop, timer_id id, void *context) {
 
 void process_wait_request(client_connection *client_conn,
                           int num_object_requests,
-                          object_request object_requests[],
+                          ObjectRequest object_requests[],
                           uint64_t timeout_ms,
                           int num_ready_objects) {
   CHECK(client_conn != NULL);
@@ -1081,7 +1081,7 @@ void process_wait_request(client_connection *client_conn,
   wait_req->timer = -1;
   wait_req->num_object_requests = num_object_requests;
   wait_req->object_requests =
-      malloc(num_object_requests * sizeof(object_request));
+      malloc(num_object_requests * sizeof(ObjectRequest));
   for (int i = 0; i < num_object_requests; ++i) {
     wait_req->object_requests[i].object_id = object_requests[i].object_id;
     wait_req->object_requests[i].type = object_requests[i].type;
@@ -1349,8 +1349,8 @@ void process_message(event_loop *loop,
   case MessageType_PlasmaWaitRequest: {
     LOG_DEBUG("Processing wait");
     int num_object_ids = plasma_read_WaitRequest_num_object_ids(data);
-    object_request *object_requests =
-        malloc(num_object_ids * sizeof(object_request));
+    ObjectRequest *object_requests =
+        malloc(num_object_ids * sizeof(ObjectRequest));
     int64_t timeout_ms;
     int num_ready_objects;
     plasma_read_WaitRequest(data, &object_requests[0], num_object_ids,

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -71,7 +71,7 @@ void destroy_plasma_manager_state(plasma_manager_state *state);
  * manager.
  */
 void process_transfer(event_loop *loop,
-                      object_id object_id,
+                      ObjectID object_id,
                       uint8_t addr[4],
                       int port,
                       client_connection *conn);
@@ -93,7 +93,7 @@ void process_transfer(event_loop *loop,
  */
 void process_data(event_loop *loop,
                   int client_sock,
-                  object_id object_id,
+                  ObjectID object_id,
                   int64_t data_size,
                   int64_t metadata_size,
                   client_connection *conn);
@@ -170,7 +170,7 @@ client_connection *new_client_connection(event_loop *loop,
 typedef struct plasma_request_buffer plasma_request_buffer;
 struct plasma_request_buffer {
   int type;
-  object_id object_id;
+  ObjectID object_id;
   uint8_t *data;
   int64_t data_size;
   uint8_t *metadata;
@@ -193,7 +193,7 @@ struct plasma_request_buffer {
  * @param context The plasma manager state.
  * @return Void.
  */
-void call_request_transfer(object_id object_id,
+void call_request_transfer(ObjectID object_id,
                            int manager_count,
                            const char *manager_vector[],
                            void *context);
@@ -277,6 +277,6 @@ int get_client_sock(client_connection *conn);
  * @return A bool that is true if the requested object is local and false
  *         otherwise.
  */
-bool is_object_local(plasma_manager_state *state, object_id object_id);
+bool is_object_local(plasma_manager_state *state, ObjectID object_id);
 
 #endif /* PLASMA_MANAGER_H */

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -21,7 +21,7 @@
 #define BUFSIZE 4096
 
 typedef struct plasma_manager_state plasma_manager_state;
-typedef struct client_connection client_connection;
+typedef struct ClientConnection ClientConnection;
 typedef struct client_object_request client_object_request;
 
 /**
@@ -63,7 +63,7 @@ void destroy_plasma_manager_state(plasma_manager_state *state);
  * @param object_id The object_id of the object we will be sending.
  * @param addr The IP address of the plasma manager to send the object to.
  * @param port The port of the plasma manager we are sending the object to.
- * @param conn The client_connection to the other plasma manager.
+ * @param conn The ClientConnection to the other plasma manager.
  * @return Void.
  *
  * This establishes a connection to the remote manager if one doesn't already
@@ -74,7 +74,7 @@ void process_transfer(event_loop *loop,
                       ObjectID object_id,
                       uint8_t addr[4],
                       int port,
-                      client_connection *conn);
+                      ClientConnection *conn);
 
 /**
  * Process a request from another object store manager to receive data.
@@ -84,7 +84,7 @@ void process_transfer(event_loop *loop,
  * @param object_id The object_id of the object we will be reading.
  * @param data_size Size of the object.
  * @param metadata_size Size of the metadata.
- * @param conn The client_connection to the other plasma manager.
+ * @param conn The ClientConnection to the other plasma manager.
  * @return Void.
  *
  * Initializes the object we are going to write to in the local plasma store
@@ -96,7 +96,7 @@ void process_data(event_loop *loop,
                   ObjectID object_id,
                   int64_t data_size,
                   int64_t metadata_size,
-                  client_connection *conn);
+                  ClientConnection *conn);
 
 /**
  * Read the next chunk of the object in transit from the plasma manager
@@ -105,7 +105,7 @@ void process_data(event_loop *loop,
  *
  * @param loop This is the event loop of the plasma manager.
  * @param data_sock The connection to the other plasma manager.
- * @param context The client_connection to the other plasma manager.
+ * @param context The ClientConnection to the other plasma manager.
  * @return Void.
  */
 void process_data_chunk(event_loop *loop,
@@ -136,7 +136,7 @@ void process_object_notification(event_loop *loop,
  *
  * @param loop This is the event loop of the plasma manager.
  * @param data_sock This is the socket the other plasma manager is listening on.
- * @param context The client_connection to the other plasma manager, contains a
+ * @param context The ClientConnection to the other plasma manager, contains a
  *        queue of objects that will be sent.
  * @return Void.
  */
@@ -154,10 +154,10 @@ void send_queued_request(event_loop *loop,
  * @param context The plasma manager state.
  * @return Void.
  */
-client_connection *new_client_connection(event_loop *loop,
-                                         int listener_sock,
-                                         void *context,
-                                         int events);
+ClientConnection *ClientConnection_init(event_loop *loop,
+                                        int listener_sock,
+                                        void *context,
+                                        int events);
 
 /**
  * The following definitions are internal to the plasma manager code but are
@@ -214,7 +214,7 @@ int fetch_timeout_handler(event_loop *loop, timer_id id, void *context);
  * @param object_id The object ID whose context we want to delete.
  * @return Void.
  */
-void remove_object_request(client_connection *client_conn,
+void remove_object_request(ClientConnection *client_conn,
                            client_object_request *object_req);
 
 /**
@@ -226,7 +226,7 @@ void remove_object_request(client_connection *client_conn,
  * @param port The port that the remote manager is listening on.
  * @return A pointer to the connection to the remote manager.
  */
-client_connection *get_manager_connection(plasma_manager_state *state,
+ClientConnection *get_manager_connection(plasma_manager_state *state,
                                           const char *ip_addr,
                                           int port);
 
@@ -240,7 +240,7 @@ client_connection *get_manager_connection(plasma_manager_state *state,
  *         object. 1 means that the client has sent all the data, 0 means there
  *         is more.
  */
-int read_object_chunk(client_connection *conn, plasma_request_buffer *buf);
+int read_object_chunk(ClientConnection *conn, plasma_request_buffer *buf);
 
 /**
  * Writes an object chunk from a buffer to the given client. This is the
@@ -250,7 +250,7 @@ int read_object_chunk(client_connection *conn, plasma_request_buffer *buf);
  * @param buf The buffer to read data from.
  * @return Void.
  */
-void write_object_chunk(client_connection *conn, plasma_request_buffer *buf);
+void write_object_chunk(ClientConnection *conn, plasma_request_buffer *buf);
 
 /**
  * Get the event loop of the given plasma manager state.
@@ -267,7 +267,7 @@ event_loop *get_event_loop(plasma_manager_state *state);
  * @param conn The connection to the client who's sending or reading data.
  * @return A file descriptor for the socket.
  */
-int get_client_sock(client_connection *conn);
+int get_client_sock(ClientConnection *conn);
 
 /**
  * Return whether or not the object is local.

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -227,8 +227,8 @@ void remove_object_request(ClientConnection *client_conn,
  * @return A pointer to the connection to the remote manager.
  */
 ClientConnection *get_manager_connection(plasma_manager_state *state,
-                                          const char *ip_addr,
-                                          int port);
+                                         const char *ip_addr,
+                                         int port);
 
 /**
  * Reads an object chunk sent by the given client into a buffer. This is the

--- a/src/plasma/plasma_protocol.c
+++ b/src/plasma/plasma_protocol.c
@@ -154,7 +154,7 @@ void plasma_read_CreateReply(uint8_t *data,
 
 #define DEFINE_SIMPLE_SEND_REQUEST(MESSAGE_NAME)                       \
   int plasma_send_##MESSAGE_NAME(int sock, protocol_builder *B,        \
-                                 ObjectID object_id) {                \
+                                 ObjectID object_id) {                 \
     Plasma##MESSAGE_NAME##_start_as_root(B);                           \
     Plasma##MESSAGE_NAME##_object_id_create(                           \
         B, (const char *) &object_id.id[0], sizeof(object_id.id));     \
@@ -164,7 +164,7 @@ void plasma_read_CreateReply(uint8_t *data,
   }
 
 #define DEFINE_SIMPLE_READ_REQUEST(MESSAGE_NAME)                               \
-  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id) {       \
+  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id) {        \
     DCHECK(data);                                                              \
     Plasma##MESSAGE_NAME##_table_t req = Plasma##MESSAGE_NAME##_as_root(data); \
     flatbuffers_string_t id = Plasma##MESSAGE_NAME##_object_id(req);           \
@@ -174,7 +174,7 @@ void plasma_read_CreateReply(uint8_t *data,
 
 #define DEFINE_SIMPLE_SEND_REPLY(MESSAGE_NAME)                         \
   int plasma_send_##MESSAGE_NAME(int sock, protocol_builder *B,        \
-                                 ObjectID object_id, int error) {     \
+                                 ObjectID object_id, int error) {      \
     Plasma##MESSAGE_NAME##_start_as_root(B);                           \
     Plasma##MESSAGE_NAME##_object_id_create(                           \
         B, (const char *) &object_id.id[0], sizeof(object_id.id));     \
@@ -185,7 +185,7 @@ void plasma_read_CreateReply(uint8_t *data,
   }
 
 #define DEFINE_SIMPLE_READ_REPLY(MESSAGE_NAME)                                 \
-  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id,         \
+  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id,          \
                                   int *error) {                                \
     DCHECK(data);                                                              \
     Plasma##MESSAGE_NAME##_table_t req = Plasma##MESSAGE_NAME##_as_root(data); \

--- a/src/plasma/plasma_protocol.c
+++ b/src/plasma/plasma_protocol.c
@@ -30,7 +30,7 @@ void free_protocol_builder(protocol_builder *builder) {
  * @return Reference to the flatbuffer string vector.
  */
 flatbuffers_string_vec_ref_t object_ids_to_flatbuffer(flatcc_builder_t *B,
-                                                      object_id object_ids[],
+                                                      ObjectID object_ids[],
                                                       int64_t num_objects) {
   flatbuffers_string_vec_start(B);
   for (int i = 0; i < num_objects; i++) {
@@ -52,7 +52,7 @@ flatbuffers_string_vec_ref_t object_ids_to_flatbuffer(flatcc_builder_t *B,
  * @return Void.
  */
 void object_ids_from_flatbuffer(flatbuffers_string_vec_t object_id_vector,
-                                object_id object_ids[],
+                                ObjectID object_ids[],
                                 int64_t num_objects) {
   CHECK(flatbuffers_string_vec_len(object_id_vector) == num_objects);
   for (int64_t i = 0; i < num_objects; ++i) {
@@ -92,7 +92,7 @@ uint8_t *plasma_receive(int sock, int64_t message_type) {
 
 int plasma_send_CreateRequest(int sock,
                               protocol_builder *B,
-                              object_id object_id,
+                              ObjectID object_id,
                               int64_t data_size,
                               int64_t metadata_size) {
   PlasmaCreateRequest_start_as_root(B);
@@ -105,7 +105,7 @@ int plasma_send_CreateRequest(int sock,
 }
 
 void plasma_read_CreateRequest(uint8_t *data,
-                               object_id *object_id,
+                               ObjectID *object_id,
                                int64_t *data_size,
                                int64_t *metadata_size) {
   DCHECK(data);
@@ -119,7 +119,7 @@ void plasma_read_CreateRequest(uint8_t *data,
 
 int plasma_send_CreateReply(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             plasma_object *object,
                             int error_code) {
   PlasmaCreateReply_start_as_root(B);
@@ -134,7 +134,7 @@ int plasma_send_CreateReply(int sock,
 }
 
 void plasma_read_CreateReply(uint8_t *data,
-                             object_id *object_id,
+                             ObjectID *object_id,
                              plasma_object *object,
                              int *error_code) {
   DCHECK(data);
@@ -154,7 +154,7 @@ void plasma_read_CreateReply(uint8_t *data,
 
 #define DEFINE_SIMPLE_SEND_REQUEST(MESSAGE_NAME)                       \
   int plasma_send_##MESSAGE_NAME(int sock, protocol_builder *B,        \
-                                 object_id object_id) {                \
+                                 ObjectID object_id) {                \
     Plasma##MESSAGE_NAME##_start_as_root(B);                           \
     Plasma##MESSAGE_NAME##_object_id_create(                           \
         B, (const char *) &object_id.id[0], sizeof(object_id.id));     \
@@ -164,7 +164,7 @@ void plasma_read_CreateReply(uint8_t *data,
   }
 
 #define DEFINE_SIMPLE_READ_REQUEST(MESSAGE_NAME)                               \
-  void plasma_read_##MESSAGE_NAME(uint8_t *data, object_id *object_id) {       \
+  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id) {       \
     DCHECK(data);                                                              \
     Plasma##MESSAGE_NAME##_table_t req = Plasma##MESSAGE_NAME##_as_root(data); \
     flatbuffers_string_t id = Plasma##MESSAGE_NAME##_object_id(req);           \
@@ -174,7 +174,7 @@ void plasma_read_CreateReply(uint8_t *data,
 
 #define DEFINE_SIMPLE_SEND_REPLY(MESSAGE_NAME)                         \
   int plasma_send_##MESSAGE_NAME(int sock, protocol_builder *B,        \
-                                 object_id object_id, int error) {     \
+                                 ObjectID object_id, int error) {     \
     Plasma##MESSAGE_NAME##_start_as_root(B);                           \
     Plasma##MESSAGE_NAME##_object_id_create(                           \
         B, (const char *) &object_id.id[0], sizeof(object_id.id));     \
@@ -185,7 +185,7 @@ void plasma_read_CreateReply(uint8_t *data,
   }
 
 #define DEFINE_SIMPLE_READ_REPLY(MESSAGE_NAME)                                 \
-  void plasma_read_##MESSAGE_NAME(uint8_t *data, object_id *object_id,         \
+  void plasma_read_##MESSAGE_NAME(uint8_t *data, ObjectID *object_id,         \
                                   int *error) {                                \
     DCHECK(data);                                                              \
     Plasma##MESSAGE_NAME##_table_t req = Plasma##MESSAGE_NAME##_as_root(data); \
@@ -197,7 +197,7 @@ void plasma_read_CreateReply(uint8_t *data,
 
 int plasma_send_SealRequest(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             unsigned char *digest) {
   PlasmaSealRequest_start_as_root(B);
   PlasmaSealRequest_object_id_create(B, (const char *) &object_id.id[0],
@@ -208,7 +208,7 @@ int plasma_send_SealRequest(int sock,
 }
 
 void plasma_read_SealRequest(uint8_t *data,
-                             object_id *object_id,
+                             ObjectID *object_id,
                              unsigned char *digest) {
   DCHECK(data);
   PlasmaSealRequest_table_t req = PlasmaSealRequest_as_root(data);
@@ -237,7 +237,7 @@ DEFINE_SIMPLE_READ_REPLY(DeleteReply);
 
 int plasma_send_StatusRequest(int sock,
                               protocol_builder *B,
-                              object_id object_ids[],
+                              ObjectID object_ids[],
                               int64_t num_objects) {
   PlasmaStatusRequest_start_as_root(B);
   PlasmaStatusRequest_object_ids_add(
@@ -253,7 +253,7 @@ int64_t plasma_read_StatusRequest_num_objects(uint8_t *data) {
 }
 
 void plasma_read_StatusRequest(uint8_t *data,
-                               object_id object_ids[],
+                               ObjectID object_ids[],
                                int64_t num_objects) {
   DCHECK(data);
   PlasmaStatusRequest_table_t req = PlasmaStatusRequest_as_root(data);
@@ -263,7 +263,7 @@ void plasma_read_StatusRequest(uint8_t *data,
 
 int plasma_send_StatusReply(int sock,
                             protocol_builder *B,
-                            object_id object_ids[],
+                            ObjectID object_ids[],
                             int object_status[],
                             int64_t num_objects) {
   PlasmaStatusReply_start_as_root(B);
@@ -285,7 +285,7 @@ int64_t plasma_read_StatusReply_num_objects(uint8_t *data) {
 }
 
 void plasma_read_StatusReply(uint8_t *data,
-                             object_id object_ids[],
+                             ObjectID object_ids[],
                              int object_status[],
                              int64_t num_objects) {
   DCHECK(data);
@@ -302,7 +302,7 @@ void plasma_read_StatusReply(uint8_t *data,
 
 int plasma_send_ContainsRequest(int sock,
                                 protocol_builder *B,
-                                object_id object_id) {
+                                ObjectID object_id) {
   PlasmaContainsRequest_start_as_root(B);
   PlasmaContainsRequest_object_id_create(B, (const char *) &object_id.id[0],
                                          sizeof(object_id.id));
@@ -310,7 +310,7 @@ int plasma_send_ContainsRequest(int sock,
   return finalize_buffer_and_send(B, sock, MessageType_PlasmaContainsRequest);
 }
 
-void plasma_read_ContainsRequest(uint8_t *data, object_id *object_id) {
+void plasma_read_ContainsRequest(uint8_t *data, ObjectID *object_id) {
   DCHECK(data);
   PlasmaContainsRequest_table_t req = PlasmaContainsRequest_as_root(data);
   flatbuffers_string_t id = PlasmaContainsRequest_object_id(req);
@@ -320,7 +320,7 @@ void plasma_read_ContainsRequest(uint8_t *data, object_id *object_id) {
 
 int plasma_send_ContainsReply(int sock,
                               protocol_builder *B,
-                              object_id object_id,
+                              ObjectID object_id,
                               int has_object) {
   PlasmaContainsReply_start_as_root(B);
   PlasmaContainsReply_object_id_create(B, (const char *) &object_id.id[0],
@@ -331,7 +331,7 @@ int plasma_send_ContainsReply(int sock,
 }
 
 void plasma_read_ContainsReply(uint8_t *data,
-                               object_id *object_id,
+                               ObjectID *object_id,
                                int *has_object) {
   DCHECK(data);
   PlasmaContainsReply_table_t rep = PlasmaContainsReply_as_root(data);
@@ -401,7 +401,7 @@ void plasma_read_EvictReply(uint8_t *data, int64_t *num_bytes) {
 
 int plasma_send_GetRequest(int sock,
                            protocol_builder *B,
-                           object_id object_ids[],
+                           ObjectID object_ids[],
                            int64_t num_objects,
                            int64_t timeout_ms) {
   PlasmaGetRequest_start_as_root(B);
@@ -419,7 +419,7 @@ int64_t plasma_read_GetRequest_num_objects(uint8_t *data) {
 }
 
 void plasma_read_GetRequest(uint8_t *data,
-                            object_id object_ids[],
+                            ObjectID object_ids[],
                             int64_t *timeout_ms,
                             int64_t num_objects) {
   DCHECK(data);
@@ -431,7 +431,7 @@ void plasma_read_GetRequest(uint8_t *data,
 
 int plasma_send_GetReply(int sock,
                          protocol_builder *B,
-                         object_id object_ids[],
+                         ObjectID object_ids[],
                          plasma_object plasma_objects[],
                          int64_t num_objects) {
   PlasmaGetReply_start_as_root(B);
@@ -460,7 +460,7 @@ int plasma_send_GetReply(int sock,
 }
 
 void plasma_read_GetReply(uint8_t *data,
-                          object_id object_ids[],
+                          ObjectID object_ids[],
                           plasma_object plasma_objects[],
                           int64_t num_objects) {
   CHECK(data);
@@ -486,7 +486,7 @@ void plasma_read_GetReply(uint8_t *data,
 
 int plasma_send_FetchRequest(int sock,
                              protocol_builder *B,
-                             object_id object_ids[],
+                             ObjectID object_ids[],
                              int64_t num_objects) {
   PlasmaFetchRequest_start_as_root(B);
   PlasmaFetchRequest_object_ids_add(
@@ -502,7 +502,7 @@ int64_t plasma_read_FetchRequest_num_objects(uint8_t *data) {
 }
 
 void plasma_read_FetchRequest(uint8_t *data,
-                              object_id object_ids[],
+                              ObjectID object_ids[],
                               int64_t num_objects) {
   DCHECK(data);
   PlasmaFetchRequest_table_t req = PlasmaFetchRequest_as_root(data);
@@ -604,7 +604,7 @@ int plasma_send_SubscribeRequest(int sock, protocol_builder *B) {
 
 int plasma_send_DataRequest(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             const char *address,
                             int port) {
   PlasmaDataRequest_start_as_root(B);
@@ -617,7 +617,7 @@ int plasma_send_DataRequest(int sock,
 }
 
 void plasma_read_DataRequest(uint8_t *data,
-                             object_id *object_id,
+                             ObjectID *object_id,
                              char **address,
                              int *port) {
   DCHECK(data);
@@ -631,7 +631,7 @@ void plasma_read_DataRequest(uint8_t *data,
 
 int plasma_send_DataReply(int sock,
                           protocol_builder *B,
-                          object_id object_id,
+                          ObjectID object_id,
                           int64_t object_size,
                           int64_t metadata_size) {
   PlasmaDataReply_start_as_root(B);
@@ -644,7 +644,7 @@ int plasma_send_DataReply(int sock,
 }
 
 void plasma_read_DataReply(uint8_t *data,
-                           object_id *object_id,
+                           ObjectID *object_id,
                            int64_t *object_size,
                            int64_t *metadata_size) {
   DCHECK(data);

--- a/src/plasma/plasma_protocol.c
+++ b/src/plasma/plasma_protocol.c
@@ -517,7 +517,7 @@ void plasma_read_FetchRequest(uint8_t *data,
 
 int plasma_send_WaitRequest(int sock,
                             protocol_builder *B,
-                            object_request object_requests[],
+                            ObjectRequest object_requests[],
                             int num_requests,
                             int num_ready_objects,
                             int64_t timeout_ms) {
@@ -544,7 +544,7 @@ int plasma_read_WaitRequest_num_object_ids(uint8_t *data) {
 }
 
 void plasma_read_WaitRequest(uint8_t *data,
-                             object_request object_requests[],
+                             ObjectRequest object_requests[],
                              int num_object_ids,
                              int64_t *timeout_ms,
                              int *num_ready_objects) {
@@ -564,7 +564,7 @@ void plasma_read_WaitRequest(uint8_t *data,
 
 int plasma_send_WaitReply(int sock,
                           protocol_builder *B,
-                          object_request object_requests[],
+                          ObjectRequest object_requests[],
                           int num_ready_objects) {
   PlasmaWaitReply_start_as_root(B);
   ObjectReply_vec_start(B);
@@ -582,7 +582,7 @@ int plasma_send_WaitReply(int sock,
 }
 
 void plasma_read_WaitReply(uint8_t *data,
-                           object_request object_requests[],
+                           ObjectRequest object_requests[],
                            int *num_ready_objects) {
   DCHECK(data);
   PlasmaWaitReply_table_t req = PlasmaWaitReply_as_root(data);

--- a/src/plasma/plasma_protocol.h
+++ b/src/plasma/plasma_protocol.h
@@ -202,7 +202,7 @@ void plasma_read_FetchRequest(uint8_t *data,
 
 int plasma_send_WaitRequest(int sock,
                             protocol_builder *B,
-                            object_request object_requests[],
+                            ObjectRequest object_requests[],
                             int num_requests,
                             int num_ready_objects,
                             int64_t timeout_ms);
@@ -210,18 +210,18 @@ int plasma_send_WaitRequest(int sock,
 int plasma_read_WaitRequest_num_object_ids(uint8_t *data);
 
 void plasma_read_WaitRequest(uint8_t *data,
-                             object_request object_requests[],
+                             ObjectRequest object_requests[],
                              int num_object_ids,
                              int64_t *timeout_ms,
                              int *num_ready_objects);
 
 int plasma_send_WaitReply(int sock,
                           protocol_builder *B,
-                          object_request object_requests[],
+                          ObjectRequest object_requests[],
                           int num_ready_objects);
 
 void plasma_read_WaitReply(uint8_t *data,
-                           object_request object_requests[],
+                           ObjectRequest object_requests[],
                            int *num_ready_objects);
 
 /* Plasma Subscribe message functions. */

--- a/src/plasma/plasma_protocol.h
+++ b/src/plasma/plasma_protocol.h
@@ -38,12 +38,12 @@ void plasma_read_CreateRequest(uint8_t *data,
 int plasma_send_CreateReply(int sock,
                             protocol_builder *B,
                             ObjectID object_id,
-                            plasma_object *object,
+                            PlasmaObject *object,
                             int error);
 
 void plasma_read_CreateReply(uint8_t *data,
                              ObjectID *object_id,
-                             plasma_object *object,
+                             PlasmaObject *object,
                              int *error);
 
 /* Plasma Seal message functions. */
@@ -82,12 +82,12 @@ void plasma_read_GetRequest(uint8_t *data,
 int plasma_send_GetReply(int sock,
                          protocol_builder *B,
                          ObjectID object_ids[],
-                         plasma_object plasma_objects[],
+                         PlasmaObject plasma_objects[],
                          int64_t num_objects);
 
 void plasma_read_GetReply(uint8_t *data,
                           ObjectID object_ids[],
-                          plasma_object plasma_objects[],
+                          PlasmaObject plasma_objects[],
                           int64_t num_objects);
 
 /* Plasma Release message functions. */

--- a/src/plasma/plasma_protocol.h
+++ b/src/plasma/plasma_protocol.h
@@ -26,23 +26,23 @@ uint8_t *plasma_receive(int sock, int64_t message_type);
 
 int plasma_send_CreateRequest(int sock,
                               protocol_builder *B,
-                              object_id object_id,
+                              ObjectID object_id,
                               int64_t data_size,
                               int64_t metadata_size);
 
 void plasma_read_CreateRequest(uint8_t *data,
-                               object_id *object_id,
+                               ObjectID *object_id,
                                int64_t *data_size,
                                int64_t *metadata_size);
 
 int plasma_send_CreateReply(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             plasma_object *object,
                             int error);
 
 void plasma_read_CreateReply(uint8_t *data,
-                             object_id *object_id,
+                             ObjectID *object_id,
                              plasma_object *object,
                              int *error);
 
@@ -50,43 +50,43 @@ void plasma_read_CreateReply(uint8_t *data,
 
 int plasma_send_SealRequest(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             unsigned char *digest);
 
 void plasma_read_SealRequest(uint8_t *data,
-                             OUT object_id *object_id,
+                             OUT ObjectID *object_id,
                              OUT unsigned char *digest);
 
 int plasma_send_SealReply(int sock,
                           protocol_builder *B,
-                          object_id object_id,
+                          ObjectID object_id,
                           int error);
 
-void plasma_read_SealReply(uint8_t *data, object_id *object_id, int *error);
+void plasma_read_SealReply(uint8_t *data, ObjectID *object_id, int *error);
 
 /* Plasma Get message functions. */
 
 int plasma_send_GetRequest(int sock,
                            protocol_builder *B,
-                           object_id object_ids[],
+                           ObjectID object_ids[],
                            int64_t num_objects,
                            int64_t timeout_ms);
 
 int64_t plasma_read_GetRequest_num_objects(uint8_t *data);
 
 void plasma_read_GetRequest(uint8_t *data,
-                            object_id object_ids[],
+                            ObjectID object_ids[],
                             int64_t *timeout_ms,
                             int64_t num_objects);
 
 int plasma_send_GetReply(int sock,
                          protocol_builder *B,
-                         object_id object_ids[],
+                         ObjectID object_ids[],
                          plasma_object plasma_objects[],
                          int64_t num_objects);
 
 void plasma_read_GetReply(uint8_t *data,
-                          object_id object_ids[],
+                          ObjectID object_ids[],
                           plasma_object plasma_objects[],
                           int64_t num_objects);
 
@@ -94,55 +94,55 @@ void plasma_read_GetReply(uint8_t *data,
 
 int plasma_send_ReleaseRequest(int sock,
                                protocol_builder *B,
-                               object_id object_id);
+                               ObjectID object_id);
 
-void plasma_read_ReleaseRequest(uint8_t *data, object_id *object_id);
+void plasma_read_ReleaseRequest(uint8_t *data, ObjectID *object_id);
 
 int plasma_send_ReleaseReply(int sock,
                              protocol_builder *B,
-                             object_id object_id,
+                             ObjectID object_id,
                              int error);
 
-void plasma_read_ReleaseReply(uint8_t *data, object_id *object_id, int *error);
+void plasma_read_ReleaseReply(uint8_t *data, ObjectID *object_id, int *error);
 
 /* Plasma Delete message functions. */
 
 int plasma_send_DeleteRequest(int sock,
                               protocol_builder *B,
-                              object_id object_id);
+                              ObjectID object_id);
 
-void plasma_read_DeleteRequest(uint8_t *data, object_id *object_id);
+void plasma_read_DeleteRequest(uint8_t *data, ObjectID *object_id);
 
 int plasma_send_DeleteReply(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             int error);
 
-void plasma_read_DeleteReply(uint8_t *data, object_id *object_id, int *error);
+void plasma_read_DeleteReply(uint8_t *data, ObjectID *object_id, int *error);
 
 /* Plasma Status message functions. */
 
 int plasma_send_StatusRequest(int sock,
                               protocol_builder *B,
-                              object_id object_ids[],
+                              ObjectID object_ids[],
                               int64_t num_objects);
 
 int64_t plasma_read_StatusRequest_num_objects(uint8_t *data);
 
 void plasma_read_StatusRequest(uint8_t *data,
-                               object_id object_ids[],
+                               ObjectID object_ids[],
                                int64_t num_objects);
 
 int plasma_send_StatusReply(int sock,
                             protocol_builder *B,
-                            object_id object_ids[],
+                            ObjectID object_ids[],
                             int object_status[],
                             int64_t num_objects);
 
 int64_t plasma_read_StatusReply_num_objects(uint8_t *data);
 
 void plasma_read_StatusReply(uint8_t *data,
-                             object_id object_ids[],
+                             ObjectID object_ids[],
                              int object_status[],
                              int64_t num_objects);
 
@@ -150,17 +150,17 @@ void plasma_read_StatusReply(uint8_t *data,
 
 int plasma_send_ContainsRequest(int sock,
                                 protocol_builder *B,
-                                object_id object_id);
+                                ObjectID object_id);
 
-void plasma_read_ContainsRequest(uint8_t *data, object_id *object_id);
+void plasma_read_ContainsRequest(uint8_t *data, ObjectID *object_id);
 
 int plasma_send_ContainsReply(int sock,
                               protocol_builder *B,
-                              object_id object_id,
+                              ObjectID object_id,
                               int has_object);
 
 void plasma_read_ContainsReply(uint8_t *data,
-                               object_id *object_id,
+                               ObjectID *object_id,
                                int *has_object);
 
 /* Plasma Connect message functions. */
@@ -189,13 +189,13 @@ void plasma_read_EvictReply(uint8_t *data, int64_t *num_bytes);
 
 int plasma_send_FetchRequest(int sock,
                              protocol_builder *B,
-                             object_id object_ids[],
+                             ObjectID object_ids[],
                              int64_t num_objects);
 
 int64_t plasma_read_FetchRequest_num_objects(uint8_t *data);
 
 void plasma_read_FetchRequest(uint8_t *data,
-                              object_id object_ids[],
+                              ObjectID object_ids[],
                               int64_t num_objects);
 
 /* Plasma Wait message functions. */
@@ -232,23 +232,23 @@ int plasma_send_SubscribeRequest(int sock, protocol_builder *B);
 
 int plasma_send_DataRequest(int sock,
                             protocol_builder *B,
-                            object_id object_id,
+                            ObjectID object_id,
                             const char *address,
                             int port);
 
 void plasma_read_DataRequest(uint8_t *data,
-                             object_id *object_id,
+                             ObjectID *object_id,
                              char **address,
                              int *port);
 
 int plasma_send_DataReply(int sock,
                           protocol_builder *B,
-                          object_id object_id,
+                          ObjectID object_id,
                           int64_t object_size,
                           int64_t metadata_size);
 
 void plasma_read_DataReply(uint8_t *data,
-                           object_id *object_id,
+                           ObjectID *object_id,
                            int64_t *object_size,
                            int64_t *metadata_size);
 

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -124,7 +124,8 @@ struct PlasmaStoreState {
 
 UT_icd byte_icd = {sizeof(uint8_t), NULL, NULL, NULL};
 
-PlasmaStoreState *PlasmaStoreState_init(event_loop *loop, int64_t system_memory) {
+PlasmaStoreState *PlasmaStoreState_init(event_loop *loop,
+                                        int64_t system_memory) {
   PlasmaStoreState *state = malloc(sizeof(PlasmaStoreState));
   state->loop = loop;
   state->object_get_requests = NULL;
@@ -615,9 +616,9 @@ void send_notifications(event_loop *loop,
 
     /* Attempt to send a notification about this object ID. */
     int nbytes = send(client_sock, (char const *) notification,
-                      sizeof(* notification), 0);
+                      sizeof(*notification), 0);
     if (nbytes >= 0) {
-      CHECK(nbytes == sizeof(* notification));
+      CHECK(nbytes == sizeof(*notification));
     } else if (nbytes == -1 &&
                (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
       LOG_DEBUG(

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -112,7 +112,7 @@ struct plasma_store_state {
   notification_queue *pending_notifications;
   /** The plasma store information, including the object tables, that is exposed
    *  to the eviction policy. */
-  plasma_store_info *plasma_store_info;
+  PlasmaStoreInfo *plasma_store_info;
   /** The state that is managed by the eviction policy. */
   eviction_state *eviction_state;
   /** Input buffer. This is allocated only once to avoid mallocs for every
@@ -130,7 +130,7 @@ plasma_store_state *init_plasma_store(event_loop *loop, int64_t system_memory) {
   state->object_get_requests = NULL;
   state->pending_notifications = NULL;
   /* Initialize the plasma store info. */
-  state->plasma_store_info = malloc(sizeof(plasma_store_info));
+  state->plasma_store_info = malloc(sizeof(PlasmaStoreInfo));
   state->plasma_store_info->objects = NULL;
   state->plasma_store_info->memory_capacity = system_memory;
   /* Initialize the eviction state. */

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -378,7 +378,7 @@ void update_object_get_requests(PlasmaStoreState *store_state,
                   sizeof(obj_id), entry);
         CHECK(entry != NULL);
 
-        if (object_ids_equal(get_req->object_ids[j], obj_id)) {
+        if (ObjectID_equal(get_req->object_ids[j], obj_id)) {
           PlasmaObject_init(&get_req->objects[j], entry);
           num_updated += 1;
           get_req->num_satisfied += 1;

--- a/src/plasma/plasma_store.c
+++ b/src/plasma/plasma_store.c
@@ -94,10 +94,10 @@ typedef struct {
   /** Handle for the uthash table in the store state that keeps track of the get
    *  requests involving this object ID. */
   UT_hash_handle hh;
-} object_get_requests;
+} ObjectGetRequests;
 
 /** This is used to define the utarray of get requests in the
- *  object_get_requests struct. */
+ *  ObjectGetRequests struct. */
 UT_icd get_request_icd = {sizeof(get_request *), NULL, NULL, NULL};
 
 struct PlasmaStoreState {
@@ -105,7 +105,7 @@ struct PlasmaStoreState {
   event_loop *loop;
   /** A hash table mapping object IDs to a vector of the get requests that are
    *  waiting for the object to arrive. */
-  object_get_requests *object_get_requests;
+  ObjectGetRequests *object_get_requests;
   /** The pending notifications that have not been sent to subscribers because
    *  the socket send buffers were full. This is a hash table from client file
    *  descriptor to an array of object_ids to send to that client. */
@@ -242,14 +242,14 @@ int create_object(Client *client_context,
 void add_get_request_for_object(PlasmaStoreState *store_state,
                                 ObjectID object_id,
                                 get_request *get_req) {
-  object_get_requests *object_get_reqs;
+  ObjectGetRequests *object_get_reqs;
   HASH_FIND(hh, store_state->object_get_requests, &object_id, sizeof(object_id),
             object_get_reqs);
   /* If there are currently no get requests involving this object ID, create a
-   * new object_get_requests struct for this object ID and add it to the hash
+   * new ObjectGetRequests struct for this object ID and add it to the hash
    * table. */
   if (object_get_reqs == NULL) {
-    object_get_reqs = malloc(sizeof(object_get_requests));
+    object_get_reqs = malloc(sizeof(ObjectGetRequests));
     object_get_reqs->object_id = object_id;
     utarray_new(object_get_reqs->get_requests, &get_request_icd);
     HASH_ADD(hh, store_state->object_get_requests, object_id,
@@ -263,7 +263,7 @@ void add_get_request_for_object(PlasmaStoreState *store_state,
 void remove_get_request_for_object(PlasmaStoreState *store_state,
                                    ObjectID object_id,
                                    get_request *get_req) {
-  object_get_requests *object_get_reqs;
+  ObjectGetRequests *object_get_reqs;
   HASH_FIND(hh, store_state->object_get_requests, &object_id, sizeof(object_id),
             object_get_reqs);
   /* If there is a vector of get requests for this object ID, and if this vector
@@ -354,7 +354,7 @@ void return_from_get(PlasmaStoreState *store_state, get_request *get_req) {
 void update_object_get_requests(PlasmaStoreState *store_state,
                                 ObjectID obj_id) {
   /* Update the in-progress get requests. */
-  object_get_requests *object_get_reqs;
+  ObjectGetRequests *object_get_reqs;
   HASH_FIND(hh, store_state->object_get_requests, &obj_id, sizeof(obj_id),
             object_get_reqs);
   if (object_get_reqs != NULL) {

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -3,7 +3,7 @@
 
 #include "plasma.h"
 
-typedef struct client client;
+typedef struct Client Client;
 
 typedef struct PlasmaStoreState PlasmaStoreState;
 
@@ -24,7 +24,7 @@ typedef struct PlasmaStoreState PlasmaStoreState;
  *           create the object. In this case, the client should not call
  *           plasma_release.
  */
-int create_object(client *client_context,
+int create_object(Client *client_context,
                   ObjectID object_id,
                   int64_t data_size,
                   int64_t metadata_size,
@@ -43,7 +43,7 @@ int create_object(client *client_context,
  * @param object_id Object ID of the object to be gotten.
  * @return The status of the object (object_status in plasma.h).
  */
-int get_object(client *client_context,
+int get_object(Client *client_context,
                int conn,
                ObjectID object_id,
                PlasmaObject *result);
@@ -55,7 +55,7 @@ int get_object(client *client_context,
  * @param object_id The object ID of the object that is being released.
  * @param Void.
  */
-void release_object(client *client_context, ObjectID object_id);
+void release_object(Client *client_context, ObjectID object_id);
 
 /**
  * Seal an object. The object is now immutable and can be accessed with get.
@@ -66,7 +66,7 @@ void release_object(client *client_context, ObjectID object_id);
  *        with the same object ID are the same.
  * @return Void.
  */
-void seal_object(client *client_context,
+void seal_object(Client *client_context,
                  ObjectID object_id,
                  unsigned char digest[]);
 
@@ -77,7 +77,7 @@ void seal_object(client *client_context,
  * @param object_id Object ID that will be checked.
  * @return OBJECT_FOUND if the object is in the store, OBJECT_NOT_FOUND if not
  */
-int contains_object(client *client_context, ObjectID object_id);
+int contains_object(Client *client_context, ObjectID object_id);
 
 /**
  * Send notifications about sealed objects to the subscribers. This is called

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -5,7 +5,7 @@
 
 typedef struct client client;
 
-typedef struct plasma_store_state plasma_store_state;
+typedef struct PlasmaStoreState PlasmaStoreState;
 
 /**
  * Create a new object. The client must do a call to release_object to tell the
@@ -114,7 +114,7 @@ void send_notifications(event_loop *loop,
                         void *plasma_state,
                         int events);
 
-void remove_objects(plasma_store_state *plasma_state,
+void remove_objects(PlasmaStoreState *plasma_state,
                     int64_t num_objects_to_evict,
                     ObjectID *objects_to_evict);
 

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -28,7 +28,7 @@ int create_object(client *client_context,
                   ObjectID object_id,
                   int64_t data_size,
                   int64_t metadata_size,
-                  plasma_object *result);
+                  PlasmaObject *result);
 
 /**
  * Get an object. This method assumes that we currently have or will eventually
@@ -46,25 +46,7 @@ int create_object(client *client_context,
 int get_object(client *client_context,
                int conn,
                ObjectID object_id,
-               plasma_object *result);
-
-/**
- * Get an object from the local Plasma Store. This function is not blocking.
- *
- * Once a client gets an object it must release it when it is done with it.
- * This function is indepontent. If a client calls repeatedly get_object_local()
- * on the same object_id, the client needs to call release_object() only once.
- *
- * @param client_context The context of the client making this request.
- * @param conn The client connection that requests the object.
- * @param object_id Object ID of the object to be gotten.
- * @return Return OBJECT_FOUND if object was found, and OBJECT_NOT_FOUND
- *         otherwise.
- */
-int get_object_local(client *client_context,
-                     int conn,
-                     ObjectID object_id,
-                     plasma_object *result);
+               PlasmaObject *result);
 
 /**
  * Record the fact that a particular client is no longer using an object.

--- a/src/plasma/plasma_store.h
+++ b/src/plasma/plasma_store.h
@@ -25,7 +25,7 @@ typedef struct plasma_store_state plasma_store_state;
  *           plasma_release.
  */
 int create_object(client *client_context,
-                  object_id object_id,
+                  ObjectID object_id,
                   int64_t data_size,
                   int64_t metadata_size,
                   plasma_object *result);
@@ -45,7 +45,7 @@ int create_object(client *client_context,
  */
 int get_object(client *client_context,
                int conn,
-               object_id object_id,
+               ObjectID object_id,
                plasma_object *result);
 
 /**
@@ -63,7 +63,7 @@ int get_object(client *client_context,
  */
 int get_object_local(client *client_context,
                      int conn,
-                     object_id object_id,
+                     ObjectID object_id,
                      plasma_object *result);
 
 /**
@@ -73,7 +73,7 @@ int get_object_local(client *client_context,
  * @param object_id The object ID of the object that is being released.
  * @param Void.
  */
-void release_object(client *client_context, object_id object_id);
+void release_object(client *client_context, ObjectID object_id);
 
 /**
  * Seal an object. The object is now immutable and can be accessed with get.
@@ -85,7 +85,7 @@ void release_object(client *client_context, object_id object_id);
  * @return Void.
  */
 void seal_object(client *client_context,
-                 object_id object_id,
+                 ObjectID object_id,
                  unsigned char digest[]);
 
 /**
@@ -95,7 +95,7 @@ void seal_object(client *client_context,
  * @param object_id Object ID that will be checked.
  * @return OBJECT_FOUND if the object is in the store, OBJECT_NOT_FOUND if not
  */
-int contains_object(client *client_context, object_id object_id);
+int contains_object(client *client_context, ObjectID object_id);
 
 /**
  * Send notifications about sealed objects to the subscribers. This is called
@@ -116,6 +116,6 @@ void send_notifications(event_loop *loop,
 
 void remove_objects(plasma_store_state *plasma_state,
                     int64_t num_objects_to_evict,
-                    object_id *objects_to_evict);
+                    ObjectID *objects_to_evict);
 
 #endif /* PLASMA_STORE_H */

--- a/src/plasma/test/client_tests.c
+++ b/src/plasma/test/client_tests.c
@@ -116,8 +116,8 @@ bool is_equal_data_123(uint8_t *data1, uint8_t *data2, uint64_t size) {
 }
 
 TEST plasma_nonblocking_get_tests(void) {
-  PlasmaConnection *plasma_conn = plasma_connect(
-      "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
+  PlasmaConnection *plasma_conn = plasma_connect("/tmp/store1", "/tmp/manager1",
+                                                 PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid = globally_unique_id();
   ObjectID oid_array[1] = {oid};
   ObjectBuffer obj_buffer;

--- a/src/plasma/test/client_tests.c
+++ b/src/plasma/test/client_tests.c
@@ -120,7 +120,7 @@ TEST plasma_nonblocking_get_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid = globally_unique_id();
   ObjectID oid_array[1] = {oid};
-  object_buffer obj_buffer;
+  ObjectBuffer obj_buffer;
 
   /* Test for object non-existence. */
   plasma_get(plasma_conn, oid_array, 1, 0, &obj_buffer);
@@ -220,7 +220,7 @@ TEST plasma_get_tests(void) {
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
   ObjectID oid2 = globally_unique_id();
-  object_buffer obj_buffer;
+  ObjectBuffer obj_buffer;
 
   ObjectID oid_array1[1] = {oid1};
   ObjectID oid_array2[1] = {oid2};
@@ -259,7 +259,7 @@ TEST plasma_get_multiple_tests(void) {
   ObjectID oid1 = globally_unique_id();
   ObjectID oid2 = globally_unique_id();
   ObjectID obj_ids[NUM_OBJ_REQUEST];
-  object_buffer obj_buffer[NUM_OBJ_REQUEST];
+  ObjectBuffer obj_buffer[NUM_OBJ_REQUEST];
   int obj1_first = 1, obj2_first = 2;
 
   obj_ids[0] = oid1;

--- a/src/plasma/test/client_tests.c
+++ b/src/plasma/test/client_tests.c
@@ -155,7 +155,7 @@ TEST plasma_wait_for_objects_tests(void) {
   ObjectID oid2 = globally_unique_id();
 #define NUM_OBJ_REQUEST 2
 #define WAIT_TIMEOUT_MS 1000
-  object_request obj_requests[NUM_OBJ_REQUEST];
+  ObjectRequest obj_requests[NUM_OBJ_REQUEST];
 
   obj_requests[0].object_id = oid1;
   obj_requests[0].type = PLASMA_QUERY_ANYWHERE;

--- a/src/plasma/test/client_tests.c
+++ b/src/plasma/test/client_tests.c
@@ -11,9 +11,9 @@
 SUITE(plasma_client_tests);
 
 TEST plasma_status_tests(void) {
-  plasma_connection *plasma_conn1 = plasma_connect(
+  PlasmaConnection *plasma_conn1 = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  plasma_connection *plasma_conn2 = plasma_connect(
+  PlasmaConnection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
 
@@ -46,9 +46,9 @@ TEST plasma_status_tests(void) {
 }
 
 TEST plasma_fetch_tests(void) {
-  plasma_connection *plasma_conn1 = plasma_connect(
+  PlasmaConnection *plasma_conn1 = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  plasma_connection *plasma_conn2 = plasma_connect(
+  PlasmaConnection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
 
@@ -116,7 +116,7 @@ bool is_equal_data_123(uint8_t *data1, uint8_t *data2, uint64_t size) {
 }
 
 TEST plasma_nonblocking_get_tests(void) {
-  plasma_connection *plasma_conn = plasma_connect(
+  PlasmaConnection *plasma_conn = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid = globally_unique_id();
   ObjectID oid_array[1] = {oid};
@@ -147,9 +147,9 @@ TEST plasma_nonblocking_get_tests(void) {
 }
 
 TEST plasma_wait_for_objects_tests(void) {
-  plasma_connection *plasma_conn1 = plasma_connect(
+  PlasmaConnection *plasma_conn1 = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  plasma_connection *plasma_conn2 = plasma_connect(
+  PlasmaConnection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
   ObjectID oid2 = globally_unique_id();
@@ -214,9 +214,9 @@ TEST plasma_wait_for_objects_tests(void) {
 }
 
 TEST plasma_get_tests(void) {
-  plasma_connection *plasma_conn1 = plasma_connect(
+  PlasmaConnection *plasma_conn1 = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  plasma_connection *plasma_conn2 = plasma_connect(
+  PlasmaConnection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
   ObjectID oid2 = globally_unique_id();
@@ -252,9 +252,9 @@ TEST plasma_get_tests(void) {
 }
 
 TEST plasma_get_multiple_tests(void) {
-  plasma_connection *plasma_conn1 = plasma_connect(
+  PlasmaConnection *plasma_conn1 = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  plasma_connection *plasma_conn2 = plasma_connect(
+  PlasmaConnection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
   ObjectID oid1 = globally_unique_id();
   ObjectID oid2 = globally_unique_id();

--- a/src/plasma/test/client_tests.c
+++ b/src/plasma/test/client_tests.c
@@ -15,7 +15,7 @@ TEST plasma_status_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   plasma_connection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid1 = globally_unique_id();
+  ObjectID oid1 = globally_unique_id();
 
   /* Test for object non-existence. */
   int status = plasma_status(plasma_conn1, oid1);
@@ -50,7 +50,7 @@ TEST plasma_fetch_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   plasma_connection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid1 = globally_unique_id();
+  ObjectID oid1 = globally_unique_id();
 
   /* Test for object non-existence. */
   int status;
@@ -71,7 +71,7 @@ TEST plasma_fetch_tests(void) {
   /* Object with ID oid1 has been just inserted. On the next fetch we might
    * either find the object or not, depending on whether the Plasma Manager has
    * received the notification from the Plasma Store or not. */
-  object_id oid_array1[1] = {oid1};
+  ObjectID oid_array1[1] = {oid1};
   plasma_fetch(plasma_conn1, 1, oid_array1);
   status = plasma_status(plasma_conn1, oid1);
   ASSERT((status == ObjectStatus_Local) ||
@@ -118,8 +118,8 @@ bool is_equal_data_123(uint8_t *data1, uint8_t *data2, uint64_t size) {
 TEST plasma_nonblocking_get_tests(void) {
   plasma_connection *plasma_conn = plasma_connect(
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid = globally_unique_id();
-  object_id oid_array[1] = {oid};
+  ObjectID oid = globally_unique_id();
+  ObjectID oid_array[1] = {oid};
   object_buffer obj_buffer;
 
   /* Test for object non-existence. */
@@ -151,8 +151,8 @@ TEST plasma_wait_for_objects_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   plasma_connection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid1 = globally_unique_id();
-  object_id oid2 = globally_unique_id();
+  ObjectID oid1 = globally_unique_id();
+  ObjectID oid2 = globally_unique_id();
 #define NUM_OBJ_REQUEST 2
 #define WAIT_TIMEOUT_MS 1000
   object_request obj_requests[NUM_OBJ_REQUEST];
@@ -218,12 +218,12 @@ TEST plasma_get_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   plasma_connection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid1 = globally_unique_id();
-  object_id oid2 = globally_unique_id();
+  ObjectID oid1 = globally_unique_id();
+  ObjectID oid2 = globally_unique_id();
   object_buffer obj_buffer;
 
-  object_id oid_array1[1] = {oid1};
-  object_id oid_array2[1] = {oid2};
+  ObjectID oid_array1[1] = {oid1};
+  ObjectID oid_array2[1] = {oid2};
 
   int64_t data_size = 4;
   uint8_t metadata[] = {5};
@@ -256,9 +256,9 @@ TEST plasma_get_multiple_tests(void) {
       "/tmp/store1", "/tmp/manager1", PLASMA_DEFAULT_RELEASE_DELAY);
   plasma_connection *plasma_conn2 = plasma_connect(
       "/tmp/store2", "/tmp/manager2", PLASMA_DEFAULT_RELEASE_DELAY);
-  object_id oid1 = globally_unique_id();
-  object_id oid2 = globally_unique_id();
-  object_id obj_ids[NUM_OBJ_REQUEST];
+  ObjectID oid1 = globally_unique_id();
+  ObjectID oid2 = globally_unique_id();
+  ObjectID obj_ids[NUM_OBJ_REQUEST];
   object_buffer obj_buffer[NUM_OBJ_REQUEST];
   int obj1_first = 1, obj2_first = 2;
 

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -260,7 +260,7 @@ TEST object_notifications_test(void) {
   CHECK(fcntl(fd[1], F_SETFL, flags | O_NONBLOCK) == 0);
 
   ObjectID oid = globally_unique_id();
-  object_info info = {.obj_id = oid,
+  ObjectInfo info = {.obj_id = oid,
                       .data_size = 10,
                       .metadata_size = 1,
                       .create_time = 0,

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -49,12 +49,12 @@ typedef struct {
   plasma_manager_state *state;
   event_loop *loop;
   /* Accept a connection from the local manager on the remote manager. */
-  client_connection *write_conn;
-  client_connection *read_conn;
+  ClientConnection *write_conn;
+  ClientConnection *read_conn;
   /* Connect a new client to the local plasma manager and mock a request to an
    * object. */
   PlasmaConnection *plasma_conn;
-  client_connection *client_conn;
+  ClientConnection *client_conn;
 } plasma_mock;
 
 plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
@@ -77,7 +77,7 @@ plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
         get_manager_connection(remote_mock->state, manager_addr, mock->port);
     wait_for_pollin(mock->manager_remote_fd);
     mock->read_conn =
-        new_client_connection(mock->loop, mock->manager_remote_fd, mock->state,
+        ClientConnection_init(mock->loop, mock->manager_remote_fd, mock->state,
                               PLASMA_DEFAULT_RELEASE_DELAY);
   } else {
     mock->write_conn = NULL;
@@ -89,7 +89,7 @@ plasma_mock *init_plasma_mock(plasma_mock *remote_mock) {
                                      utstring_body(manager_socket_name), 0);
   wait_for_pollin(mock->manager_local_fd);
   mock->client_conn =
-      new_client_connection(mock->loop, mock->manager_local_fd, mock->state, 0);
+      ClientConnection_init(mock->loop, mock->manager_local_fd, mock->state, 0);
   utstring_free(manager_socket_name);
   return mock;
 }

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -53,7 +53,7 @@ typedef struct {
   client_connection *read_conn;
   /* Connect a new client to the local plasma manager and mock a request to an
    * object. */
-  plasma_connection *plasma_conn;
+  PlasmaConnection *plasma_conn;
   client_connection *client_conn;
 } plasma_mock;
 

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -261,12 +261,12 @@ TEST object_notifications_test(void) {
 
   ObjectID oid = globally_unique_id();
   ObjectInfo info = {.obj_id = oid,
-                      .data_size = 10,
-                      .metadata_size = 1,
-                      .create_time = 0,
-                      .construct_duration = 0,
-                      .digest = {0},
-                      .is_deletion = false};
+                     .data_size = 10,
+                     .metadata_size = 1,
+                     .create_time = 0,
+                     .construct_duration = 0,
+                     .digest = {0},
+                     .is_deletion = false};
 
   /* Check that the object is not local at first. */
   bool is_local = is_object_local(local_mock->state, oid);

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -138,7 +138,7 @@ TEST request_transfer_test(void) {
   char *address;
   int port;
   plasma_read_DataRequest(request_data, &oid2, &address, &port);
-  ASSERT(object_ids_equal(oid, oid2));
+  ASSERT(ObjectID_equal(oid, oid2));
   free(address);
   /* Clean up. */
   utstring_free(addr);
@@ -192,7 +192,7 @@ TEST request_transfer_retry_test(void) {
   int port;
   plasma_read_DataRequest(request_data, &oid2, &address, &port);
   free(address);
-  ASSERT(object_ids_equal(oid, oid2));
+  ASSERT(ObjectID_equal(oid, oid2));
   /* Clean up. */
   utstring_free(addr0);
   utstring_free(addr1);

--- a/src/plasma/test/manager_tests.c
+++ b/src/plasma/test/manager_tests.c
@@ -23,7 +23,7 @@ SUITE(plasma_manager_tests);
 const char *plasma_store_socket_name = "/tmp/plasma_store_socket_1";
 const char *plasma_manager_socket_name_format = "/tmp/plasma_manager_socket_%d";
 const char *manager_addr = "127.0.0.1";
-object_id oid;
+ObjectID oid;
 
 void wait_for_pollin(int fd) {
   struct pollfd poll_list[1];
@@ -134,7 +134,7 @@ TEST request_transfer_test(void) {
   int read_fd = get_client_sock(remote_mock->read_conn);
   uint8_t *request_data =
       plasma_receive(read_fd, MessageType_PlasmaDataRequest);
-  object_id oid2;
+  ObjectID oid2;
   char *address;
   int port;
   plasma_read_DataRequest(request_data, &oid2, &address, &port);
@@ -187,7 +187,7 @@ TEST request_transfer_retry_test(void) {
   int read_fd = get_client_sock(remote_mock2->read_conn);
   uint8_t *request_data =
       plasma_receive(read_fd, MessageType_PlasmaDataRequest);
-  object_id oid2;
+  ObjectID oid2;
   char *address;
   int port;
   plasma_read_DataRequest(request_data, &oid2, &address, &port);
@@ -259,7 +259,7 @@ TEST object_notifications_test(void) {
   int flags = fcntl(fd[1], F_GETFL, 0);
   CHECK(fcntl(fd[1], F_SETFL, flags | O_NONBLOCK) == 0);
 
-  object_id oid = globally_unique_id();
+  ObjectID oid = globally_unique_id();
   object_info info = {.obj_id = oid,
                       .data_size = 10,
                       .metadata_size = 1,

--- a/src/plasma/test/serialization_tests.c
+++ b/src/plasma/test/serialization_tests.c
@@ -60,12 +60,12 @@ plasma_object random_plasma_object(void) {
 
 TEST plasma_create_request_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   int64_t data_size1 = 42;
   int64_t metadata_size1 = 11;
   plasma_send_CreateRequest(fd, g_B, object_id1, data_size1, metadata_size1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaCreateRequest);
-  object_id object_id2;
+  ObjectID object_id2;
   int64_t data_size2;
   int64_t metadata_size2;
   plasma_read_CreateRequest(data, &object_id2, &data_size2, &metadata_size2);
@@ -79,11 +79,11 @@ TEST plasma_create_request_test(void) {
 
 TEST plasma_create_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   plasma_object object1 = random_plasma_object();
   plasma_send_CreateReply(fd, g_B, object_id1, &object1, 0);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaCreateReply);
-  object_id object_id2;
+  ObjectID object_id2;
   plasma_object object2;
   memset(&object2, 0, sizeof(object2));
   int error_code;
@@ -97,12 +97,12 @@ TEST plasma_create_reply_test(void) {
 
 TEST plasma_seal_request_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   unsigned char digest1[DIGEST_SIZE];
   memset(&digest1[0], 7, DIGEST_SIZE);
   plasma_send_SealRequest(fd, g_B, object_id1, &digest1[0]);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaSealRequest);
-  object_id object_id2;
+  ObjectID object_id2;
   unsigned char digest2[DIGEST_SIZE];
   plasma_read_SealRequest(data, &object_id2, &digest2[0]);
   ASSERT(object_ids_equal(object_id1, object_id2));
@@ -114,11 +114,11 @@ TEST plasma_seal_request_test(void) {
 
 TEST plasma_seal_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   int error1 = 5;
   plasma_send_SealReply(fd, g_B, object_id1, error1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaSealReply);
-  object_id object_id2;
+  ObjectID object_id2;
   int error2;
   plasma_read_SealReply(data, &object_id2, &error2);
   ASSERT(object_ids_equal(object_id1, object_id2));
@@ -130,14 +130,14 @@ TEST plasma_seal_reply_test(void) {
 
 TEST plasma_get_request_test(void) {
   int fd = create_temp_file();
-  object_id object_ids[2];
+  ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
   int64_t timeout_ms = 1234;
   plasma_send_GetRequest(fd, g_B, object_ids, 2, timeout_ms);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaGetRequest);
   int64_t num_objects;
-  object_id object_ids_return[2];
+  ObjectID object_ids_return[2];
   int64_t timeout_ms_return;
   plasma_read_GetRequest(data, &object_ids_return[0], &timeout_ms_return, 2);
   ASSERT(object_ids_equal(object_ids[0], object_ids_return[0]));
@@ -150,7 +150,7 @@ TEST plasma_get_request_test(void) {
 
 TEST plasma_get_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_ids[2];
+  ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
   plasma_object plasma_objects[2];
@@ -159,7 +159,7 @@ TEST plasma_get_reply_test(void) {
   plasma_send_GetReply(fd, g_B, object_ids, plasma_objects, 2);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaGetReply);
   int64_t num_objects = plasma_read_GetRequest_num_objects(data);
-  object_id object_ids_return[num_objects];
+  ObjectID object_ids_return[num_objects];
   plasma_object plasma_objects_return[2];
   plasma_read_GetReply(data, object_ids_return, &plasma_objects_return[0],
                        num_objects);
@@ -176,10 +176,10 @@ TEST plasma_get_reply_test(void) {
 
 TEST plasma_release_request_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   plasma_send_ReleaseRequest(fd, g_B, object_id1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaReleaseRequest);
-  object_id object_id2;
+  ObjectID object_id2;
   plasma_read_ReleaseRequest(data, &object_id2);
   ASSERT(object_ids_equal(object_id1, object_id2));
   free(data);
@@ -189,11 +189,11 @@ TEST plasma_release_request_test(void) {
 
 TEST plasma_release_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   int error1 = 5;
   plasma_send_ReleaseReply(fd, g_B, object_id1, error1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaReleaseReply);
-  object_id object_id2;
+  ObjectID object_id2;
   int error2;
   plasma_read_ReleaseReply(data, &object_id2, &error2);
   ASSERT(object_ids_equal(object_id1, object_id2));
@@ -205,10 +205,10 @@ TEST plasma_release_reply_test(void) {
 
 TEST plasma_delete_request_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   plasma_send_DeleteRequest(fd, g_B, object_id1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaDeleteRequest);
-  object_id object_id2;
+  ObjectID object_id2;
   plasma_read_DeleteRequest(data, &object_id2);
   ASSERT(object_ids_equal(object_id1, object_id2));
   free(data);
@@ -218,11 +218,11 @@ TEST plasma_delete_request_test(void) {
 
 TEST plasma_delete_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   int error1 = 5;
   plasma_send_DeleteReply(fd, g_B, object_id1, error1);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaDeleteReply);
-  object_id object_id2;
+  ObjectID object_id2;
   int error2;
   plasma_read_DeleteReply(data, &object_id2, &error2);
   ASSERT(object_ids_equal(object_id1, object_id2));
@@ -234,13 +234,13 @@ TEST plasma_delete_reply_test(void) {
 
 TEST plasma_status_request_test(void) {
   int fd = create_temp_file();
-  object_id object_ids[2];
+  ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
   plasma_send_StatusRequest(fd, g_B, object_ids, 2);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaStatusRequest);
   int64_t num_objects = plasma_read_StatusRequest_num_objects(data);
-  object_id object_ids_read[num_objects];
+  ObjectID object_ids_read[num_objects];
   plasma_read_StatusRequest(data, object_ids_read, num_objects);
   ASSERT(object_ids_equal(object_ids[0], object_ids_read[0]));
   ASSERT(object_ids_equal(object_ids[1], object_ids_read[1]));
@@ -251,14 +251,14 @@ TEST plasma_status_request_test(void) {
 
 TEST plasma_status_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_ids[2];
+  ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
   int object_statuses[2] = {42, 43};
   plasma_send_StatusReply(fd, g_B, object_ids, object_statuses, 2);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaStatusReply);
   int64_t num_objects = plasma_read_StatusReply_num_objects(data);
-  object_id object_ids_read[num_objects];
+  ObjectID object_ids_read[num_objects];
   int object_statuses_read[num_objects];
   plasma_read_StatusReply(data, object_ids_read, object_statuses_read,
                           num_objects);
@@ -274,7 +274,7 @@ TEST plasma_status_reply_test(void) {
 TEST plasma_evict_request_test(void) {
   int fd = create_temp_file();
   int64_t num_bytes = 111;
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   plasma_send_EvictRequest(fd, g_B, num_bytes);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaEvictRequest);
   int64_t num_bytes_received;
@@ -288,7 +288,7 @@ TEST plasma_evict_request_test(void) {
 TEST plasma_evict_reply_test(void) {
   int fd = create_temp_file();
   int64_t num_bytes = 111;
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   plasma_send_EvictReply(fd, g_B, num_bytes);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaEvictReply);
   int64_t num_bytes_received;
@@ -301,12 +301,12 @@ TEST plasma_evict_reply_test(void) {
 
 TEST plasma_fetch_request_test(void) {
   int fd = create_temp_file();
-  object_id object_ids[2];
+  ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
   plasma_send_FetchRequest(fd, g_B, object_ids, 2);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaFetchRequest);
-  object_id object_ids_read[2];
+  ObjectID object_ids_read[2];
   plasma_read_FetchRequest(data, &object_ids_read[0], 2);
   ASSERT(object_ids_equal(object_ids[0], object_ids_read[0]));
   ASSERT(object_ids_equal(object_ids[1], object_ids_read[1]));
@@ -373,13 +373,13 @@ TEST plasma_wait_reply_test(void) {
 
 TEST plasma_data_request_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   const char *address1 = "address1";
   int port1 = 12345;
   plasma_send_DataRequest(fd, g_B, object_id1, address1, port1);
   /* Reading message back. */
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaDataRequest);
-  object_id object_id2;
+  ObjectID object_id2;
   char *address2;
   int port2;
   plasma_read_DataRequest(data, &object_id2, &address2, &port2);
@@ -394,13 +394,13 @@ TEST plasma_data_request_test(void) {
 
 TEST plasma_data_reply_test(void) {
   int fd = create_temp_file();
-  object_id object_id1 = globally_unique_id();
+  ObjectID object_id1 = globally_unique_id();
   int64_t object_size1 = 146;
   int64_t metadata_size1 = 198;
   plasma_send_DataReply(fd, g_B, object_id1, object_size1, metadata_size1);
   /* Reading message back. */
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaDataReply);
-  object_id object_id2;
+  ObjectID object_id2;
   int64_t object_size2;
   int64_t metadata_size2;
   plasma_read_DataReply(data, &object_id2, &object_size2, &metadata_size2);

--- a/src/plasma/test/serialization_tests.c
+++ b/src/plasma/test/serialization_tests.c
@@ -71,7 +71,7 @@ TEST plasma_create_request_test(void) {
   plasma_read_CreateRequest(data, &object_id2, &data_size2, &metadata_size2);
   ASSERT_EQ(data_size1, data_size2);
   ASSERT_EQ(metadata_size1, metadata_size2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   free(data);
   close(fd);
   PASS();
@@ -88,7 +88,7 @@ TEST plasma_create_reply_test(void) {
   memset(&object2, 0, sizeof(object2));
   int error_code;
   plasma_read_CreateReply(data, &object_id2, &object2, &error_code);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(memcmp(&object1, &object2, sizeof(object1)) == 0);
   free(data);
   close(fd);
@@ -105,7 +105,7 @@ TEST plasma_seal_request_test(void) {
   ObjectID object_id2;
   unsigned char digest2[DIGEST_SIZE];
   plasma_read_SealRequest(data, &object_id2, &digest2[0]);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(memcmp(&digest1[0], &digest2[0], DIGEST_SIZE) == 0);
   free(data);
   close(fd);
@@ -121,7 +121,7 @@ TEST plasma_seal_reply_test(void) {
   ObjectID object_id2;
   int error2;
   plasma_read_SealReply(data, &object_id2, &error2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(error1 == error2);
   free(data);
   close(fd);
@@ -140,8 +140,8 @@ TEST plasma_get_request_test(void) {
   ObjectID object_ids_return[2];
   int64_t timeout_ms_return;
   plasma_read_GetRequest(data, &object_ids_return[0], &timeout_ms_return, 2);
-  ASSERT(object_ids_equal(object_ids[0], object_ids_return[0]));
-  ASSERT(object_ids_equal(object_ids[1], object_ids_return[1]));
+  ASSERT(ObjectID_equal(object_ids[0], object_ids_return[0]));
+  ASSERT(ObjectID_equal(object_ids[1], object_ids_return[1]));
   ASSERT(timeout_ms == timeout_ms_return);
   free(data);
   close(fd);
@@ -163,8 +163,8 @@ TEST plasma_get_reply_test(void) {
   PlasmaObject plasma_objects_return[2];
   plasma_read_GetReply(data, object_ids_return, &plasma_objects_return[0],
                        num_objects);
-  ASSERT(object_ids_equal(object_ids[0], object_ids_return[0]));
-  ASSERT(object_ids_equal(object_ids[1], object_ids_return[1]));
+  ASSERT(ObjectID_equal(object_ids[0], object_ids_return[0]));
+  ASSERT(ObjectID_equal(object_ids[1], object_ids_return[1]));
   ASSERT(memcmp(&plasma_objects[0], &plasma_objects_return[0],
                 sizeof(PlasmaObject)) == 0);
   ASSERT(memcmp(&plasma_objects[1], &plasma_objects_return[1],
@@ -181,7 +181,7 @@ TEST plasma_release_request_test(void) {
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaReleaseRequest);
   ObjectID object_id2;
   plasma_read_ReleaseRequest(data, &object_id2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   free(data);
   close(fd);
   PASS();
@@ -196,7 +196,7 @@ TEST plasma_release_reply_test(void) {
   ObjectID object_id2;
   int error2;
   plasma_read_ReleaseReply(data, &object_id2, &error2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(error1 == error2);
   free(data);
   close(fd);
@@ -210,7 +210,7 @@ TEST plasma_delete_request_test(void) {
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaDeleteRequest);
   ObjectID object_id2;
   plasma_read_DeleteRequest(data, &object_id2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   free(data);
   close(fd);
   PASS();
@@ -225,7 +225,7 @@ TEST plasma_delete_reply_test(void) {
   ObjectID object_id2;
   int error2;
   plasma_read_DeleteReply(data, &object_id2, &error2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(error1 == error2);
   free(data);
   close(fd);
@@ -242,8 +242,8 @@ TEST plasma_status_request_test(void) {
   int64_t num_objects = plasma_read_StatusRequest_num_objects(data);
   ObjectID object_ids_read[num_objects];
   plasma_read_StatusRequest(data, object_ids_read, num_objects);
-  ASSERT(object_ids_equal(object_ids[0], object_ids_read[0]));
-  ASSERT(object_ids_equal(object_ids[1], object_ids_read[1]));
+  ASSERT(ObjectID_equal(object_ids[0], object_ids_read[0]));
+  ASSERT(ObjectID_equal(object_ids[1], object_ids_read[1]));
   free(data);
   close(fd);
   PASS();
@@ -262,8 +262,8 @@ TEST plasma_status_reply_test(void) {
   int object_statuses_read[num_objects];
   plasma_read_StatusReply(data, object_ids_read, object_statuses_read,
                           num_objects);
-  ASSERT(object_ids_equal(object_ids[0], object_ids_read[0]));
-  ASSERT(object_ids_equal(object_ids[1], object_ids_read[1]));
+  ASSERT(ObjectID_equal(object_ids[0], object_ids_read[0]));
+  ASSERT(ObjectID_equal(object_ids[1], object_ids_read[1]));
   ASSERT_EQ(object_statuses[0], object_statuses_read[0]);
   ASSERT_EQ(object_statuses[1], object_statuses_read[1]);
   free(data);
@@ -308,8 +308,8 @@ TEST plasma_fetch_request_test(void) {
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaFetchRequest);
   ObjectID object_ids_read[2];
   plasma_read_FetchRequest(data, &object_ids_read[0], 2);
-  ASSERT(object_ids_equal(object_ids[0], object_ids_read[0]));
-  ASSERT(object_ids_equal(object_ids[1], object_ids_read[1]));
+  ASSERT(ObjectID_equal(object_ids[0], object_ids_read[0]));
+  ASSERT(ObjectID_equal(object_ids[1], object_ids_read[1]));
   free(data);
   close(fd);
   PASS();
@@ -335,9 +335,9 @@ TEST plasma_wait_request_test(void) {
   int64_t timeout_ms_read;
   plasma_read_WaitRequest(data, &object_requests_read[0], num_object_ids_read,
                           &timeout_ms_read, &num_ready_objects_read);
-  ASSERT(object_ids_equal(object_requests[0].object_id,
+  ASSERT(ObjectID_equal(object_requests[0].object_id,
                           object_requests_read[0].object_id));
-  ASSERT(object_ids_equal(object_requests[1].object_id,
+  ASSERT(ObjectID_equal(object_requests[1].object_id,
                           object_requests_read[1].object_id));
   ASSERT(object_requests[0].type == object_requests_read[0].type);
   ASSERT(object_requests[1].type == object_requests_read[1].type);
@@ -360,9 +360,9 @@ TEST plasma_wait_reply_test(void) {
   ObjectRequest object_replies2[2];
   int num_ready_objects_read2;
   plasma_read_WaitReply(data, &object_replies2[0], &num_ready_objects_read2);
-  ASSERT(object_ids_equal(object_replies1[0].object_id,
+  ASSERT(ObjectID_equal(object_replies1[0].object_id,
                           object_replies2[0].object_id));
-  ASSERT(object_ids_equal(object_replies1[1].object_id,
+  ASSERT(ObjectID_equal(object_replies1[1].object_id,
                           object_replies2[1].object_id));
   ASSERT(object_replies1[0].status == object_replies2[0].status);
   ASSERT(object_replies1[1].status == object_replies2[1].status);
@@ -383,7 +383,7 @@ TEST plasma_data_request_test(void) {
   char *address2;
   int port2;
   plasma_read_DataRequest(data, &object_id2, &address2, &port2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(strcmp(address1, address2) == 0);
   ASSERT(port1 == port2);
   free(address2);
@@ -404,7 +404,7 @@ TEST plasma_data_reply_test(void) {
   int64_t object_size2;
   int64_t metadata_size2;
   plasma_read_DataReply(data, &object_id2, &object_size2, &metadata_size2);
-  ASSERT(object_ids_equal(object_id1, object_id2));
+  ASSERT(ObjectID_equal(object_id1, object_id2));
   ASSERT(object_size1 == object_size2);
   ASSERT(metadata_size1 == metadata_size2);
   free(data);

--- a/src/plasma/test/serialization_tests.c
+++ b/src/plasma/test/serialization_tests.c
@@ -336,9 +336,9 @@ TEST plasma_wait_request_test(void) {
   plasma_read_WaitRequest(data, &object_requests_read[0], num_object_ids_read,
                           &timeout_ms_read, &num_ready_objects_read);
   ASSERT(ObjectID_equal(object_requests[0].object_id,
-                          object_requests_read[0].object_id));
+                        object_requests_read[0].object_id));
   ASSERT(ObjectID_equal(object_requests[1].object_id,
-                          object_requests_read[1].object_id));
+                        object_requests_read[1].object_id));
   ASSERT(object_requests[0].type == object_requests_read[0].type);
   ASSERT(object_requests[1].type == object_requests_read[1].type);
   free(data);
@@ -361,9 +361,9 @@ TEST plasma_wait_reply_test(void) {
   int num_ready_objects_read2;
   plasma_read_WaitReply(data, &object_replies2[0], &num_ready_objects_read2);
   ASSERT(ObjectID_equal(object_replies1[0].object_id,
-                          object_replies2[0].object_id));
+                        object_replies2[0].object_id));
   ASSERT(ObjectID_equal(object_replies1[1].object_id,
-                          object_replies2[1].object_id));
+                        object_replies2[1].object_id));
   ASSERT(object_replies1[0].status == object_replies2[0].status);
   ASSERT(object_replies1[1].status == object_replies2[1].status);
   free(data);

--- a/src/plasma/test/serialization_tests.c
+++ b/src/plasma/test/serialization_tests.c
@@ -45,9 +45,9 @@ uint8_t *read_message_from_file(int fd, int message_type) {
   return data;
 }
 
-plasma_object random_plasma_object(void) {
+PlasmaObject random_plasma_object(void) {
   int random = rand();
-  plasma_object object;
+  PlasmaObject object;
   memset(&object, 0, sizeof(object));
   object.handle.store_fd = random + 7;
   object.handle.mmap_size = random + 42;
@@ -80,11 +80,11 @@ TEST plasma_create_request_test(void) {
 TEST plasma_create_reply_test(void) {
   int fd = create_temp_file();
   ObjectID object_id1 = globally_unique_id();
-  plasma_object object1 = random_plasma_object();
+  PlasmaObject object1 = random_plasma_object();
   plasma_send_CreateReply(fd, g_B, object_id1, &object1, 0);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaCreateReply);
   ObjectID object_id2;
-  plasma_object object2;
+  PlasmaObject object2;
   memset(&object2, 0, sizeof(object2));
   int error_code;
   plasma_read_CreateReply(data, &object_id2, &object2, &error_code);
@@ -153,22 +153,22 @@ TEST plasma_get_reply_test(void) {
   ObjectID object_ids[2];
   object_ids[0] = globally_unique_id();
   object_ids[1] = globally_unique_id();
-  plasma_object plasma_objects[2];
+  PlasmaObject plasma_objects[2];
   plasma_objects[0] = random_plasma_object();
   plasma_objects[1] = random_plasma_object();
   plasma_send_GetReply(fd, g_B, object_ids, plasma_objects, 2);
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaGetReply);
   int64_t num_objects = plasma_read_GetRequest_num_objects(data);
   ObjectID object_ids_return[num_objects];
-  plasma_object plasma_objects_return[2];
+  PlasmaObject plasma_objects_return[2];
   plasma_read_GetReply(data, object_ids_return, &plasma_objects_return[0],
                        num_objects);
   ASSERT(object_ids_equal(object_ids[0], object_ids_return[0]));
   ASSERT(object_ids_equal(object_ids[1], object_ids_return[1]));
   ASSERT(memcmp(&plasma_objects[0], &plasma_objects_return[0],
-                sizeof(plasma_object)) == 0);
+                sizeof(PlasmaObject)) == 0);
   ASSERT(memcmp(&plasma_objects[1], &plasma_objects_return[1],
-                sizeof(plasma_object)) == 0);
+                sizeof(PlasmaObject)) == 0);
   free(data);
   close(fd);
   PASS();

--- a/src/plasma/test/serialization_tests.c
+++ b/src/plasma/test/serialization_tests.c
@@ -317,7 +317,7 @@ TEST plasma_fetch_request_test(void) {
 
 TEST plasma_wait_request_test(void) {
   int fd = create_temp_file();
-  object_request object_requests[2];
+  ObjectRequest object_requests[2];
   object_requests[0].object_id = globally_unique_id();
   object_requests[0].type = PLASMA_QUERY_ANYWHERE;
   object_requests[1].object_id = globally_unique_id();
@@ -328,7 +328,7 @@ TEST plasma_wait_request_test(void) {
                           timeout_ms);
   /* Read message back. */
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaWaitRequest);
-  object_request object_requests_read[2];
+  ObjectRequest object_requests_read[2];
   int num_object_ids_read = plasma_read_WaitRequest_num_object_ids(data);
   ASSERT_EQ(num_object_ids_read, 2);
   int num_ready_objects_read;
@@ -348,7 +348,7 @@ TEST plasma_wait_request_test(void) {
 
 TEST plasma_wait_reply_test(void) {
   int fd = create_temp_file();
-  object_request object_replies1[2];
+  ObjectRequest object_replies1[2];
   object_replies1[0].object_id = globally_unique_id();
   object_replies1[0].status = ObjectStatus_Local;
   object_replies1[1].object_id = globally_unique_id();
@@ -357,7 +357,7 @@ TEST plasma_wait_reply_test(void) {
   plasma_send_WaitReply(fd, g_B, object_replies1, num_ready_objects1);
   /* Read message back. */
   uint8_t *data = read_message_from_file(fd, MessageType_PlasmaWaitReply);
-  object_request object_replies2[2];
+  ObjectRequest object_replies2[2];
   int num_ready_objects_read2;
   plasma_read_WaitReply(data, &object_replies2[0], &num_ready_objects_read2);
   ASSERT(object_ids_equal(object_replies1[0].object_id,


### PR DESCRIPTION
This changes types to be named with no space and upper cases, as in `ObjectID`, `Task`, or `LocalSchedulerAlgorithmState`.

It also changes methods to contain the type followed by the method name in lower case separated by underscores, as in `ObjectID_is_nil`, `Task_set_local_scheduler_id`.