### PR TITLE
Test getting/putting numpy arrays of length 0.

### DIFF
--- a/src/numbuf/python/test/runtest.py
+++ b/src/numbuf/python/test/runtest.py
@@ -19,7 +19,7 @@ TEST_OBJECTS = [{(1, 2): 1}, {(): 2}, [1, "hello", 3.0], 42, 43,
                 {"hello": "world", 1: 42, 2.5: 45}, {},
                 np.int8(3), np.int32(4), np.int64(5),
                 np.uint8(3), np.uint32(4), np.uint64(5),
-                np.float32(1.0), np.float64(1.0)]
+                np.float32(1.0), np.float64(1.0), np.zeros((0,))]
 
 if sys.version_info < (3, 0):
   TEST_OBJECTS += [long(42), long(1 << 62)]  # noqa: F821

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -75,7 +75,7 @@ PRIMITIVE_OBJECTS = [0, 0.0, 0.9, 1 << 62, "a", string.printable, "\u262F",
                      u"hello world", u"\xff\xfe\x9c\x001\x000\x00", None, True,
                      False, [], (), {}, np.int8(3), np.int32(4), np.int64(5),
                      np.uint8(3), np.uint32(4), np.uint64(5), np.float32(1.9),
-                     np.float64(1.9), np.zeros([100, 100]),
+                     np.float64(1.9), np.zeros([100, 100]), np.zeros((0,)),
                      np.random.normal(size=[100, 100]), np.array(["hi", 3]),
                      np.array(["hi", 3], dtype=object)] + long_extras
 


### PR DESCRIPTION
Add a test for #500 so that the problem doesn't recur.

I'm creating the PR, but the test I added to the numbuf suite actually seems to fail with

```
testBuffer (__main__.SerializationTests) ... /Users/rkn/Workspace/ray/src/numbuf/python/src/pynumbuf/numbuf.cc191 Check failed: _s.ok() Bad status: Invalid: Not an Arrow file
```