### PR TITLE
Fix compilation on CentOS.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1,4 +1,3 @@
-#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This is similar to the problem from #463.

We need to define `__STDC_FORMAT_MACROS` before we do `#include <inttypes.h>` (this is done in `common.h`).

Note we should C++ify the logging and use an approach similar to what Arrow does so we can get rid of all of the instances of `PRId64`.