### PR TITLE
Test building wheels in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,19 @@ matrix:
     - os: linux
       dist: trusty
       env: PYTHON=2.7
+
     - os: linux
       dist: trusty
       env: PYTHON=3.5
+
     - os: osx
       osx_image: xcode7
       env: PYTHON=2.7
+
     - os: osx
       osx_image: xcode7
       env: PYTHON=3.5
+
     - os: linux
       dist: trusty
       env: LINT=1
@@ -38,6 +42,7 @@ matrix:
         - cd ..
         # Run Python linting.
         - flake8 --exclude=python/ray/core/src/common/flatbuffers_ep-prefix/,python/ray/core/generated/,src/numbuf/thirdparty/,src/common/format/,doc/source/conf.py
+
     - os: linux
       dist: trusty
       env: VALGRIND=1 PYTHON=2.7
@@ -59,6 +64,28 @@ matrix:
         - python ./python/ray/plasma/test/test.py valgrind
         - python ./python/ray/local_scheduler/test/test.py valgrind
         - python ./python/ray/global_scheduler/test/test.py valgrind
+
+    # Build Linux wheels.
+    - os: linux
+      dist: trusty
+      env: LINUX_WHEELS=1
+      install:
+        - ./.travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - docker run --rm -w /ray -v `pwd`:/ray -ti quay.io/xhochy/arrow_manylinux1_x86_64_base:ARROW-1024 /ray/python/build-wheel-manylinux1.sh
+      script:
+        - ./.travis/test-wheels.sh
+
+    # Build MacOS wheels.
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1
+      install:
+        - ./.travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./python/build-wheel-macos.sh
+      script:
+        - ./.travis/test-wheels.sh
 
 install:
   - ./.travis/install-dependencies.sh

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -74,6 +74,12 @@ elif [[ "$LINT" == "1" ]]; then
   export PATH="$HOME/miniconda/bin:$PATH"
   # Install Python linting tools.
   pip install flake8
+elif [[ "$LINUX_WHEELS" == "1" ]]; then
+  sudo apt-get install docker
+  sudo usermod -a -G docker travis
+elif [[ "$MAC_WHEELS" == "1" ]]; then
+  # Don't need to do anything here.
+  true
 else
   echo "Unrecognized environment."
   exit 1

--- a/.travis/test-wheels.sh
+++ b/.travis/test-wheels.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
+# Show explicitly which commands are currently running.
+set -x
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+
+platform="unknown"
+unamestr="$(uname)"
+if [[ "$unamestr" == "Linux" ]]; then
+  echo "Platform is linux."
+  platform="linux"
+elif [[ "$unamestr" == "Darwin" ]]; then
+  echo "Platform is macosx."
+  platform="macosx"
+else
+  echo "Unrecognized platform."
+  exit 1
+fi
+
+TEST_SCRIPT=$ROOT_DIR/../test/microbenchmarks.py
+
+if [[ "$platform" == "linux" ]]; then
+  # First test Python 2.7.
+
+  # Install miniconda.
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda2.sh
+  bash miniconda2.sh -b -p $HOME/miniconda2
+
+  # Find the right wheel by grepping for the Python version.
+  PYTHON_WHEEL=$(find $ROOT_DIR/../.whl -type f -maxdepth 1 -print | grep -m1 '27')
+
+  # Install the wheel.
+  $HOME/miniconda2/bin/pip install $PYTHON_WHEEL
+
+  # Run a simple test script to make sure that the wheel works.
+  $HOME/miniconda2/bin/python $TEST_SCRIPT
+
+  # Now test Python 3.6.
+
+  # Install miniconda.
+  wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda3.sh
+  bash miniconda3.sh -b -p $HOME/miniconda3
+
+  # Find the right wheel by grepping for the Python version.
+  PYTHON_WHEEL=$(find $ROOT_DIR/../.whl -type f -maxdepth 1 -print | grep -m1 '36')
+
+  # Install the wheel.
+  $HOME/miniconda3/bin/pip install $PYTHON_WHEEL
+
+  # Run a simple test script to make sure that the wheel works.
+  $HOME/miniconda3/bin/python $TEST_SCRIPT
+
+elif [[ "$platform" == "macosx" ]]; then
+  MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+  PY_MMS=("2.7"
+          "3.4"
+          "3.5"
+          "3.6")
+  # This array is just used to find the right wheel.
+  PY_WHEEL_VERSIONS=("27"
+                     "34"
+                     "35"
+                     "36")
+
+  for ((i=0; i<${#PY_MMS[@]}; ++i)); do
+    PY_MM=${PY_MMS[i]}
+    PY_WHEEL_VERSION=${PY_WHEEL_VERSIONS[i]}
+
+    PYTHON_EXE=$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM
+    PIP_CMD="$(dirname $PYTHON_EXE)/pip$PY_MM"
+
+    # Find the appropriate wheel by grepping for the Python version.
+    PYTHON_WHEEL=$(find $ROOT_DIR/../.whl -type f -maxdepth 1 -print | grep -m1 '$PY_WHEEL_VERSION')
+
+    # Install the wheel.
+    $PIP_CMD install $PYTHON_WHEEL
+
+    # Run a simple test script to make sure that the wheel works.
+    $PYTHON_EXE $TEST_SCRIPT
+  done
+else
+  echo "Unrecognized environment."
+  exit 1
+fi

--- a/.travis/test-wheels.sh
+++ b/.travis/test-wheels.sh
@@ -74,7 +74,7 @@ elif [[ "$platform" == "macosx" ]]; then
     PIP_CMD="$(dirname $PYTHON_EXE)/pip$PY_MM"
 
     # Find the appropriate wheel by grepping for the Python version.
-    PYTHON_WHEEL=$(find $ROOT_DIR/../.whl -type f -maxdepth 1 -print | grep -m1 '$PY_WHEEL_VERSION')
+    PYTHON_WHEEL=$(find $ROOT_DIR/../.whl -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
 
     # Install the wheel.
     $PIP_CMD install $PYTHON_WHEEL


### PR DESCRIPTION
This builds the Mac and Linux wheels in Travis and runs a small test script to check that the wheels work.

This should help with two things.
- Wheel building shouldn't break anymore.
- This should fix #625. The CentOS build shouldn't break anymore because the Docker image used to build the Linux wheels uses CentOS.