### PR TITLE
Pass string into json.loads, not bytes object.

### DIFF
--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -461,7 +461,7 @@ class Monitor(object):
                             result = pipe.hget(local_scheduler_id,
                                                "gpus_in_use")
                             gpus_in_use = (dict() if result is None else
-                                           json.loads(result))
+                                           json.loads(result.decode("ascii")))
 
                             driver_id_hex = binary_to_hex(driver_id)
                             if driver_id_hex in gpus_in_use:


### PR DESCRIPTION
This should fix an error I was seeing with Python 3.5 in `monitor.py`.

```
INFO:root:Driver cada6249d73320004f3f128bbb5d00722e9e1685 has been removed.
Traceback (most recent call last):
  File "/home/ubuntu/ray/python/ray/monitor.py", line 479, in <module>
    monitor.run()
  File "/home/ubuntu/ray/python/ray/monitor.py", line 430, in run
    self.process_messages()
  File "/home/ubuntu/ray/python/ray/monitor.py", line 390, in process_messages
    message_handler(channel, data)
  File "/home/ubuntu/ray/python/ray/monitor.py", line 325, in driver_removed_handler
    else json.loads(result))
  File "/home/ubuntu/anaconda3/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```