### PR TITLE
Expose GPU IDs to tasks.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,9 +4,8 @@ from __future__ import print_function
 
 from ray.worker import (register_class, error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
-                        flush_log)
+                        flush_log, get_gpu_ids)
 from ray.actor import actor
-from ray.actor import get_gpu_ids
 from ray.worker import EnvironmentVariable, env
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -101,7 +101,7 @@ class TestGlobalScheduler(unittest.TestCase):
           static_resource_list=[10, 0])
       # Connect to the scheduler.
       local_scheduler_client = local_scheduler.LocalSchedulerClient(
-          local_scheduler_name, NIL_ACTOR_ID, False)
+          local_scheduler_name, NIL_ACTOR_ID, False, 0)
       self.local_scheduler_clients.append(local_scheduler_client)
       self.local_scheduler_pids.append(p4)
 

--- a/python/ray/local_scheduler/test/test.py
+++ b/python/ray/local_scheduler/test/test.py
@@ -46,7 +46,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
         plasma_store_name, use_valgrind=USE_VALGRIND)
     # Connect to the scheduler.
     self.local_scheduler_client = local_scheduler.LocalSchedulerClient(
-        scheduler_name, NIL_ACTOR_ID, False)
+        scheduler_name, NIL_ACTOR_ID, False, 0)
 
   def tearDown(self):
     # Check that the processes are still alive.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1291,33 +1291,38 @@ def import_thread(worker):
         raise Exception("This code should be unreachable.")
       num_imported += 1
 
-  for msg in worker.import_pubsub_client.listen():
-    with worker.lock:
-      if msg["type"] == "psubscribe":
-        continue
-      assert msg["data"] == b"rpush"
-      num_imports = worker.redis_client.llen("Exports")
-      assert num_imports >= num_imported
-      for i in range(num_imported, num_imports):
-        key = worker.redis_client.lindex("Exports", i)
-        if key.startswith(b"RemoteFunction"):
-          with log_span("ray:import_remote_function", worker=worker):
-            fetch_and_register_remote_function(key, worker=worker)
-        elif key.startswith(b"EnvironmentVariables"):
-          with log_span("ray:import_environment_variable", worker=worker):
-            fetch_and_register_environment_variable(key, worker=worker)
-        elif key.startswith(b"FunctionsToRun"):
-          with log_span("ray:import_function_to_run", worker=worker):
-            fetch_and_execute_function_to_run(key, worker=worker)
-        elif key.startswith(b"Actor"):
-          # Only get the actor if the actor ID matches the actor ID of this
-          # worker.
-          actor_id, = worker.redis_client.hmget(key, "actor_id")
-          if worker.actor_id == actor_id:
-            worker.fetch_and_register["Actor"](key, worker)
-        else:
-          raise Exception("This code should be unreachable.")
-        num_imported += 1
+  try:
+    for msg in worker.import_pubsub_client.listen():
+      with worker.lock:
+        if msg["type"] == "psubscribe":
+          continue
+        assert msg["data"] == b"rpush"
+        num_imports = worker.redis_client.llen("Exports")
+        assert num_imports >= num_imported
+        for i in range(num_imported, num_imports):
+          key = worker.redis_client.lindex("Exports", i)
+          if key.startswith(b"RemoteFunction"):
+            with log_span("ray:import_remote_function", worker=worker):
+              fetch_and_register_remote_function(key, worker=worker)
+          elif key.startswith(b"EnvironmentVariables"):
+            with log_span("ray:import_environment_variable", worker=worker):
+              fetch_and_register_environment_variable(key, worker=worker)
+          elif key.startswith(b"FunctionsToRun"):
+            with log_span("ray:import_function_to_run", worker=worker):
+              fetch_and_execute_function_to_run(key, worker=worker)
+          elif key.startswith(b"Actor"):
+            # Only get the actor if the actor ID matches the actor ID of this
+            # worker.
+            actor_id, = worker.redis_client.hmget(key, "actor_id")
+            if worker.actor_id == actor_id:
+              worker.fetch_and_register["Actor"](key, worker)
+          else:
+            raise Exception("This code should be unreachable.")
+          num_imported += 1
+  except redis.ConnectionError:
+    # When Redis terminates the listen call will throw a ConnectionError, which
+    # we catch here.
+    pass
 
 
 def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,

--- a/src/common/lib/python/common_extension.h
+++ b/src/common/lib/python/common_extension.h
@@ -20,7 +20,9 @@ typedef struct {
 
 typedef struct {
   PyObject_HEAD
+  /** The size of the task spec. */
   int64_t size;
+  /** The task spec object. This must be freed in the PyTask destructor. */
   TaskSpec *spec;
 } PyTask;
 // clang-format on

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -10,10 +10,13 @@ enum MessageType:int {
   // Log a message to the event table. This is sent from a worker to a local
   // scheduler.
   EventLogMessage,
-  // Send an initial connection message to the local scheduler. This is ent from
-  // a worker to a local scheduler.
+  // Send an initial connection message to the local scheduler. This is sent
+  // from a worker to a local scheduler.
   // This contains the worker's process ID and actor ID.
   RegisterWorkerInfo,
+  // Send a reply confirming the registration of the worker. This contains the
+  // IDs of the GPUs reserved for the worker (if the worker is an actor).
+  RegisterWorkerReply,
   // Get a new task from the local scheduler. This is sent from a worker to a
   // local scheduler.
   GetTask,
@@ -44,6 +47,16 @@ table RegisterWorkerInfo {
   actor_id: string;
   // The process ID of this worker.
   worker_pid: long;
+  // The number of GPUs required by this actor.
+  num_gpus: long;
+}
+
+// This struct is used by the local scheduler to reply to a worker that has
+// registered. It currently only contains the IDs of the GPUs reserved for the
+// worker.
+table RegisterWorkerReply {
+  // The IDs of the GPUs that are reserved for this worker.
+  gpu_ids: [int];
 }
 
 table ReconstructObject {
@@ -56,4 +69,12 @@ table PutObject {
   task_id: string;
   // Object ID of the object that is being put.
   object_id: string;
+}
+
+// This message is sent from the local scheduler to a worker.
+table GetTaskReply {
+  // A string of bytes representing the task specification.
+  task_spec: string;
+  // The IDs of the GPUs that the worker is allowed to use for this task.
+  gpu_ids: [int];
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -849,8 +849,6 @@ void process_message(event_loop *loop,
         release_resources(state, worker, (double) worker->cpus_in_use, 0);
       }
 
-
-
       /* If we're connected to Redis, update tables. */
       if (state->db != NULL) {
         /* Update control state tables. */

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -557,9 +557,8 @@ void send_register_worker_reply(LocalSchedulerState *state,
           "client may have hung up.",
           worker->sock);
     } else {
-      LOG_FATAL(
-          "Failed to send register worker reply to client on fd %d.",
-          worker->sock);
+      LOG_FATAL("Failed to send register worker reply to client on fd %d.",
+                worker->sock);
     }
   }
 }
@@ -880,7 +879,6 @@ void process_message(event_loop *loop,
         release_resources(
             state, worker,
             TaskSpec_get_required_resource(spec, ResourceIndex_CPU), 0);
-
 
         handle_worker_blocked(state, state->algorithm_state, worker);
         print_worker_info("Reconstructing", state->algorithm_state);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -551,11 +551,13 @@ void send_register_worker_reply(LocalSchedulerState *state,
       /* Something went wrong, so kill the worker. */
       kill_worker(worker, false);
       LOG_WARN(
-          "Failed to give task to worker on fd %d. The client may have hung "
-          "up.",
+          "Failed to give send register worker reply to worker on fd %d. The "
+          "client may have hung up.",
           worker->sock);
     } else {
-      LOG_FATAL("Failed to give task to client on fd %d.", worker->sock);
+      LOG_FATAL(
+          "Failed to send register worker reply to client on fd %d.",
+          worker->sock);
     }
   }
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -386,7 +386,7 @@ LocalSchedulerState *LocalSchedulerState_init(
     const double static_resource_conf[],
     const char *start_worker_command,
     int num_workers) {
-  LocalSchedulerState *state = new LocalSchedulerState;
+  LocalSchedulerState *state = new LocalSchedulerState();
   /* Set the configuration struct for the local scheduler. */
   if (start_worker_command != NULL) {
     state->config.start_worker_command = parse_command(start_worker_command);
@@ -917,7 +917,7 @@ void new_client_connection(event_loop *loop,
   int new_socket = accept_client(listener_sock);
   /* Create a struct for this worker. This will be freed when we free the local
    * scheduler state. */
-  LocalSchedulerClient *worker = new LocalSchedulerClient;
+  LocalSchedulerClient *worker = new LocalSchedulerClient();
   worker->sock = new_socket;
   worker->task_in_progress = NULL;
   worker->cpus_in_use = 0;

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -515,7 +515,7 @@ void assign_task_to_worker(LocalSchedulerState *state,
   /* Send the message to the local scheduler. */
   if (write_message(worker->sock, MessageType_ExecuteTask, fbb.GetSize(),
                     fbb.GetBufferPointer()) < 0) {
-    if (errno == EPIPE || errno == EBADF) {
+    if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
       /* Something went wrong, so kill the worker. */
       kill_worker(worker, false);
       LOG_WARN(
@@ -547,7 +547,7 @@ void send_register_worker_reply(LocalSchedulerState *state,
   /* Send the message to the worker. */
   if (write_message(worker->sock, MessageType_RegisterWorkerReply,
                     fbb.GetSize(), fbb.GetBufferPointer()) < 0) {
-    if (errno == EPIPE || errno == EBADF) {
+    if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
       /* Something went wrong, so kill the worker. */
       kill_worker(worker, false);
       LOG_WARN(

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -487,6 +487,8 @@ void assign_task_to_worker(LocalSchedulerState *state,
                            TaskSpec *spec,
                            int64_t task_spec_size,
                            LocalSchedulerClient *worker) {
+  CHECK(worker != NULL);
+  CHECK(ActorID_equal(worker->actor_id, TaskSpec_actor_id(spec)));
   Task *task = Task_alloc(spec, task_spec_size, TASK_STATUS_RUNNING,
                           state->db ? get_db_client_id(state->db) : NIL_ID);
   /* Record which task this worker is executing. This will be freed in

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -131,7 +131,7 @@ int force_kill_worker(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerClient *worker = (LocalSchedulerClient *) context;
   kill(worker->pid, SIGKILL);
   close(worker->sock);
-  free(worker);
+  delete worker;
   return EVENT_LOOP_TIMER_DONE;
 }
 

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -104,8 +104,7 @@ bool check_dynamic_resources(LocalSchedulerState *state,
                              double num_gpus);
 
 /**
- * Acquire resources (CPUs and GPUs) for a worker. If the worker already has
- * some resources allocated for it, this will acquire additional resources.
+ * Acquire additional resources (CPUs and GPUs) for a worker.
  *
  * @param state The local scheduler state.
  * @param worker The worker who is acquiring resources.

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -92,14 +92,31 @@ void kill_worker(LocalSchedulerClient *worker, bool wait);
 void start_worker(LocalSchedulerState *state, ActorID actor_id);
 
 /**
- * Check if sufficient resources are available to run a task.
+ * Check if a certain quantity of dynamic resources are available.
  *
  * @param state The state of the local scheduler.
- * @param spec The task spec whose resource requirements we are checking.
- * @return True if there are enough resources to run the task and false
- *         otherwise.
+ * @param num_cpus Check if this many CPUs are available.
+ * @param num_gpus Check if this many GPUs are available.
+ * @return True if there are enough CPUs and GPUs and false otherwise.
  */
-bool sufficient_resources_for_task(LocalSchedulerState *state, TaskSpec *spec);
+bool check_dynamic_resources(LocalSchedulerState *state,
+                             double num_cpus,
+                             double num_gpus);
+
+/**
+ * Acquire resources (CPUs and GPUs) for a worker. If the worker already has
+ * some resources allocated for it, this will acquire additional resources.
+ *
+ * @param state The local scheduler state.
+ * @param worker The worker who is acquiring resources.
+ * @param num_cpus The number of CPU resources to acquire.
+ * @param num_gpus The number of GPU resources to acquire.
+ * @return Void.
+ */
+void acquire_resources(LocalSchedulerState *state,
+                       LocalSchedulerClient *worker,
+                       double num_cpus,
+                       double num_gpus);
 
 /**
  * Return resources (CPUs and GPUs) being used by a worker to the local
@@ -107,25 +124,14 @@ bool sufficient_resources_for_task(LocalSchedulerState *state, TaskSpec *spec);
  *
  * @param state The local scheduler state.
  * @param worker The worker who is returning resources.
- * @param ignore_gpus If this is true, GPUs will not be returned. If it is
- *        false, they will be returned.
+ * @param num_cpus The number of CPU resources to return.
+ * @param num_gpus The number of GPU resources to return.
  * @return Void.
  */
-void return_worker_resources(LocalSchedulerState *state,
-                             LocalSchedulerClient *worker,
-                             bool ignore_gpus);
-
-/**
- * Acquire the resources (CPUs and GPUs) needed to run the task on the worker.
- * If the worker already has some resources allocated for it, this will only
- * acquire the extra resources needed to execute the task.
- *
- * @param state The local scheduler state.
- * @param worker The worker who is acquiring resources.
- * @return Void.
- */
-void acquire_worker_resources_for_task(LocalSchedulerState *state,
-                                       LocalSchedulerClient *worker);
+void release_resources(LocalSchedulerState *state,
+                       LocalSchedulerClient *worker,
+                       double num_cpus,
+                       double num_gpus);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -92,20 +92,40 @@ void kill_worker(LocalSchedulerClient *worker, bool wait);
 void start_worker(LocalSchedulerState *state, ActorID actor_id);
 
 /**
- * Update our accounting for the current resources being used, according to
- * some task that is starting or finishing execution.
+ * Check if sufficient resources are available to run a task.
+ *
+ * @param state The state of the local scheduler.
+ * @param spec The task spec whose resource requirements we are checking.
+ * @return True if there are enough resources to run the task and false
+ *         otherwise.
+ */
+bool sufficient_resources_for_task(LocalSchedulerState *state, TaskSpec *spec);
+
+/**
+ * Return resources (CPUs and GPUs) being used by a worker to the local
+ * scheduler.
  *
  * @param state The local scheduler state.
- * @param spec The specification for the task that is or was using resources.
- * @param return_resources A boolean representing whether the task is starting
- *        or finishing execution. If true, then the task is finishing execution
- *        (possibly temporarily), so it will add to the dynamic resources
- *        available. Else, it will take from the dynamic resources available.
+ * @param worker The worker who is returning resources.
+ * @param ignore_gpus If this is true, GPUs will not be returned. If it is
+ *        false, they will be returned.
  * @return Void.
  */
-void update_dynamic_resources(LocalSchedulerState *state,
-                              TaskSpec *spec,
-                              bool return_resources);
+void return_worker_resources(LocalSchedulerState *state,
+                             LocalSchedulerClient *worker,
+                             bool ignore_gpus);
+
+/**
+ * Acquire the resources (CPUs and GPUs) needed to run the task on the worker.
+ * If the worker already has some resources allocated for it, this will only
+ * acquire the extra resources needed to execute the task.
+ *
+ * @param state The local scheduler state.
+ * @param worker The worker who is acquiring resources.
+ * @return Void.
+ */
+void acquire_worker_resources_for_task(LocalSchedulerState *state,
+                                       LocalSchedulerClient *worker);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -285,6 +285,68 @@ void remove_actor(SchedulingAlgorithmState *algorithm_state, ActorID actor_id) {
   free(entry);
 }
 
+/**
+ * Dispatch a task to an actor if possible.
+ *
+ * @param state The state of the local scheduler.
+ * @param algorithm_state The state of the scheduling algorithm.
+ * @param actor_id The ID of the actor corresponding to the worker.
+ * @return Void.
+ */
+void dispatch_actor_task(LocalSchedulerState *state,
+                         SchedulingAlgorithmState *algorithm_state,
+                         ActorID actor_id) {
+  /* Make sure this worker actually is an actor. */
+  CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
+  /* Make sure this actor belongs to this local scheduler. */
+  actor_map_entry *actor_entry;
+  HASH_FIND(hh, state->actor_mapping, &actor_id, sizeof(actor_id), actor_entry);
+  CHECK(actor_entry != NULL);
+  CHECK(DBClientID_equal(actor_entry->local_scheduler_id,
+                         get_db_client_id(state->db)));
+
+  /* Get the local actor entry for this actor. */
+  LocalActorInfo *entry;
+  HASH_FIND(hh, algorithm_state->local_actor_infos, &actor_id, sizeof(actor_id),
+            entry);
+  CHECK(entry != NULL);
+
+  if (entry->task_queue->empty()) {
+    /* There are no queued tasks for this actor, so we cannot dispatch a task to
+     * the actor. */
+    return;
+  }
+  TaskQueueEntry first_task = entry->task_queue->front();
+  int64_t next_task_counter = TaskSpec_actor_counter(first_task.spec);
+  if (next_task_counter != entry->task_counter) {
+    /* We cannot execute the next task on this actor without violating the
+     * in-order execution guarantee for actor tasks. */
+    CHECK(next_task_counter > entry->task_counter);
+    return;
+  }
+  /* If the worker is not available, we cannot assign a task to it. */
+  if (!entry->worker_available) {
+    return;
+  }
+
+  /* Check that there are enough resources to run the task. */
+  if (!sufficient_resources_for_task(state, first_task.spec)) {
+    /* TODO(rkn): When we change actor methods to respect dynamic resource
+     * constraints, we should return early here. */
+  }
+
+  /* Assign the first task in the task queue to the worker and mark the worker
+   * as unavailable. */
+  entry->task_counter += 1;
+  assign_task_to_worker(state, first_task.spec, first_task.task_spec_size,
+                        entry->worker);
+  entry->worker_available = false;
+  /* Free the task queue entry. */
+  TaskQueueEntry_free(&first_task);
+  /* Remove the task from the actor's task queue. */
+  entry->task_queue->pop_front();
+}
+
 void handle_actor_worker_connect(LocalSchedulerState *state,
                                  SchedulingAlgorithmState *algorithm_state,
                                  ActorID actor_id,
@@ -300,6 +362,8 @@ void handle_actor_worker_connect(LocalSchedulerState *state,
      * filled out, so fill out the correct worker field now. */
     entry->worker = worker;
   }
+  /* TODO(rkn): Is this necessary? */
+  dispatch_actor_task(state, algorithm_state, actor_id);
 }
 
 void handle_actor_worker_disconnect(LocalSchedulerState *state,
@@ -387,62 +451,6 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
       task_table_add_task(state->db, task, NULL, NULL, NULL);
     }
   }
-}
-
-/**
- * Dispatch a task to an actor if possible.
- *
- * @param state The state of the local scheduler.
- * @param algorithm_state The state of the scheduling algorithm.
- * @param actor_id The ID of the actor corresponding to the worker.
- * @return True if a task was dispatched to the actor and false otherwise.
- */
-bool dispatch_actor_task(LocalSchedulerState *state,
-                         SchedulingAlgorithmState *algorithm_state,
-                         ActorID actor_id) {
-  /* Make sure this worker actually is an actor. */
-  CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
-  /* Make sure this actor belongs to this local scheduler. */
-  actor_map_entry *actor_entry;
-  HASH_FIND(hh, state->actor_mapping, &actor_id, sizeof(actor_id), actor_entry);
-  CHECK(actor_entry != NULL);
-  CHECK(DBClientID_equal(actor_entry->local_scheduler_id,
-                         get_db_client_id(state->db)));
-
-  /* Get the local actor entry for this actor. */
-  LocalActorInfo *entry;
-  HASH_FIND(hh, algorithm_state->local_actor_infos, &actor_id, sizeof(actor_id),
-            entry);
-  CHECK(entry != NULL);
-
-  if (entry->task_queue->empty()) {
-    /* There are no queued tasks for this actor, so we cannot dispatch a task to
-     * the actor. */
-    return false;
-  }
-  TaskQueueEntry first_task = entry->task_queue->front();
-  int64_t next_task_counter = TaskSpec_actor_counter(first_task.spec);
-  if (next_task_counter != entry->task_counter) {
-    /* We cannot execute the next task on this actor without violating the
-     * in-order execution guarantee for actor tasks. */
-    CHECK(next_task_counter > entry->task_counter);
-    return false;
-  }
-  /* If the worker is not available, we cannot assign a task to it. */
-  if (!entry->worker_available) {
-    return false;
-  }
-  /* Assign the first task in the task queue to the worker and mark the worker
-   * as unavailable. */
-  entry->task_counter += 1;
-  assign_task_to_worker(state, first_task.spec, first_task.task_spec_size,
-                        entry->worker);
-  entry->worker_available = false;
-  /* Free the task queue entry. */
-  TaskQueueEntry_free(&first_task);
-  /* Remove the task from the actor's task queue. */
-  entry->task_queue->pop_front();
-  return true;
 }
 
 /**
@@ -611,16 +619,7 @@ void dispatch_tasks(LocalSchedulerState *state,
       return;
     }
     /* Skip to the next task if this task cannot currently be satisfied. */
-    bool task_satisfied = true;
-    for (int i = 0; i < ResourceIndex_MAX; i++) {
-      if (TaskSpec_get_required_resource(task.spec, i) >
-          state->dynamic_resources[i]) {
-        /* Insufficient capacity for this task, proceed to the next task. */
-        task_satisfied = false;
-        break;
-      }
-    }
-    if (!task_satisfied) {
+    if (!sufficient_resources_for_task(state, task.spec)) {
       /* This task could not be satisfied -- proceed to the next task. */
       ++it;
       continue;
@@ -1066,11 +1065,16 @@ void handle_actor_worker_available(LocalSchedulerState *state,
   entry->worker_available = true;
   /* Assign a task to this actor if possible. */
   dispatch_actor_task(state, algorithm_state, actor_id);
+  /* TODO(rkn): In the setting where actor methods respect dynamic resource
+   * constraints, the availability of an actor (or any worker) must trigger the
+   * dispatch of arbitrary tasks and actor methods, not just methods for the
+   * actor that just became available. */
 }
 
 void handle_worker_blocked(LocalSchedulerState *state,
                            SchedulingAlgorithmState *algorithm_state,
                            LocalSchedulerClient *worker) {
+  CHECK(worker->task_in_progress != NULL);
   /* Find the worker in the list of executing workers. */
   for (int i = 0; i < utarray_len(algorithm_state->executing_workers); ++i) {
     LocalSchedulerClient **p = (LocalSchedulerClient **) utarray_eltptr(
@@ -1090,10 +1094,9 @@ void handle_worker_blocked(LocalSchedulerState *state,
       /* Add the worker to the list of blocked workers. */
       worker->is_blocked = true;
       utarray_push_back(algorithm_state->blocked_workers, &worker);
-      /* Return the resources that the blocked worker was using. */
-      CHECK(worker->task_in_progress != NULL);
-      TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-      update_dynamic_resources(state, spec, true);
+      /* Return the resources that the blocked worker was using, but not GPU
+       * resources because it will still be using memory on those GPUs. */
+      return_worker_resources(state, worker, true);
 
       /* Try to dispatch tasks, since we may have freed up some resources. */
       dispatch_tasks(state, algorithm_state);
@@ -1111,6 +1114,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
 void handle_worker_unblocked(LocalSchedulerState *state,
                              SchedulingAlgorithmState *algorithm_state,
                              LocalSchedulerClient *worker) {
+  CHECK(worker->task_in_progress != NULL);
   /* Find the worker in the list of blocked workers. */
   for (int i = 0; i < utarray_len(algorithm_state->blocked_workers); ++i) {
     LocalSchedulerClient **p = (LocalSchedulerClient **) utarray_eltptr(
@@ -1127,14 +1131,15 @@ void handle_worker_unblocked(LocalSchedulerState *state,
         DCHECK(*q != worker);
       }
 
-      /* Lease back the resources that the blocked worker will need. */
+      /* Lease back the resources that the blocked worker will need. However,
+       * do not return GPU resources because the blocked worker will still be
+       * using memory on the GPUs. */
       /* TODO(swang): Leasing back the resources to blocked workers can cause
        * us to transiently exceed the maximum number of resources. This can be
        * fixed by having blocked workers explicitly yield and wait to be given
        * back resources before continuing execution. */
-      CHECK(worker->task_in_progress != NULL);
-      TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-      update_dynamic_resources(state, spec, false);
+      acquire_worker_resources_for_task(state, worker);
+
       /* Add the worker to the list of executing workers. */
       worker->is_blocked = false;
       utarray_push_back(algorithm_state->executing_workers, &worker);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -331,8 +331,8 @@ void dispatch_actor_task(LocalSchedulerState *state,
 
   /* Check that there are enough resources to run the task. */
   if (!check_dynamic_resources(
-          state, TaskSpec_get_required_resource(first_task.spec,
-                                                ResourceIndex_CPU),
+          state,
+          TaskSpec_get_required_resource(first_task.spec, ResourceIndex_CPU),
           TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU))) {
     /* TODO(rkn): When we change actor methods to respect dynamic resource
      * constraints, we should return early here. */

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -321,7 +321,9 @@ void dispatch_actor_task(LocalSchedulerState *state,
   if (next_task_counter != entry->task_counter) {
     /* We cannot execute the next task on this actor without violating the
      * in-order execution guarantee for actor tasks. */
-    CHECK(next_task_counter > entry->task_counter);
+    CHECKM(next_task_counter > entry->task_counter,
+           "next_task_counter is %d and entry->task_counter is %d",
+           (int) next_task_counter, (int) entry->task_counter);
     return;
   }
   /* If the worker is not available, we cannot assign a task to it. */

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -52,6 +52,8 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
     if (ActorID_equal(actor_id, NIL_ACTOR_ID)) {
       CHECK(reply_message->gpu_ids()->size() == 0);
     }
+    /* Free the reply message. */
+    free(reply);
   }
   /* Return the connection object. */
   return result;

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -12,7 +12,7 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
     ActorID actor_id,
     bool is_worker,
     int64_t num_gpus) {
-  LocalSchedulerConnection *result = new LocalSchedulerConnection;
+  LocalSchedulerConnection *result = new LocalSchedulerConnection();
   result->conn = connect_ipc_sock_retry(local_scheduler_socket, -1, -1);
   result->actor_id = actor_id;
 

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -8,6 +8,11 @@ typedef struct {
   /** File descriptor of the Unix domain socket that connects to local
    *  scheduler. */
   int conn;
+  /** The actor ID of this client. If this client is not an actor, then this
+   *  should be NIL_ACTOR_ID. */
+  ActorID actor_id;
+  /** The IDs of the GPUs that this client can use. */
+  std::vector<int> *gpu_ids;
 } LocalSchedulerConnection;
 
 /**
@@ -19,12 +24,15 @@ typedef struct {
  *        running on this actor, this should be NIL_ACTOR_ID.
  * @param is_worker Whether this client is a worker. If it is a worker, an
  *        additional message will be sent to register as one.
+ * @param num_gpus The number of GPUs required by this worker. This is only used
+ *        if the worker is an actor.
  * @return The connection information.
  */
 LocalSchedulerConnection *LocalSchedulerConnection_init(
     const char *local_scheduler_socket,
     ActorID actor_id,
-    bool is_worker);
+    bool is_worker,
+    int64_t num_gpus);
 
 /**
  * Disconnect from the local scheduler.

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -12,7 +12,7 @@ typedef struct {
    *  should be NIL_ACTOR_ID. */
   ActorID actor_id;
   /** The IDs of the GPUs that this client can use. */
-  std::vector<int> *gpu_ids;
+  std::vector<int> gpu_ids;
 } LocalSchedulerConnection;
 
 /**

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -130,12 +130,12 @@ static PyObject *PyLocalSchedulerClient_compute_put_id(PyObject *self,
 
 static PyObject *PyLocalSchedulerClient_gpu_ids(PyObject *self) {
   /* Construct a Python list of GPU IDs. */
-  std::vector<int> *gpu_ids =
+  std::vector<int> gpu_ids =
       ((PyLocalSchedulerClient *) self)->local_scheduler_connection->gpu_ids;
-  int num_gpu_ids = gpu_ids->size();
+  int num_gpu_ids = gpu_ids.size();
   PyObject *gpu_ids_list = PyList_New((Py_ssize_t) num_gpu_ids);
   for (int i = 0; i < num_gpu_ids; ++i) {
-    PyList_SetItem(gpu_ids_list, i, PyLong_FromLong((*gpu_ids)[i]));
+    PyList_SetItem(gpu_ids_list, i, PyLong_FromLong(gpu_ids[i]));
   }
   return gpu_ids_list;
 }

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -1,6 +1,7 @@
 #include <Python.h>
 
 #include "common_extension.h"
+#include "format/local_scheduler_generated.h"
 #include "local_scheduler_client.h"
 #include "task.h"
 
@@ -19,19 +20,24 @@ static int PyLocalSchedulerClient_init(PyLocalSchedulerClient *self,
   char *socket_name;
   ActorID actor_id;
   PyObject *is_worker;
-  if (!PyArg_ParseTuple(args, "sO&O", &socket_name, PyStringToUniqueID,
-                        &actor_id, &is_worker)) {
+  int num_gpus;
+  if (!PyArg_ParseTuple(args, "sO&Oi", &socket_name, PyStringToUniqueID,
+                        &actor_id, &is_worker, &num_gpus)) {
+    self->local_scheduler_connection = NULL;
     return -1;
   }
-  /* Connect to the local scheduler. */
+  /* Connect to the local scheduler. TODO(rkn): We could drop the GIL here, but
+   * is there a point to doing that? */
   self->local_scheduler_connection = LocalSchedulerConnection_init(
-      socket_name, actor_id, (bool) PyObject_IsTrue(is_worker));
+      socket_name, actor_id, (bool) PyObject_IsTrue(is_worker), num_gpus);
   return 0;
 }
 
 static void PyLocalSchedulerClient_dealloc(PyLocalSchedulerClient *self) {
-  LocalSchedulerConnection_free(
-      ((PyLocalSchedulerClient *) self)->local_scheduler_connection);
+  if (((PyLocalSchedulerClient *) self)->local_scheduler_connection != NULL) {
+    LocalSchedulerConnection_free(
+        ((PyLocalSchedulerClient *) self)->local_scheduler_connection);
+  }
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
@@ -48,15 +54,29 @@ static PyObject *PyLocalSchedulerClient_submit(PyObject *self, PyObject *args) {
 
 // clang-format off
 static PyObject *PyLocalSchedulerClient_get_task(PyObject *self) {
-  TaskSpec *task_spec;
+  uint8_t *task_reply;
+  int64_t task_reply_size;
   /* Drop the global interpreter lock while we get a task because
    * local_scheduler_get_task may block for a long time. */
-  int64_t task_size;
   Py_BEGIN_ALLOW_THREADS
-  task_spec = local_scheduler_get_task(
-      ((PyLocalSchedulerClient *) self)->local_scheduler_connection, &task_size);
+  task_reply = local_scheduler_get_task(
+      ((PyLocalSchedulerClient *) self)->local_scheduler_connection,
+      &task_reply_size);
   Py_END_ALLOW_THREADS
-  return PyTask_make(task_spec, task_size);
+
+  /* Parse the TaskSpec from the reply. */
+  auto message = flatbuffers::GetRoot<GetTaskReply>(task_reply);
+  TaskSpec *task_spec = (TaskSpec *) message->task_spec()->data();
+  int64_t task_spec_size = message->task_spec()->size();
+
+  /* Copy the TaskSpec and give ownership of the copy to PyTask_make. This will
+   * be freed in the PyTask destructor. */
+  TaskSpec *task_spec_copy = (TaskSpec *) malloc(task_spec_size);
+  memcpy(task_spec_copy, task_spec, task_spec_size);
+
+  /* Free the task reply that was allocated by local_scheduler_get_task. */
+  free(task_reply);
+  return PyTask_make(task_spec_copy, task_spec_size);
 }
 // clang-format on
 
@@ -108,6 +128,18 @@ static PyObject *PyLocalSchedulerClient_compute_put_id(PyObject *self,
   return PyObjectID_make(put_id);
 }
 
+static PyObject *PyLocalSchedulerClient_gpu_ids(PyObject *self) {
+  /* Construct a Python list of GPU IDs. */
+  std::vector<int> *gpu_ids =
+      ((PyLocalSchedulerClient *) self)->local_scheduler_connection->gpu_ids;
+  int num_gpu_ids = gpu_ids->size();
+  PyObject *gpu_ids_list = PyList_New((Py_ssize_t) num_gpu_ids);
+  for (int i = 0; i < num_gpu_ids; ++i) {
+    PyList_SetItem(gpu_ids_list, i, PyLong_FromLong((*gpu_ids)[i]));
+  }
+  return gpu_ids_list;
+}
+
 static PyMethodDef PyLocalSchedulerClient_methods[] = {
     {"submit", (PyCFunction) PyLocalSchedulerClient_submit, METH_VARARGS,
      "Submit a task to the local scheduler."},
@@ -122,6 +154,8 @@ static PyMethodDef PyLocalSchedulerClient_methods[] = {
      METH_NOARGS, "Notify the local scheduler that we are unblocked."},
     {"compute_put_id", (PyCFunction) PyLocalSchedulerClient_compute_put_id,
      METH_VARARGS, "Return the object ID for a put call within a task."},
+    {"gpu_ids", (PyCFunction) PyLocalSchedulerClient_gpu_ids, METH_NOARGS,
+     "Get the IDs of the GPUs that are reserved for this client."},
     {NULL} /* Sentinel */
 };
 

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -69,7 +69,7 @@ typedef struct {
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
   /** The IDs of the available GPUs. */
-  std::vector<int> *available_gpus;
+  std::vector<int> available_gpus;
 } LocalSchedulerState;
 
 /** Contains all information associated with a local scheduler client. */
@@ -91,7 +91,7 @@ typedef struct {
    *  constant for the duration of a task and will have length equal to the
    *  number of GPUs requested by the task (in particular it will not change
    *  if the task blocks). */
-  std::vector<int> *gpus_in_use;
+  std::vector<int> gpus_in_use;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -68,6 +68,8 @@ typedef struct {
   /** Vector of dynamic attributes associated with the node owned by this local
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
+  /** The IDs of the available GPUs. */
+  std::vector<int> *available_gpus;
 } LocalSchedulerState;
 
 /** Contains all information associated with a local scheduler client. */
@@ -78,6 +80,18 @@ typedef struct {
    *  no task is running on the worker, this will be NULL. This is used to
    *  update the task table. */
   Task *task_in_progress;
+  /** The number of CPUs that the worker is currently using. This will only be
+   *  nonzero when the worker is actively executing a task. If the worker is
+   *  blocked, then this value will be zero. */
+  int cpus_in_use;
+  /** A vector of the IDs of the GPUs that are currently being used by this
+   *  actor. If the worker is an actor, this will be constant throughout the
+   *  lifetime of the actor (and will have length equal to the number of GPUs
+   *  requested by the actor). If the worker is not an actor, this will be
+   *  constant for the duration of a task and will have length equal to the
+   *  number of GPUs requested by the task (in particular it will not change
+   *  if the task blocks). */
+  std::vector<int> *gpus_in_use;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -65,8 +65,8 @@ static void register_clients(int num_mock_workers,
     LocalSchedulerClient **worker = (LocalSchedulerClient **) utarray_eltptr(
         mock->local_scheduler_state->workers, i);
 
-    process_message(mock->local_scheduler_state->loop, (*worker)->sock,
-                    *worker, 0);
+    process_message(mock->local_scheduler_state->loop, (*worker)->sock, *worker,
+                    0);
   }
 }
 
@@ -118,8 +118,8 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   mock->conns = (LocalSchedulerConnection **) malloc(
       sizeof(LocalSchedulerConnection *) * num_mock_workers);
 
-  std::thread background_thread = std::thread(register_clients,
-                                              num_mock_workers, mock);
+  std::thread background_thread =
+      std::thread(register_clients, num_mock_workers, mock);
 
   for (int i = 0; i < num_mock_workers; ++i) {
     mock->conns[i] = LocalSchedulerConnection_init(

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -103,7 +103,7 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
       sizeof(LocalSchedulerConnection *) * num_mock_workers);
   for (int i = 0; i < num_mock_workers; ++i) {
     mock->conns[i] = LocalSchedulerConnection_init(
-        utstring_body(local_scheduler_socket_name), NIL_ACTOR_ID, true);
+        utstring_body(local_scheduler_socket_name), NIL_ACTOR_ID, true, 0);
     new_client_connection(mock->loop, mock->local_scheduler_fd,
                           (void *) mock->local_scheduler_state, 0);
   }

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -56,8 +56,11 @@ typedef struct {
   LocalSchedulerConnection **conns;
 } LocalSchedulerMock;
 
-static void register_clients(int num_mock_workers,
-                             LocalSchedulerMock *mock) {
+/**
+ * Register clients of the local scheduler. This function is started in a
+ * separate thread so enable a blocking call to register the clients.
+ */
+static void register_clients(int num_mock_workers, LocalSchedulerMock *mock) {
   for (int i = 0; i < num_mock_workers; ++i) {
     new_client_connection(mock->loop, mock->local_scheduler_fd,
                           (void *) mock->local_scheduler_state, 0);

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -747,6 +747,7 @@ class ActorsWithGPUs(unittest.TestCase):
     ray.worker._init(
         start_ray_local=True, num_workers=0,
         num_local_schedulers=num_local_schedulers,
+        num_cpus=num_gpus_per_scheduler,
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
 
     def check_intervals_non_overlapping(list_of_intervals):
@@ -878,7 +879,7 @@ class ActorsWithGPUs(unittest.TestCase):
   def testActorsAndTasksWithGPUsVersionTwo(self):
     # Create tasks and actors that both use GPUs and make sure that they are
     # given different GPUs
-    ray.init(num_gpus=10)
+    ray.init(num_cpus=10, num_gpus=10)
 
     @ray.remote(num_gpus=1)
     def f():

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import numpy as np
+import time
 import unittest
 
 import ray
@@ -611,6 +613,7 @@ class ActorsWithGPUs(unittest.TestCase):
         self.gpu_ids = ray.get_gpu_ids()
 
       def get_location_and_ids(self):
+        assert ray.get_gpu_ids() == self.gpu_ids
         return (ray.worker.global_worker.plasma_client.store_socket_name,
                 tuple(self.gpu_ids))
 
@@ -621,11 +624,13 @@ class ActorsWithGPUs(unittest.TestCase):
                                  for actor in actors])
     node_names = set([location for location, gpu_id in locations_and_ids])
     self.assertEqual(len(node_names), num_local_schedulers)
-    location_actor_combinations = []
+
+    # Keep track of which GPU IDs are being used for each location.
+    gpus_in_use = {node_name: [] for node_name in node_names}
+    for location, gpu_ids in locations_and_ids:
+      gpus_in_use[location].extend(gpu_ids)
     for node_name in node_names:
-      location_actor_combinations.append((node_name, (0, 1)))
-      location_actor_combinations.append((node_name, (2, 3)))
-    self.assertEqual(set(locations_and_ids), set(location_actor_combinations))
+      self.assertEqual(len(set(gpus_in_use[node_name])), 4)
 
     # Creating a new actor should fail because all of the GPUs are being used.
     with self.assertRaises(Exception):
@@ -646,12 +651,14 @@ class ActorsWithGPUs(unittest.TestCase):
     # Make sure that no two actors are assigned to the same GPU.
     locations_and_ids = ray.get([actor.get_location_and_ids()
                                  for actor in actors])
-    node_names = set([location for location, gpu_id in locations_and_ids])
-    self.assertEqual(len(node_names), num_local_schedulers)
-    location_actor_combinations = []
+    self.assertEqual(node_names,
+                     set([location for location, gpu_id in locations_and_ids]))
+
+    for location, gpu_ids in locations_and_ids:
+      gpus_in_use[location].extend(gpu_ids)
     for node_name in node_names:
-      location_actor_combinations.append((node_name, (4,)))
-    self.assertEqual(set(locations_and_ids), set(location_actor_combinations))
+      self.assertEqual(len(gpus_in_use[node_name]), 5)
+      self.assertEqual(set(gpus_in_use[node_name]), set(range(5)))
 
     # Creating a new actor should fail because all of the GPUs are being used.
     with self.assertRaises(Exception):
@@ -733,6 +740,171 @@ class ActorsWithGPUs(unittest.TestCase):
       Actor()
 
     ray.worker.cleanup()
+
+  def testActorsAndTasksWithGPUs(self):
+    num_local_schedulers = 3
+    num_gpus_per_scheduler = 6
+    ray.worker._init(
+        start_ray_local=True, num_workers=0,
+        num_local_schedulers=num_local_schedulers,
+        num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
+
+    def check_intervals_non_overlapping(list_of_intervals):
+      for i in range(len(list_of_intervals)):
+        for j in range(i):
+          first_interval = list_of_intervals[i]
+          second_interval = list_of_intervals[j]
+          # Check that list_of_intervals[i] and list_of_intervals[j] don't
+          # overlap.
+          assert first_interval[0] < first_interval[1]
+          assert second_interval[0] < second_interval[1]
+          assert (first_interval[1] < second_interval[0] or
+                  second_interval[1] < first_interval[0])
+
+    @ray.remote(num_gpus=1)
+    def f1():
+      t1 = time.time()
+      time.sleep(0.1)
+      t2 = time.time()
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 1
+      assert gpu_ids[0] in range(num_gpus_per_scheduler)
+      return (ray.worker.global_worker.plasma_client.store_socket_name,
+              tuple(gpu_ids), [t1, t2])
+
+    @ray.remote(num_gpus=2)
+    def f2():
+      t1 = time.time()
+      time.sleep(0.1)
+      t2 = time.time()
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 2
+      assert gpu_ids[0] in range(num_gpus_per_scheduler)
+      assert gpu_ids[1] in range(num_gpus_per_scheduler)
+      return (ray.worker.global_worker.plasma_client.store_socket_name,
+              tuple(gpu_ids), [t1, t2])
+
+    @ray.actor(num_gpus=1)
+    class Actor1(object):
+      def __init__(self):
+        self.gpu_ids = ray.get_gpu_ids()
+        assert len(self.gpu_ids) == 1
+        assert self.gpu_ids[0] in range(num_gpus_per_scheduler)
+
+      def get_location_and_ids(self):
+        assert ray.get_gpu_ids() == self.gpu_ids
+        return (ray.worker.global_worker.plasma_client.store_socket_name,
+                tuple(self.gpu_ids))
+
+    def locations_to_intervals_for_many_tasks():
+      # Launch a bunch of GPU tasks.
+      locations_ids_and_intervals = ray.get(
+          [f1.remote() for _
+           in range(5 * num_local_schedulers * num_gpus_per_scheduler)] +
+          [f2.remote() for _
+           in range(5 * num_local_schedulers * num_gpus_per_scheduler)] +
+          [f1.remote() for _
+           in range(5 * num_local_schedulers * num_gpus_per_scheduler)])
+
+      locations_to_intervals = collections.defaultdict(lambda: [])
+      for location, gpu_ids, interval in locations_ids_and_intervals:
+        for gpu_id in gpu_ids:
+          locations_to_intervals[(location, gpu_id)].append(interval)
+      return locations_to_intervals
+
+    # Run a bunch of GPU tasks.
+    locations_to_intervals = locations_to_intervals_for_many_tasks()
+    # Make sure that all GPUs were used.
+    self.assertEqual(len(locations_to_intervals),
+                     num_local_schedulers * num_gpus_per_scheduler)
+    # For each GPU, verify that the set of tasks that used this specific GPU
+    # did not overlap in time.
+    for locations in locations_to_intervals:
+      check_intervals_non_overlapping(locations_to_intervals[locations])
+
+    # Create an actor that uses a GPU.
+    a = Actor1()
+    actor_location = ray.get(a.get_location_and_ids())
+    actor_location = (actor_location[0], actor_location[1][0])
+    # This check makes sure that actor_location is formatted the same way that
+    # the keys of locations_to_intervals are formatted.
+    self.assertIn(actor_location, locations_to_intervals)
+
+    # Run a bunch of GPU tasks.
+    locations_to_intervals = locations_to_intervals_for_many_tasks()
+    # Make sure that all but one of the GPUs were used.
+    self.assertEqual(len(locations_to_intervals),
+                     num_local_schedulers * num_gpus_per_scheduler - 1)
+    # For each GPU, verify that the set of tasks that used this specific GPU
+    # did not overlap in time.
+    for locations in locations_to_intervals:
+      check_intervals_non_overlapping(locations_to_intervals[locations])
+    # Make sure that the actor's GPU was not used.
+    self.assertNotIn(actor_location, locations_to_intervals)
+
+    # Create several more actors that use GPUs.
+    actors = [Actor1() for _ in range(3)]
+    actor_locations = ray.get([actor.get_location_and_ids()
+                               for actor in actors])
+
+    # Run a bunch of GPU tasks.
+    locations_to_intervals = locations_to_intervals_for_many_tasks()
+    # Make sure that all but 11 of the GPUs were used.
+    self.assertEqual(len(locations_to_intervals),
+                     num_local_schedulers * num_gpus_per_scheduler - 1 - 3)
+    # For each GPU, verify that the set of tasks that used this specific GPU
+    # did not overlap in time.
+    for locations in locations_to_intervals:
+      check_intervals_non_overlapping(locations_to_intervals[locations])
+    # Make sure that the GPUs were not used.
+    self.assertNotIn(actor_location, locations_to_intervals)
+    for location in actor_locations:
+      self.assertNotIn(location, locations_to_intervals)
+
+    # Create more actors to fill up all the GPUs.
+    more_actors = [Actor1() for _ in
+                   range(num_local_schedulers *
+                         num_gpus_per_scheduler - 1 - 3)]
+    # Wait for the actors to finish being created.
+    ray.get([actor.get_location_and_ids() for actor in more_actors])
+
+    # Now if we run some GPU tasks, they should not be scheduled.
+    results = [f1.remote() for _ in range(30)]
+    ready_ids, remaining_ids = ray.wait(results, timeout=1000)
+    self.assertEqual(len(ready_ids), 0)
+
+    ray.worker.cleanup()
+
+  def testActorsAndTasksWithGPUsVersionTwo(self):
+    # Create tasks and actors that both use GPUs and make sure that they are
+    # given different GPUs
+    ray.init(num_gpus=10)
+
+    @ray.remote(num_gpus=1)
+    def f():
+      time.sleep(4)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 1
+      return gpu_ids[0]
+
+    @ray.actor(num_gpus=1)
+    class Actor(object):
+      def __init__(self):
+        self.gpu_ids = ray.get_gpu_ids()
+        assert len(self.gpu_ids) == 1
+
+      def get_gpu_id(self):
+        assert ray.get_gpu_ids() == self.gpu_ids
+        return self.gpu_ids[0]
+
+    results = []
+    for _ in range(5):
+      results.append(f.remote())
+      a = Actor()
+      results.append(a.get_gpu_id())
+
+    gpu_ids = ray.get(results)
+    self.assertEqual(set(gpu_ids), set(range(10)))
 
 
 if __name__ == "__main__":

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -706,7 +706,7 @@ class ActorsWithGPUs(unittest.TestCase):
     num_gpus_per_scheduler = 10
     ray.worker._init(
         start_ray_local=True, num_workers=0,
-        num_local_schedulers=num_local_schedulers,
+        num_local_schedulers=num_local_schedulers, redirect_output=True,
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
 
     @ray.remote

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1097,6 +1097,66 @@ class ResourcesTest(unittest.TestCase):
 
     ray.worker.cleanup()
 
+  def testGPUIDs(self):
+    ray.init(num_cpus=10, num_gpus=10)
+
+    @ray.remote(num_gpus=0)
+    def f0():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    @ray.remote(num_gpus=1)
+    def f1():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    @ray.remote(num_gpus=2)
+    def f2():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    @ray.remote(num_gpus=3)
+    def f3():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    @ray.remote(num_gpus=4)
+    def f4():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    @ray.remote(num_gpus=5)
+    def f5():
+      time.sleep(0.1)
+      return ray.get_gpu_ids()
+
+    list_of_ids = ray.get([f0.remote() for _ in range(10)])
+    self.assertEqual(list_of_ids, 10 * [[]])
+
+    list_of_ids = ray.get([f1.remote() for _ in range(10)])
+    set_of_ids = set([tuple(gpu_ids) for gpu_ids in list_of_ids])
+    self.assertEqual(set_of_ids, set([(i,) for i in range(10)]))
+
+    list_of_ids = ray.get([f2.remote(), f4.remote(), f4.remote()])
+    all_ids = [gpu_id for gpu_ids in list_of_ids for gpu_id in gpu_ids]
+    self.assertEqual(set(all_ids), set(range(10)))
+
+    remaining = [f5.remote() for _ in range(20)]
+    for _ in range(10):
+      t1 = time.time()
+      ready, remaining = ray.wait(remaining, num_returns=2)
+      t2 = time.time()
+      # There are only 10 GPUs, and each task uses 2 GPUs, so there should only
+      # be 2 tasks scheduled at a given time, so if we wait for 2 tasks to
+      # finish, then it should take at least 0.1 seconds for each pair of tasks
+      # to finish.
+      self.assertGreater(t2 - t1, 0.09)
+      list_of_ids = ray.get(ready)
+      all_ids = [gpu_id for gpu_ids in list_of_ids for gpu_id in gpu_ids]
+      self.assertEqual(set(all_ids), set(range(10)))
+
+    ray.worker.cleanup()
+
   def testMultipleLocalSchedulers(self):
     # This test will define a bunch of tasks that can only be assigned to
     # specific local schedulers, and we will check that they are assigned to


### PR DESCRIPTION
This PR does the following.

1. Exposes GPU IDs to tasks.
2. Implements the CPU/GPU bookkeeping described in https://github.com/ray-project/ray/issues/379#issuecomment-288308442.

After this PR, within a task, you can do the following.

```python
@ray.remote(num_gpus=2)
def f():
  ray.get_gpu_ids()  # This is a list like [0, 1].
```

Similarly, within actors, you can do the same (that was already implemented).

```python
@ray.actor(num_gpus=1)
class Foo(object):
  def __init__(self):
    ray.get_gpu_ids()  # This is a list like [2].
```

This PR makes the local scheduler do some bookkeeping about which GPU IDs are currently in use, so that the same IDs are not given to multiple tasks or actors.

**Not done yet:**

1. Global task scheduling is not aware of actors. So if some actors are using all of the GPUs on a machine, then a GPU task may still be scheduled on that machine but will hang because the actors may never go away.
2. Similarly, actor placement is not aware of what GPU tasks are running, so actor placement may be done poorly.
3. Actor creation currently is not queued by the local scheduler if there are no GPUs available. In that case we create the actor anyway but with 0 GPUs.
4. The local scheduler does not check dynamic resource capacities before scheduling actor methods.