### PR TITLE
Remove incorrect check in local scheduler cleanup.

### DIFF
--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -186,7 +186,10 @@ void SchedulingAlgorithmState_free(SchedulingAlgorithmState *algorithm_state) {
   object_entry *obj_entry, *tmp_obj_entry;
   HASH_ITER(hh, algorithm_state->local_objects, obj_entry, tmp_obj_entry) {
     HASH_DELETE(hh, algorithm_state->local_objects, obj_entry);
-    CHECK(obj_entry->dependent_tasks->empty());
+    /* The check below is commented out because it could fail if
+     * SchedulingAlgorithmState_free is called in response to a SIGINT which
+     * arrives in the middle of handle_object_available. */
+    /* CHECK(obj_entry->dependent_tasks->empty()); */
     delete obj_entry->dependent_tasks;
     free(obj_entry);
   }


### PR DESCRIPTION
This should address #361.

@stephanie-wang, what do you think about this? The check is a good idea, but it seems that it could fail if we get unlucky. Is there a better way to handle this?