### PR TITLE
Push an error to the driver when the workload hangs on `ray.put` reconstruction

### DIFF
--- a/python/ray/common/redis_module/runtest.py
+++ b/python/ray/common/redis_module/runtest.py
@@ -294,7 +294,7 @@ class TestGlobalStateStore(unittest.TestCase):
     response = self.redis.execute_command("RAY.TASK_TABLE_TEST_AND_UPDATE",
                                           "task_id",
                                           *task_args[:3])
-    self.assertEqual(response, None)
+    self.assertEqual(response, get_response)
     # Check that the update did not happen.
     get_response2 = self.redis.execute_command("RAY.TASK_TABLE_GET", "task_id")
     self.assertEqual(get_response2, get_response)
@@ -315,7 +315,7 @@ class TestGlobalStateStore(unittest.TestCase):
     response = self.redis.execute_command("RAY.TASK_TABLE_TEST_AND_UPDATE",
                                           "task_id",
                                           *task_args[:3])
-    self.assertEqual(response, None)
+    self.assertEqual(response, old_response)
     # Check that the update did not happen.
     get_response = self.redis.execute_command("RAY.TASK_TABLE_GET", "task_id")
     self.assertEqual(get_response, old_response)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -708,7 +708,7 @@ def error_info(worker=global_worker):
           PUT_RECONSTRUCTION_ERROR_TYPE):
         function_id = error_contents[b"data"]
         if function_id == NIL_FUNCTION_ID:
-          function_name = "Driver"
+          function_name = b"Driver"
         else:
           function_name = worker.redis_client.hget("RemoteFunction:{}".format(function_id), "name")
         error_contents[b"data"] = function_name

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -707,7 +707,10 @@ def error_info(worker=global_worker):
       if (error_type == OBJECT_HASH_MISMATCH_ERROR_TYPE or error_type ==
           PUT_RECONSTRUCTION_ERROR_TYPE):
         function_id = error_contents[b"data"]
-        function_name = worker.redis_client.hget("RemoteFunction:{}".format(function_id), "name")
+        if function_id == NIL_FUNCTION_ID:
+          function_name = "Driver"
+        else:
+          function_name = worker.redis_client.hget("RemoteFunction:{}".format(function_id), "name")
         error_contents[b"data"] = function_name
       errors.append(error_contents)
 

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -127,3 +127,12 @@ table LocalSchedulerInfoMessage {
 }
 
 root_type LocalSchedulerInfoMessage;
+
+table ResultTableReply {
+  // The task ID of the task that created the object.
+  task_id: string;
+  // Whether the task created the object through a ray.put.
+  is_put: bool;
+}
+
+root_type ResultTableReply;

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -90,6 +90,9 @@ table TaskReply {
   local_scheduler_id: string;
   // A string of bytes representing the task specification.
   task_spec: string;
+  // A boolean representing whether the update was successful. This field
+  // should only be used for test-and-set operations.
+  updated: bool;
 }
 
 root_type TaskReply;

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -116,6 +116,10 @@ int connect_ipc_sock_retry(const char *socket_pathname,
     if (fd >= 0) {
       break;
     }
+    if (num_attempts == 0) {
+      LOG_ERROR("Connection to socket failed for pathname %s.",
+                socket_pathname);
+    }
     /* Sleep for timeout milliseconds. */
     usleep(timeout * 1000);
   }
@@ -147,7 +151,7 @@ int connect_ipc_sock(const char *socket_pathname) {
 
   if (connect(socket_fd, (struct sockaddr *) &socket_address,
               sizeof(socket_address)) != 0) {
-    LOG_ERROR("Connection to socket failed for pathname %s.", socket_pathname);
+    close(socket_fd);
     return -1;
   }
 
@@ -172,6 +176,10 @@ int connect_inet_sock_retry(const char *ip_addr,
     fd = connect_inet_sock(ip_addr, port);
     if (fd >= 0) {
       break;
+    }
+    if (num_attempts == 0) {
+      LOG_ERROR("Connection to socket failed for address %s:%d.", ip_addr,
+                port);
     }
     /* Sleep for timeout milliseconds. */
     usleep(timeout * 1000);
@@ -203,7 +211,6 @@ int connect_inet_sock(const char *ip_addr, int port) {
   addr.sin_port = htons(port);
 
   if (connect(fd, (struct sockaddr *) &addr, sizeof(addr)) != 0) {
-    LOG_ERROR("Connection to socket failed for address %s:%d.", ip_addr, port);
     close(fd);
     return -1;
   }

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -543,14 +543,3 @@ PyObject *check_simple_value(PyObject *self, PyObject *args) {
   }
   Py_RETURN_FALSE;
 }
-
-PyObject *compute_put_id(PyObject *self, PyObject *args) {
-  int put_index;
-  TaskID task_id;
-  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
-                        &put_index)) {
-    return NULL;
-  }
-  ObjectID put_id = task_compute_put_id(task_id, put_index);
-  return PyObjectID_make(put_id);
-}

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -829,10 +829,8 @@ int ResultTableLookup_RedisCommand(RedisModuleCtx *ctx,
   RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS, "task", &task_id, "is_put",
                       &is_put, NULL);
   RedisModule_CloseKey(key);
-  if (task_id == NULL) {
-    RedisModule_FreeString(ctx, is_put);
-    RedisModule_FreeString(ctx, task_id);
-    return RedisModule_ReplyWithError(ctx, "Empty result table entry");
+  if (task_id == NULL || is_put == NULL) {
+    return RedisModule_ReplyWithNull(ctx);
   }
 
   /* Check to make sure the is_put field was a 0 or a 1. */

--- a/src/common/state/error_table.h
+++ b/src/common/state/error_table.h
@@ -18,14 +18,19 @@ typedef enum {
   /** An object was added with a different hash from the existing
    *  one. */
   OBJECT_HASH_MISMATCH_ERROR_INDEX = 0,
+  /** An object that was created through a ray.put is lost. */
+  PUT_RECONSTRUCTION_ERROR_INDEX,
   /** The total number of error types. */
   MAX_ERROR_INDEX
 } error_index;
 
 /** Information about the error to be displayed to the user. */
-static const char *error_types[] = {"object_hash_mismatch"};
+static const char *error_types[] = {"object_hash_mismatch",
+                                    "put_reconstruction"};
 static const char *error_messages[] = {
-    "A nondeterministic task was reexecuted."};
+    "A nondeterministic task was reexecuted.",
+    "A task created an object using `ray.put` that was evicted and could not "
+    "be reconstructed. The driver may need to be restarted."};
 
 /**
  * Push an error to the given Python driver.

--- a/src/common/state/error_table.h
+++ b/src/common/state/error_table.h
@@ -29,8 +29,8 @@ static const char *error_types[] = {"object_hash_mismatch",
                                     "put_reconstruction"};
 static const char *error_messages[] = {
     "A nondeterministic task was reexecuted.",
-    "A task created an object using `ray.put` that was evicted and could not "
-    "be reconstructed. The driver may need to be restarted."};
+    "An object created by ray.put was evicted and could not be reconstructed. "
+    "The driver may need to be restarted."};
 
 /**
  * Push an error to the given Python driver.

--- a/src/common/state/object_table.cc
+++ b/src/common/state/object_table.cc
@@ -104,13 +104,16 @@ void object_info_subscribe(DBHandle *db_handle,
 
 void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
-                      TaskID task_id_arg,
+                      TaskID task_id,
+                      bool is_put,
                       RetryInfo *retry,
                       result_table_done_callback done_callback,
                       void *user_context) {
-  TaskID *task_id_copy = (TaskID *) malloc(sizeof(TaskID));
-  memcpy(task_id_copy, task_id_arg.id, sizeof(*task_id_copy));
-  init_table_callback(db_handle, object_id, __func__, task_id_copy, retry,
+  ResultTableAddInfo *info =
+      (ResultTableAddInfo *) malloc(sizeof(ResultTableAddInfo));
+  info->task_id = task_id;
+  info->is_put = is_put;
+  init_table_callback(db_handle, object_id, __func__, info, retry,
                       (table_done_callback) done_callback,
                       redis_result_table_add, user_context);
 }

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -224,6 +224,15 @@ typedef struct {
 typedef void (*result_table_done_callback)(ObjectID object_id,
                                            void *user_context);
 
+/** Information about a result table entry to add. */
+typedef struct {
+  /** The task ID of the task that created the requested object. */
+  TaskID task_id;
+  /** True if the object was created through a put, and false if created by
+   *  return value. */
+  bool is_put;
+} ResultTableAddInfo;
+
 /**
  * Add information about a new object to the object table. This
  * is immutable information like the ID of the task that
@@ -232,6 +241,8 @@ typedef void (*result_table_done_callback)(ObjectID object_id,
  * @param db_handle Handle to object_table database.
  * @param object_id ID of the object to add.
  * @param task_id ID of the task that creates this object.
+ * @param is_put A boolean that is true if the object was created through a
+ *        ray.put, and false if the object was created by return value.
  * @param retry Information about retrying the request to the database.
  * @param done_callback Function to be called when database returns result.
  * @param user_context Context passed by the caller.
@@ -240,6 +251,7 @@ typedef void (*result_table_done_callback)(ObjectID object_id,
 void result_table_add(DBHandle *db_handle,
                       ObjectID object_id,
                       TaskID task_id,
+                      bool is_put,
                       RetryInfo *retry,
                       result_table_done_callback done_callback,
                       void *user_context);
@@ -247,6 +259,7 @@ void result_table_add(DBHandle *db_handle,
 /** Callback called when the result table lookup completes. */
 typedef void (*result_table_lookup_callback)(ObjectID object_id,
                                              TaskID task_id,
+                                             bool is_put,
                                              void *user_context);
 
 /**

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -767,12 +767,8 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
   /* Parse the task from the reply. */
   Task *task = parse_and_construct_task_from_redis_reply(reply);
   /* Determine whether the update happened. */
-  bool updated = false;
-  if (task != NULL) {
-    TaskTableTestAndUpdateData *update_data =
-        (TaskTableTestAndUpdateData *) callback_data->data;
-    updated = (Task_state(task) == update_data->update_state);
-  }
+  auto message = flatbuffers::GetRoot<TaskReply>(reply->str);
+  bool updated = message->updated();
 
   /* Call the done callback if there is one. */
   task_table_test_and_update_callback done_callback =

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -766,11 +766,19 @@ void redis_task_table_test_and_update_callback(redisAsyncContext *c,
   redisReply *reply = (redisReply *) r;
   /* Parse the task from the reply. */
   Task *task = parse_and_construct_task_from_redis_reply(reply);
+  /* Determine whether the update happened. */
+  bool updated = false;
+  if (task != NULL) {
+    TaskTableTestAndUpdateData *update_data =
+        (TaskTableTestAndUpdateData *) callback_data->data;
+    updated = (Task_state(task) == update_data->update_state);
+  }
+
   /* Call the done callback if there is one. */
-  task_table_get_callback done_callback =
-      (task_table_get_callback) callback_data->done_callback;
+  task_table_test_and_update_callback done_callback =
+      (task_table_test_and_update_callback) callback_data->done_callback;
   if (done_callback != NULL) {
-    done_callback(task, callback_data->user_context);
+    done_callback(task, callback_data->user_context, updated);
   }
   /* Free the task if it is not NULL. */
   if (task != NULL) {

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -342,12 +342,14 @@ void redis_result_table_add(TableCallbackData *callback_data) {
   CHECK(callback_data);
   DBHandle *db = callback_data->db_handle;
   ObjectID id = callback_data->id;
-  TaskID *result_task_id = (TaskID *) callback_data->data;
+  ResultTableAddInfo *info = (ResultTableAddInfo *) callback_data->data;
+  int is_put = info->is_put ? 1 : 0;
+
   /* Add the result entry to the result table. */
   int status = redisAsyncCommand(
       db->context, redis_result_table_add_callback,
-      (void *) callback_data->timer_id, "RAY.RESULT_TABLE_ADD %b %b", id.id,
-      sizeof(id.id), result_task_id->id, sizeof(result_task_id->id));
+      (void *) callback_data->timer_id, "RAY.RESULT_TABLE_ADD %b %b %d", id.id,
+      sizeof(id.id), info->task_id.id, sizeof(info->task_id.id), is_put);
   if ((status == REDIS_ERR) || db->context->err) {
     LOG_REDIS_DEBUG(db->context, "Error in result table add");
   }
@@ -386,16 +388,19 @@ void redis_result_table_lookup_callback(redisAsyncContext *c,
          reply->type);
   /* Parse the task from the reply. */
   TaskID result_id = NIL_TASK_ID;
+  bool is_put = false;
   if (reply->type == REDIS_REPLY_STRING) {
-    CHECK(reply->len == sizeof(result_id));
-    memcpy(&result_id, reply->str, reply->len);
+    auto message = flatbuffers::GetRoot<ResultTableReply>(reply->str);
+    result_id = from_flatbuf(message->task_id());
+    is_put = message->is_put();
   }
 
   /* Call the done callback if there is one. */
   result_table_lookup_callback done_callback =
       (result_table_lookup_callback) callback_data->done_callback;
   if (done_callback != NULL) {
-    done_callback(callback_data->id, result_id, callback_data->user_context);
+    done_callback(callback_data->id, result_id, is_put,
+                  callback_data->user_context);
   }
   /* Clean up timer and callback. */
   destroy_timer_callback(db->loop, callback_data);

--- a/src/common/state/task_table.cc
+++ b/src/common/state/task_table.cc
@@ -33,13 +33,14 @@ void task_table_update(DBHandle *db_handle,
                       redis_task_table_update, user_context);
 }
 
-void task_table_test_and_update(DBHandle *db_handle,
-                                TaskID task_id,
-                                int test_state_bitmask,
-                                int update_state,
-                                RetryInfo *retry,
-                                task_table_get_callback done_callback,
-                                void *user_context) {
+void task_table_test_and_update(
+    DBHandle *db_handle,
+    TaskID task_id,
+    int test_state_bitmask,
+    int update_state,
+    RetryInfo *retry,
+    task_table_test_and_update_callback done_callback,
+    void *user_context) {
   TaskTableTestAndUpdateData *update_data =
       (TaskTableTestAndUpdateData *) malloc(sizeof(TaskTableTestAndUpdateData));
   update_data->test_state_bitmask = test_state_bitmask;

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -28,6 +28,13 @@ typedef void (*task_table_done_callback)(TaskID task_id, void *user_context);
  * was not in the task table, then the task pointer will be NULL. */
 typedef void (*task_table_get_callback)(Task *task, void *user_context);
 
+/* Callback called when a task table test-and-update operation completes. If
+ * the task ID was not in the task table, then the task pointer will be NULL.
+ * If the update succeeded, the updated field will be set to true. */
+typedef void (*task_table_test_and_update_callback)(Task *task,
+                                                    void *user_context,
+                                                    bool updated);
+
 /**
  * Get a task's entry from the task table.
  *
@@ -107,13 +114,14 @@ void task_table_update(DBHandle *db_handle,
  *        fail_callback.
  * @return Void.
  */
-void task_table_test_and_update(DBHandle *db_handle,
-                                TaskID task_id,
-                                int test_state_bitmask,
-                                int update_state,
-                                RetryInfo *retry,
-                                task_table_get_callback done_callback,
-                                void *user_context);
+void task_table_test_and_update(
+    DBHandle *db_handle,
+    TaskID task_id,
+    int test_state_bitmask,
+    int update_state,
+    RetryInfo *retry,
+    task_table_test_and_update_callback done_callback,
+    void *user_context);
 
 /* Data that is needed to test and set the task's scheduling state. */
 typedef struct {

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -34,6 +34,7 @@ void new_object_fail_callback(UniqueID id,
 
 void new_object_done_callback(ObjectID object_id,
                               TaskID task_id,
+                              bool is_put,
                               void *user_context) {
   new_object_succeeded = 1;
   CHECK(ObjectID_equal(object_id, new_object_id));
@@ -60,7 +61,7 @@ void new_object_task_callback(TaskID task_id, void *user_context) {
       .fail_callback = new_object_fail_callback,
   };
   DBHandle *db = (DBHandle *) user_context;
-  result_table_add(db, new_object_id, new_object_task_id, &retry,
+  result_table_add(db, new_object_id, new_object_task_id, false, &retry,
                    new_object_lookup_callback, (void *) db);
 }
 
@@ -95,6 +96,7 @@ TEST new_object_test(void) {
 
 void new_object_no_task_callback(ObjectID object_id,
                                  TaskID task_id,
+                                 bool is_put,
                                  void *user_context) {
   new_object_succeeded = 1;
   CHECK(IS_NIL_ID(task_id));

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -26,7 +26,9 @@ enum MessageType:int {
   // For a worker that was blocked on some object(s), tell the local scheduler
   // that the worker is now unblocked. This is sent from a worker to a local
   // scheduler.
-  NotifyUnblocked
+  NotifyUnblocked,
+  // Add a result table entry for an object put.
+  PutObject
 }
 
 table EventLogMessage {
@@ -46,5 +48,12 @@ table RegisterWorkerInfo {
 
 table ReconstructObject {
   // Object ID of the object that needs to be reconstructed.
+  object_id: string;
+}
+
+table PutObject {
+  // Task ID of the task that performed the put.
+  task_id: string;
+  // Object ID of the object that is being put.
   object_id: string;
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -424,11 +424,16 @@ void update_dynamic_resources(LocalSchedulerState *state,
        * subtract the resource quantities from our accounting. */
       resource *= -1;
     }
+
+    bool oversubscribed =
+        (!return_resources && state->dynamic_resources[i] < 0);
     /* Add or subtract the task's resources from our count. */
     state->dynamic_resources[i] += resource;
 
-    if (!return_resources && state->dynamic_resources[i] < 0) {
-      /* We are using more resources than we have been allocated. */
+    if ((!return_resources && state->dynamic_resources[i] < 0) &&
+        !oversubscribed) {
+      /* Log a warning if we are using more resources than we have been
+       * allocated, and we weren't already oversubscribed. */
       LOG_WARN("local_scheduler dynamic resources dropped to %8.4f\t%8.4f\n",
                state->dynamic_resources[0], state->dynamic_resources[1]);
     }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -503,9 +503,7 @@ void process_plasma_notification(event_loop *loop,
 void reconstruct_task_update_callback(Task *task,
                                       void *user_context,
                                       bool updated) {
-  /* The task ID should be in the task table for all tasks except the driver
-   * task. We should never request reconstruction for an object produced by the
-   * driver task. */
+  /* The task ID should be in the task table. */
   CHECK(task != NULL);
   if (!updated) {
     /* The test-and-set of the task's scheduling state failed, so the task was

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -522,8 +522,10 @@ void reconstruct_task_update_callback(Task *task, void *user_context) {
 }
 
 void log_put_reconstruction_error(Task *task, void *user_context) {
-  LOG_WARN("Put reconstruction!");
   if (task == NULL) {
+    LOG_WARN(
+        "Reconstruction requested for a driver ray.put, unable to push error "
+        "to driver");
     return;
   }
   LocalSchedulerState *state = (LocalSchedulerState *) user_context;

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -530,21 +530,11 @@ void reconstruct_task_update_callback(Task *task,
 void reconstruct_put_task_update_callback(Task *task,
                                           void *user_context,
                                           bool updated) {
+  CHECK(task != NULL);
   if (updated) {
     /* The update to TASK_STATUS_RECONSTRUCTING succeeded, so continue with
      * reconstruction as usual. */
     reconstruct_task_update_callback(task, user_context, updated);
-    return;
-  }
-
-  if (task == NULL) {
-    /* The driver task needs to be reexecuted. */
-    /* TODO(swang): Store an entry for the driver task in the task table, so
-     * that we can push the error directly to the user instead of logging a
-     * warning here.  */
-    LOG_WARN(
-        "Reconstruction requested for a driver ray.put, unable to push error "
-        "to driver");
     return;
   }
 

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1080,13 +1080,13 @@ void handle_worker_blocked(LocalSchedulerState *state,
         DCHECK(*q != worker);
       }
 
+      /* Add the worker to the list of blocked workers. */
+      worker->is_blocked = true;
+      utarray_push_back(algorithm_state->blocked_workers, &worker);
       /* Return the resources that the blocked worker was using. */
       CHECK(worker->task_in_progress != NULL);
       TaskSpec *spec = Task_task_spec(worker->task_in_progress);
       update_dynamic_resources(state, spec, true);
-      /* Add the worker to the list of blocked workers. */
-      worker->is_blocked = true;
-      utarray_push_back(algorithm_state->blocked_workers, &worker);
 
       /* Try to dispatch tasks, since we may have freed up some resources. */
       dispatch_tasks(state, algorithm_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1088,6 +1088,8 @@ void handle_worker_blocked(LocalSchedulerState *state,
       worker->is_blocked = true;
       utarray_push_back(algorithm_state->blocked_workers, &worker);
 
+      /* Try to dispatch tasks, since we may have freed up some resources. */
+      dispatch_tasks(state, algorithm_state);
       return;
     }
   }

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -92,3 +92,15 @@ void local_scheduler_log_message(LocalSchedulerConnection *conn) {
 void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn) {
   write_message(conn->conn, MessageType_NotifyUnblocked, 0, NULL);
 }
+
+void local_scheduler_put_object(LocalSchedulerConnection *conn,
+                                TaskID task_id,
+                                ObjectID object_id) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = CreatePutObject(fbb, to_flatbuf(fbb, task_id),
+                                 to_flatbuf(fbb, object_id));
+  fbb.Finish(message);
+
+  write_message(conn->conn, MessageType_PutObject, fbb.GetSize(),
+                fbb.GetBufferPointer());
+}

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -112,4 +112,16 @@ void local_scheduler_log_message(LocalSchedulerConnection *conn);
  */
 void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn);
 
+/**
+ * Record the mapping from object ID to task ID for put events.
+ *
+ * @param conn The connection information.
+ * @param task_id The ID of the task that called put.
+ * @param object_id The ID of the object being stored.
+ * @return Void.
+ */
+void local_scheduler_put_object(LocalSchedulerConnection *conn,
+                                TaskID task_id,
+                                ObjectID object_id);
+
 #endif

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -93,6 +93,21 @@ static PyObject *PyLocalSchedulerClient_notify_unblocked(PyObject *self) {
   Py_RETURN_NONE;
 }
 
+static PyObject *PyLocalSchedulerClient_compute_put_id(PyObject *self,
+                                                       PyObject *args) {
+  int put_index;
+  TaskID task_id;
+  if (!PyArg_ParseTuple(args, "O&i", &PyObjectToUniqueID, &task_id,
+                        &put_index)) {
+    return NULL;
+  }
+  ObjectID put_id = task_compute_put_id(task_id, put_index);
+  local_scheduler_put_object(
+      ((PyLocalSchedulerClient *) self)->local_scheduler_connection, task_id,
+      put_id);
+  return PyObjectID_make(put_id);
+}
+
 static PyMethodDef PyLocalSchedulerClient_methods[] = {
     {"submit", (PyCFunction) PyLocalSchedulerClient_submit, METH_VARARGS,
      "Submit a task to the local scheduler."},
@@ -105,6 +120,8 @@ static PyMethodDef PyLocalSchedulerClient_methods[] = {
      "Log an event to the event log through the local scheduler."},
     {"notify_unblocked", (PyCFunction) PyLocalSchedulerClient_notify_unblocked,
      METH_NOARGS, "Notify the local scheduler that we are unblocked."},
+    {"compute_put_id", (PyCFunction) PyLocalSchedulerClient_compute_put_id,
+     METH_VARARGS, "Return the object ID for a put call within a task."},
     {NULL} /* Sentinel */
 };
 
@@ -152,8 +169,6 @@ static PyTypeObject PyLocalSchedulerClientType = {
 static PyMethodDef local_scheduler_methods[] = {
     {"check_simple_value", check_simple_value, METH_VARARGS,
      "Should the object be passed by value?"},
-    {"compute_put_id", compute_put_id, METH_VARARGS,
-     "Return the object ID for a put call within a task."},
     {"task_from_string", PyTask_from_string, METH_VARARGS,
      "Creates a Python PyTask object from a string representation of "
      "TaskSpec."},

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1316,6 +1316,7 @@ void log_object_hash_mismatch_error_task_callback(Task *task,
 
 void log_object_hash_mismatch_error_result_callback(ObjectID object_id,
                                                     TaskID task_id,
+                                                    bool is_put,
                                                     void *user_context) {
   CHECK(!IS_NIL_ID(task_id));
   PlasmaManagerState *state = (PlasmaManagerState *) user_context;

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -503,8 +503,8 @@ class ReconstructionTests(unittest.TestCase):
     def error_check(errors):
       return len(errors) > 1
     errors = self.wait_for_errors(error_check)
-    print(errors)
-    self.assertTrue(all(error[b"type"] == b"driver_put_reconstruction" for error in errors))
+    self.assertTrue(all(error[b"type"] == b"put_reconstruction" for error in errors))
+    self.assertTrue(all(error[b"data"] == b"Driver" for error in errors))
 
 
 class ReconstructionTestsMultinode(ReconstructionTests):

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -361,14 +361,14 @@ class ReconstructionTests(unittest.TestCase):
       self.assertEqual(value[0], i)
 
     def error_check(errors):
-      return len(errors) > num_objects / 2
+      return len(errors) >= num_objects / 2
     errors = self.wait_for_errors(error_check)
     # Make sure all the errors have the correct type.
     self.assertTrue(all(error[b"type"] == b"object_hash_mismatch" for error in errors))
     # Make sure all the errors have the correct function name.
     self.assertTrue(all(error[b"data"] == b"__main__.foo" for error in errors))
 
-  def testPut(self):
+  def testPutErrors(self):
     # Define the size of one task's return argument so that the combined sum of
     # all objects' sizes is at least twice the plasma stores' combined allotted
     # memory.

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -208,6 +208,12 @@ class ReconstructionTests(unittest.TestCase):
     for i in range(num_objects):
       value = ray.get(args[i])
       self.assertEqual(value[0], i)
+    # Get values sequentially, in chunks.
+    num_chunks = 4 * self.num_local_schedulers
+    chunk = num_objects // num_chunks
+    for i in range(num_chunks):
+      values = ray.get(args[i * chunk : (i + 1) * chunk])
+      del values
 
   def testRecursive(self):
     # Define the size of one task's return argument so that the combined sum of
@@ -252,6 +258,12 @@ class ReconstructionTests(unittest.TestCase):
       i  = np.random.randint(num_objects)
       value = ray.get(args[i])
       self.assertEqual(value[0], i)
+    # Get values sequentially, in chunks.
+    num_chunks = 4 * self.num_local_schedulers
+    chunk = num_objects // num_chunks
+    for i in range(num_chunks):
+      values = ray.get(args[i * chunk : (i + 1) * chunk])
+      del values
 
   def testMultipleRecursive(self):
     # Define the size of one task's return argument so that the combined sum of


### PR DESCRIPTION
Most `ray.put` reconstructions are not supported. If an object created by `ray.put` is evicted and requires reconstruction, the originating task is probably still executing. This suppresses reconstruction, so if the object is necessary for workload completion, the workload will hang.

This pull request returns an error to the user to notify them that this may be the case.

This behavior can be tested using:
`python test/stress_tests.py ReconstructionTests.testPutErrors`