### PR TITLE
Make task timeline work with ipywidgets==7.0.0, change slider default values.

### DIFF
--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -49,7 +49,7 @@ def get_sliders(update):
     # Percentage slider. Indicates either % of total time or total tasks
     # depending on what breakdown_opt is set to.
     range_slider = widgets.IntRangeSlider(
-        value=[70, 100],
+        value=[0, 100],
         min=0,
         max=100,
         step=1,

--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -57,7 +57,6 @@ def get_sliders(update):
         continuous_update=False,
         orientation="horizontal",
         readout=True,
-        readout_format=".0i%",
     )
 
     # Indicates the number of tasks that the user wants to be returned. Is


### PR DESCRIPTION
This addresses one aspect of #903. It also partially addresses #912.

However, it seems to introduce a change in behavior with the task timeline. Now when you click "View task timeline", the sliders and boxes and buttons disappear. @alanamarzoev @Wapaul1 any ideas about this behavior?

@alanamarzoev can you comment on what this line was doing before and whether it is necessary or not?