### PR TITLE
Fix bug in actor task dispatch.

### DIFF
--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -913,6 +913,8 @@ void handle_actor_task_scheduled(LocalSchedulerState *state,
    * is responsible for. */
   ActorID actor_id = TaskSpec_actor_id(spec);
   DCHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
+  /* Push the task to the appropriate queue. */
+  add_task_to_actor_queue(state, algorithm_state, spec, task_spec_size, true);
   if (state->actor_mapping.count(actor_id) == 1) {
     /* This means that an actor has been assigned to this local scheduler, and a
      * task for that actor has been received by this local scheduler, but this
@@ -921,14 +923,12 @@ void handle_actor_task_scheduled(LocalSchedulerState *state,
      * happen, it's ok. */
     DCHECK(DBClientID_equal(state->actor_mapping[actor_id].local_scheduler_id,
                             get_db_client_id(state->db)));
+    dispatch_actor_task(state, algorithm_state, actor_id);
   } else {
     LOG_INFO(
         "handle_actor_task_scheduled called on local scheduler but the "
         "corresponding actor_map_entry is not present. This should be rare.");
   }
-  /* Push the task to the appropriate queue. */
-  add_task_to_actor_queue(state, algorithm_state, spec, task_spec_size, true);
-  dispatch_actor_task(state, algorithm_state, actor_id);
 }
 
 void handle_worker_available(LocalSchedulerState *state,


### PR DESCRIPTION
Consider a script which (A) creates and actor and (B) submits a task to that actor.

(A) will send a message, call it message (1) (via Redis) to the local scheduler responsible for the actor. When message (1) arrives, the local scheduler will create a new worker to run the actor.

(B) will send a message, call it message (2) to the local scheduler responsible for the actor. When message (2) arrives, the local scheduler will queue the task and potentially give it to the newly created worker to execute.

However, in the rare situation where message (2) arrives before message (1), we cannot give the task to the worker yet because the worker hasn't been created. However, it looks like we were trying to do so.

Now that I think about it, another fix would be to just change `dispatch_actor_task` to return without doing anything if message (1) has not arrived yet instead of failing. **UPDATE:** I changed it to this approach.