### PR TITLE
Recreate actors when local schedulers die.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -5,9 +5,11 @@ from __future__ import print_function
 from ray.worker import (register_class, error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
                         flush_log, get_gpu_ids)
-from ray.actor import actor
 from ray.worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from ray.worker import global_state
+# We import ray.actor because some code is run in actor.py which initializes
+# some functions in the worker.
+import ray.actor  # noqa: F401
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -254,11 +254,6 @@ def reconstruct_actor_state(actor_id, worker):
     worker.main_loop()
 
 
-def actor(*args, **kwargs):
-    raise Exception("The @ray.actor decorator is deprecated. Instead, please "
-                    "use @ray.remote.")
-
-
 def make_actor(cls, num_cpus, num_gpus):
     # Modify the class to have an additional method that will be used for
     # terminating the worker.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -11,8 +11,8 @@ import traceback
 import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
-from ray.utils import (FunctionProperties, binary_to_hex, hex_to_binary,
-                       random_string, select_local_scheduler)
+from ray.utils import (FunctionProperties, hex_to_binary, random_string,
+                       select_local_scheduler)
 
 
 def random_actor_id():
@@ -180,11 +180,10 @@ def reconstruct_actor_state(actor_id, worker):
 
     relevant_tasks = []
 
-    # TODO(rkn): Maybe task_table should return the task specs like below
-    # instead of unpacking them into dictionarys.
+    # Loop over the task table and keep the tasks that are relevant to this
+    # actor.
     for _, task_info in tasks.items():
         task_spec_info = task_info["TaskSpec"]
-        # Keep track of only the tasks that are relevant for this actor.
         if hex_to_binary(task_spec_info["ActorID"]) == actor_id:
             relevant_tasks.append(task_spec_info)
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -173,6 +173,8 @@ def reconstruct_actor_state(actor_id, worker):
         actor_id: The ID of the actor being reconstructed.
         worker: The worker object that is running the actor.
     """
+    # TODO(rkn): This call is expensive. It'd be nice to find a way to get only
+    # the tasks that are relevant to this actor.
     tasks = ray.global_state.task_table()
 
     def hex_to_object_id(hex_id):
@@ -186,9 +188,6 @@ def reconstruct_actor_state(actor_id, worker):
         task_spec_info = task_info["TaskSpec"]
         if hex_to_binary(task_spec_info["ActorID"]) == actor_id:
             relevant_tasks.append(task_spec_info)
-
-    print("There are {} relevant tasks out of {} tasks."
-          .format(len(relevant_tasks), len(tasks)))
 
     # Sort the tasks by actor ID.
     relevant_tasks.sort(key=lambda task: task["ActorCounter"])

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -10,11 +10,9 @@ import redis
 import time
 
 import ray
-from ray.services import get_ip_address
-from ray.services import get_port
-from ray.utils import binary_to_object_id
-from ray.utils import binary_to_hex
-from ray.utils import hex_to_binary
+from ray.services import get_ip_address, get_port
+import ray.utils
+from ray.utils import binary_to_object_id, binary_to_hex, hex_to_binary
 
 # Import flatbuffer bindings.
 from ray.core.generated.SubscribeToDBClientTableReply \
@@ -97,6 +95,41 @@ class Monitor(object):
         """
         self.subscribe_client.subscribe(channel)
         self.subscribed[channel] = False
+
+    def cleanup_actors(self):
+        """Recreate any live actors whose corresponding local scheduler died.
+
+        For any live actor whose local scheduler just died, we choose a new
+        local scheduler and broadcast a notification to create that actor.
+        """
+        actor_info = self.state.actors()
+        for actor_id, info in actor_info.items():
+            if (not info["removed"] and
+                    info["local_scheduler_id"] in self.dead_local_schedulers):
+                # Choose a new local scheduler to run the actor.
+                local_scheduler_id = ray.utils.select_local_scheduler(
+                    info["driver_id"], self.state.local_schedulers(),
+                    info["num_gpus"], self.redis)
+                import sys
+                sys.stdout.flush()
+                # The new local scheduler should not be the same as the old
+                # local scheduler. TODO(rkn): This should not be an assert, it
+                # should be something more benign.
+                assert (binary_to_hex(local_scheduler_id) !=
+                        info["local_scheduler_id"])
+                # Announce to all of the local schedulers that the actor should
+                # be recreated on this new local scheduler.
+                ray.utils.publish_actor_creation(
+                    hex_to_binary(actor_id), hex_to_binary(info["driver_id"]),
+                    local_scheduler_id, True, self.redis)
+                log.info("Actor {} for driver {} was on dead local scheduler "
+                         "{}. It is being recreated on local scheduler {}"
+                         .format(actor_id, info["driver_id"],
+                                 info["local_scheduler_id"],
+                                 binary_to_hex(local_scheduler_id)))
+                # Update the actor info in Redis.
+                self.redis.hset(b"Actor:" + hex_to_binary(actor_id),
+                                "local_scheduler_id", local_scheduler_id)
 
     def cleanup_task_table(self):
         """Clean up global state for failed local schedulers.
@@ -348,6 +381,7 @@ class Monitor(object):
         # state in the state tables.
         if len(self.dead_local_schedulers) > 0:
             self.cleanup_task_table()
+            self.cleanup_actors()
         if len(self.dead_plasma_managers) > 0:
             self.cleanup_object_table()
         log.debug("{} dead local schedulers, {} plasma managers total, {} "
@@ -369,6 +403,7 @@ class Monitor(object):
             # dead in this round, clean up the associated state.
             if len(self.dead_local_schedulers) > num_dead_local_schedulers:
                 self.cleanup_task_table()
+                self.cleanup_actors()
             if len(self.dead_plasma_managers) > num_dead_plasma_managers:
                 self.cleanup_object_table()
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -183,7 +183,7 @@ def select_local_scheduler(driver_id, local_schedulers, num_gpus,
 
 
 def publish_actor_creation(actor_id, driver_id, local_scheduler_id,
-                           redis_client):
+                           reconstruct, redis_client):
     """Publish a notification that an actor should be created.
 
     This broadcast will be received by all of the local schedulers. The local
@@ -197,11 +197,14 @@ def publish_actor_creation(actor_id, driver_id, local_scheduler_id,
         driver_id: The ID of the driver responsible for the actor.
         local_scheduler_id: The ID of the local scheduler that is suposed to
             create the actor.
+        reconstruct: True if the actor should be created in "reconstruct" mode.
         redis_client: The client used to interact with Redis.
     """
+    reconstruct_bit = b"1" if reconstruct else b"0"
     # Really we should encode this message as a flatbuffer object. However,
     # we're having trouble getting that to work. It almost works, but in Python
     # 2.7, builder.CreateString fails on byte strings that contain characters
     # outside range(128).
     redis_client.publish("actor_notifications",
-                         actor_id + driver_id + local_scheduler_id)
+                         actor_id + driver_id + local_scheduler_id +
+                         reconstruct_bit)

--- a/src/common/state/actor_notification_table.h
+++ b/src/common/state/actor_notification_table.h
@@ -14,6 +14,7 @@ typedef void (*actor_notification_table_subscribe_callback)(
     ActorID actor_id,
     WorkerID driver_id,
     DBClientID local_scheduler_id,
+    bool reconstruct,
     void *user_context);
 
 /**

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -1527,24 +1527,25 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     CHECK(sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) +
               1 ==
           payload->len);
+    char *current_ptr = payload->str;
     /* Parse the actor ID. */
-    memcpy(&actor_id, payload->str, sizeof(actor_id));
+    memcpy(&actor_id, current_ptr, sizeof(actor_id));
+    current_ptr += sizeof(actor_id);
     /* Parse the driver ID. */
-    memcpy(&driver_id, payload->str + sizeof(actor_id), sizeof(driver_id));
+    memcpy(&driver_id, current_ptr, sizeof(driver_id));
+    current_ptr += sizeof(driver_id);
     /* Parse the local scheduler ID. */
-    memcpy(&local_scheduler_id,
-           payload->str + sizeof(actor_id) + sizeof(driver_id),
-           sizeof(local_scheduler_id));
+    memcpy(&local_scheduler_id, current_ptr, sizeof(local_scheduler_id));
+    current_ptr += sizeof(local_scheduler_id);
     /* Parse the reconstruct bit. */
-    if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
-          sizeof(local_scheduler_id)) == '1') {
+    if (*current_ptr == '1') {
       reconstruct = true;
-    } else if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
-                 sizeof(local_scheduler_id)) == '0') {
+    } else if (*current_ptr == '0') {
       reconstruct = false;
     } else {
       LOG_FATAL("This code should be unreachable.");
     }
+    current_ptr += 1;
 
     if (data->subscribe_callback) {
       data->subscribe_callback(actor_id, driver_id, local_scheduler_id,

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -1523,16 +1523,32 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
     ActorID actor_id;
     WorkerID driver_id;
     DBClientID local_scheduler_id;
-    CHECK(sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) ==
+    bool reconstruct;
+    CHECK(sizeof(actor_id) + sizeof(driver_id) + sizeof(local_scheduler_id) +
+              1 ==
           payload->len);
+    /* Parse the actor ID. */
     memcpy(&actor_id, payload->str, sizeof(actor_id));
+    /* Parse the driver ID. */
     memcpy(&driver_id, payload->str + sizeof(actor_id), sizeof(driver_id));
+    /* Parse the local scheduler ID. */
     memcpy(&local_scheduler_id,
            payload->str + sizeof(actor_id) + sizeof(driver_id),
            sizeof(local_scheduler_id));
+    /* Parse the reconstruct bit. */
+    if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
+          sizeof(local_scheduler_id)) == '1') {
+      reconstruct = true;
+    } else if (*(payload->str + sizeof(actor_id) + sizeof(driver_id) +
+                 sizeof(local_scheduler_id)) == '0') {
+      reconstruct = false;
+    } else {
+      LOG_FATAL("This code should be unreachable.");
+    }
+
     if (data->subscribe_callback) {
       data->subscribe_callback(actor_id, driver_id, local_scheduler_id,
-                               data->subscribe_context);
+                               reconstruct, data->subscribe_context);
     }
   } else if (strcmp(message_type->str, "subscribe") == 0) {
     /* The reply for the initial SUBSCRIBE command. */

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -114,9 +114,13 @@ void kill_worker(LocalSchedulerState *state,
  * @param state The local scheduler state.
  * @param actor_id The ID of the actor for this worker. If this worker is not an
  *        actor, then NIL_ACTOR_ID should be used.
+ * @param reconstruct True if the worker is an actor and is being started in
+ *        reconstruct mode.
  * @param Void.
  */
-void start_worker(LocalSchedulerState *state, ActorID actor_id);
+void start_worker(LocalSchedulerState *state,
+                  ActorID actor_id,
+                  bool reconstruct);
 
 /**
  * Check if a certain quantity of dynamic resources are available. If num_cpus

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -88,12 +88,14 @@ void handle_actor_task_submitted(LocalSchedulerState *state,
  * @param state The state of the local scheduler.
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @param actor_id The ID of the actor being created.
+ * @param reconstruct True if the actor is being created in "reconstruct" mode.
  * @return Void.
  */
 void handle_actor_creation_notification(
     LocalSchedulerState *state,
     SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id);
+    ActorID actor_id,
+    bool reconstruct);
 
 /**
  * This function will be called when a task is assigned by the global scheduler

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -646,7 +646,7 @@ TEST start_kill_workers_test(void) {
             num_workers - 1);
 
   /* Start a worker after the local scheduler has been initialized. */
-  start_worker(local_scheduler->local_scheduler_state, NIL_ACTOR_ID);
+  start_worker(local_scheduler->local_scheduler_state, NIL_ACTOR_ID, false);
   /* Accept the workers as clients to the plasma manager. */
   int new_worker_fd = accept_client(local_scheduler->plasma_manager_fd);
   /* The new worker should register its process ID. */

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1095,5 +1095,125 @@ class ActorsWithGPUs(unittest.TestCase):
         ray.worker.cleanup()
 
 
+class ActorReconstruction(unittest.TestCase):
+
+    def testLocalSchedulerDying(self):
+        ray.worker._init(start_ray_local=True, num_local_schedulers=2,
+                         num_workers=0, redirect_output=True)
+
+        @ray.remote
+        class Counter(object):
+            def __init__(self):
+                self.x = 0
+
+            def local_plasma(self):
+                return ray.worker.global_worker.plasma_client.store_socket_name
+
+            def inc(self):
+                self.x += 1
+                return self.x
+
+        local_plasma = ray.worker.global_worker.plasma_client.store_socket_name
+
+        # Create an actor that is not on the local scheduler.
+        actor = Counter.remote()
+        while ray.get(actor.local_plasma.remote()) == local_plasma:
+            actor = Counter.remote()
+
+        ids = [actor.inc.remote() for _ in range(100)]
+
+        # Wait for the last task to finish running.
+        ray.get(ids[-1])
+
+        # Kill the second local scheduler.
+        process = ray.services.all_processes[
+            ray.services.PROCESS_TYPE_LOCAL_SCHEDULER][1]
+        process.kill()
+        process.wait()
+        # Kill the corresponding plasma store to get rid of the cached objects.
+        process = ray.services.all_processes[
+            ray.services.PROCESS_TYPE_PLASMA_STORE][1]
+        process.kill()
+        process.wait()
+
+        # Get all of the results
+        results = ray.get(ids)
+
+        self.assertEqual(results, list(range(1, 1 + len(results))))
+
+        ray.worker.cleanup()
+
+    def testManyLocalSchedulersDying(self):
+        # This test can be made more stressful by increasing the numbers below.
+        # The total number of actors created will be
+        # num_actors_at_a_time * num_local_schedulers.
+        num_local_schedulers = 5
+        num_actors_at_a_time = 3
+        num_function_calls_at_a_time = 10
+
+        ray.worker._init(start_ray_local=True,
+                         num_local_schedulers=num_local_schedulers,
+                         num_workers=0, redirect_output=True)
+
+        @ray.remote
+        class SlowCounter(object):
+            def __init__(self):
+                self.x = 0
+
+            def inc(self, duration):
+                time.sleep(duration)
+                self.x += 1
+                return self.x
+
+        # Create some initial actors.
+        actors = [SlowCounter.remote() for _ in range(num_actors_at_a_time)]
+
+        # Wait for the actors to start up.
+        time.sleep(1)
+
+        # This is a mapping from actor handles to object IDs returned by
+        # methods on that actor.
+        result_ids = collections.defaultdict(lambda: [])
+
+        # In a loop we are going to create some actors, run some methods, kill
+        # a local scheduler, and run some more methods.
+        for i in range(num_local_schedulers - 1):
+            # Create some actors.
+            actors.extend([SlowCounter.remote()
+                           for _ in range(num_actors_at_a_time)])
+            # Run some methods.
+            for j in range(len(actors)):
+                actor = actors[j]
+                for _ in range(num_function_calls_at_a_time):
+                    result_ids[actor].append(
+                        actor.inc.remote(j ** 2 * 0.000001))
+            # Kill a local scheduler. Don't kill the first local scheduler
+            # since that is the one that the driver is connected to.
+            process = ray.services.all_processes[
+                ray.services.PROCESS_TYPE_LOCAL_SCHEDULER][i + 1]
+            process.kill()
+            process.wait()
+            # Kill the corresponding plasma store to get rid of the cached
+            # objects.
+            process = ray.services.all_processes[
+                ray.services.PROCESS_TYPE_PLASMA_STORE][i + 1]
+            process.kill()
+            process.wait()
+
+            # Run some more methods.
+            for j in range(len(actors)):
+                actor = actors[j]
+                for _ in range(num_function_calls_at_a_time):
+                    result_ids[actor].append(
+                        actor.inc.remote(j ** 2 * 0.000001))
+
+        # Get the results and check that they have the correct values.
+        for _, result_id_list in result_ids.items():
+            self.assertEqual(ray.get(result_id_list),
+                             list(range(1, len(result_id_list) + 1)))
+
+        ray.worker.cleanup()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**In this PR:**
- When a local scheduler dies, the monitor process broadcasts messages to reconstruct all of that local scheduler's actors that were still alive.
- A new local scheduler will create the actor (with the `--reconstruct` flag), and the other local schedulers will update their internal data structures to route tasks to the new local scheduler.
- The re-created actor will fetch all of the tasks from the task table, find the ones that are relevant to it, sort them by actor counter, resubmit them to its local scheduler, and then get them from its local scheduler (later on we can allow it to pick and choose which tasks to re-execute).

**Not handled in this PR:**
- The case where the monitor can't find a local scheduler capable of recreating the actor (e.g., there are not enough GPUs).
- The case where an actor dies but its local scheduler does not die.
- Checkpointing the actor state.

This doesn't do checkpointing, but it begins working on the actor fault tolerance described in #605.