### PR TITLE
upgrade flatbuffers to 1.6.0

### DIFF
--- a/src/common/cmake/Common.cmake
+++ b/src/common/cmake/Common.cmake
@@ -5,7 +5,7 @@ include(CMakeParseArguments)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-set(FLATBUFFERS_VERSION "1.3.0")
+set(FLATBUFFERS_VERSION "1.6.0")
 
 set(FLATBUFFERS_PREFIX "${CMAKE_BINARY_DIR}/flatbuffers_ep-prefix/src/flatbuffers_ep-install")
 if (NOT TARGET flatbuffers_ep)

--- a/src/numbuf/thirdparty/download_thirdparty.sh
+++ b/src/numbuf/thirdparty/download_thirdparty.sh
@@ -11,4 +11,4 @@ if [ ! -d $TP_DIR/arrow ]; then
   git clone https://github.com/pcmoritz/arrow.git "$TP_DIR/arrow"
 fi
 cd "$TP_DIR/arrow"
-git checkout c88bd70c13cf16c07b840623cb466aa98d535be0
+git checkout a4a5526e4a8fbc4e4d5382a5c806ec871d2fbd9f


### PR DESCRIPTION
This PR upgrades flatbuffers to 1.6.0 (a prerequisite for moving the local scheduler and redis to flatbuffers).

Arrow's flatbuffers is also upgraded, see https://github.com/ray-project/ray/issues/342

Note that this PR introduces the performance optimization that @atumanov integrated into our fork of arrow.