### PR TITLE
Reducing the size of objects created for the global scheduler test.

### DIFF
--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -243,8 +243,8 @@ class TestGlobalScheduler(unittest.TestCase):
     num_tasks = 1000
     for _ in range(num_tasks):
       # Create a new object for each task.
-      data_size = np.random.randint(1 << 20)
-      metadata_size = np.random.randint(1 << 10)
+      data_size = np.random.randint(1 << 12)
+      metadata_size = np.random.randint(1 << 9)
       plasma_client = self.plasma_clients[0]
       object_dep, memory_buffer, metadata = create_object(plasma_client,
                                                           data_size,


### PR DESCRIPTION
This addresses #457 by reducing the size of the objects created by the global scheduler test. Prior to this PR, it was possible for the test to create a number of objects that exceeds plasma store capacity, when running on small memory instances (e.g., plasma store with 1GB capacity). This triggered reconstruction, which failed and killed the local scheduler. AS a result, during tearDown, the failure of the local scheduler resulted in a an assertion failure when checking whether all local schedulers are still live.
* Note that it is impossible for reconstruction to succeed in this case, because all objects are created by the unit test driver.

Testing: no errors or warnings after 94 iterations of the global scheduler test.
```
$ egrep OK log  |wc -l 
      94
✔ ~/devrepo/github/ray-mydev [globalsched-test-fix L|…850⚑ 14] 
01:38 $ egrep -i warn log  
✘-1 ~/devrepo/github/ray-mydev [globalsched-test-fix L|…850⚑ 14] 
01:38 $ egrep -i error log  
✘-1 ~/devrepo/github/ray-mydev [globalsched-test-fix L|…850⚑ 14] 
```
