### PR TITLE
[WIP] Reconstruct actor state.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -9,7 +9,7 @@ from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from ray.worker import global_state
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
-import ray.actor
+import ray.actor  # noqa: F401
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -5,9 +5,11 @@ from __future__ import print_function
 from ray.worker import (register_class, error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
                         flush_log, get_gpu_ids)
-from ray.actor import actor
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from ray.worker import global_state
+# We import ray.actor because some code is run in actor.py which initializes
+# some functions in the worker.
+import ray.actor
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -168,9 +168,47 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
                                      worker.redis_client)
 
 
-def actor(*args, **kwargs):
-    raise Exception("The @ray.actor decorator is deprecated. Instead, please "
-                    "use @ray.remote.")
+def reconstruct_actor_state(actor_id, redis_client):
+    """Reconstruct the state of an actor that is being reconstructed.
+
+    Args:
+        actor_id: The ID of the actor being reconstructed.
+        redis_client: A redis client used to get tasks to rerun from Redis.
+    """
+    tasks = ray.global_state.task_table()
+
+    def hex_to_object_id(hex_id):
+        return ray.local_scheduler.ObjectID(hex_to_binary(hex_id))
+
+    relevant_tasks = []
+
+
+    # TODO(rkn): Maybe task_table should return the task specs like below
+    # instead of unpacking them into dictionarys.
+    for task in tasks:
+        task_spec_info = task["TaskSpec"]
+        task_spec = ray.local_scheduler.Task(
+            hex_to_object_id(task_spec["DriverID"]),
+            hex_to_object_id(task_spec["FunctionID"]),
+            task_spec["Args"],
+            len(task_spec["ReturnObjectIDs"]),
+            hex_to_object_id(task_spec["ParentTaskID"]),
+            task_spec["ParentCounter"],
+            hex_to_object_id(task_spec["ActorID"]),
+            task_spec["ActorCounter"],
+            task_spec["RequiredResources"])
+        relevant_tasks.append(task_spec)
+
+        # Verify that the return object IDs are the same as they were the first
+        # time.
+        assert task_spec_info["ReturnObjectIDs"] == task_spec.returns()
+
+    print("There are {} relevant tasks out of {} tasks.".format(len(relevant_tasks), len(tasks)))
+
+    # Do a little replica of the worker's main_loop here.
+    # 1. sort the tasks by actor counter.
+    # 2. call wait_for... so we know we can run the function
+    # 3. call process_task on the actor tasks
 
 
 def make_actor(cls, num_cpus, num_gpus):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -205,6 +205,11 @@ def reconstruct_actor_state(actor_id, redis_client):
 
     print("There are {} relevant tasks out of {} tasks.".format(len(relevant_tasks), len(tasks)))
 
+    # Sort the tasks by actor ID.
+    relevant_tasks.sort(key=lambda task: task.actor_counter())
+    for i in range(len(relevant_tasks)):
+        assert relevant_tasks[i].actor_counter() == i
+
     # Do a little replica of the worker's main_loop here.
     # 1. sort the tasks by actor counter.
     # 2. call wait_for... so we know we can run the function

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -172,7 +172,8 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
     # channel. Therefore, this message may be missed and the workload will
     # hang. This is a bug.
     ray.utils.publish_actor_creation(actor_id.id(), driver_id,
-                                     local_scheduler_id, worker.redis_client)
+                                     local_scheduler_id, False,
+                                     worker.redis_client)
 
 
 def actor(*args, **kwargs):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -272,6 +272,8 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
     # notification so that when the newly created actor attempts to fetch the
     # information from Redis, it is already there.
     worker.redis_client.hmset(key, {"class_id": class_id,
+                                    "driver_id": driver_id,
+                                    "local_scheduler_id": local_scheduler_id,
                                     "num_gpus": num_gpus})
 
     # Really we should encode this message as a flatbuffer object. However,

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -6,8 +6,6 @@ import cloudpickle as pickle
 import hashlib
 import inspect
 import json
-import numpy as np
-import redis
 import traceback
 
 import ray.local_scheduler
@@ -182,7 +180,6 @@ def reconstruct_actor_state(actor_id, worker):
 
     relevant_tasks = []
 
-
     # TODO(rkn): Maybe task_table should return the task specs like below
     # instead of unpacking them into dictionarys.
     for _, task_info in tasks.items():
@@ -205,7 +202,8 @@ def reconstruct_actor_state(actor_id, worker):
             # first time.
             assert task_spec_info["ReturnObjectIDs"] == task_spec.returns()
 
-    print("There are {} relevant tasks out of {} tasks.".format(len(relevant_tasks), len(tasks)))
+    print("There are {} relevant tasks out of {} tasks."
+          .format(len(relevant_tasks), len(tasks)))
 
     # Sort the tasks by actor ID.
     relevant_tasks.sort(key=lambda task: task.actor_counter())
@@ -245,8 +243,9 @@ def reconstruct_actor_state(actor_id, worker):
         del worker.task_index
 
         # Get the task from the local scheduler.
-        retrieved_task = worker._get_next_task_from_local_scheduler()
-        # TODO(rkn): Assert that task == retrieved_task.
+        worker._get_next_task_from_local_scheduler()
+        # TODO(rkn): Assert that the retrieved task is the same as the
+        # constructed task.
 
         # Wait for the task to be ready and execute the task.
         worker._wait_for_and_process_task(task)

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -14,7 +14,7 @@ import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
 from ray.utils import (FunctionProperties, binary_to_hex, hex_to_binary,
-                       random_string)
+                       random_string, select_local_scheduler)
 
 
 def random_actor_id():
@@ -102,117 +102,6 @@ def fetch_and_register_actor(actor_class_key, worker):
             # for the actor.
 
 
-def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler, worker):
-    """Attempt to acquire GPUs on a particular local scheduler for an actor.
-
-    Args:
-        num_gpus: The number of GPUs to acquire.
-        driver_id: The ID of the driver responsible for creating the actor.
-        local_scheduler: Information about the local scheduler.
-
-    Returns:
-        True if the GPUs were successfully reserved and false otherwise.
-    """
-    assert num_gpus != 0
-    local_scheduler_id = local_scheduler["DBClientID"]
-    local_scheduler_total_gpus = int(local_scheduler["NumGPUs"])
-
-    success = False
-
-    # Attempt to acquire GPU IDs atomically.
-    with worker.redis_client.pipeline() as pipe:
-        while True:
-            try:
-                # If this key is changed before the transaction below (the
-                # multi/exec block), then the transaction will not take place.
-                pipe.watch(local_scheduler_id)
-
-                # Figure out which GPUs are currently in use.
-                result = worker.redis_client.hget(local_scheduler_id,
-                                                  "gpus_in_use")
-                gpus_in_use = dict() if result is None else json.loads(
-                    result.decode("ascii"))
-                num_gpus_in_use = 0
-                for key in gpus_in_use:
-                    num_gpus_in_use += gpus_in_use[key]
-                assert num_gpus_in_use <= local_scheduler_total_gpus
-
-                pipe.multi()
-
-                if local_scheduler_total_gpus - num_gpus_in_use >= num_gpus:
-                    # There are enough available GPUs, so try to reserve some.
-                    # We use the hex driver ID in hex as a dictionary key so
-                    # that the dictionary is JSON serializable.
-                    driver_id_hex = binary_to_hex(driver_id)
-                    if driver_id_hex not in gpus_in_use:
-                        gpus_in_use[driver_id_hex] = 0
-                    gpus_in_use[driver_id_hex] += num_gpus
-
-                    # Stick the updated GPU IDs back in Redis
-                    pipe.hset(local_scheduler_id, "gpus_in_use",
-                              json.dumps(gpus_in_use))
-                    success = True
-
-                pipe.execute()
-                # If a WatchError is not raised, then the operations should
-                # have gone through atomically.
-                break
-            except redis.WatchError:
-                # Another client must have changed the watched key between the
-                # time we started WATCHing it and the pipeline's execution. We
-                # should just retry.
-                success = False
-                continue
-
-    return success
-
-
-def select_local_scheduler(local_schedulers, num_gpus, worker):
-    """Select a local scheduler to assign this actor to.
-
-    Args:
-        local_schedulers: A list of dictionaries of information about the local
-            schedulers.
-        num_gpus (int): The number of GPUs that must be reserved for this
-            actor.
-
-    Returns:
-        The ID of the local scheduler that has been chosen.
-
-    Raises:
-        Exception: An exception is raised if no local scheduler can be found
-            with sufficient resources.
-    """
-    driver_id = worker.task_driver_id.id()
-
-    local_scheduler_id = None
-    # Loop through all of the local schedulers in a random order.
-    local_schedulers = np.random.permutation(local_schedulers)
-    for local_scheduler in local_schedulers:
-        if local_scheduler["NumCPUs"] < 1:
-            continue
-        if local_scheduler["NumGPUs"] < num_gpus:
-            continue
-        if num_gpus == 0:
-            local_scheduler_id = hex_to_binary(local_scheduler["DBClientID"])
-            break
-        else:
-            # Try to reserve enough GPUs on this local scheduler.
-            success = attempt_to_reserve_gpus(num_gpus, driver_id,
-                                              local_scheduler, worker)
-            if success:
-                local_scheduler_id = hex_to_binary(
-                                         local_scheduler["DBClientID"])
-                break
-
-    if local_scheduler_id is None:
-        raise Exception("Could not find a node with enough GPUs or other "
-                        "resources to create this actor. The local scheduler "
-                        "information is {}.".format(local_schedulers))
-
-    return local_scheduler_id
-
-
 def export_actor_class(class_id, Class, actor_method_names, worker):
     if worker.mode is None:
         raise NotImplemented("TODO(pcm): Cache actors")
@@ -264,8 +153,9 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
                     not client["Deleted"]):
                 local_schedulers.append(client)
     # Select a local scheduler for the actor.
-    local_scheduler_id = select_local_scheduler(local_schedulers, num_gpus,
-                                                worker)
+    local_scheduler_id = select_local_scheduler(worker.task_driver_id.id(),
+                                                local_schedulers, num_gpus,
+                                                worker.redis_client)
     assert local_scheduler_id is not None
 
     # We must put the actor information in Redis before publishing the actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -144,18 +144,10 @@ def export_actor(actor_id, class_id, actor_method_names, num_cpus, num_gpus,
                                num_gpus=0,
                                max_calls=0))
 
-    # Get a list of the local schedulers from the client table.
-    client_table = ray.global_state.client_table()
-    local_schedulers = []
-    for ip_address, clients in client_table.items():
-        for client in clients:
-            if (client["ClientType"] == "local_scheduler" and
-                    not client["Deleted"]):
-                local_schedulers.append(client)
     # Select a local scheduler for the actor.
-    local_scheduler_id = select_local_scheduler(worker.task_driver_id.id(),
-                                                local_schedulers, num_gpus,
-                                                worker.redis_client)
+    local_scheduler_id = select_local_scheduler(
+        worker.task_driver_id.id(), ray.global_state.local_schedulers(),
+        num_gpus, worker.redis_client)
     assert local_scheduler_id is not None
 
     # We must put the actor information in Redis before publishing the actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -255,8 +255,7 @@ def make_actor(cls, num_cpus, num_gpus):
         args = signature.extend_args(function_signature, args, kwargs)
 
         function_id = get_actor_method_function_id(attr)
-        object_ids = ray.worker.global_worker.submit_task(function_id, "",
-                                                          args,
+        object_ids = ray.worker.global_worker.submit_task(function_id, args,
                                                           actor_id=actor_id)
         if len(object_ids) == 1:
             return object_ids[0]

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -632,6 +632,22 @@ class GlobalState(object):
             }
         return workers_data
 
+    def actors(self):
+        actor_keys = self.redis_client.keys("Actor:*")
+        actor_info = dict()
+        for key in actor_keys:
+            info = self.redis_client.hgetall(key)
+            actor_id = key[len("Actor:"):]
+            assert len(actor_id) == 20
+            actor_info[binary_to_hex(actor_id)] = {
+                "class_id": binary_to_hex(info[b"class_id"]),
+                "driver_id": binary_to_hex(info[b"driver_id"]),
+                "local_scheduler_id":
+                    binary_to_hex(info[b"local_scheduler_id"]),
+                "num_gpus": int(info[b"num_gpus"]),
+                "removed": decode(info[b"removed"]) == "True"}
+        return actor_info
+
     def _job_length(self):
         event_log_sets = self.redis_client.keys("event_log*")
         overall_smallest = sys.maxsize

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -608,6 +608,21 @@ class GlobalState(object):
         all_times.append(data["store_outputs_end"])
         return all_times
 
+    def local_schedulers(self):
+        """Get a list of live local schedulers.
+
+        Returns:
+            A list of the live local schedulers.
+        """
+        clients = self.client_table()
+        local_schedulers = []
+        for ip_address, client_list in clients.items():
+            for client in client_list:
+                if (client["ClientType"] == "local_scheduler" and
+                        not client["Deleted"]):
+                    local_schedulers.append(client)
+        return local_schedulers
+
     def workers(self):
         """Get a dictionary mapping worker ID to worker information."""
         worker_keys = self.redis_client.keys("Worker*")

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -108,8 +108,8 @@ class Monitor(object):
                     info["local_scheduler_id"] in self.dead_local_schedulers):
                 # Choose a new local scheduler to run the actor.
                 local_scheduler_id = ray.utils.select_local_scheduler(
-                    info["driver_id"], local_schedulers, info["num_gpus"],
-                    self.redis_client)
+                    info["driver_id"], self.state.local_schedulers(),
+                    info["num_gpus"], self.redis_client)
                 # The new local scheduler should not be the same as the old
                 # local scheduler. TODO(rkn): This should not be an assert, it
                 # should be something more benign.

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -118,7 +118,7 @@ class Monitor(object):
                 # Announce to all of the local schedulers that the actor should
                 # be recreated on this new local scheduler.
                 ray.utils.publish_actor_creation(actor_id, info["driver_id"],
-                                                 local_scheduler_id,
+                                                 local_scheduler_id, True,
                                                  self.redis_client)
                 log.info("Actor {} for driver {} was on dead local scheduler "
                          "{}. It is being recreated on local scheduler {}"

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -110,6 +110,8 @@ class Monitor(object):
                 local_scheduler_id = ray.utils.select_local_scheduler(
                     info["driver_id"], self.state.local_schedulers(),
                     info["num_gpus"], self.redis)
+                import sys
+                sys.stdout.flush()
                 # The new local scheduler should not be the same as the old
                 # local scheduler. TODO(rkn): This should not be an assert, it
                 # should be something more benign.
@@ -127,8 +129,7 @@ class Monitor(object):
                                  binary_to_hex(local_scheduler_id)))
                 # Update the actor info in Redis.
                 self.redis.hset(b"Actor:" + hex_to_binary(actor_id),
-                                "local_scheduler_id",
-                                binary_to_hex(local_scheduler_id))
+                                "local_scheduler_id", local_scheduler_id)
 
     def cleanup_task_table(self):
         """Clean up global state for failed local schedulers.

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -184,7 +184,7 @@ def select_local_scheduler(driver_id, local_schedulers, num_gpus,
 
 
 def publish_actor_creation(actor_id, driver_id, local_scheduler_id,
-                           redis_client):
+                           reconstruct, redis_client):
     """Publish a notification that an actor should be created.
 
     This broadcast will be received by all of the local schedulers. The local
@@ -198,10 +198,14 @@ def publish_actor_creation(actor_id, driver_id, local_scheduler_id,
         driver_id: The ID of the driver responsible for the actor.
         local_scheduler_id: The ID of the local scheduler that is suposed to
             create the actor.
+        reconstruct: True if the actor should be created in "reconstruct" mode.
+        redis_client: The client used to interact with Redis.
     """
+    reconstruct_bit = b"1" if reconstruct else b"0"
     # Really we should encode this message as a flatbuffer object. However,
     # we're having trouble getting that to work. It almost works, but in Python
     # 2.7, builder.CreateString fails on byte strings that contain characters
     # outside range(128).
     redis_client.publish("actor_notifications",
-                         actor_id + driver_id + local_scheduler_id)
+                         actor_id + driver_id + local_scheduler_id +
+                         reconstruct_bit)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -97,8 +97,7 @@ def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler,
                 pipe.watch(local_scheduler_id)
 
                 # Figure out which GPUs are currently in use.
-                result = redis_client.hget(local_scheduler_id,
-                                                  "gpus_in_use")
+                result = redis_client.hget(local_scheduler_id, "gpus_in_use")
                 gpus_in_use = dict() if result is None else json.loads(
                     result.decode("ascii"))
                 num_gpus_in_use = 0

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -4,7 +4,9 @@ from __future__ import print_function
 
 import binascii
 import collections
+import json
 import numpy as np
+import redis
 import sys
 
 import ray.local_scheduler
@@ -65,3 +67,117 @@ FunctionProperties = collections.namedtuple("FunctionProperties",
                                              "num_gpus",
                                              "max_calls"])
 """FunctionProperties: A named tuple storing remote functions information."""
+
+
+def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler,
+                            redis_client):
+    """Attempt to acquire GPUs on a particular local scheduler for an actor.
+
+    Args:
+        num_gpus: The number of GPUs to acquire.
+        driver_id: The ID of the driver responsible for creating the actor.
+        local_scheduler: Information about the local scheduler.
+        redis_client: The redis client to use for interacting with Redis.
+
+    Returns:
+        True if the GPUs were successfully reserved and false otherwise.
+    """
+    assert num_gpus != 0
+    local_scheduler_id = local_scheduler["DBClientID"]
+    local_scheduler_total_gpus = int(local_scheduler["NumGPUs"])
+
+    success = False
+
+    # Attempt to acquire GPU IDs atomically.
+    with redis_client.pipeline() as pipe:
+        while True:
+            try:
+                # If this key is changed before the transaction below (the
+                # multi/exec block), then the transaction will not take place.
+                pipe.watch(local_scheduler_id)
+
+                # Figure out which GPUs are currently in use.
+                result = redis_client.hget(local_scheduler_id,
+                                                  "gpus_in_use")
+                gpus_in_use = dict() if result is None else json.loads(
+                    result.decode("ascii"))
+                num_gpus_in_use = 0
+                for key in gpus_in_use:
+                    num_gpus_in_use += gpus_in_use[key]
+                assert num_gpus_in_use <= local_scheduler_total_gpus
+
+                pipe.multi()
+
+                if local_scheduler_total_gpus - num_gpus_in_use >= num_gpus:
+                    # There are enough available GPUs, so try to reserve some.
+                    # We use the hex driver ID in hex as a dictionary key so
+                    # that the dictionary is JSON serializable.
+                    driver_id_hex = binary_to_hex(driver_id)
+                    if driver_id_hex not in gpus_in_use:
+                        gpus_in_use[driver_id_hex] = 0
+                    gpus_in_use[driver_id_hex] += num_gpus
+
+                    # Stick the updated GPU IDs back in Redis
+                    pipe.hset(local_scheduler_id, "gpus_in_use",
+                              json.dumps(gpus_in_use))
+                    success = True
+
+                pipe.execute()
+                # If a WatchError is not raised, then the operations should
+                # have gone through atomically.
+                break
+            except redis.WatchError:
+                # Another client must have changed the watched key between the
+                # time we started WATCHing it and the pipeline's execution. We
+                # should just retry.
+                success = False
+                continue
+
+    return success
+
+
+def select_local_scheduler(driver_id, local_schedulers, num_gpus,
+                           redis_client):
+    """Select a local scheduler to assign this actor to.
+
+    Args:
+        driver_id: The ID of the driver who the actor is for.
+        local_schedulers: A list of dictionaries of information about the local
+            schedulers.
+        num_gpus (int): The number of GPUs that must be reserved for this
+            actor.
+        redis_client: The Redis client to use for interacting with Redis.
+
+    Returns:
+        The ID of the local scheduler that has been chosen.
+
+    Raises:
+        Exception: An exception is raised if no local scheduler can be found
+            with sufficient resources.
+    """
+    local_scheduler_id = None
+    # Loop through all of the local schedulers in a random order.
+    local_schedulers = np.random.permutation(local_schedulers)
+    for local_scheduler in local_schedulers:
+        if local_scheduler["NumCPUs"] < 1:
+            continue
+        if local_scheduler["NumGPUs"] < num_gpus:
+            continue
+        if num_gpus == 0:
+            local_scheduler_id = hex_to_binary(local_scheduler["DBClientID"])
+            break
+        else:
+            # Try to reserve enough GPUs on this local scheduler.
+            success = attempt_to_reserve_gpus(num_gpus, driver_id,
+                                              local_scheduler, redis_client)
+            if success:
+                local_scheduler_id = hex_to_binary(
+                                         local_scheduler["DBClientID"])
+                break
+
+    if local_scheduler_id is None:
+        raise Exception("Could not find a node with enough GPUs or other "
+                        "resources to create this actor. The local scheduler "
+                        "information is {}.".format(local_schedulers))
+
+    return local_scheduler_id

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -469,15 +469,14 @@ class Worker(object):
             assert final_results[i][0] == object_ids[i].id()
         return [result[1][0] for result in final_results]
 
-    def submit_task(self, function_id, func_name, args, actor_id=None):
+    def submit_task(self, function_id, args, actor_id=None):
         """Submit a remote task to the scheduler.
 
-        Tell the scheduler to schedule the execution of the function with name
-        func_name with arguments args. Retrieve object IDs for the outputs of
+        Tell the scheduler to schedule the execution of a function with ID
+        function_id with arguments args. Retrieve object IDs for the outputs of
         the function from the scheduler and immediately return them.
 
         Args:
-            func_name (str): The name of the function to be executed.
             args (List[Any]): The arguments to pass into the function.
                 Arguments can be object IDs or they can be values. If they are
                 values, they must be serializable objecs.
@@ -684,7 +683,6 @@ class Worker(object):
         for i in range(len(objectids)):
             self.put_object(objectids[i], outputs[i])
 
-
     def _process_task(self, task):
         """Execute a task assigned to this worker.
 
@@ -764,7 +762,6 @@ class Worker(object):
                                         str(failure_object),
                                         data={"function_id": function_id.id(),
                                               "function_name": function_name})
-
 
     def _wait_for_and_process_task(self, task):
         """Wait for a task to be ready and process the task.
@@ -1991,7 +1988,7 @@ def format_error_message(exception_message, task_exception=False):
     return "\n".join(lines)
 
 
-def _submit_task(function_id, func_name, args, worker=global_worker):
+def _submit_task(function_id, args, worker=global_worker):
     """This is a wrapper around worker.submit_task.
 
     We use this wrapper so that in the remote decorator, we can call
@@ -1999,7 +1996,7 @@ def _submit_task(function_id, func_name, args, worker=global_worker):
     attempt to serialize remote functions, we don't attempt to serialize the
     worker object, which cannot be serialized.
     """
-    return worker.submit_task(function_id, func_name, args)
+    return worker.submit_task(function_id, args)
 
 
 def _mode(worker=global_worker):
@@ -2142,7 +2139,7 @@ def remote(*args, **kwargs):
                     # immutable remote objects.
                     result = func(*copy.deepcopy(args))
                     return result
-                objectids = _submit_task(function_id, func_name, args)
+                objectids = _submit_task(function_id, args)
                 if len(objectids) == 1:
                     return objectids[0]
                 elif len(objectids) > 1:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -578,7 +578,6 @@ class Worker(object):
                                             "data": data})
         self.redis_client.rpush("ErrorKeys", error_key)
 
-
     def _wait_for_function(self, function_id, driver_id, timeout=10):
         """Wait until the function to be executed is present on this worker.
 
@@ -658,7 +657,6 @@ class Worker(object):
 
             arguments.append(argument)
         return arguments
-
 
     def _store_outputs_in_objstore(self, objectids, outputs):
         """Store the outputs of a remote function in the local object store.
@@ -759,9 +757,9 @@ class Worker(object):
             self._store_outputs_in_objstore(return_object_ids, failure_objects)
             # Log the error message.
             self.push_error_to_driver(self.task_driver_id.id(), "task",
-                                        str(failure_object),
-                                        data={"function_id": function_id.id(),
-                                              "function_name": function_name})
+                                      str(failure_object),
+                                      data={"function_id": function_id.id(),
+                                            "function_name": function_name})
 
     def _wait_for_and_process_task(self, task):
         """Wait for a task to be ready and process the task.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -647,7 +647,7 @@ class Worker(object):
         for (i, arg) in enumerate(serialized_args):
             if isinstance(arg, ray.local_scheduler.ObjectID):
                 # get the object from the local object store
-                argument = worker.get_object([arg])[0]
+                argument = self.get_object([arg])[0]
                 if isinstance(argument, RayTaskError):
                     # If the result is a RayTaskError, then the task that
                     # created this object failed, and we should propagate the

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -810,6 +810,16 @@ class Worker(object):
             ray.worker.global_worker.local_scheduler_client.disconnect()
             os._exit(0)
 
+    def _get_next_task_from_local_scheduler(self):
+        """Get the next task from the local scheduler.
+
+        Returns:
+            A task from the local scheduler.
+        """
+        with log_span("ray:get_task", worker=self):
+            task = self.local_scheduler_client.get_task()
+        return task
+
     def main_loop(self):
         """The main loop a worker runs to receive and execute tasks."""
 
@@ -821,9 +831,7 @@ class Worker(object):
 
         check_main_thread()
         while True:
-            with log_span("ray:get_task", worker=self):
-                task = self.local_scheduler_client.get_task()
-
+            task = self._get_next_task_from_local_scheduler()
             self._wait_for_and_process_task(task)
 
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -766,6 +766,53 @@ class Worker(object):
                                               "function_name": function_name})
 
 
+    def _wait_for_and_process_task(self, task):
+        """Wait for a task to be ready and process the task.
+
+        Args:
+            task: The task to execute.
+        """
+        function_id = task.function_id()
+        # Wait until the function to be executed has actually been registered
+        # on this worker. We will push warnings to the user if we spend too
+        # long in this loop.
+        with log_span("ray:wait_for_function", worker=self):
+            self._wait_for_function(function_id, task.driver_id().id())
+
+        # Execute the task.
+        # TODO(rkn): Consider acquiring this lock with a timeout and pushing a
+        # warning to the user if we are waiting too long to acquire the lock
+        # because that may indicate that the system is hanging, and it'd be
+        # good to know where the system is hanging.
+        log(event_type="ray:acquire_lock", kind=LOG_SPAN_START, worker=self)
+        with self.lock:
+            log(event_type="ray:acquire_lock", kind=LOG_SPAN_END,
+                worker=self)
+
+            function_name, _ = (self.functions[task.driver_id().id()]
+                                [function_id.id()])
+            contents = {"function_name": function_name,
+                        "task_id": task.task_id().hex(),
+                        "worker_id": binary_to_hex(self.worker_id)}
+            with log_span("ray:task", contents=contents, worker=self):
+                self._process_task(task)
+
+        # Push all of the log events to the global state store.
+        flush_log()
+
+        # Increase the task execution counter.
+        (self.num_task_executions[task.driver_id().id()]
+                                 [function_id.id()]) += 1
+
+        reached_max_executions = (
+            self.num_task_executions[task.driver_id().id()]
+                                    [function_id.id()] ==
+            self.function_properties[task.driver_id().id()]
+                                    [function_id.id()].max_calls)
+        if reached_max_executions:
+            ray.worker.global_worker.local_scheduler_client.disconnect()
+            os._exit(0)
+
     def main_loop(self):
         """The main loop a worker runs to receive and execute tasks."""
 
@@ -780,46 +827,7 @@ class Worker(object):
             with log_span("ray:get_task", worker=self):
                 task = self.local_scheduler_client.get_task()
 
-            function_id = task.function_id()
-            # Wait until the function to be executed has actually been registered
-            # on this worker. We will push warnings to the user if we spend too
-            # long in this loop.
-            with log_span("ray:wait_for_function", worker=self):
-                self._wait_for_function(function_id, task.driver_id().id())
-
-            # Execute the task.
-            # TODO(rkn): Consider acquiring this lock with a timeout and pushing a
-            # warning to the user if we are waiting too long to acquire the lock
-            # because that may indicate that the system is hanging, and it'd be
-            # good to know where the system is hanging.
-            log(event_type="ray:acquire_lock", kind=LOG_SPAN_START, worker=self)
-            with self.lock:
-                log(event_type="ray:acquire_lock", kind=LOG_SPAN_END,
-                    worker=self)
-
-                function_name, _ = (self.functions[task.driver_id().id()]
-                                    [function_id.id()])
-                contents = {"function_name": function_name,
-                            "task_id": task.task_id().hex(),
-                            "worker_id": binary_to_hex(self.worker_id)}
-                with log_span("ray:task", contents=contents, worker=self):
-                    self._process_task(task)
-
-            # Push all of the log events to the global state store.
-            flush_log()
-
-            # Increase the task execution counter.
-            (self.num_task_executions[task.driver_id().id()]
-                                       [function_id.id()]) += 1
-
-            reached_max_executions = (
-                self.num_task_executions[task.driver_id().id()]
-                                        [function_id.id()] ==
-                self.function_properties[task.driver_id().id()]
-                                        [function_id.id()].max_calls)
-            if reached_max_executions:
-                ray.worker.global_worker.local_scheduler_client.disconnect()
-                os._exit(0)
+            self._wait_for_and_process_task(task)
 
 
 def get_gpu_ids():

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
         # task) should be caught and handled inside of the call to
         # main_loop. If an exception is thrown here, then that means that
         # there is some error that we didn't anticipate.
-        ray.worker.main_loop()
+        ray.worker.global_worker.main_loop()
     except Exception as e:
         traceback_str = traceback.format_exc() + error_explanation
         DRIVER_ID_LENGTH = 20

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -82,10 +82,11 @@ if __name__ == "__main__":
     # If this is an actor started in reconstruct mode, rerun tasks to
     # reconstruct its state.
     if args.reconstruct:
-        redis_client = create_redis_client(args.redis_address)
         try:
-            ray.actor.reconstruct_actor_state(actor_id, redis_client)
+            ray.actor.reconstruct_actor_state(actor_id,
+                                              ray.worker.global_worker)
         except Exception as e:
+            redis_client = create_redis_client(args.redis_address)
             push_error_to_all_drivers(redis_client, traceback.format_exc())
             raise e
 

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -24,6 +24,9 @@ parser.add_argument("--local-scheduler-name", required=True, type=str,
                     help="the local scheduler's name")
 parser.add_argument("--actor-id", required=False, type=str,
                     help="the actor ID of this worker")
+parser.add_argument("--reconstruct", action="store_true",
+                    help=("true if the actor should be started in reconstruct "
+                          "mode"))
 
 
 def random_string():
@@ -32,6 +35,11 @@ def random_string():
 
 if __name__ == "__main__":
     args = parser.parse_args()
+
+    # If this worker is not an actor, it cannot be started in reconstruct mode.
+    if args.actor_id is None:
+        assert not args.reconstruct
+
     info = {"node_ip_address": args.node_ip_address,
             "redis_address": args.redis_address,
             "store_socket_name": args.object_store_name,

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -362,6 +362,16 @@ static PyObject *PyTask_task_id(PyObject *self) {
   return PyObjectID_make(task_id);
 }
 
+static PyObject *PyTask_parent_task_id(PyObject *self) {
+  TaskID task_id = TaskSpec_parent_task_id(((PyTask *) self)->spec);
+  return PyObjectID_make(task_id);
+}
+
+static PyObject *PyTask_parent_counter(PyObject *self) {
+  int64_t parent_counter = TaskSpec_parent_counter(((PyTask *) self)->spec);
+  return PyLong_FromLongLong(parent_counter);
+}
+
 static PyObject *PyTask_arguments(PyObject *self) {
   TaskSpec *task = ((PyTask *) self)->spec;
   int64_t num_args = TaskSpec_num_args(task);
@@ -409,6 +419,10 @@ static PyObject *PyTask_returns(PyObject *self) {
 static PyMethodDef PyTask_methods[] = {
     {"function_id", (PyCFunction) PyTask_function_id, METH_NOARGS,
      "Return the function ID for this task."},
+    {"parent_task_id", (PyCFunction) PyTask_parent_task_id, METH_NOARGS,
+     "Return the task ID of the parent task."},
+    {"parent_counter", (PyCFunction) PyTask_parent_counter, METH_NOARGS,
+     "Return the parent counter of this task."},
     {"actor_id", (PyCFunction) PyTask_actor_id, METH_NOARGS,
      "Return the actor ID for this task."},
     {"actor_counter", (PyCFunction) PyTask_actor_counter, METH_NOARGS,

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -347,6 +347,11 @@ static PyObject *PyTask_actor_id(PyObject *self) {
   return PyObjectID_make(actor_id);
 }
 
+static PyObject *PyTask_actor_counter(PyObject *self) {
+  int64_t actor_counter = TaskSpec_actor_counter(((PyTask *) self)->spec);
+  return PyLong_FromLongLong(actor_counter);
+}
+
 static PyObject *PyTask_driver_id(PyObject *self) {
   UniqueID driver_id = TaskSpec_driver_id(((PyTask *) self)->spec);
   return PyObjectID_make(driver_id);
@@ -406,6 +411,8 @@ static PyMethodDef PyTask_methods[] = {
      "Return the function ID for this task."},
     {"actor_id", (PyCFunction) PyTask_actor_id, METH_NOARGS,
      "Return the actor ID for this task."},
+    {"actor_counter", (PyCFunction) PyTask_actor_counter, METH_NOARGS,
+     "Return the actor counter for this task."},
     {"driver_id", (PyCFunction) PyTask_driver_id, METH_NOARGS,
      "Return the driver ID for this task."},
     {"task_id", (PyCFunction) PyTask_task_id, METH_NOARGS,

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -14,6 +14,7 @@ typedef void (*actor_notification_table_subscribe_callback)(
     ActorID actor_id,
     WorkerID driver_id,
     DBClientID local_scheduler_id,
+    bool reconstruct,
     void *user_context);
 
 /**

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -1523,16 +1523,27 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     ActorID actor_id;
     WorkerID driver_id;
     DBClientID local_scheduler_id;
-    CHECK(sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) ==
-          payload->len);
+    bool reconstruct;
+    CHECK(
+        sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) + 1 ==
+        payload->len);
     memcpy(&actor_id, payload->str, sizeof(actor_id));
     memcpy(&driver_id, payload->str + sizeof(actor_id), sizeof(driver_id));
     memcpy(&local_scheduler_id,
            payload->str + sizeof(actor_id) + sizeof(driver_id),
            sizeof(local_scheduler_id));
+    if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
+          sizeof(local_scheduler_id)) == '1') {
+      reconstruct = true;
+    } else if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
+          sizeof(local_scheduler_id)) == '0') {
+      reconstruct = false;
+    } else {
+      LOG_FATAL("This code should be unreachable.");
+    }
     if (data->subscribe_callback) {
       data->subscribe_callback(actor_id, driver_id, local_scheduler_id,
-                               data->subscribe_context);
+                               reconstruct, data->subscribe_context);
     }
   } else if (strcmp(message_type->str, "subscribe") == 0) {
     /* The reply for the initial SUBSCRIBE command. */

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -1524,9 +1524,9 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     WorkerID driver_id;
     DBClientID local_scheduler_id;
     bool reconstruct;
-    CHECK(
-        sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) + 1 ==
-        payload->len);
+    CHECK(sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) +
+              1 ==
+          payload->len);
     memcpy(&actor_id, payload->str, sizeof(actor_id));
     memcpy(&driver_id, payload->str + sizeof(actor_id), sizeof(driver_id));
     memcpy(&local_scheduler_id,
@@ -1536,7 +1536,7 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
           sizeof(local_scheduler_id)) == '1') {
       reconstruct = true;
     } else if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
-          sizeof(local_scheduler_id)) == '0') {
+                 sizeof(local_scheduler_id)) == '0') {
       reconstruct = false;
     } else {
       LOG_FATAL("This code should be unreachable.");

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -226,6 +226,18 @@ UniqueID TaskSpec_driver_id(TaskSpec *spec) {
   return from_flatbuf(message->driver_id());
 }
 
+TaskID TaskSpec_parent_task_id(TaskSpec *spec) {
+  CHECK(spec);
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec);
+  return from_flatbuf(message->parent_task_id());
+}
+
+int64_t TaskSpec_parent_counter(TaskSpec *spec) {
+  CHECK(spec);
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec);
+  return message->parent_counter();
+}
+
 int64_t TaskSpec_num_args(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -144,6 +144,23 @@ int64_t TaskSpec_actor_counter(TaskSpec *spec);
 UniqueID TaskSpec_driver_id(TaskSpec *spec);
 
 /**
+ * Return the task ID of the parent task.
+ *
+ * @param spec The task_spec in question.
+ * @return The task ID of the parent task.
+ */
+TaskID TaskSpec_parent_task_id(TaskSpec *spec);
+
+/**
+ * Return the task counter of the parent task. For example, this equals 5 if
+ * this task was the 6th task submitted by the parent task.
+ *
+ * @param spec The task_spec in question.
+ * @return The task counter of the parent task.
+ */
+int64_t TaskSpec_parent_counter(TaskSpec *spec);
+
+/**
  * Return the task ID of the task.
  *
  * @param spec The task_spec in question.

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -611,15 +611,18 @@ void reconstruct_task_update_callback(Task *task,
   TaskSpec *spec = Task_task_spec(task);
   /* If the task is an actor task, then we currently do not reconstruct it.
    * TODO(rkn): Handle this better. */
-  CHECK(ActorID_equal(TaskSpec_actor_id(spec), NIL_ACTOR_ID));
-  /* Resubmit the task. */
-  handle_task_submitted(state, state->algorithm_state, spec,
-                        Task_task_spec_size(task));
-  /* Recursively reconstruct the task's inputs, if necessary. */
-  for (int64_t i = 0; i < TaskSpec_num_args(spec); ++i) {
-    if (TaskSpec_arg_by_ref(spec, i)) {
-      ObjectID arg_id = TaskSpec_arg_id(spec, i);
-      reconstruct_object(state, arg_id);
+  if (!ActorID_equal(TaskSpec_actor_id(spec), NIL_ACTOR_ID)) {
+    LOG_WARN("We are not resubmitting this task because it is an actor task.");
+  } else {
+    /* Resubmit the task. */
+    handle_task_submitted(state, state->algorithm_state, spec,
+                          Task_task_spec_size(task));
+    /* Recursively reconstruct the task's inputs, if necessary. */
+    for (int64_t i = 0; i < TaskSpec_num_args(spec); ++i) {
+      if (TaskSpec_arg_by_ref(spec, i)) {
+        ObjectID arg_id = TaskSpec_arg_id(spec, i);
+        reconstruct_object(state, arg_id);
+      }
     }
   }
 }

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -114,9 +114,13 @@ void kill_worker(LocalSchedulerState *state,
  * @param state The local scheduler state.
  * @param actor_id The ID of the actor for this worker. If this worker is not an
  *        actor, then NIL_ACTOR_ID should be used.
+ * @param reconstruct True if the worker is an actor and is being started in
+ *        reconstruct mode.
  * @param Void.
  */
-void start_worker(LocalSchedulerState *state, ActorID actor_id);
+void start_worker(LocalSchedulerState *state,
+                  ActorID actor_id,
+                  bool reconstruct);
 
 /**
  * Check if a certain quantity of dynamic resources are available. If num_cpus

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -447,8 +447,9 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
          * the task table, so just update the entry. */
         task_table_update(state->db, task, NULL, NULL, NULL);
       } else {
-        /* Otherwise, this is the first time the task has been seen in the system
-         * (unless it's a resubmission of a previous task), so add the entry. */
+        /* Otherwise, this is the first time the task has been seen in the
+         * system (unless it's a resubmission of a previous task), so add the
+         * entry. */
         task_table_add_task(state->db, task, NULL, NULL, NULL);
       }
     }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -664,7 +664,7 @@ void dispatch_tasks(LocalSchedulerState *state,
       if (state->child_pids.size() == 0) {
         /* If there are no workers, including those pending PID registration,
          * then we must start a new one to replenish the worker pool. */
-        start_worker(state, NIL_ACTOR_ID);
+        start_worker(state, NIL_ACTOR_ID, false);
       }
       return;
     }
@@ -977,7 +977,8 @@ void handle_actor_task_submitted(LocalSchedulerState *state,
 void handle_actor_creation_notification(
     LocalSchedulerState *state,
     SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id) {
+    ActorID actor_id,
+    bool reconstruct) {
   int num_cached_actor_tasks =
       algorithm_state->cached_submitted_actor_tasks.size();
 

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -88,12 +88,14 @@ void handle_actor_task_submitted(LocalSchedulerState *state,
  * @param state The state of the local scheduler.
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @param actor_id The ID of the actor being created.
+ * @param reconstruct True if the actor is being created in "reconstruct" mode.
  * @return Void.
  */
 void handle_actor_creation_notification(
     LocalSchedulerState *state,
     SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id);
+    ActorID actor_id,
+    bool reconstruct);
 
 /**
  * This function will be called when a task is assigned by the global scheduler

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -646,7 +646,7 @@ TEST start_kill_workers_test(void) {
             num_workers - 1);
 
   /* Start a worker after the local scheduler has been initialized. */
-  start_worker(local_scheduler->local_scheduler_state, NIL_ACTOR_ID);
+  start_worker(local_scheduler->local_scheduler_state, NIL_ACTOR_ID, false);
   /* Accept the workers as clients to the plasma manager. */
   int new_worker_fd = accept_client(local_scheduler->plasma_manager_fd);
   /* The new worker should register its process ID. */

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1091,5 +1091,61 @@ class ActorsWithGPUs(unittest.TestCase):
         ray.worker.cleanup()
 
 
+class ActorReconstruction(unittest.TestCase):
+
+    def testLocalSchedulerDying(self):
+        ray.worker._init(start_ray_local=True, num_local_schedulers=10,
+                         num_workers=0, redirect_output=True)
+
+        @ray.remote
+        class SlowCounter(object):
+            def __init__(self):
+                self.x = 0
+
+            def inc(self, duration):
+                time.sleep(duration)
+                self.x += 1
+                return self.x
+
+        # Create some initial actors.
+        actors = [SlowCounter.remote() for _ in range(10)]
+
+        # Wait for the actors to start up.
+        time.sleep(1)
+
+        # This is a mapping from actor handles to object IDs returned by
+        # methods on that actor.
+        result_ids = collections.defaultdict(lambda: [])
+
+        # In a loop we are going to create some actors, run some methods, kill
+        # a local scheduler, and run some more methods.
+        for i in range(9):
+            # Create some actors.
+            actors.extend([SlowCounter.remote() for _ in range(10)])
+            # Run some methods.
+            for j in range(len(actors)):
+                actor = actors[j]
+                for _ in range(10):
+                    result_ids[actor].append(actor.inc.remote(j ** 2 * 0.0001))
+            # Kill a local scheduler. Don't kill the first local scheduler
+            # since that is the one that the driver is connected to.
+            process = ray.services.all_processes[
+                ray.services.PROCESS_TYPE_LOCAL_SCHEDULER][i + 1]
+            process.kill()
+            process.wait()
+            # Run some more methods.
+            for j in range(len(actors)):
+                actor = actors[j]
+                for _ in range(10):
+                    result_ids[actor].append(actor.inc.remote(j ** 2 * 0.0001))
+
+        # Get the results and check that they have the correct values.
+        for _, result_id_list in result_ids.items():
+            self.assertEqual(ray.get(result_id_list),
+                             list(range(1, len(result_id_list) + 1)))
+
+        ray.worker.cleanup()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**In this PR:**
- When a local scheduler dies, the monitor process broadcasts messages to reconstruct all of that local scheduler's actors that were still alive.
- A new local scheduler will create the actor (with the `--reconstruct` flag), and the other local schedulers will update their internal data structures to route tasks to the new local scheduler.
- The re-created actor will fetch all of the tasks from the task table, find the ones that are relevant to it, sort them by actor counter, resubmit them to its local scheduler, and then get them from its local scheduler (later on we can allow it to pick and choose which tasks to re-execute).

**Not handled in this PR:**
- The case where the monitor can't find a local scheduler capable of recreating the actor (e.g., there are not enough GPUs).
- The case where an actor dies but its local scheduler does not die.
- Checkpointing the actor state.

**Should do the following (in this PR):**
- I moved a lot of the functions in `worker.py` into the Worker class so they can be called from other places. I could move these changes to a different PR.
- Tests

This doesn't do checkpointing, but it begins working on the actor fault tolerance described in #605.