### PR TITLE
Print the driver stdout/stderr if we fail to decode it in jenkins.

### DIFF
--- a/test/jenkins_tests/multi_node_docker_test.py
+++ b/test/jenkins_tests/multi_node_docker_test.py
@@ -20,10 +20,20 @@ def wait_for_output(proc):
     A tuple of the stdout and stderr of the process as strings.
   """
   stdout_data, stderr_data = proc.communicate()
-  stdout_data = (stdout_data.decode("ascii") if stdout_data is not None
-                 else None)
-  stderr_data = (stderr_data.decode("ascii") if stderr_data is not None
-                 else None)
+
+  if stdout_data is not None:
+    try:
+      stdout_data = stdout_data.decode("ascii")
+    except UnicodeDecodeError:
+      raise Exception("Failed to decode stdout_data:", stdout_data)
+
+  if stderr_data is not None:
+    try:
+      stderr_data = stderr_data.decode("ascii")
+    except UnicodeDecodeError:
+
+      raise Exception("Failed to decode stderr_data:", stderr_data)
+
   return stdout_data, stderr_data
 
 

--- a/test/jenkins_tests/multi_node_docker_test.py
+++ b/test/jenkins_tests/multi_node_docker_test.py
@@ -23,12 +23,18 @@ def wait_for_output(proc):
 
   if stdout_data is not None:
     try:
+      # NOTE(rkn): This try/except block is here because I once saw an
+      # exception raised here and want to print more information if that
+      # happens again.
       stdout_data = stdout_data.decode("ascii")
     except UnicodeDecodeError:
       raise Exception("Failed to decode stdout_data:", stdout_data)
 
   if stderr_data is not None:
     try:
+      # NOTE(rkn): This try/except block is here because I once saw an
+      # exception raised here and want to print more information if that
+      # happens again.
       stderr_data = stderr_data.decode("ascii")
     except UnicodeDecodeError:
       raise Exception("Failed to decode stderr_data:", stderr_data)

--- a/test/jenkins_tests/multi_node_docker_test.py
+++ b/test/jenkins_tests/multi_node_docker_test.py
@@ -31,7 +31,6 @@ def wait_for_output(proc):
     try:
       stderr_data = stderr_data.decode("ascii")
     except UnicodeDecodeError:
-
       raise Exception("Failed to decode stderr_data:", stderr_data)
 
   return stdout_data, stderr_data


### PR DESCRIPTION
I'm referring to the failure here https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/830/console, which occurred in #539.