### PR TITLE
Fix bug with reused file descriptors

### DIFF
--- a/src/common/event_loop.cc
+++ b/src/common/event_loop.cc
@@ -20,7 +20,7 @@ void event_loop_destroy(event_loop *loop) {
   aeDeleteEventLoop(loop);
 }
 
-void event_loop_add_file(event_loop *loop,
+bool event_loop_add_file(event_loop *loop,
                          int fd,
                          int events,
                          event_loop_file_handler handler,
@@ -30,11 +30,13 @@ void event_loop_add_file(event_loop *loop,
   /* If it cannot be added, increase the size of the event loop. */
   if (err == AE_ERR && errno == ERANGE) {
     err = aeResizeSetSize(loop, 3 * aeGetSetSize(loop) / 2);
-    CHECK(err == AE_OK);
+    if (err != AE_OK) {
+      return false;
+    }
     err = aeCreateFileEvent(loop, fd, events, handler, context);
   }
   /* In any case, test if there were errors. */
-  CHECK(err == AE_OK);
+  return (err == AE_OK);
 }
 
 void event_loop_remove_file(event_loop *loop, int fd) {

--- a/src/common/event_loop.h
+++ b/src/common/event_loop.h
@@ -60,7 +60,7 @@ void event_loop_destroy(event_loop *loop);
  * argument to the handler. Currently there can only be one handler per file.
  * The events parameter specifies which events we listen to: EVENT_LOOP_READ
  * or EVENT_LOOP_WRITE. */
-void event_loop_add_file(event_loop *loop,
+bool event_loop_add_file(event_loop *loop,
                          int fd,
                          int events,
                          event_loop_file_handler handler,

--- a/src/plasma/plasma.cc
+++ b/src/plasma/plasma.cc
@@ -7,16 +7,17 @@
 
 #include "plasma_protocol.h"
 
-bool warn_if_sigpipe(int status, int client_sock) {
+int _warn_if_sigpipe(int status, int client_sock, const char *caller) {
   if (status >= 0) {
-    return false;
+    return 0;
   }
   if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
     LOG_WARN(
-        "Received SIGPIPE or BAD FILE DESCRIPTOR when sending a message to "
-        "client on fd %d. The client on the other end may have hung up.",
-        client_sock);
-    return true;
+        "Received SIGPIPE, BAD FILE DESCRIPTOR, or ECONNRESET in %s when "
+        "sending a message to client on fd %d. The client on the other end may "
+        "have hung up.",
+        caller, client_sock);
+    return errno;
   }
   LOG_FATAL("Failed to write message to client on fd %d.", client_sock);
 }

--- a/src/plasma/plasma.cc
+++ b/src/plasma/plasma.cc
@@ -7,16 +7,15 @@
 
 #include "plasma_protocol.h"
 
-int _warn_if_sigpipe(int status, int client_sock, const char *caller) {
+int warn_if_sigpipe(int status, int client_sock) {
   if (status >= 0) {
     return 0;
   }
   if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
     LOG_WARN(
-        "Received SIGPIPE, BAD FILE DESCRIPTOR, or ECONNRESET in %s when "
+        "Received SIGPIPE, BAD FILE DESCRIPTOR, or ECONNRESET when "
         "sending a message to client on fd %d. The client on the other end may "
-        "have hung up.",
-        caller, client_sock);
+        "have hung up.", client_sock);
     return errno;
   }
   LOG_FATAL("Failed to write message to client on fd %d.", client_sock);

--- a/src/plasma/plasma.cc
+++ b/src/plasma/plasma.cc
@@ -15,7 +15,8 @@ int warn_if_sigpipe(int status, int client_sock) {
     LOG_WARN(
         "Received SIGPIPE, BAD FILE DESCRIPTOR, or ECONNRESET when "
         "sending a message to client on fd %d. The client on the other end may "
-        "have hung up.", client_sock);
+        "have hung up.",
+        client_sock);
     return errno;
   }
   LOG_FATAL("Failed to write message to client on fd %d.", client_sock);

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -148,15 +148,18 @@ ObjectTableEntry *get_object_table_entry(PlasmaStoreInfo *store_info,
  * situations where the store writes to a client file descriptor, and the client
  * may already have disconnected. If we have processed the disconnection and
  * closed the file descriptor, we should get a BAD FILE DESCRIPTOR error. If we
- * have not, then we should get a SIGPIPE.
+ * have not, then we should get a SIGPIPE. If we write to a TCP socket that
+ * isn't connected yet, then we should get an ECONNRESET.
  *
  * @param status The status to check. If it is less less than zero, we will
  *        print a warning.
  * @param client_sock The client socket. This is just used to print some extra
  *        information.
- * @return Void.
+ * @return The errno set.
  */
-bool warn_if_sigpipe(int status, int client_sock);
+int _warn_if_sigpipe(int status, int client_sock, const char *caller);
+
+#define warn_if_sigpipe(s, c) _warn_if_sigpipe(s, c, __func__)
 
 uint8_t *create_object_info_buffer(ObjectInfoT *object_info);
 

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -157,9 +157,7 @@ ObjectTableEntry *get_object_table_entry(PlasmaStoreInfo *store_info,
  *        information.
  * @return The errno set.
  */
-int _warn_if_sigpipe(int status, int client_sock, const char *caller);
-
-#define WARN_IF_SIGPIPE(s, c) _warn_if_sigpipe(s, c, __func__)
+int warn_if_sigpipe(int status, int client_sock);
 
 uint8_t *create_object_info_buffer(ObjectInfoT *object_info);
 

--- a/src/plasma/plasma.h
+++ b/src/plasma/plasma.h
@@ -159,7 +159,7 @@ ObjectTableEntry *get_object_table_entry(PlasmaStoreInfo *store_info,
  */
 int _warn_if_sigpipe(int status, int client_sock, const char *caller);
 
-#define warn_if_sigpipe(s, c) _warn_if_sigpipe(s, c, __func__)
+#define WARN_IF_SIGPIPE(s, c) _warn_if_sigpipe(s, c, __func__)
 
 uint8_t *create_object_info_buffer(ObjectInfoT *object_info);
 

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -400,7 +400,7 @@ void remove_wait_request(PlasmaManagerState *manager_state,
 void return_from_wait(PlasmaManagerState *manager_state,
                       WaitRequest *wait_req) {
   /* Send the reply to the client. */
-  WARN_IF_SIGPIPE(plasma_send_WaitReply(
+  warn_if_sigpipe(plasma_send_WaitReply(
                       wait_req->client_conn->fd, manager_state->builder,
                       wait_req->object_requests, wait_req->num_object_requests),
                   wait_req->client_conn->fd);
@@ -648,7 +648,7 @@ void send_queued_request(event_loop *loop,
   int err = 0;
   switch (buf->type) {
   case MessageType_PlasmaDataRequest:
-    err = WARN_IF_SIGPIPE(
+    err = warn_if_sigpipe(
         plasma_send_DataRequest(conn->fd, state->builder, buf->object_id,
                                 state->addr, state->port),
         conn->fd);
@@ -658,7 +658,7 @@ void send_queued_request(event_loop *loop,
     if (conn->cursor == 0) {
       /* If the cursor is zero, we haven't sent any requests for this object
        * yet, so send the initial data request. */
-      err = WARN_IF_SIGPIPE(
+      err = warn_if_sigpipe(
           plasma_send_DataReply(conn->fd, state->builder, buf->object_id,
                                 buf->data_size, buf->metadata_size),
           conn->fd);
@@ -1266,7 +1266,7 @@ void request_status_done(ObjectID object_id,
   ClientConnection *client_conn = (ClientConnection *) context;
   int status =
       request_status(object_id, manager_count, manager_vector, context);
-  WARN_IF_SIGPIPE(plasma_send_StatusReply(client_conn->fd,
+  warn_if_sigpipe(plasma_send_StatusReply(client_conn->fd,
                                           client_conn->manager_state->builder,
                                           &object_id, &status, 1),
                   client_conn->fd);
@@ -1301,7 +1301,7 @@ void process_status_request(ClientConnection *client_conn, ObjectID object_id) {
   /* Return success immediately if we already have this object. */
   if (is_object_local(client_conn->manager_state, object_id)) {
     int status = ObjectStatus_Local;
-    WARN_IF_SIGPIPE(plasma_send_StatusReply(client_conn->fd,
+    warn_if_sigpipe(plasma_send_StatusReply(client_conn->fd,
                                             client_conn->manager_state->builder,
                                             &object_id, &status, 1),
                     client_conn->fd);
@@ -1310,7 +1310,7 @@ void process_status_request(ClientConnection *client_conn, ObjectID object_id) {
 
   if (client_conn->manager_state->db == NULL) {
     int status = ObjectStatus_Nonexistent;
-    WARN_IF_SIGPIPE(plasma_send_StatusReply(client_conn->fd,
+    warn_if_sigpipe(plasma_send_StatusReply(client_conn->fd,
                                             client_conn->manager_state->builder,
                                             &object_id, &status, 1),
                     client_conn->fd);

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -257,7 +257,7 @@ int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
  * @param buf The buffer to read data from.
  * @return Void.
  */
-void write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
+bool write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 
 /**
  * Get the event loop of the given plasma manager state.

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -255,9 +255,9 @@ int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
  *
  * @param conn The connection to the client who's receiving the data.
  * @param buf The buffer to read data from.
- * @return Void.
+ * @return The errno set, if the write wasn't successful.
  */
-bool write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
+int write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 
 /**
  * Get the event loop of the given plasma manager state.


### PR DESCRIPTION
This fixes a bug where we were not properly cleaning up old file descriptors. This sometimes prevented new clients from connecting, if they were assigned a reused file descriptor. We see this in the cluster setting, when many nodes leave and rejoin simultaneously.

This also fixes a bug where we were crashing or hanging on an `ECONNRESET` error when trying to transfer an object between plasma managers. This error appears when there are many plasma managers simultaneously initializing TCP connections, so some plasma managers may try to write data before fully connected.