### PR TITLE
doc: mention cython in installation note.

### DIFF
--- a/doc/source/install-on-macosx.rst
+++ b/doc/source/install-on-macosx.rst
@@ -28,7 +28,7 @@ To build Ray, first install the following dependencies. We recommend using
   brew update
   brew install cmake pkg-config automake autoconf libtool boost wget
 
-  pip install numpy cloudpickle funcsigs click colorama psutil redis flatbuffers --ignore-installed six
+  pip install numpy cloudpickle funcsigs click colorama psutil redis flatbuffers cython --ignore-installed six
 
 If you are using Anaconda, you may also need to run the following.
 

--- a/doc/source/install-on-ubuntu.rst
+++ b/doc/source/install-on-ubuntu.rst
@@ -35,7 +35,7 @@ To build Ray, first install the following dependencies. We recommend using
   # If you are on Ubuntu 14.04, you need the following.
   pip install cmake
 
-  pip install numpy cloudpickle funcsigs click colorama psutil redis flatbuffers
+  pip install numpy cloudpickle funcsigs click colorama psutil redis flatbuffers cython
 
 
 If you are using Anaconda, you may also need to run the following.


### PR DESCRIPTION
I was following http://ray.readthedocs.io/en/latest/install-on-macosx.html to install `ray` for the first time.  Everything worked until the line
```
python setup.py install
```
which prompted a cython-not-imported error.  An extra `pip install cython` let me get past this.