### PR TITLE
Changes to local scheduler client protocol.

### DIFF
--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -23,6 +23,7 @@ PLASMA_STORE_MEMORY = 1000000000
 ID_SIZE = 20
 NUM_CLUSTER_NODES = 2
 
+NIL_WORKER_ID = 20 * b"\xff"
 NIL_ACTOR_ID = 20 * b"\xff"
 
 # These constants must match the scheduling state enum in task.h.
@@ -101,7 +102,7 @@ class TestGlobalScheduler(unittest.TestCase):
           static_resource_list=[10, 0])
       # Connect to the scheduler.
       local_scheduler_client = local_scheduler.LocalSchedulerClient(
-          local_scheduler_name, NIL_ACTOR_ID, False)
+          local_scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False)
       self.local_scheduler_clients.append(local_scheduler_client)
       self.local_scheduler_pids.append(p4)
 

--- a/python/ray/local_scheduler/test/test.py
+++ b/python/ray/local_scheduler/test/test.py
@@ -16,6 +16,7 @@ import ray.plasma as plasma
 USE_VALGRIND = False
 ID_SIZE = 20
 
+NIL_WORKER_ID = 20 * b"\xff"
 NIL_ACTOR_ID = 20 * b"\xff"
 
 
@@ -47,7 +48,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
         plasma_store_name, use_valgrind=USE_VALGRIND)
     # Connect to the scheduler.
     self.local_scheduler_client = local_scheduler.LocalSchedulerClient(
-        scheduler_name, NIL_ACTOR_ID, False)
+        scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False)
 
   def tearDown(self):
     # Check that the processes are still alive.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1400,7 +1400,8 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
                                                  info["manager_socket_name"])
   # Create the local scheduler client.
   worker.local_scheduler_client = ray.local_scheduler.LocalSchedulerClient(
-      info["local_scheduler_socket_name"], worker.actor_id, is_worker)
+      info["local_scheduler_socket_name"], worker.worker_id, worker.actor_id,
+      is_worker)
 
   # If this is a driver, set the current task ID, the task driver ID, and set
   # the task index to 0.

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -16,6 +16,7 @@ struct TaskBuilder;
 #define NIL_TASK_ID NIL_ID
 #define NIL_ACTOR_ID NIL_ID
 #define NIL_FUNCTION_ID NIL_ID
+#define NIL_WORKER_ID NIL_ID
 
 typedef UniqueID FunctionID;
 

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -10,10 +10,12 @@ enum MessageType:int {
   // Log a message to the event table. This is sent from a worker to a local
   // scheduler.
   EventLogMessage,
-  // Send an initial connection message to the local scheduler. This is ent from
-  // a worker to a local scheduler.
-  // This contains the worker's process ID and actor ID.
-  RegisterWorkerInfo,
+  // Send an initial connection message to the local scheduler. This is sent
+  // from a worker or driver to a local scheduler.
+  RegisterClientRequest,
+  // Send a reply confirming the successful registration of a worker or driver.
+  // This is sent from the local scheduler to a worker or driver.
+  RegisterClientReply,
   // Get a new task from the local scheduler. This is sent from a worker to a
   // local scheduler.
   GetTask,
@@ -31,6 +33,12 @@ enum MessageType:int {
   PutObject
 }
 
+// This message is sent from the local scheduler to a worker.
+table GetTaskReply {
+  // A string of bytes representing the task specification.
+  task_spec: string;
+}
+
 table EventLogMessage {
   key: string;
   value: string;
@@ -38,12 +46,18 @@ table EventLogMessage {
 
 // This struct is used to register a new worker with the local scheduler.
 // It is shipped as part of local_scheduler_connect.
-table RegisterWorkerInfo {
-  // The ID of the actor.
-  // This is NIL_ACTOR_ID if the worker is not an actor.
+table RegisterClientRequest {
+  // True if the client is a worker and false if the client is a driver.
+  is_worker: bool;
+  // The ID of the worker or driver.
+  client_id: string;
+  // The ID of the actor. This is NIL_ACTOR_ID if the worker is not an actor.
   actor_id: string;
   // The process ID of this worker.
   worker_pid: long;
+}
+
+table RegisterClientReply {
 }
 
 table ReconstructObject {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -460,7 +460,6 @@ void assign_task_to_worker(LocalSchedulerState *state,
                            LocalSchedulerClient *worker) {
   /* Construct a flatbuffer object to send to the worker. */
   flatbuffers::FlatBufferBuilder fbb;
-  //Does CreateString take ownership of the string?
   auto message =
       CreateGetTaskReply(fbb, fbb.CreateString((char *) spec, task_spec_size));
   fbb.Finish(message);
@@ -676,10 +675,9 @@ void send_client_register_reply(LocalSchedulerState *state,
   }
 }
 
-void handle_client_register(
-    LocalSchedulerState *state,
-    LocalSchedulerClient *worker,
-    const RegisterClientRequest *message) {
+void handle_client_register(LocalSchedulerState *state,
+                            LocalSchedulerClient *worker,
+                            const RegisterClientRequest *message) {
   /* Register the worker or driver. */
   if (message->is_worker()) {
     /* Update the actor mapping with the actor ID of the worker (if an actor is

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -23,6 +23,7 @@ typedef struct {
  */
 LocalSchedulerConnection *LocalSchedulerConnection_init(
     const char *local_scheduler_socket,
+    UniqueID worker_id,
     ActorID actor_id,
     bool is_worker);
 

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -17,21 +17,25 @@ static int PyLocalSchedulerClient_init(PyLocalSchedulerClient *self,
                                        PyObject *args,
                                        PyObject *kwds) {
   char *socket_name;
+  UniqueID client_id;
   ActorID actor_id;
   PyObject *is_worker;
-  if (!PyArg_ParseTuple(args, "sO&O", &socket_name, PyStringToUniqueID,
-                        &actor_id, &is_worker)) {
+  self->local_scheduler_connection = NULL;
+  if (!PyArg_ParseTuple(args, "sO&O&O", &socket_name, PyStringToUniqueID,
+                        &client_id, PyStringToUniqueID, &actor_id,
+                        &is_worker)) {
     return -1;
   }
   /* Connect to the local scheduler. */
   self->local_scheduler_connection = LocalSchedulerConnection_init(
-      socket_name, actor_id, (bool) PyObject_IsTrue(is_worker));
+      socket_name, client_id, actor_id, (bool) PyObject_IsTrue(is_worker));
   return 0;
 }
 
 static void PyLocalSchedulerClient_dealloc(PyLocalSchedulerClient *self) {
-  LocalSchedulerConnection_free(
-      ((PyLocalSchedulerClient *) self)->local_scheduler_connection);
+  if (self->local_scheduler_connection != NULL) {
+    LocalSchedulerConnection_free(self->local_scheduler_connection);
+  }
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -7,6 +7,8 @@
 #include <sys/socket.h>
 #include <sys/wait.h>
 
+#include <thread>
+
 #include "common.h"
 #include "test/test_common.h"
 #include "test/example_task.h"
@@ -53,6 +55,23 @@ typedef struct {
   /** Local scheduler client connections. */
   LocalSchedulerConnection **conns;
 } LocalSchedulerMock;
+
+/**
+ * Register clients of the local scheduler. This function is started in a
+ * separate thread so enable a blocking call to register the clients.
+ */
+static void register_clients(int num_mock_workers, LocalSchedulerMock *mock) {
+  for (int i = 0; i < num_mock_workers; ++i) {
+    new_client_connection(mock->loop, mock->local_scheduler_fd,
+                          (void *) mock->local_scheduler_state, 0);
+
+    LocalSchedulerClient **worker = (LocalSchedulerClient **) utarray_eltptr(
+        mock->local_scheduler_state->workers, i);
+
+    process_message(mock->local_scheduler_state->loop, (*worker)->sock, *worker,
+                    0);
+  }
+}
 
 LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
                                             int num_mock_workers) {
@@ -101,12 +120,17 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   mock->num_local_scheduler_conns = num_mock_workers;
   mock->conns = (LocalSchedulerConnection **) malloc(
       sizeof(LocalSchedulerConnection *) * num_mock_workers);
+
+  std::thread background_thread =
+      std::thread(register_clients, num_mock_workers, mock);
+
   for (int i = 0; i < num_mock_workers; ++i) {
     mock->conns[i] = LocalSchedulerConnection_init(
-        utstring_body(local_scheduler_socket_name), NIL_ACTOR_ID, true);
-    new_client_connection(mock->loop, mock->local_scheduler_fd,
-                          (void *) mock->local_scheduler_state, 0);
+        utstring_body(local_scheduler_socket_name), NIL_WORKER_ID, NIL_ACTOR_ID,
+        true);
   }
+
+  background_thread.join();
 
   utstring_free(worker_command);
   utstring_free(plasma_manager_socket_name);


### PR DESCRIPTION
Some changes in this PR.

1. Both workers and drivers now register with the local scheduler.
2. Workers and drivers receive a reply from the local scheduler after registering.
3. The local scheduler sends a flatbuffer object instead of a raw TaskSpec when the worker gets a task.

This is a subset of the functionality in #403. I'm breaking that PR into smaller pieces to simplify things.