### PR TITLE
Divide up large fetch requests from local scheduler, also print warni…

### DIFF
--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -554,8 +554,8 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
   for (int j = 0; j < num_object_ids; j += fetch_request_size) {
     int num_objects_in_request =
         std::min(num_object_ids, j + fetch_request_size) - j;
-    ARROW_CHECK_OK(state->plasma_conn->Fetch(num_objects_in_request,
-                                             &object_ids[j]));
+    ARROW_CHECK_OK(
+        state->plasma_conn->Fetch(num_objects_in_request, &object_ids[j]));
   }
   for (int k = 0; k < num_object_ids; ++k) {
     reconstruct_object(state, object_ids[k]);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -565,7 +565,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
   /* Print a warning if this method took too long. */
   int64_t end_time = current_time_ms();
   int64_t max_time_for_handler = 1000;
-  if (end_time - start_time > -1) {
+  if (end_time - start_time > max_time_for_handler) {
     LOG_WARN("fetch_object_timeout_handler took %" PRId64 " milliseconds.",
              end_time - start_time);
   }


### PR DESCRIPTION
…ng if fetch handler is slow.

This is similar to #678.

Note that the loop which calls `reconstruct_object` on each object ID probably needs to be broken down into smaller pieces or it could take too long.