### PR TITLE
Prevent actors from being placed on removed nodes or nodes with no CPUs.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -240,6 +240,11 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus,
   # having trouble getting that to work. It almost works, but in Python 2.7,
   # builder.CreateString fails on byte strings that contain characters outside
   # range(128).
+
+  # TODO(rkn): There is actually no guarantee that the local scheduler that we
+  # are publishing to has already subscribed to the actor_notifications
+  # channel. Therefore, this message may be missed and the workload will hang.
+  # This is a bug.
   worker.redis_client.publish("actor_notifications",
                               actor_id.id() + driver_id + local_scheduler_id)
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -205,7 +205,8 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus,
   """
   ray.worker.check_main_thread()
   if worker.mode is None:
-    raise NotImplemented("TODO(pcm): Cache actors")
+    raise Exception("Actors cannot be created before Ray has been started. "
+                    "You can start Ray with 'ray.init()'.")
   key = "Actor:{}".format(actor_id.id())
   pickled_class = pickling.dumps(Class)
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -216,11 +216,12 @@ def export_actor(actor_id, Class, actor_method_names, num_cpus, num_gpus,
   local_schedulers = []
   for ip_address, clients in client_table.items():
     for client in clients:
-      if client["ClientType"] == "local_scheduler":
+      if client["ClientType"] == "local_scheduler" and not client["Deleted"]:
         local_schedulers.append(client)
   # Select a local scheduler for the actor.
   local_scheduler_id = select_local_scheduler(local_schedulers, num_gpus,
                                               worker)
+  assert local_scheduler_id is not None
 
   d = {"driver_id": driver_id,
        "actor_id": actor_id.id(),

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -6,7 +6,6 @@ import hashlib
 import inspect
 import json
 import numpy as np
-import random
 import redis
 import traceback
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -565,6 +565,19 @@ class ActorSchedulingProperties(unittest.TestCase):
 
 class ActorsOnMultipleNodes(unittest.TestCase):
 
+  def testActorsOnNodesWithNoCPUs(self):
+    ray.init(num_cpus=0)
+
+    @ray.actor
+    class Foo(object):
+      def __init__(self):
+        pass
+
+    with self.assertRaises(Exception):
+      Foo()
+
+    ray.worker.cleanup()
+
   def testActorLoadBalancing(self):
     num_local_schedulers = 3
     ray.worker._init(start_ray_local=True, num_workers=0,


### PR DESCRIPTION
This should address #474 and #475.

Also fixed #528.