### PR TITLE
Make sure user seeding does not affect actor ID generation.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import hashlib
 import inspect
 import json
-import numpy as np
 import random
 import redis
 import traceback

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -14,7 +14,7 @@ import ray.local_scheduler
 import ray.pickling as pickling
 import ray.signature as signature
 import ray.worker
-from ray.utils import binary_to_hex, hex_to_binary
+from ray.utils import random_string, binary_to_hex, hex_to_binary
 
 # This is a variable used by each actor to indicate the IDs of the GPUs that
 # the worker is currently allowed to use.
@@ -28,10 +28,6 @@ def get_gpu_ids():
   number of GPUs that the node has.
   """
   return gpu_ids
-
-
-def random_string():
-  return np.random.bytes(20)
 
 
 def random_actor_id():

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -3,9 +3,35 @@ from __future__ import division
 from __future__ import print_function
 
 import binascii
+import numpy as np
 import sys
 
 import ray.local_scheduler
+
+
+def random_string():
+  """Generate a random string to use as an ID.
+
+  Note that users may seed numpy, which could cause this function to generate
+  duplicate IDs. Therefore, we need to seed numpy ourselves, but we can't
+  interfere with the state of the user's random number generator, so we extract
+  the state of the random number generator and reset it after we are done.
+
+  TODO(rkn): If we want to later guarantee that these are generated in a
+  deterministic manner, then we will need to make some changes here.
+
+  Returns:
+    A random byte string of length 20.
+  """
+  # Get the state of the numpy random number generator.
+  numpy_state = np.random.get_state()
+  # Try to use true randomness.
+  np.random.seed(None)
+  # Generate the random ID.
+  random_id = np.random.bytes(20)
+  # Reset the state of the numpy random number generator.
+  np.random.set_state(numpy_state)
+  return random_id
 
 
 def decode(byte_str):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -27,6 +27,7 @@ import ray.signature as signature
 import ray.numbuf
 import ray.local_scheduler
 import ray.plasma
+from ray.utils import random_string
 
 SCRIPT_MODE = 0
 WORKER_MODE = 1
@@ -58,14 +59,6 @@ PUT_RECONSTRUCTION_ERROR_TYPE = b"put_reconstruction"
 
 # This must be kept in sync with the `scheduling_state` enum in common/task.h.
 TASK_STATUS_RUNNING = 8
-
-
-def random_string():
-  return np.random.bytes(20)
-
-
-def random_object_id():
-  return ray.local_scheduler.ObjectID(random_string())
 
 
 class FunctionID(object):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import random
 import unittest
 
 import ray
@@ -206,6 +207,27 @@ class ActorAPI(unittest.TestCase):
     class Actor(object):
       def __init__(self):
         pass
+
+    ray.worker.cleanup()
+
+  def testRandomIDGeneration(self):
+    ray.init(num_workers=0)
+
+    @ray.actor
+    class Foo(object):
+      def __init__(self):
+        pass
+
+    # Make sure that seeding numpy does not interfere with the generation of
+    # actor IDs.
+    np.random.seed(1234)
+    random.seed(1234)
+    f1 = Foo()
+    np.random.seed(1234)
+    random.seed(1234)
+    f2 = Foo()
+
+    self.assertNotEqual(f1._ray_actor_id.id(), f2._ray_actor_id.id())
 
     ray.worker.cleanup()
 


### PR DESCRIPTION
This fixes #507.

Note that this makes the generation of actor IDs and function IDs a little more expensive, but it shouldn't be critical for those operations to be very fast.