### PR TITLE
Actor checkpointing with object lineage reconstruction

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -216,6 +216,7 @@ def fetch_and_register_actor(actor_class_key, worker):
 
     try:
         unpickled_class = pickle.loads(pickled_class)
+        worker.actor_class = unpickled_class
     except Exception:
         # If an exception was thrown when the actor was imported, we record the
         # traceback and notify the scheduler of the failure.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -99,11 +99,10 @@ def put_dummy_object(worker, dummy_object_id):
     Args:
         worker: The worker to use to perform the put.
         dummy_object_id: The object ID of the dummy object.
-
     """
     # Add the dummy output for actor tasks. TODO(swang): We use
     # a numpy array as a hack to pin the object in the object
-    # store.  Once we allow object pinning in the store, we may
+    # store. Once we allow object pinning in the store, we may
     # use `None`.
     dummy_object = np.zeros(1)
     worker.put_object(dummy_object_id, dummy_object)
@@ -138,8 +137,8 @@ def make_actor_method_executor(worker, method_name, method):
 
     Returns:
         A function that executes the given actor method on the worker's stored
-        instance of the actor. The function also updates the worker's internal
-        state to record the executed method.
+            instance of the actor. The function also updates the worker's
+            internal state to record the executed method.
     """
 
     def actor_method_executor(dummy_return_id, task_counter, actor,
@@ -376,7 +375,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
             This task checkpoints the current state of the actor. If the actor
             has not yet executed to `task_counter`, then the task instead
             attempts to resume from a saved checkpoint that matches
-            `task_counter`.  If the most recently saved checkpoint is earlier
+            `task_counter`. If the most recently saved checkpoint is earlier
             than `task_counter`, the task requests reconstruction of the tasks
             that executed since the previous checkpoint and before
             `task_counter`.
@@ -570,7 +569,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
 
             Returns:
                 object_ids: A list of object IDs returned by the remote actor
-                method.
+                    method.
             """
             ray.worker.check_connected()
             ray.worker.check_main_thread()

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -409,7 +409,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
             # set to True if we fail to load the checkpoint. `error` will be
             # set to the Exception, if one is thrown.
             actor_checkpoint_failed = False
-            error = None
+            error_to_return = None
 
             # Save or resume the checkpoint.
             if previous_object_id in worker.actor_pinned_objects:
@@ -439,7 +439,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                 except Exception as error:
                     # Checkpoint saves should not block execution on the actor,
                     # so we still consider the task successful.
-                    pass
+                    error_to_return = error
             else:
                 # The preceding task has not yet executed on this actor
                 # instance. Try to resume from the most recent checkpoint.
@@ -456,7 +456,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                         # We could not resume the checkpoint, so count the task
                         # as failed.
                         actor_checkpoint_failed = True
-                        pass
+                        error_to_return = error
                 else:
                     # We cannot resume a mismatching checkpoint, so count the
                     # task as failed.
@@ -469,7 +469,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                     plasma_id.binary())
                 worker.local_scheduler_client.notify_unblocked()
 
-            return actor_checkpoint_failed, error
+            return actor_checkpoint_failed, error_to_return
 
     Class.__module__ = cls.__module__
     Class.__name__ = cls.__name__

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -310,7 +310,7 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                 # TODO(rkn): It's possible that this will cause problems. When
                 # you unpickle the same object twice, the two objects will not
                 # have the same class.
-                actor_object = pickle.loads(checkpoint)
+                actor_object = checkpoint
             return actor_object
 
         def __ray_checkpoint__(self, task_counter, previous_object_id):
@@ -497,8 +497,11 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
             self._ray_actor_counter += 1
             self._ray_actor_cursor = object_ids.pop()
 
-            if self._ray_actor_counter % checkpoint_interval == 0:
-                self._actor_method_invokers["__ray_checkpoint__"].remote()
+            if checkpoint_interval > 0:
+                if (self._ray_actor_counter > 0 and self._ray_actor_counter %
+                        checkpoint_interval == 0):
+                    self.__ray_checkpoint__.remote()
+
 
             if len(object_ids) == 1:
                 return object_ids[0]

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -397,12 +397,8 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                     loaded (whether the actor can safely execute the next task)
                     and an Exception instance, if one was thrown.
             """
-            previous_object_id = previous_object_id[0]
-            # Make sure that a previous object was given.
-            if previous_object_id is None:
-                return False
-
             worker = ray.worker.global_worker
+            previous_object_id = previous_object_id[0]
             plasma_id = plasma.ObjectID(previous_object_id.id())
 
             # Initialize the return values. `actor_checkpoint_failed` will be

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -719,7 +719,8 @@ class Worker(object):
                     outputs = function_executor.executor(arguments)
                 else:
                     outputs = function_executor(
-                        dummy_return_id, task.actor_counter(), self.actors[task.actor_id().id()],
+                        dummy_return_id, task.actor_counter(),
+                        self.actors[task.actor_id().id()],
                         *arguments)
         except Exception as e:
             # Determine whether the exception occured during a task, not an
@@ -806,13 +807,6 @@ class Worker(object):
         if reached_max_executions:
             ray.worker.global_worker.local_scheduler_client.disconnect()
             os._exit(0)
-
-        # Checkpoint the actor state if it is the right time to do so.
-        actor_counter = task.actor_counter()
-        if (self.actor_id != NIL_ACTOR_ID and
-                self.actor_checkpoint_interval != -1 and
-                actor_counter % self.actor_checkpoint_interval == 0):
-            self._checkpoint_actor_state(actor_counter)
 
     def _get_next_task_from_local_scheduler(self):
         """Get the next task from the local scheduler.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -227,6 +227,7 @@ class Worker(object):
         self.make_actor = None
         self.actors = {}
         self.actor_task_counter = 0
+        self.task_success = False
         # TODO(swang): This is a hack to prevent the object store from evicting
         # dummy objects. Once we allow object pinning in the store, we may
         # remove this variable.
@@ -816,7 +817,10 @@ class Worker(object):
         """
         with log_span("ray:get_task", worker=self):
             task = self.local_scheduler_client.get_task(
-                self.actor_task_counter)
+                self.task_success)
+            # Assume that this task will succeed. The task executor is
+            # responsible for setting this to False if necessary.
+            self.task_success = True
 
         # Automatically restrict the GPUs available to this task.
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -230,7 +230,7 @@ class Worker(object):
         # This field is used to report whether the last task executed on this
         # worker was a success. Workers are not assigned a task on startup, so
         # we initialize to False.
-        self.task_success = False
+        self.actor_task_success = False
         # TODO(swang): This is a hack to prevent the object store from evicting
         # dummy objects. Once we allow object pinning in the store, we may
         # remove this variable.
@@ -819,12 +819,12 @@ class Worker(object):
             A task from the local scheduler.
         """
         with log_span("ray:get_task", worker=self):
-            task = self.local_scheduler_client.get_task(self.task_success)
+            task = self.local_scheduler_client.get_task(self.actor_task_success)
             # We assume that the task will succeed. The task executor is
             # responsible for reporting task failure to the local scheduler
             # (e.g., if an actor checkpoint method fails, the local scheduler's
             # task counter should not be updated).
-            self.task_success = True
+            self.actor_task_success = True
 
         # Automatically restrict the GPUs available to this task.
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -217,11 +217,7 @@ ActorID TaskSpec_actor_id(TaskSpec *spec) {
 int64_t TaskSpec_actor_counter(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  int64_t actor_counter = message->actor_counter();
-  if (actor_counter < 0) {
-    actor_counter *= -1;
-  }
-  return actor_counter;
+  return std::abs(message->actor_counter());
 }
 
 int64_t TaskSpec_actor_is_checkpoint_method(TaskSpec *spec) {

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -220,7 +220,7 @@ int64_t TaskSpec_actor_counter(TaskSpec *spec) {
   return std::abs(message->actor_counter());
 }
 
-int64_t TaskSpec_actor_is_checkpoint_method(TaskSpec *spec) {
+bool TaskSpec_actor_is_checkpoint_method(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
   int64_t actor_counter = message->actor_counter();

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -217,7 +217,18 @@ ActorID TaskSpec_actor_id(TaskSpec *spec) {
 int64_t TaskSpec_actor_counter(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return message->actor_counter();
+  int64_t actor_counter = message->actor_counter();
+  if (actor_counter < 0) {
+    actor_counter *= -1;
+  }
+  return actor_counter;
+}
+
+int64_t TaskSpec_actor_is_checkpoint_method(TaskSpec *spec) {
+  CHECK(spec);
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec);
+  int64_t actor_counter = message->actor_counter();
+  return actor_counter < 0;
 }
 
 UniqueID TaskSpec_driver_id(TaskSpec *spec) {

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -135,7 +135,7 @@ UniqueID TaskSpec_actor_id(TaskSpec *spec);
  */
 int64_t TaskSpec_actor_counter(TaskSpec *spec);
 
-int64_t TaskSpec_actor_is_checkpoint_method(TaskSpec *spec);
+bool TaskSpec_actor_is_checkpoint_method(TaskSpec *spec);
 
 /**
  * Return the driver ID of the task.

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -135,6 +135,8 @@ UniqueID TaskSpec_actor_id(TaskSpec *spec);
  */
 int64_t TaskSpec_actor_counter(TaskSpec *spec);
 
+int64_t TaskSpec_actor_is_checkpoint_method(TaskSpec *spec);
+
 /**
  * Return the driver ID of the task.
  *

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -38,7 +38,7 @@ enum MessageType:int {
 
 // This message is sent from a worker to a local scheduler.
 table GetTaskRequest {
-  actor_task_counter: int;
+  task_success: bool;
 }
 
 // This message is sent from the local scheduler to a worker.

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -38,12 +38,10 @@ enum MessageType:int {
 
 // This message is sent from a worker to a local scheduler.
 table GetTaskRequest {
-  // Whether the previously assigned task was successful. This is currently
-  // only set to false when either 1) the worker just started and has not yet
-  // been assigned a task, or 2) an actor checkpoint method failed because the
-  // checkpoint did not exist. In the latter case, the local scheduler uses
-  // this field to determine whether to update the actor's task counter.
-  task_success: bool;
+  // Whether the previously assigned task was a checkpoint task that failed.
+  // If true, then the local scheduler will not update the actor's task
+  // counter to match the assigned checkpoint index.
+  actor_checkpoint_failed: bool;
 }
 
 // This message is sent from the local scheduler to a worker.

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -38,6 +38,11 @@ enum MessageType:int {
 
 // This message is sent from a worker to a local scheduler.
 table GetTaskRequest {
+  // Whether the previously assigned task was successful. This is currently
+  // only set to false when either 1) the worker just started and has not yet
+  // been assigned a task, or 2) an actor checkpoint method failed because the
+  // checkpoint did not exist. In the latter case, the local scheduler uses
+  // this field to determine whether to update the actor's task counter.
   task_success: bool;
 }
 

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -36,6 +36,11 @@ enum MessageType:int {
   PutObject
 }
 
+// This message is sent from a worker to a local scheduler.
+table GetTaskRequest {
+  task_successful: bool;
+}
+
 // This message is sent from the local scheduler to a worker.
 table GetTaskReply {
   // A string of bytes representing the task specification.

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -38,7 +38,7 @@ enum MessageType:int {
 
 // This message is sent from a worker to a local scheduler.
 table GetTaskRequest {
-  task_successful: bool;
+  actor_task_counter: int;
 }
 
 // This message is sent from the local scheduler to a worker.

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -985,7 +985,7 @@ void process_message(event_loop *loop,
     } else {
       auto message = flatbuffers::GetRoot<GetTaskRequest>(input);
       handle_actor_worker_available(state, state->algorithm_state, worker,
-          message->task_successful());
+                                    message->actor_task_counter());
     }
   } break;
   case MessageType_ReconstructObject: {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -737,17 +737,17 @@ void reconstruct_object_lookup_callback(
    * object table entry is up-to-date. */
   LocalSchedulerState *state = (LocalSchedulerState *) user_context;
   /* Look up the task that created the object in the result table. */
-  if (!never_created && manager_vector.size() == 0) {
-    /* If the object was created and later evicted, we reconstruct the object
-     * if and only if there are no other instances of the task running. */
-    result_table_lookup(state->db, reconstruct_object_id, NULL,
-                        reconstruct_evicted_result_lookup_callback,
-                        (void *) state);
-  } else if (never_created) {
+  if (never_created) {
     /* If the object has not been created yet, we reconstruct the object if and
      * only if the task that created the object failed to complete. */
     result_table_lookup(state->db, reconstruct_object_id, NULL,
                         reconstruct_failed_result_lookup_callback,
+                        (void *) state);
+  } else if (manager_vector.size() == 0) {
+    /* If the object was created and later evicted, we reconstruct the object
+     * if and only if there are no other instances of the task running. */
+    result_table_lookup(state->db, reconstruct_object_id, NULL,
+                        reconstruct_evicted_result_lookup_callback,
                         (void *) state);
   }
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -983,7 +983,9 @@ void process_message(event_loop *loop,
     if (ActorID_equal(worker->actor_id, NIL_ACTOR_ID)) {
       handle_worker_available(state, state->algorithm_state, worker);
     } else {
-      handle_actor_worker_available(state, state->algorithm_state, worker);
+      auto message = flatbuffers::GetRoot<GetTaskRequest>(input);
+      handle_actor_worker_available(state, state->algorithm_state, worker,
+          message->task_successful());
     }
   } break;
   case MessageType_ReconstructObject: {

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -56,13 +56,13 @@ void assign_task_to_worker(LocalSchedulerState *state,
  *
  * @param state The local scheduler state.
  * @param worker The worker that finished the task.
- * @param task_success Whether the previously assigned task was
- *        successful.
+ * @param actor_checkpoint_failed If the last task assigned was a checkpoint
+ *        task that failed.
  * @return Void.
  */
 void finish_task(LocalSchedulerState *state,
                  LocalSchedulerClient *worker,
-                 bool task_success);
+                 bool actor_checkpoint_failed);
 
 /**
  * This is the callback that is used to process a notification from the Plasma

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -56,9 +56,13 @@ void assign_task_to_worker(LocalSchedulerState *state,
  *
  * @param state The local scheduler state.
  * @param worker The worker that finished the task.
+ * @param task_success Whether the previously assigned task was
+ *        successful.
  * @return Void.
  */
-void finish_task(LocalSchedulerState *state, LocalSchedulerClient *worker);
+void finish_task(LocalSchedulerState *state,
+                 LocalSchedulerClient *worker,
+                 bool task_success);
 
 /**
  * This is the callback that is used to process a notification from the Plasma

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -323,7 +323,6 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   }
   /* Assign the first task in the task queue to the worker and mark the worker
    * as unavailable. */
-  entry.task_counter += 1;
   assign_task_to_worker(state, first_task.spec, first_task.task_spec_size,
                         entry.worker);
   entry.worker_available = false;
@@ -1166,7 +1165,8 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
 
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
-                                   LocalSchedulerClient *worker) {
+                                   LocalSchedulerClient *worker,
+                                   bool increment_task_counter) {
   ActorID actor_id = worker->actor_id;
   CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
   /* Get the actor info for this worker. */
@@ -1176,6 +1176,9 @@ void handle_actor_worker_available(LocalSchedulerState *state,
 
   CHECK(worker == entry.worker);
   CHECK(!entry.worker_available);
+  if (increment_task_counter) {
+    entry.task_counter++;
+  }
   entry.worker_available = true;
   /* Assign new tasks if possible. */
   dispatch_all_tasks(state, algorithm_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -330,7 +330,7 @@ bool dispatch_actor_task(LocalSchedulerState *state,
       break;
     } else {
       /* A later task that is not a checkpoint. Wait for the preceding tasks to
-       * execute.  */
+       * execute. */
       return false;
     }
   }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -300,44 +300,56 @@ bool dispatch_actor_task(LocalSchedulerState *state,
 
   /* There should be some queued tasks for this actor. */
   CHECK(!entry.task_queue->empty());
-
-  TaskQueueEntry first_task = entry.task_queue->front();
-  int64_t next_task_counter = TaskSpec_actor_counter(first_task.spec);
-  if (next_task_counter != entry.task_counter) {
-    /* We cannot execute the next task on this actor without violating the
-     * in-order execution guarantee for actor tasks. */
-    CHECK(next_task_counter > entry.task_counter);
-    if (!TaskSpec_actor_is_checkpoint_method(first_task.spec)) {
-      int64_t num_args = TaskSpec_num_args(first_task.spec);
-      ObjectID dummy_object_id = TaskSpec_arg_id(first_task.spec, num_args - 1);
-      reconstruct_object(state, dummy_object_id);
-      return false;
-    }
-  }
   /* If the worker is not available, we cannot assign a task to it. */
   if (!entry.worker_available) {
     return false;
   }
+
+  /* Find the first task that either matches the task counter or that is a
+   * checkpoint method. Remove any tasks that we have already executed past
+   * (e.g., by executing a more recent checkpoint method). */
+  auto task = entry.task_queue->begin();
+  int64_t next_task_counter = TaskSpec_actor_counter(task->spec);
+  while (next_task_counter != entry.task_counter) {
+    if (next_task_counter < entry.task_counter) {
+      /* A task that we have already executed past. Remove it. */
+      task = entry.task_queue->erase(task);
+      /* If there are no more tasks in the queue, wait. */
+      if (task == entry.task_queue->end()) {
+        algorithm_state->actors_with_pending_tasks.erase(actor_id);
+        return false;
+      }
+      /* Move on to the next task. */
+      next_task_counter = TaskSpec_actor_counter(task->spec);
+    } else if (TaskSpec_actor_is_checkpoint_method(task->spec)) {
+      /* A later task that is a checkpoint method. Checkpoint methods can
+       * always be executed. */
+      break;
+    } else {
+      /* A later task that is not a checkpoint. Wait for the preceding tasks to
+       * execute.  */
+      return false;
+    }
+  }
+
   /* If there are not enough resources available, we cannot assign the task. */
-  CHECK(0 ==
-        TaskSpec_get_required_resource(first_task.spec, ResourceIndex_GPU));
+  CHECK(0 == TaskSpec_get_required_resource(task->spec, ResourceIndex_GPU));
   if (!check_dynamic_resources(
-          state,
-          TaskSpec_get_required_resource(first_task.spec, ResourceIndex_CPU), 0,
-          TaskSpec_get_required_resource(first_task.spec,
-                                         ResourceIndex_CustomResource))) {
+          state, TaskSpec_get_required_resource(task->spec, ResourceIndex_CPU),
+          0, TaskSpec_get_required_resource(task->spec,
+                                            ResourceIndex_CustomResource))) {
     return false;
   }
+
   /* Assign the first task in the task queue to the worker and mark the worker
    * as unavailable. */
-  assign_task_to_worker(state, first_task.spec, first_task.task_spec_size,
-                        entry.worker);
+  assign_task_to_worker(state, task->spec, task->task_spec_size, entry.worker);
   entry.assigned_task_counter = next_task_counter;
   entry.worker_available = false;
   /* Free the task queue entry. */
-  TaskQueueEntry_free(&first_task);
+  TaskQueueEntry_free(&(*task));
   /* Remove the task from the actor's task queue. */
-  entry.task_queue->pop_front();
+  entry.task_queue->erase(task);
 
   /* If there are no more tasks in the queue, then indicate that the actor has
    * no tasks. */
@@ -410,12 +422,11 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
    * guaranteeing in-order execution of the tasks on the actor). TODO(rkn): This
    * check will fail if the fault-tolerance mechanism resubmits a task on an
    * actor. */
-  bool task_is_redundant = false;
   if (task_counter < entry.task_counter) {
     LOG_INFO(
         "A task that has already been executed has been resubmitted, so we "
         "are ignoring it. This should only happen during reconstruction.");
-    task_is_redundant = true;
+    return;
   }
 
   /* Create a new task queue entry. */
@@ -433,32 +444,47 @@ void add_task_to_actor_queue(LocalSchedulerState *state,
   if (it != entry.task_queue->end() &&
       task_counter == TaskSpec_actor_counter(it->spec)) {
     LOG_INFO(
-        "A task that has already been executed has been resubmitted, so we "
-        "are ignoring it. This should only happen during reconstruction.");
-    task_is_redundant = true;
+        "A task was resubmitted, so we are ignoring it. This should only "
+        "happen during reconstruction.");
+    return;
   }
 
-  if (!task_is_redundant) {
-    entry.task_queue->insert(it, elt);
+  /* The task has a counter that has not been executed or submitted before. Add
+   * it to the actor queue. */
+  entry.task_queue->insert(it, elt);
 
-    /* Update the task table. */
-    if (state->db != NULL) {
-      Task *task = Task_alloc(spec, task_spec_size, TASK_STATUS_QUEUED,
-                              get_db_client_id(state->db));
-      if (from_global_scheduler) {
-        /* If the task is from the global scheduler, it's already been added to
-         * the task table, so just update the entry. */
-        task_table_update(state->db, task, NULL, NULL, NULL);
-      } else {
-        /* Otherwise, this is the first time the task has been seen in the
-         * system (unless it's a resubmission of a previous task), so add the
-         * entry. */
-        task_table_add_task(state->db, task, NULL, NULL, NULL);
-      }
+  /* Update the task table. */
+  if (state->db != NULL) {
+    Task *task = Task_alloc(spec, task_spec_size, TASK_STATUS_QUEUED,
+                            get_db_client_id(state->db));
+    if (from_global_scheduler) {
+      /* If the task is from the global scheduler, it's already been added to
+       * the task table, so just update the entry. */
+      task_table_update(state->db, task, NULL, NULL, NULL);
+    } else {
+      /* Otherwise, this is the first time the task has been seen in the
+       * system (unless it's a resubmission of a previous task), so add the
+       * entry. */
+      task_table_add_task(state->db, task, NULL, NULL, NULL);
     }
+  }
 
-    /* Record the fact that this actor has a task waiting to execute. */
-    algorithm_state->actors_with_pending_tasks.insert(actor_id);
+  /* Record the fact that this actor has a task waiting to execute. */
+  algorithm_state->actors_with_pending_tasks.insert(actor_id);
+
+  /* Register any missing dependencies. TODO(swang): Unify with
+   * `fetch_missing_dependencies` for non-actor tasks. */
+  if (entry.task_counter != task_counter) {
+    int64_t num_args = TaskSpec_num_args(spec);
+    ObjectID dummy_object_id = TaskSpec_arg_id(spec, num_args - 1);
+    if (algorithm_state->local_objects.count(dummy_object_id) == 0) {
+      ObjectEntry entry;
+      /* TODO(swang): Objects in `remote_objects` will get fetched from
+       * remote plasma managers. Do not fetch actor dummy objects. Otherwise,
+       * if the plasma manager associated with the dead local scheduler is
+       * still alive, reconstruction will never complete. */
+      state->algorithm_state->remote_objects[dummy_object_id] = entry;
+    }
   }
 }
 

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -305,7 +305,12 @@ bool dispatch_actor_task(LocalSchedulerState *state,
     /* We cannot execute the next task on this actor without violating the
      * in-order execution guarantee for actor tasks. */
     CHECK(next_task_counter > entry.task_counter);
-    return false;
+    if (!TaskSpec_actor_is_checkpoint_method(first_task.spec)) {
+      int64_t num_args = TaskSpec_num_args(first_task.spec);
+      ObjectID dummy_object_id = TaskSpec_arg_id(first_task.spec, num_args - 1);
+      reconstruct_object(state, dummy_object_id);
+      return false;
+    }
   }
   /* If the worker is not available, we cannot assign a task to it. */
   if (!entry.worker_available) {

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1166,7 +1166,7 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
                                    LocalSchedulerClient *worker,
-                                   bool increment_task_counter) {
+                                   int task_counter) {
   ActorID actor_id = worker->actor_id;
   CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
   /* Get the actor info for this worker. */
@@ -1176,9 +1176,7 @@ void handle_actor_worker_available(LocalSchedulerState *state,
 
   CHECK(worker == entry.worker);
   CHECK(!entry.worker_available);
-  if (increment_task_counter) {
-    entry.task_counter++;
-  }
+  entry.task_counter = task_counter;
   entry.worker_available = true;
   /* Assign new tasks if possible. */
   dispatch_all_tasks(state, algorithm_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1207,7 +1207,7 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
                                    LocalSchedulerClient *worker,
-                                   bool task_success) {
+                                   bool actor_checkpoint_failed) {
   ActorID actor_id = worker->actor_id;
   CHECK(!ActorID_equal(actor_id, NIL_ACTOR_ID));
   /* Get the actor info for this worker. */
@@ -1217,7 +1217,10 @@ void handle_actor_worker_available(LocalSchedulerState *state,
 
   CHECK(worker == entry.worker);
   CHECK(!entry.worker_available);
-  if (task_success) {
+  /* If the assigned task was not a checkpoint task, or if it was but it
+   * loaded the checkpoint successfully, then we update the actor's counter
+   * to the assigned counter. */
+  if (!actor_checkpoint_failed) {
     entry.task_counter = entry.assigned_task_counter + 1;
   }
   entry.assigned_task_counter = -1;

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -42,6 +42,9 @@ typedef struct {
    *  restrict the submission of tasks on actors to the process that created the
    *  actor. */
   int64_t task_counter;
+  /** The index of the task assigned to this actor. Set to -1 if no task is
+   *  currently assigned. If the actor process reports back success for the
+   *  assigned task execution, task_counter should be set to this value. */
   int64_t assigned_task_counter;
   /** A queue of tasks to be executed on this actor. The tasks will be sorted by
    *  the order of their actor counters. */

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -184,7 +184,7 @@ void handle_worker_removed(LocalSchedulerState *state,
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
                                    LocalSchedulerClient *worker,
-                                   bool increment_task_counter);
+                                   int actor_task_counter);
 
 /**
  * Handle the fact that a new worker is available for running an actor.

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -184,7 +184,7 @@ void handle_worker_removed(LocalSchedulerState *state,
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
                                    LocalSchedulerClient *worker,
-                                   int actor_task_counter);
+                                   bool task_success);
 
 /**
  * Handle the fact that a new worker is available for running an actor.

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -183,7 +183,8 @@ void handle_worker_removed(LocalSchedulerState *state,
  */
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
-                                   LocalSchedulerClient *worker);
+                                   LocalSchedulerClient *worker,
+                                   bool increment_task_counter);
 
 /**
  * Handle the fact that a new worker is available for running an actor.

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -178,13 +178,15 @@ void handle_worker_removed(LocalSchedulerState *state,
  *
  * @param state The state of the local scheduler.
  * @param algorithm_state State maintained by the scheduling algorithm.
- * @param wi Information about the worker that is available.
+ * @param worker The worker that is available.
+ * @param actor_checkpoint_failed If the last task assigned was a checkpoint
+ *        task that failed.
  * @return Void.
  */
 void handle_actor_worker_available(LocalSchedulerState *state,
                                    SchedulingAlgorithmState *algorithm_state,
                                    LocalSchedulerClient *worker,
-                                   bool task_success);
+                                   bool actor_checkpoint_failed);
 
 /**
  * Handle the fact that a new worker is available for running an actor.

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -96,9 +96,9 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
 
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   bool task_success) {
+                                   bool actor_checkpoint_failed) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateGetTaskRequest(fbb, task_success);
+  auto message = CreateGetTaskRequest(fbb, actor_checkpoint_failed);
   fbb.Finish(message);
   write_message(conn->conn, MessageType_GetTask, fbb.GetSize(),
                 fbb.GetBufferPointer());

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -95,14 +95,18 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
 }
 
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
-                                   int64_t *task_size) {
-  write_message(conn->conn, MessageType_GetTask, 0, NULL);
+                                   int64_t *task_size,
+                                   bool task_successful) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = CreateGetTaskRequest(fbb, task_successful);
+  fbb.Finish(message);
+  write_message(conn->conn, MessageType_GetTask, fbb.GetSize(), fbb.GetBufferPointer());
   int64_t type;
-  int64_t message_size;
-  uint8_t *message;
+  int64_t reply_size;
+  uint8_t *reply;
   /* Receive a task from the local scheduler. This will block until the local
    * scheduler gives this client a task. */
-  read_message(conn->conn, &type, &message_size, &message);
+  read_message(conn->conn, &type, &reply_size, &reply);
   if (type == DISCONNECT_CLIENT) {
     LOG_WARN("Exiting because local scheduler closed connection.");
     exit(1);
@@ -110,7 +114,7 @@ TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
   CHECK(type == MessageType_ExecuteTask);
 
   /* Parse the flatbuffer object. */
-  auto reply_message = flatbuffers::GetRoot<GetTaskReply>(message);
+  auto reply_message = flatbuffers::GetRoot<GetTaskReply>(reply);
 
   /* Set the GPU IDs for this task. We only do this for non-actor tasks because
    * for actors the GPUs are associated with the actor itself and not with the
@@ -127,7 +131,7 @@ TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
   TaskSpec *data = (TaskSpec *) reply_message->task_spec()->data();
   TaskSpec *spec = TaskSpec_copy(data, *task_size);
   /* Free the original message from the local scheduler. */
-  free(message);
+  free(reply);
   /* Return the copy of the task spec and pass ownership to the caller. */
   return spec;
 }

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -96,9 +96,9 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
 
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   bool task_successful) {
+                                   int actor_task_counter) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateGetTaskRequest(fbb, task_successful);
+  auto message = CreateGetTaskRequest(fbb, actor_task_counter);
   fbb.Finish(message);
   write_message(conn->conn, MessageType_GetTask, fbb.GetSize(), fbb.GetBufferPointer());
   int64_t type;

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -100,7 +100,8 @@ TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
   flatbuffers::FlatBufferBuilder fbb;
   auto message = CreateGetTaskRequest(fbb, task_success);
   fbb.Finish(message);
-  write_message(conn->conn, MessageType_GetTask, fbb.GetSize(), fbb.GetBufferPointer());
+  write_message(conn->conn, MessageType_GetTask, fbb.GetSize(),
+                fbb.GetBufferPointer());
   int64_t type;
   int64_t reply_size;
   uint8_t *reply;

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -96,9 +96,9 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
 
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   int actor_task_counter) {
+                                   bool task_success) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateGetTaskRequest(fbb, actor_task_counter);
+  auto message = CreateGetTaskRequest(fbb, task_success);
   fbb.Finish(message);
   write_message(conn->conn, MessageType_GetTask, fbb.GetSize(), fbb.GetBufferPointer());
   int64_t type;

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -98,7 +98,7 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
  */
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   int actor_task_counter);
+                                   bool task_success);
 
 /**
  * Tell the local scheduler that the client has finished executing a task.

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -95,13 +95,13 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
  *
  * @param conn The connection information.
  * @param task_size A pointer to fill out with the task size.
- * @param task_success Whether the previously assigned task was
- *        successful.
+ * @param actor_checkpoint_failed If the last task assigned was a checkpoint
+ *        task that failed.
  * @return The address of the assigned task.
  */
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   bool task_success);
+                                   bool actor_checkpoint_failed);
 
 /**
  * Tell the local scheduler that the client has finished executing a task.

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -94,6 +94,9 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
  * @todo When does this actually get freed?
  *
  * @param conn The connection information.
+ * @param task_size A pointer to fill out with the task size.
+ * @param task_success Whether the previously assigned task was
+ *        successful.
  * @return The address of the assigned task.
  */
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -98,7 +98,7 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
  */
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
                                    int64_t *task_size,
-                                   bool task_error);
+                                   int actor_task_counter);
 
 /**
  * Tell the local scheduler that the client has finished executing a task.

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -97,7 +97,8 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
  * @return The address of the assigned task.
  */
 TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
-                                   int64_t *task_size);
+                                   int64_t *task_size,
+                                   bool task_error);
 
 /**
  * Tell the local scheduler that the client has finished executing a task.

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -60,8 +60,8 @@ static PyObject *PyLocalSchedulerClient_submit(PyObject *self, PyObject *args) {
 
 // clang-format off
 static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args) {
-  PyObject *task_successful;
-  if (!PyArg_ParseTuple(args, "O", &task_successful)) {
+  int actor_task_counter;
+  if (!PyArg_ParseTuple(args, "i", &actor_task_counter)) {
     return NULL;
   }
   TaskSpec *task_spec;
@@ -71,7 +71,7 @@ static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args)
   Py_BEGIN_ALLOW_THREADS
   task_spec = local_scheduler_get_task(
       ((PyLocalSchedulerClient *) self)->local_scheduler_connection,
-      &task_size, (bool) PyObject_IsTrue(task_successful));
+      &task_size, actor_task_counter);
   Py_END_ALLOW_THREADS
   return PyTask_make(task_spec, task_size);
 }

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -60,8 +60,8 @@ static PyObject *PyLocalSchedulerClient_submit(PyObject *self, PyObject *args) {
 
 // clang-format off
 static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args) {
-  int actor_task_counter;
-  if (!PyArg_ParseTuple(args, "i", &actor_task_counter)) {
+  PyObject *task_success;
+  if (!PyArg_ParseTuple(args, "O", &task_success)) {
     return NULL;
   }
   TaskSpec *task_spec;
@@ -71,7 +71,7 @@ static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args)
   Py_BEGIN_ALLOW_THREADS
   task_spec = local_scheduler_get_task(
       ((PyLocalSchedulerClient *) self)->local_scheduler_connection,
-      &task_size, actor_task_counter);
+      &task_size, (bool) PyObject_IsTrue(task_success));
   Py_END_ALLOW_THREADS
   return PyTask_make(task_spec, task_size);
 }

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -60,24 +60,24 @@ static PyObject *PyLocalSchedulerClient_submit(PyObject *self, PyObject *args) {
 
 // clang-format off
 static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args) {
-  PyObject *py_task_success = NULL;
-  if (!PyArg_ParseTuple(args, "|O", &py_task_success)) {
+  PyObject *py_actor_checkpoint_failed = NULL;
+  if (!PyArg_ParseTuple(args, "|O", &py_actor_checkpoint_failed)) {
     return NULL;
   }
   TaskSpec *task_spec;
   int64_t task_size;
-  /* If no argument for task_success was provided, default to false, since
-   * we assume that there was no previous task. */
-  bool task_success = false;
-  if (py_task_success != NULL) {
-    task_success = (bool) PyObject_IsTrue(py_task_success);
+  /* If no argument for actor_checkpoint_failed was provided, default to false,
+   * since we assume that there was no previous task. */
+  bool actor_checkpoint_failed = false;
+  if (py_actor_checkpoint_failed != NULL) {
+    actor_checkpoint_failed = (bool) PyObject_IsTrue(py_actor_checkpoint_failed);
   }
   /* Drop the global interpreter lock while we get a task because
    * local_scheduler_get_task may block for a long time. */
   Py_BEGIN_ALLOW_THREADS
   task_spec = local_scheduler_get_task(
       ((PyLocalSchedulerClient *) self)->local_scheduler_connection,
-      &task_size, task_success);
+      &task_size, actor_checkpoint_failed);
   Py_END_ALLOW_THREADS
   return PyTask_make(task_spec, task_size);
 }

--- a/src/local_scheduler/local_scheduler_extension.cc
+++ b/src/local_scheduler/local_scheduler_extension.cc
@@ -60,18 +60,24 @@ static PyObject *PyLocalSchedulerClient_submit(PyObject *self, PyObject *args) {
 
 // clang-format off
 static PyObject *PyLocalSchedulerClient_get_task(PyObject *self, PyObject *args) {
-  PyObject *task_success;
-  if (!PyArg_ParseTuple(args, "O", &task_success)) {
+  PyObject *py_task_success = NULL;
+  if (!PyArg_ParseTuple(args, "|O", &py_task_success)) {
     return NULL;
   }
   TaskSpec *task_spec;
+  int64_t task_size;
+  /* If no argument for task_success was provided, default to false, since
+   * we assume that there was no previous task. */
+  bool task_success = false;
+  if (py_task_success != NULL) {
+    task_success = (bool) PyObject_IsTrue(py_task_success);
+  }
   /* Drop the global interpreter lock while we get a task because
    * local_scheduler_get_task may block for a long time. */
-  int64_t task_size;
   Py_BEGIN_ALLOW_THREADS
   task_spec = local_scheduler_get_task(
       ((PyLocalSchedulerClient *) self)->local_scheduler_connection,
-      &task_size, (bool) PyObject_IsTrue(task_success));
+      &task_size, task_success);
   Py_END_ALLOW_THREADS
   return PyTask_make(task_spec, task_size);
 }

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -210,12 +210,12 @@ TEST object_reconstruction_test(void) {
     int64_t task_assigned_size;
     local_scheduler_submit(worker, spec, task_size);
     TaskSpec *task_assigned =
-        local_scheduler_get_task(worker, &task_assigned_size);
+        local_scheduler_get_task(worker, &task_assigned_size, true);
     ASSERT_EQ(memcmp(task_assigned, spec, task_size), 0);
     ASSERT_EQ(task_assigned_size, task_size);
     int64_t reconstruct_task_size;
     TaskSpec *reconstruct_task =
-        local_scheduler_get_task(worker, &reconstruct_task_size);
+        local_scheduler_get_task(worker, &reconstruct_task_size, true);
     ASSERT_EQ(memcmp(reconstruct_task, spec, task_size), 0);
     ASSERT_EQ(reconstruct_task_size, task_size);
     /* Clean up. */
@@ -315,7 +315,7 @@ TEST object_reconstruction_recursive_test(void) {
     /* Make sure we receive each task from the initial submission. */
     for (int i = 0; i < NUM_TASKS; ++i) {
       int64_t task_size;
-      TaskSpec *task_assigned = local_scheduler_get_task(worker, &task_size);
+      TaskSpec *task_assigned = local_scheduler_get_task(worker, &task_size, true);
       ASSERT_EQ(memcmp(task_assigned, specs[i], task_sizes[i]), 0);
       ASSERT_EQ(task_size, task_sizes[i]);
       free(task_assigned);
@@ -325,7 +325,7 @@ TEST object_reconstruction_recursive_test(void) {
     for (int i = 0; i < NUM_TASKS; ++i) {
       int64_t task_assigned_size;
       TaskSpec *task_assigned =
-          local_scheduler_get_task(worker, &task_assigned_size);
+          local_scheduler_get_task(worker, &task_assigned_size, true);
       bool found = false;
       for (int j = 0; j < NUM_TASKS; ++j) {
         if (specs[j] == NULL) {
@@ -410,7 +410,7 @@ TEST object_reconstruction_suppression_test(void) {
      * object_table_add callback completes. */
     int64_t task_assigned_size;
     TaskSpec *task_assigned =
-        local_scheduler_get_task(worker, &task_assigned_size);
+        local_scheduler_get_task(worker, &task_assigned_size, true);
     ASSERT_EQ(memcmp(task_assigned, object_reconstruction_suppression_spec,
                      object_reconstruction_suppression_size),
               0);

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -315,7 +315,8 @@ TEST object_reconstruction_recursive_test(void) {
     /* Make sure we receive each task from the initial submission. */
     for (int i = 0; i < NUM_TASKS; ++i) {
       int64_t task_size;
-      TaskSpec *task_assigned = local_scheduler_get_task(worker, &task_size, true);
+      TaskSpec *task_assigned =
+          local_scheduler_get_task(worker, &task_size, true);
       ASSERT_EQ(memcmp(task_assigned, specs[i], task_sizes[i]), 0);
       ASSERT_EQ(task_size, task_sizes[i]);
       free(task_assigned);

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1188,12 +1188,8 @@ class ActorReconstruction(unittest.TestCase):
         # Wait for the last task to finish running.
         ray.get(ids[-1])
 
-        # Kill the second local scheduler.
-        process = ray.services.all_processes[
-            ray.services.PROCESS_TYPE_LOCAL_SCHEDULER][1]
-        process.kill()
-        process.wait()
-        # Kill the corresponding plasma store to get rid of the cached objects.
+        # Kill the second plasma store to get rid of the cached objects and
+        # trigger the corresponding local scheduler to exit.
         process = ray.services.all_processes[
             ray.services.PROCESS_TYPE_PLASMA_STORE][1]
         process.kill()
@@ -1250,14 +1246,10 @@ class ActorReconstruction(unittest.TestCase):
                 for _ in range(num_function_calls_at_a_time):
                     result_ids[actor].append(
                         actor.inc.remote(j ** 2 * 0.000001))
-            # Kill a local scheduler. Don't kill the first local scheduler
-            # since that is the one that the driver is connected to.
-            process = ray.services.all_processes[
-                ray.services.PROCESS_TYPE_LOCAL_SCHEDULER][i + 1]
-            process.kill()
-            process.wait()
-            # Kill the corresponding plasma store to get rid of the cached
-            # objects.
+            # Kill a plasma store to get rid of the cached objects and trigger
+            # exit of the corresponding local scheduler. Don't kill the first
+            # local scheduler since that is the one that the driver is
+            # connected to.
             process = ray.services.all_processes[
                 ray.services.PROCESS_TYPE_PLASMA_STORE][i + 1]
             process.kill()

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1324,12 +1324,12 @@ class ActorReconstruction(unittest.TestCase):
         args = [ray.put(0) for _ in range(100)]
         ids = [actor.inc.remote(*args[i:]) for i in range(100)]
 
-        # Wait for the last task to finish running.
-        ray.get(ids[-1])
         return actor, ids
 
     def testCheckpointing(self):
         actor, ids = self.setup_test_checkpointing()
+        # Wait for the last task to finish running.
+        ray.get(ids[-1])
 
         # Kill the corresponding plasma store to get rid of the cached objects.
         process = ray.services.all_processes[
@@ -1351,6 +1351,8 @@ class ActorReconstruction(unittest.TestCase):
 
     def testLostCheckpoint(self):
         actor, ids = self.setup_test_checkpointing()
+        # Wait for the first fraction of tasks to finish running.
+        ray.get(ids[len(ids) // 10])
 
         actor_key = b"Actor:" + actor._ray_actor_id.id()
         for index in ray.actor.get_checkpoint_indices(

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1272,7 +1272,7 @@ class ActorReconstruction(unittest.TestCase):
     def setup_test_checkpointing(self, save_exception=False,
                                  resume_exception=False):
         ray.worker._init(start_ray_local=True, num_local_schedulers=2,
-                         num_workers=0, redirect_output=False)
+                         num_workers=0, redirect_output=True)
 
         @ray.remote(checkpoint_interval=5)
         class Counter(object):


### PR DESCRIPTION
Actor checkpointing built on top of the existing reconstruction infrastructure.

Briefly, at every task interval for a given actor, a mock task responsible for saving and resuming checkpoints is submitted. The task tries to save a checkpoint to Redis during normal execution. During reconstruction, the task tries to resume from the most recent checkpoint. If the most recent checkpoint is older, then the task requests reconstruction of the preceding tasks.