### PR TITLE
Do resource bookkeeping for actor methods.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -971,9 +971,9 @@ void process_message(event_loop *loop,
        * workers explicitly yield and wait to be given back resources before
        * continuing execution. */
       TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-      acquire_resources(
-          state, worker,
-          TaskSpec_get_required_resource(spec, ResourceIndex_CPU), 0);
+      acquire_resources(state, worker,
+                        TaskSpec_get_required_resource(spec, ResourceIndex_CPU),
+                        0);
       /* Let the scheduling algorithm process the fact that the worker is
        * unblocked. */
       if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -992,7 +992,7 @@ void process_message(event_loop *loop,
   int64_t end_time = current_time_ms();
   int64_t max_time_for_handler = 1000;
   if (end_time - start_time > max_time_for_handler) {
-    LOG_WARN("process_message of type % " PRId64 " took %" PRId64
+    LOG_WARN("process_message of type %" PRId64 " took %" PRId64
              " milliseconds.",
              type, end_time - start_time);
   }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -474,12 +474,14 @@ void assign_task_to_worker(LocalSchedulerState *state,
                            TaskSpec *spec,
                            int64_t task_spec_size,
                            LocalSchedulerClient *worker) {
-  /* Acquire the necessary resources for running this task. TODO(rkn): We are
-   * currently ignoring resource bookkeeping for actor methods. */
-  if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
-    acquire_resources(state, worker,
-                      TaskSpec_get_required_resource(spec, ResourceIndex_CPU),
-                      TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
+  /* Acquire the necessary resources for running this task. */
+  acquire_resources(state, worker,
+                    TaskSpec_get_required_resource(spec, ResourceIndex_CPU),
+                    TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
+  /* Check that actor tasks don't have GPU requirements. Any necessary GPUs
+   * should already have been acquired by the actor worker. */
+  if (!ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
+    CHECK(TaskSpec_get_required_resource(spec, ResourceIndex_GPU) == 0);
   }
 
   CHECK(ActorID_equal(worker->actor_id, TaskSpec_actor_id(spec)));
@@ -525,15 +527,17 @@ void assign_task_to_worker(LocalSchedulerState *state,
 void finish_task(LocalSchedulerState *state, LocalSchedulerClient *worker) {
   if (worker->task_in_progress != NULL) {
     TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-    /* Return dynamic resources back for the task in progress. TODO(rkn): We
-     * are currently ignoring resource bookkeeping for actor methods. */
+    /* Return dynamic resources back for the task in progress. */
+    CHECK(worker->cpus_in_use ==
+          TaskSpec_get_required_resource(spec, ResourceIndex_CPU));
     if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
-      CHECK(worker->cpus_in_use ==
-            TaskSpec_get_required_resource(spec, ResourceIndex_CPU));
       CHECK(worker->gpus_in_use.size() ==
             TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
       release_resources(state, worker, worker->cpus_in_use,
                         worker->gpus_in_use.size());
+    } else {
+      CHECK(0 == TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
+      release_resources(state, worker, worker->cpus_in_use, 0);
     }
     /* If we're connected to Redis, update tables. */
     if (state->db != NULL) {
@@ -931,20 +935,21 @@ void process_message(event_loop *loop,
   case MessageType_ReconstructObject: {
     auto message = flatbuffers::GetRoot<ReconstructObject>(input);
     if (worker->task_in_progress != NULL && !worker->is_blocked) {
-      /* TODO(swang): For now, we don't handle blocked actors. */
+      /* If the worker was executing a task (i.e. non-driver) and it wasn't
+       * already blocked on an object that's not locally available, update its
+       * state to blocked. */
+      worker->is_blocked = true;
+      /* Return the CPU resources that the blocked worker was using, but not
+       * GPU resources. */
+      release_resources(state, worker, worker->cpus_in_use, 0);
+      /* Let the scheduling algorithm process the fact that the worker is
+       * blocked. */
       if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
-        /* If the worker was executing a task (i.e. non-driver) and it wasn't
-         * already blocked on an object that's not locally available, update its
-         * state to blocked. */
-        worker->is_blocked = true;
-        /* Return the CPU resources that the blocked worker was using, but not
-         * GPU resources. */
-        release_resources(state, worker, worker->cpus_in_use, 0);
-        /* Let the scheduling algorithm process the fact that the worker is
-         * blocked. */
         handle_worker_blocked(state, state->algorithm_state, worker);
-        print_worker_info("Reconstructing", state->algorithm_state);
+      } else {
+        handle_actor_worker_blocked(state, state->algorithm_state, worker);
       }
+      print_worker_info("Reconstructing", state->algorithm_state);
     }
     reconstruct_object(state, from_flatbuf(message->object_id()));
   } break;
@@ -955,25 +960,26 @@ void process_message(event_loop *loop,
   case MessageType_NotifyUnblocked: {
     /* TODO(rkn): A driver may call this as well, right? */
     if (worker->task_in_progress != NULL) {
-      /* TODO(swang): For now, we don't handle blocked actors. */
+      /* If the worker was executing a task (i.e. non-driver), update its
+       * state to not blocked. */
+      CHECK(worker->is_blocked);
+      worker->is_blocked = false;
+      /* Lease back the CPU resources that the blocked worker needs (note that
+       * it never released its GPU resources). TODO(swang): Leasing back the
+       * resources to blocked workers can cause us to transiently exceed the
+       * maximum number of resources. This could be fixed by having blocked
+       * workers explicitly yield and wait to be given back resources before
+       * continuing execution. */
+      TaskSpec *spec = Task_task_spec(worker->task_in_progress);
+      acquire_resources(
+          state, worker,
+          TaskSpec_get_required_resource(spec, ResourceIndex_CPU), 0);
+      /* Let the scheduling algorithm process the fact that the worker is
+       * unblocked. */
       if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
-        /* If the worker was executing a task (i.e. non-driver), update its
-         * state to not blocked. */
-        CHECK(worker->is_blocked);
-        worker->is_blocked = false;
-        /* Lease back the CPU resources that the blocked worker needs (note that
-         * it never released its GPU resources). TODO(swang): Leasing back the
-         * resources to blocked workers can cause us to transiently exceed the
-         * maximum number of resources. This could be fixed by having blocked
-         * workers explicitly yield and wait to be given back resources before
-         * continuing execution. */
-        TaskSpec *spec = Task_task_spec(worker->task_in_progress);
-        acquire_resources(
-            state, worker,
-            TaskSpec_get_required_resource(spec, ResourceIndex_CPU), 0);
-        /* Let the scheduling algorithm process the fact that the worker is
-         * unblocked. */
         handle_worker_unblocked(state, state->algorithm_state, worker);
+      } else {
+        handle_actor_worker_unblocked(state, state->algorithm_state, worker);
       }
     }
     print_worker_info("Worker unblocked", state->algorithm_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -303,11 +303,11 @@ bool dispatch_actor_task(LocalSchedulerState *state,
     return false;
   }
   /* If there are not enough resources available, we cannot assign the task. */
-  CHECK(0 == TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU));
-  if (!check_dynamic_resources(
-          state,
-          TaskSpec_get_required_resource(first_task.spec, ResourceIndex_CPU),
-          0)) {
+  CHECK(0 ==
+        TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU));
+  if (!check_dynamic_resources(state, TaskSpec_get_required_resource(
+                                          first_task.spec, ResourceIndex_CPU),
+                               0)) {
     return false;
   }
   /* Assign the first task in the task queue to the worker and mark the worker
@@ -1068,8 +1068,7 @@ void handle_worker_unblocked(LocalSchedulerState *state,
 
 void handle_actor_worker_unblocked(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
-                                   LocalSchedulerClient *worker) {
-}
+                                   LocalSchedulerClient *worker) {}
 
 void handle_object_available(LocalSchedulerState *state,
                              SchedulingAlgorithmState *algorithm_state,

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -277,8 +277,8 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   /* Make sure this worker actually is an actor. */
   CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
   /* Make sure this actor actually has pending tasks. */
-  CHECK(algorithm_state->actors_with_pending_tasks.find(actor_id)
-        != algorithm_state->actors_with_pending_tasks.end());
+  CHECK(algorithm_state->actors_with_pending_tasks.find(actor_id) !=
+        algorithm_state->actors_with_pending_tasks.end());
   /* Make sure this actor belongs to this local scheduler. */
   if (state->actor_mapping.count(actor_id) != 1) {
     /* The creation notification for this actor has not yet arrived at the local

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -261,6 +261,9 @@ void remove_actor(SchedulingAlgorithmState *algorithm_state, ActorID actor_id) {
   delete entry.task_queue;
   /* Remove the entry from the hash table. */
   algorithm_state->local_actor_infos.erase(actor_id);
+
+  /* Remove the actor ID from the set of actors with pending tasks. */
+  algorithm_state->actors_with_pending_tasks.erase(actor_id);
 }
 
 /**

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -663,11 +663,16 @@ void dispatch_all_tasks(LocalSchedulerState *state,
   dispatch_tasks(state, algorithm_state);
 
   /* Attempt to dispatch actor tasks. */
-  for (auto actor_id : algorithm_state->actors_with_pending_tasks) {
+  auto it = algorithm_state->actors_with_pending_tasks.begin();
+  while (it != algorithm_state->actors_with_pending_tasks.end()) {
     /* Terminate early if there are no more resources available. */
     if (!resources_available(state)) {
       break;
     }
+    /* We increment the iterator ahead of time because the call to
+     * dispatch_actor_task may invalidate the current iterator. */
+    ActorID actor_id = *it;
+    it++;
     /* Dispatch tasks for the current actor. */
     dispatch_actor_task(state, algorithm_state, actor_id);
   }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -276,9 +276,11 @@ bool dispatch_actor_task(LocalSchedulerState *state,
                          ActorID actor_id) {
   /* Make sure this worker actually is an actor. */
   CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
-  /* Make sure this actor actually has pending tasks. */
-  CHECK(algorithm_state->actors_with_pending_tasks.find(actor_id) !=
-        algorithm_state->actors_with_pending_tasks.end());
+  /* Return if this actor doesn't have any pending tasks. */
+  if (algorithm_state->actors_with_pending_tasks.find(actor_id) ==
+      algorithm_state->actors_with_pending_tasks.end()) {
+    return false;
+  }
   /* Make sure this actor belongs to this local scheduler. */
   if (state->actor_mapping.count(actor_id) != 1) {
     /* The creation notification for this actor has not yet arrived at the local

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -38,8 +38,6 @@ struct ObjectEntry {
 /** This struct contains information about a specific actor. This struct will be
  *  used inside of a hash table. */
 typedef struct {
-  /** The ID of the actor. This is used as a key in the hash table. */
-  ActorID actor_id;
   /** The number of tasks that have been executed on this actor so far. This is
    *  used to guarantee the in-order execution of tasks on actors (in the order
    *  that the tasks were submitted). This is currently meaningful because we

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -218,6 +218,19 @@ void handle_worker_blocked(LocalSchedulerState *state,
                            LocalSchedulerClient *worker);
 
 /**
+ * This function is called when an actor that was executing a task becomes
+ * blocked on an object that isn't available locally yet.
+ *
+ * @param state The state of the local scheduler.
+ * @param algorithm_state State maintained by the scheduling algorithm.
+ * @param worker The worker that is blocked.
+ * @return Void.
+ */
+void handle_actor_worker_blocked(LocalSchedulerState *state,
+                                 SchedulingAlgorithmState *algorithm_state,
+                                 LocalSchedulerClient *worker);
+
+/**
  * This function is called when a worker that was blocked on an object that
  * wasn't available locally yet becomes unblocked.
  *
@@ -229,6 +242,19 @@ void handle_worker_blocked(LocalSchedulerState *state,
 void handle_worker_unblocked(LocalSchedulerState *state,
                              SchedulingAlgorithmState *algorithm_state,
                              LocalSchedulerClient *worker);
+
+/**
+ * This function is called when an actor that was blocked on an object that
+ * wasn't available locally yet becomes unblocked.
+ *
+ * @param state The state of the local scheduler.
+ * @param algorithm_state State maintained by the scheduling algorithm.
+ * @param worker The worker that is now unblocked.
+ * @return Void.
+ */
+void handle_actor_worker_unblocked(LocalSchedulerState *state,
+                                   SchedulingAlgorithmState *algorithm_state,
+                                   LocalSchedulerClient *worker);
 
 /**
  * Process the fact that a driver has been removed. This will remove all of the

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1602,7 +1602,7 @@ void process_message(event_loop *loop,
   int64_t end_time = current_time_ms();
   int64_t max_time_for_handler = 1000;
   if (end_time - start_time > max_time_for_handler) {
-    LOG_WARN("process_message of type % " PRId64 " took %" PRId64
+    LOG_WARN("process_message of type %" PRId64 " took %" PRId64
              " milliseconds.",
              type, end_time - start_time);
   }

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -993,6 +993,8 @@ class ActorsWithGPUs(unittest.TestCase):
     gpu_ids = ray.get(results)
     self.assertEqual(set(gpu_ids), set(range(10)))
 
+    ray.worker.cleanup()
+
   def testActorsAndTaskResourceBookkeeping(self):
     ray.init(num_cpus=1)
 


### PR DESCRIPTION
This should address #379.

Recall that GPU resources are not associated with actor methods and are instead associated with actors for the lifetimes of the actors.

This PR does the following.
- Actor tasks are only dispatched if there are enough CPU resources to run them.
- When an actor task blocks in a call to `ray.get`, it returns its CPU (not GPU) resources to the local scheduler.
- When an actor task gets unblocked, it reacquires CPU resources.
- When an actor task finishes, it returns its CPU resources to the local scheduler.