### PR TITLE
[webui] Scalability fixes for the task timeline and visualizations

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -743,35 +743,36 @@ class GlobalState(object):
                                 seen_obj[arg] = 0
                             seen_obj[arg] += 1
                             owner_task = self._object_table(arg)["TaskID"]
-                            owner_worker = (workers[
-                                task_info[owner_task]["worker_id"]])
-                            # Adding/subtracting 2 to the time associated with
-                            # the beginning/ending of the flow event is
-                            # necessary to make the flow events show up
-                            # reliably. When these times are exact, this is
-                            # presumably an edge case, and catapult doesn't
-                            # recognize that there is a duration event at that
-                            # exact point in time that the flow event should be
-                            # bound to. This issue is solved by adding the 2 ms
-                            # to the start/end time of the flow event, which
-                            # guarantees overlap with the duration event that
-                            # it's associated with, and the flow event
-                            # therefore always gets drawn.
-                            owner = {
-                                "cat": "obj_dependency",
-                                "pid": ("Node " +
-                                        owner_worker["node_ip_address"]),
-                                "tid": task_info[owner_task]["worker_id"],
-                                "ts": micros_rel(task_info[
-                                    owner_task]["store_outputs_end"]) - 2,
-                                "ph": "s",
-                                "name": "ObjectDependency",
-                                "args": {},
-                                "bp": "e",
-                                "cname": "cq_build_attempt_failed",
-                                "id": "obj" + str(arg) + str(seen_obj[arg])
-                            }
-                            full_trace.append(owner)
+                            if owner_task in task_info:
+                                owner_worker = (workers[
+                                    task_info[owner_task]["worker_id"]])
+                                # Adding/subtracting 2 to the time associated with
+                                # the beginning/ending of the flow event is
+                                # necessary to make the flow events show up
+                                # reliably. When these times are exact, this is
+                                # presumably an edge case, and catapult doesn't
+                                # recognize that there is a duration event at that
+                                # exact point in time that the flow event should be
+                                # bound to. This issue is solved by adding the 2 ms
+                                # to the start/end time of the flow event, which
+                                # guarantees overlap with the duration event that
+                                # it's associated with, and the flow event
+                                # therefore always gets drawn.
+                                owner = {
+                                    "cat": "obj_dependency",
+                                    "pid": ("Node " +
+                                            owner_worker["node_ip_address"]),
+                                    "tid": task_info[owner_task]["worker_id"],
+                                    "ts": micros_rel(task_info[
+                                        owner_task]["store_outputs_end"]) - 2,
+                                    "ph": "s",
+                                    "name": "ObjectDependency",
+                                    "args": {},
+                                    "bp": "e",
+                                    "cname": "cq_build_attempt_failed",
+                                    "id": "obj" + str(arg) + str(seen_obj[arg])
+                                }
+                                full_trace.append(owner)
 
                             dependent = {
                                 "cat": "obj_dependency",

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -746,18 +746,18 @@ class GlobalState(object):
                             if owner_task in task_info:
                                 owner_worker = (workers[
                                     task_info[owner_task]["worker_id"]])
-                                # Adding/subtracting 2 to the time associated with
-                                # the beginning/ending of the flow event is
-                                # necessary to make the flow events show up
+                                # Adding/subtracting 2 to the time associated
+                                # with the beginning/ending of the flow event
+                                # is necessary to make the flow events show up
                                 # reliably. When these times are exact, this is
                                 # presumably an edge case, and catapult doesn't
-                                # recognize that there is a duration event at that
-                                # exact point in time that the flow event should be
-                                # bound to. This issue is solved by adding the 2 ms
-                                # to the start/end time of the flow event, which
-                                # guarantees overlap with the duration event that
-                                # it's associated with, and the flow event
-                                # therefore always gets drawn.
+                                # recognize that there is a duration event at
+                                # that exact point in time that the flow event
+                                # should be bound to. This issue is solved by
+                                # adding the 2 ms to the start/end time of the
+                                # flow event, which guarantees overlap with the
+                                # duration event that it's associated with, and
+                                # the flow event therefore always gets drawn.
                                 owner = {
                                     "cat": "obj_dependency",
                                     "pid": ("Node " +

--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -292,7 +292,7 @@ def _truncated_task_profiles(start=None, end=None, num_tasks=None, fwd=True):
         print(
             "Warning: too many tasks to visualize, "
             "fetching only the first {} of {}.".format(
-            MAX_TASKS_TO_VISUALIZE, num_tasks))
+                MAX_TASKS_TO_VISUALIZE, num_tasks))
         num_tasks = MAX_TASKS_TO_VISUALIZE
     return ray.global_state.task_profiles(num_tasks, start, end, fwd)
 

--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -413,14 +413,15 @@ def task_timeline():
             raise ValueError("Unexpected time value '{}'".format(
                                                             time_opt.value))
         # Write trace to a JSON file
-        print("{} tasks to trace".format(len(tasks)))
-        print("Dumping task profiling data to " + json_tmp)
+        print("Collected profiles for {} tasks.".format(len(tasks)))
+        print(
+            "Dumping task profile data to {}, "
+            "this might take a while...".format(json_tmp))
         ray.global_state.dump_catapult_trace(json_tmp,
                                              tasks,
                                              breakdowns=breakdown,
                                              obj_dep=obj_dep.value,
                                              task_dep=task_dep.value)
-
         print("Opening html file in browser...")
 
         # Check that the catapult repo is cloned to the correct location

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1661,10 +1661,10 @@ class GlobalStateAPI(unittest.TestCase):
         # Make sure the event log has the correct number of events.
         start_time = time.time()
         while time.time() - start_time < 10:
-            profiles = ray.global_state.task_profiles(start=0, end=time.time())
-            limited_profiles = ray.global_state.task_profiles(start=0,
-                                                              end=time.time(),
-                                                              num_tasks=1)
+            profiles = ray.global_state.task_profiles(
+                100, start=0, end=time.time())
+            limited_profiles = ray.global_state.task_profiles(1, start=0,
+                                                              end=time.time())
             if len(profiles) == num_calls and len(limited_profiles) == 1:
                 break
             time.sleep(0.1)
@@ -1729,7 +1729,8 @@ class GlobalStateAPI(unittest.TestCase):
         ray.get([actor.method.remote() for actor in actors])
 
         path = os.path.join("/tmp/ray_test_trace")
-        task_info = ray.global_state.task_profiles(start=0, end=time.time())
+        task_info = ray.global_state.task_profiles(
+            100, start=0, end=time.time())
         ray.global_state.dump_catapult_trace(path, task_info)
 
         # TODO(rkn): This test is not perfect because it does not verify that


### PR DESCRIPTION
This PR ensures web ui responsiveness (https://github.com/ray-project/ray/issues/933) by adding a hard cap on the number of tasks returned (10000).

You can test with the following snippet which launches one million tasks locally. The UI should respond fluidly in all the visualizations except the timeline, which still should update within about 10 seconds.
```
import time
import ray

@ray.remote
def f(x):
    return x

print("Launching tasks")

ray.init()
for x in range(1000000):
    y = f.remote(x)
ray.get(y)
print("Done")

time.sleep(99999999)
```

cc @alanamarzoev @robertnishihara 