### PR TITLE
Remove register_class from API.

### DIFF
--- a/doc/source/actors.rst
+++ b/doc/source/actors.rst
@@ -220,8 +220,6 @@ We can put this all together as follows.
 
   # Load the MNIST dataset and tell Ray how to serialize the custom classes.
   mnist = input_data.read_data_sets("MNIST_data", one_hot=True)
-  ray.register_class(type(mnist))
-  ray.register_class(type(mnist.train))
 
   # Create the actor.
   nn = NeuralNetOnGPU.remote(mnist)

--- a/doc/source/serialization.rst
+++ b/doc/source/serialization.rst
@@ -9,16 +9,15 @@ store.
 
 1. The return values of a remote function.
 2. The value ``x`` in a call to ``ray.put(x)``.
-3. Large objects or objects other than simple primitive types that are passed
-   as arguments into remote functions.
+3. Arguments to remote functions (except for simple arguments like ints or
+   floats).
 
 A Python object may have an arbitrary number of pointers with arbitrarily deep
 nesting. To place an object in the object store or send it between processes,
 it must first be converted to a contiguous string of bytes. This process is
 known as serialization. The process of converting the string of bytes back into a
 Python object is known as deserialization. Serialization and deserialization
-are often bottlenecks in distributed computing if the time needed to compute
-on the data is relatively low.
+are often bottlenecks in distributed computing.
 
 Pickle is one example of a library for serialization and deserialization in
 Python.
@@ -40,9 +39,8 @@ overheads, even when all processes are read-only and could easily share memory.
 In Ray, we optimize for numpy arrays by using the `Apache Arrow`_ data format.
 When we deserialize a list of numpy arrays from the object store, we still
 create a Python list of numpy array objects. However, rather than copy each
-numpy array over again, each numpy array object holds a pointer to the relevant
-array held in shared memory. There are some advantages to this form of
-serialization.
+numpy array, each numpy array object holds a pointer to the relevant array held
+in shared memory. There are some advantages to this form of serialization.
 
 - Deserialization can be very fast.
 - Memory is shared between processes so worker processes can all read the same
@@ -54,84 +52,18 @@ What Objects Does Ray Handle
 ----------------------------
 
 Ray does not currently support serialization of arbitrary Python objects.  The
-set of Python objects that Ray can serialize includes the following.
+set of Python objects that Ray can serialize using _`Apache Arrow` includes the
+following.
 
 1. Primitive types: ints, floats, longs, bools, strings, unicode, and numpy
    arrays.
 2. Any list, dictionary, or tuple whose elements can be serialized by Ray.
-3. Objects whose classes can be registered with ``ray.register_class``. This
-   point is described below.
 
-Registering Custom Classes
---------------------------
-
-We currently support serializing a limited subset of custom classes. For
-example, suppose you define a new class ``Foo`` as follows.
-
-.. code-block:: python
-
-  class Foo(object):
-    def __init__(self, a, b):
-      self.a = a
-      self.b = b
-
-Simply calling ``ray.put(Foo(1, 2))`` will fail with a message like
-
-.. code-block:: python
-
-  Ray does not know how to serialize the object <__main__.Foo object at 0x1077d7c50>.
-
-This can be addressed by calling ``ray.register_class(Foo)``.
-
-.. code-block:: python
-
-  import ray
-
-  ray.init()
-
-  # Define a custom class.
-  class Foo(object):
-    def __init__(self, a, b):
-      self.a = a
-      self.b = b
-
-  # Calling ray.register_class(Foo) ships the class definition to all of the
-  # workers so that workers know how to construct new Foo objects.
-  ray.register_class(Foo)
-
-  # Create a Foo object, place it in the object store, and retrieve it.
-  f = Foo(1, 2)
-  f_id = ray.put(f)
-  ray.get(f_id)  # prints <__main__.Foo at 0x1078128d0>
-
-Under the hood, ``ray.put`` places ``f.__dict__``, the dictionary of attributes
-of ``f``, into the object store instead of ``f`` itself. In this case, this is
-the dictionary, ``{"a": 1, "b": 2}``. Then during deserialization, ``ray.get``
-constructs a new ``Foo`` object from the dictionary of fields.
-
-This naive substitution won't work in all cases. For example, this scheme does
-not support Python objects of type ``function`` (e.g., ``f = lambda x: x +
-1``). In these cases, the call to ``ray.register_class`` will give an error
-message, and you should fall back to pickle.
-
-.. code-block:: python
-
-  # This call tells Ray to fall back to using pickle when it encounters objects
-  # of type function (we actually already do this under the hood).
-  f = lambda x: x + 1
-  ray.register_class(type(f), pickle=True)
-
-  f_new = ray.get(ray.put(f))
-  f_new(0)  # prints 1
-
-However, it's best to avoid using pickle for the efficiency reasons described
-above. If you find yourself needing to pickle certain objects, consider trying
-to use more efficient data structures like arrays.
-
-**Note:** Another setting where the naive replacement of an object with its
-``__dict__`` attribute fails is recursion, e.g., an object contains itself or
-multiple objects contain each other. To see more examples of this, see the
-section `Notes and Limitations`_.
+For a more general object, Ray will first attempt to serialize the object by
+unpacking the object as a dictionary of its fields. This behavior is not
+correct in all cases. If Ray cannot serialize the object as a dictionary of its
+fields, Ray will fall back to using pickle. However, using pickle will likely
+be inefficient.
 
 Notes and limitations
 ---------------------
@@ -166,9 +98,6 @@ Notes and limitations
   .. code-block:: bash
 
     This object exceeds the maximum recursion depth. It may contain itself recursively.
-
-- If you need to pass a custom class into a remote function, you should call
-  ``ray.register_class`` on the class **before defining the remote function**.
 
 - Whenever possible, use numpy arrays for maximum performance.
 

--- a/doc/source/serialization.rst
+++ b/doc/source/serialization.rst
@@ -52,8 +52,7 @@ What Objects Does Ray Handle
 ----------------------------
 
 Ray does not currently support serialization of arbitrary Python objects.  The
-set of Python objects that Ray can serialize using _`Apache Arrow` includes the
-following.
+set of Python objects that Ray can serialize using Arrow includes the following.
 
 1. Primitive types: ints, floats, longs, bools, strings, unicode, and numpy
    arrays.

--- a/examples/evolution_strategies/evolution_strategies.py
+++ b/examples/evolution_strategies/evolution_strategies.py
@@ -154,10 +154,6 @@ if __name__ == "__main__":
   ray.init(redis_address=args.redis_address,
            num_workers=(0 if args.redis_address is None else None))
 
-  # Tell Ray to serialize Config and Result objects.
-  ray.register_class(Config)
-  ray.register_class(Result)
-
   config = Config(l2coeff=0.005,
                   noise_stdev=0.02,
                   episodes_per_batch=10000,

--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -33,10 +33,6 @@ if __name__ == "__main__":
 
   ray.init(redis_address=args.redis_address)
 
-  ray.register_class(AtariRamPreprocessor)
-  ray.register_class(AtariPixelPreprocessor)
-  ray.register_class(NoPreprocessor)
-
   mdp_name = args.environment
   if args.environment == "Pong-v0":
     preprocessor = AtariPixelPreprocessor()

--- a/python/ray/experimental/array/distributed/core.py
+++ b/python/ray/experimental/array/distributed/core.py
@@ -72,10 +72,6 @@ class DistArray(object):
     return a[sliced]
 
 
-# Register the DistArray class with Ray so that it knows how to serialize it.
-ray.register_class(DistArray)
-
-
 @ray.remote
 def assemble(a):
   return a.assemble()

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-
 import ray.numbuf
 import ray.pickling as pickling
 
@@ -38,29 +36,29 @@ def check_serializable(cls):
     # This case works.
     return
   if not hasattr(cls, "__new__"):
-    raise RayNotDictionarySerializable("The class {} does not have a '__new__' attribute, and is "
-                    "probably an old-style class. We do not support this. "
-                    "Please either make it a new-style class by inheriting "
-                    "from 'object', or use "
-                    "'ray.register_class(cls, pickle=True)'. However, note "
-                    "that pickle is inefficient.".format(cls))
+    print("The class {} does not have a '__new__' attribute and is probably "
+          "an old-stye class. Please make it a new-style class by inheriting "
+          "from 'object'.")
+    raise RayNotDictionarySerializable("The class {} does not have a "
+                                       "'__new__' attribute and is probably "
+                                       "an old-style class. We do not support "
+                                       "this. Please make it a new-style "
+                                       "class by inheriting from 'object'."
+                                       .format(cls))
   try:
     obj = cls.__new__(cls)
   except:
-    raise RayNotDictionarySerializable("The class {} has overridden '__new__', so Ray may not be "
-                    "able to serialize it efficiently. Try using "
-                    "'ray.register_class(cls, pickle=True)'. However, note "
-                    "that pickle is inefficient.".format(cls))
+    raise RayNotDictionarySerializable("The class {} has overridden '__new__'"
+                                       ", so Ray may not be able to serialize "
+                                       "it efficiently.".format(cls))
   if not hasattr(obj, "__dict__"):
-    raise RayNotDictionarySerializable("Objects of the class {} do not have a `__dict__` "
-                    "attribute, so Ray cannot serialize it efficiently. Try "
-                    "using 'ray.register_class(cls, pickle=True)'. However, "
-                    "note that pickle is inefficient.".format(cls))
+    raise RayNotDictionarySerializable("Objects of the class {} do not have a "
+                                       "'__dict__' attribute, so Ray cannot "
+                                       "serialize it efficiently.".format(cls))
   if hasattr(obj, "__slots__"):
-    raise RayNotDictionarySerializable("The class {} uses '__slots__', so Ray may not be able to "
-                    "serialize it efficiently. Try using "
-                    "'ray.register_class(cls, pickle=True)'. However, note "
-                    "that pickle is inefficient.".format(cls))
+    raise RayNotDictionarySerializable("The class {} uses '__slots__', so Ray "
+                                       "may not be able to serialize it "
+                                       "efficiently.".format(cls))
 
 
 # This field keeps track of a whitelisted set of classes that Ray will
@@ -97,8 +95,6 @@ def add_class_to_whitelist(cls, class_id, pickle=False, custom_serializer=None,
     custom_deserializer: This argument is optional, but can be provided to
       deserialize objects of the class in a particular way.
   """
-  if cls in type_to_class_id:
-    print("Warning, ", cls, "already in type_to_class_id")
   type_to_class_id[cls] = class_id
   whitelisted_classes[class_id] = cls
   if pickle:

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -118,9 +118,7 @@ def serialize(obj):
   """
   if type(obj) not in type_to_class_id:
     raise RaySerializationException("Ray does not know how to serialize "
-                                    "objects of type {}. To fix this, call "
-                                    "'ray.register_class' with this class."
-                                    .format(type(obj)),
+                                    "objects of type {}.".format(type(obj)),
                                     obj)
   class_id = type_to_class_id[type(obj)]
 
@@ -160,9 +158,10 @@ def deserialize(serialized_obj):
   class_id = serialized_obj["_pytype_"]
 
   if class_id not in whitelisted_classes:
-    # If this happens, that means that the call to register_class, which should
-    # have added the class to the list of whitelisted classes, has not yet
-    # propagated to this worker. It should happen if we wait a little longer.
+    # If this happens, that means that the call to _register_class, which
+    # should have added the class to the list of whitelisted classes, has not
+    # yet propagated to this worker. It should happen if we wait a little
+    # longer.
     raise RayDeserializationException("The class {} is not one of the "
                                       "whitelisted classes.".format(class_id),
                                       class_id)

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -8,6 +8,22 @@ import ray.numbuf
 import ray.pickling as pickling
 
 
+class RaySerializationException(Exception):
+  def __init__(self, message, example_object):
+    Exception.__init__(self, message)
+    self.example_object = example_object
+
+
+class RayDeserializationException(Exception):
+  def __init__(self, message, class_id):
+    Exception.__init__(self, message)
+    self.class_id = class_id
+
+
+class RayNotDictionarySerializable(Exception):
+  pass
+
+
 def check_serializable(cls):
   """Throws an exception if Ray cannot serialize this class efficiently.
 
@@ -22,7 +38,7 @@ def check_serializable(cls):
     # This case works.
     return
   if not hasattr(cls, "__new__"):
-    raise Exception("The class {} does not have a '__new__' attribute, and is "
+    raise RayNotDictionarySerializable("The class {} does not have a '__new__' attribute, and is "
                     "probably an old-style class. We do not support this. "
                     "Please either make it a new-style class by inheriting "
                     "from 'object', or use "
@@ -31,17 +47,17 @@ def check_serializable(cls):
   try:
     obj = cls.__new__(cls)
   except:
-    raise Exception("The class {} has overridden '__new__', so Ray may not be "
+    raise RayNotDictionarySerializable("The class {} has overridden '__new__', so Ray may not be "
                     "able to serialize it efficiently. Try using "
                     "'ray.register_class(cls, pickle=True)'. However, note "
                     "that pickle is inefficient.".format(cls))
   if not hasattr(obj, "__dict__"):
-    raise Exception("Objects of the class {} do not have a `__dict__` "
+    raise RayNotDictionarySerializable("Objects of the class {} do not have a `__dict__` "
                     "attribute, so Ray cannot serialize it efficiently. Try "
                     "using 'ray.register_class(cls, pickle=True)'. However, "
                     "note that pickle is inefficient.".format(cls))
   if hasattr(obj, "__slots__"):
-    raise Exception("The class {} uses '__slots__', so Ray may not be able to "
+    raise RayNotDictionarySerializable("The class {} uses '__slots__', so Ray may not be able to "
                     "serialize it efficiently. Try using "
                     "'ray.register_class(cls, pickle=True)'. However, note "
                     "that pickle is inefficient.".format(cls))
@@ -49,15 +65,11 @@ def check_serializable(cls):
 
 # This field keeps track of a whitelisted set of classes that Ray will
 # serialize.
-whitelisted_classes = {}
+type_to_class_id = dict()
+whitelisted_classes = dict()
 classes_to_pickle = set()
-custom_serializers = {}
-custom_deserializers = {}
-
-
-def class_identifier(typ):
-  """Return a string that identifies this type."""
-  return "{}.{}".format(typ.__module__, typ.__name__)
+custom_serializers = dict()
+custom_deserializers = dict()
 
 
 def is_named_tuple(cls):
@@ -71,12 +83,13 @@ def is_named_tuple(cls):
   return all(type(n) == str for n in f)
 
 
-def add_class_to_whitelist(cls, pickle=False, custom_serializer=None,
+def add_class_to_whitelist(cls, class_id, pickle=False, custom_serializer=None,
                            custom_deserializer=None):
   """Add cls to the list of classes that we can serialize.
 
   Args:
     cls (type): The class that we can serialize.
+    class_id: A string of bytes used to identify the class.
     pickle (bool): True if the serialization should be done with pickle. False
       if it should be done efficiently with Ray.
     custom_serializer: This argument is optional, but can be provided to
@@ -84,28 +97,15 @@ def add_class_to_whitelist(cls, pickle=False, custom_serializer=None,
     custom_deserializer: This argument is optional, but can be provided to
       deserialize objects of the class in a particular way.
   """
-  class_id = class_identifier(cls)
+  if cls in type_to_class_id:
+    print("Warning, ", cls, "already in type_to_class_id")
+  type_to_class_id[cls] = class_id
   whitelisted_classes[class_id] = cls
   if pickle:
     classes_to_pickle.add(class_id)
   if custom_serializer is not None:
     custom_serializers[class_id] = custom_serializer
     custom_deserializers[class_id] = custom_deserializer
-
-
-# Here we define a custom serializer and deserializer for handling numpy
-# arrays that contain objects.
-def array_custom_serializer(obj):
-  return obj.tolist(), obj.dtype.str
-
-
-def array_custom_deserializer(serialized_obj):
-  return np.array(serialized_obj[0], dtype=np.dtype(serialized_obj[1]))
-
-
-add_class_to_whitelist(np.ndarray, pickle=False,
-                       custom_serializer=array_custom_serializer,
-                       custom_deserializer=array_custom_deserializer)
 
 
 def serialize(obj):
@@ -120,14 +120,17 @@ def serialize(obj):
     A dictionary that has the key "_pyttype_" to identify the class, and
       contains all information needed to reconstruct the object.
   """
-  class_id = class_identifier(type(obj))
-  if class_id not in whitelisted_classes:
-    raise Exception("Ray does not know how to serialize objects of type {}. "
-                    "To fix this, call 'ray.register_class' with this class."
-                    .format(type(obj)))
+  if type(obj) not in type_to_class_id:
+    raise RaySerializationException("Ray does not know how to serialize "
+                                    "objects of type {}. To fix this, call "
+                                    "'ray.register_class' with this class."
+                                    .format(type(obj)),
+                                    obj)
+  class_id = type_to_class_id[type(obj)]
+
   if class_id in classes_to_pickle:
     serialized_obj = {"data": pickling.dumps(obj)}
-  elif class_id in custom_serializers.keys():
+  elif class_id in custom_serializers:
     serialized_obj = {"data": custom_serializers[class_id](obj)}
   else:
     # Handle the namedtuple case.
@@ -137,8 +140,8 @@ def serialize(obj):
     elif hasattr(obj, "__dict__"):
       serialized_obj = obj.__dict__
     else:
-      raise Exception("We do not know how to serialize the object '{}'"
-                      .format(obj))
+      raise RaySerializationException("We do not know how to serialize the "
+                                      "object '{}'".format(obj), obj)
   result = dict(serialized_obj, **{"_pytype_": class_id})
   return result
 
@@ -154,12 +157,24 @@ def deserialize(serialized_obj):
 
   Returns:
     A Python object.
+
+  Raises:
+    An exception is raised if we do not know how to deserialize the object.
   """
   class_id = serialized_obj["_pytype_"]
+
+  if class_id not in whitelisted_classes:
+    # If this happens, that means that the call to register_class, which should
+    # have added the class to the list of whitelisted classes, has not yet
+    # propagated to this worker. It should happen if we wait a little longer.
+    raise RayDeserializationException("The class {} is not one of the "
+                                      "whitelisted classes.".format(class_id),
+                                      class_id)
   cls = whitelisted_classes[class_id]
+
   if class_id in classes_to_pickle:
     obj = pickling.loads(serialized_obj["data"])
-  elif class_id in custom_deserializers.keys():
+  elif class_id in custom_deserializers:
     obj = custom_deserializers[class_id](serialized_obj["data"])
   else:
     # In this case, serialized_obj should just be the __dict__ field.

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -196,3 +196,11 @@ def set_callbacks():
   callback.
   """
   ray.numbuf.register_callbacks(serialize, deserialize)
+
+
+def clear_state():
+  type_to_class_id.clear()
+  whitelisted_classes.clear()
+  classes_to_pickle.clear()
+  custom_serializers.clear()
+  custom_deserializers.clear()

--- a/python/ray/test/test_functions.py
+++ b/python/ray/test/test_functions.py
@@ -107,13 +107,3 @@ def python_mode_g(x):
 @ray.remote
 def no_op():
   pass
-
-
-class TestClass(object):
-  def __init__(self):
-    self.a = 5
-
-
-@ray.remote
-def test_unknown_type():
-  return TestClass()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -484,7 +484,7 @@ class Worker(object):
 
     Args:
       object_id: The ID of the object to store.
-      value: The to put in the object store.
+      value: The value to put in the object store.
       depth: The maximum number of classes to recursively register.
 
     Raises:
@@ -1663,7 +1663,7 @@ def disconnect(worker=global_worker):
 
 def register_class(cls, pickle=False, worker=global_worker):
   raise Exception("The function ray.register_class is deprecated. It should "
-                  "safe to remove any calls to this function.")
+                  "be safe to remove any calls to this function.")
 
 
 def _register_class(cls, pickle=False, worker=global_worker):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -566,15 +566,12 @@ class Worker(object):
         # currently have the worker lock, we need to release it so that the
         # import thread can acquire it.
         print("Waiting for an import to arrive.")
-        try:
+        if self.mode == WORKER_MODE:
           self.lock.release()
-          released = True
-        except RuntimeError:
-          released = False
         time.sleep(0.01)
-        if released:
+        if self.mode == WORKER_MODE:
           self.lock.acquire()
-        #TODO: IF WE WAIT TOO LONG PRINT A WARNING OR SOMETHING
+        # #TODO: IF WE WAIT TOO LONG PRINT A WARNING OR SOMETHING
 
   def get_object(self, object_ids):
     """Get the value or values in the object store associated with object_ids.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -564,6 +564,7 @@ class Worker(object):
       except serialization.RayDeserializationException as e:
         # Wait a little bit for the import thread to import the class ## BUG::: This doesn't work on workers because if this happens inside
         # of a task we are still holding on to worker.lock, which is preventing the import thread from working.
+        print("Waiting for an import time arrive.")
         time.sleep(0.01)
         #TODO: IF WE WAIT TOO LONG PRINT A WARNING OR SOMETHING
 
@@ -868,7 +869,7 @@ def initialize_numbuf(worker=global_worker):
     return ray.local_scheduler.ObjectID(serialized_obj)
 
   serialization.add_class_to_whitelist(
-      ray.local_scheduler.ObjectID, random_string(), pickle=False,
+      ray.local_scheduler.ObjectID, 20 * b"\x00", pickle=False,
       custom_serializer=objectid_custom_serializer,
       custom_deserializer=objectid_custom_deserializer)
 
@@ -881,7 +882,7 @@ def initialize_numbuf(worker=global_worker):
     return np.array(serialized_obj[0], dtype=np.dtype(serialized_obj[1]))
 
   serialization.add_class_to_whitelist(
-      np.ndarray, random_string(), pickle=False,
+      np.ndarray, 20 * b"\x01", pickle=False,
       custom_serializer=array_custom_serializer,
       custom_deserializer=array_custom_deserializer)
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1645,6 +1645,7 @@ def disconnect(worker=global_worker):
   worker.cached_functions_to_run = []
   worker.cached_remote_functions = []
   env._cached_environment_variables = []
+  serialization.clear_state()
 
 
 def register_class(cls, pickle=False, worker=global_worker):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -141,7 +141,6 @@ class ActorAPI(unittest.TestCase):
     class Foo(object):
       def __init__(self, x):
         self.x = x
-    ray.register_class(Foo)
 
     @ray.remote
     class Actor(object):

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -28,42 +28,6 @@ def wait_for_errors(error_type, num_errors, timeout=10):
   print("Timing out of wait.")
 
 
-class FailureTest(unittest.TestCase):
-  def testUnknownSerialization(self):
-    reload(test_functions)
-    ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
-
-    test_functions.test_unknown_type.remote()
-    wait_for_errors(b"task", 1)
-    self.assertEqual(len(relevant_errors(b"task")), 1)
-
-    ray.worker.cleanup()
-
-
-class TaskSerializationTest(unittest.TestCase):
-  def testReturnAndPassUnknownType(self):
-    ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
-
-    class Foo(object):
-      pass
-
-    # Check that returning an unknown type from a remote function raises an
-    # exception.
-    @ray.remote
-    def f():
-      return Foo()
-    self.assertRaises(Exception, lambda: ray.get(f.remote()))
-
-    # Check that passing an unknown type into a remote function raises an
-    # exception.
-    @ray.remote
-    def g(x):
-      return 1
-    self.assertRaises(Exception, lambda: g.remote(Foo()))
-
-    ray.worker.cleanup()
-
-
 class TaskStatusTest(unittest.TestCase):
   def testFailedTask(self):
     reload(test_functions)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -761,35 +761,6 @@ class APITest(unittest.TestCase):
 
     ray.worker.cleanup()
 
-  # def testPassingInfoToAllWorkers(self):
-  #   ray.init(num_workers=10, num_cpus=10)
-  #
-  #   def f(worker_info):
-  #     sys.path.append(worker_info)
-  #   ray.worker.global_worker.run_function_on_all_workers(f)
-  #
-  #   @ray.remote
-  #   def get_path():
-  #     time.sleep(1)
-  #     return sys.path
-  #   # Retrieve the values that we stored in the worker paths.
-  #   paths = ray.get([get_path.remote() for _ in range(10)])
-  #   # Add the driver's path to the list.
-  #   paths.append(sys.path)
-  #   worker_infos = [path[-1] for path in paths]
-  #   for worker_info in worker_infos:
-  #     self.assertEqual(list(worker_info.keys()), ["counter"])
-  #   counters = [worker_info["counter"] for worker_info in worker_infos]
-  #   # We use range(11) because the driver also runs the function.
-  #   self.assertEqual(set(counters), set(range(11)))
-  #
-  #   # Clean up the worker paths.
-  #   def f(worker_info):
-  #     sys.path.pop(-1)
-  #   ray.worker.global_worker.run_function_on_all_workers(f)
-  #
-  #   ray.worker.cleanup()
-
   def testLoggingAPI(self):
     ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2,15 +2,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import unittest
-import ray
+from collections import defaultdict, namedtuple
 import numpy as np
-import time
+import os
+import ray
+import re
 import shutil
 import string
 import sys
-from collections import defaultdict, namedtuple
+import time
+import unittest
 
 import ray.test.test_functions as test_functions
 
@@ -312,6 +313,10 @@ class APITest(unittest.TestCase):
 
     foo = ray.get(f.remote(Foo(7)))
     self.assertEqual(foo, Foo(7))
+
+    regex = re.compile(r"\d+\.\d*")
+    new_regex = ray.get(f.remote(regex))
+    self.assertEqual(regex, new_regex)
 
     # Test returning custom classes created on workers.
     @ray.remote


### PR DESCRIPTION
In this PR:

- When a worker/driver calls `ray.put` on a custom class (that the worker/driver hasn't seen before), the worker/driver will call `register_class` under the hood.
- When a worker/driver attempts to call `ray.get` on a custom class (that the worker/driver hasn't seen before), the worker/driver will just loop for a little while until it receives the class definition. The class definition must be on its way because if a worker/driver is trying to deserialize an object, then the object must have been serialized at some point, which would have triggered a call to `register_class`.
- `register_class` must export custom class definitions to the driver as well (because a worker may return a custom class from a task and the driver may try to deserialize it). To implement this, we give drivers an "import thread" (before this PR, only workers have import threads). Note that this means that functions that we export to run on all workers will actually run twice on the worker/driver that does the exporting. This could be changed if it is a problem.
- We identify custom classes with random IDs instead of with the class name. That way it is fine to define multiple classes with the same name.

Potential problems:
- Consider the remote function

    ```python
    @ray.remote
    def f():
      class Foo(object):
        pass
      return Foo()
    ```

    when we call `f.remote()`, the task will create a new `Foo` class and return a new `Foo` object. This will trigger a call to `register_class` under the hood every single time `f.remote` is executed.
- After this PR, all drivers run all `FunctionsToRun`. These `FunctionsToRun` are only used for two cases, adding things to the PYTHONPATH and registering class definitions. Currently there isn't any isolation between drivers for these things, so if two users are using the same cluster, they will each have each other's working directories added to their PYTHONPATHs.