### PR TITLE
Simplify resource bookkeeping in local scheduler.

### DIFF
--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -109,20 +109,46 @@ void kill_worker(LocalSchedulerState *state,
 void start_worker(LocalSchedulerState *state, ActorID actor_id);
 
 /**
- * Update our accounting for the current resources being used, according to
- * some task that is starting or finishing execution.
+ * Check if a certain quantity of dynamic resources are available. If num_cpus
+ * is 0, we ignore the dynamic number of available CPUs (which may be negative).
+ *
+ * @param state The state of the local scheduler.
+ * @param num_cpus Check if this many CPUs are available.
+ * @param num_gpus Check if this many GPUs are available.
+ * @return True if there are enough CPUs and GPUs and false otherwise.
+ */
+bool check_dynamic_resources(LocalSchedulerState *state,
+                             double num_cpus,
+                             double num_gpus);
+
+/**
+ * Acquire additional resources (CPUs and GPUs) for a worker.
  *
  * @param state The local scheduler state.
- * @param spec The specification for the task that is or was using resources.
- * @param return_resources A boolean representing whether the task is starting
- *        or finishing execution. If true, then the task is finishing execution
- *        (possibly temporarily), so it will add to the dynamic resources
- *        available. Else, it will take from the dynamic resources available.
+ * @param worker The worker who is acquiring resources.
+ * @param num_cpus The number of CPU resources to acquire.
+ * @param num_gpus The number of GPU resources to acquire.
  * @return Void.
  */
-void update_dynamic_resources(LocalSchedulerState *state,
-                              TaskSpec *spec,
-                              bool return_resources);
+void acquire_resources(LocalSchedulerState *state,
+                       LocalSchedulerClient *worker,
+                       double num_cpus,
+                       double num_gpus);
+
+/**
+ * Return resources (CPUs and GPUs) being used by a worker to the local
+ * scheduler.
+ *
+ * @param state The local scheduler state.
+ * @param worker The worker who is returning resources.
+ * @param num_cpus The number of CPU resources to return.
+ * @param num_gpus The number of GPU resources to return.
+ * @return Void.
+ */
+void release_resources(LocalSchedulerState *state,
+                       LocalSchedulerClient *worker,
+                       double num_cpus,
+                       double num_gpus);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1022,12 +1022,7 @@ void handle_worker_blocked(LocalSchedulerState *state,
   DCHECK(!worker_in_vector(algorithm_state->blocked_workers, worker));
 
   /* Add the worker to the list of blocked workers. */
-  worker->is_blocked = true;
   algorithm_state->blocked_workers.push_back(worker);
-  /* Return the resources that the blocked worker was using. */
-  CHECK(worker->task_in_progress != NULL);
-  TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-  update_dynamic_resources(state, spec, true);
 
   /* Try to dispatch tasks, since we may have freed up some resources. */
   dispatch_tasks(state, algorithm_state);
@@ -1042,16 +1037,7 @@ void handle_worker_unblocked(LocalSchedulerState *state,
   /* Check that the worker isn't in the list of executing workers. */
   DCHECK(!worker_in_vector(algorithm_state->executing_workers, worker));
 
-  /* Lease back the resources that the blocked worker will need. */
-  /* TODO(swang): Leasing back the resources to blocked workers can cause
-   * us to transiently exceed the maximum number of resources. This can be
-   * fixed by having blocked workers explicitly yield and wait to be given
-   * back resources before continuing execution. */
-  CHECK(worker->task_in_progress != NULL);
-  TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-  update_dynamic_resources(state, spec, false);
   /* Add the worker to the list of executing workers. */
-  worker->is_blocked = false;
   algorithm_state->executing_workers.push_back(worker);
 }
 

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -91,6 +91,17 @@ struct LocalSchedulerClient {
    *  no task is running on the worker, this will be NULL. This is used to
    *  update the task table. */
   Task *task_in_progress;
+  /** The number of CPUs that the worker is currently using. This will only be
+   *  nonzero when the worker is actively executing a task. If the worker is
+   *  blocked, then this value will be zero. */
+  int cpus_in_use;
+  /** The number of GPUs that the worker is currently using. If the worker is an
+   *  actor, this will be constant throughout the lifetime of the actor (and
+   *  will be equal to the number of GPUs requested by the actor). If the worker
+   *  is not an actor, this will be constant for the duration of a task and will
+   *  have length equal to the number of GPUs requested by the task (in
+   *  particular it will not change if the task blocks). */
+  int gpus_in_use;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -94,14 +94,14 @@ struct LocalSchedulerClient {
   /** The number of CPUs that the worker is currently using. This will only be
    *  nonzero when the worker is actively executing a task. If the worker is
    *  blocked, then this value will be zero. */
-  int cpus_in_use;
+  double cpus_in_use;
   /** The number of GPUs that the worker is currently using. If the worker is an
    *  actor, this will be constant throughout the lifetime of the actor (and
    *  will be equal to the number of GPUs requested by the actor). If the worker
    *  is not an actor, this will be constant for the duration of a task and will
    *  have length equal to the number of GPUs requested by the task (in
    *  particular it will not change if the task blocks). */
-  int gpus_in_use;
+  double gpus_in_use;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;


### PR DESCRIPTION
This breaks off a small self-contained piece of #403.

Note this also makes a couple changes so that local schedulers do not do bookkeeping for resources for actor tasks.