### PR TITLE
Prototype actor checkpointing.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -11,8 +11,8 @@ import traceback
 import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
-from ray.utils import (FunctionProperties, binary_to_object_id, hex_to_binary,
-                       random_string, select_local_scheduler)
+from ray.utils import (FunctionProperties, hex_to_binary, random_string,
+                       select_local_scheduler)
 
 
 def random_actor_id():
@@ -308,7 +308,8 @@ def reconstruct_actor_state(actor_id, worker):
         # If the task happened before the most recent checkpoint, ignore it.
         # Otherwise, execute it.
         if retrieved_task.actor_counter() > checkpoint_index:
-            # Assert that the retrieved task is the same as the constructed task.
+            # Assert that the retrieved task is the same as the constructed
+            # task.
             assert (ray.local_scheduler.task_to_string(task_spec) ==
                     ray.local_scheduler.task_to_string(retrieved_task))
             # Wait for the task to be ready and then execute it.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -334,21 +334,15 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
             os._exit(0)
 
         def __ray_save_checkpoint__(self):
-            print("Saving actor state!!!!!!!!!!!!!!!!")
-            import sys
-            sys.stdout.flush()
-
             if hasattr(self, "__ray_save__"):
                 object_to_serialize = self.__ray_save__()
             else:
                 object_to_serialize = self
             return pickle.dumps(object_to_serialize)
 
-        # def __ray_restore__(self, checkpoint):
-        #     self = pickle.loads(checkpoint)
-
         @classmethod
-        def __ray_restore_from_checkpoint__(cls, checkpoint):
+        def __ray_restore_from_checkpoint__(cls, pickled_checkpoint):
+            checkpoint = pickle.loads(pickled_checkpoint)
             if hasattr(cls, "__ray_restore__"):
                 actor_object = cls.__new__(cls)
                 actor_object.__ray_restore__(checkpoint)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -811,6 +811,19 @@ class Worker(object):
             ray.worker.global_worker.local_scheduler_client.disconnect()
             os._exit(0)
 
+        # Checkpoint the actor state if it is the right time to do so.
+        if self.actor_id != NIL_ACTOR_ID and task.actor_counter() % 10 == 0:
+            checkpoint = self.actors[self.actor_id].__ray_save_checkpoint__()
+
+            print("XXX")
+
+            # Restore from the checkpoint.
+            self.actors[self.actor_id] = ray.actor.actor_class_xxx.__ray_restore_from_checkpoint__(checkpoint)
+
+            print("YYY")
+            import sys
+            sys.stdout.flush()
+
     def _get_next_task_from_local_scheduler(self):
         """Get the next task from the local scheduler.
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1258,7 +1258,6 @@ class ActorReconstruction(unittest.TestCase):
         while ray.get(actor.local_plasma.remote()) == local_plasma:
             actor = Counter.remote()
 
-
         args = [ray.put(0) for _ in range(100)]
         ids = [actor.inc.remote(*args[i:]) for i in range(100)]
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1222,13 +1222,20 @@ class ActorReconstruction(unittest.TestCase):
         class Counter(object):
             def __init__(self):
                 self.x = 0
+                # The number of times that inc has been called. We won't bother
+                # restoring this in the checkpoint
+                self.num_inc_calls = 0
 
             def local_plasma(self):
                 return ray.worker.global_worker.plasma_client.store_socket_name
 
-            def inc(self):
+            def inc(self, *xs):
+                self.num_inc_calls += 1
                 self.x += 1
                 return self.x
+
+            def get_num_inc_calls(self):
+                return self.num_inc_calls
 
             def test_restore(self):
                 # This method will only work if __ray_restore__ has been run.
@@ -1239,6 +1246,7 @@ class ActorReconstruction(unittest.TestCase):
 
             def __ray_restore__(self, checkpoint):
                 self.x, val = checkpoint
+                self.num_inc_calls = 0
                 # Test that __ray_save__ has been run.
                 assert val == -1
                 self.y = self.x
@@ -1250,7 +1258,9 @@ class ActorReconstruction(unittest.TestCase):
         while ray.get(actor.local_plasma.remote()) == local_plasma:
             actor = Counter.remote()
 
-        ids = [actor.inc.remote() for _ in range(100)]
+
+        args = [ray.put(0) for _ in range(100)]
+        ids = [actor.inc.remote(*args[i:]) for i in range(100)]
 
         # Wait for the last task to finish running.
         ray.get(ids[-1])
@@ -1271,6 +1281,10 @@ class ActorReconstruction(unittest.TestCase):
         # self.assertEqual(results, list(range(1, 1 + len(results))))
 
         self.assertEqual(ray.get(actor.test_restore.remote()), 99)
+
+        # The inc method should only have executed once on the new actor (for
+        # the one method call since the most recent checkpoint).
+        self.assertEqual(ray.get(actor.get_num_inc_calls.remote()), 1)
 
         ray.worker.cleanup()
 


### PR DESCRIPTION
This is a first pass at actor checkpointing. Makes some progress on #605.

- It is off by default.
- To use checkpointing, you can define an actor with the decorator `@ray.remote(checkpoint_interval=100)`.
- It currently stores the checkpoints in Redis, which is probably not the right place to store them.
