### PR TITLE
Serialize lambdas, sets, and types with pickle by default.

### DIFF
--- a/doc/source/serialization.rst
+++ b/doc/source/serialization.rst
@@ -117,7 +117,7 @@ message, and you should fall back to pickle.
 .. code-block:: python
 
   # This call tells Ray to fall back to using pickle when it encounters objects
-  # of type function.
+  # of type function (we actually already do this under the hood).
   f = lambda x: x + 1
   ray.register_class(type(f), pickle=True)
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -805,6 +805,8 @@ def initialize_numbuf(worker=global_worker):
     register_class(RayTaskError)
     register_class(RayGetError)
     register_class(RayGetArgumentError)
+    # Tell Ray to serialize lambdas with pickle.
+    register_class(type(lambda: 0), pickle=True)
 
 
 def get_address_info_from_redis_helper(redis_address, node_ip_address):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -809,6 +809,8 @@ def initialize_numbuf(worker=global_worker):
     register_class(type(lambda: 0), pickle=True)
     # Tell Ray to serialize sets with pickle.
     register_class(type(set()), pickle=True)
+    # Tell Ray to serialize types with pickle.
+    register_class(type(int), pickle=True)
 
 
 def get_address_info_from_redis_helper(redis_address, node_ip_address):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -807,6 +807,8 @@ def initialize_numbuf(worker=global_worker):
     register_class(RayGetArgumentError)
     # Tell Ray to serialize lambdas with pickle.
     register_class(type(lambda: 0), pickle=True)
+    # Tell Ray to serialize sets with pickle.
+    register_class(type(set()), pickle=True)
 
 
 def get_address_info_from_redis_helper(redis_address, node_ip_address):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -10,7 +10,7 @@ import time
 import shutil
 import string
 import sys
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 
 import ray.test.test_functions as test_functions
 
@@ -302,13 +302,13 @@ class APITest(unittest.TestCase):
     # throws an exception.
     class TempClass(object):
       pass
-    self.assertRaises(Exception, lambda: ray.put(Foo))
+    self.assertRaises(Exception, lambda: ray.put(TempClass()))
     # Check that registering a class that Ray cannot serialize efficiently
     # raises an exception.
-    self.assertRaises(Exception, lambda: ray.register_class(type(True)))
+    self.assertRaises(Exception, lambda: ray.register_class(defaultdict))
     # Check that registering the same class with pickle works.
-    ray.register_class(type(float), pickle=True)
-    self.assertEqual(ray.get(ray.put(float)), float)
+    ray.register_class(defaultdict, pickle=True)
+    ray.get(ray.put(defaultdict(lambda: 0)))
 
     ray.worker.cleanup()
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -224,6 +224,11 @@ class SerializationTest(unittest.TestCase):
     self.assertEqual(ray.get(f.remote(temp))(), 1)
     self.assertEqual(ray.get(f.remote(lambda x: x + 1))(3), 4)
 
+    # Test sets.
+    self.assertEqual(ray.get(f.remote(set())), set())
+    s = set([1, (1, 2, "hi")])
+    self.assertEqual(ray.get(f.remote(s)), s)
+
     ray.worker.cleanup()
 
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -229,6 +229,19 @@ class SerializationTest(unittest.TestCase):
     s = set([1, (1, 2, "hi")])
     self.assertEqual(ray.get(f.remote(s)), s)
 
+    # Test types.
+    self.assertEqual(ray.get(f.remote(int)), int)
+    self.assertEqual(ray.get(f.remote(float)), float)
+    self.assertEqual(ray.get(f.remote(str)), str)
+
+    class Foo(object):
+      def __init__(self):
+        pass
+
+    # Make sure that we can put and get a custom type. Note that the result
+    # won't be "equal" to Foo.
+    ray.get(ray.put(Foo))
+
     ray.worker.cleanup()
 
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -209,6 +209,23 @@ class SerializationTest(unittest.TestCase):
 
     ray.worker.cleanup()
 
+  def testPassingArgumentsByValueOutOfTheBox(self):
+    ray.init(num_workers=1)
+
+    @ray.remote
+    def f(x):
+      return x
+
+    # Test passing lambdas.
+
+    def temp():
+      return 1
+
+    self.assertEqual(ray.get(f.remote(temp))(), 1)
+    self.assertEqual(ray.get(f.remote(lambda x: x + 1))(3), 4)
+
+    ray.worker.cleanup()
+
 
 class WorkerTest(unittest.TestCase):
 


### PR DESCRIPTION
What are the important classes to handle out of the box?

We could handle sets with pickle as well. One of the dangers with using pickle is of course that we will handle numpy arrays inefficiently, but sets can't contain numpy arrays I think, so this may not be much of an issue).

There are other things we may want to handle out of the box, but which will differ between Python 2 and Python 3 (e.g., `range(10)` is a list in Python 2 and a range object in Python 3, we could reasonably use pickle here as well). A lot of different container types are different in Python 3 as well, and so on.

TODO
- This change invalidates some examples in the documentation.