### PR TITLE
Divide large plasma requests into smaller chunks, and wait longer before reissuing large requests.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -415,7 +415,7 @@ class Worker(object):
                        enumerate(final_results) if val is None)
     was_blocked = (len(unready_ids) > 0)
     # Try reconstructing any objects we haven't gotten yet. Try to get them
-    # until GET_TIMEOUT_MILLISECONDS milliseconds passes, then repeat.
+    # until at least GET_TIMEOUT_MILLISECONDS milliseconds passes, then repeat.
     while len(unready_ids) > 0:
       for unready_id in unready_ids:
         self.local_scheduler_client.reconstruct_object(unready_id)
@@ -427,8 +427,9 @@ class Worker(object):
       for i in range(0, len(object_ids_to_fetch), fetch_request_size):
         self.plasma_client.fetch(
             object_ids_to_fetch[i:(i + fetch_request_size)])
-      results = self.retrieve_and_deserialize(list(unready_ids.keys()),
-                                              GET_TIMEOUT_MILLISECONDS)
+      results = self.retrieve_and_deserialize(
+          list(unready_ids.keys()),
+          max([GET_TIMEOUT_MILLISECONDS, int(0.01 * len(unready_ids))]))
       # Remove any entries for objects we received during this iteration so we
       # don't retrieve the same object twice.
       for object_id, val in results:

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -871,6 +871,8 @@ void process_message(event_loop *loop,
                      int client_sock,
                      void *context,
                      int events) {
+  int64_t start_time = current_time_ms();
+
   LocalSchedulerClient *worker = (LocalSchedulerClient *) context;
   LocalSchedulerState *state = worker->local_scheduler_state;
 
@@ -1000,6 +1002,15 @@ void process_message(event_loop *loop,
   default:
     /* This code should be unreachable. */
     CHECK(0);
+  }
+
+  /* Print a warning if this method took too long. */
+  int64_t end_time = current_time_ms();
+  int64_t max_time_for_handler = 1000;
+  if (end_time - start_time > max_time_for_handler) {
+    LOG_WARN("process_message of type % " PRId64 " took %" PRId64
+             " milliseconds.",
+             type, end_time - start_time);
   }
 }
 

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1023,7 +1023,12 @@ int fetch_timeout_handler(event_loop *loop, timer_id id, void *context) {
   }
   free(object_ids_to_request);
 
-  return MANAGER_TIMEOUT;
+  /* Wait at least MANAGER_TIMEOUT before sending running this timeout handler
+   * again. But if we're waiting for a large number of objects, wait longer
+   * (e.g., 10 seconds for one million objects) so that we don't overwhelm other
+   * components like Redis with too many requests (and so that we don't
+   * overwhelm this manager with responses). */
+  return std::max(MANAGER_TIMEOUT, int(0.01 * num_object_ids));
 }
 
 bool is_object_local(PlasmaManagerState *state, ObjectID object_id) {

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1535,6 +1535,8 @@ void process_message(event_loop *loop,
                      int client_sock,
                      void *context,
                      int events) {
+  int64_t start_time = current_time_ms();
+
   ClientConnection *conn = (ClientConnection *) context;
 
   int64_t length;
@@ -1596,6 +1598,15 @@ void process_message(event_loop *loop,
     LOG_FATAL("invalid request %" PRId64, type);
   }
   free(data);
+
+  /* Print a warning if this method took too long. */
+  int64_t end_time = current_time_ms();
+  int64_t max_time_for_handler = 1000;
+  if (end_time - start_time > max_time_for_handler) {
+    LOG_WARN("process_message of type % " PRId64 " took %" PRId64
+             " milliseconds.",
+             type, end_time - start_time);
+  }
 }
 
 int heartbeat_handler(event_loop *loop, timer_id id, void *context) {


### PR DESCRIPTION
This should address #677.

This PR does two things:
1. We divide fetch and get requests into smaller chunks so that individual requests don't block the store or manager for a long time. **NOTE:** We should also do the same thing with wait requests, and we should consider doing this under the hood in the store/manager or in the plasma client instead of in Python.
2. We wait longer in the manager and worker before reissuing fetch requests if there are a ton of objects being requested. Currently, if a plasma manager is attempting to fetch 10 million objects from other managers, it will reissue 10 million requests every second. This can cause problems. It probably makes sense to wait longer before reissuing the requests if we are requesting tons of objects.

cc @stephanie-wang @atumanov 