### PR TITLE
Make it possible to use actor definitions within remote functions and other actors.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -375,7 +375,7 @@ def make_actor(Class, num_cpus, num_gpus):
       # The following is needed so we can still access self.actor_methods.
       if attr in ["_manual_init", "_ray_actor_id", "_ray_actor_methods",
                   "_actor_method_invokers", "_ray_method_signatures"]:
-        return super(NewClass, self).__getattribute__(attr)
+        return object.__getattribute__(self, attr)
       if attr in self._ray_actor_methods.keys():
         return self._actor_method_invokers[attr]
       # There is no method with this name, so raise an exception.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -385,6 +385,9 @@ def make_actor(Class, num_cpus, num_gpus):
     def __repr__(self):
       return "Actor(" + self._ray_actor_id.hex() + ")"
 
+    def __reduce__(self):
+      raise Exception("Actor objects cannot be pickled.")
+
   return NewClass
 
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -415,6 +415,7 @@ class ActorNesting(unittest.TestCase):
     class Actor1(object):
       def __init__(self, x):
         self.x = x
+
       def get_val(self):
         return self.x
 
@@ -462,6 +463,7 @@ class ActorNesting(unittest.TestCase):
     class Actor1(object):
       def __init__(self, x):
         self.x = x
+
       def get_values(self):
         return self.x
 


### PR DESCRIPTION
This addresses #280.