### PR TITLE
Use flatbuffers for some messages from Redis.

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -20,7 +20,7 @@ fi
 if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
-  sudo pip install cloudpickle funcsigs colorama psutil redis tensorflow
+  sudo pip install cloudpickle funcsigs colorama psutil redis tensorflow flatbuffers
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake python-dev python-numpy build-essential autoconf curl libtool libboost-all-dev unzip
@@ -28,7 +28,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow
+  pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow flatbuffers
 elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -41,7 +41,7 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   fi
   brew install cmake automake autoconf libtool boost
   sudo easy_install pip
-  sudo pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow --ignore-installed six
+  sudo pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow flatbuffers --ignore-installed six
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -57,7 +57,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow
+  pip install numpy cloudpickle funcsigs colorama psutil redis tensorflow flatbuffers
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake build-essential autoconf curl libtool libboost-all-dev unzip

--- a/doc/source/install-on-macosx.md
+++ b/doc/source/install-on-macosx.md
@@ -11,7 +11,7 @@ To install Ray, first install the following dependencies. We recommend using
 brew update
 brew install cmake automake autoconf libtool boost wget
 
-pip install numpy cloudpickle funcsigs colorama psutil redis --ignore-installed six
+pip install numpy cloudpickle funcsigs colorama psutil redis flatbuffers --ignore-installed six
 ```
 
 If you are using Anaconda, you may also need to run the following.

--- a/doc/source/install-on-ubuntu.md
+++ b/doc/source/install-on-ubuntu.md
@@ -12,7 +12,7 @@ To install Ray, first install the following dependencies. We recommend using
 sudo apt-get update
 sudo apt-get install -y cmake build-essential autoconf curl libtool libboost-all-dev unzip python-dev python-pip  # If you're using Anaconda, then python-dev and python-pip are unnecessary.
 
-pip install numpy cloudpickle funcsigs colorama psutil redis
+pip install numpy cloudpickle funcsigs colorama psutil redis flatbuffers
 ```
 
 If you are using Anaconda, you may also need to run the following.

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -11,4 +11,5 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
     && rm /tmp/anaconda.sh
 ENV PATH "/opt/conda/bin:$PATH"
 RUN conda install -y libgcc
+RUN pip install flatbuffers
 RUN pip install --upgrade pip cloudpickle

--- a/python/ray/common/redis_module/runtest.py
+++ b/python/ray/common/redis_module/runtest.py
@@ -11,7 +11,7 @@ import unittest
 import redis
 import ray.services
 
-# Import flatbuffers bindings.
+# Import flatbuffer bindings.
 from ray.core.generated.SubscribeToNotificationsReply import SubscribeToNotificationsReply
 from ray.core.generated.SubscribeToTasksReply import SubscribeToTasksReply
 

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -34,7 +34,7 @@ TASK_STATUS_QUEUED = 4
 TASK_STATUS_RUNNING = 8
 TASK_STATUS_DONE = 16
 
-# These constants are an implementation detail of ray_redis_module.c, so this
+# These constants are an implementation detail of ray_redis_module.cc, so this
 # must be kept in sync with that file.
 DB_CLIENT_PREFIX = "CL:"
 TASK_PREFIX = "TT:"

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -12,6 +12,9 @@ import time
 from ray.services import get_ip_address
 from ray.services import get_port
 
+# Import flatbuffer bindings.
+from ray.core.generated.SubscribeToDBClientTableReply import SubscribeToDBClientTableReply
+
 # These variables must be kept in sync with the C codebase.
 # common/common.h
 DB_CLIENT_ID_SIZE = 20
@@ -89,14 +92,12 @@ class Monitor(object):
 
     # Parse the message.
     data = message["data"]
-    db_client_id = data[:DB_CLIENT_ID_SIZE]
-    data = data[DB_CLIENT_ID_SIZE + 1:]
-    data = data.split(b" ")
-    client_type, auxiliary_address, is_insertion = data
-    is_insertion = int(is_insertion)
-    if is_insertion != 1 and is_insertion != 0:
-      raise Exception("Expected 0 or 1 for insertion field, got {} instead".format(is_insertion))
-    is_insertion = bool(is_insertion)
+
+    notification_object = SubscribeToDBClientTableReply.GetRootAsSubscribeToDBClientTableReply(data, 0)
+    db_client_id = notification_object.DbClientId()
+    client_type = notification_object.ClientType()
+    auxiliary_address = notification_object.AuxAddress()
+    is_insertion = notification_object.IsInsertion()
 
     return db_client_id, client_type, auxiliary_address, is_insertion
 

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -18,7 +18,7 @@ DB_CLIENT_ID_SIZE = 20
 NIL_ID = b"\xff" * DB_CLIENT_ID_SIZE
 # common/task.h
 TASK_STATUS_LOST = 32
-# common/redis_module/ray_redis_module.c
+# common/redis_module/ray_redis_module.cc
 TASK_PREFIX = "TT:"
 DB_CLIENT_PREFIX = "CL:"
 DB_CLIENT_TABLE_NAME = b"db_clients"

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -723,7 +723,7 @@ def get_address_info_from_redis_helper(redis_address, node_ip_address):
   # must have run "CONFIG SET protected-mode no".
   redis_client = redis.StrictRedis(host=redis_ip_address, port=int(redis_port))
   # The client table prefix must be kept in sync with the file
-  # "src/common/redis_module/ray_redis_module.c" where it is defined.
+  # "src/common/redis_module/ray_redis_module.cc" where it is defined.
   REDIS_CLIENT_TABLE_PREFIX = "CL:"
   client_keys = redis_client.keys("{}*".format(REDIS_CLIENT_TABLE_PREFIX))
   # Filter to clients on the same node and do some basic checking.

--- a/scripts/start_ray.py
+++ b/scripts/start_ray.py
@@ -21,7 +21,7 @@ def check_no_existing_redis_clients(node_ip_address, redis_address):
   redis_ip_address, redis_port = redis_address.split(":")
   redis_client = redis.StrictRedis(host=redis_ip_address, port=int(redis_port))
   # The client table prefix must be kept in sync with the file
-  # "src/common/redis_module/ray_redis_module.c" where it is defined.
+  # "src/common/redis_module/ray_redis_module.cc" where it is defined.
   REDIS_CLIENT_TABLE_PREFIX = "CL:"
   client_keys = redis_client.keys("{}*".format(REDIS_CLIENT_TABLE_PREFIX))
   # Filter to clients on the same node and do some basic checking.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,6 +24,15 @@ add_custom_command(
   COMMENT "Running flatc compiler on ${COMMON_FBS_SRC}"
   VERBATIM)
 
+# Generate Python bindings for the flatbuffers objects.
+set(PYTHON_OUTPUT_DIR ${CMAKE_BINARY_DIR}/generated/)
+add_custom_command(
+  TARGET gen_common_fbs
+  COMMAND ${FLATBUFFERS_COMPILER} -p -o ${PYTHON_OUTPUT_DIR} ${COMMON_FBS_SRC}
+  DEPENDS ${FBS_DEPENDS}
+  COMMENT "Running flatc compiler on ${COMMON_FBS_SRC}"
+  VERBATIM)
+
 add_dependencies(gen_common_fbs flatbuffers_ep)
 
 add_custom_target(

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -49,7 +49,7 @@ table TaskInfo {
   required_resources: [double];
 }
 
-root_type TaskInfo;
+//root_type TaskInfo;
 
 table SubscribeToNotificationsReply {
   // The object ID of the object that the notification is about.
@@ -61,3 +61,17 @@ table SubscribeToNotificationsReply {
 }
 
 root_type SubscribeToNotificationsReply;
+
+table SubscribeToTasksReply {
+  // The task ID of the task that the message is about.
+  task_id: string;
+  // The state of the task. This is encoded as a bit mask of scheduling_state
+  // enum values in task.h.
+  state: long;
+  // A local scheduler ID.
+  local_scheduler_id: string;
+  // A string of bytes representing the task specification.
+  task_spec: string;
+}
+
+root_type SubscribeToTasksReply;

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -75,3 +75,18 @@ table SubscribeToTasksReply {
 }
 
 root_type SubscribeToTasksReply;
+
+table SubscribeToDBClientTableReply {
+  // The db client ID of the client that the message is about.
+  db_client_id: string;
+  // The type of the client.
+  client_type: string;
+  // If the client is a local scheduler, this is the address of the plasma
+  // manager that the local scheduler is connected to. Otherwise, it is empty.
+  aux_address: string;
+  // True if the message is about the addition of a client and false if it is
+  // about the deletion of a client.
+  is_insertion: bool;
+}
+
+root_type SubscribeToDBClientTableReply;

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -62,7 +62,7 @@ table SubscribeToNotificationsReply {
 
 root_type SubscribeToNotificationsReply;
 
-table SubscribeToTasksReply {
+table TaskReply {
   // The task ID of the task that the message is about.
   task_id: string;
   // The state of the task. This is encoded as a bit mask of scheduling_state
@@ -74,7 +74,7 @@ table SubscribeToTasksReply {
   task_spec: string;
 }
 
-root_type SubscribeToTasksReply;
+root_type TaskReply;
 
 table SubscribeToDBClientTableReply {
   // The db client ID of the client that the message is about.

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -90,3 +90,22 @@ table SubscribeToDBClientTableReply {
 }
 
 root_type SubscribeToDBClientTableReply;
+
+table LocalSchedulerInfoMessage {
+  // The db client ID of the client that the message is about.
+  db_client_id: string;
+  // The total number of workers that are connected to this local scheduler.
+  total_num_workers: long;
+  // The number of tasks queued in this local scheduler.
+  task_queue_length: long;
+  // The number of workers that are available and waiting for tasks.
+  available_workers: long;
+  // The resource vector of resources generally available to this local
+  // scheduler.
+  static_resources: [double];
+  // The resource vector of resources currently available to this local
+  // scheduler.
+  dynamic_resources: [double];
+}
+
+root_type LocalSchedulerInfoMessage;

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -50,3 +50,14 @@ table TaskInfo {
 }
 
 root_type TaskInfo;
+
+table SubscribeToNotificationsReply {
+  // The object ID of the object that the notification is about.
+  object_id: string;
+  // The size of the object.
+  object_size: long;
+  // The IDs of the managers that contain this object.
+  manager_ids: [string];
+}
+
+root_type SubscribeToNotificationsReply;

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -49,7 +49,7 @@ table TaskInfo {
   required_resources: [double];
 }
 
-//root_type TaskInfo;
+root_type TaskInfo;
 
 table SubscribeToNotificationsReply {
   // The object ID of the object that the notification is about.

--- a/src/common/redis_module/CMakeLists.txt
+++ b/src/common/redis_module/CMakeLists.txt
@@ -3,15 +3,15 @@ cmake_minimum_required(VERSION 2.8)
 project(ray_redis_module)
 
 if(APPLE)
-  set(REDIS_MODULE_CFLAGS -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2)
+  set(REDIS_MODULE_CFLAGS -W -Wall -dynamic -fno-common -g -ggdb -std=c++11 -O2)
   set(REDIS_MODULE_LDFLAGS "-undefined dynamic_lookup")
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 else()
-  set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c99 -O2)
+  set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c++11 -O2)
   set(REDIS_MODULE_LDFLAGS -shared)
 endif()
 
-add_library(ray_redis_module SHARED ray_redis_module.c)
+add_library(ray_redis_module SHARED ray_redis_module.cc)
 
 target_compile_options(ray_redis_module PUBLIC ${REDIS_MODULE_CFLAGS} -fPIC)
 target_link_libraries(ray_redis_module ${REDIS_MODULE_LDFLAGS})

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -721,15 +721,8 @@ int ReplyWithTask(RedisModuleCtx *ctx, RedisModuleString *task_id) {
     }
 
     long long state_integer;
-    if (RedisModule_StringToLongLong(state, &state_integer) != REDISMODULE_OK) {
-      RedisModule_CloseKey(key);
-      RedisModule_FreeString(ctx, state);
-      RedisModule_FreeString(ctx, local_scheduler_id);
-      RedisModule_FreeString(ctx, task_spec);
-      return RedisModule_ReplyWithError(ctx,
-                                        "Scheduling state must be integer.");
-    }
-    if (state_integer < 0) {
+    if (RedisModule_StringToLongLong(state, &state_integer) != REDISMODULE_OK ||
+        state_integer < 0) {
       RedisModule_CloseKey(key);
       RedisModule_FreeString(ctx, state);
       RedisModule_FreeString(ctx, local_scheduler_id);
@@ -743,6 +736,7 @@ int ReplyWithTask(RedisModuleCtx *ctx, RedisModuleString *task_id) {
                         RedisStringToFlatbuf(fbb, local_scheduler_id),
                         RedisStringToFlatbuf(fbb, task_spec));
     fbb.Finish(message);
+
     RedisModuleString *reply = RedisModule_CreateString(
         ctx, (char *) fbb.GetBufferPointer(), fbb.GetSize());
     RedisModule_ReplyWithString(ctx, reply);

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -381,16 +381,13 @@ bool PublishObjectNotification(RedisModuleCtx *ctx,
       fbb.CreateVector(manager_ids));
   fbb.Finish(message);
 
-  //FREE SOME STRINGS!!
-
   /* Publish the notification to the clients notification channel.
    * TODO(rkn): These notifications could be batched together. */
   RedisModuleString *channel_name =
       RedisString_Format(ctx, "%s%S", OBJECT_CHANNEL_PREFIX, client_id);
 
-  RedisModuleString *payload =
-      RedisModule_CreateString(ctx, (const char *) fbb.GetBufferPointer(),
-                               fbb.GetSize());
+  RedisModuleString *payload = RedisModule_CreateString(
+      ctx, (const char *) fbb.GetBufferPointer(), fbb.GetSize());
 
   RedisModuleCallReply *reply;
   reply = RedisModule_Call(ctx, "PUBLISH", "ss", channel_name, payload);

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -724,8 +724,7 @@ int ReplyWithTask(RedisModuleCtx *ctx, RedisModuleString *task_id) {
     }
 
     long long state_integer;
-    if (RedisModule_StringToLongLong(state, &state_integer) !=
-        REDISMODULE_OK) {
+    if (RedisModule_StringToLongLong(state, &state_integer) != REDISMODULE_OK) {
       RedisModule_CloseKey(key);
       RedisModule_FreeString(ctx, state);
       RedisModule_FreeString(ctx, local_scheduler_id);
@@ -842,21 +841,18 @@ int TaskTableWrite(RedisModuleCtx *ctx,
   /* Build the PUBLISH topic and message for task table subscribers. The topic
    * is a string in the format "TASK_PREFIX:<local scheduler ID>:<state>". The
    * message is a serialized SubscribeToTasksReply flatbuffer object. */
-  RedisModuleString *publish_topic =
-      RedisString_Format(ctx, "%s%S:%S", TASK_PREFIX, local_scheduler_id,
-                         formatted_state);
+  RedisModuleString *publish_topic = RedisString_Format(
+      ctx, "%s%S:%S", TASK_PREFIX, local_scheduler_id, formatted_state);
   RedisModule_FreeString(ctx, formatted_state);
 
   /* Construct the flatbuffers object for the payload. */
   flatbuffers::FlatBufferBuilder fbb;
   /* Extract the task ID. */
   size_t task_id_size;
-  const char *task_id_str =
-      RedisModule_StringPtrLen(task_id, &task_id_size);
+  const char *task_id_str = RedisModule_StringPtrLen(task_id, &task_id_size);
   /* Extract the scheduling state. */
   long long state_value;
-  if (RedisModule_StringToLongLong(state, &state_value) !=
-      REDISMODULE_OK) {
+  if (RedisModule_StringToLongLong(state, &state_value) != REDISMODULE_OK) {
     return RedisModule_ReplyWithError(ctx, "scheduling state must be integer");
   }
   /* Extract the local scheduler ID. */
@@ -879,9 +875,8 @@ int TaskTableWrite(RedisModuleCtx *ctx,
       fbb.CreateString(task_spec_str, task_spec_size));
   fbb.Finish(message);
 
-  RedisModuleString *publish_message =
-      RedisModule_CreateString(ctx, (const char *) fbb.GetBufferPointer(),
-                               fbb.GetSize());
+  RedisModuleString *publish_message = RedisModule_CreateString(
+      ctx, (const char *) fbb.GetBufferPointer(), fbb.GetSize());
 
   RedisModuleCallReply *reply =
       RedisModule_Call(ctx, "PUBLISH", "ss", publish_topic, publish_message);

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -42,7 +42,8 @@ RedisModuleKey *OpenPrefixedKey(RedisModuleCtx *ctx,
                                 int mode) {
   RedisModuleString *prefixed_keyname =
       RedisString_Format(ctx, "%s%S", prefix, keyname);
-  RedisModuleKey *key = RedisModule_OpenKey(ctx, prefixed_keyname, mode);
+  RedisModuleKey *key =
+      (RedisModuleKey *) RedisModule_OpenKey(ctx, prefixed_keyname, mode);
   RedisModule_FreeString(ctx, prefixed_keyname);
   return key;
 }
@@ -1038,6 +1039,8 @@ int TaskTableGet_RedisCommand(RedisModuleCtx *ctx,
   return ReplyWithTask(ctx, argv[1]);
 }
 
+extern "C" {
+
 /* This function must be present on each Redis module. It is used in order to
  * register the commands into the Redis server. */
 int RedisModule_OnLoad(RedisModuleCtx *ctx,
@@ -1135,3 +1138,5 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx,
 
   return REDISMODULE_OK;
 }
+
+} /* extern "C" */

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -27,6 +27,10 @@ extern "C" {
 #include "redis.h"
 #include "io.h"
 
+#include "format/common_generated.h"
+
+#include "common_protocol.h"
+
 #ifndef _WIN32
 /* This function is actually not declared in standard POSIX, so declare it. */
 extern int usleep(useconds_t usec);
@@ -502,81 +506,6 @@ void redis_object_table_lookup_callback(redisAsyncContext *c,
   }
 }
 
-/**
- * This will parse a payload string published on the object notification
- * channel. The string must have the format:
- *
- *    <object id> MANAGERS <manager id1> <manager id2> ...
- *
- * where there may be any positive number of manager IDs.
- *
- * @param db The db handle.
- * @param payload The payload string.
- * @param length The length of the string.
- * @param manager_count This method will write the number of managers at this
- *        address.
- * @param manager_vector This method will allocate an array of pointers to
- *        manager addresses and write the address of the array at this address.
- *        The caller is responsible for freeing this array.
- * @return The object ID that the notification is about.
- */
-ObjectID parse_subscribe_to_notifications_payload(
-    DBHandle *db,
-    char *payload,
-    int length,
-    int64_t *data_size,
-    int *manager_count,
-    const char ***manager_vector) {
-  long long data_size_value = 0;
-  int num_managers = (length - sizeof(ObjectID) - 1 - sizeof(data_size_value) -
-                      1 - strlen("MANAGERS")) /
-                     (1 + sizeof(DBClientID));
-
-  int64_t rval = sizeof(ObjectID) + 1 + sizeof(data_size_value) + 1 +
-                 strlen("MANAGERS") + num_managers * (1 + sizeof(DBClientID));
-
-  CHECKM(length == rval,
-         "length mismatch: num_managers = %d, length = %d, rval = %" PRId64,
-         num_managers, length, rval);
-  CHECK(num_managers > 0);
-  ObjectID obj_id;
-  /* Track our current offset in the payload. */
-  int offset = 0;
-  /* Parse the object ID. */
-  memcpy(&obj_id.id, &payload[offset], sizeof(obj_id.id));
-  offset += sizeof(obj_id.id);
-  /* The next part of the payload is a space. */
-  const char *space_str = " ";
-  CHECK(memcmp(&payload[offset], space_str, strlen(space_str)) == 0);
-  offset += strlen(space_str);
-  /* The next part of the payload is binary data_size. */
-  memcpy(&data_size_value, &payload[offset], sizeof(data_size_value));
-  offset += sizeof(data_size_value);
-  /* The next part of the payload is the string " MANAGERS" with leading ' '. */
-  const char *managers_str = " MANAGERS";
-  CHECK(memcmp(&payload[offset], managers_str, strlen(managers_str)) == 0);
-  offset += strlen(managers_str);
-  /* Parse the managers. */
-  const char **managers = (const char **) malloc(num_managers * sizeof(char *));
-  for (int i = 0; i < num_managers; ++i) {
-    /* First there is a space. */
-    CHECK(memcmp(&payload[offset], " ", strlen(" ")) == 0);
-    offset += strlen(" ");
-    /* Get the manager ID. */
-    DBClientID manager_id;
-    memcpy(&manager_id.id, &payload[offset], sizeof(manager_id.id));
-    offset += sizeof(manager_id.id);
-    /* Write the address of the corresponding manager to the returned array. */
-    redis_get_cached_db_client(db, manager_id, &managers[i]);
-  }
-  CHECK(offset == length);
-  /* Return the manager array and the object ID. */
-  *manager_count = num_managers;
-  *manager_vector = managers;
-  *data_size = data_size_value;
-  return obj_id;
-}
-
 void object_table_redis_subscribe_to_notifications_callback(
     redisAsyncContext *c,
     void *r,
@@ -603,13 +532,22 @@ void object_table_redis_subscribe_to_notifications_callback(
             message_type->str);
 
   if (strcmp(message_type->str, "message") == 0) {
-    /* Handle an object notification. */
-    int64_t data_size = 0;
-    int manager_count;
-    const char **manager_vector;
-    ObjectID obj_id = parse_subscribe_to_notifications_payload(
-        db, reply->element[2]->str, reply->element[2]->len, &data_size,
-        &manager_count, &manager_vector);
+    /* We received an object notification. Parse the payload. */
+    auto message = flatbuffers::GetRoot<SubscribeToNotificationsReply>(
+        reply->element[2]->str);
+    /* Extract the object ID. */
+    ObjectID obj_id = from_flatbuf(message->object_id());
+    /* Extract the data size. */
+    int64_t data_size = message->object_size();
+    int manager_count = message->manager_ids()->size();
+    /* Construct the manager vector from the flatbuffers object. */
+    const char **manager_vector =
+        (const char **) malloc(manager_count * sizeof(char *));
+    for (int i = 0; i < manager_count; ++i) {
+      DBClientID manager_id = from_flatbuf(message->manager_ids()->Get(i));
+      redis_get_cached_db_client(db, manager_id, &manager_vector[i]);
+    }
+
     /* Call the subscribe callback. */
     ObjectTableSubscribeData *data =
         (ObjectTableSubscribeData *) callback_data->data;

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -641,7 +641,7 @@ void redis_object_table_subscribe_to_notifications(
     TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   /* The object channel prefix must match the value defined in
-   * src/common/redismodule/ray_redis_module.c. */
+   * src/common/redismodule/ray_redis_module.cc. */
   const char *object_channel_prefix = "OC:";
   const char *object_channel_bcast = "BCAST";
   int status = REDIS_OK;
@@ -869,7 +869,7 @@ void redis_task_table_test_and_update(TableCallbackData *callback_data) {
   }
 }
 
-/* The format of the payload is described in ray_redis_module.c and is
+/* The format of the payload is described in ray_redis_module.cc and is
  * "<task ID> <state> <local scheduler ID> <task specification>". TODO(rkn):
  * Make this code nicer. */
 void parse_task_table_subscribe_callback(char *payload,
@@ -969,7 +969,7 @@ void redis_task_table_subscribe_callback(redisAsyncContext *c,
 void redis_task_table_subscribe(TableCallbackData *callback_data) {
   DBHandle *db = callback_data->db_handle;
   TaskTableSubscribeData *data = (TaskTableSubscribeData *) callback_data->data;
-  /* TASK_CHANNEL_PREFIX is defined in ray_redis_module.c and must be kept in
+  /* TASK_CHANNEL_PREFIX is defined in ray_redis_module.cc and must be kept in
    * sync with that file. */
   const char *TASK_CHANNEL_PREFIX = "TT:";
   int status;

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -862,17 +862,17 @@ void redis_task_table_subscribe(TableCallbackData *callback_data) {
   if (IS_NIL_ID(data->local_scheduler_id)) {
     /* TODO(swang): Implement the state_filter by translating the bitmask into
      * a Redis key-matching pattern. */
-    status = redisAsyncCommand(
-        db->sub_context, redis_task_table_subscribe_callback,
-        (void *) callback_data->timer_id, "PSUBSCRIBE %s*:%d",
-        TASK_CHANNEL_PREFIX, data->state_filter);
+    status =
+        redisAsyncCommand(db->sub_context, redis_task_table_subscribe_callback,
+                          (void *) callback_data->timer_id, "PSUBSCRIBE %s*:%d",
+                          TASK_CHANNEL_PREFIX, data->state_filter);
   } else {
     DBClientID local_scheduler_id = data->local_scheduler_id;
-    status = redisAsyncCommand(
-        db->sub_context, redis_task_table_subscribe_callback,
-        (void *) callback_data->timer_id, "SUBSCRIBE %s%b:%d",
-        TASK_CHANNEL_PREFIX, (char *) local_scheduler_id.id,
-        sizeof(local_scheduler_id.id), data->state_filter);
+    status =
+        redisAsyncCommand(db->sub_context, redis_task_table_subscribe_callback,
+                          (void *) callback_data->timer_id, "SUBSCRIBE %s%b:%d",
+                          TASK_CHANNEL_PREFIX, (char *) local_scheduler_id.id,
+                          sizeof(local_scheduler_id.id), data->state_filter);
   }
   if ((status == REDIS_ERR) || db->sub_context->err) {
     LOG_REDIS_DEBUG(db->sub_context, "error in redis_task_table_subscribe");

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -877,13 +877,13 @@ void redis_task_table_subscribe(TableCallbackData *callback_data) {
      * a Redis key-matching pattern. */
     status = redisAsyncCommand(
         db->sub_context, redis_task_table_subscribe_callback,
-        (void *) callback_data->timer_id, "PSUBSCRIBE %s*:%2d",
+        (void *) callback_data->timer_id, "PSUBSCRIBE %s*:%d",
         TASK_CHANNEL_PREFIX, data->state_filter);
   } else {
     DBClientID local_scheduler_id = data->local_scheduler_id;
     status = redisAsyncCommand(
         db->sub_context, redis_task_table_subscribe_callback,
-        (void *) callback_data->timer_id, "SUBSCRIBE %s%b:%2d",
+        (void *) callback_data->timer_id, "SUBSCRIBE %s%b:%d",
         TASK_CHANNEL_PREFIX, (char *) local_scheduler_id.id,
         sizeof(local_scheduler_id.id), data->state_filter);
   }

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -996,8 +996,8 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
   if (strcmp(message_type->str, "message") == 0) {
     /* Handle a local scheduler heartbeat. Parse the payload and call the
      * subscribe callback. */
-    auto message = flatbuffers::GetRoot<LocalSchedulerInfoMessage>(
-        reply->element[2]->str);
+    auto message =
+        flatbuffers::GetRoot<LocalSchedulerInfoMessage>(reply->element[2]->str);
 
     /* Extract the client ID. */
     DBClientID client_id = from_flatbuf(message->db_client_id());
@@ -1006,10 +1006,10 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
     info.total_num_workers = message->total_num_workers();
     info.task_queue_length = message->task_queue_length();
     info.available_workers = message->available_workers();
-    for (int i = 0; i < ResourceIndex_MAX; ++i){
+    for (int i = 0; i < ResourceIndex_MAX; ++i) {
       info.static_resources[i] = message->static_resources()->Get(i);
     }
-    for (int i = 0; i < ResourceIndex_MAX; ++i){
+    for (int i = 0; i < ResourceIndex_MAX; ++i) {
       info.dynamic_resources[i] = message->dynamic_resources()->Get(i);
     }
 

--- a/webui/backend/ray_ui.py
+++ b/webui/backend/ray_ui.py
@@ -19,7 +19,7 @@ loop = asyncio.get_event_loop()
 
 IDENTIFIER_LENGTH = 20
 
-# This prefix must match the value defined in ray_redis_module.c.
+# This prefix must match the value defined in ray_redis_module.cc.
 DB_CLIENT_PREFIX = b"CL:"
 
 def hex_identifier(identifier):


### PR DESCRIPTION
This replaces the messages published over the object notification subscription channel and the task subscription channel with serialized flatbuffers objects to avoid doing pointer arithmetic.

Note that this depends on flatbuffers >= 1.4 for the Python flatbuffer bindings to be properly generated.