### PR TITLE
[rllib] [Minor] Start off at iteration 0 instead of 1

### DIFF
--- a/python/ray/rllib/common.py
+++ b/python/ray/rllib/common.py
@@ -141,8 +141,8 @@ class Agent(object):
         """
 
         start = time.time()
-        self.iteration += 1
         result = self._train()
+        self.iteration += 1
         time_this_iter = time.time() - start
 
         self.time_total += time_this_iter


### PR DESCRIPTION
Turns out PPO relies on iteration == 0 to check whether to print out some debugging output, so starting off at 1 broke this.