### PR TITLE
Local scheduler sends a null heartbeat to global scheduler

### DIFF
--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -129,6 +129,9 @@ table LocalSchedulerInfoMessage {
   // The resource vector of resources currently available to this local
   // scheduler.
   dynamic_resources: [double];
+  // Whether the local scheduler is dead. If true, then all other fields
+  // besides `db_client_id` will not be set.
+  is_dead: bool;
 }
 
 root_type LocalSchedulerInfoMessage;

--- a/src/common/state/local_scheduler_table.cc
+++ b/src/common/state/local_scheduler_table.cc
@@ -27,3 +27,7 @@ void local_scheduler_table_send_info(DBHandle *db_handle,
   init_table_callback(db_handle, NIL_ID, __func__, data, retry, NULL,
                       redis_local_scheduler_table_send_info, NULL);
 }
+
+void local_scheduler_table_disconnect(DBHandle *db_handle) {
+  redis_local_scheduler_table_disconnect(db_handle);
+}

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -21,6 +21,9 @@ typedef struct {
   /** The resource vector of resources currently available to this local
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
+  /** Whether the local scheduler is dead. If true, then all other fields
+   * should be ignored. */
+  bool is_dead;
 } LocalSchedulerInfo;
 
 /*
@@ -58,13 +61,14 @@ typedef struct {
 } LocalSchedulerTableSubscribeData;
 
 /**
- * Send a heartbeat to all subscriers to the local scheduler table. This
+ * Send a heartbeat to all subscribers to the local scheduler table. This
  * heartbeat contains some information about the load on the local scheduler.
  *
  * @param db_handle Database handle.
  * @param info Information about the local scheduler, including the load on the
  *        local scheduler.
  * @param retry Information about retrying the request to the database.
+ * @return Void.
  */
 void local_scheduler_table_send_info(DBHandle *db_handle,
                                      LocalSchedulerInfo *info,
@@ -76,5 +80,15 @@ typedef struct {
   /* The information to be sent. */
   LocalSchedulerInfo info;
 } LocalSchedulerTableSendInfoData;
+
+/**
+ * Send a null heartbeat to all subscribers to the local scheduler table to
+ * notify them that we are about to exit. This operation is performed
+ * synchronously.
+ *
+ * @param db_handle Database handle.
+ * @return Void.
+ */
+void local_scheduler_table_disconnect(DBHandle *db_handle);
 
 #endif /* LOCAL_SCHEDULER_TABLE_H */

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -22,7 +22,7 @@ typedef struct {
    *  scheduler. */
   double dynamic_resources[ResourceIndex_MAX];
   /** Whether the local scheduler is dead. If true, then all other fields
-   * should be ignored. */
+   *  should be ignored. */
   bool is_dead;
 } LocalSchedulerInfo;
 

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -292,6 +292,15 @@ void redis_local_scheduler_table_subscribe(TableCallbackData *callback_data);
 void redis_local_scheduler_table_send_info(TableCallbackData *callback_data);
 
 /**
+ * Synchronously publish a null update to the local scheduler table signifying
+ * that we are about to exit.
+ *
+ * @param db The database handle of the dying local scheduler.
+ * @return Void.
+ */
+void redis_local_scheduler_table_disconnect(DBHandle *db);
+
+/**
  * Subscribe to updates from the driver table.
  *
  * @param callback_data Data structure containing redis connection and timeout

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -175,10 +175,9 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
    * responsible for deleting our entry from the db_client table, so do not
    * delete it here. */
   if (state->db != NULL) {
-    /* TODO(swang): Add a null heartbeat that tells the global scheduler that
-     * we are dead. This avoids having to wait for the timeout before marking
-     * us as dead in the db_client table, in cases where we can do a clean
-     * exit. */
+    /* Send a null heartbeat that tells the global scheduler that we are dead
+     * to avoid waiting for the heartbeat timeout. */
+    local_scheduler_table_disconnect(state->db);
     DBHandle_free(state->db);
   }
 

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -185,8 +185,6 @@ LocalSchedulerState *LocalSchedulerState_init(
     const char *worker_path,
     int num_workers);
 
-void LocalSchedulerState_free(LocalSchedulerState *state);
-
 SchedulingAlgorithmState *get_algorithm_state(LocalSchedulerState *state);
 
 void process_message(event_loop *loop,

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -121,4 +121,13 @@ struct LocalSchedulerClient {
   LocalSchedulerState *local_scheduler_state;
 };
 
+/**
+ * Free the local scheduler state. This disconnects all clients and notifies
+ * the global scheduler of the local scheduler's exit.
+ *
+ * @param state The state to free.
+ * @return Void
+ */
+void LocalSchedulerState_free(LocalSchedulerState *state);
+
 #endif /* LOCAL_SCHEDULER_SHARED_H */

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -151,11 +151,12 @@ class ComponentFailureTest(unittest.TestCase):
         components = ray.services.all_processes[component_type]
         for process in components[1:]:
             process.terminate()
-            time.sleep(0.1)
+            time.sleep(1)
+
+        for process in components[1:]:
             process.kill()
             process.wait()
             self.assertNotEqual(process.poll(), None)
-            time.sleep(1)
 
         # Make sure that we can still get the objects after the executing tasks
         # died.


### PR DESCRIPTION
Upon a clean exit, the local scheduler sends a null heartbeat to the global scheduler to notify that it is about to die. This allows the global scheduler to avoid waiting for the heartbeat timeout before marking the local scheduler as dead.