### PR TITLE
add serializing numpy boolean

### DIFF
--- a/src/numbuf/python/src/pynumbuf/adapters/numpy.cc
+++ b/src/numbuf/python/src/pynumbuf/adapters/numpy.cc
@@ -32,6 +32,7 @@ Status SerializeArray(PyArrayObject* array, SequenceBuilder& builder,
     std::vector<PyObject*>& subdicts, std::vector<PyObject*>& tensors_out) {
   int dtype = PyArray_TYPE(array);
   switch (dtype) {
+    case NPY_BOOL:
     case NPY_UINT8:
     case NPY_INT8:
     case NPY_UINT16:


### PR DESCRIPTION
This improves performance:

```
In [1]: import numpy as np

In [2]: a = np.array(10000 * [True])

In [3]: b = np.array(100000 * [True])

In [4]: a_id = ray.put(a)

In [5]: b_id = ray.put(b)

before:

In [6]: %timeit ray.put(a)
1000 loops, best of 3: 732 µs per loop

In [7]: %timeit ray.put(b)
100 loops, best of 3: 4.71 ms per loop

In [8]: %timeit ray.get(a_id)
1000 loops, best of 3: 924 µs per loop

In [9]: %timeit ray.get(b_id)
100 loops, best of 3: 8.43 ms per loop

after:

In [10]: %timeit ray.put(a)
1000 loops, best of 3: 210 µs per loop

In [11]: %timeit ray.put(b)
1000 loops, best of 3: 254 µs per loop

In [12]: %timeit ray.get(a_id)
10000 loops, best of 3: 50.8 µs per loop

In [13]: %timeit ray.get(b_id)
10000 loops, best of 3: 50.8 µs per loop
```