### PR TITLE
Re-enable recursive remote functions in a limited form.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,3 +92,4 @@ script:
   - python test/stress_tests.py
   - python test/component_failures_test.py
   - python test/multi_node_test.py
+  - python test/recursion_test.py

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -1,0 +1,24 @@
+# This test is not inside of runtest.py because when a recursive remote
+# function is defined inside of another function, we currently can't handle
+# that.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import ray
+
+ray.init()
+
+@ray.remote
+def factorial(n):
+  if n == 0:
+    return 1
+  return n * ray.get(factorial.remote(n - 1))
+
+assert ray.get(factorial.remote(0)) == 1
+assert ray.get(factorial.remote(1)) == 1
+assert ray.get(factorial.remote(2)) == 2
+assert ray.get(factorial.remote(3)) == 6
+assert ray.get(factorial.remote(4)) == 24
+assert ray.get(factorial.remote(5)) == 120

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -10,11 +10,13 @@ import ray
 
 ray.init()
 
+
 @ray.remote
 def factorial(n):
   if n == 0:
     return 1
   return n * ray.get(factorial.remote(n - 1))
+
 
 assert ray.get(factorial.remote(0)) == 1
 assert ray.get(factorial.remote(1)) == 1


### PR DESCRIPTION
This should partially address #398. This worked before but was broken because it wasn't being tested in the CI.

However, it's unclear if we should support this because we currently cannot fully support it.

For example, the following works.

```python
@ray.remote
def f():
  return [f.remote()]

f.remote()
```

However, the following does not work.

```python
def create_f():
  @ray.remote
  def f():
    return [f.remote()]
  return f

create_f().remote()
```

The following also does not work.

```python
def create_and_call_f():
  @ray.remote
  def f():
    return [f.remote()]

  f.remote()  

create_and_call_f()
```

Given that we aren't supporting it fully, do we want to partially support it?

@mehrdadn what do you think about this?