### PR TITLE
Have local scheduler ignore SIGCHLD so workers don't become zombies.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1130,6 +1130,9 @@ void start_server(const char *node_ip_address,
   /* Ignore SIGPIPE signals. If we don't do this, then when we attempt to write
    * to a client that has already died, the local scheduler could die. */
   signal(SIGPIPE, SIG_IGN);
+  /* Ignore SIGCHLD signals. If we don't do this, then worker processes will
+   * become zombies instead of dying gracefully. */
+  signal(SIGCHLD, SIG_IGN);
   int fd = bind_ipc_sock(socket_name, true);
   event_loop *loop = event_loop_create();
   g_state = LocalSchedulerState_init(


### PR DESCRIPTION
This may be another factor at play in #476. If we keep creating new worker processes, even if the workers are killed, they currently become zombies instead of dying gracefully. This PR changes that so that they don't become zombies.

See https://stackoverflow.com/questions/7171722/how-can-i-handle-sigchld-in-c/7171836#7171836.