### PR TITLE
Download boost 1.65.1 from bintray.

### DIFF
--- a/src/thirdparty/build_boost.sh
+++ b/src/thirdparty/build_boost.sh
@@ -7,23 +7,26 @@ set -e
 
 TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
+BOOST_VERSION=1.65.1
+BOOST_VERSION_UNDERSCORE=1_65_1
+
 # Download and compile boost if it isn't already present.
 if [ ! -d $TP_DIR/boost ]; then
   # The wget command frequently fails, so retry up to 20 times.
   for COUNT in {1..20}; do
     # Attempt to wget boost and break from the retry loop if it succeeds.
-    wget --no-check-certificate http://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.gz -O $TP_DIR/boost_1_60_0.tar.gz && break
+    wget https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -O $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE.tar.gz && break
     # If none of the retries succeeded at getting boost, then fail.
     if [[ $COUNT == 20 ]]; then
       exit 1
     fi
   done
 
-  tar xf $TP_DIR/boost_1_60_0.tar.gz -C $TP_DIR/
-  rm -rf $TP_DIR/boost_1_60_0.tar.gz
+  tar xf $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -C $TP_DIR/
+  rm -rf $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE.tar.gz
 
   # Compile boost.
-  pushd $TP_DIR/boost_1_60_0
+  pushd $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE
     ./bootstrap.sh
     ./bjam cxxflags=-fPIC cflags=-fPIC --prefix=$TP_DIR/boost --with-filesystem --with-system install > /dev/null
   popd

--- a/src/thirdparty/build_boost.sh
+++ b/src/thirdparty/build_boost.sh
@@ -15,7 +15,7 @@ if [ ! -d $TP_DIR/boost ]; then
   # The wget command frequently fails, so retry up to 20 times.
   for COUNT in {1..20}; do
     # Attempt to wget boost and break from the retry loop if it succeeds.
-    wget https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -O $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE.tar.gz && break
+    wget --no-check-certificate https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -O $TP_DIR/boost_$BOOST_VERSION_UNDERSCORE.tar.gz && break
     # If none of the retries succeeded at getting boost, then fail.
     if [[ $COUNT == 20 ]]; then
       exit 1


### PR DESCRIPTION
Hopefully this will be more reliable than sourceforge #1012.

This also changes the boost version from 1.60.0 to 1.65.1.