### PR TITLE
Allow plasma manager to gracefully handle EPROTOTYPE.

### DIFF
--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -51,28 +51,24 @@ int handle_sigpipe(Status s, int fd) {
   switch (errno) {
   case EPIPE: {
     ARROW_LOG(WARNING)
-        << "Received EPIPE when sending a message to client on fd "
-        << fd << ". The client on the other end may "
-                 "have hung up.";
+        << "Received EPIPE when sending a message to client on fd " << fd
+        << ". The client on the other end may have hung up.";
   } break;
   case EBADF: {
     ARROW_LOG(WARNING)
-        << "Received EBADF when sending a message to client on fd "
-        << fd << ". The client on the other end may "
-                 "have hung up.";
+        << "Received EBADF when sending a message to client on fd " << fd
+        << ". The client on the other end may have hung up.";
   } break;
   case ECONNRESET: {
     ARROW_LOG(WARNING)
-        << "Received ECONNRESET when sending a message to client on fd "
-        << fd << ". The client on the other end may "
-                 "have hung up.";
+        << "Received ECONNRESET when sending a message to client on fd " << fd
+        << ". The client on the other end may have hung up.";
   } break;
   case EPROTOTYPE: {
     /* TODO(rkn): What triggers this case? */
     ARROW_LOG(WARNING)
-        << "Received EPROTOTYPE when sending a message to client on fd "
-        << fd << ". The client on the other end may "
-                 "have hung up.";
+        << "Received EPROTOTYPE when sending a message to client on fd " << fd
+        << ". The client on the other end may have hung up.";
   } break;
   default:
     /* This code should be unreachable. */

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -47,15 +47,38 @@ int handle_sigpipe(Status s, int fd) {
   if (s.ok()) {
     return 0;
   }
-  if (errno == EPIPE || errno == EBADF || errno == ECONNRESET) {
+
+  switch (errno) {
+  case EPIPE: {
     ARROW_LOG(WARNING)
-        << "Received SIGPIPE, BAD FILE DESCRIPTOR, or ECONNRESET when "
-           "sending a message to client on fd "
+        << "Received EPIPE when sending a message to client on fd "
         << fd << ". The client on the other end may "
                  "have hung up.";
-    return errno;
+  } break;
+  case EBADF: {
+    ARROW_LOG(WARNING)
+        << "Received EBADF when sending a message to client on fd "
+        << fd << ". The client on the other end may "
+                 "have hung up.";
+  } break;
+  case ECONNRESET: {
+    ARROW_LOG(WARNING)
+        << "Received ECONNRESET when sending a message to client on fd "
+        << fd << ". The client on the other end may "
+                 "have hung up.";
+  } break;
+  case EPROTOTYPE: {
+    /* TODO(rkn): What triggers this case? */
+    ARROW_LOG(WARNING)
+        << "Received EPROTOTYPE when sending a message to client on fd "
+        << fd << ". The client on the other end may "
+                 "have hung up.";
+  } break;
+  default:
+    /* This code should be unreachable. */
+    CHECK(0);
+    LOG_FATAL("Failed to write message to client on fd %d", fd);
   }
-  ARROW_LOG(FATAL) << "Failed to write message to client on fd " << fd << ".";
 }
 
 /**


### PR DESCRIPTION
This may partially (but not fully) address #794. I saw a similar error occur on a branch that I'm developing, and the problem was that the manager was getting a `EPROTOTYPE` error when sending a `plasma::SendDataRequest` to a dead manager. I'm not sure why it would that errno would come up.

This was more difficult to debug than it should have been because the manager got the `EPROTOTYPE` error and then aborted with `ARROW_LOG(FATAL)` which kills the process silently (as discussed in #672). So in this PR, I reverted to `LOG_FATAL`, which immediately made the error apparent.

The only substantive change in this PR is handling the `EPROTOTYPE` case. I just added the switch statement to print slightly more informative messages.