### PR TITLE
Wait longer to reissue fetches from manager if there are many fetch requests.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -411,9 +411,9 @@ class Worker(object):
       # Do another fetch for objects that aren't available locally yet, in case
       # they were evicted since the last fetch.
       self.plasma_client.fetch(list(unready_ids.keys()))
-      results = self.retrieve_and_deserialize(list(unready_ids.keys()),
-                                              max([GET_TIMEOUT_MILLISECONDS,
-                                                   0.01 * len(unready_ids)]))
+      results = self.retrieve_and_deserialize(
+          list(unready_ids.keys()),
+          max([GET_TIMEOUT_MILLISECONDS, int(0.01 * len(unready_ids))]))
       # Remove any entries for objects we received during this iteration so we
       # don't retrieve the same object twice.
       for object_id, val in results:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -404,7 +404,7 @@ class Worker(object):
                        enumerate(final_results) if val is None)
     was_blocked = (len(unready_ids) > 0)
     # Try reconstructing any objects we haven't gotten yet. Try to get them
-    # until GET_TIMEOUT_MILLISECONDS milliseconds passes, then repeat.
+    # until at least GET_TIMEOUT_MILLISECONDS milliseconds passes, then repeat.
     while len(unready_ids) > 0:
       for unready_id in unready_ids:
         self.local_scheduler_client.reconstruct_object(unready_id)
@@ -412,7 +412,8 @@ class Worker(object):
       # they were evicted since the last fetch.
       self.plasma_client.fetch(list(unready_ids.keys()))
       results = self.retrieve_and_deserialize(list(unready_ids.keys()),
-                                              GET_TIMEOUT_MILLISECONDS)
+                                              max([GET_TIMEOUT_MILLISECONDS,
+                                                   0.01 * len(unready_ids)]))
       # Remove any entries for objects we received during this iteration so we
       # don't retrieve the same object twice.
       for object_id, val in results:

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1023,7 +1023,12 @@ int fetch_timeout_handler(event_loop *loop, timer_id id, void *context) {
   }
   free(object_ids_to_request);
 
-  return MANAGER_TIMEOUT;
+  /* Wait at least MANAGER_TIMEOUT before sending running this timeout handler
+   * again. But if we're waiting for a large number of objects, wait longer
+   * (e.g., 10 seconds for one million objects) so that we don't overwhelm other
+   * components like Redis with too many requests (and so that we don't
+   * overwhelm this manager with responses). */
+  return std::max(MANAGER_TIMEOUT, int(0.01 * num_object_ids));
 }
 
 bool is_object_local(PlasmaManagerState *state, ObjectID object_id) {


### PR DESCRIPTION
Currently, if a plasma manager is attempting to fetch 10 million objects from other managers, it will reissue 10 million requests every second. This can cause problems. It probably makes sense to wait longer before reissuing the requests if we are requesting tons of objects.

Now that I think about it, we should probably do the same thing in `get_object` in `worker.py` where we have a hardcoded `GET_TIMEOUT_MILLISECONDS = 1000`.

cc @stephanie-wang @atumanov