### PR TITLE
Stopped nodes can rejoin immediately

### DIFF
--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -199,6 +199,9 @@ class Monitor(object):
     elif client_type == PLASMA_MANAGER_CLIENT_TYPE:
       if db_client_id not in self.dead_plasma_managers:
         self.dead_plasma_managers.add(db_client_id)
+      # Stop tracking this plasma manager's heartbeats, since it's
+      # already dead.
+      del self.live_plasma_managers[db_client_id]
 
   def plasma_manager_heartbeat_handler(self, channel, data):
     """Handle a plasma manager heartbeat from Redis.

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -183,9 +183,21 @@ DBHandle *db_connect(const char *db_address,
 }
 
 void db_disconnect(DBHandle *db) {
+  /* Notify others that this client is disconnecting from Redis. If a client of
+   * the same type on the same node wants to reconnect again, they must
+   * reconnect and get assigned a different client ID. */
+  redisReply *reply =
+      (redisReply *) redisCommand(db->sync_context, "RAY.DISCONNECT %b",
+                                  db->client.id, sizeof(db->client.id));
+  CHECK(strcmp(reply->str, "OK") == 0);
+  freeReplyObject(reply);
+
+  /* Clean up the Redis connection state. */
   redisFree(db->sync_context);
   redisAsyncFree(db->context);
   redisAsyncFree(db->sub_context);
+
+  /* Clean up memory. */
   DBClientCacheEntry *e, *tmp;
   HASH_ITER(hh, db->db_client_cache, e, tmp) {
     free(e->addr);

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -558,6 +558,18 @@ void PlasmaManagerState_free(PlasmaManagerState *state) {
     free(entry);
   }
 
+  ObjectWaitRequests *wait_reqs, *tmp_wait_reqs;
+  HASH_ITER(hh, state->object_wait_requests_local, wait_reqs, tmp_wait_reqs) {
+    HASH_DELETE(hh, state->object_wait_requests_local, wait_reqs);
+    utarray_free(wait_reqs->wait_requests);
+    free(wait_reqs);
+  }
+  HASH_ITER(hh, state->object_wait_requests_remote, wait_reqs, tmp_wait_reqs) {
+    HASH_DELETE(hh, state->object_wait_requests_remote, wait_reqs);
+    utarray_free(wait_reqs->wait_requests);
+    free(wait_reqs);
+  }
+
   plasma_disconnect(state->plasma_conn);
   event_loop_destroy(state->loop);
   free_protocol_builder(state->builder);


### PR DESCRIPTION
This allows nodes that were stopped with `stop_ray.sh` (or more generally, individual processes that were stopped with a `SIGTERM`) to rejoin immediately after the original processes exit. On a `SIGTERM`, database clients mark themselves as deleted before exiting.

This allows drivers that were connected to a stopped node to rejoin after the node has rejoined.