### PR TITLE
Convert some local scheduler data structures to C++ STL.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -22,7 +22,6 @@
 #include "state/object_table.h"
 #include "state/error_table.h"
 #include "utarray.h"
-#include "uthash.h"
 
 UT_icd task_ptr_icd = {sizeof(Task *), NULL, NULL, NULL};
 
@@ -83,8 +82,7 @@ void kill_worker(LocalSchedulerState *state,
   /* Erase the local scheduler's reference to the worker. */
   auto it = std::find(state->workers.begin(), state->workers.end(), worker);
   CHECK(it != state->workers.end());
-  std::swap(*it, state->workers.back());
-  state->workers.pop_back();
+  state->workers.erase(it);
 
   /* Make sure that we removed the worker. */
   it = std::find(state->workers.begin(), state->workers.end(), worker);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -25,7 +25,6 @@
 #include "uthash.h"
 
 UT_icd task_ptr_icd = {sizeof(Task *), NULL, NULL, NULL};
-UT_icd workers_icd = {sizeof(LocalSchedulerClient *), NULL, NULL, NULL};
 
 UT_icd pid_t_icd = {sizeof(pid_t), NULL, NULL, NULL};
 
@@ -63,7 +62,7 @@ int force_kill_worker(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerClient *worker = (LocalSchedulerClient *) context;
   kill(worker->pid, SIGKILL);
   close(worker->sock);
-  free(worker);
+  delete worker;
   return EVENT_LOOP_TIMER_DONE;
 }
 
@@ -78,28 +77,25 @@ int force_kill_worker(event_loop *loop, timer_id id, void *context) {
  *        to clean up its own state.
  * @return Void.
  */
-void kill_worker(LocalSchedulerClient *worker, bool cleanup) {
+void kill_worker(LocalSchedulerState *state,
+                 LocalSchedulerClient *worker,
+                 bool cleanup) {
   /* Erase the local scheduler's reference to the worker. */
-  LocalSchedulerState *state = worker->local_scheduler_state;
-  int num_workers = utarray_len(state->workers);
-  for (int i = 0; i < utarray_len(state->workers); ++i) {
-    LocalSchedulerClient *active_worker =
-        *(LocalSchedulerClient **) utarray_eltptr(state->workers, i);
-    if (active_worker == worker) {
-      utarray_erase(state->workers, i, 1);
-    }
-  }
-  /* Make sure that we erased exactly 1 worker. */
-  CHECKM(!(utarray_len(state->workers) < num_workers - 1),
-         "Found duplicate workers");
-  CHECKM(utarray_len(state->workers) != num_workers,
-         "Tried to kill worker that doesn't exist");
+  auto it = std::find(state->workers.begin(), state->workers.end(), worker);
+  CHECK(it != state->workers.end());
+  std::swap(*it, state->workers.back());
+  state->workers.pop_back();
+
+  /* Make sure that we removed the worker. */
+  it = std::find(state->workers.begin(), state->workers.end(), worker);
+  CHECK(it == state->workers.end());
+
   /* Erase the algorithm state's reference to the worker. */
   handle_worker_removed(state, state->algorithm_state, worker);
 
   /* Remove the client socket from the event loop so that we don't process the
    * SIGPIPE when the worker is killed. */
-  event_loop_remove_file(worker->local_scheduler_state->loop, worker->sock);
+  event_loop_remove_file(state->loop, worker->sock);
 
   /* If the worker has registered a process ID with us and it's a child
    * process, use it to send a kill signal. */
@@ -154,7 +150,7 @@ void kill_worker(LocalSchedulerClient *worker, bool cleanup) {
     /* Clean up the client socket after killing the worker so that the worker
      * can't receive the SIGPIPE before exiting. */
     close(worker->sock);
-    free(worker);
+    delete worker;
   }
 }
 
@@ -165,24 +161,20 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   signal(SIGTERM, SIG_DFL);
 
   /* Kill any child processes that didn't register as a worker yet. */
-  pid_t *worker_pid;
-  for (worker_pid = (pid_t *) utarray_front(state->child_pids);
-       worker_pid != NULL;
-       worker_pid = (pid_t *) utarray_next(state->child_pids, worker_pid)) {
-    kill(*worker_pid, SIGKILL);
-    waitpid(*worker_pid, NULL, 0);
-    LOG_DEBUG("Killed pid %d", *worker_pid);
+  for (auto const &worker_pid : state->child_pids) {
+    kill(worker_pid, SIGKILL);
+    waitpid(worker_pid, NULL, 0);
+    LOG_INFO("Killed worker pid %d which hadn't started yet.", worker_pid);
   }
-  utarray_free(state->child_pids);
 
   /* Kill any registered workers. */
   /* TODO(swang): It's possible that the local scheduler will exit before all
    * of its task table updates make it to redis. */
-  for (LocalSchedulerClient **worker =
-           (LocalSchedulerClient **) utarray_front(state->workers);
-       worker != NULL;
-       worker = (LocalSchedulerClient **) utarray_front(state->workers)) {
-    kill_worker(*worker, true);
+  while (state->workers.size() > 0) {
+    /* Note that kill_worker modifies the container state->workers, so it is
+     * important to do this loop in a way that does not use invalidated
+     * iterators. */
+    kill_worker(state, state->workers.back(), true);
   }
 
   /* Disconnect from plasma. */
@@ -208,11 +200,6 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
     state->config.start_worker_command = NULL;
   }
 
-  /* Free the list of workers and any tasks that are still in progress on those
-   * workers. */
-  utarray_free(state->workers);
-  state->workers = NULL;
-
   /* Free the mapping from the actor ID to the ID of the local scheduler
    * responsible for that actor. */
   actor_map_entry *current_actor_map_entry, *temp_actor_map_entry;
@@ -231,8 +218,9 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   /* Destroy the event loop. */
   event_loop_destroy(state->loop);
   state->loop = NULL;
+
   /* Free the scheduler state. */
-  free(state);
+  delete state;
 }
 
 /**
@@ -250,7 +238,7 @@ void start_worker(LocalSchedulerState *state, ActorID actor_id) {
   /* Launch the process to create the worker. */
   pid_t pid = fork();
   if (pid != 0) {
-    utarray_push_back(state->child_pids, &pid);
+    state->child_pids.push_back(pid);
     LOG_INFO("Started worker with pid %d", pid);
     return;
   }
@@ -332,8 +320,7 @@ LocalSchedulerState *LocalSchedulerState_init(
     const double static_resource_conf[],
     const char *start_worker_command,
     int num_workers) {
-  LocalSchedulerState *state =
-      (LocalSchedulerState *) malloc(sizeof(LocalSchedulerState));
+  LocalSchedulerState *state = new LocalSchedulerState();
   /* Set the configuration struct for the local scheduler. */
   if (start_worker_command != NULL) {
     state->config.start_worker_command = parse_command(start_worker_command);
@@ -348,8 +335,7 @@ LocalSchedulerState *LocalSchedulerState_init(
   state->config.global_scheduler_exists = global_scheduler_exists;
 
   state->loop = loop;
-  /* Initialize the list of workers. */
-  utarray_new(state->workers, &workers_icd);
+
   /* Initialize the hash table mapping actor ID to the ID of the local scheduler
    * that is responsible for that actor. */
   state->actor_mapping = NULL;
@@ -418,7 +404,6 @@ LocalSchedulerState *LocalSchedulerState_init(
   print_resource_info(state, NULL);
 
   /* Start the initial set of workers. */
-  utarray_new(state->child_pids, &pid_t_icd);
   for (int i = 0; i < num_workers; ++i) {
     start_worker(state, NIL_ACTOR_ID);
   }
@@ -663,7 +648,7 @@ void send_client_register_reply(LocalSchedulerState *state,
                     fbb.GetSize(), fbb.GetBufferPointer()) < 0) {
     if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
       /* Something went wrong, so kill the worker. */
-      kill_worker(worker, false);
+      kill_worker(state, worker, false);
       LOG_WARN(
           "Failed to give send register client reply to worker on fd %d. The "
           "client may have hung up.",
@@ -682,7 +667,7 @@ void handle_client_register(LocalSchedulerState *state,
   if (message->is_worker()) {
     /* Update the actor mapping with the actor ID of the worker (if an actor is
      * running on the worker). */
-    int64_t worker_pid = message->worker_pid();
+    worker->pid = message->worker_pid();
     ActorID actor_id = from_flatbuf(message->actor_id());
     if (!ActorID_equal(actor_id, NIL_ACTOR_ID)) {
       /* Make sure that the local scheduler is aware that it is responsible for
@@ -702,29 +687,24 @@ void handle_client_register(LocalSchedulerState *state,
     }
 
     /* Register worker process id with the scheduler. */
-    worker->pid = worker_pid;
     /* Determine if this worker is one of our child processes. */
-    LOG_DEBUG("PID is %d", worker_pid);
-    pid_t *child_pid;
-    int index = 0;
-    for (child_pid = (pid_t *) utarray_front(state->child_pids);
-         child_pid != NULL;
-         child_pid = (pid_t *) utarray_next(state->child_pids, child_pid)) {
-      if (*child_pid == worker_pid) {
-        /* If this worker is one of our child processes, mark it as a child so
-         * that we know that we can wait for the process to exit during
-         * cleanup. */
-        worker->is_child = true;
-        utarray_erase(state->child_pids, index, 1);
-        LOG_DEBUG("Found matching child pid %d", worker_pid);
-        break;
-      }
-      ++index;
+    LOG_DEBUG("PID is %d", worker->pid);
+    auto it = std::find(state->child_pids.begin(), state->child_pids.end(),
+                        worker->pid);
+    if (it != state->child_pids.end()) {
+      /* If this worker is one of our child processes, mark it as a child so
+       * that we know that we can wait for the process to exit during
+       * cleanup. */
+      worker->is_child = true;
+      state->child_pids.erase(it);
+      LOG_DEBUG("Found matching child pid %d", worker->pid);
     }
   } else {
     /* Register the driver. Currently we don't do anything here. */
   }
 }
+
+/* End of the cleanup code. */
 
 void process_message(event_loop *loop,
                      int client_sock,
@@ -822,7 +802,7 @@ void process_message(event_loop *loop,
   } break;
   case DISCONNECT_CLIENT: {
     LOG_INFO("Disconnecting client on fd %d", client_sock);
-    kill_worker(worker, false);
+    kill_worker(state, worker, false);
     if (!ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
       /* Let the scheduling algorithm process the absence of this worker. */
       handle_actor_worker_disconnect(state, state->algorithm_state,
@@ -861,8 +841,7 @@ void new_client_connection(event_loop *loop,
   int new_socket = accept_client(listener_sock);
   /* Create a struct for this worker. This will be freed when we free the local
    * scheduler state. */
-  LocalSchedulerClient *worker =
-      (LocalSchedulerClient *) malloc(sizeof(LocalSchedulerClient));
+  LocalSchedulerClient *worker = new LocalSchedulerClient();
   worker->sock = new_socket;
   worker->task_in_progress = NULL;
   worker->is_blocked = false;
@@ -870,7 +849,7 @@ void new_client_connection(event_loop *loop,
   worker->is_child = false;
   worker->actor_id = NIL_ACTOR_ID;
   worker->local_scheduler_state = state;
-  utarray_push_back(state->workers, &worker);
+  state->workers.push_back(worker);
   event_loop_add_file(loop, new_socket, EVENT_LOOP_READ, process_message,
                       worker);
   LOG_DEBUG("new connection with fd %d", new_socket);
@@ -894,18 +873,18 @@ void signal_handler(int signal) {
   }
 }
 
-/* End of the cleanup code. */
-
-void handle_task_scheduled_callback(Task *original_task, void *user_context) {
+void handle_task_scheduled_callback(Task *original_task,
+                                    void *subscribe_context) {
+  LocalSchedulerState *state = (LocalSchedulerState *) subscribe_context;
   TaskSpec *spec = Task_task_spec(original_task);
   if (ActorID_equal(TaskSpec_actor_id(spec), NIL_ACTOR_ID)) {
     /* This task does not involve an actor. Handle it normally. */
-    handle_task_scheduled(g_state, g_state->algorithm_state, spec,
+    handle_task_scheduled(state, state->algorithm_state, spec,
                           Task_task_spec_size(original_task));
   } else {
     /* This task involves an actor. Call the scheduling algorithm's actor
      * handler. */
-    handle_actor_task_scheduled(g_state, g_state->algorithm_state, spec,
+    handle_actor_task_scheduled(state, state->algorithm_state, spec,
                                 Task_task_spec_size(original_task));
   }
 }
@@ -992,7 +971,7 @@ void start_server(const char *node_ip_address,
   if (g_state->db != NULL) {
     task_table_subscribe(g_state->db, get_db_client_id(g_state->db),
                          TASK_STATUS_SCHEDULED, handle_task_scheduled_callback,
-                         NULL, NULL, NULL, NULL);
+                         g_state, NULL, NULL, NULL);
   }
   /* Subscribe to notifications about newly created actors. */
   if (g_state->db != NULL) {

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -72,12 +72,15 @@ void print_resource_info(const LocalSchedulerState *s, const TaskSpec *spec);
 /**
  * Kill a worker.
  *
+ * @param state The local scheduler state.
  * @param worker The local scheduler client to kill.
  * @param wait A boolean representing whether to wait for the killed worker to
  *        exit.
  * @param Void.
  */
-void kill_worker(LocalSchedulerClient *worker, bool wait);
+void kill_worker(LocalSchedulerState *state,
+                 LocalSchedulerClient *worker,
+                 bool wait);
 
 /**
  * Start a worker. This forks a new worker process that can be added to the

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -962,17 +962,17 @@ void handle_worker_available(LocalSchedulerState *state,
                              LocalSchedulerClient *worker) {
   CHECK(worker->task_in_progress == NULL);
   /* Check that the worker isn't in the pool of available workers. */
-  CHECK(!worker_in_vector(algorithm_state->available_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->available_workers, worker));
 
   /* Check that the worker isn't in the list of blocked workers. */
-  CHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
 
   /* If the worker was executing a task, it must have finished, so remove it
    * from the list of executing workers. If the worker is connecting for the
    * first time, it will not be in the list of executing workers. */
   remove_worker_from_vector(algorithm_state->executing_workers, worker);
   /* Double check that we successfully removed the worker. */
-  CHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
 
   /* Add worker to the list of available workers. */
   algorithm_state->available_workers.push_back(worker);
@@ -993,21 +993,21 @@ void handle_worker_removed(LocalSchedulerState *state,
       remove_worker_from_vector(algorithm_state->available_workers, worker);
   num_times_removed += removed_from_available;
   /* Double check that we actually removed the worker. */
-  CHECK(!worker_in_vector(algorithm_state->available_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->available_workers, worker));
 
   /* Remove the worker from executing workers, if it's there. */
   bool removed_from_executing =
       remove_worker_from_vector(algorithm_state->executing_workers, worker);
   num_times_removed += removed_from_executing;
   /* Double check that we actually removed the worker. */
-  CHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
 
   /* Remove the worker from blocked workers, if it's there. */
   bool removed_from_blocked =
       remove_worker_from_vector(algorithm_state->blocked_workers, worker);
   num_times_removed += removed_from_blocked;
   /* Double check that we actually removed the worker. */
-  CHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
 
   /* Make sure we removed the worker at most once. */
   CHECK(num_times_removed <= 1);
@@ -1037,7 +1037,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
   CHECK(remove_worker_from_vector(algorithm_state->executing_workers, worker));
 
   /* Check that the worker isn't in the list of blocked workers. */
-  CHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
 
   /* Add the worker to the list of blocked workers. */
   worker->is_blocked = true;
@@ -1058,7 +1058,7 @@ void handle_worker_unblocked(LocalSchedulerState *state,
   CHECK(remove_worker_from_vector(algorithm_state->blocked_workers, worker));
 
   /* Check that the worker isn't in the list of executing workers. */
-  CHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
+  DCHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
 
   /* Lease back the resources that the blocked worker will need. */
   /* TODO(swang): Leasing back the resources to blocked workers can cause

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -8,10 +8,10 @@
 #include "utarray.h"
 #include "uthash.h"
 
+#include <vector>
+
 /* These are needed to define the UT_arrays. */
 extern UT_icd task_ptr_icd;
-extern UT_icd workers_icd;
-extern UT_icd pid_t_icd;
 
 /** This struct is used to maintain a mapping from actor IDs to the ID of the
  *  local scheduler that is responsible for the actor. */
@@ -27,6 +27,8 @@ typedef struct {
 /** Internal state of the scheduling algorithm. */
 typedef struct SchedulingAlgorithmState SchedulingAlgorithmState;
 
+struct LocalSchedulerClient;
+
 /** A struct storing the configuration state of the local scheduler. This should
  *  consist of values that don't change over the lifetime of the local
  *  scheduler. */
@@ -38,7 +40,7 @@ typedef struct {
 } local_scheduler_config;
 
 /** The state of the local scheduler. */
-typedef struct {
+struct LocalSchedulerState {
   /** The configuration for the local scheduler. */
   local_scheduler_config config;
   /** The local scheduler event loop. */
@@ -46,10 +48,10 @@ typedef struct {
   /** List of workers available to this node. This is used to free the worker
    *  structs when we free the scheduler state and also to access the worker
    *  structs in the tests. */
-  UT_array *workers;
+  std::vector<LocalSchedulerClient *> workers;
   /** List of the process IDs for child processes (workers) started by the
    *  local scheduler that have not sent a REGISTER_PID message yet. */
-  UT_array *child_pids;
+  std::vector<pid_t> child_pids;
   /** A hash table mapping actor IDs to the db_client_id of the local scheduler
    *  that is responsible for the actor. */
   actor_map_entry *actor_mapping;
@@ -68,10 +70,10 @@ typedef struct {
   /** Vector of dynamic attributes associated with the node owned by this local
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
-} LocalSchedulerState;
+};
 
 /** Contains all information associated with a local scheduler client. */
-typedef struct {
+struct LocalSchedulerClient {
   /** The socket used to communicate with the client. */
   int sock;
   /** A pointer to the task object that is currently running on this client. If
@@ -91,6 +93,6 @@ typedef struct {
   ActorID actor_id;
   /** A pointer to the local scheduler state. */
   LocalSchedulerState *local_scheduler_state;
-} LocalSchedulerClient;
+};
 
 #endif /* LOCAL_SCHEDULER_SHARED_H */


### PR DESCRIPTION
This makes some more progress on #404. In particular,

- replaces some hash tables with `std::unordered_map` in the local scheduler
- replaces some UT_arrays with `std::vector` in the local scheduler
- improves the efficiency of some of the array operations by using the trick of removing an element from the middle by swapping it with the last element and popping the last element