### PR TITLE
Fault tolerance race

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -971,10 +971,6 @@ int TaskTableWrite(RedisModuleCtx *ctx,
     }
 
     if (num_clients == 0) {
-      LOG_WARN(
-          "No subscribers received this publish. This most likely means that "
-          "either the intended recipient has not subscribed yet or that the "
-          "pubsub connection to the intended recipient has been broken.");
       /* This reply will be received by redis_task_table_update_callback or
        * redis_task_table_add_task_callback in redis.cc, which will then reissue
        * the command. */

--- a/src/common/state/db.h
+++ b/src/common/state/db.h
@@ -52,6 +52,14 @@ void db_attach(DBHandle *db, event_loop *loop, bool reattach);
 void db_disconnect(DBHandle *db);
 
 /**
+ * Free the database handle.
+ *
+ * @param db The database connection to clean up.
+ * @return Void.
+ */
+void DBHandle_free(DBHandle *db);
+
+/**
  * Returns the db client ID.
  *
  * @param db The handle to the database.

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -872,45 +872,25 @@ void redis_task_table_add_task_callback(redisAsyncContext *c,
                                         void *privdata) {
   REDIS_CALLBACK_HEADER(db, callback_data, r);
 
-  /* Do some minimal checking. */
   redisReply *reply = (redisReply *) r;
-
-  /* If the publish which happens inside of the call to RAY.TASK_TABLE_ADD was
-   * not received by any subscribers, then reissue the command. TODO(rkn): This
-   * entire if block should be temporary. Once we address the problem where in
-   * which a global scheduler may publish a task to a local scheduler before the
-   * local scheduler has subscribed to the relevant channel, we shouldn't need
-   * this block any more. */
+  // If no subscribers received the message, call the failure callback. The
+  // caller should decide whether to retry the add. NOTE(swang): The caller
+  // should check whether the receiving subscriber is still alive in the
+  // db_client table before retrying the add.
   if (reply->type == REDIS_REPLY_ERROR &&
       strcmp(reply->str, "No subscribers received message.") == 0) {
-    Task *task = (Task *) callback_data->data;
-    TaskID task_id = Task_task_id(task);
-    DBClientID local_scheduler_id = Task_local_scheduler(task);
-    redisAsyncContext *context = get_redis_context(db, task_id);
-    int state = Task_state(task);
-    TaskSpec *spec = Task_task_spec(task);
-    /* Reissue the command. */
-    CHECKM(task != NULL, "NULL task passed to redis_task_table_add_task.");
-    int status = redisAsyncCommand(
-        context, redis_task_table_add_task_callback,
-        (void *) callback_data->timer_id, "RAY.TASK_TABLE_ADD %b %d %b %b",
-        task_id.id, sizeof(task_id.id), state, local_scheduler_id.id,
-        sizeof(local_scheduler_id.id), spec, Task_task_spec_size(task));
-    if ((status == REDIS_ERR) || context->err) {
-      LOG_REDIS_DEBUG(context, "error in redis_task_table_add_task");
+    callback_data->retry.fail_callback(
+        callback_data->id, callback_data->user_context, callback_data->data);
+  } else {
+    CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
+    /* Call the done callback if there is one. */
+    if (callback_data->done_callback != NULL) {
+      task_table_done_callback done_callback =
+          (task_table_done_callback) callback_data->done_callback;
+      done_callback(callback_data->id, callback_data->user_context);
     }
-    /* Since we are reissuing the same command with the same callback data,
-     * return early to avoid freeing the callback data. */
-    return;
   }
 
-  CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
-  /* Call the done callback if there is one. */
-  if (callback_data->done_callback != NULL) {
-    task_table_done_callback done_callback =
-        (task_table_done_callback) callback_data->done_callback;
-    done_callback(callback_data->id, callback_data->user_context);
-  }
   /* Clean up the timer and callback. */
   destroy_timer_callback(db->loop, callback_data);
 }

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -879,8 +879,11 @@ void redis_task_table_add_task_callback(redisAsyncContext *c,
   // db_client table before retrying the add.
   if (reply->type == REDIS_REPLY_ERROR &&
       strcmp(reply->str, "No subscribers received message.") == 0) {
-    callback_data->retry.fail_callback(
-        callback_data->id, callback_data->user_context, callback_data->data);
+    LOG_WARN("No subscribers received the task_table_add message.");
+    if (callback_data->retry.fail_callback != NULL) {
+      callback_data->retry.fail_callback(
+          callback_data->id, callback_data->user_context, callback_data->data);
+    }
   } else {
     CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
     /* Call the done callback if there is one. */
@@ -928,8 +931,11 @@ void redis_task_table_update_callback(redisAsyncContext *c,
   // alive in the db_client table.
   if (reply->type == REDIS_REPLY_ERROR &&
       strcmp(reply->str, "No subscribers received message.") == 0) {
-    callback_data->retry.fail_callback(
-        callback_data->id, callback_data->user_context, callback_data->data);
+    LOG_WARN("No subscribers received the task_table_update message.");
+    if (callback_data->retry.fail_callback != NULL) {
+      callback_data->retry.fail_callback(
+          callback_data->id, callback_data->user_context, callback_data->data);
+    }
   } else {
     CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
 

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -950,16 +950,17 @@ void redis_task_table_update_callback(redisAsyncContext *c,
       strcmp(reply->str, "No subscribers received message.") == 0) {
     callback_data->retry.fail_callback(
         callback_data->id, callback_data->user_context, callback_data->data);
-    return;
-  }
-  CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
+  } else {
+    CHECKM(strcmp(reply->str, "OK") == 0, "reply->str is %s", reply->str);
 
-  /* Call the done callback if there is one. */
-  if (callback_data->done_callback != NULL) {
-    task_table_done_callback done_callback =
-        (task_table_done_callback) callback_data->done_callback;
-    done_callback(callback_data->id, callback_data->user_context);
+    /* Call the done callback if there is one. */
+    if (callback_data->done_callback != NULL) {
+      task_table_done_callback done_callback =
+          (task_table_done_callback) callback_data->done_callback;
+      done_callback(callback_data->id, callback_data->user_context);
+    }
   }
+
   /* Clean up the timer and callback. */
   destroy_timer_callback(db->loop, callback_data);
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -147,6 +147,9 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   /* Reset the SIGTERM handler to default behavior, so we try to clean up the
    * local scheduler at most once. If a SIGTERM is caught afterwards, there is
    * the possibility of orphan worker processes. */
+  /* TODO(swang): Add a null heartbeat that tells the global scheduler that we
+   * are dead. This avoids having to wait for the timeout before marking us as
+   * dead in the db_client table, in cases where we can do a clean exit. */
   signal(SIGTERM, SIG_DFL);
 
   /* Kill any child processes that didn't register as a worker yet. */
@@ -170,12 +173,6 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   ARROW_CHECK_OK(state->plasma_conn->Disconnect());
   delete state->plasma_conn;
   state->plasma_conn = NULL;
-
-  /* Disconnect from the database. */
-  if (state->db != NULL) {
-    db_disconnect(state->db);
-    state->db = NULL;
-  }
 
   /* Free the command for starting new workers. */
   if (state->config.start_worker_command != NULL) {

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -131,7 +131,7 @@ class ComponentFailureTest(unittest.TestCase):
         num_local_schedulers = 4
         num_workers_per_scheduler = 8
         ray.worker._init(
-            num_workers=num_local_schedulers * num_workers_per_scheduler,
+            num_workers=num_workers_per_scheduler,
             num_local_schedulers=num_local_schedulers,
             start_ray_local=True,
             num_cpus=[num_workers_per_scheduler] * num_local_schedulers,


### PR DESCRIPTION
This fixes three fault tolerance issues when a local scheduler dies:

1. Do not mark the local scheduler as dead in the db_client table during local scheduler cleanup. The global scheduler should be responsible for marking local schedulers as dead, to prevent races in task assignment.
2. Do not retry task assignments on the global scheduler if the local scheduler has been removed.
3. When submitting an actor task from one local scheduler to another, look up the most recent local scheduler to actor mapping before retrying a failed submission. This prevents us from infinitely retrying a dead local scheduler.

This fixes #871 (most likely caused by the second race).