### PR TITLE
Workaround for passing empty list to ray.wait.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2114,6 +2114,12 @@ def wait(object_ids, num_returns=1, timeout=None, worker=global_worker):
         if worker.mode == PYTHON_MODE:
             return object_ids[:num_returns], object_ids[num_returns:]
 
+        # TODO(rkn): This is a temporary workaround for
+        # https://github.com/ray-project/ray/issues/997. However, it should be
+        # fixed in Arrow instead of here.
+        if len(object_ids) == 0:
+            return [], []
+
         object_id_strs = [plasma.ObjectID(object_id.id())
                           for object_id in object_ids]
         timeout = timeout if timeout is not None else 2 ** 30

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -704,6 +704,11 @@ class APITest(unittest.TestCase):
         x = ray.put(1)
         self.assertRaises(Exception, lambda: ray.wait([x, x]))
 
+        # Make sure it is possible to call wait with an empty list.
+        ready_ids, remaining_ids = ray.wait([])
+        self.assertEqual(ready_ids, [])
+        self.assertEqual(remaining_ids, [])
+
     def testMultipleWaitsAndGets(self):
         # It is important to use three workers here, so that the three tasks
         # launched in this experiment can run at the same time.


### PR DESCRIPTION
This is a workaround to temporarily address #997.

Once we fix this in Arrow we can remove this workaround.