### PR TITLE
Unify function signature handling between remote functions and actor …

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -211,7 +211,7 @@ def actor(*args, **kwargs):
                             **kwargs):
         ray.worker.check_connected()
         ray.worker.check_main_thread()
-        args = ray.signature.extend_args(function_signature, args, kwargs)
+        args = signature.extend_args(function_signature, args, kwargs)
 
         function_id = get_actor_method_function_id(attr)
         # TODO(pcm): Extend args with keyword args.
@@ -239,8 +239,8 @@ def actor(*args, **kwargs):
             # We don't raise an exception because if the actor inherits from a
             # class that has a method whose signature we don't support, we
             # there may not be much the user can do about it.
-            ray.signature.check_signature_supported(v, warn=True)
-            self._ray_method_signatures[k] = ray.signature.extract_signature(
+            signature.check_signature_supported(v, warn=True)
+            self._ray_method_signatures[k] = signature.extract_signature(
                 v, ignore_first=True)
 
           export_actor(self._ray_actor_id, Class,

--- a/python/ray/signature.py
+++ b/python/ray/signature.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+import funcsigs
+
+FunctionSignature = namedtuple("FunctionSignature", ["sig_params",
+                                                     "keyword_names",
+                                                     "function_name"])
+
+
+def check_signature_supported(func):
+  """Check if we support the signature of this function.
+
+  We currently do not allow remote functions to have **kwargs. We also do not
+  support keyword arguments in conjunction with a *args argument.
+
+  Args:
+    func: The function whose signature should be checked.
+
+  Raises:
+    Exception: An exception is raised if the signature is not supported.
+  """
+  function_name = func.__name__
+  sig_params = [(k, v) for k, v
+                in funcsigs.signature(func).parameters.items()]
+
+  has_vararg_param = False
+  has_kwargs_param = False
+  has_keyword_arg = False
+  for keyword_name, parameter in funcsigs.signature(func).parameters.items():
+    if parameter.kind == parameter.VAR_KEYWORD:
+      has_kwargs_param = True
+    if parameter.kind == parameter.VAR_POSITIONAL:
+      has_vararg_param = True
+    if parameter.default != funcsigs._empty:
+      has_keyword_arg = True
+
+  if has_kwargs_param:
+    raise Exception("The function {} has a **kwargs argument, which is "
+                    "currently not supported.".format(function_name))
+  # Check if the user specified a variable number of arguments and any keyword
+  # arguments.
+  if has_vararg_param and has_keyword_arg:
+    raise Exception("Function {} has a *args argument as well as a keyword "
+                    "argument, which is currently not supported."
+                    .format(function_name))
+
+
+def extract_signature(func, ignore_first=False):
+  """Extract the function signature from the function.
+
+  Args:
+    func: The function whose signature should be extracted.
+    ignore_first: True if the first argument should be ignored. This should be
+      used when func is a method of a class.
+
+  Returns:
+    A function signature object, which includes the names of the keyword
+      arguments as well as their default values.
+  """
+  sig_params = [(k, v) for k, v
+                in funcsigs.signature(func).parameters.items()]
+
+  if ignore_first:
+    if len(sig_params) == 0:
+      raise Exception("Methods must take a 'self' argument, but the method "
+                      "'{}' does not have one.".format(func.__name__))
+    sig_params = sig_params[1:]
+
+  # Extract the names of the keyword arguments.
+  keyword_names = set()
+  for keyword_name, parameter in funcsigs.signature(func).parameters.items():
+    if parameter.default != funcsigs._empty:
+      keyword_names.add(keyword_name)
+
+  return FunctionSignature(sig_params, keyword_names, func.__name__)
+
+
+def extend_args(function_signature, args, kwargs):
+  """Extend the arguments that were passed into a function.
+
+  This extends the arguments that were passed into a function with the default
+  arguments provided in the function definition.
+
+  Args:
+    function_signature: The function signature of the function being called.
+    args: The non-keyword arguments passed into the function.
+    kwargs: The keyword arguments passed into the function.
+
+  Returns:
+    An extended list of arguments to pass into the function.
+
+  Raises:
+    Exception: An exception may be raised if the function cannot be called with
+      these arguments.
+  """
+  sig_params = function_signature.sig_params
+  keyword_names = function_signature.keyword_names
+  function_name = function_signature.function_name
+
+  args = list(args)
+
+  for keyword_name in kwargs:
+    if keyword_name not in keyword_names:
+      raise Exception("The name '{}' is not a valid keyword argument for the "
+                      "function '{}'.".format(keyword_name, function_name))
+
+  # Fill in the remaining arguments.
+  for keyword_name, param in sig_params[len(args):]:
+    if keyword_name in kwargs:
+      args.append(kwargs[keyword_name])
+    else:
+      default_value = param.default
+      if default_value != funcsigs._empty:
+        args.append(default_value)
+      else:
+        # This means that there is a missing argument. Unless this is the last
+        # argument and it is a *args argument in which case it can be omitted.
+        if param.kind != param.VAR_POSITIONAL:
+          raise Exception("No value was provided for the argument '{}' for "
+                          "the function '{}'.".format(keyword_name,
+                                                      function_name))
+  return args

--- a/python/ray/signature.py
+++ b/python/ray/signature.py
@@ -165,7 +165,7 @@ def extend_args(function_signature, args, kwargs):
 
   too_many_arguments = (len(args) > len(arg_names) and
                         (len(arg_is_positionals) == 0 or
-                        arg_is_positionals[-1] != True))
+                         not arg_is_positionals[-1]))
   if too_many_arguments:
     raise Exception("Too many arguments were passed to the function '{}'"
                     .format(function_name))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -6,7 +6,6 @@ import atexit
 import collections
 import colorama
 import copy
-import funcsigs
 import hashlib
 import inspect
 import json

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2067,7 +2067,7 @@ def remote(*args, **kwargs):
         """This gets run immediately when a worker calls a remote function."""
         check_connected()
         check_main_thread()
-        args = ray.signature.extend_args(function_signature, args, kwargs)
+        args = signature.extend_args(function_signature, args, kwargs)
 
         if _mode() == PYTHON_MODE:
           # In PYTHON_MODE, remote calls simply execute the function. We copy
@@ -2106,8 +2106,8 @@ def remote(*args, **kwargs):
       else:
         func_invoker.func_doc = func.func_doc
 
-      ray.signature.check_signature_supported(func)
-      function_signature = ray.signature.extract_signature(func)
+      signature.check_signature_supported(func)
+      function_signature = signature.extract_signature(func)
 
       # Everything ready - export the function
       if worker.mode in [SCRIPT_MODE, SILENT_MODE]:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -24,6 +24,7 @@ import ray.experimental.state as state
 import ray.pickling as pickling
 import ray.serialization as serialization
 import ray.services as services
+import ray.signature as signature
 import ray.numbuf
 import ray.local_scheduler
 import ray.plasma
@@ -2067,13 +2068,8 @@ def remote(*args, **kwargs):
         """This gets run immediately when a worker calls a remote function."""
         check_connected()
         check_main_thread()
-        args = list(args)
-        # Fill in the remaining arguments.
-        args.extend([kwargs[keyword] if keyword in kwargs else default
-                     for keyword, default in keyword_defaults[len(args):]])
-        if any([arg is funcsigs._empty for arg in args]):
-          raise Exception("Not enough arguments were provided to {}."
-                          .format(func_name))
+        args = ray.signature.extend_args(function_signature, args, kwargs)
+
         if _mode() == PYTHON_MODE:
           # In PYTHON_MODE, remote calls simply execute the function. We copy
           # the arguments to prevent the function call from mutating them and
@@ -2111,15 +2107,8 @@ def remote(*args, **kwargs):
       else:
         func_invoker.func_doc = func.func_doc
 
-      sig_params = [(k, v) for k, v
-                    in funcsigs.signature(func).parameters.items()]
-      keyword_defaults = [(k, v.default) for k, v in sig_params]
-      has_vararg_param = any([v.kind == v.VAR_POSITIONAL
-                              for k, v in sig_params])
-      func_invoker.has_vararg_param = has_vararg_param
-      has_kwargs_param = any([v.kind == v.VAR_KEYWORD for k, v in sig_params])
-      check_signature_supported(has_kwargs_param, has_vararg_param,
-                                keyword_defaults, func_name)
+      ray.signature.check_signature_supported(func)
+      function_signature = ray.signature.extract_signature(func)
 
       # Everything ready - export the function
       if worker.mode in [SCRIPT_MODE, SILENT_MODE]:
@@ -2160,37 +2149,6 @@ def remote(*args, **kwargs):
                                "num_gpus" in kwargs), error_string
     assert "function_id" not in kwargs
     return make_remote_decorator(num_return_vals, num_cpus, num_gpus)
-
-
-def check_signature_supported(has_kwargs_param, has_vararg_param,
-                              keyword_defaults, name):
-  """Check if we support the signature of this function.
-
-  We currently do not allow remote functions to have **kwargs. We also do not
-  support keyword arguments in conjunction with a *args argument.
-
-  Args:
-    has_kwards_param (bool): True if the function being checked has a **kwargs
-      argument.
-    has_vararg_param (bool): True if the function being checked has a *args
-      argument.
-    keyword_defaults (List): A list of the default values for the arguments to
-      the function being checked.
-    name (str): The name of the function to check.
-
-  Raises:
-    Exception: An exception is raised if the signature is not supported.
-  """
-  # Check if the user specified kwargs.
-  if has_kwargs_param:
-    raise ("Function {} has a **kwargs argument, which is currently not "
-           "supported.".format(name))
-  # Check if the user specified a variable number of arguments and any keyword
-  # arguments.
-  if has_vararg_param and any([d != funcsigs._empty
-                               for _, d in keyword_defaults]):
-    raise ("Function {} has a *args argument as well as a keyword argument, "
-           "which is currently not supported.".format(name))
 
 
 def get_arguments_for_execution(function_name, serialized_args,

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -83,6 +83,21 @@ class ActorAPI(unittest.TestCase):
     self.assertEqual(ray.get(actor.get_values(2, 3, 1, 2, 3, 4)),
                      (3, 5, ("a", "b", "c", "d"), (1, 2, 3, 4)))
 
+    @ray.actor
+    class Actor(object):
+      def __init__(self, *args):
+        self.args = args
+
+      def get_values(self, *args):
+        return self.args, args
+
+    a = Actor()
+    self.assertEqual(ray.get(a.get_values()), ((), ()))
+    a = Actor(1)
+    self.assertEqual(ray.get(a.get_values(2)), ((1,), (2,)))
+    a = Actor(1, 2)
+    self.assertEqual(ray.get(a.get_values(3, 4)), ((1, 2), (3, 4)))
+
     ray.worker.cleanup()
 
   def testNoArgs(self):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -32,17 +32,27 @@ class ActorAPI(unittest.TestCase):
     actor = Actor(1, 2, "c")
     self.assertEqual(ray.get(actor.get_values(2, 3, "d")), (3, 5, "cd"))
 
+    actor = Actor(1, arg2="c")
+    self.assertEqual(ray.get(actor.get_values(0, arg2="d")), (1, 3, "cd"))
+    self.assertEqual(ray.get(actor.get_values(0, arg2="d", arg1=0)),
+                     (1, 1, "cd"))
+
+    actor = Actor(1, arg2="c", arg1=2)
+    self.assertEqual(ray.get(actor.get_values(0, arg2="d")), (1, 4, "cd"))
+    self.assertEqual(ray.get(actor.get_values(0, arg2="d", arg1=0)),
+                     (1, 2, "cd"))
+
     # Make sure we get an exception if the constructor is called incorrectly.
-    actor = Actor()
     with self.assertRaises(Exception):
-      ray.get(ray.get(actor.get_values(1)))
+      actor = Actor()
+
     with self.assertRaises(Exception):
-      ray.get(ray.get(actor.get_values()))
+      actor = Actor(0, 1, 2, arg3=3)
 
     # Make sure we get an exception if the method is called incorrectly.
     actor = Actor(1)
     with self.assertRaises(Exception):
-      ray.get(ray.get(actor.get_values()))
+      ray.get(actor.get_values())
 
     ray.worker.cleanup()
 

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -297,55 +297,25 @@ class ActorTest(unittest.TestCase):
         pass
 
     # Make sure that we get errors if we call the constructor incorrectly.
-    # TODO(rkn): These errors should instead be thrown when the method is
-    # called.
 
     # Create an actor with too few arguments.
-    a = Actor()
-    wait_for_errors(b"task", 1)
-    self.assertEqual(len(ray.error_info()), 1)
-    if sys.version_info >= (3, 0):
-      self.assertIn("missing 1 required",
-                    ray.error_info()[0][b"message"].decode("ascii"))
-    else:
-      self.assertIn("takes exactly 2 arguments",
-                    ray.error_info()[0][b"message"].decode("ascii"))
+    with self.assertRaises(Exception):
+      a = Actor()
 
     # Create an actor with too many arguments.
-    a = Actor(1, 2)
-    wait_for_errors(b"task", 2)
-    self.assertEqual(len(ray.error_info()), 2)
-    if sys.version_info >= (3, 0):
-      self.assertIn("but 3 were given",
-                    ray.error_info()[1][b"message"].decode("ascii"))
-    else:
-      self.assertIn("takes exactly 2 arguments",
-                    ray.error_info()[1][b"message"].decode("ascii"))
+    with self.assertRaises(Exception):
+      a = Actor(1, 2)
 
     # Create an actor the correct number of arguments.
     a = Actor(1)
 
     # Call a method with too few arguments.
-    a.get_val()
-    wait_for_errors(b"task", 3)
-    self.assertEqual(len(ray.error_info()), 3)
-    if sys.version_info >= (3, 0):
-      self.assertIn("missing 1 required",
-                    ray.error_info()[2][b"message"].decode("ascii"))
-    else:
-      self.assertIn("takes exactly 2 arguments",
-                    ray.error_info()[2][b"message"].decode("ascii"))
+    with self.assertRaises(Exception):
+      a.get_val()
 
     # Call a method with too many arguments.
-    a.get_val(1, 2)
-    wait_for_errors(b"task", 4)
-    self.assertEqual(len(ray.error_info()), 4)
-    if sys.version_info >= (3, 0):
-      self.assertIn("but 3 were given",
-                    ray.error_info()[3][b"message"].decode("ascii"))
-    else:
-      self.assertIn("takes exactly 2 arguments",
-                    ray.error_info()[3][b"message"].decode("ascii"))
+    with self.assertRaises(Exception):
+      a.get_val(1, 2)
     # Call a method that doesn't exist.
     with self.assertRaises(AttributeError):
       a.nonexistent_method()

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -312,6 +312,30 @@ class APITest(unittest.TestCase):
     x = test_functions.keyword_fct3.remote(0, 1)
     self.assertEqual(ray.get(x), "0 1 hello world")
 
+    # Check that we cannot pass invalid keyword arguments to functions.
+    @ray.remote
+    def f1():
+      return
+
+    @ray.remote
+    def f2(x, y=0, z=0):
+      return
+
+    with self.assertRaises(Exception):
+      f1.remote(3)
+
+    with self.assertRaises(Exception):
+      f1.remote(x=3)
+
+    with self.assertRaises(Exception):
+      f2.remote(0, w=0)
+
+    @ray.remote
+    def f3(x):
+      return x
+
+    self.assertEqual(ray.get(f3.remote(4)), 4)
+
     ray.worker.cleanup()
 
   def testVariableNumberOfArgs(self):


### PR DESCRIPTION
…methods.

This does the following:
- Allows actor methods to handle keyword arguments.
- This should also address #439.

Actor methods and remote functions still do not handle `**kwargs` arguments.