### PR TITLE
Increase socket listen backlog from 5 to 128.

### DIFF
--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -49,7 +49,7 @@ int bind_inet_sock(const int port, bool shall_listen) {
     close(socket_fd);
     return -1;
   }
-  if (shall_listen && listen(socket_fd, 5) == -1) {
+  if (shall_listen && listen(socket_fd, 128) == -1) {
     LOG_ERROR("Could not listen to socket %d", port);
     close(socket_fd);
     return -1;
@@ -90,7 +90,7 @@ int bind_ipc_sock(const char *socket_pathname, bool shall_listen) {
     close(socket_fd);
     return -1;
   }
-  if (shall_listen && listen(socket_fd, 5) == -1) {
+  if (shall_listen && listen(socket_fd, 128) == -1) {
     LOG_ERROR("Could not listen to socket %s", socket_pathname);
     close(socket_fd);
     return -1;

--- a/src/plasma/plasma_io.cc
+++ b/src/plasma/plasma_io.cc
@@ -122,7 +122,7 @@ int bind_ipc_sock(const std::string &pathname, bool shall_listen) {
     close(socket_fd);
     return -1;
   }
-  if (shall_listen && listen(socket_fd, 5) == -1) {
+  if (shall_listen && listen(socket_fd, 128) == -1) {
     ARROW_LOG(ERROR) << "Could not listen to socket " << pathname;
     close(socket_fd);
     return -1;

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1619,8 +1619,8 @@ void start_server(const char *store_socket_name,
       redis_primary_addr, redis_primary_port);
   CHECK(g_manager_state);
 
-  CHECK(listen(remote_sock, 5) != -1);
-  CHECK(listen(local_sock, 5) != -1);
+  CHECK(listen(remote_sock, 128) != -1);
+  CHECK(listen(local_sock, 128) != -1);
 
   LOG_DEBUG("Started server connected to store %s, listening on port %d",
             store_socket_name, port);


### PR DESCRIPTION
This should address #503.

Note that the problem in #503 could still occur with more nodes. Note that on some systems, the backlog may be silently truncated to 5, and on other systems maybe it is truncated to 128 (http://www.linuxjournal.com/files/linuxjournal.com/linuxjournal/articles/023/2333/2333s2.html).

It looks like the problem was that many plasma managers were all initiating connections to a single plasma manager. The single plasma manager could only process a few at a time, so the others had to retry. This manifested itself as a call to `connect` which took tens of seconds on some of the remote plasma managers.

**Note:** I also increased the backlogs for the `listen` calls that are for IPC, which should be unrelated to #503, but there's probably no harm in increasing them and it may save us some problems down the road.

**Note:** The change to `plasma_io.cc` should probably be ported to apache/arrow#742, or it may get overwritten.