### PR TITLE
Expose GPU IDs to remote functions.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,9 +4,8 @@ from __future__ import print_function
 
 from ray.worker import (register_class, error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
-                        flush_log)
+                        flush_log, get_gpu_ids)
 from ray.actor import actor
-from ray.actor import get_gpu_ids
 from ray.worker import EnvironmentVariable, env
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from ray.worker import global_state

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -15,19 +15,6 @@ import ray.signature as signature
 import ray.worker
 from ray.utils import random_string, binary_to_hex, hex_to_binary
 
-# This is a variable used by each actor to indicate the IDs of the GPUs that
-# the worker is currently allowed to use.
-gpu_ids = []
-
-
-def get_gpu_ids():
-  """Get the IDs of the GPU that are available to the worker.
-
-  Each ID is an integer in the range [0, NUM_GPUS - 1], where NUM_GPUS is the
-  number of GPUs that the node has.
-  """
-  return gpu_ids
-
 
 def random_actor_id():
   return ray.local_scheduler.ObjectID(random_string())
@@ -60,8 +47,6 @@ def fetch_and_register_actor(key, worker):
   actor_name = actor_name.decode("ascii")
   module = module.decode("ascii")
   actor_method_names = json.loads(actor_method_names.decode("ascii"))
-  global gpu_ids
-  gpu_ids = json.loads(assigned_gpu_ids.decode("ascii"))
 
   # Create a temporary actor with some temporary methods so that if the actor
   # fails to be unpickled, the temporary actor can be used (just to produce
@@ -233,8 +218,7 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus,
   driver_id = worker.task_driver_id.id()
   for actor_method_name in actor_method_names:
     function_id = get_actor_method_function_id(actor_method_name).id()
-    worker.function_properties[driver_id][function_id] = (1, num_cpus,
-                                                          num_gpus)
+    worker.function_properties[driver_id][function_id] = (1, num_cpus, 0)
 
   # Get a list of the local schedulers from the client table.
   client_table = ray.global_state.client_table()
@@ -247,22 +231,27 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus,
   local_scheduler_id, gpu_ids = select_local_scheduler(local_schedulers,
                                                        num_gpus, worker)
 
-  # Really we should encode this message as a flatbuffer object. However, we're
-  # having trouble getting that to work. It almost works, but in Python 2.7,
-  # builder.CreateString fails on byte strings that contain characters outside
-  # range(128).
-  worker.redis_client.publish("actor_notifications",
-                              actor_id.id() + driver_id + local_scheduler_id)
-
   d = {"driver_id": driver_id,
        "actor_id": actor_id.id(),
        "name": Class.__name__,
        "module": Class.__module__,
        "class": pickled_class,
        "gpu_ids": json.dumps(gpu_ids),
+       "num_gpus": num_gpus,
        "actor_method_names": json.dumps(list(actor_method_names))}
   worker.redis_client.hmset(key, d)
   worker.redis_client.rpush("Exports", key)
+
+  # We publish the actor notification after the call to hmset so that when the
+  # newly created actor queries Redis to find the number of GPUs assigned to
+  # it, that value is present.
+
+  # Really we should encode this message as a flatbuffer object. However, we're
+  # having trouble getting that to work. It almost works, but in Python 2.7,
+  # builder.CreateString fails on byte strings that contain characters outside
+  # range(128).
+  worker.redis_client.publish("actor_notifications",
+                              actor_id.id() + driver_id + local_scheduler_id)
 
 
 def actor(*args, **kwargs):

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -102,7 +102,7 @@ class TestGlobalScheduler(unittest.TestCase):
           static_resource_list=[10, 0])
       # Connect to the scheduler.
       local_scheduler_client = local_scheduler.LocalSchedulerClient(
-          local_scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False)
+          local_scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False, 0)
       self.local_scheduler_clients.append(local_scheduler_client)
       self.local_scheduler_pids.append(p4)
 

--- a/python/ray/local_scheduler/test/test.py
+++ b/python/ray/local_scheduler/test/test.py
@@ -48,7 +48,7 @@ class TestLocalSchedulerClient(unittest.TestCase):
         plasma_store_name, use_valgrind=USE_VALGRIND)
     # Connect to the scheduler.
     self.local_scheduler_client = local_scheduler.LocalSchedulerClient(
-        scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False)
+        scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False, 0)
 
   def tearDown(self):
     # Check that the processes are still alive.

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -243,7 +243,7 @@ class Monitor(object):
       if int(local_scheduler["NumGPUs"]) > 0:
         local_scheduler_id = local_scheduler["DBClientID"]
 
-        returned_gpu_ids = []
+        num_gpus_returned = 0
 
         # Perform a transaction to return the GPUs.
         with self.redis.pipeline() as pipe:
@@ -258,7 +258,7 @@ class Monitor(object):
 
               driver_id_hex = ray.utils.binary_to_hex(driver_id)
               if driver_id_hex in gpus_in_use:
-                returned_gpu_ids = gpus_in_use.pop(driver_id_hex)
+                num_gpus_returned = gpus_in_use.pop(driver_id_hex)
 
               pipe.multi()
 
@@ -276,7 +276,7 @@ class Monitor(object):
               continue
 
         log.info("Driver {} is returning GPU IDs {} to local scheduler {}."
-                 .format(driver_id, returned_gpu_ids, local_scheduler_id))
+                 .format(driver_id, num_gpus_returned, local_scheduler_id))
 
   def process_messages(self):
     """Process all messages ready in the subscription channels.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -673,6 +673,15 @@ class Worker(object):
     self.redis_client.rpush("ErrorKeys", error_key)
 
 
+def get_gpu_ids():
+  """Get the IDs of the GPU that are available to the worker.
+
+  Each ID is an integer in the range [0, NUM_GPUS - 1], where NUM_GPUS is the
+  number of GPUs that the node has.
+  """
+  return global_worker.local_scheduler_client.gpu_ids()
+
+
 global_worker = Worker()
 """Worker: The global Worker object for this worker process.
 
@@ -1339,8 +1348,12 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
   Args:
     info (dict): A dictionary with address of the Redis server and the sockets
       of the plasma store, plasma manager, and local scheduler.
+    object_id_seed: A seed to use to make the generation of object IDs
+      deterministic.
     mode: The mode of the worker. One of SCRIPT_MODE, WORKER_MODE, PYTHON_MODE,
       and SILENT_MODE.
+    actor_id: The ID of the actor running on this worker. If this worker is not
+      an actor, then this is NIL_ACTOR_ID.
   """
   check_main_thread()
   # Do some basic checking to make sure we didn't call ray.init twice.
@@ -1407,9 +1420,14 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
   worker.plasma_client = ray.plasma.PlasmaClient(info["store_socket_name"],
                                                  info["manager_socket_name"])
   # Create the local scheduler client.
+  if worker.actor_id != NIL_ACTOR_ID:
+    num_gpus = int(worker.redis_client.hget("Actor:{}".format(actor_id),
+                                            "num_gpus"))
+  else:
+    num_gpus = 0
   worker.local_scheduler_client = ray.local_scheduler.LocalSchedulerClient(
       info["local_scheduler_socket_name"], worker.worker_id, worker.actor_id,
-      is_worker)
+      is_worker, num_gpus)
 
   # If this is a driver, set the current task ID, the task driver ID, and set
   # the task index to 0.

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -4,7 +4,7 @@ enum MessageType:int {
   // Task is submitted to the local scheduler. This is sent from a worker to a
   // local scheduler.
   SubmitTask = 1,
-  // Notify the local scheduler that a task has finished. This is sent  from a
+  // Notify the local scheduler that a task has finished. This is sent from a
   // worker to a local scheduler.
   TaskDone,
   // Log a message to the event table. This is sent from a worker to a local
@@ -37,6 +37,8 @@ enum MessageType:int {
 table GetTaskReply {
   // A string of bytes representing the task specification.
   task_spec: string;
+  // The IDs of the GPUs that the worker is allowed to use for this task.
+  gpu_ids: [int];
 }
 
 table EventLogMessage {
@@ -55,9 +57,13 @@ table RegisterClientRequest {
   actor_id: string;
   // The process ID of this worker.
   worker_pid: long;
+  // The number of GPUs required by this actor.
+  num_gpus: long;
 }
 
 table RegisterClientReply {
+  // The IDs of the GPUs that are reserved for this worker.
+  gpu_ids: [int];
 }
 
 table ReconstructObject {

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -589,8 +589,8 @@ void dispatch_tasks(LocalSchedulerState *state,
     }
     /* Skip to the next task if this task cannot currently be satisfied. */
     if (!check_dynamic_resources(
-        state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
-        TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU))) {
+            state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
+            TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU))) {
       /* This task could not be satisfied -- proceed to the next task. */
       ++it;
       continue;

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -588,16 +588,9 @@ void dispatch_tasks(LocalSchedulerState *state,
       return;
     }
     /* Skip to the next task if this task cannot currently be satisfied. */
-    bool task_satisfied = true;
-    for (int i = 0; i < ResourceIndex_MAX; i++) {
-      if (TaskSpec_get_required_resource(task.spec, i) >
-          state->dynamic_resources[i]) {
-        /* Insufficient capacity for this task, proceed to the next task. */
-        task_satisfied = false;
-        break;
-      }
-    }
-    if (!task_satisfied) {
+    if (!check_dynamic_resources(
+        state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
+        TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU))) {
       /* This task could not be satisfied -- proceed to the next task. */
       ++it;
       continue;

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -11,10 +11,11 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
     const char *local_scheduler_socket,
     UniqueID client_id,
     ActorID actor_id,
-    bool is_worker) {
-  LocalSchedulerConnection *result =
-      (LocalSchedulerConnection *) malloc(sizeof(LocalSchedulerConnection));
+    bool is_worker,
+    int64_t num_gpus) {
+  LocalSchedulerConnection *result = new LocalSchedulerConnection();
   result->conn = connect_ipc_sock_retry(local_scheduler_socket, -1, -1);
+  result->actor_id = actor_id;
 
   /* Register with the local scheduler.
    * NOTE(swang): If the local scheduler exits and we are registered as a
@@ -22,7 +23,8 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
   flatbuffers::FlatBufferBuilder fbb;
   auto message =
       CreateRegisterClientRequest(fbb, is_worker, to_flatbuf(fbb, client_id),
-                                  to_flatbuf(fbb, actor_id), getpid());
+                                  to_flatbuf(fbb, result->actor_id), getpid(),
+                                  num_gpus);
   fbb.Finish(message);
   /* Register the process ID with the local scheduler. */
   int success = write_message(result->conn, MessageType_RegisterClientRequest,
@@ -40,8 +42,16 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
   }
   CHECK(type == MessageType_RegisterClientReply);
 
-  /* Parse the reply object. We currently don't do anything with it. */
+  /* Parse the reply object. */
   auto reply_message = flatbuffers::GetRoot<RegisterClientReply>(reply);
+  for (int i = 0; i < reply_message->gpu_ids()->size(); ++i) {
+    result->gpu_ids.push_back(reply_message->gpu_ids()->Get(i));
+  }
+  /* If the worker is not an actor, there should not be any GPU IDs here. */
+  if (ActorID_equal(result->actor_id, NIL_ACTOR_ID)) {
+    CHECK(reply_message->gpu_ids()->size() == 0);
+  }
+
   free(reply);
 
   return result;
@@ -49,7 +59,7 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
 
 void LocalSchedulerConnection_free(LocalSchedulerConnection *conn) {
   close(conn->conn);
-  free(conn);
+  delete conn;
 }
 
 void local_scheduler_log_event(LocalSchedulerConnection *conn,
@@ -90,6 +100,17 @@ TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
 
   /* Parse the flatbuffer object. */
   auto reply_message = flatbuffers::GetRoot<GetTaskReply>(message);
+
+  /* Set the GPU IDs for this task. We only do this for non-actor tasks because
+   * for actors the GPUs are associated with the actor itself and not with the
+   * actor methods. */
+  if (ActorID_equal(conn->actor_id, NIL_ACTOR_ID)) {
+    conn->gpu_ids.clear();
+    for (int i = 0; i < reply_message->gpu_ids()->size(); ++i) {
+      conn->gpu_ids.push_back(reply_message->gpu_ids()->Get(i));
+    }
+  }
+
   /* Create a copy of the task spec so we can free the reply. */
   *task_size = reply_message->task_spec()->size();
   TaskSpec *data = (TaskSpec *) reply_message->task_spec()->data();

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -21,10 +21,9 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
    * NOTE(swang): If the local scheduler exits and we are registered as a
    * worker, we will get killed. */
   flatbuffers::FlatBufferBuilder fbb;
-  auto message =
-      CreateRegisterClientRequest(fbb, is_worker, to_flatbuf(fbb, client_id),
-                                  to_flatbuf(fbb, result->actor_id), getpid(),
-                                  num_gpus);
+  auto message = CreateRegisterClientRequest(
+      fbb, is_worker, to_flatbuf(fbb, client_id),
+      to_flatbuf(fbb, result->actor_id), getpid(), num_gpus);
   fbb.Finish(message);
   /* Register the process ID with the local scheduler. */
   int success = write_message(result->conn, MessageType_RegisterClientRequest,

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -4,11 +4,16 @@
 #include "common/task.h"
 #include "local_scheduler_shared.h"
 
-typedef struct {
+struct LocalSchedulerConnection {
   /** File descriptor of the Unix domain socket that connects to local
    *  scheduler. */
   int conn;
-} LocalSchedulerConnection;
+  /** The actor ID of this client. If this client is not an actor, then this
+   *  should be NIL_ACTOR_ID. */
+  ActorID actor_id;
+  /** The IDs of the GPUs that this client can use. */
+  std::vector<int> gpu_ids;
+};
 
 /**
  * Connect to the local scheduler.
@@ -19,13 +24,16 @@ typedef struct {
  *        running on this actor, this should be NIL_ACTOR_ID.
  * @param is_worker Whether this client is a worker. If it is a worker, an
  *        additional message will be sent to register as one.
+ * @param num_gpus The number of GPUs required by this worker. This is only
+ *        used if the worker is an actor.
  * @return The connection information.
  */
 LocalSchedulerConnection *LocalSchedulerConnection_init(
     const char *local_scheduler_socket,
     UniqueID worker_id,
     ActorID actor_id,
-    bool is_worker);
+    bool is_worker,
+    int64_t num_gpus);
 
 /**
  * Disconnect from the local scheduler.

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -74,6 +74,10 @@ struct LocalSchedulerState {
   /** Vector of dynamic attributes associated with the node owned by this local
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
+  /** The IDs of the available GPUs. There is redundancy here in that
+   *  available_gpus.size() == dynamic_resources[ResourceIndex_GPU] should
+   *  always be true. */
+  std::vector<int> available_gpus;
 };
 
 /** Contains all information associated with a local scheduler client. */
@@ -95,13 +99,13 @@ struct LocalSchedulerClient {
    *  nonzero when the worker is actively executing a task. If the worker is
    *  blocked, then this value will be zero. */
   double cpus_in_use;
-  /** The number of GPUs that the worker is currently using. If the worker is an
-   *  actor, this will be constant throughout the lifetime of the actor (and
-   *  will be equal to the number of GPUs requested by the actor). If the worker
-   *  is not an actor, this will be constant for the duration of a task and will
-   *  have length equal to the number of GPUs requested by the task (in
-   *  particular it will not change if the task blocks). */
-  double gpus_in_use;
+  /** A vector of the IDs of the GPUs that the worker is currently using. If the
+   *  worker is an actor, this will be constant throughout the lifetime of the
+   *  actor (and will be equal to the number of GPUs requested by the actor). If
+   *  the worker is not an actor, this will be constant for the duration of a
+   *  task and will have length equal to the number of GPUs requested by the
+   *  task (in particular it will not change if the task blocks). */
+  std::vector<int> gpus_in_use;
   /** A flag to indicate whether this worker is currently blocking on an
    *  object(s) that isn't available locally yet. */
   bool is_blocked;

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -123,7 +123,7 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   for (int i = 0; i < num_mock_workers; ++i) {
     mock->conns[i] = LocalSchedulerConnection_init(
         utstring_body(local_scheduler_socket_name), NIL_WORKER_ID, NIL_ACTOR_ID,
-        true);
+        true, 0);
   }
 
   background_thread.join();

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import random
 import numpy as np
 import time
 import unittest

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1187,6 +1187,91 @@ class ResourcesTest(unittest.TestCase):
 
     ray.worker.cleanup()
 
+  def testGPUIDs(self):
+    num_gpus = 10
+    ray.init(num_cpus=10, num_gpus=num_gpus)
+
+    @ray.remote(num_gpus=0)
+    def f0():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 0
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    @ray.remote(num_gpus=1)
+    def f1():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 1
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    @ray.remote(num_gpus=2)
+    def f2():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 2
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    @ray.remote(num_gpus=3)
+    def f3():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 3
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    @ray.remote(num_gpus=4)
+    def f4():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 4
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    @ray.remote(num_gpus=5)
+    def f5():
+      time.sleep(0.1)
+      gpu_ids = ray.get_gpu_ids()
+      assert len(gpu_ids) == 5
+      for gpu_id in gpu_ids:
+        assert gpu_id in range(num_gpus)
+      return gpu_ids
+
+    list_of_ids = ray.get([f0.remote() for _ in range(10)])
+    self.assertEqual(list_of_ids, 10 * [[]])
+
+    list_of_ids = ray.get([f1.remote() for _ in range(10)])
+    set_of_ids = set([tuple(gpu_ids) for gpu_ids in list_of_ids])
+    self.assertEqual(set_of_ids, set([(i,) for i in range(10)]))
+
+    list_of_ids = ray.get([f2.remote(), f4.remote(), f4.remote()])
+    all_ids = [gpu_id for gpu_ids in list_of_ids for gpu_id in gpu_ids]
+    self.assertEqual(set(all_ids), set(range(10)))
+
+    remaining = [f5.remote() for _ in range(20)]
+    for _ in range(10):
+      t1 = time.time()
+      ready, remaining = ray.wait(remaining, num_returns=2)
+      t2 = time.time()
+      # There are only 10 GPUs, and each task uses 2 GPUs, so there should only
+      # be 2 tasks scheduled at a given time, so if we wait for 2 tasks to
+      # finish, then it should take at least 0.1 seconds for each pair of tasks
+      # to finish.
+      self.assertGreater(t2 - t1, 0.09)
+      list_of_ids = ray.get(ready)
+      all_ids = [gpu_id for gpu_ids in list_of_ids for gpu_id in gpu_ids]
+      self.assertEqual(set(all_ids), set(range(10)))
+
+    ray.worker.cleanup()
+
   def testMultipleLocalSchedulers(self):
     # This test will define a bunch of tasks that can only be assigned to
     # specific local schedulers, and we will check that they are assigned to


### PR DESCRIPTION
Note in this PR, we should also remove the GPU ID assignment to actors that happens through Redis (this still happens but the resulting GPU IDs are unused).

This replaces #403.