### PR TITLE
Make builds with CMake incremental

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -15,10 +15,11 @@ include_directories(thirdparty/ae)
 set(COMMON_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/common.fbs")
 set(OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/format/)
 
-add_custom_target(gen_common_fbs ALL)
+set(COMMON_FBS_OUTPUT_FILES
+  "${OUTPUT_DIR}/common_generated.h")
 
 add_custom_command(
-  TARGET gen_common_fbs
+  OUTPUT ${COMMON_FBS_OUTPUT_FILES}
   # The --gen-object-api flag generates a C++ class MessageT for each
   # flatbuffers message Message, which can be used to store deserialized
   # messages in data structures. This is currently used for ObjectInfo for
@@ -27,6 +28,8 @@ add_custom_command(
   DEPENDS ${FBS_DEPENDS}
   COMMENT "Running flatc compiler on ${COMMON_FBS_SRC}"
   VERBATIM)
+
+add_custom_target(gen_common_fbs DEPENDS ${COMMON_FBS_OUTPUT_FILES})
 
 # Generate Python bindings for the flatbuffers objects.
 set(PYTHON_OUTPUT_DIR ${CMAKE_BINARY_DIR}/generated/)

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -29,14 +29,17 @@ include_directories("${CMAKE_CURRENT_LIST_DIR}/../common/format/")
 set(LOCAL_SCHEDULER_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/local_scheduler.fbs")
 set(OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/format/)
 
-add_custom_target(gen_local_scheduler_fbs ALL)
+set(LOCAL_SCHEDULER_FBS_OUTPUT_FILES
+  "${OUTPUT_DIR}/local_scheduler_generated.h")
 
 add_custom_command(
-  TARGET gen_local_scheduler_fbs
+  OUTPUT ${LOCAL_SCHEDULER_FBS_OUTPUT_FILES}
   COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${LOCAL_SCHEDULER_FBS_SRC}
   DEPENDS ${FBS_DEPENDS}
   COMMENT "Running flatc compiler on ${LOCAL_SCHEDULER_FBS_SRC}"
   VERBATIM)
+
+add_custom_target(gen_local_scheduler_fbs DEPENDS ${LOCAL_SCHEDULER_FBS_OUTPUT_FILES})
 
 add_dependencies(gen_local_scheduler_fbs flatbuffers_ep)
 

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -19,15 +19,17 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -D_XOPEN_SOURCE=500 -D_POSIX
 set(PLASMA_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/plasma.fbs")
 set(OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/format/)
 
-add_custom_target(gen_plasma_fbs ALL)
+set(PLASMA_FBS_OUTPUT_FILES
+  "${OUTPUT_DIR}/plasma_generated.h")
 
 add_custom_command(
-  TARGET gen_plasma_fbs
+  OUTPUT ${PLASMA_FBS_OUTPUT_FILES}
   COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${PLASMA_FBS_SRC}
   DEPENDS ${PLASMA_FBS_SRC}
   COMMENT "Running flatc compiler on ${PLASMA_FBS_SRC}"
-  VERBATIM
-)
+  VERBATIM)
+
+add_custom_target(gen_plasma_fbs DEPENDS ${PLASMA_FBS_OUTPUT_FILES})
 
 add_dependencies(gen_plasma_fbs flatbuffers_ep)
 


### PR DESCRIPTION
This PR makes it possible to do incremental builds using

```
cd python/ray/core
make
```

This is especially useful when combined with ```python setup.py develop``` and makes the development process of the C++ backend faster.