### PR TITLE
[rllib] Partial rollouts for PPO

### DIFF
--- a/python/ray/rllib/models/fcnet.py
+++ b/python/ray/rllib/models/fcnet.py
@@ -15,6 +15,7 @@ class FullyConnectedNetwork(Model):
     def _init(self, inputs, num_outputs, options):
         hiddens = options.get("fcnet_hiddens", [256, 256])
         fcnet_activation = options.get("fcnet_activation", "tanh")
+        last_layer_init = options.get("last_layer_init", 0.01)
         if fcnet_activation == "tanh":
             activation = tf.nn.tanh
         elif fcnet_activation == "relu":
@@ -33,6 +34,6 @@ class FullyConnectedNetwork(Model):
                 i += 1
             output = slim.fully_connected(
                 last_layer, num_outputs,
-                weights_initializer=normc_initializer(0.01),
+                weights_initializer=normc_initializer(last_layer_init),
                 activation_fn=None, scope="fc_out")
             return output, last_layer

--- a/python/ray/rllib/parallel.py
+++ b/python/ray/rllib/parallel.py
@@ -100,6 +100,7 @@ class LocalSyncParallelOptimizer(object):
         else:
             run_options = tf.RunOptions(trace_level=tf.RunOptions.NO_TRACE)
         run_metadata = tf.RunMetadata()
+        import ipdb; ipdb.set_trace()
 
         sess.run(
             [t.init_op for t in self._towers],

--- a/python/ray/rllib/parallel.py
+++ b/python/ray/rllib/parallel.py
@@ -100,7 +100,6 @@ class LocalSyncParallelOptimizer(object):
         else:
             run_options = tf.RunOptions(trace_level=tf.RunOptions.NO_TRACE)
         run_metadata = tf.RunMetadata()
-
         sess.run(
             [t.init_op for t in self._towers],
             feed_dict=feed_dict,

--- a/python/ray/rllib/parallel.py
+++ b/python/ray/rllib/parallel.py
@@ -100,7 +100,6 @@ class LocalSyncParallelOptimizer(object):
         else:
             run_options = tf.RunOptions(trace_level=tf.RunOptions.NO_TRACE)
         run_metadata = tf.RunMetadata()
-        import ipdb; ipdb.set_trace()
 
         sess.run(
             [t.init_op for t in self._towers],

--- a/python/ray/rllib/ppo/loss.py
+++ b/python/ray/rllib/ppo/loss.py
@@ -32,6 +32,7 @@ class ProximalPolicyLoss(object):
             # Do not split the last layer of the value function into
             # mean parameters and standard deviation parameters and
             # do not make the standard deviations free variables.
+            vf_config["last_layer_init"] = 1.0
             vf_config["free_log_std"] = False
             with tf.variable_scope("value_function"):
                 self.value_function = ModelCatalog.get_model(

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -76,7 +76,8 @@ DEFAULT_CONFIG = {
     # is detected
     "tf_debug_inf_or_nan": False,
     # If True, we write tensorflow logs and checkpoints
-    "write_logs": True
+    "write_logs": True,
+    "trunc_nstep": None
 }
 
 
@@ -115,8 +116,12 @@ class PPOAgent(Agent):
         iter_start = time.time()
         weights = ray.put(model.get_weights())
         [a.load_weights.remote(weights) for a in agents]
-        trajectory, total_reward, traj_len_mean = collect_samples(
-            agents, config)
+        if config["trunc_nstep"] is not None:
+            trajectory, total_reward, traj_len_mean = collect_partial(
+                agents, config)
+        else:
+            trajectory, total_reward, traj_len_mean = collect_samples(
+                agents, config)
         print("total reward is ", total_reward)
         print("trajectory length mean is ", traj_len_mean)
         print("timesteps:", trajectory["dones"].shape[0])

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -122,7 +122,6 @@ class PPOAgent(Agent):
         else:
             trajectory, total_reward, traj_len_mean = collect_samples(
                 agents, config)
-        import ipdb; ipdb.set_trace()
         print("total reward is ", total_reward)
         print("trajectory length mean is ", traj_len_mean)
         print("timesteps:", trajectory["dones"].shape[0])

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -211,6 +211,18 @@ class PPOAgent(Agent):
                         tag=metric_prefix + "mean_loss",
                         simple_value=loss),
                     tf.Summary.Value(
+                        tag=metric_prefix + "vf_loss",
+                        simple_value=vf_loss),
+                    tf.Summary.Value(
+                        tag=metric_prefix + "pi_loss",
+                        simple_value=policy_loss),
+                    tf.Summary.Value(
+                        tag=metric_prefix + "rollout_time",
+                        simple_value=rollouts_time),
+                    tf.Summary.Value(
+                        tag=metric_prefix + "sgd_time",
+                        simple_value=sgd_time),
+                    tf.Summary.Value(
                         tag=metric_prefix + "mean_kl",
                         simple_value=kl)])
                 if self.file_writer:

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -13,7 +13,7 @@ from tensorflow.python import debug as tf_debug
 import ray
 from ray.rllib.common import Agent, TrainingResult
 from ray.rllib.ppo.runner import Runner, RemoteRunner
-from ray.rllib.ppo.rollout import collect_samples
+from ray.rllib.ppo.rollout import collect_samples, collect_partial
 from ray.rllib.ppo.utils import shuffle
 
 

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -117,6 +117,7 @@ class PPOAgent(Agent):
         weights = ray.put(model.get_weights())
         [a.load_weights.remote(weights) for a in agents]
         if config["trunc_nstep"] is not None:
+            assert config["horizon"] == 0 and config["min_steps_per_task"] == 0
             trajectory, total_reward, traj_len_mean = collect_partial(
                 agents, config)
         else:

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -122,6 +122,7 @@ class PPOAgent(Agent):
         else:
             trajectory, total_reward, traj_len_mean = collect_samples(
                 agents, config)
+        import ipdb; ipdb.set_trace()
         print("total reward is ", total_reward)
         print("trajectory length mean is ", traj_len_mean)
         print("timesteps:", trajectory["dones"].shape[0])

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -216,12 +216,14 @@ def collect_partial(agents,
                        config["trunc_nstep"])] = (
             agent)
         trajectory, rewards, lengths = ray.get(next_trajectory)
+
+        # TODO(rliaw): make "total_reward" to only recall full rollouts?
         total_rewards.extend(rewards)
         trajectory_lengths.extend(lengths)
         num_timesteps_so_far += len(trajectory["observations"])
         trajectories.append(trajectory)
-    return (concatenate(trajectories), np.mean(total_rewards),
-            np.mean(trajectory_lengths))
+    return (concatenate(trajectories), np.nanmean(total_rewards),
+            np.nanmean(trajectory_lengths))
 
 
 def collect_samples(agents,

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -61,6 +61,66 @@ def rollouts(policy, env, horizon, observation_filter=NoFilter(),
             "vf_preds": np.vstack(vf_preds),
             "dones": np.vstack(dones)}
 
+def partial_rollouts(policy, env, last_observation,
+                     steps, observation_filter=NoFilter(),
+                     reward_filter=NoFilter()):
+    """Perform a batch of rollouts of a policy in an environment.
+
+    Args:
+        policy: The policy that will be rollout out. Can be an arbitrary object
+            that supports a compute_actions(observation) function.
+        env: The environment the rollout is computed in. Needs to support the
+            OpenAI gym API and needs to support batches of data.
+        horizon: Upper bound for the number of timesteps for each rollout in
+            the batch.
+        observation_filter: Function that is applied to each of the
+            observations.
+        reward_filter: Function that is applied to each of the rewards.
+
+    Returns:
+        A trajectory, which is a dictionary with keys "observations",
+            "rewards", "orig_rewards", "actions", "logprobs", "dones". Each
+            value is an array of shape (num_timesteps, env.batchsize, shape).
+    """
+    # TODO (rliaw): Would be nice to have as an iterator to store intermediate state
+
+    if type(env, BatchedEnv) and env.batchsize > 1:
+        assert False, "No support for multi-batch case"
+
+    observation = last_observation if last_observation else env.reset()
+    observation = observation_filter(observation)
+    # done = np.array(env.batchsize * [False])
+    t = 0
+    observations = []  # Filtered observations
+    raw_rewards = []   # Empirical rewards
+    actions = []  # Actions sampled by the policy
+    logprobs = []  # Last layer of the policy network
+    vf_preds = []  # Value function predictions
+    dones = []  # Has this rollout terminated?
+
+    while (not done.all()) and t < steps:
+        action, logprob, vfpred = policy.compute(observation)
+        vf_preds.append(vfpred)
+        observations.append(observation[None])
+        actions.append(action[None])
+        logprobs.append(logprob[None])
+        observation, raw_reward, done = env.step(action)
+        observation = observation_filter(observation)
+        raw_rewards.append(raw_reward[None])
+        dones.append(done[None])
+        t += 1
+
+    last_observation = observation if not done.all() else None
+    last_value = policy.compute(observation)[2] if not done.all() else 0.0
+
+    return {"observations": np.vstack(observations),
+            "raw_rewards": np.vstack(raw_rewards),
+            "actions": np.vstack(actions),
+            "logprobs": np.vstack(logprobs),
+            "vf_preds": np.vstack(vf_preds),
+            "dones": np.vstack(dones),
+            "last_observation": last_observation,
+            "last_value": last_value }
 
 def add_return_values(trajectory, gamma, reward_filter):
     rewards = trajectory["raw_rewards"]
@@ -83,6 +143,8 @@ def add_advantage_values(trajectory, gamma, lam, reward_filter):
     advantages = np.zeros_like(rewards)
     last_advantage = np.zeros(rewards.shape[1], dtype="float32")
 
+    import ipdb; ipdb.set_trace()  # breakpoint 12465f42 //
+
     for t in reversed(range(len(rewards) - 1)):
         delta = rewards[t, :] * (1 - dones[t, :]) + \
             gamma * vf_preds[t+1, :] * (1 - dones[t+1, :]) - vf_preds[t, :]
@@ -96,15 +158,68 @@ def add_advantage_values(trajectory, gamma, lam, reward_filter):
         trajectory["advantages"] + trajectory["vf_preds"]
 
 
-def collect_partial_rollouts(agents, config, observation_filter=NoFilter(),
-                             reward_filter=NoFilter()):
-    pass
+def discount(x, gamma):
+    return scipy.signal.lfilter([1], [1, -gamma], x[::-1], axis=0)[::-1]
+
+
+def add_truncated_advantages(trajectory, gamma, lam, reward_filter):
+    import ipdb; ipdb.set_trace()
+    rewards = np.asarray(rollout.rewards)
+    vpred_t = np.asarray(rollout.values + [rollout.r])
+
+    rewards_plus_v = np.asarray(rollout.rewards + [rollout.r])
+    batch_r = discount(rewards_plus_v, gamma)[:-1]
+    delta_t = rewards + gamma * vpred_t[1:] - vpred_t[:-1]
+    # This formula for the advantage comes "Generalized Advantage Estimation":
+    # https://arxiv.org/abs/1506.02438
+    batch_adv = discount(delta_t, gamma * lambda_)
+
+    trajectory["advantages"] = advantages
+    trajectory["td_lambda_returns"] = \
+        trajectory["advantages"] + trajectory["vf_preds"]
+
+
+
+def collect_partial(agents,
+                    config,
+                    observation_filter=NoFilter(),
+                    reward_filter=NoFilter()):
+    num_timesteps_so_far = 0
+    trajectories = []
+    total_rewards = []
+    trajectory_lengths = []
+    # This variable maps the object IDs of trajectories that are currently
+    # computed to the agent that they are computed on; we start some initial
+    # tasks here.
+    agent_dict = {agent.compute_partial_steps.remote(
+                      config["gamma"], config["lambda"],
+                      config["horizon"], config["mini_nstep"]):
+                  agent for agent in agents}
+    while num_timesteps_so_far < config["timesteps_per_batch"]:
+        # TODO(pcm): Make wait support arbitrary iterators and remove the
+        # conversion to list here.
+        [next_trajectory], waiting_trajectories = ray.wait(
+            list(agent_dict.keys()))
+        agent = agent_dict.pop(next_trajectory)
+        # Start task with next trajectory and record it in the dictionary.
+        agent_dict[agent.compute_partial_steps.remote(
+                       config["gamma"], config["lambda"],
+                       config["horizon"], config["min_steps_per_task"])] = (
+            agent)
+        trajectory, rewards, lengths = ray.get(next_trajectory)
+        total_rewards.extend(rewards)
+        trajectory_lengths.extend(lengths)
+        num_timesteps_so_far += len(trajectory["dones"])
+        trajectories.append(trajectory)
+    return (concatenate(trajectories), np.mean(total_rewards),
+            np.mean(trajectory_lengths))
 
 
 def collect_samples(agents,
                     config,
                     observation_filter=NoFilter(),
                     reward_filter=NoFilter()):
+    # TODO(rliaw): observation, reward filters are UNUSED
     num_timesteps_so_far = 0
     trajectories = []
     total_rewards = []

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -71,8 +71,7 @@ def partial_rollouts(policy, env, last_observation,
             that supports a compute_actions(observation) function.
         env: The environment the rollout is computed in. Needs to support the
             OpenAI gym API and needs to support batches of data.
-        horizon: Upper bound for the number of timesteps for each rollout in
-            the batch.
+        last_observation: For continuing 
         observation_filter: Function that is applied to each of the
             observations.
         reward_filter: Function that is applied to each of the rewards.
@@ -111,7 +110,12 @@ def partial_rollouts(policy, env, last_observation,
         t += 1
 
     last_observation = observation if not done.all() else None
-    last_value = policy.compute(observation)[2] if not done.all() else 0.0
+    import ipdb; ipdb.set_trace()  # breakpoint 741e9c2d //
+
+    truncation_vf = policy.compute(observation)[2] * (1 - done)
+    vf_preds.append(truncation_vf)
+    # to make add_advantage work without weird edge cases
+    dones.append(done[None]) 
 
     return {"observations": np.vstack(observations),
             "raw_rewards": np.vstack(raw_rewards),
@@ -119,8 +123,7 @@ def partial_rollouts(policy, env, last_observation,
             "logprobs": np.vstack(logprobs),
             "vf_preds": np.vstack(vf_preds),
             "dones": np.vstack(dones),
-            "last_observation": last_observation,
-            "last_value": last_value }
+            "last_observation": last_observation}
 
 def add_return_values(trajectory, gamma, reward_filter):
     rewards = trajectory["raw_rewards"]
@@ -158,21 +161,21 @@ def add_advantage_values(trajectory, gamma, lam, reward_filter):
         trajectory["advantages"] + trajectory["vf_preds"]
 
 
-def discount(x, gamma):
-    return scipy.signal.lfilter([1], [1, -gamma], x[::-1], axis=0)[::-1]
-
-
 def add_truncated_advantages(trajectory, gamma, lam, reward_filter):
-    import ipdb; ipdb.set_trace()
-    rewards = np.asarray(rollout.rewards)
-    vpred_t = np.asarray(rollout.values + [rollout.r])
+    rewards = trajectory["raw_rewards"]
+    vf_preds = trajectory["vf_preds"]
+    dones = trajectory["dones"]
+    advantages = np.zeros_like(rewards)
+    last_advantage = np.zeros(rewards.shape[1], dtype="float32")
 
-    rewards_plus_v = np.asarray(rollout.rewards + [rollout.r])
-    batch_r = discount(rewards_plus_v, gamma)[:-1]
-    delta_t = rewards + gamma * vpred_t[1:] - vpred_t[:-1]
-    # This formula for the advantage comes "Generalized Advantage Estimation":
-    # https://arxiv.org/abs/1506.02438
-    batch_adv = discount(delta_t, gamma * lambda_)
+    for t in reversed(range(len(rewards))):
+        delta = rewards[t, :] * (1 - dones[t, :]) + \
+            gamma * vf_preds[t+1, :] * (1 - dones[t+1, :]) - vf_preds[t, :]
+        last_advantage = \
+            delta + gamma * lam * last_advantage * (1 - dones[t+1, :])
+        advantages[t, :] = last_advantage
+        reward_filter(advantages[t, :])
+    dones = dones[:-1, :] # hack to get bootstrap running
 
     trajectory["advantages"] = advantages
     trajectory["td_lambda_returns"] = \
@@ -204,12 +207,12 @@ def collect_partial(agents,
         # Start task with next trajectory and record it in the dictionary.
         agent_dict[agent.compute_partial_steps.remote(
                        config["gamma"], config["lambda"],
-                       config["horizon"], config["min_steps_per_task"])] = (
+                       config["horizon"], config["mini_nstep"])] = (
             agent)
         trajectory, rewards, lengths = ray.get(next_trajectory)
         total_rewards.extend(rewards)
         trajectory_lengths.extend(lengths)
-        num_timesteps_so_far += len(trajectory["dones"])
+        num_timesteps_so_far += len(trajectory["observations"])
         trajectories.append(trajectory)
     return (concatenate(trajectories), np.mean(total_rewards),
             np.mean(trajectory_lengths))

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -86,7 +86,6 @@ def partial_rollouts(policy, env, last_observation,
 
     if type(env) == BatchedEnv and env.batchsize > 1:
         assert False, "No support for multi-batch case"
-    import ipdb; ipdb.set_trace()
     observation = last_observation if last_observation else env.reset()
     observation = observation_filter(observation)
     # done = np.array(env.batchsize * [False])

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -96,6 +96,11 @@ def add_advantage_values(trajectory, gamma, lam, reward_filter):
         trajectory["advantages"] + trajectory["vf_preds"]
 
 
+def collect_partial_rollouts(agents, config, observation_filter=NoFilter(),
+                             reward_filter=NoFilter()):
+    pass
+
+
 def collect_samples(agents,
                     config,
                     observation_filter=NoFilter(),

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -167,7 +167,8 @@ def continuous_partial_rollouts(policy, env, observation,
     vf_preds = []  # Value function predictions
     dones = []  # Has this rollout terminated?
 
-    for t in range(steps):
+    t = 0
+    while True:
         observation = env.reset() if observation is None else observation
         observation = observation_filter(observation)
 
@@ -178,10 +179,16 @@ def continuous_partial_rollouts(policy, env, observation,
         logprobs.append(logprob[None])
 
         observation, raw_reward, done = env.step(action)
+        t += 1
         raw_rewards.append(raw_reward[None])
         dones.append(done[None])
         if (done[0]):
             observation = None
+        if t >= steps:
+            if truncate: # truncate right after #steps
+                break
+            elif done: # truncate after full data collected
+                break
 
     last_observation = observation
     truncation_vf = policy.compute(observation)[2] if observation is not None else 0

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -85,8 +85,9 @@ def partial_rollouts(policy, env, last_observation,
     # TODO (rliaw): Would be nice to have as an iterator to store intermediate state
 
     if type(env) == BatchedEnv and env.batchsize > 1:
+        # Treatment for last_observation in batched setting is not implemented only
         assert False, "No support for multi-batch case"
-    observation = last_observation if last_observation else env.reset()
+    observation = last_observation if last_observation is not None else env.reset()
     observation = observation_filter(observation)
     # done = np.array(env.batchsize * [False])
     t = 0
@@ -175,7 +176,6 @@ def add_trunc_advantage_values(trajectory, gamma, lam, reward_filter):
             delta + gamma * lam * last_advantage * (1 - dones[t+1, :])
         advantages[t, :] = last_advantage
         reward_filter(advantages[t, :])
-    import ipdb; ipdb.set_trace()
 
     trajectory["dones"] = dones[:-1, :] # hack to get bootstrap running
     trajectory["raw_rewards"] = rewards[:-1, :] # hack to get bootstrap running

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -134,7 +134,7 @@ def partial_rollouts(policy, env, last_observation,
 
 def continuous_partial_rollouts(policy, env, observation,
                      steps, observation_filter=NoFilter(),
-                     reward_filter=NoFilter()):
+                     reward_filter=NoFilter(), truncate=True):
     """Perform a batch of rollouts of a policy in an environment.
 
     Args:

--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -158,9 +158,9 @@ def add_advantage_values(trajectory, gamma, lam, reward_filter):
         advantages[t, :] = last_advantage
         reward_filter(advantages[t, :])
 
-    dones = dones[:-1, :] # hack to get bootstrap running
-    rewards = rewards[:-1, :] # hack to get bootstrap running
-    vf_preds = vf_preds[:-1, :] # hack to get bootstrap running
+    trajectory["dones"] = dones[:-1, :] # hack to get bootstrap running
+    trajectory["raw_rewards"] = rewards[:-1, :] # hack to get bootstrap running
+    trajectory["vf_preds"] = vf_preds[:-1, :] # hack to get bootstrap running
 
     trajectory["advantages"] = advantages
     trajectory["td_lambda_returns"] = \

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -223,10 +223,7 @@ class Runner(object):
             self.common_policy, self.last_obs,
             self.env, steps, self.observation_filter, self.reward_filter)
         self.last_obs = trajectory["last_observation"]
-        if self.config["use_gae"]:
-            add_advantage_values(trajectory, gamma, lam, self.reward_filter)
-        else:
-            add_return_values(trajectory, gamma, self.reward_filter)
+        add_advantage_values(trajectory, gamma, lam, self.reward_filter)
         return trajectory
 
     def compute_partial_steps(self, gamma, lam, nstep=20):

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -210,7 +210,6 @@ class Runner(object):
             add_advantage_values(trajectory, gamma, lam, self.reward_filter)
         else:
             add_return_values(trajectory, gamma, self.reward_filter)
-        import ipdb; ipdb.set_trace()
         return trajectory
 
     def compute_partial_trajectory(self, gamma, lam, steps):
@@ -259,7 +258,6 @@ class Runner(object):
         # in the batch terminated, so we can potentially get rid of
         # some of the states here.
         del trajectory["last_observation"]
-        import ipdb; ipdb.set_trace()
         trajectory = {key: val[not_done]
                       for key, val in trajectory.items()}
         num_steps_so_far += trajectory["raw_rewards"].shape[0]

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -253,6 +253,7 @@ class Runner(object):
             np.logical_not(trajectory["dones"]).sum(axis=0).mean())
         trajectory = flatten(trajectory)
         not_done = np.logical_not(trajectory["dones"])
+        import ipdb; ipdb.set_trace()
         # Filtering out states that are done. We do this because
         # trajectories are batched and cut only if all the trajectories
         # in the batch terminated, so we can potentially get rid of

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -224,6 +224,7 @@ class Runner(object):
             self.common_policy, self.env, self.last_obs, steps,
             self.observation_filter, self.reward_filter)
         self.last_obs = trajectory["last_observation"]
+        # avoids issues with concatenation etc
         del trajectory["last_observation"]
         add_trunc_advantage_values(trajectory, gamma, lam, self.reward_filter)
         return trajectory
@@ -234,9 +235,7 @@ class Runner(object):
         Args:
             gamma: MDP discount factor
             lam: GAE(lambda) parameter
-            horizon: Number of steps after which a rollout gets cut
-            min_steps_per_task: Lower bound on the number of states to be
-                collected.
+            nstep: Number of steps to progress the rollout
 
         Returns:
             states: List of states.

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -224,6 +224,7 @@ class Runner(object):
             self.common_policy, self.env, self.last_obs, steps,
             self.observation_filter, self.reward_filter)
         self.last_obs = trajectory["last_observation"]
+        del trajectory["last_observation"]
         add_trunc_advantage_values(trajectory, gamma, lam, self.reward_filter)
         return trajectory
 
@@ -257,7 +258,6 @@ class Runner(object):
         # trajectories are batched and cut only if all the trajectories
         # in the batch terminated, so we can potentially get rid of
         # some of the states here.
-        del trajectory["last_observation"]
         trajectory = {key: val[not_done]
                       for key, val in trajectory.items()}
         num_steps_so_far += trajectory["raw_rewards"].shape[0]

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -18,7 +18,8 @@ from ray.rllib.ppo.env import BatchedEnv
 from ray.rllib.ppo.loss import ProximalPolicyLoss
 from ray.rllib.ppo.filter import NoFilter, MeanStdFilter
 from ray.rllib.ppo.rollout import (
-    rollouts, add_return_values, add_advantage_values)
+    rollouts, partial_rollouts,
+    add_return_values, add_advantage_values)
 from ray.rllib.ppo.utils import flatten, concatenate
 
 # TODO(pcm): Make sure that both observation_filter and reward_filter
@@ -261,8 +262,6 @@ class Runner(object):
         num_steps_so_far += trajectory["raw_rewards"].shape[0]
         trajectories.append(trajectory)
         return concatenate(trajectories), total_rewards, trajectory_lengths
-
-
 
     def compute_steps(self, gamma, lam, horizon, min_steps_per_task=-1):
         """Compute multiple rollouts and concatenate the results.

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -221,8 +221,8 @@ class Runner(object):
         if not hasattr(self, "last_obs"):
             self.last_obs = None
         trajectory = partial_rollouts(
-            self.common_policy, self.last_obs,
-            self.env, steps, self.observation_filter, self.reward_filter)
+            self.common_policy, self.env, self.last_obs, steps,
+            self.observation_filter, self.reward_filter)
         self.last_obs = trajectory["last_observation"]
         add_advantage_values(trajectory, gamma, lam, self.reward_filter)
         return trajectory

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -19,7 +19,8 @@ from ray.rllib.ppo.loss import ProximalPolicyLoss
 from ray.rllib.ppo.filter import NoFilter, MeanStdFilter
 from ray.rllib.ppo.rollout import (
     rollouts, partial_rollouts,
-    add_return_values, add_advantage_values)
+    add_return_values, add_advantage_values,
+    add_trunc_advantage_values)
 from ray.rllib.ppo.utils import flatten, concatenate
 
 # TODO(pcm): Make sure that both observation_filter and reward_filter
@@ -224,7 +225,7 @@ class Runner(object):
             self.common_policy, self.env, self.last_obs, steps,
             self.observation_filter, self.reward_filter)
         self.last_obs = trajectory["last_observation"]
-        add_advantage_values(trajectory, gamma, lam, self.reward_filter)
+        add_trunc_advantage_values(trajectory, gamma, lam, self.reward_filter)
         return trajectory
 
     def compute_partial_steps(self, gamma, lam, nstep=20):
@@ -253,11 +254,11 @@ class Runner(object):
             np.logical_not(trajectory["dones"]).sum(axis=0).mean())
         trajectory = flatten(trajectory)
         not_done = np.logical_not(trajectory["dones"])
-        import ipdb; ipdb.set_trace()
         # Filtering out states that are done. We do this because
         # trajectories are batched and cut only if all the trajectories
         # in the batch terminated, so we can potentially get rid of
         # some of the states here.
+        import ipdb; ipdb.set_trace()
         trajectory = {key: val[not_done]
                       for key, val in trajectory.items()}
         num_steps_so_far += trajectory["raw_rewards"].shape[0]

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -258,6 +258,7 @@ class Runner(object):
         # trajectories are batched and cut only if all the trajectories
         # in the batch terminated, so we can potentially get rid of
         # some of the states here.
+        del trajectory["last_observation"]
         import ipdb; ipdb.set_trace()
         trajectory = {key: val[not_done]
                       for key, val in trajectory.items()}

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -208,6 +208,18 @@ class Runner(object):
             add_advantage_values(trajectory, gamma, lam, self.reward_filter)
         else:
             add_return_values(trajectory, gamma, self.reward_filter)
+        import ipdb; ipdb.set_trace()
+        return trajectory
+
+    def compute_partial_trajectory(self, gamma, lam, horizon):
+        """Compute a single rollout on the agent and return."""
+        trajectory = rollouts(
+            self.common_policy,
+            self.env, horizon, self.observation_filter, self.reward_filter)
+        if self.config["use_gae"]:
+            add_advantage_values(trajectory, gamma, lam, self.reward_filter)
+        else:
+            add_return_values(trajectory, gamma, self.reward_filter)
         return trajectory
 
     def compute_steps(self, gamma, lam, horizon, min_steps_per_task=-1):

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -95,3 +95,5 @@ if __name__ == "__main__":
 
         if (i + 1) % args.checkpoint_freq == 0:
             print("checkpoint path: {}".format(alg.save()))
+        if result.episode_reward_mean > 6000.0:
+            break


### PR DESCRIPTION
You can run PPO with bootstrapped partial rollouts by adding `trunc_nstep: [int]` to the configuration string passed into `train.py`. Requires `use_gae = True`.

`python train.py --env CartPole-v0 --alg PPO --config '{"num_workers":1, "timesteps_per_batch":256, "trunc_nstep":200 }'`

- [x]  FIXED: The printed statistics per each SGD step are rather meaningless, so we could fix that a little. 
- [ ] Note - doesn't support BatchedEnv with `num_envs > 1` right now

@ericl @pcmoritz 