### PR TITLE
Increase max number of redis client

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -303,6 +303,8 @@ def start_redis(node_ip_address="127.0.0.1", port=None, num_retries=20,
   redis_client = redis.StrictRedis(host="127.0.0.1", port=port)
   # Wait for the Redis server to start.
   wait_for_redis_to_start("127.0.0.1", port)
+  # Increase the maximum number of redis clients
+  redis_client.config_set("maxclients", "10000")
   # Configure Redis to generate keyspace notifications. TODO(rkn): Change this
   # to only generate notifications for the export keys.
   redis_client.config_set("notify-keyspace-events", "Kl")


### PR DESCRIPTION
If many actors or many workers are created, it is possible to run out of redis connections. This PR is supposed to fix that problem.