### PR TITLE
Fix test failures in actor_test.py.

### DIFF
--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -308,7 +308,7 @@ class ActorNesting(unittest.TestCase):
 
   def testDefineActorWithinActor(self):
     # Make sure we can use remote funtions within actors.
-    ray.init()
+    ray.init(num_cpus=10)
 
     @ray.actor
     class Actor1(object):
@@ -337,7 +337,7 @@ class ActorNesting(unittest.TestCase):
   # error.
   # def testUseActorWithinActor(self):
   #   # Make sure we can use remote funtions within actors.
-  #   ray.init()
+  #   ray.init(num_cpus=10)
   #
   #   @ray.actor
   #   class Actor1(object):
@@ -362,7 +362,7 @@ class ActorNesting(unittest.TestCase):
 
   def testDefineActorWithinRemoteFunction(self):
     # Make sure we can define and actors within remote funtions.
-    ray.init()
+    ray.init(num_cpus=10)
 
     @ray.remote
     def f(x, n):
@@ -383,7 +383,7 @@ class ActorNesting(unittest.TestCase):
   # This test currently fails with a pickling error.
   # def testUseActorWithinRemoteFunction(self):
   #   # Make sure we can create and use actors within remote funtions.
-  #   ray.init()
+  #   ray.init(num_cpus=10)
   #
   #   @ray.actor
   #   class Actor1(object):
@@ -405,7 +405,7 @@ class ActorNesting(unittest.TestCase):
     # This is mostly a test of the export counters to make sure that when an
     # actor is imported, all of the necessary remote functions have been
     # imported.
-    ray.init()
+    ray.init(num_cpus=10)
 
     # Export a bunch of remote functions.
     num_remote_functions = 50


### PR DESCRIPTION
I believe this is the cause of some test failures we're seeing, e.g., https://s3.amazonaws.com/archive.travis-ci.org/jobs/205104856/log.txt

We should undo this when we unify the way tasks and actors do resource management.

There is still a test failure here in `actor_test.py`, but I'm not sure what the problem is. https://api.travis-ci.org/jobs/205406427/log.txt?deansi=true