### PR TITLE
Remove UT data structures from global scheduler.

### DIFF
--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -77,7 +77,6 @@ GlobalSchedulerState *GlobalSchedulerState_init(event_loop *loop,
                                                 const char *redis_primary_addr,
                                                 int redis_primary_port) {
   GlobalSchedulerState *state = new GlobalSchedulerState();
-  /* Must initialize state to 0. Sets hashmap head(s) to NULL. */
   state->db = db_connect(std::string(redis_primary_addr), redis_primary_port,
                          "global_scheduler", node_ip_address, 0, NULL);
   db_attach(state->db, loop, false);
@@ -344,7 +343,7 @@ int heartbeat_timeout_handler(event_loop *loop, timer_id id, void *context) {
        * next iterator. */
       it = remove_local_scheduler(state, it);
     } else {
-      ++it->second.num_heartbeats_missed;
+      it->second.num_heartbeats_missed += 1;
       it++;
     }
   }

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -154,10 +154,10 @@ void add_local_scheduler(GlobalSchedulerState *state,
 }
 
 std::unordered_map<DBClientID, LocalScheduler, UniqueIDHasher>::iterator
-    remove_local_scheduler(
-        GlobalSchedulerState *state,
-        std::unordered_map<DBClientID, LocalScheduler, UniqueIDHasher>::iterator
-            it) {
+remove_local_scheduler(
+    GlobalSchedulerState *state,
+    std::unordered_map<DBClientID, LocalScheduler, UniqueIDHasher>::iterator
+        it) {
   CHECK(it != state->local_schedulers.end());
   DBClientID local_scheduler_id = it->first;
   it = state->local_schedulers.erase(it);

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -3,6 +3,8 @@
 
 #include "task.h"
 
+#include <unordered_map>
+
 #include "state/db.h"
 #include "state/local_scheduler_table.h"
 #include "utarray.h"
@@ -68,10 +70,10 @@ typedef struct {
   event_loop *loop;
   /** The global state store database. */
   DBHandle *db;
-  /** The local schedulers that are connected to Redis. TODO(rkn): This probably
-   *  needs to be a hashtable since we often look up the local_scheduler struct
-   *  based on its db_client_id. */
-  UT_array *local_schedulers;
+  /** A hash table mapping local scheduler ID to the local schedulers that are
+   *  connected to Redis. */
+  std::unordered_map<DBClientID, LocalScheduler, UniqueIDHasher>
+      local_schedulers;
   /** The state managed by the scheduling policy. */
   GlobalSchedulerPolicyState *policy_state;
   /** The plasma_manager ip:port -> local_scheduler_db_client_id association. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -36,8 +36,6 @@ typedef struct GlobalSchedulerPolicyState GlobalSchedulerPolicyState;
  * This defines a hash table used to cache information about different objects.
  */
 typedef struct {
-  /** The object ID in question. */
-  ObjectID object_id;
   /** The size in bytes of the object. */
   int64_t data_size;
   /** A vector of object locations for this object. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -47,20 +47,6 @@ typedef struct {
 } SchedulerObjectInfo;
 
 /**
- * A struct used for caching local scheduler to Plasma association.
- */
-typedef struct {
-  /** IP:port string for the plasma_manager. */
-  char *aux_address;
-  /** Local scheduler db client id. */
-  DBClientID local_scheduler_db_client_id;
-  /** Plasma_manager ip:port -> local_scheduler_db_client_id. */
-  UT_hash_handle plasma_local_scheduler_hh;
-  /** local_scheduler_db_client_id -> plasma_manager ip:port. */
-  UT_hash_handle local_scheduler_plasma_hh;
-} AuxAddressEntry;
-
-/**
  * Global scheduler state structure.
  */
 typedef struct {
@@ -75,9 +61,10 @@ typedef struct {
   /** The state managed by the scheduling policy. */
   GlobalSchedulerPolicyState *policy_state;
   /** The plasma_manager ip:port -> local_scheduler_db_client_id association. */
-  AuxAddressEntry *plasma_local_scheduler_map;
+  std::unordered_map<std::string, DBClientID> plasma_local_scheduler_map;
   /** The local_scheduler_db_client_id -> plasma_manager ip:port association. */
-  AuxAddressEntry *local_scheduler_plasma_map;
+  std::unordered_map<DBClientID, std::string, UniqueIDHasher>
+      local_scheduler_plasma_map;
   /** Objects cached by this global scheduler instance. */
   std::unordered_map<ObjectID, SchedulerObjectInfo, UniqueIDHasher>
       scheduler_object_info_table;

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -42,10 +42,8 @@ typedef struct {
   ObjectID object_id;
   /** The size in bytes of the object. */
   int64_t data_size;
-  /** An array of object locations for this object. */
-  UT_array *object_locations;
-  /** Handle for the uthash table. */
-  UT_hash_handle hh;
+  /** A vector of object locations for this object. */
+  std::vector<std::string> object_locations;
 } SchedulerObjectInfo;
 
 /**
@@ -81,7 +79,8 @@ typedef struct {
   /** The local_scheduler_db_client_id -> plasma_manager ip:port association. */
   AuxAddressEntry *local_scheduler_plasma_map;
   /** Objects cached by this global scheduler instance. */
-  SchedulerObjectInfo *scheduler_object_info_table;
+  std::unordered_map<ObjectID, SchedulerObjectInfo, UniqueIDHasher>
+      scheduler_object_info_table;
   /** An array of tasks that haven't been scheduled yet. */
   std::vector<Task *> pending_tasks;
 } GlobalSchedulerState;

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -7,8 +7,6 @@
 
 #include "state/db.h"
 #include "state/local_scheduler_table.h"
-#include "utarray.h"
-#include "uthash.h"
 
 /* The frequency with which the global scheduler checks if there are any tasks
  * that haven't been scheduled yet. */

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -81,7 +81,7 @@ typedef struct {
   /** Objects cached by this global scheduler instance. */
   SchedulerObjectInfo *scheduler_object_info_table;
   /** An array of tasks that haven't been scheduled yet. */
-  UT_array *pending_tasks;
+  std::vector<Task *> pending_tasks;
 } GlobalSchedulerState;
 
 /**

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -6,8 +6,7 @@
 #include "global_scheduler_algorithm.h"
 
 GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void) {
-  GlobalSchedulerPolicyState *policy_state =
-      (GlobalSchedulerPolicyState *) malloc(sizeof(GlobalSchedulerPolicyState));
+  GlobalSchedulerPolicyState *policy_state = new GlobalSchedulerPolicyState();
   policy_state->round_robin_index = 0;
 
   int num_weight_elem =
@@ -23,7 +22,7 @@ GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void) {
 }
 
 void GlobalSchedulerPolicyState_free(GlobalSchedulerPolicyState *policy_state) {
-  free(policy_state);
+  delete policy_state;
 }
 
 /**

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -44,49 +44,6 @@ bool constraints_satisfied_hard(const LocalScheduler *scheduler,
   return true;
 }
 
-DBClientID get_local_scheduler_id(GlobalSchedulerState *state,
-                                  const char *plasma_location) {
-  AuxAddressEntry *aux_entry = NULL;
-  DBClientID local_scheduler_id = NIL_ID;
-  if (plasma_location != NULL) {
-    LOG_DEBUG("max object size location found : %s", plasma_location);
-    /* Lookup association of plasma location to local scheduler. */
-    HASH_FIND(plasma_local_scheduler_hh, state->plasma_local_scheduler_map,
-              plasma_location, uthash_strlen(plasma_location), aux_entry);
-    if (aux_entry) {
-      LOG_DEBUG(
-          "found local scheduler db client association for plasma ip:port = %s",
-          aux_entry->aux_address);
-      /* Plasma to local scheduler db client ID association found, get local
-       * scheduler ID. */
-      local_scheduler_id = aux_entry->local_scheduler_db_client_id;
-    } else {
-      LOG_ERROR(
-          "local scheduler db client association not found for plasma "
-          "ip:port=%s",
-          plasma_location);
-    }
-  }
-
-  char id_string[ID_STRING_SIZE];
-  LOG_DEBUG("local scheduler ID found = %s",
-            ObjectID_to_string(local_scheduler_id, id_string, ID_STRING_SIZE));
-  UNUSED(id_string);
-
-  if (IS_NIL_ID(local_scheduler_id)) {
-    return local_scheduler_id;
-  }
-
-  /* Check to make sure this local_scheduler_db_client_id matches one of the
-   * schedulers. */
-  if (state->local_schedulers.find(local_scheduler_id) ==
-      state->local_schedulers.end()) {
-    LOG_WARN(
-        "local_scheduler_id didn't match any cached local scheduler entries");
-  }
-  return local_scheduler_id;
-}
-
 double inner_product(double a[], double b[], int size) {
   double result = 0;
   for (int i = 0; i < size; i++) {

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -78,9 +78,12 @@ double calculate_score_dynvec_normalized(GlobalSchedulerState *state,
   return score;
 }
 
-int64_t calculate_data_per_local_scheduler(const GlobalSchedulerState *state,
-                                           DBClientID local_scheduler_id,
-                                           TaskSpec *task_spec) {
+int64_t locally_available_data_size(const GlobalSchedulerState *state,
+                                    DBClientID local_scheduler_id,
+                                    TaskSpec *task_spec) {
+  /* This function will compute the total size of all the object dependencies
+   * for the given task that are already locally available to the specified
+   * local scheduler. */
   int64_t task_data_size = 0;
 
   CHECK(state->local_scheduler_plasma_map.count(local_scheduler_id) == 1);
@@ -139,7 +142,7 @@ double calculate_cost_pending(const GlobalSchedulerState *state,
   /* Calculate how much data is already present on this machine. TODO(rkn): Note
    * that this information is not being used yet. Fix this. */
   int64_t data_size =
-      calculate_data_per_local_scheduler(state, scheduler->id, task_spec);
+      locally_available_data_size(state, scheduler->id, task_spec);
   /* TODO(rkn): This logic does not load balance properly when the different
    * machines have different sizes. Fix this. */
   return scheduler->num_recent_tasks_sent + scheduler->info.task_queue_length;

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -26,12 +26,6 @@ struct GlobalSchedulerPolicyState {
   double resource_attribute_weight[ResourceIndex_MAX + 1];
 };
 
-typedef struct {
-  const char *object_location;
-  int64_t total_object_size;
-  UT_hash_handle hh;
-} ObjectSizeEntry;
-
 /**
  * Create the state of the global scheduler policy. This state must be freed by
  * the caller.


### PR DESCRIPTION
Note this also removes a bunch of unused code that I thought would be easier to rewrite later than to convert.

More progress on #404.