### PR TITLE
Don't link Python extensions to libpython

### DIFF
--- a/src/common/cmake/Common.cmake
+++ b/src/common/cmake/Common.cmake
@@ -43,46 +43,21 @@ message(STATUS "PYTHON_LIBRARY_NAME: " ${PYTHON_LIBRARY_NAME})
 execute_process(COMMAND ${CUSTOM_PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *; print(get_python_inc())"
                 OUTPUT_VARIABLE PYTHON_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "PYTHON_INCLUDE_DIRS: " ${PYTHON_INCLUDE_DIRS})
-# Now find the Python libraries. We'll start by looking near the Python
-# executable. If that fails, then we'll look near the Python include
-# directories.
-execute_process(COMMAND ${CUSTOM_PYTHON_EXECUTABLE} -c "import sys; print(sys.exec_prefix)"
-                OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS "PYTHON_PREFIX: " ${PYTHON_PREFIX})
-# The name ending in "m" is for miniconda.
-FIND_LIBRARY(PYTHON_LIBRARIES
-             NAMES "${PYTHON_LIBRARY_NAME}" "${PYTHON_LIBRARY_NAME}m"
-             HINTS "${PYTHON_PREFIX}"
-             PATH_SUFFIXES "lib" "libs"
-             NO_DEFAULT_PATH)
-message(STATUS "PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
-# If that failed, perhaps because the user is in a virtualenv, search around
-# the Python include directories.
-if(NOT PYTHON_LIBRARIES)
-  message(STATUS "Failed to find PYTHON_LIBRARIES near the Python executable, so now looking near the Python include directories.")
-  # The name ending in "m" is for miniconda.
-  FIND_LIBRARY(PYTHON_LIBRARIES
-               NAMES "${PYTHON_LIBRARY_NAME}" "${PYTHON_LIBRARY_NAME}m"
-               HINTS "${PYTHON_INCLUDE_DIRS}/../.."
-               PATH_SUFFIXES "lib" "libs"
-               NO_DEFAULT_PATH)
-  message(STATUS "PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
-endif()
+
 # If we found the Python libraries and the include directories, then continue
 # on. If not, then try find_package as a last resort, but it probably won't
 # work.
-if(PYTHON_LIBRARIES AND PYTHON_INCLUDE_DIRS)
+if(PYTHON_INCLUDE_DIRS)
   message(STATUS "The custom approach for finding Python succeeded.")
   SET(PYTHONLIBS_FOUND TRUE)
 else()
   message(WARNING "The custom approach for finding Python failed. Defaulting to find_package.")
   find_package(PythonInterp REQUIRED)
-  find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
+  find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
   set(CUSTOM_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE})
 endif()
 
 message(STATUS "Using CUSTOM_PYTHON_EXECUTABLE: " ${CUSTOM_PYTHON_EXECUTABLE})
-message(STATUS "Using PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
 message(STATUS "Using PYTHON_INCLUDE_DIRS: " ${PYTHON_INCLUDE_DIRS})
 
 # Common libraries

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -47,17 +47,15 @@ add_library(local_scheduler_library SHARED
   local_scheduler_extension.cc
   ../common/lib/python/common_extension.cc)
 
-get_filename_component(PYTHON_SHARED_LIBRARY ${PYTHON_LIBRARIES} NAME)
-if(APPLE)
-  add_custom_command(TARGET local_scheduler_library
-                     POST_BUILD COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${PYTHON_SHARED_LIBRARY} ${PYTHON_LIBRARIES} liblocal_scheduler_library.so)
-endif(APPLE)
-
 add_library(local_scheduler_client STATIC local_scheduler_client.cc)
 
 add_dependencies(local_scheduler_client gen_local_scheduler_fbs)
 
-target_link_libraries(local_scheduler_library local_scheduler_client common ${PYTHON_LIBRARIES})
+if(APPLE)
+  target_link_libraries(local_scheduler_library "-undefined dynamic_lookup" local_scheduler_client common)
+else(APPLE)
+  target_link_libraries(local_scheduler_library local_scheduler_client common)
+endif(APPLE)
 
 add_dependencies(local_scheduler_library gen_local_scheduler_fbs)
 

--- a/src/numbuf/CMakeLists.txt
+++ b/src/numbuf/CMakeLists.txt
@@ -58,22 +58,15 @@ add_library(numbuf SHARED
   python/src/pynumbuf/adapters/python.cc
   ${COMMON_EXTENSION})
 
-get_filename_component(PYTHON_SHARED_LIBRARY ${PYTHON_LIBRARIES} NAME)
-if(APPLE)
-  add_custom_command(TARGET numbuf
-      POST_BUILD COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${PYTHON_SHARED_LIBRARY} ${PYTHON_LIBRARIES} libnumbuf.so)
-endif(APPLE)
 
 if(APPLE)
-  target_link_libraries(numbuf ${ARROW_LIB} ${ARROW_PYTHON_LIB} ${PYTHON_LIBRARIES} -lpthread)
+  target_link_libraries(numbuf "-undefined dynamic_lookup" ${ARROW_LIB} ${ARROW_PYTHON_LIB} -lpthread)
 else()
-  target_link_libraries(numbuf -Wl,--whole-archive ${ARROW_LIB} -Wl,--no-whole-archive ${ARROW_PYTHON_LIB} ${PYTHON_LIBRARIES} -lpthread)
+  target_link_libraries(numbuf -Wl,--whole-archive ${ARROW_LIB} -Wl,--no-whole-archive ${ARROW_PYTHON_LIB} -lpthread)
 endif()
 
 if(HAS_PLASMA)
-  target_link_libraries(numbuf ${ARROW_LIB} ${ARROW_PYTHON_LIB} ${PYTHON_LIBRARIES} plasma_lib common ${FLATBUFFERS_STATIC_LIB} -lpthread)
-else()
-  target_link_libraries(numbuf ${ARROW_LIB} ${ARROW_PYTHON_LIB} ${PYTHON_LIBRARIES} -lpthread)
+  target_link_libraries(numbuf plasma_lib common)
 endif()
 
 install(TARGETS numbuf DESTINATION ${CMAKE_SOURCE_DIR}/numbuf/)

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -51,16 +51,10 @@ add_library(plasma SHARED
 
 add_dependencies(plasma gen_plasma_fbs)
 
-get_filename_component(PYTHON_SHARED_LIBRARY ${PYTHON_LIBRARIES} NAME)
 if(APPLE)
-  add_custom_command(TARGET plasma
-                     POST_BUILD COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${PYTHON_SHARED_LIBRARY} ${PYTHON_LIBRARIES} libplasma.so)
-endif(APPLE)
-
-if(APPLE)
-  target_link_libraries(plasma -Wl,-force_load,${FLATBUFFERS_STATIC_LIB} common ${PYTHON_LIBRARIES} ${FLATBUFFERS_STATIC_LIB} -lpthread)
+  target_link_libraries(plasma "-undefined dynamic_lookup" -Wl,-force_load,${FLATBUFFERS_STATIC_LIB} common  ${FLATBUFFERS_STATIC_LIB} -lpthread)
 else(APPLE)
-  target_link_libraries(plasma -Wl,--whole-archive ${FLATBUFFERS_STATIC_LIB} -Wl,--no-whole-archive common ${PYTHON_LIBRARIES} ${FLATBUFFERS_STATIC_LIB} -lpthread)
+  target_link_libraries(plasma -Wl,--whole-archive ${FLATBUFFERS_STATIC_LIB} -Wl,--no-whole-archive common ${FLATBUFFERS_STATIC_LIB} -lpthread)
 endif(APPLE)
 
 include_directories("${FLATBUFFERS_INCLUDE_DIR}")


### PR DESCRIPTION
It shouldn't be necessary, and might make the extension modules stop working when the Python binary is updated.