### PR TITLE
[WIP] Worker deadlock policy

### DIFF
--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -165,11 +165,12 @@ class TestGlobalScheduler(unittest.TestCase):
     def test_task_default_resources(self):
         task1 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
-                                     0)
+                                     0, 0)
         self.assertEqual(task1.required_resources(), [1.0, 0.0, 0.0])
         task2 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
-                                     0, local_scheduler.ObjectID(NIL_ACTOR_ID),
+                                     0, 0,
+                                     local_scheduler.ObjectID(NIL_ACTOR_ID),
                                      0, [1.0, 2.0, 0.0])
         self.assertEqual(task2.required_resources(), [1.0, 2.0, 0.0])
 
@@ -208,7 +209,7 @@ class TestGlobalScheduler(unittest.TestCase):
         task = local_scheduler.Task(
             random_driver_id(), random_function_id(),
             [local_scheduler.ObjectID(object_dep.binary())],
-            num_return_vals[0], random_task_id(), 0)
+            num_return_vals[0], random_task_id(), 0, 0)
         self.local_scheduler_clients[0].submit(task)
         time.sleep(0.1)
         # There should now be a task in Redis, and it should get assigned to
@@ -263,7 +264,7 @@ class TestGlobalScheduler(unittest.TestCase):
                 random_driver_id(),
                 random_function_id(),
                 [local_scheduler.ObjectID(object_dep.binary())],
-                num_return_vals[0], random_task_id(), 0)
+                num_return_vals[0], random_task_id(), 0, 0)
             self.local_scheduler_clients[0].submit(task)
         # Check that there are the correct number of tasks in Redis and that
         # they all get assigned to the local scheduler.

--- a/python/ray/local_scheduler/test/test.py
+++ b/python/ray/local_scheduler/test/test.py
@@ -108,7 +108,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
             for num_return_vals in [0, 1, 2, 3, 5, 10, 100]:
                 task = local_scheduler.Task(random_driver_id(), function_id,
                                             args, num_return_vals,
-                                            random_task_id(), 0)
+                                            random_task_id(), 0, 0)
                 # Submit a task.
                 self.local_scheduler_client.submit(task)
                 # Get the task.
@@ -130,7 +130,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
             for num_return_vals in [0, 1, 2, 3, 5, 10, 100]:
                 task = local_scheduler.Task(random_driver_id(), function_id,
                                             args, num_return_vals,
-                                            random_task_id(), 0)
+                                            random_task_id(), 0, 0)
                 self.local_scheduler_client.submit(task)
         # Get all of the tasks.
         for args in args_list:
@@ -141,7 +141,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
         # Create a task and submit it.
         object_id = random_object_id()
         task = local_scheduler.Task(random_driver_id(), random_function_id(),
-                                    [object_id], 0, random_task_id(), 0)
+                                    [object_id], 0, random_task_id(), 0, 0)
         self.local_scheduler_client.submit(task)
 
         # Launch a thread to get the task.
@@ -165,7 +165,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
         object_id2 = random_object_id()
         task = local_scheduler.Task(random_driver_id(), random_function_id(),
                                     [object_id1, object_id2], 0,
-                                    random_task_id(), 0)
+                                    random_task_id(), 0, 0)
         self.local_scheduler_client.submit(task)
 
         # Launch a thread to get the task.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -511,6 +511,7 @@ class Worker(object):
                 function_properties.num_return_vals,
                 self.current_task_id,
                 self.task_index,
+                self.submit_depth + 1,
                 actor_id,
                 self.actor_counters[actor_id],
                 [function_properties.num_cpus, function_properties.num_gpus,
@@ -710,6 +711,7 @@ class Worker(object):
             self.current_task_id = task.task_id()
             self.current_function_id = task.function_id().id()
             self.task_index = 0
+            self.submit_depth = task.submit_depth()
             self.put_index = 0
             function_id = task.function_id()
             args = task.arguments()
@@ -1723,6 +1725,7 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
         np.random.set_state(numpy_state)
         # Set other fields needed for computing task IDs.
         worker.task_index = 0
+        worker.submit_depth = 0
         worker.put_index = 0
 
         # Create an entry for the driver task in the task table. This task is
@@ -1738,6 +1741,7 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
             0,
             worker.current_task_id,
             worker.task_index,
+            worker.submit_depth,
             ray.local_scheduler.ObjectID(NIL_ACTOR_ID),
             worker.actor_counters[actor_id],
             [0, 0, 0])

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -32,6 +32,8 @@ table TaskInfo {
   parent_task_id: string;
   // A count of the number of tasks submitted by the parent task before this one.
   parent_counter: int;
+  // The task's recursion depth, or its level in the submit graph.
+  submit_depth: int;
   // Actor ID of the task. This is the actor that this task is executed on
   // or NIL_ACTOR_ID if the task is just a normal task.
   actor_id: string;

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -84,6 +84,9 @@ void free_task_builder(TaskBuilder *builder);
  * @param parent_task_id The task ID of the task that submitted this task.
  * @param parent_counter A counter indicating how many tasks were submitted by
  *        the parent task prior to this one.
+ * @param submit_depth An index indicating the task's recursion depth, or its
+ *        level in the submit graph. This is one greater than its parent task's
+ *        submit_depth.
  * @param function_id The function ID of the function to execute in this task.
  * @param num_args The number of arguments that this task has.
  * @param num_returns The number of return values that this task has.
@@ -95,6 +98,7 @@ void TaskSpec_start_construct(TaskBuilder *B,
                               UniqueID driver_id,
                               TaskID parent_task_id,
                               int64_t parent_counter,
+                              int64_t submit_depth,
                               UniqueID actor_id,
                               int64_t actor_counter,
                               FunctionID function_id,
@@ -117,6 +121,14 @@ uint8_t *TaskSpec_finish_construct(TaskBuilder *builder, int64_t *size);
  * @return The function ID of the function to execute in this task.
  */
 FunctionID TaskSpec_function(TaskSpec *spec);
+
+/**
+ * Return the task's recursion depth.
+ *
+ * @param spec The task_spec in question.
+ * @return The recursion depth of the task.
+ */
+int64_t TaskSpec_submit_depth(TaskSpec *spec);
 
 /**
  * Return the actor ID of the task.

--- a/src/common/test/example_task.h
+++ b/src/common/test/example_task.h
@@ -10,11 +10,12 @@ const int64_t arg_value_size = 1000;
 static inline TaskSpec *example_task_spec_with_args(int64_t num_args,
                                                     int64_t num_returns,
                                                     ObjectID arg_ids[],
+                                                    int64_t submit_depth,
                                                     int64_t *task_spec_size) {
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
-  TaskSpec_start_construct(g_task_builder, NIL_ID, parent_task_id, 0, 0,
-                           NIL_ACTOR_ID, 0, func_id, num_returns);
+  TaskSpec_start_construct(g_task_builder, NIL_ID, parent_task_id, 0,
+                           submit_depth, NIL_ACTOR_ID, 0, func_id, num_returns);
   for (int64_t i = 0; i < num_args; ++i) {
     ObjectID arg_id;
     if (arg_ids == NULL) {
@@ -27,10 +28,19 @@ static inline TaskSpec *example_task_spec_with_args(int64_t num_args,
   return TaskSpec_finish_construct(g_task_builder, task_spec_size);
 }
 
+static inline TaskSpec *example_task_spec_with_submit_depth(
+    int64_t num_args,
+    int64_t num_returns,
+    int64_t submit_depth,
+    int64_t *task_spec_size) {
+  return example_task_spec_with_args(num_args, num_returns, NULL, submit_depth,
+                                     task_spec_size);
+}
+
 static inline TaskSpec *example_task_spec(int64_t num_args,
                                           int64_t num_returns,
                                           int64_t *task_spec_size) {
-  return example_task_spec_with_args(num_args, num_returns, NULL,
+  return example_task_spec_with_args(num_args, num_returns, NULL, 0,
                                      task_spec_size);
 }
 
@@ -40,7 +50,7 @@ static inline Task *example_task_with_args(int64_t num_args,
                                            ObjectID arg_ids[]) {
   int64_t task_spec_size;
   TaskSpec *spec = example_task_spec_with_args(num_args, num_returns, arg_ids,
-                                               &task_spec_size);
+                                               0, &task_spec_size);
   Task *instance = Task_alloc(spec, task_spec_size, task_state, NIL_ID);
   TaskSpec_free(spec);
   return instance;

--- a/src/common/test/example_task.h
+++ b/src/common/test/example_task.h
@@ -13,7 +13,7 @@ static inline TaskSpec *example_task_spec_with_args(int64_t num_args,
                                                     int64_t *task_spec_size) {
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
-  TaskSpec_start_construct(g_task_builder, NIL_ID, parent_task_id, 0,
+  TaskSpec_start_construct(g_task_builder, NIL_ID, parent_task_id, 0, 0,
                            NIL_ACTOR_ID, 0, func_id, num_returns);
   for (int64_t i = 0; i < num_args; ++i) {
     ObjectID arg_id;

--- a/src/common/test/task_tests.cc
+++ b/src/common/test/task_tests.cc
@@ -15,8 +15,8 @@ TEST task_test(void) {
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
   TaskBuilder *builder = make_task_builder();
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 2);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 2);
 
   UniqueID arg1 = globally_unique_id();
   TaskSpec_args_add_ref(builder, arg1);
@@ -54,16 +54,16 @@ TEST deterministic_ids_test(void) {
   uint8_t *arg2 = (uint8_t *) "hello world";
 
   /* Construct a first task. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size1;
   TaskSpec *spec1 = TaskSpec_finish_construct(builder, &size1);
 
   /* Construct a second identical task. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size2;
@@ -82,7 +82,7 @@ TEST deterministic_ids_test(void) {
   /* Create more tasks that are only mildly different. */
 
   /* Construct a task with a different parent task ID. */
-  TaskSpec_start_construct(builder, NIL_ID, globally_unique_id(), 0,
+  TaskSpec_start_construct(builder, NIL_ID, globally_unique_id(), 0, 0,
                            NIL_ACTOR_ID, 0, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
@@ -90,32 +90,32 @@ TEST deterministic_ids_test(void) {
   TaskSpec *spec3 = TaskSpec_finish_construct(builder, &size3);
 
   /* Construct a task with a different parent counter. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 1, NIL_ACTOR_ID, 0,
-                           func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 1, 0, NIL_ACTOR_ID,
+                           0, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size4;
   TaskSpec *spec4 = TaskSpec_finish_construct(builder, &size4);
 
   /* Construct a task with a different function ID. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           globally_unique_id(), 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, globally_unique_id(), 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size5;
   TaskSpec *spec5 = TaskSpec_finish_construct(builder, &size5);
 
   /* Construct a task with a different object ID argument. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 3);
   TaskSpec_args_add_ref(builder, globally_unique_id());
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size6;
   TaskSpec *spec6 = TaskSpec_finish_construct(builder, &size6);
 
   /* Construct a task with a different value argument. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, (uint8_t *) "hello_world", 11);
   int64_t size7;
@@ -159,8 +159,8 @@ TEST send_task(void) {
   TaskBuilder *builder = make_task_builder();
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           func_id, 2);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, 0, NIL_ACTOR_ID,
+                           0, func_id, 2);
   TaskSpec_args_add_ref(builder, globally_unique_id());
   TaskSpec_args_add_val(builder, (uint8_t *) "Hello", 5);
   TaskSpec_args_add_val(builder, (uint8_t *) "World", 5);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -3,6 +3,9 @@
 #include <list>
 #include <vector>
 #include <unordered_map>
+#include <map>
+#include "utarray.h"
+#include "utlist.h"
 
 #include "state/task_table.h"
 #include "state/local_scheduler_table.h"
@@ -58,7 +61,7 @@ struct SchedulingAlgorithmState {
   std::list<TaskQueueEntry> *waiting_task_queue;
   /** An array of pointers to tasks whose dependencies are ready but that are
    *  waiting to be assigned to a worker. */
-  std::list<TaskQueueEntry> *dispatch_task_queue;
+  std::map<int64_t, std::list<TaskQueueEntry>> *dispatch_task_queue;
   /** This is a hash table from actor ID to information about that actor. In
    *  particular, a queue of tasks that are waiting to execute on that actor.
    *  This is only used for actors that exist locally. */
@@ -113,7 +116,8 @@ SchedulingAlgorithmState *SchedulingAlgorithmState_init(void) {
   SchedulingAlgorithmState *algorithm_state = new SchedulingAlgorithmState();
   /* Initialize the local data structures used for queuing tasks and workers. */
   algorithm_state->waiting_task_queue = new std::list<TaskQueueEntry>();
-  algorithm_state->dispatch_task_queue = new std::list<TaskQueueEntry>();
+  algorithm_state->dispatch_task_queue =
+      new std::map<int64_t, std::list<TaskQueueEntry>>();
 
   return algorithm_state;
 }
@@ -126,8 +130,10 @@ void SchedulingAlgorithmState_free(SchedulingAlgorithmState *algorithm_state) {
   algorithm_state->waiting_task_queue->clear();
   delete algorithm_state->waiting_task_queue;
   /* Free all the tasks in the dispatch queue. */
-  for (auto &task : *algorithm_state->dispatch_task_queue) {
-    TaskQueueEntry_free(&task);
+  for (auto &task_queue : *algorithm_state->dispatch_task_queue) {
+    for (auto &task : task_queue.second) {
+      TaskQueueEntry_free(&task);
+    }
   }
   algorithm_state->dispatch_task_queue->clear();
   delete algorithm_state->dispatch_task_queue;
@@ -675,53 +681,54 @@ bool resources_available(LocalSchedulerState *state) {
 void dispatch_tasks(LocalSchedulerState *state,
                     SchedulingAlgorithmState *algorithm_state) {
   /* Assign as many tasks as we can, while there are workers available. */
-  for (auto it = algorithm_state->dispatch_task_queue->begin();
-       it != algorithm_state->dispatch_task_queue->end();) {
-    TaskQueueEntry task = *it;
-    /* If there is a task to assign, but there are no more available workers in
-     * the worker pool, then exit. Ensure that there will be an available
-     * worker during a future invocation of dispatch_tasks. */
-    if (algorithm_state->available_workers.size() == 0) {
-      if (state->child_pids.size() == 0) {
-        /* If there are no workers, including those pending PID registration,
-         * then we must start a new one to replenish the worker pool. */
-        start_worker(state, NIL_ACTOR_ID, false);
+  for (auto &queue : *algorithm_state->dispatch_task_queue) {
+    for (auto it = queue.second.begin(); it != queue.second.end();) {
+      TaskQueueEntry task = *it;
+      /* If there is a task to assign, but there are no more available workers in
+       * the worker pool, then exit. Ensure that there will be an available
+       * worker during a future invocation of dispatch_tasks. */
+      if (algorithm_state->available_workers.size() == 0) {
+        if (state->child_pids.size() == 0) {
+          /* If there are no workers, including those pending PID registration,
+           * then we must start a new one to replenish the worker pool. */
+          start_worker(state, NIL_ACTOR_ID, false);
+        }
+        return;
       }
-      return;
-    }
 
-    /* Terminate early if there are no more resources available. */
-    if (!resources_available(state)) {
-      return;
-    }
+      /* Terminate early if there are no more resources available. */
+      if (!resources_available(state)) {
+        return;
+      }
 
-    /* Skip to the next task if this task cannot currently be satisfied. */
-    if (!check_dynamic_resources(
-            state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
-            TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU),
-            TaskSpec_get_required_resource(task.spec,
-                                           ResourceIndex_CustomResource))) {
-      /* This task could not be satisfied -- proceed to the next task. */
-      ++it;
-      continue;
-    }
+      /* Skip to the next task if this task cannot currently be satisfied. */
+      if (!check_dynamic_resources(
+              state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
+              TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU),
+              TaskSpec_get_required_resource(task.spec,
+                                             ResourceIndex_CustomResource))) {
+        /* This task could not be satisfied -- proceed to the next task. */
+        ++it;
+        continue;
+      }
 
-    /* Dispatch this task to an available worker and dequeue the task. */
-    LOG_DEBUG("Dispatching task");
-    /* Get the last available worker in the available worker queue. */
-    LocalSchedulerClient *worker = algorithm_state->available_workers.back();
-    /* Tell the available worker to execute the task. */
-    assign_task_to_worker(state, task.spec, task.task_spec_size, worker);
-    /* Remove the worker from the available queue, and add it to the executing
-     * workers. */
-    algorithm_state->available_workers.pop_back();
-    algorithm_state->executing_workers.push_back(worker);
-    print_resource_info(state, task.spec);
-    /* Free the task queue entry. */
-    TaskQueueEntry_free(&task);
-    /* Dequeue the task. */
-    it = algorithm_state->dispatch_task_queue->erase(it);
-  } /* End for each task in the dispatch queue. */
+      /* Dispatch this task to an available worker and dequeue the task. */
+      LOG_DEBUG("Dispatching task");
+      /* Get the last available worker in the available worker queue. */
+      LocalSchedulerClient *worker = algorithm_state->available_workers.back();
+      /* Tell the available worker to execute the task. */
+      assign_task_to_worker(state, task.spec, task.task_spec_size, worker);
+      /* Remove the worker from the available queue, and add it to the executing
+       * workers. */
+      algorithm_state->available_workers.pop_back();
+      algorithm_state->executing_workers.push_back(worker);
+      print_resource_info(state, task.spec);
+      /* Free the task queue entry. */
+      TaskQueueEntry_free(&task);
+      /* Dequeue the task. */
+      it = queue.second.erase(it);
+    } /* End for each task in the dispatch queue. */
+  }
 }
 
 /**
@@ -841,8 +848,10 @@ void queue_dispatch_task(LocalSchedulerState *state,
                          bool from_global_scheduler) {
   LOG_DEBUG("Queueing task in dispatch queue");
   TaskQueueEntry task_entry = TaskQueueEntry_init(spec, task_spec_size);
-  queue_task(state, algorithm_state->dispatch_task_queue, &task_entry,
-             from_global_scheduler);
+  auto depth = TaskSpec_submit_depth(spec);
+  std::list<TaskQueueEntry> &queue =
+      (*algorithm_state->dispatch_task_queue)[depth];
+  queue_task(state, &queue, &task_entry, from_global_scheduler);
 }
 
 /**
@@ -1207,7 +1216,8 @@ void handle_object_available(LocalSchedulerState *state,
     for (auto &it : entry.dependent_tasks) {
       if (can_run(algorithm_state, it->spec)) {
         LOG_DEBUG("Moved task to dispatch queue");
-        algorithm_state->dispatch_task_queue->push_back(*it);
+        auto depth = TaskSpec_submit_depth(it->spec);
+        (*algorithm_state->dispatch_task_queue)[depth].push_back(*it);
         /* Remove the entry with a matching TaskSpec pointer from the waiting
          * queue, but do not free the task spec. */
         algorithm_state->waiting_task_queue->erase(it);
@@ -1236,19 +1246,19 @@ void handle_object_removed(LocalSchedulerState *state,
    * tasks in the dispatch queue, or batching object notifications. */
   /* Track the dependency for tasks that were in the dispatch queue. Remove
    * these tasks from the dispatch queue and push them to the waiting queue. */
-  for (auto it = algorithm_state->dispatch_task_queue->begin();
-       it != algorithm_state->dispatch_task_queue->end();) {
-    TaskQueueEntry task = *it;
-    if (TaskSpec_is_dependent_on(task.spec, removed_object_id)) {
-      /* This task was dependent on the removed object. */
-      LOG_DEBUG("Moved task from dispatch queue back to waiting queue");
-      algorithm_state->waiting_task_queue->push_back(task);
-      /* Remove the task from the dispatch queue, but do not free the task
-       * spec. */
-      it = algorithm_state->dispatch_task_queue->erase(it);
-    } else {
-      /* The task can still run, so continue to the next task. */
-      ++it;
+  for (auto &queue : *algorithm_state->dispatch_task_queue) {
+    for (auto it = queue.second.begin(); it != queue.second.end();) {
+      if (TaskSpec_is_dependent_on(it->spec, removed_object_id)) {
+        /* This task was dependent on the removed object. */
+        LOG_DEBUG("Moved task from dispatch queue back to waiting queue");
+        algorithm_state->waiting_task_queue->push_back(*it);
+        /* Remove the task from the dispatch queue, but do not free the task
+         * spec. */
+        it = queue.second.erase(it);
+      } else {
+        /* The task can still run, so continue to the next task. */
+        ++it;
+      }
     }
   }
 
@@ -1261,6 +1271,7 @@ void handle_object_removed(LocalSchedulerState *state,
       if (TaskSpec_arg_by_ref(it->spec, i)) {
         ObjectID arg_id = TaskSpec_arg_id(it->spec, i);
         if (ObjectID_equal(arg_id, removed_object_id)) {
+          LOG_INFO("adding back dependency %d", i);
           fetch_missing_dependency(state, algorithm_state, it,
                                    removed_object_id.to_plasma_id());
         }
@@ -1310,12 +1321,13 @@ void handle_driver_removed(LocalSchedulerState *state,
   }
 
   /* Remove this driver's tasks from the dispatch task queue. */
-  it = algorithm_state->dispatch_task_queue->begin();
-  while (it != algorithm_state->dispatch_task_queue->end()) {
-    if (WorkerID_equal(TaskSpec_driver_id(it->spec), driver_id)) {
-      it = algorithm_state->dispatch_task_queue->erase(it);
-    } else {
-      it++;
+  for (auto &queue : *algorithm_state->dispatch_task_queue) {
+    for (auto it = queue.second.begin(); it != queue.second.end();) {
+      if (WorkerID_equal(TaskSpec_driver_id(it->spec), driver_id)) {
+        it = queue.second.erase(it);
+      } else {
+        it++;
+      }
     }
   }
 
@@ -1327,7 +1339,11 @@ int num_waiting_tasks(SchedulingAlgorithmState *algorithm_state) {
 }
 
 int num_dispatch_tasks(SchedulingAlgorithmState *algorithm_state) {
-  return algorithm_state->dispatch_task_queue->size();
+  int count = 0;
+  for (auto &queue : *algorithm_state->dispatch_task_queue) {
+    count += queue.second.size();
+  }
+  return count;
 }
 
 void print_worker_info(const char *message,

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -78,6 +78,8 @@ struct LocalSchedulerState {
   int64_t previous_heartbeat_time;
 };
 
+typedef struct LocalSchedulerClient LocalSchedulerClient;
+
 /** Contains all information associated with a local scheduler client. */
 struct LocalSchedulerClient {
   /** The socket used to communicate with the client. */
@@ -117,6 +119,8 @@ struct LocalSchedulerClient {
   /** The ID of the actor on this worker. If there is no actor running on this
    *  worker, this should be NIL_ACTOR_ID. */
   ActorID actor_id;
+  LocalSchedulerClient *parent_worker;
+  LocalSchedulerClient *child_worker;
   /** A pointer to the local scheduler state. */
   LocalSchedulerState *local_scheduler_state;
 };

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -607,8 +607,7 @@ TEST task_submit_depth_test(void) {
   LocalSchedulerState *state = local_scheduler->local_scheduler_state;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
   /* Get the first worker. */
-  LocalSchedulerClient *worker =
-      *((LocalSchedulerClient **) utarray_eltptr(state->workers, 0));
+  LocalSchedulerClient *worker = state->workers.front();
 
   /* Create NUM_TASK tasks, with submit depths from 0 to NUM_TASKS - 1. */
   const int NUM_TASKS = 10;

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -477,26 +477,29 @@ class ReconstructionTestsMultinode(ReconstructionTests):
     num_local_schedulers = 4
 
 # NOTE(swang): This test tries to launch 1000 workers and breaks.
-# class WorkerPoolTests(unittest.TestCase):
-#
-#   def tearDown(self):
-#     ray.worker.cleanup()
-#
-#   def testBlockingTasks(self):
-#     @ray.remote
-#     def f(i, j):
-#       return (i, j)
-#
-#     @ray.remote
-#     def g(i):
-#       # Each instance of g submits and blocks on the result of another remote
-#       # task.
-#       object_ids = [f.remote(i, j) for j in range(10)]
-#       return ray.get(object_ids)
-#
-#     ray.init(num_workers=1)
-#     ray.get([g.remote(i) for i in range(1000)])
-#     ray.worker.cleanup()
+class WorkerPoolTests(unittest.TestCase):
+
+  def tearDown(self):
+    ray.worker.cleanup()
+
+  def testBlockingTasks(self):
+    @ray.remote
+    def f(i, j):
+      print("Executing F: {} {}".format(i, j))
+      return (i, j)
+
+    @ray.remote
+    def g(i):
+      # Each instance of g submits and blocks on the result of another remote
+      # task.
+      print("Executing G: {}".format(i))
+      object_ids = [f.remote(i, j) for j in range(10)]
+      #object_ids = [f.remote(i, j) for j in range(1)]
+      return ray.get(object_ids)
+
+    ray.init(num_workers=1)
+    ray.get([g.remote(i) for i in range(1000)])
+    ray.worker.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This implements a DFS-like algorithm to try to limit the number of workers started. When a worker is blocked, it will temporarily return its resources. Before this commit, we would reassign the resources to the next task queued, in FIFO order of submission time. Now, we first try to reassign the resources to a task with a greater submit depth, prioritizing unblocking the worker. Then, the number of workers started will be a function of the recursion depth of the workload, modulo some error due to timing.