### PR TITLE
Don't reconstruct all objects in every fetch request in local scheduler.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1200,11 +1200,11 @@ void start_server(const char *node_ip_address,
                          heartbeat_handler, g_state);
   }
   /* Create a timer for fetching queued tasks' missing object dependencies. */
-  event_loop_add_timer(loop, LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS,
+  event_loop_add_timer(loop, kLocalSchedulerFetchTimeoutMilliseconds,
                        fetch_object_timeout_handler, g_state);
   /* Create a timer for initiating the reconstruction of tasks' missing object
    * dependencies. */
-  event_loop_add_timer(loop, LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS,
+  event_loop_add_timer(loop, kLocalSchedulerReconstructionTimeoutMilliseconds,
                        reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -395,6 +395,9 @@ LocalSchedulerState *LocalSchedulerState_init(
   /* Initialize the time at which the previous heartbeat was sent. */
   state->previous_heartbeat_time = current_time_ms();
 
+  /* Initialize the reconstruct counter. */
+  state->reconstruct_counter = 0;
+
   return state;
 }
 

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -395,9 +395,6 @@ LocalSchedulerState *LocalSchedulerState_init(
   /* Initialize the time at which the previous heartbeat was sent. */
   state->previous_heartbeat_time = current_time_ms();
 
-  /* Initialize the reconstruct counter. */
-  state->reconstruct_counter = 0;
-
   return state;
 }
 

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1202,6 +1202,10 @@ void start_server(const char *node_ip_address,
   /* Create a timer for fetching queued tasks' missing object dependencies. */
   event_loop_add_timer(loop, LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS,
                        fetch_object_timeout_handler, g_state);
+  /* Create a timer for initiating the reconstruction of tasks' missing object
+   * dependencies. */
+  event_loop_add_timer(loop, LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS,
+                       reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);
 }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -538,7 +538,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
   /* Only try the fetches if we are connected to the object store manager. */
   if (!plasma_manager_is_connected(state->plasma_conn)) {
     LOG_INFO("Local scheduler is not connected to a object store manager");
-    return LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS;
+    return kLocalSchedulerFetchTimeoutMilliseconds;
   }
 
   std::vector<ObjectID> object_id_vec;
@@ -571,7 +571,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context) {
    * this timeout handler again. But if we're waiting for a large number of
    * objects, wait longer (e.g., 10 seconds for one million objects) so that we
    * don't overwhelm the plasma manager. */
-  return std::max(LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS,
+  return std::max(kLocalSchedulerFetchTimeoutMilliseconds,
                   int64_t(0.01 * num_object_ids));
 }
 
@@ -609,7 +609,7 @@ int reconstruct_object_timeout_handler(event_loop *loop,
              end_time - start_time);
   }
 
-  return LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS;
+  return kLocalSchedulerReconstructionTimeoutMilliseconds;
 }
 
 /**

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -599,8 +599,8 @@ int reconstruct_object_timeout_handler(event_loop *loop,
   int64_t num_to_reconstruct = std::min(num_object_ids, max_num_to_reconstruct);
   /* Initiate reconstruction for some of the missing task dependencies. */
   for (int64_t i = 0; i < num_to_reconstruct; i++) {
-    reconstruct_object(
-        state, object_ids[(reconstruct_counter + i) % num_object_ids]);
+    reconstruct_object(state,
+                       object_ids[(reconstruct_counter + i) % num_object_ids]);
   }
   reconstruct_counter += num_to_reconstruct;
 

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -592,7 +592,7 @@ int reconstruct_object_timeout_handler(event_loop *loop,
 
   /* If the set is empty, repopulate it. */
   if (object_ids_to_reconstruct.size() == 0) {
-    for (auto const &entry : state->algorithm_state->remote_objects){
+    for (auto const &entry : state->algorithm_state->remote_objects) {
       object_ids_to_reconstruct.insert(entry.first);
     }
   }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -592,7 +592,7 @@ int reconstruct_object_timeout_handler(event_loop *loop,
   int64_t num_object_ids = object_id_vec.size();
 
   int64_t max_num_to_reconstruct = 10000;
-  int64_t num_to_reconstruct = std::min(num_object_ids, num_to_reconstruct);
+  int64_t num_to_reconstruct = std::min(num_object_ids, max_num_to_reconstruct);
   /* Initiate reconstruction for some of the missing task dependencies. */
   for (int64_t i = 0; i < num_to_reconstruct; i++) {
     reconstruct_object(

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -589,16 +589,16 @@ int reconstruct_object_timeout_handler(event_loop *loop,
   for (auto const &entry : state->algorithm_state->remote_objects) {
     object_id_vec.push_back(entry.first);
   }
-
   int64_t num_object_ids = object_id_vec.size();
 
-  int64_t num_to_reconstruct = 10000;
-
-  for (int64_t k = 0; k < std::min(num_object_ids, num_to_reconstruct); ++k) {
+  int64_t max_num_to_reconstruct = 10000;
+  int64_t num_to_reconstruct = std::min(num_object_ids, num_to_reconstruct);
+  /* Initiate reconstruction for some of the missing task dependencies. */
+  for (int64_t i = 0; i < num_to_reconstruct; i++) {
     reconstruct_object(
-        state, object_id_vec[(reconstruct_counter + k) % num_object_ids]);
-    reconstruct_counter += 1;
+        state, object_id_vec[(reconstruct_counter + i) % num_object_ids]);
   }
+  reconstruct_counter += num_to_reconstruct;
 
   /* Print a warning if this method took too long. */
   int64_t end_time = current_time_ms();

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -8,12 +8,12 @@
 /* The duration that the local scheduler will wait before reinitiating a fetch
  * request for a missing task dependency. This time may adapt based on the
  * number of missing task dependencies. */
-static const int64_t LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS = 1000;
+constexpr int64_t kLocalSchedulerFetchTimeoutMilliseconds = 1000;
 /* The duration that the local scheduler will wait between initiating
  * reconstruction calls for missing task dependencies. If there are many missing
  * task dependencies, we will only iniate reconstruction calls for some of them
  * each time. */
-static const int64_t LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS = 1000;
+constexpr int64_t kLocalSchedulerReconstructionTimeoutMilliseconds = 1000;
 
 /* ==== The scheduling algorithm ====
  *
@@ -277,7 +277,7 @@ void handle_driver_removed(LocalSchedulerState *state,
 
 /**
  * This function fetches queued task's missing object dependencies. It is
- * called every LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS.
+ * called every kLocalSchedulerFetchTimeoutMilliseconds.
  *
  * @param loop The local scheduler's event loop.
  * @param id The ID of the timer that triggers this function.
@@ -290,7 +290,7 @@ int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context);
 /**
  * This function initiates reconstruction for task's missing object
  * dependencies. It is called every
- * LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS, but it may not initiate
+ * kLocalSchedulerReconstructionTimeoutMilliseconds, but it may not initiate
  * reconstruction for every missing object.
  *
  * @param loop The local scheduler's event loop.

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -6,9 +6,14 @@
 #include "state/local_scheduler_table.h"
 
 /* The duration that the local scheduler will wait before reinitiating a fetch
- * request for a missing task dependency. TODO(rkn): We may want this to be
- * adaptable based on the load on the local scheduler. */
-#define LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS 1000
+ * request for a missing task dependency. This time may adapt based on the
+ * number of missing task dependencies. */
+static const int64_t LOCAL_SCHEDULER_FETCH_TIMEOUT_MILLISECONDS = 1000;
+/* The duration that the local scheduler will wait between initiating
+ * reconstruction calls for missing task dependencies. If there are many missing
+ * task dependencies, we will only iniate reconstruction calls for some of them
+ * each time. */
+static const int64_t LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS = 1000;
 
 /* ==== The scheduling algorithm ====
  *
@@ -281,6 +286,22 @@ void handle_driver_removed(LocalSchedulerState *state,
  *         next invocation of the function.
  */
 int fetch_object_timeout_handler(event_loop *loop, timer_id id, void *context);
+
+/**
+ * This function initiates reconstruction for task's missing object
+ * dependencies. It is called every
+ * LOCAL_SCHEDULER_RECONSTRUCT_TIMEOUT_MILLISECONDS, but it may not initiate
+ * reconstruction for every missing object.
+ *
+ * @param loop The local scheduler's event loop.
+ * @param id The ID of the timer that triggers this function.
+ * @param context The function's context.
+ * @return An integer representing the time interval in seconds before the
+ *         next invocation of the function.
+ */
+int reconstruct_object_timeout_handler(event_loop *loop,
+                                       timer_id id,
+                                       void *context);
 
 /**
  * A helper function to print debug information about the current state and

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -76,12 +76,6 @@ struct LocalSchedulerState {
   /** The time (in milliseconds since the Unix epoch) when the most recent
    *  heartbeat was sent. */
   int64_t previous_heartbeat_time;
-  /** This is used to track how many reconstruct calls have been made. Since
-   *  reconstruct_object_timeout_handler doesn't necessarily call reconstruct on
-   *  all missinng object dependencies, this is used to ensure that the
-   *  different calls to reconstruct_object_timeout_handler cycle through the
-   *  various missing object dependencies. */
-  int64_t reconstruct_counter;
 };
 
 /** Contains all information associated with a local scheduler client. */

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -76,6 +76,12 @@ struct LocalSchedulerState {
   /** The time (in milliseconds since the Unix epoch) when the most recent
    *  heartbeat was sent. */
   int64_t previous_heartbeat_time;
+  /** This is used to track how many reconstruct calls have been made. Since
+   *  reconstruct_object_timeout_handler doesn't necessarily call reconstruct on
+   *  all missinng object dependencies, this is used to ensure that the
+   *  different calls to reconstruct_object_timeout_handler cycle through the
+   *  various missing object dependencies. */
+  int64_t reconstruct_counter;
 };
 
 /** Contains all information associated with a local scheduler client. */

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1022,9 +1022,9 @@ int fetch_timeout_handler(event_loop *loop, timer_id id, void *context) {
   }
   free(object_ids_to_request);
 
-  /* Wait at least MANAGER_TIMEOUT before sending running this timeout handler
-   * again. But if we're waiting for a large number of objects, wait longer
-   * (e.g., 10 seconds for one million objects) so that we don't overwhelm other
+  /* Wait at least MANAGER_TIMEOUT before running this timeout handler again.
+   * But if we're waiting for a large number of objects, wait longer (e.g., 10
+   * seconds for one million objects) so that we don't overwhelm other
    * components like Redis with too many requests (and so that we don't
    * overwhelm this manager with responses). */
   return std::max(MANAGER_TIMEOUT, int(0.01 * num_object_ids));


### PR DESCRIPTION
This might address #685.

This PR does a few things.
1. The local scheduler used to have a timer which would fire every second and would do two things: a) send a fetch request for all missing object dependencies to the plasma manager, b) call `reconstruct` for all missing object dependencies. This PR separates these two functionalities into two separate timer events: `fetch_object_timeout_handler` and `reconstruct_object_timeout_handler`.
2. For `fetch_object_timeout_handler`, the behavior is the same, but we manually divide large requests into chunks of size 10000 to avoid overwhelming the plasma manager with a single fetch request. If there are many missing objects, we wait longer before running the handler again.
3. For `reconstruct_object_timeout_handler`, we call `reconstruct` on a maximum of 10000 missing objects. This handler still goes off once every second, and it cycles through the missing objects.