### PR TITLE
Suppress warning in start_ray.sh from subprocess.Popen.

### DIFF
--- a/scripts/start_ray.sh
+++ b/scripts/start_ray.sh
@@ -2,4 +2,4 @@
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
-python "$ROOT_DIR/start_ray.py" "$@"
+python "$ROOT_DIR/start_ray.py" "$@" 2> /dev/null


### PR DESCRIPTION
This is a hack to address #363 by suppressing STDERR instead of actually addressing the problem.