### PR TITLE
[webui] Make the ui link a bit more obvious

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -507,8 +507,12 @@ def start_ui(redis_address, stdout_file=None, stderr_file=None, cleanup=True):
         if cleanup:
             all_processes[PROCESS_TYPE_WEB_UI].append(ui_process)
 
+        print()
+        print("=" * 70)
         print("View the web UI at http://localhost:{}/notebooks/ray_ui{}.ipynb"
               .format(port, random_ui_id))
+        print("=" * 70)
+        print()
 
 
 def start_local_scheduler(redis_address,


### PR DESCRIPTION
It's currently pretty easy to lose in the logs, even when you're looking for it.

Before:
```
Allowing the Plasma store to use up to 4.91027GB of memory.
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
Starting local scheduler with 4 CPUs, 0 GPUs
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22110
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22111
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22112
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22113
View the web UI at http://localhost:8893/notebooks/ray_ui83038.ipynb
initial run
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
```


After:
```
Allowing the Plasma store to use up to 4.91027GB of memory.
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
Starting local scheduler with 4 CPUs, 0 GPUs
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22110
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22111
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22112
[INFO] (/home/eric/Desktop/ray-private/src/local_scheduler/local_scheduler.cc:231) Started worker with pid 22113

======================================================================
View the web UI at http://localhost:8893/notebooks/ray_ui83038.ipynb
======================================================================

initial run
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
  from pkg_resources import get_distribution, DistributionNotFound
/home/eric/Desktop/ray-private/python/ray/pyarrow_files/pyarrow/__init__.py:20: UserWarning: Module ray was already imported from /home/eric/Desktop/ray-private/python/ray/__init__.py, but /usr/local/lib/python3.5/dist-packages/ray-0.0.1-py3.5.egg is being added to sys.path
```