### PR TITLE
Debugging for policy gradients

### DIFF
--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -38,7 +38,8 @@ config = {"kl_coeff": 0.2,
           "num_agents": 5,
           "tensorboard_log_dir": "/tmp/ray",
           "full_trace_nth_sgd_batch": -1,
-          "full_trace_data_load": False}
+          "full_trace_data_load": False,
+          "use_tf_debugger": False}
 
 
 if __name__ == "__main__":

--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -87,9 +87,10 @@ if __name__ == "__main__":
     iter_start = time.time()
     print()  # Print newline for readability.
     print("== iteration", j)
-    checkpoint_path = saver.save(
-        agent.sess, config["model_checkpoint_file"] % j)
-    print("Model saved in file: %s" % checkpoint_path)
+    if config["model_checkpoint_file"]:
+      checkpoint_path = saver.save(
+          agent.sess, config["model_checkpoint_file"] % j)
+      print("Model saved in file: %s" % checkpoint_path)
     checkpointing_end = time.time()
     weights = ray.put(agent.get_weights())
     [a.load_weights.remote(weights) for a in agents]

--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     if config["model_checkpoint_file"]:
       checkpoint_path = saver.save(
           agent.sess, config["model_checkpoint_file"] % j)
-      print("Model saved in file: %s" % checkpoint_path)
+      print("Checkpoint saved in file: %s" % checkpoint_path)
     checkpointing_end = time.time()
     weights = ray.put(agent.get_weights())
     [a.load_weights.remote(weights) for a in agents]

--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -85,9 +85,10 @@ if __name__ == "__main__":
   saver = tf.train.Saver(max_to_keep=None)
   for j in range(config["max_iterations"]):
     iter_start = time.time()
-    print() # Print newline for readability.
+    print()  # Print newline for readability.
     print("== iteration", j)
-    checkpoint_path = saver.save(agent.sess, config["model_checkpoint_file"] % j)
+    checkpoint_path = saver.save(
+        agent.sess, config["model_checkpoint_file"] % j)
     print("Model saved in file: %s" % checkpoint_path)
     checkpointing_end = time.time()
     weights = ray.put(agent.get_weights())

--- a/examples/policy_gradient/examples/example.py
+++ b/examples/policy_gradient/examples/example.py
@@ -94,8 +94,7 @@ if __name__ == "__main__":
 
   for j in range(config["max_iterations"]):
     iter_start = time.time()
-    print()  # Print newline for readability.
-    print("== iteration", j)
+    print("\n== iteration", j)
     if config["model_checkpoint_file"]:
       checkpoint_path = saver.save(
           agent.sess, config["model_checkpoint_file"] % j)

--- a/examples/policy_gradient/reinforce/agent.py
+++ b/examples/policy_gradient/reinforce/agent.py
@@ -20,6 +20,11 @@ from reinforce.filter import MeanStdFilter
 from reinforce.rollout import rollouts, add_advantage_values
 from reinforce.utils import make_divisible_by, average_gradients
 
+# TODO(pcm): Make sure that both observation_filter and reward_filter
+# are correctly handled, i.e. (a) the values are accumulated accross
+# workers (if neccessary), (b) they are passed between all the methods
+# correctly and no default arguments are used and (c) they are saved
+# as part of the checkpoint so training can resume properly.
 
 # Each tower is a copy of the policy graph pinned to a specific device
 Tower = namedtuple("Tower", ["init_op", "grads", "policy"])

--- a/examples/policy_gradient/reinforce/agent.py
+++ b/examples/policy_gradient/reinforce/agent.py
@@ -22,11 +22,11 @@ from reinforce.utils import make_divisible_by, average_gradients
 
 # TODO(pcm): Make sure that both observation_filter and reward_filter
 # are correctly handled, i.e. (a) the values are accumulated accross
-# workers (if neccessary), (b) they are passed between all the methods
-# correctly and no default arguments are used and (c) they are saved
+# workers (if necessary), (b) they are passed between all the methods
+# correctly and no default arguments are used, and (c) they are saved
 # as part of the checkpoint so training can resume properly.
 
-# Each tower is a copy of the policy graph pinned to a specific device
+# Each tower is a copy of the policy graph pinned to a specific device.
 Tower = namedtuple("Tower", ["init_op", "grads", "policy"])
 
 

--- a/examples/policy_gradient/reinforce/agent.py
+++ b/examples/policy_gradient/reinforce/agent.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 import os
 
 from tensorflow.python.client import timeline
+from tensorflow.python import debug as tf_debug
 
 import ray
 
@@ -58,6 +59,9 @@ class Agent(object):
       config_proto = tf.ConfigProto(**config["tf_session_args"])
     self.preprocessor = preprocessor
     self.sess = tf.Session(config=config_proto)
+    if config["use_tf_debugger"] and not is_remote:
+      self.sess = tf_debug.LocalCLIDebugWrapperSession(self.sess)
+      self.sess.add_tensor_filter("has_inf_or_nan", tf_debug.has_inf_or_nan)
 
     # Defines the training inputs.
     self.kl_coeff = tf.placeholder(name="newkl", shape=(), dtype=tf.float32)


### PR DESCRIPTION
Run the example with
```
python example.py --env CartPole-v0 --use-tf-debugger=True
```
then the debugger comes up (there might be output from the workers, you can refresh the debugging screen by pressing "Enter") and you can type in:

```
run -f has_inf_or_nan
```

It will interrupt execution if NaNs are detected in the current computation. See [the TensorFlow documentation](https://www.tensorflow.org/programmers_guide/debugger) on how to explore things in the debugger.

This PR also adds checkpointing for models and the solver state, which can be convenient for debugging NaNs: Run the code in normal TensorFlow mode until you see NaNs and then load the last good solver state and perform the SGD steps in the debugger. Training the whole model in the debugger would be too slow.