### PR TITLE
Kill workers after they run GPU tasks.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -904,6 +904,7 @@ void process_message(event_loop *loop,
   } break;
   case MessageType_GetTask: {
     /* If this worker reports a completed task: account for resources. */
+    bool is_gpu_task = false;
     if (worker->task_in_progress != NULL) {
       TaskSpec *spec = Task_task_spec(worker->task_in_progress);
       /* Return dynamic resources back for the task in progress. TODO(rkn): We
@@ -915,13 +916,10 @@ void process_message(event_loop *loop,
               TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
         release_resources(state, worker, worker->cpus_in_use,
                           worker->gpus_in_use.size());
-
-        /* If the task was a GPU task, kill the worker to ensure that the GPU
-         * resources are released. */
-        if (TaskSpec_get_required_resource(spec, ResourceIndex_GPU) > 0) {
-          kill_worker(state, worker, false, true);
-        }
       }
+
+      is_gpu_task = TaskSpec_get_required_resource(spec, ResourceIndex_GPU) > 0;
+
       /* If we're connected to Redis, update tables. */
       if (state->db != NULL) {
         /* Update control state tables. */
@@ -938,7 +936,13 @@ void process_message(event_loop *loop,
     /* Let the scheduling algorithm process the fact that there is an available
      * worker. */
     if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
-      handle_worker_available(state, state->algorithm_state, worker);
+      /* If the task was a GPU task, kill the worker to ensure that the GPU
+       * resources are released. */
+      if (is_gpu_task) {
+        kill_worker(state, worker, false, true);
+      } else {
+        handle_worker_available(state, state->algorithm_state, worker);
+      }
     } else {
       handle_actor_worker_available(state, state->algorithm_state, worker);
     }


### PR DESCRIPTION
This does two things.

1. When a non-actor worker completes a GPU task, we kill the worker to force it to release GPU resources.
2. When we assign a GPU task to a non-actor worker, we start a new worker in the background to replace the worker that will be killed (the new worker is started before the worker is killed in order to reduce the time we spend waiting for the worker to start up).

This should address #616.