### PR TITLE
Change UniqueID hash function to look at the lowest bytes.

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -159,7 +159,7 @@ struct UniqueIDHasher {
   /* ObjectID hashing function. */
   size_t operator()(const UniqueID &id) const {
     size_t result;
-    memcpy(&result, id.id + UNIQUE_ID_SIZE - sizeof(size_t), sizeof(size_t));
+    memcpy(&result, id.id, sizeof(size_t));
     return result;
   }
 };


### PR DESCRIPTION
Sometimes new UniqueIDs are created by manipulating the lowest bytes of an existing one.