### PR TITLE
Implement local scheduler task queues using C++ data structures

### DIFF
--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -275,6 +275,19 @@ double TaskSpec_get_required_resource(const TaskSpec *spec,
   return message->required_resources()->Get(resource_index);
 }
 
+bool TaskSpec_is_dependent_on(TaskSpec *spec, ObjectID object_id) {
+  int64_t num_args = TaskSpec_num_args(spec);
+  for (int i = 0; i < num_args; ++i) {
+    if (TaskSpec_arg_by_ref(spec, i)) {
+      ObjectID arg_id = TaskSpec_arg_id(spec, i);
+      if (ObjectID_equal(arg_id, object_id)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void TaskSpec_free(TaskSpec *spec) {
   free(spec);
 }

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -264,6 +264,16 @@ double TaskSpec_get_required_resource(const TaskSpec *spec,
                                       int64_t resource_index);
 
 /**
+ * Compute whether the task is dependent on an object ID.
+ *
+ * @param spec Task specification.
+ * @param object_id The object ID that the task may be dependent on.
+ * @return bool This returns true if the task is dependent on the given object
+ *         ID and false otherwise.
+ */
+bool TaskSpec_is_dependent_on(TaskSpec *spec, ObjectID object_id);
+
+/**
  * Compute the object id associated to a put call.
  *
  * @param task_id The task id of the parent task that called the put.

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -31,7 +31,7 @@ typedef struct {
    * the tasks in the waiting queue. Each element is actually store a reference
    * to the corresponding task's queue entry in waiting queue, for fast
    * deletion when all of the task's dependencies become available. */
-  std::vector<std::list<TaskQueueEntry>::const_iterator> *dependent_tasks;
+  std::vector<std::list<TaskQueueEntry>::iterator> *dependent_tasks;
   /** Handle for the uthash table. NOTE: This handle is used for both the
    *  scheduling algorithm state's local_objects and remote_objects tables.
    *  We must enforce the uthash invariant that the entry be in at most one of
@@ -456,11 +456,10 @@ bool dispatch_actor_task(LocalSchedulerState *state,
  * @param obj_id The ID of the object that the task is dependent on.
  * @returns Void.
  */
-void fetch_missing_dependency(
-    LocalSchedulerState *state,
-    SchedulingAlgorithmState *algorithm_state,
-    std::list<TaskQueueEntry>::const_iterator task_entry_it,
-    ObjectID obj_id) {
+void fetch_missing_dependency(LocalSchedulerState *state,
+                              SchedulingAlgorithmState *algorithm_state,
+                              std::list<TaskQueueEntry>::iterator task_entry_it,
+                              ObjectID obj_id) {
   object_entry *entry;
   HASH_FIND(hh, algorithm_state->remote_objects, &obj_id, sizeof(obj_id),
             entry);
@@ -478,7 +477,7 @@ void fetch_missing_dependency(
     entry = (object_entry *) malloc(sizeof(object_entry));
     entry->object_id = obj_id;
     entry->dependent_tasks =
-        new std::vector<std::list<TaskQueueEntry>::const_iterator>();
+        new std::vector<std::list<TaskQueueEntry>::iterator>();
     HASH_ADD(hh, algorithm_state->remote_objects, object_id,
              sizeof(entry->object_id), entry);
   }
@@ -498,7 +497,7 @@ void fetch_missing_dependency(
 void fetch_missing_dependencies(
     LocalSchedulerState *state,
     SchedulingAlgorithmState *algorithm_state,
-    std::list<TaskQueueEntry>::const_iterator task_entry_it) {
+    std::list<TaskQueueEntry>::iterator task_entry_it) {
   TaskSpec *task = task_entry_it->spec;
   int64_t num_args = TaskSpec_num_args(task);
   int num_missing_dependencies = 0;
@@ -1166,7 +1165,7 @@ void handle_object_available(LocalSchedulerState *state,
     entry = (object_entry *) malloc(sizeof(object_entry));
     entry->object_id = object_id;
     entry->dependent_tasks =
-        new std::vector<std::list<TaskQueueEntry>::const_iterator>();
+        new std::vector<std::list<TaskQueueEntry>::iterator>();
   }
 
   /* Add the entry to the set of locally available objects. */

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -28,9 +28,9 @@ typedef struct {
   /** Object id of this object. */
   ObjectID object_id;
   /** A vector of tasks dependent on this object. These tasks are a subset of
-   *  the tasks in the waiting queue. Each element is actually store a
-   *  reference to the corresponding task's queue entry in waiting queue, for
-   *  fast deletion when all of the task's dependencies become available. */
+   *  the tasks in the waiting queue. Each element actually stores a reference
+   *  to the corresponding task's queue entry in waiting queue, for fast
+   *  deletion when all of the task's dependencies become available. */
   std::vector<std::list<TaskQueueEntry>::iterator> *dependent_tasks;
   /** Handle for the uthash table. NOTE: This handle is used for both the
    *  scheduling algorithm state's local_objects and remote_objects tables.
@@ -583,8 +583,8 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
 void dispatch_tasks(LocalSchedulerState *state,
                     SchedulingAlgorithmState *algorithm_state) {
   /* Assign as many tasks as we can, while there are workers available. */
-  auto it = algorithm_state->dispatch_task_queue->begin();
-  while (it != algorithm_state->dispatch_task_queue->end()) {
+  for (auto it = algorithm_state->dispatch_task_queue->begin();
+       it != algorithm_state->dispatch_task_queue->end();) {
     TaskQueueEntry task = *it;
     /* If there is a task to assign, but there are no more available workers in
      * the worker pool, then exit. Ensure that there will be an available

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1247,15 +1247,11 @@ void handle_object_removed(LocalSchedulerState *state,
 }
 
 int num_waiting_tasks(SchedulingAlgorithmState *algorithm_state) {
-  TaskQueueEntry *elt;
-  int count = algorithm_state->waiting_task_queue->size();
-  return count;
+  return algorithm_state->waiting_task_queue->size();
 }
 
 int num_dispatch_tasks(SchedulingAlgorithmState *algorithm_state) {
-  TaskQueueEntry *elt;
-  int count = algorithm_state->dispatch_task_queue->size();
-  return count;
+  return algorithm_state->dispatch_task_queue->size();
 }
 
 void print_worker_info(const char *message,


### PR DESCRIPTION
This replaces the `utarray` and `utlist` C library implementation for the local scheduler's task queue with an implementation using the C++ STL.