### PR TITLE
Fix build-docker.sh bug

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,7 +8,7 @@ case $key in
     NO_CACHE="--no-cache"
     ;;
     --skip-examples)
-    SKIP_EXAMPLES=YES
+    SKIP_EXAMPLES=NO
     ;;
     --output-sha)
     # output the SHA sum of the last built file (either ray-project/deploy

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,7 +8,7 @@ case $key in
     NO_CACHE="--no-cache"
     ;;
     --skip-examples)
-    SKIP_EXAMPLES=NO
+    SKIP_EXAMPLES=YES
     ;;
     --output-sha)
     # output the SHA sum of the last built file (either ray-project/deploy
@@ -45,6 +45,8 @@ rm ./docker/deploy/ray.tar ./docker/deploy/git-rev
 if [ ! $SKIP_EXAMPLES ]; then
     if [ $OUTPUT_SHA ]; then
         IMAGE_SHA=$(docker build $NO_CACHE -q -t ray-project/examples docker/examples)
+    else
+        docker build --no-cache -t ray-project/examples docker/examples
     fi
 fi
 


### PR DESCRIPTION
Builds the `examples`container even if `--output-sha` is not passed in