### PR TITLE
Adding basic support for a user-interpretable resource label

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -105,6 +105,7 @@ def fetch_and_register_actor(actor_class_key, worker):
             FunctionProperties(num_return_vals=1,
                                num_cpus=1,
                                num_gpus=0,
+                               num_uirs=0,
                                max_calls=0))
         worker.num_task_executions[driver_id][function_id] = 0
 
@@ -174,6 +175,7 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
             FunctionProperties(num_return_vals=1,
                                num_cpus=1,
                                num_gpus=0,
+                               num_uirs=0,
                                max_calls=0))
 
     # Select a local scheduler for the actor.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -105,7 +105,7 @@ def fetch_and_register_actor(actor_class_key, worker):
             FunctionProperties(num_return_vals=1,
                                num_cpus=1,
                                num_gpus=0,
-                               num_uirs=0,
+                               num_custom_resource=0,
                                max_calls=0))
         worker.num_task_executions[driver_id][function_id] = 0
 
@@ -175,7 +175,7 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
             FunctionProperties(num_return_vals=1,
                                num_cpus=1,
                                num_gpus=0,
-                               num_uirs=0,
+                               num_custom_resource=0,
                                max_calls=0))
 
     # Select a local scheduler for the actor.
@@ -261,7 +261,8 @@ def reconstruct_actor_state(actor_id, worker):
             hex_to_object_id(task_spec_info["ActorID"]),
             task_spec_info["ActorCounter"],
             [task_spec_info["RequiredResources"]["CPUs"],
-             task_spec_info["RequiredResources"]["GPUs"]])
+             task_spec_info["RequiredResources"]["GPUs"],
+             task_spec_info["RequiredResources"]["CustomResource"]])
 
         # Verify that the return object IDs are the same as they were the
         # first time.

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -260,9 +260,10 @@ class GlobalState(object):
         # TODO: need to import a common header enumerating resource types,
         # e.g., generated from thrift or protobuf, with multiple language support.
         assert task_spec_message.RequiredResourcesLength() == 3
-        required_resources = {"CPUs": task_spec_message.RequiredResources(0),
-                              "GPUs": task_spec_message.RequiredResources(1),
-                              "UIRs": task_spec_message.RequiredResources(2)}
+        required_resources = {
+            "CPUs": task_spec_message.RequiredResources(0),
+            "GPUs": task_spec_message.RequiredResources(1),
+            "CustomResource": task_spec_message.RequiredResources(2)}
         task_spec_info = {
             "DriverID": binary_to_hex(task_spec_message.DriverId()),
             "TaskID": binary_to_hex(task_spec_message.TaskId()),
@@ -354,6 +355,9 @@ class GlobalState(object):
             if b"num_gpus" in client_info:
                 client_info_parsed["NumGPUs"] = float(
                     decode(client_info[b"num_gpus"]))
+            if b"num_custom_resource" in client_info:
+                client_info_parsed["NumCustomResource"] = float(
+                    decode(client_info[b"num_custom_resource"]))
             if b"local_scheduler_socket_name" in client_info:
                 client_info_parsed["LocalSchedulerSocketName"] = decode(
                     client_info[b"local_scheduler_socket_name"])

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -257,8 +257,8 @@ class GlobalState(object):
                 args.append(binary_to_object_id(arg.ObjectId()))
             else:
                 args.append(pickle.loads(arg.Data()))
-        # TODO: need to import a common header enumerating resource types,
-        # e.g., generated from thrift or protobuf, with multiple language support.
+        # TODO(atumanov): Instead of hard coding these indices, we should use
+        # the flatbuffer constants.
         assert task_spec_message.RequiredResourcesLength() == 3
         required_resources = {
             "CPUs": task_spec_message.RequiredResources(0),

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -257,9 +257,12 @@ class GlobalState(object):
                 args.append(binary_to_object_id(arg.ObjectId()))
             else:
                 args.append(pickle.loads(arg.Data()))
-        assert task_spec_message.RequiredResourcesLength() == 2
+        # TODO: need to import a common header enumerating resource types,
+        # e.g., generated from thrift or protobuf, with multiple language support.
+        assert task_spec_message.RequiredResourcesLength() == 3
         required_resources = {"CPUs": task_spec_message.RequiredResources(0),
-                              "GPUs": task_spec_message.RequiredResources(1)}
+                              "GPUs": task_spec_message.RequiredResources(1),
+                              "UIRs": task_spec_message.RequiredResources(2)}
         task_spec_info = {
             "DriverID": binary_to_hex(task_spec_message.DriverId()),
             "TaskID": binary_to_hex(task_spec_message.TaskId()),

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -166,12 +166,12 @@ class TestGlobalScheduler(unittest.TestCase):
         task1 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
                                      0)
-        self.assertEqual(task1.required_resources(), [1.0, 0.0])
+        self.assertEqual(task1.required_resources(), [1.0, 0.0, 0.0])
         task2 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
                                      0, local_scheduler.ObjectID(NIL_ACTOR_ID),
-                                     0, [1.0, 2.0])
-        self.assertEqual(task2.required_resources(), [1.0, 2.0])
+                                     0, [1.0, 2.0, 0.0])
+        self.assertEqual(task2.required_resources(), [1.0, 2.0, 0.0])
 
     def test_redis_only_single_task(self):
         # Tests global scheduler functionality by interacting with Redis and

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -59,14 +59,15 @@ def cli():
               help="the number of CPUs on this node")
 @click.option("--num-gpus", required=False, type=int,
               help="the number of GPUs on this node")
-@click.option("--num-uirs", required=False, type=int,
-              help="the number of UIRs on this node")
+@click.option("--num-custom-resource", required=False, type=int,
+              help="the amount of a user-defined custom resource on this node")
 @click.option("--head", is_flag=True, default=False,
               help="provide this argument for the head node")
 @click.option("--block", is_flag=True, default=False,
               help="provide this argument to block forever in this command")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
-          object_manager_port, num_workers, num_cpus, num_gpus, num_uirs, head, block):
+          object_manager_port, num_workers, num_cpus, num_gpus,
+          num_custom_resource, head, block):
     # Note that we redirect stdout and stderr to /dev/null because otherwise
     # attempts to print may cause exceptions if a process is started inside of
     # an SSH connection and the SSH connection dies. TODO(rkn): This is a
@@ -101,7 +102,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redirect_output=True,
             num_cpus=num_cpus,
             num_gpus=num_gpus,
-            num_uirs=num_uirs,
+            num_custom_resource=num_custom_resource,
             num_redis_shards=num_redis_shards)
         print(address_info)
         print("\nStarted Ray on this node. You can add additional nodes to "
@@ -148,7 +149,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redirect_output=True,
             num_cpus=num_cpus,
             num_gpus=num_gpus,
-            num_uirs=num_uirs)
+            num_custom_resource=num_custom_resource)
         print(address_info)
         print("\nStarted Ray on this node. If you wish to terminate the "
               "processes that have been started, run\n\n"

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -59,12 +59,14 @@ def cli():
               help="the number of CPUs on this node")
 @click.option("--num-gpus", required=False, type=int,
               help="the number of GPUs on this node")
+@click.option("--num-uirs", required=False, type=int,
+              help="the number of UIRs on this node")
 @click.option("--head", is_flag=True, default=False,
               help="provide this argument for the head node")
 @click.option("--block", is_flag=True, default=False,
               help="provide this argument to block forever in this command")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
-          object_manager_port, num_workers, num_cpus, num_gpus, head, block):
+          object_manager_port, num_workers, num_cpus, num_gpus, num_uirs, head, block):
     # Note that we redirect stdout and stderr to /dev/null because otherwise
     # attempts to print may cause exceptions if a process is started inside of
     # an SSH connection and the SSH connection dies. TODO(rkn): This is a
@@ -99,6 +101,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redirect_output=True,
             num_cpus=num_cpus,
             num_gpus=num_gpus,
+            num_uirs=num_uirs,
             num_redis_shards=num_redis_shards)
         print(address_info)
         print("\nStarted Ray on this node. You can add additional nodes to "
@@ -144,7 +147,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             cleanup=False,
             redirect_output=True,
             num_cpus=num_cpus,
-            num_gpus=num_gpus)
+            num_gpus=num_gpus,
+            num_uirs=num_uirs)
         print(address_info)
         print("\nStarted Ray on this node. If you wish to terminate the "
               "processes that have been started, run\n\n"

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -512,6 +512,7 @@ def start_local_scheduler(redis_address,
                           cleanup=True,
                           num_cpus=None,
                           num_gpus=None,
+                          num_uirs=None,
                           num_workers=0):
     """Start a local scheduler process.
 
@@ -536,6 +537,8 @@ def start_local_scheduler(redis_address,
             with.
         num_gpus: The number of GPUs the local scheduler should be configured
             with.
+        num_uirs: The number of UIRs the local scheduler should be configured
+            with.
         num_workers (int): The number of workers that the local scheduler
             should start.
 
@@ -549,8 +552,11 @@ def start_local_scheduler(redis_address,
     if num_gpus is None:
         # By default, assume this node has no GPUs.
         num_gpus = 0
-    print("Starting local scheduler with {} CPUs and {} GPUs."
-          .format(num_cpus, num_gpus))
+    if num_uirs is None:
+        # By default, defer configuration of UIRs to the local scheduler.
+        num_uirs = -1
+    print("Starting local scheduler with {} CPUs, {} GPUs, {} UIRs"
+          .format(num_cpus, num_gpus, num_uirs))
     local_scheduler_name, p = ray.local_scheduler.start_local_scheduler(
         plasma_store_name,
         plasma_manager_name,
@@ -561,7 +567,7 @@ def start_local_scheduler(redis_address,
         use_profiler=RUN_LOCAL_SCHEDULER_PROFILER,
         stdout_file=stdout_file,
         stderr_file=stderr_file,
-        static_resource_list=[num_cpus, num_gpus],
+        static_resource_list=[num_cpus, num_gpus, num_uirs],
         num_workers=num_workers)
     if cleanup:
         all_processes[PROCESS_TYPE_LOCAL_SCHEDULER].append(p)
@@ -752,7 +758,8 @@ def start_ray_processes(address_info=None,
                         include_webui=False,
                         start_workers_from_local_scheduler=True,
                         num_cpus=None,
-                        num_gpus=None):
+                        num_gpus=None,
+                        num_uirs=None):
     """Helper method to start Ray processes.
 
     Args:
@@ -796,6 +803,8 @@ def start_ray_processes(address_info=None,
             of CPUs each local scheduler should be configured with.
         num_gpus: A list of length num_local_schedulers containing the number
             of GPUs each local scheduler should be configured with.
+        num_uirs: A list of length num_local_schedulers containing the number
+            of UIRs each local scheduler should be configured with.
 
     Returns:
         A dictionary of the address information for the processes that were
@@ -805,8 +814,11 @@ def start_ray_processes(address_info=None,
         num_cpus = num_local_schedulers * [num_cpus]
     if not isinstance(num_gpus, list):
         num_gpus = num_local_schedulers * [num_gpus]
+    if not isinstance(num_uirs, list):
+        num_uirs = num_local_schedulers * [num_uirs]
     assert len(num_cpus) == num_local_schedulers
     assert len(num_gpus) == num_local_schedulers
+    assert len(num_uirs) == num_local_schedulers
 
     if num_workers is not None:
         workers_per_local_scheduler = num_local_schedulers * [num_workers]
@@ -940,6 +952,7 @@ def start_ray_processes(address_info=None,
             cleanup=cleanup,
             num_cpus=num_cpus[i],
             num_gpus=num_gpus[i],
+            num_uirs=num_uirs[i],
             num_workers=num_local_scheduler_workers)
         local_scheduler_socket_names.append(local_scheduler_name)
         time.sleep(0.1)
@@ -991,7 +1004,8 @@ def start_ray_node(node_ip_address,
                    cleanup=True,
                    redirect_output=False,
                    num_cpus=None,
-                   num_gpus=None):
+                   num_gpus=None,
+                   num_uirs=None):
     """Start the Ray processes for a single node.
 
     This assumes that the Ray processes on some master node have already been
@@ -1030,7 +1044,8 @@ def start_ray_node(node_ip_address,
                                cleanup=cleanup,
                                redirect_output=redirect_output,
                                num_cpus=num_cpus,
-                               num_gpus=num_gpus)
+                               num_gpus=num_gpus,
+                               num_uirs=num_uirs)
 
 
 def start_ray_head(address_info=None,
@@ -1045,6 +1060,7 @@ def start_ray_head(address_info=None,
                    start_workers_from_local_scheduler=True,
                    num_cpus=None,
                    num_gpus=None,
+                   num_uirs=None,
                    num_redis_shards=None):
     """Start Ray in local mode.
 
@@ -1102,6 +1118,7 @@ def start_ray_head(address_info=None,
         start_workers_from_local_scheduler=start_workers_from_local_scheduler,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
+        num_uirs=num_uirs,
         num_redis_shards=num_redis_shards)
 
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -512,7 +512,7 @@ def start_local_scheduler(redis_address,
                           cleanup=True,
                           num_cpus=None,
                           num_gpus=None,
-                          num_uirs=None,
+                          num_custom_resource=None,
                           num_workers=0):
     """Start a local scheduler process.
 
@@ -537,8 +537,8 @@ def start_local_scheduler(redis_address,
             with.
         num_gpus: The number of GPUs the local scheduler should be configured
             with.
-        num_uirs: The number of UIRs the local scheduler should be configured
-            with.
+        num_custom_resource: The quantity of a user-defined custom resource
+            that the local scheduler should be configured with.
         num_workers (int): The number of workers that the local scheduler
             should start.
 
@@ -552,11 +552,11 @@ def start_local_scheduler(redis_address,
     if num_gpus is None:
         # By default, assume this node has no GPUs.
         num_gpus = 0
-    if num_uirs is None:
-        # By default, defer configuration of UIRs to the local scheduler.
-        num_uirs = -1
-    print("Starting local scheduler with {} CPUs, {} GPUs, {} UIRs"
-          .format(num_cpus, num_gpus, num_uirs))
+    if num_custom_resource is None:
+        # By default, assume this node has none of the custom resource.
+        num_custom_resource = 0
+    print("Starting local scheduler with {} CPUs, {} GPUs"
+          .format(num_cpus, num_gpus, num_custom_resource))
     local_scheduler_name, p = ray.local_scheduler.start_local_scheduler(
         plasma_store_name,
         plasma_manager_name,
@@ -567,7 +567,7 @@ def start_local_scheduler(redis_address,
         use_profiler=RUN_LOCAL_SCHEDULER_PROFILER,
         stdout_file=stdout_file,
         stderr_file=stderr_file,
-        static_resource_list=[num_cpus, num_gpus, num_uirs],
+        static_resource_list=[num_cpus, num_gpus, num_custom_resource],
         num_workers=num_workers)
     if cleanup:
         all_processes[PROCESS_TYPE_LOCAL_SCHEDULER].append(p)
@@ -759,7 +759,7 @@ def start_ray_processes(address_info=None,
                         start_workers_from_local_scheduler=True,
                         num_cpus=None,
                         num_gpus=None,
-                        num_uirs=None):
+                        num_custom_resource=None):
     """Helper method to start Ray processes.
 
     Args:
@@ -803,8 +803,9 @@ def start_ray_processes(address_info=None,
             of CPUs each local scheduler should be configured with.
         num_gpus: A list of length num_local_schedulers containing the number
             of GPUs each local scheduler should be configured with.
-        num_uirs: A list of length num_local_schedulers containing the number
-            of UIRs each local scheduler should be configured with.
+        num_custom_resource: A list of length num_local_schedulers containing
+            the quantity of a user-defined custom resource that each local
+            scheduler should be configured with.
 
     Returns:
         A dictionary of the address information for the processes that were
@@ -814,11 +815,11 @@ def start_ray_processes(address_info=None,
         num_cpus = num_local_schedulers * [num_cpus]
     if not isinstance(num_gpus, list):
         num_gpus = num_local_schedulers * [num_gpus]
-    if not isinstance(num_uirs, list):
-        num_uirs = num_local_schedulers * [num_uirs]
+    if not isinstance(num_custom_resource, list):
+        num_custom_resource = num_local_schedulers * [num_custom_resource]
     assert len(num_cpus) == num_local_schedulers
     assert len(num_gpus) == num_local_schedulers
-    assert len(num_uirs) == num_local_schedulers
+    assert len(num_custom_resource) == num_local_schedulers
 
     if num_workers is not None:
         workers_per_local_scheduler = num_local_schedulers * [num_workers]
@@ -952,7 +953,7 @@ def start_ray_processes(address_info=None,
             cleanup=cleanup,
             num_cpus=num_cpus[i],
             num_gpus=num_gpus[i],
-            num_uirs=num_uirs[i],
+            num_custom_resource=num_custom_resource[i],
             num_workers=num_local_scheduler_workers)
         local_scheduler_socket_names.append(local_scheduler_name)
         time.sleep(0.1)
@@ -1005,7 +1006,7 @@ def start_ray_node(node_ip_address,
                    redirect_output=False,
                    num_cpus=None,
                    num_gpus=None,
-                   num_uirs=None):
+                   num_custom_resource=None):
     """Start the Ray processes for a single node.
 
     This assumes that the Ray processes on some master node have already been
@@ -1045,7 +1046,7 @@ def start_ray_node(node_ip_address,
                                redirect_output=redirect_output,
                                num_cpus=num_cpus,
                                num_gpus=num_gpus,
-                               num_uirs=num_uirs)
+                               num_custom_resource=num_custom_resource)
 
 
 def start_ray_head(address_info=None,
@@ -1060,7 +1061,7 @@ def start_ray_head(address_info=None,
                    start_workers_from_local_scheduler=True,
                    num_cpus=None,
                    num_gpus=None,
-                   num_uirs=None,
+                   num_custom_resource=None,
                    num_redis_shards=None):
     """Start Ray in local mode.
 
@@ -1118,7 +1119,7 @@ def start_ray_head(address_info=None,
         start_workers_from_local_scheduler=start_workers_from_local_scheduler,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
-        num_uirs=num_uirs,
+        num_custom_resource=num_custom_resource,
         num_redis_shards=num_redis_shards)
 
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -65,6 +65,7 @@ FunctionProperties = collections.namedtuple("FunctionProperties",
                                             ["num_return_vals",
                                              "num_cpus",
                                              "num_gpus",
+                                             "num_uirs",
                                              "max_calls"])
 """FunctionProperties: A named tuple storing remote functions information."""
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -65,7 +65,7 @@ FunctionProperties = collections.namedtuple("FunctionProperties",
                                             ["num_return_vals",
                                              "num_cpus",
                                              "num_gpus",
-                                             "num_uirs",
+                                             "num_custom_resource",
                                              "max_calls"])
 """FunctionProperties: A named tuple storing remote functions information."""
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -514,7 +514,7 @@ class Worker(object):
                 actor_id,
                 self.actor_counters[actor_id],
                 [function_properties.num_cpus, function_properties.num_gpus,
-                 function_properties.num_uirs])
+                 function_properties.num_custom_resource])
             # Increment the worker's task index to track how many tasks have
             # been submitted by the current task so far.
             self.task_index += 1
@@ -1121,7 +1121,7 @@ def _init(address_info=None,
           start_workers_from_local_scheduler=True,
           num_cpus=None,
           num_gpus=None,
-          num_uirs=None,
+          num_custom_resource=None,
           num_redis_shards=None):
     """Helper method to connect to an existing Ray cluster or start a new one.
 
@@ -1161,8 +1161,9 @@ def _init(address_info=None,
             should be configured with.
         num_gpus: A list containing the number of GPUs the local schedulers
             should be configured with.
-        num_uirs: A list containing the number of UIRs the local schedulers
-            should be configured with.
+        num_custom_resource: A list containing the quantity of a user-defined
+            custom resource that the local schedulers should be configured
+            with.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
 
@@ -1222,7 +1223,7 @@ def _init(address_info=None,
                 start_workers_from_local_scheduler),
             num_cpus=num_cpus,
             num_gpus=num_gpus,
-            num_uirs=num_uirs,
+            num_custom_resource=num_custom_resource,
             num_redis_shards=num_redis_shards)
     else:
         if redis_address is None:
@@ -1234,9 +1235,11 @@ def _init(address_info=None,
         if num_local_schedulers is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_local_schedulers must not be provided.")
-        if num_cpus is not None or num_gpus is not None or num_uirs is not None:
-            raise Exception("When connecting to an existing cluster, resource labels "
-                            "(e.g., num_gpus,num_cpus,num_uirs) must not be provided.")
+        if (num_cpus is not None or num_gpus is not None or
+                num_custom_resource is not None):
+            raise Exception("When connecting to an existing cluster, resource "
+                            "labels (e.g., num_gpus, num_cpus, "
+                            "num_custom_resource) must not be provided.")
         if num_redis_shards is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_redis_shards must not be provided.")
@@ -1273,7 +1276,8 @@ def _init(address_info=None,
 
 def init(redis_address=None, node_ip_address=None, object_id_seed=None,
          num_workers=None, driver_mode=SCRIPT_MODE, redirect_output=False,
-         num_cpus=None, num_gpus=None, num_uirs=None, num_redis_shards=None):
+         num_cpus=None, num_gpus=None, num_custom_resource=None,
+         num_redis_shards=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1301,8 +1305,9 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
             be configured with.
         num_gpus (int): Number of gpus the user wishes all local schedulers to
             be configured with.
-        num_uirs (int): Number of user-interpretable resource units to configure
-            the local schedulers with.
+        num_custom_resource (int): The quantity of a user-defined custom
+            resource that the local scheduler should be configured with. This
+            flag is highly unstable and should not be used.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
 
@@ -1318,7 +1323,8 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
     return _init(address_info=info, start_ray_local=(redis_address is None),
                  num_workers=num_workers, driver_mode=driver_mode,
                  redirect_output=redirect_output, num_cpus=num_cpus,
-                 num_gpus=num_gpus, num_uirs=num_uirs, num_redis_shards=num_redis_shards)
+                 num_gpus=num_gpus, num_custom_resource=num_custom_resource,
+                 num_redis_shards=num_redis_shards)
 
 
 def cleanup(worker=global_worker):
@@ -1431,8 +1437,8 @@ def print_error_messages(worker):
 def fetch_and_register_remote_function(key, worker=global_worker):
     """Import a remote function."""
     (driver_id, function_id_str, function_name,
-     serialized_function, num_return_vals, module,
-     num_cpus, num_gpus, num_uirs, max_calls) = worker.redis_client.hmget(
+     serialized_function, num_return_vals, module, num_cpus,
+     num_gpus, num_custom_resource, max_calls) = worker.redis_client.hmget(
         key, ["driver_id",
               "function_id",
               "name",
@@ -1441,7 +1447,7 @@ def fetch_and_register_remote_function(key, worker=global_worker):
               "module",
               "num_cpus",
               "num_gpus",
-              "num_uirs",
+              "num_custom_resource",
               "max_calls"])
     function_id = ray.local_scheduler.ObjectID(function_id_str)
     function_name = function_name.decode("ascii")
@@ -1449,7 +1455,7 @@ def fetch_and_register_remote_function(key, worker=global_worker):
         num_return_vals=int(num_return_vals),
         num_cpus=int(num_cpus),
         num_gpus=int(num_gpus),
-        num_uirs = int(num_uirs),
+        num_custom_resource = int(num_custom_resource),
         max_calls=int(max_calls))
     module = module.decode("ascii")
 
@@ -2115,7 +2121,7 @@ def export_remote_function(function_id, func_name, func, func_invoker,
         "num_return_vals": function_properties.num_return_vals,
         "num_cpus": function_properties.num_cpus,
         "num_gpus": function_properties.num_gpus,
-        "num_uirs": function_properties.num_uirs,
+        "num_custom_resource": function_properties.num_custom_resource,
         "max_calls": function_properties.max_calls})
     worker.redis_client.rpush("Exports", key)
 
@@ -2164,14 +2170,10 @@ def remote(*args, **kwargs):
         num_return_vals (int): The number of object IDs that a call to this
             function should return.
         num_cpus (int): The number of CPUs needed to execute this function.
-            This should only be passed in when defining the remote function on
-            the driver.
         num_gpus (int): The number of GPUs needed to execute this function.
-            This should only be passed in when defining the remote function on
-            the driver.
-        num_uirs (int): The number of UIRSs (User Interpretable Resources
-            needed to execute this function. This should only be passed in when
-            defining the remote function on the driver.
+        num_custom_resource (int): The quantity of a user-defined custom
+            resource that is needed to execute this function. This flag is
+            highly unstable and should not be used.
         max_calls (int): The maximum number of tasks of this kind that can be
             run on a worker before the worker needs to be restarted.
         checkpoint_interval (int): The number of tasks to run between
@@ -2179,15 +2181,16 @@ def remote(*args, **kwargs):
     """
     worker = global_worker
 
-    def make_remote_decorator(num_return_vals, num_cpus, num_gpus, num_uirs,
-                              max_calls, checkpoint_interval, func_id=None):
+    def make_remote_decorator(num_return_vals, num_cpus, num_gpus,
+                              num_custom_resource, max_calls,
+                              checkpoint_interval, func_id=None):
         def remote_decorator(func_or_class):
             if inspect.isfunction(func_or_class):
                 function_properties = FunctionProperties(
                     num_return_vals=num_return_vals,
                     num_cpus=num_cpus,
                     num_gpus=num_gpus,
-                    num_uirs=num_uirs,
+                    num_custom_resource=num_custom_resource,
                     max_calls=max_calls)
                 return remote_function_decorator(func_or_class,
                                                  function_properties)
@@ -2262,7 +2265,8 @@ def remote(*args, **kwargs):
                        in kwargs else 1)
     num_cpus = kwargs["num_cpus"] if "num_cpus" in kwargs else 1
     num_gpus = kwargs["num_gpus"] if "num_gpus" in kwargs else 0
-    num_uirs = kwargs["num_uirs"] if "num_uirs" in kwargs else 0
+    num_custom_resource = (kwargs["num_custom_resource"]
+                           if "num_custom_resource" in kwargs else 0)
     max_calls = kwargs["max_calls"] if "max_calls" in kwargs else 0
     checkpoint_interval = (kwargs["checkpoint_interval"]
                            if "checkpoint_interval" in kwargs else -1)
@@ -2271,14 +2275,15 @@ def remote(*args, **kwargs):
         if "function_id" in kwargs:
             function_id = kwargs["function_id"]
             return make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                                         num_uirs, max_calls,
+                                         num_custom_resource, max_calls,
                                          checkpoint_interval, function_id)
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # This is the case where the decorator is just @ray.remote.
         return make_remote_decorator(
             num_return_vals, num_cpus,
-            num_gpus, num_uirs, max_calls, checkpoint_interval)(args[0])
+            num_gpus, num_custom_resource,
+            max_calls, checkpoint_interval)(args[0])
     else:
         # This is the case where the decorator is something like
         # @ray.remote(num_return_vals=2).
@@ -2286,19 +2291,20 @@ def remote(*args, **kwargs):
                         "with no arguments and no parentheses, for example "
                         "'@ray.remote', or it must be applied using some of "
                         "the arguments 'num_return_vals', 'num_cpus', "
-                        "'num_gpus', num_uirs, or 'max_calls', like "
-                        "'@ray.remote(num_return_vals=2)'.")
+                        "'num_gpus', num_custom_resource, or 'max_calls', "
+                        "like '@ray.remote(num_return_vals=2)'.")
         assert (len(args) == 0 and
                 ("num_return_vals" in kwargs or
                  "num_cpus" in kwargs or
                  "num_gpus" in kwargs or
-                 "num_uirs" in kwargs or
+                 "num_custom_resource" in kwargs or
                  "max_calls" in kwargs or
                  "checkpoint_interval" in kwargs)), error_string
         for key in kwargs:
             assert key in ["num_return_vals", "num_cpus",
-                           "num_gpus", "num_uirs", "max_calls",
+                           "num_gpus", "num_custom_resource", "max_calls",
                            "checkpoint_interval"], error_string
         assert "function_id" not in kwargs
         return make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                                     num_uirs, max_calls, checkpoint_interval)
+                                     num_custom_resource, max_calls,
+                                     checkpoint_interval)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1307,7 +1307,7 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
             be configured with.
         num_custom_resource (int): The quantity of a user-defined custom
             resource that the local scheduler should be configured with. This
-            flag is highly unstable and should not be used.
+            flag is experimental and is subject to changes in the future.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
 
@@ -2173,7 +2173,7 @@ def remote(*args, **kwargs):
         num_gpus (int): The number of GPUs needed to execute this function.
         num_custom_resource (int): The quantity of a user-defined custom
             resource that is needed to execute this function. This flag is
-            highly unstable and should not be used.
+            experimental and is subject to changes in the future.
         max_calls (int): The maximum number of tasks of this kind that can be
             run on a worker before the worker needs to be restarted.
         checkpoint_interval (int): The number of tasks to run between

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1121,6 +1121,7 @@ def _init(address_info=None,
           start_workers_from_local_scheduler=True,
           num_cpus=None,
           num_gpus=None,
+          num_uirs=None,
           num_redis_shards=None):
     """Helper method to connect to an existing Ray cluster or start a new one.
 
@@ -1159,6 +1160,8 @@ def _init(address_info=None,
         num_cpus: A list containing the number of CPUs the local schedulers
             should be configured with.
         num_gpus: A list containing the number of GPUs the local schedulers
+            should be configured with.
+        num_uirs: A list containing the number of UIRs the local schedulers
             should be configured with.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
@@ -1219,6 +1222,7 @@ def _init(address_info=None,
                 start_workers_from_local_scheduler),
             num_cpus=num_cpus,
             num_gpus=num_gpus,
+            num_uirs=num_uirs,
             num_redis_shards=num_redis_shards)
     else:
         if redis_address is None:
@@ -1230,9 +1234,9 @@ def _init(address_info=None,
         if num_local_schedulers is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_local_schedulers must not be provided.")
-        if num_cpus is not None or num_gpus is not None:
-            raise Exception("When connecting to an existing cluster, num_cpus "
-                            "and num_gpus must not be provided.")
+        if num_cpus is not None or num_gpus is not None or num_uirs is not None:
+            raise Exception("When connecting to an existing cluster, resource labels "
+                            "(e.g., num_gpus,num_cpus,num_uirs) must not be provided.")
         if num_redis_shards is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_redis_shards must not be provided.")
@@ -1269,7 +1273,7 @@ def _init(address_info=None,
 
 def init(redis_address=None, node_ip_address=None, object_id_seed=None,
          num_workers=None, driver_mode=SCRIPT_MODE, redirect_output=False,
-         num_cpus=None, num_gpus=None, num_redis_shards=None):
+         num_cpus=None, num_gpus=None, num_uirs=None, num_redis_shards=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1297,6 +1301,8 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
             be configured with.
         num_gpus (int): Number of gpus the user wishes all local schedulers to
             be configured with.
+        num_uirs (int): Number of user-interpretable resource units to configure
+            the local schedulers with.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
 
@@ -1312,7 +1318,7 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
     return _init(address_info=info, start_ray_local=(redis_address is None),
                  num_workers=num_workers, driver_mode=driver_mode,
                  redirect_output=redirect_output, num_cpus=num_cpus,
-                 num_gpus=num_gpus, num_redis_shards=num_redis_shards)
+                 num_gpus=num_gpus, num_uirs=num_uirs, num_redis_shards=num_redis_shards)
 
 
 def cleanup(worker=global_worker):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2301,4 +2301,4 @@ def remote(*args, **kwargs):
                            "checkpoint_interval"], error_string
         assert "function_id" not in kwargs
         return make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                                     max_calls, checkpoint_interval)
+                                     num_uirs, max_calls, checkpoint_interval)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1455,7 +1455,7 @@ def fetch_and_register_remote_function(key, worker=global_worker):
         num_return_vals=int(num_return_vals),
         num_cpus=int(num_cpus),
         num_gpus=int(num_gpus),
-        num_custom_resource = int(num_custom_resource),
+        num_custom_resource=int(num_custom_resource),
         max_calls=int(max_calls))
     module = module.decode("ascii")
 

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -9,9 +9,11 @@ enum ResourceIndex:int {
   CPU = 0,
   // A graphics processing unit.
   GPU = 1,
+  // A user-interpreted resource.
+  UIR = 2, 
   // A dummy entry to make ResourceIndex_MAX equal to the length of
   // a resource vector.
-  DUMMY = 2
+  DUMMY = 3
 }
 
 table Arg {

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -9,8 +9,8 @@ enum ResourceIndex:int {
   CPU = 0,
   // A graphics processing unit.
   GPU = 1,
-  // A user-interpreted resource.
-  UIR = 2, 
+  // A user-defined custom resource.
+  CustomResource = 2,
   // A dummy entry to make ResourceIndex_MAX equal to the length of
   // a resource vector.
   DUMMY = 3

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -578,9 +578,9 @@ void finish_task(LocalSchedulerState *state, LocalSchedulerClient *worker) {
                         worker->resources_in_use[ResourceIndex_CustomResource]);
     } else {
       CHECK(0 == TaskSpec_get_required_resource(spec, ResourceIndex_GPU));
-      release_resources(
-          state, worker, worker->resources_in_use[ResourceIndex_CPU], 0,
-          TaskSpec_get_required_resource(spec, ResourceIndex_CustomResource));
+      release_resources(state, worker,
+                        worker->resources_in_use[ResourceIndex_CPU], 0,
+                        worker->resources_in_use[ResourceIndex_CustomResource]);
     }
     /* If we're connected to Redis, update tables. */
     if (state->db != NULL) {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1316,10 +1316,12 @@ int main(int argc, char *argv[]) {
   if (!static_resource_list) {
     /* Use defaults for this node's static resource configuration. */
     memset(&static_resource_conf[0], 0, sizeof(static_resource_conf));
+    // TODO(atumanov): define a default vector and replace individual consts.
     static_resource_conf[ResourceIndex_CPU] = DEFAULT_NUM_CPUS;
     static_resource_conf[ResourceIndex_GPU] = DEFAULT_NUM_GPUS;
     static_resource_conf[ResourceIndex_UIR] = DEFAULT_NUM_UIRS;
   } else {
+    // TODO: switch this tokenizer to reading from ifstream.
     /* Tokenize the string. */
     const char delim[2] = ",";
     char *token;
@@ -1329,6 +1331,11 @@ int main(int argc, char *argv[]) {
       static_resource_conf[idx++] = atoi(token);
       /* Attempt to get the next token. */
       token = strtok(NULL, delim);
+    }
+    if (static_resource_conf[ResourceIndex_UIR] < 0) {
+      // Interpret negative values for UIR as deferring to the default system
+      // configuration.
+      static_resource_conf[ResourceIndex_UIR] = DEFAULT_NUM_UIRS;
     }
   }
   if (!scheduler_socket_name) {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1318,6 +1318,7 @@ int main(int argc, char *argv[]) {
     memset(&static_resource_conf[0], 0, sizeof(static_resource_conf));
     static_resource_conf[ResourceIndex_CPU] = DEFAULT_NUM_CPUS;
     static_resource_conf[ResourceIndex_GPU] = DEFAULT_NUM_GPUS;
+    static_resource_conf[ResourceIndex_UIR] = DEFAULT_NUM_UIRS;
   } else {
     /* Tokenize the string. */
     const char delim[2] = ",";

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -413,7 +413,7 @@ LocalSchedulerState *LocalSchedulerState_init(
   return state;
 }
 
-/* TODO: vectorize resource counts on input. */
+/* TODO(atumanov): vectorize resource counts on input. */
 bool check_dynamic_resources(LocalSchedulerState *state,
                              double num_cpus,
                              double num_gpus,
@@ -434,7 +434,7 @@ bool check_dynamic_resources(LocalSchedulerState *state,
   return true;
 }
 
-/* TODO: just pass the required resource vector of doubles. */
+/* TODO(atumanov): just pass the required resource vector of doubles. */
 void acquire_resources(LocalSchedulerState *state,
                        LocalSchedulerClient *worker,
                        double num_cpus,
@@ -446,8 +446,8 @@ void acquire_resources(LocalSchedulerState *state,
   CHECK(worker->cpus_in_use == 0);
   CHECK(worker->inuse_resources[ResourceIndex_CPU] == 0);
   worker->cpus_in_use += num_cpus;
-  /* FIXME: shadow cpus_in_use for now; later replace with vectorized resource
-   * counter. */
+  /* TODO(atumanov): shadow cpus_in_use for now; later replace with vectorized
+   * resource counter. */
   worker->inuse_resources[ResourceIndex_CPU] += num_cpus;
   /* Log a warning if we are using more resources than we have been allocated,
    * and we weren't already oversubscribed. */
@@ -486,7 +486,8 @@ void release_resources(LocalSchedulerState *state,
                        double num_custom_resource) {
   /* Release the CPU resources. */
   CHECK(num_cpus == worker->cpus_in_use);
-  /* FIXME: shadow the hardcoded cpus_in_use for now; replace it later. */
+  /* TODO(atumanov): shadow the hardcoded cpus_in_use for now; replace it
+   * later. */
   CHECK(num_cpus == worker->inuse_resources[ResourceIndex_CPU]);
   state->dynamic_resources[ResourceIndex_CPU] += num_cpus;
   worker->cpus_in_use = 0;
@@ -1351,13 +1352,14 @@ int main(int argc, char *argv[]) {
   if (!static_resource_list) {
     /* Use defaults for this node's static resource configuration. */
     memset(&static_resource_conf[0], 0, sizeof(static_resource_conf));
-    // TODO(atumanov): define a default vector and replace individual consts.
-    static_resource_conf[ResourceIndex_CPU] = DEFAULT_NUM_CPUS;
-    static_resource_conf[ResourceIndex_GPU] = DEFAULT_NUM_GPUS;
+    /* TODO(atumanov): Define a default vector and replace individual
+     * constants. */
+    static_resource_conf[ResourceIndex_CPU] = kDefaultNumCPUs;
+    static_resource_conf[ResourceIndex_GPU] = kDefaultNumGPUs;
     static_resource_conf[ResourceIndex_CustomResource] =
-        DEFAULT_NUM_CUSTOM_RESOURCE;
+        kDefaultNumCustomResource;
   } else {
-    // TODO: switch this tokenizer to reading from ifstream.
+    /* TODO(atumanov): Switch this tokenizer to reading from ifstream. */
     /* Tokenize the string. */
     const char delim[2] = ",";
     char *token;
@@ -1369,10 +1371,10 @@ int main(int argc, char *argv[]) {
       token = strtok(NULL, delim);
     }
     if (static_resource_conf[ResourceIndex_CustomResource] < 0) {
-      // Interpret negative values for UIR as deferring to the default system
-      // configuration.
+      /* Interpret negative values for the custom resource as deferring to the
+       * default system configuration. */
       static_resource_conf[ResourceIndex_CustomResource] =
-          DEFAULT_NUM_CUSTOM_RESOURCE;
+          kDefaultNumCustomResource;
     }
   }
   if (!scheduler_socket_name) {

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -11,7 +11,7 @@
 
 #define DEFAULT_NUM_CPUS INT16_MAX
 #define DEFAULT_NUM_GPUS 0
-#define DEFAULT_NUM_UIRS INFINITY
+#define DEFAULT_NUM_CUSTOM_RESOURCE INFINITY
 
 /**
  * Establish a connection to a new client.
@@ -136,7 +136,7 @@ void start_worker(LocalSchedulerState *state,
 bool check_dynamic_resources(LocalSchedulerState *state,
                              double num_cpus,
                              double num_gpus,
-                             double num_uirs);
+                             double num_custom_resource);
 
 /**
  * Acquire additional resources (CPUs and GPUs) for a worker.
@@ -151,7 +151,7 @@ void acquire_resources(LocalSchedulerState *state,
                        LocalSchedulerClient *worker,
                        double num_cpus,
                        double num_gpus,
-                       double num_uirs);
+                       double num_custom_resource);
 
 /**
  * Return resources (CPUs and GPUs) being used by a worker to the local
@@ -167,7 +167,7 @@ void release_resources(LocalSchedulerState *state,
                        LocalSchedulerClient *worker,
                        double num_cpus,
                        double num_gpus,
-                       double num_uirs);
+                       double num_custom_resource);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -9,9 +9,9 @@
  * worker SIGKILL. */
 #define KILL_WORKER_TIMEOUT_MILLISECONDS 100
 
-#define DEFAULT_NUM_CPUS INT16_MAX
-#define DEFAULT_NUM_GPUS 0
-#define DEFAULT_NUM_CUSTOM_RESOURCE INFINITY
+constexpr double kDefaultNumCPUs = INT16_MAX;
+constexpr double kDefaultNumGPUs = 0;
+constexpr double kDefaultNumCustomResource = INFINITY;
 
 /**
  * Establish a connection to a new client.

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -1,5 +1,6 @@
 #ifndef LOCAL_SCHEDULER_H
 #define LOCAL_SCHEDULER_H
+#include <math.h>
 
 #include "task.h"
 #include "event_loop.h"
@@ -10,6 +11,7 @@
 
 #define DEFAULT_NUM_CPUS INT16_MAX
 #define DEFAULT_NUM_GPUS 0
+#define DEFAULT_NUM_UIRS INFINITY
 
 /**
  * Establish a connection to a new client.

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -135,7 +135,8 @@ void start_worker(LocalSchedulerState *state,
  */
 bool check_dynamic_resources(LocalSchedulerState *state,
                              double num_cpus,
-                             double num_gpus);
+                             double num_gpus,
+                             double num_uirs);
 
 /**
  * Acquire additional resources (CPUs and GPUs) for a worker.
@@ -149,7 +150,8 @@ bool check_dynamic_resources(LocalSchedulerState *state,
 void acquire_resources(LocalSchedulerState *state,
                        LocalSchedulerClient *worker,
                        double num_cpus,
-                       double num_gpus);
+                       double num_gpus,
+                       double num_uirs);
 
 /**
  * Return resources (CPUs and GPUs) being used by a worker to the local
@@ -164,7 +166,8 @@ void acquire_resources(LocalSchedulerState *state,
 void release_resources(LocalSchedulerState *state,
                        LocalSchedulerClient *worker,
                        double num_cpus,
-                       double num_gpus);
+                       double num_gpus,
+                       double num_uirs);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -316,7 +316,8 @@ bool dispatch_actor_task(LocalSchedulerState *state,
         TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU));
   if (!check_dynamic_resources(state, TaskSpec_get_required_resource(
                                           first_task.spec, ResourceIndex_CPU),
-                               0)) {
+                               0, TaskSpec_get_required_resource(
+                                          first_task.spec, ResourceIndex_UIR))) {
     return false;
   }
   /* Assign the first task in the task queue to the worker and mark the worker
@@ -696,7 +697,8 @@ void dispatch_tasks(LocalSchedulerState *state,
     /* Skip to the next task if this task cannot currently be satisfied. */
     if (!check_dynamic_resources(
             state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
-            TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU))) {
+            TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU),
+            TaskSpec_get_required_resource(task.spec, ResourceIndex_UIR))) {
       /* This task could not be satisfied -- proceed to the next task. */
       ++it;
       continue;
@@ -924,8 +926,9 @@ bool resource_constraints_satisfied(LocalSchedulerState *state,
   /* At the local scheduler, if required resource vector exceeds either static
    * or dynamic resource vector, the resource constraint is not satisfied. */
   for (int i = 0; i < ResourceIndex_MAX; i++) {
-    if (TaskSpec_get_required_resource(spec, i) > state->static_resources[i] ||
-        TaskSpec_get_required_resource(spec, i) > state->dynamic_resources[i]) {
+    double required_resource = TaskSpec_get_required_resource(spec, i);
+    if (required_resource > state->static_resources[i] ||
+        required_resource > state->dynamic_resources[i]) {
       return false;
     }
   }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -317,7 +317,7 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   if (!check_dynamic_resources(state, TaskSpec_get_required_resource(
                                           first_task.spec, ResourceIndex_CPU),
                                0, TaskSpec_get_required_resource(
-                                          first_task.spec, ResourceIndex_UIR))) {
+                                          first_task.spec, ResourceIndex_CustomResource))) {
     return false;
   }
   /* Assign the first task in the task queue to the worker and mark the worker
@@ -698,7 +698,8 @@ void dispatch_tasks(LocalSchedulerState *state,
     if (!check_dynamic_resources(
             state, TaskSpec_get_required_resource(task.spec, ResourceIndex_CPU),
             TaskSpec_get_required_resource(task.spec, ResourceIndex_GPU),
-            TaskSpec_get_required_resource(task.spec, ResourceIndex_UIR))) {
+            TaskSpec_get_required_resource(task.spec,
+                                           ResourceIndex_CustomResource))) {
       /* This task could not be satisfied -- proceed to the next task. */
       ++it;
       continue;

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -314,10 +314,11 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   /* If there are not enough resources available, we cannot assign the task. */
   CHECK(0 ==
         TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU));
-  if (!check_dynamic_resources(state, TaskSpec_get_required_resource(
-                                          first_task.spec, ResourceIndex_CPU),
-                               0, TaskSpec_get_required_resource(
-                                          first_task.spec, ResourceIndex_CustomResource))) {
+  if (!check_dynamic_resources(
+          state,
+          TaskSpec_get_required_resource(first_task.spec, ResourceIndex_CPU), 0,
+          TaskSpec_get_required_resource(first_task.spec,
+                                         ResourceIndex_CustomResource))) {
     return false;
   }
   /* Assign the first task in the task queue to the worker and mark the worker

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -101,8 +101,8 @@ struct LocalSchedulerClient {
    *  nonzero when the worker is actively executing a task. If the worker is
    *  blocked, then this value will be zero. */
   double cpus_in_use;
-  /** A vector of resource counts currently in use by the worker.  */
-  double inuse_resources[ResourceIndex_MAX];
+  /** An array of resource counts currently in use by the worker.  */
+  double resources_in_use[ResourceIndex_MAX];
   /** A vector of the IDs of the GPUs that the worker is currently using. If the
    *  worker is an actor, this will be constant throughout the lifetime of the
    *  actor (and will be equal to the number of GPUs requested by the actor). If

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -101,6 +101,8 @@ struct LocalSchedulerClient {
    *  nonzero when the worker is actively executing a task. If the worker is
    *  blocked, then this value will be zero. */
   double cpus_in_use;
+  /** A vector of resource counts currently in use by the worker.  */
+  double inuse_resources[ResourceIndex_MAX];
   /** A vector of the IDs of the GPUs that the worker is currently using. If the
    *  worker is an actor, this will be constant throughout the lifetime of the
    *  actor (and will be equal to the number of GPUs requested by the actor). If

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -97,10 +97,6 @@ struct LocalSchedulerClient {
    *  no task is running on the worker, this will be NULL. This is used to
    *  update the task table. */
   Task *task_in_progress;
-  /** The number of CPUs that the worker is currently using. This will only be
-   *  nonzero when the worker is actively executing a task. If the worker is
-   *  blocked, then this value will be zero. */
-  double cpus_in_use;
   /** An array of resource counts currently in use by the worker.  */
   double resources_in_use[ResourceIndex_MAX];
   /** A vector of the IDs of the GPUs that the worker is currently using. If the

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -75,8 +75,8 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   const char *node_ip_address = "127.0.0.1";
   const char *redis_addr = node_ip_address;
   int redis_port = 6379;
-  const double static_resource_conf[ResourceIndex_MAX] = {DEFAULT_NUM_CPUS,
-                                                          DEFAULT_NUM_GPUS};
+  const double static_resource_conf[ResourceIndex_MAX] = {kDefaultNumCPUs,
+                                                          kDefaultNumGPUs};
   LocalSchedulerMock *mock =
       (LocalSchedulerMock *) malloc(sizeof(LocalSchedulerMock));
   memset(mock, 0, sizeof(LocalSchedulerMock));

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1288,6 +1288,48 @@ class ResourcesTest(unittest.TestCase):
 
         ray.worker.cleanup()
 
+    def testCustomResources(self):
+        ray.worker._init(start_ray_local=True, num_local_schedulers=2,
+                         num_cpus=3, num_custom_resource=[0, 1])
+
+        @ray.remote
+        def f():
+            time.sleep(0.001)
+            return ray.worker.global_worker.plasma_client.store_socket_name
+
+        @ray.remote(num_custom_resource=1)
+        def g():
+            time.sleep(0.001)
+            return ray.worker.global_worker.plasma_client.store_socket_name
+
+        # The f tasks should be scheduled on both local schedulers.
+        self.assertEqual(len(set(ray.get([f.remote() for _ in range(50)]))), 2)
+
+        local_plasma = ray.worker.global_worker.plasma_client.store_socket_name
+
+        # The g tasks should be scheduled only on the second local scheduler.
+        local_scheduler_ids = set(ray.get([g.remote() for _ in range(50)]))
+        self.assertEqual(len(local_scheduler_ids), 1)
+        self.assertNotEqual(list(local_scheduler_ids)[0], local_plasma)
+
+        ray.worker.cleanup()
+
+    def testInfiniteCustomResource(self):
+        # Make sure that -1 corresponds to an infinite resource capacity.
+        ray.init(num_custom_resource=-1)
+
+        def f():
+            return 1
+
+        ray.get(ray.remote(num_custom_resource=0)(f).remote())
+        ray.get(ray.remote(num_custom_resource=1)(f).remote())
+        ray.get(ray.remote(num_custom_resource=2)(f).remote())
+        ray.get(ray.remote(num_custom_resource=4)(f).remote())
+        ray.get(ray.remote(num_custom_resource=8)(f).remote())
+        ray.get(ray.remote(num_custom_resource=(10 ** 10))(f).remote())
+
+        ray.worker.cleanup()
+
 
 class WorkerPoolTests(unittest.TestCase):
 


### PR DESCRIPTION
This PR provides the ability to configure an arbitrary resource per local scheduler and lets tasks request it. It natively supports infinite capacity out of the box. 

This is an experimental first pass at addressing #695. There will be API changes down the road.