### PR TITLE
Pin opencv-python version to 3.2.0.8 in dockerfile.

### DIFF
--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -3,4 +3,4 @@
 FROM ray-project/deploy
 RUN conda install -y -c conda-forge tensorflow
 RUN apt-get install -y zlib1g-dev
-RUN pip install gym[atari] opencv-python smart_open
+RUN pip install gym[atari] opencv-python==3.2.0.8 smart_open


### PR DESCRIPTION
This should address the error we're seeing in #923.