### PR TITLE
Fix policy gradients for mujoco domains

### DIFF
--- a/examples/policy_gradient/reinforce/distributions.py
+++ b/examples/policy_gradient/reinforce/distributions.py
@@ -42,7 +42,7 @@ class Categorical(object):
 class DiagGaussian(object):
   def __init__(self, flat):
     self.flat = flat
-    mean, logstd = tf.split(1, 2, flat)
+    mean, logstd = tf.split(flat, 2, axis=1)
     self.mean = mean
     self.logstd = logstd
     self.std = tf.exp(logstd)


### PR DESCRIPTION
This fixes a problem with split that seems to have come up since tensorflow 1.0