### PR TITLE
Sleep longer when starting plasma manager in valgrind case.

### DIFF
--- a/python/ray/plasma/plasma.py
+++ b/python/ray/plasma/plasma.py
@@ -136,7 +136,10 @@ def start_plasma_manager(store_name, redis_address,
         # This sleep is critical. If the plasma_manager fails to start because
         # the port is already in use, then we need it to fail within 0.1
         # seconds.
-        time.sleep(0.1)
+        if use_valgrind:
+            time.sleep(1)
+        else:
+            time.sleep(0.1)
         # See if the process has terminated
         if process.poll() is None:
             return plasma_manager_name, process, plasma_manager_port


### PR DESCRIPTION
Hopefully this addresses #791.

This gives the plasma manager a little more time to fail to bind a port.