### PR TITLE
Use miniconda for all travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   - ./.travis/install-dependencies.sh
   - ./.travis/install-ray.sh
 
-  - if [[ "$PYTHON" == "3.5" ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi
+  - export PATH="$HOME/miniconda/bin:$PATH"
 
   - cd python/ray/core
   - bash ../../../src/common/test/run_tests.sh
@@ -73,7 +73,7 @@ install:
   - cd ../../..
 
 script:
-  - if [[ "$PYTHON" == "3.5" ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi
+  - export PATH="$HOME/miniconda/bin:$PATH"
 
   - python src/numbuf/python/test/runtest.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,8 @@ matrix:
 
 install:
   - ./.travis/install-dependencies.sh
-  - ./.travis/install-ray.sh
-
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - ./.travis/install-ray.sh
 
   - cd python/ray/core
   - bash ../../../src/common/test/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ matrix:
         - sudo apt-get install -qq valgrind
       install:
         - ./.travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
         - ./.travis/install-ray.sh
 
         - cd python/ray/core

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -20,7 +20,11 @@ fi
 if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip
-  sudo pip install cloudpickle funcsigs click colorama psutil redis tensorflow flatbuffers
+  # Install miniconda.
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+  bash miniconda.sh -b -p $HOME/miniconda
+  export PATH="$HOME/miniconda/bin:$PATH"
+  pip install numpy cloudpickle funcsigs click colorama psutil redis tensorflow flatbuffers
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake python-dev python-numpy build-essential autoconf curl libtool libboost-all-dev unzip
@@ -40,8 +44,11 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
     brew update
   fi
   brew install cmake automake autoconf libtool boost
-  sudo easy_install pip
-  sudo pip install numpy cloudpickle funcsigs click colorama psutil redis tensorflow flatbuffers --ignore-installed six
+  # Install miniconda.
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh
+  bash miniconda.sh -b -p $HOME/miniconda
+  export PATH="$HOME/miniconda/bin:$PATH"
+  pip install numpy cloudpickle funcsigs click colorama psutil redis tensorflow flatbuffers
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew

--- a/.travis/install-ray.sh
+++ b/.travis/install-ray.sh
@@ -10,7 +10,7 @@ echo "PYTHON is $PYTHON"
 if [[ "$PYTHON" == "2.7" ]]; then
 
   pushd "$ROOT_DIR/../python"
-    sudo python setup.py install
+    python setup.py install --user
   popd
 
 elif [[ "$PYTHON" == "3.5" ]]; then


### PR DESCRIPTION
Our Ubuntu + Python 2.7 Travis tests seems to be failing deterministically (starting some time today) with the following error.

```
Traceback (most recent call last):
  File "../../../python/ray/workers/default_worker.py", line 7, in <module>
    import numpy as np
ImportError: No module named numpy
```

It's possible that this error will go away on its own (something probably changed upstream). However, using miniconda might solve the problem.