### PR TITLE
Fallback to custom serializer for very long python ints.

### DIFF
--- a/src/numbuf/python/src/pynumbuf/adapters/python.cc
+++ b/src/numbuf/python/src/pynumbuf/adapters/python.cc
@@ -80,8 +80,7 @@ Status get_value(std::shared_ptr<Array> arr, int32_t index, int32_t type, PyObje
   return Status::OK();
 }
 
-Status call_custom_serialization_callback(PyObject* elem,
-                                          PyObject** serialized_object) {
+Status call_custom_serialization_callback(PyObject* elem, PyObject** serialized_object) {
   *serialized_object = NULL;
   if (!numbuf_serialize_callback) {
     std::stringstream ss;

--- a/src/numbuf/python/src/pynumbuf/adapters/python.cc
+++ b/src/numbuf/python/src/pynumbuf/adapters/python.cc
@@ -80,6 +80,26 @@ Status get_value(std::shared_ptr<Array> arr, int32_t index, int32_t type, PyObje
   return Status::OK();
 }
 
+Status call_custom_serialization_callback(PyObject* elem,
+                                          PyObject** serialized_object) {
+  *serialized_object = NULL;
+  if (!numbuf_serialize_callback) {
+    std::stringstream ss;
+    ss << "data type of " << PyBytes_AS_STRING(PyObject_Repr(elem))
+       << " not recognized and custom serialization handler not registered";
+    return Status::NotImplemented(ss.str());
+  } else {
+    PyObject* arglist = Py_BuildValue("(O)", elem);
+    // The reference count of the result of the call to PyObject_CallObject
+    // must be decremented. This is done in SerializeDict in this file.
+    PyObject* result = PyObject_CallObject(numbuf_serialize_callback, arglist);
+    Py_XDECREF(arglist);
+    if (!result) { return Status::NotImplemented("python error"); }
+    *serialized_object = result;
+  }
+  return Status::OK();
+}
+
 Status append(PyObject* elem, SequenceBuilder& builder, std::vector<PyObject*>& sublists,
     std::vector<PyObject*>& subtuples, std::vector<PyObject*>& subdicts,
     std::vector<PyObject*>& tensors_out) {
@@ -91,8 +111,18 @@ Status append(PyObject* elem, SequenceBuilder& builder, std::vector<PyObject*>& 
   } else if (PyLong_Check(elem)) {
     int overflow = 0;
     int64_t data = PyLong_AsLongLongAndOverflow(elem, &overflow);
-    RETURN_NOT_OK(builder.AppendInt64(data));
-    if (overflow) { return Status::NotImplemented("long overflow"); }
+    if (!overflow) {
+      RETURN_NOT_OK(builder.AppendInt64(data));
+    } else {
+      // Attempt to serialize the object using the custom callback.
+      PyObject* serialized_object;
+      // The reference count of serialized_object is incremented in the function
+      // call_custom_serialization_callback (if the call is successful), and it will
+      // be decremented in SerializeDict in this file.
+      RETURN_NOT_OK(call_custom_serialization_callback(elem, &serialized_object));
+      builder.AppendDict(PyDict_Size(serialized_object));
+      subdicts.push_back(serialized_object);
+    }
 #if PY_MAJOR_VERSION < 3
   } else if (PyInt_Check(elem)) {
     RETURN_NOT_OK(builder.AppendInt64(static_cast<int64_t>(PyInt_AS_LONG(elem))));
@@ -130,21 +160,14 @@ Status append(PyObject* elem, SequenceBuilder& builder, std::vector<PyObject*>& 
   } else if (elem == Py_None) {
     RETURN_NOT_OK(builder.AppendNone());
   } else {
-    if (!numbuf_serialize_callback) {
-      std::stringstream ss;
-      ss << "data type of " << PyBytes_AS_STRING(PyObject_Repr(elem))
-         << " not recognized and custom serialization handler not registered";
-      return Status::NotImplemented(ss.str());
-    } else {
-      PyObject* arglist = Py_BuildValue("(O)", elem);
-      // The reference count of the result of the call to PyObject_CallObject
-      // must be decremented. This is done in SerializeDict in this file.
-      PyObject* result = PyObject_CallObject(numbuf_serialize_callback, arglist);
-      Py_XDECREF(arglist);
-      if (!result) { return Status::NotImplemented("python error"); }
-      builder.AppendDict(PyDict_Size(result));
-      subdicts.push_back(result);
-    }
+    // Attempt to serialize the object using the custom callback.
+    PyObject* serialized_object;
+    // The reference count of serialized_object is incremented in the function
+    // call_custom_serialization_callback (if the call is successful), and it will
+    // be decremented in SerializeDict in this file.
+    RETURN_NOT_OK(call_custom_serialization_callback(elem, &serialized_object));
+    builder.AppendDict(PyDict_Size(serialized_object));
+    subdicts.push_back(serialized_object);
   }
   return Status::OK();
 }

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -79,7 +79,8 @@ if sys.version_info >= (3, 0):
 else:
     long_extras = [long(0), np.array([["hi", u"hi"], [1.3, long(1)]])]  # noqa: E501,F821
 
-PRIMITIVE_OBJECTS = [0, 0.0, 0.9, 1 << 62, "a", string.printable, "\u262F",
+PRIMITIVE_OBJECTS = [0, 0.0, 0.9, 1 << 62, 1 << 100, 1 << 999,
+                     [1 << 100, [1 << 100]], "a", string.printable, "\u262F",
                      u"hello world", u"\xff\xfe\x9c\x001\x000\x00", None, True,
                      False, [], (), {}, np.int8(3), np.int32(4), np.int64(5),
                      np.uint8(3), np.uint32(4), np.uint64(5), np.float32(1.9),


### PR DESCRIPTION
This should fix #549 (and also #816).

You can test this as follows.

```python
import ray
import uuid

ray.init(num_workers=0)

ray.get(ray.put(1 << 1000))

ray.get(ray.put(uuid.UUID('053af970-3c27-463b-8131-72bf43bd1c01')))
```

TODO: double check this PR to make sure that I didn't mess up the Python reference counting in `python.cc`.