### PR TITLE
[rllib] Fix common RLLib Encoder

### DIFF
--- a/python/ray/rllib/common.py
+++ b/python/ray/rllib/common.py
@@ -22,11 +22,13 @@ logger.setLevel(logging.INFO)
 
 class RLLibEncoder(json.JSONEncoder):
     def default(self, value):
-        if isinstance(value, np.float32) or isinstance(value, np.float64):
+        if np.issubdtype(value, float):
             if np.isnan(value):
                 return None
             else:
                 return float(value)
+        elif np.issubdtype(value, int):
+            return int(value)
 
 
 class RLLibLogger(object):


### PR DESCRIPTION
`np.ints` fall through the encoding and end up being recorded as null. 

This is supposedly for Athena, but I haven't tested with Athena logging yet.

Addresses #1047.

@ericl @pcmoritz 