### PR TITLE
Expose function table to python global control state API

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -20,6 +20,7 @@ OBJECT_INFO_PREFIX = "OI:"
 OBJECT_LOCATION_PREFIX = "OL:"
 OBJECT_SUBSCRIBE_PREFIX = "OS:"
 TASK_PREFIX = "TT:"
+FUNCTION_PREFIX = "RemoteFunction:"
 OBJECT_CHANNEL_PREFIX = "OC:"
 
 # This mapping from integer to task state string must be kept up-to-date with
@@ -193,6 +194,25 @@ class GlobalState(object):
         results[binary_to_hex(task_id_binary)] = self._task_table(
             task_id_binary)
       return results
+
+  def function_table(self, function_id=None):
+    """Fetch and parse the function table.
+    
+    Returns:
+      A dictionary that maps function IDs to information about the function.
+    """
+    self._check_connected()
+    function_table_keys = self.redis_client.keys(FUNCTION_PREFIX + "*")
+    results = {}
+    for key in function_table_keys:
+      info = self.redis_client.hgetall(key)
+      function_info_parsed = {
+          "DriverID": binary_to_hex(info[b"driver_id"]),
+          "Module": decode(info[b"module"]),
+          "Name": decode(info[b"name"])
+      }
+      results[binary_to_hex(info[b"function_id"])] = function_info_parsed
+    return function_info_parsed
 
   def client_table(self):
     """Fetch and parse the Redis DB client table.

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -197,7 +197,7 @@ class GlobalState(object):
 
   def function_table(self, function_id=None):
     """Fetch and parse the function table.
-    
+
     Returns:
       A dictionary that maps function IDs to information about the function.
     """

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -212,7 +212,7 @@ class GlobalState(object):
           "Name": decode(info[b"name"])
       }
       results[binary_to_hex(info[b"function_id"])] = function_info_parsed
-    return function_info_parsed
+    return results
 
   def client_table(self):
     """Fetch and parse the Redis DB client table.


### PR DESCRIPTION
This allows visualization of the computation graph like so:

```python
import graphviz

def visualize(task_table, function_table):
  """
  Convert the Ray task table to a graphviz computation graph visualization.
  Args:
    task_table [dict]: task table from the global state
    function_table [dict]: function table from the global state
  Returns:
    Graphviz description of the computation graph
  """
  dot = graphviz.Digraph(format="pdf")
  for task_id in task_table.keys():
    task_spec = task_table[task_id]["TaskSpec"]
    if task_spec["FunctionID"] != 40 * 'f':
      function_name = function_table[task_spec["FunctionID"]]["Name"]
    else:
      function_name = "Driver"
    dot.node("task-" + task_id, label=task_id[:7] + "\n" + function_name.split(".")[-1], shape="box")
    for object_id in task_spec["ReturnObjectIDs"]:
      dot.node("object-" + object_id.hex(), label=object_id.hex()[:7])
      dot.edge("task-" + task_id, "object-" + object_id.hex())
    # edge to the task that launched this task
    if task_table[task_id]["LocalSchedulerID"] != 40 * 'f':
      dot.edge("task-" + task_spec["ParentTaskID"], "task-" + task_id, style="dotted", constraint="false")
    for object_id in task_spec["Args"]:
      if hasattr(object_id, "hex"):
        dot.node("object-" + object_id.hex(), label=object_id.hex()[:7])
        dot.edge("object-" + object_id.hex(), "task-" + task_id)
  return dot

graph = visualize(ray.worker.global_state.task_table(), ray.worker.global_state.function_table())
graph # or graph.view() outsize of IPython notebooks
```

Note that the Python API for the global control state is very experimental at this point.

![ray_graph](https://cloud.githubusercontent.com/assets/113316/25980939/dee6a120-3686-11e7-9fed-cd6840ea6bcc.png)
