### PR TITLE
Allow remote functions to specify max executions and kill worker once limit is reached.

### DIFF
--- a/python/ray/test/test_utils.py
+++ b/python/ray/test/test_utils.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 
 import json
+import os
+import psutil
 import redis
 import time
 

--- a/python/ray/test/test_utils.py
+++ b/python/ray/test/test_utils.py
@@ -99,3 +99,33 @@ def _wait_for_event(event_name, redis_address, extra_buffer=0):
       time.sleep(extra_buffer)
       return events[event_name]
     time.sleep(0.1)
+
+
+def _pid_alive(pid):
+  """Check if the process with this PID is alive or not.
+
+  Args:
+    pid: The pid to check.
+
+  Returns:
+    This returns false if the process is dead or defunct. Otherwise, it returns
+      true.
+  """
+  try:
+    os.kill(pid, 0)
+  except OSError:
+    return False
+  else:
+    if psutil.Process(pid).status() == psutil.STATUS_ZOMBIE:
+      return False
+    else:
+      return True
+
+
+def wait_for_pid_to_exit(pid, timeout=20):
+  start_time = time.time()
+  while time.time() - start_time < timeout:
+    if not _pid_alive(pid):
+      return
+    time.sleep(0.1)
+  raise Exception("Timed out while waiting for process to exit.")

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import binascii
+import collections
 import numpy as np
 import sys
 
@@ -55,3 +56,11 @@ def binary_to_hex(identifier):
 
 def hex_to_binary(hex_identifier):
   return binascii.unhexlify(hex_identifier)
+
+
+FunctionProperties = collections.namedtuple("FunctionProperties",
+                                            ["num_return_vals",
+                                             "num_cpus",
+                                             "num_gpus",
+                                             "max_calls"])
+"""FunctionProperties: A named tuple storing remote functions information."""

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1833,6 +1833,7 @@ def main_loop(worker=global_worker):
       ray.worker.global_worker.local_scheduler_client.disconnect()
       os._exit(0)
 
+
 def _submit_task(function_id, func_name, args, worker=global_worker):
   """This is a wrapper around worker.submit_task.
 

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -549,15 +549,14 @@ void finish_task(LocalSchedulerState *state, LocalSchedulerClient *worker) {
     if (state->db != NULL) {
       /* Update control state tables. */
       Task_set_state(worker->task_in_progress, TASK_STATUS_DONE);
-      task_table_update(state->db, worker->task_in_progress, NULL, NULL,
-                        NULL);
+      task_table_update(state->db, worker->task_in_progress, NULL, NULL, NULL);
       /* The call to task_table_update takes ownership of the
        * task_in_progress, so we set the pointer to NULL so it is not used. */
-     } else {
-       Task_free(worker->task_in_progress);
-     }
-     worker->task_in_progress = NULL;
-   }
+    } else {
+      Task_free(worker->task_in_progress);
+    }
+    worker->task_in_progress = NULL;
+  }
 }
 
 void process_plasma_notification(event_loop *loop,

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -904,7 +904,7 @@ void process_message(event_loop *loop,
     finish_task(state, worker);
     CHECK(!worker->disconnected);
     worker->disconnected = true;
-    /* If the dicsonnected worker was not an actor, start a new worker to make
+    /* If the disconnected worker was not an actor, start a new worker to make
      * sure there are enough workers in the pool. */
     if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
       start_worker(state, NIL_ACTOR_ID);

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -56,8 +56,7 @@ void assign_task_to_worker(LocalSchedulerState *state,
  * @param worker The worker that finished the task.
  * @return Void.
  */
-void finish_task(LocalSchedulerState *state,
-                 LocalSchedulerClient *worker);
+void finish_task(LocalSchedulerState *state, LocalSchedulerClient *worker);
 
 /**
  * This is the callback that is used to process a notification from the Plasma

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -48,6 +48,17 @@ void assign_task_to_worker(LocalSchedulerState *state,
                            int64_t task_spec_size,
                            LocalSchedulerClient *worker);
 
+/*
+ * This function is called whenever a task has finished on one of the workers.
+ * It updates the resource accounting and the global state store.
+ *
+ * @param state The local scheduler state.
+ * @param worker The worker that finished the task.
+ * @return Void.
+ */
+void finish_task(LocalSchedulerState *state,
+                 LocalSchedulerClient *worker);
+
 /**
  * This is the callback that is used to process a notification from the Plasma
  * store that an object has been sealed.

--- a/test/jenkins_tests/multi_node_tests/many_drivers_test.py
+++ b/test/jenkins_tests/multi_node_tests/many_drivers_test.py
@@ -6,9 +6,9 @@ import os
 import time
 
 import ray
-from ray.test.multi_node_tests import (_wait_for_nodes_to_join,
-                                       _broadcast_event,
-                                       _wait_for_event)
+from ray.test.test_utils import (_wait_for_nodes_to_join,
+                                 _broadcast_event,
+                                 _wait_for_event)
 
 # This test should be run with 5 nodes, which have 0, 0, 5, 6, and 50 GPUs for
 # a total of 61 GPUs. It should be run with a large number of drivers (e.g.,

--- a/test/jenkins_tests/multi_node_tests/remove_driver_test.py
+++ b/test/jenkins_tests/multi_node_tests/remove_driver_test.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import psutil
 import time
 
 import ray

--- a/test/jenkins_tests/multi_node_tests/remove_driver_test.py
+++ b/test/jenkins_tests/multi_node_tests/remove_driver_test.py
@@ -7,36 +7,16 @@ import psutil
 import time
 
 import ray
-from ray.test.multi_node_tests import (_wait_for_nodes_to_join,
-                                       _broadcast_event,
-                                       _wait_for_event)
+from ray.test.test_utils import (_wait_for_nodes_to_join,
+                                 _broadcast_event,
+                                 _wait_for_event,
+                                 wait_for_pid_to_exit)
 
 # This test should be run with 5 nodes, which have 0, 1, 2, 3, and 4 GPUs for a
 # total of 10 GPUs. It should be run with 7 drivers. Drivers 2 through 6 must
 # run on different nodes so they can check if all the relevant workers on all
 # the nodes have been killed.
 total_num_nodes = 5
-
-
-def pid_alive(pid):
-  """Check if the process with this PID is alive or not.
-
-  Args:
-    pid: The pid to check.
-
-  Returns:
-    This returns false if the process is dead or defunct. Otherwise, it returns
-      true.
-  """
-  try:
-    os.kill(pid, 0)
-  except OSError:
-    return False
-  else:
-    if psutil.Process(pid).status() == psutil.STATUS_ZOMBIE:
-      return False
-    else:
-      return True
 
 
 def actor_event_name(driver_index, actor_index):
@@ -228,14 +208,6 @@ def cleanup_driver(redis_address, driver_index):
     for i in range(4):
       actors_one_gpu.append(try_to_create_actor(Actor1, driver_index,
                                                 10 + 3 + i))
-
-  def wait_for_pid_to_exit(pid, timeout=20):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-      if not pid_alive(pid):
-        return
-      time.sleep(0.1)
-    raise Exception("Timed out while waiting for process to exit.")
 
   removed_workers = 0
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -14,7 +14,7 @@ import time
 import unittest
 
 import ray.test.test_functions as test_functions
-import ray.test.test_utils as test_functions
+import ray.test.test_utils
 
 if sys.version_info >= (3, 0):
   from importlib import reload


### PR DESCRIPTION
This PR makes it possible to limit the number of executions of a given function on a worker before the worker is restarted by the local scheduler.

This can be useful if the function uses a library that leaks memory or if the task uses a gpu through tensorflow and the gpu memory cannot be reclaimed.