### PR TITLE
Fix large memory tests.

### DIFF
--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -225,7 +225,7 @@ class Monitor(object):
     """
     message = DriverTableMessage.GetRootAsDriverTableMessage(data, 0)
     driver_id = message.DriverId()
-    log.info("Driver {} has been removed.".format(driver_id))
+    log.info("Driver {} has been removed.".format(binary_to_hex(driver_id)))
 
     # Get a list of the local schedulers.
     client_table = ray.global_state.client_table()

--- a/test/jenkins_tests/multi_node_tests/large_memory_test.py
+++ b/test/jenkins_tests/multi_node_tests/large_memory_test.py
@@ -3,48 +3,49 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from numpy.testing import assert_almost_equal
 
 import ray
 
 
 if __name__ == "__main__":
-  ray.init()
+  ray.init(num_workers=0)
 
-  A = np.zeros(2 ** 31 + 1, dtype="int8")
+  A = np.ones(2 ** 31 + 1, dtype="int8")
   a = ray.put(A)
-  assert_almost_equal(ray.get(a), A)
+  assert np.sum(ray.get(a)) == np.sum(A)
   del A
   del a
   print("Successfully put A.")
 
-  # B = {"hello": np.zeros(2 ** 30 + 1),
-  #      "world": np.ones(2 ** 30 + 1)}
-  # b = ray.put(B)
-  # assert_almost_equal(ray.get(b)["hello"], B["hello"])
-  # assert_almost_equal(ray.get(b)["world"], B["world"])
-  # del B
-  # del b
-  # print("Successfully put B.")
+  B = {"hello": np.zeros(2 ** 30 + 1),
+       "world": np.ones(2 ** 30 + 1)}
+  b = ray.put(B)
+  assert np.sum(ray.get(b)["hello"]) == np.sum(B["hello"])
+  assert np.sum(ray.get(b)["world"]) == np.sum(B["world"])
+  del B
+  del b
+  print("Successfully put B.")
 
-  # C = [np.ones(2 ** 30 + 1), 42.0 * np.ones(2 ** 30 + 1)]
-  # c = ray.put(C)
-  # assert_almost_equal(ray.get(c)[0], C[0])
-  # assert_almost_equal(ray.get(c)[1], C[1])
-  # del C
-  # del c
-  # print("Successfully put C.")
+  C = [np.ones(2 ** 30 + 1), 42.0 * np.ones(2 ** 30 + 1)]
+  c = ray.put(C)
+  assert np.sum(ray.get(c)[0]) == np.sum(C[0])
+  assert np.sum(ray.get(c)[1]) == np.sum(C[1])
+  del C
+  del c
+  print("Successfully put C.")
 
-  # D = (2 ** 30 + 1) * ["h"]
-  # d = ray.put(D)
-  # assert ray.get(d) == D
-  # del D
-  # del d
-  # print("Successfully put D.")
+  D = (2 ** 30 + 1) * ["h"]
+  d = ray.put(D)
+  assert ray.get(d)[0] == D[0]
+  assert ray.get(d)[-1] == D[-1]
+  del D
+  del d
+  print("Successfully put D.")
 
-  # E = (2 ** 30 + 1) * ("i",)
-  # e = ray.put(E)
-  # assert ray.get(e) == E
-  # del E
-  # del e
-  # print("Successfully put E.")
+  E = (2 ** 30 + 1) * ("i",)
+  e = ray.put(E)
+  assert ray.get(e)[0] == E[0]
+  assert ray.get(e)[-1] == E[-1]
+  del E
+  del e
+  print("Successfully put E.")

--- a/test/jenkins_tests/multi_node_tests/large_memory_test.py
+++ b/test/jenkins_tests/multi_node_tests/large_memory_test.py
@@ -33,19 +33,3 @@ if __name__ == "__main__":
   del C
   del c
   print("Successfully put C.")
-
-  D = (2 ** 30 + 1) * ["h"]
-  d = ray.put(D)
-  assert ray.get(d)[0] == D[0]
-  assert ray.get(d)[-1] == D[-1]
-  del D
-  del d
-  print("Successfully put D.")
-
-  E = (2 ** 30 + 1) * ("i",)
-  e = ray.put(E)
-  assert ray.get(e)[0] == E[0]
-  assert ray.get(e)[-1] == E[-1]
-  del E
-  del e
-  print("Successfully put E.")


### PR DESCRIPTION
This should address #619. By getting rid of the calls to `numpy.testing.assert_almost_equal`, we seem to be able to speed up the large memory tests a lot and reduce the memory footprint. Im not sure why that call is so expensive.

It looks like these tests use 50GB or so. That seems a bit high. You could probably get away with less memory since the object store will evict stuff if it rooms out of room.