### PR TITLE
Fix problem if old version of arrow is cloned

### DIFF
--- a/src/numbuf/thirdparty/download_thirdparty.sh
+++ b/src/numbuf/thirdparty/download_thirdparty.sh
@@ -11,6 +11,6 @@ if [ ! -d $TP_DIR/arrow ]; then
   git clone https://github.com/apache/arrow/ "$TP_DIR/arrow"
 fi
 cd $TP_DIR/arrow
+git pull origin master
 
 git checkout 670612e6fdf699486641ed0d39d22257eb8acdb2
-


### PR DESCRIPTION
If an old version of arrow is lying around, we get an error like this:

```
+ cd /--/--/--/ray/src/numbuf/thirdparty/arrow
+ git checkout 670612e6fdf699486641ed0d39d22257eb8acdb2
fatal: reference is not a tree: 670612e6fdf699486641ed0d39d22257eb8acdb2
Traceback (most recent call last):
```