### PR TITLE
[rllib] Fix logging to Athena

### DIFF
--- a/python/ray/rllib/a3c/a3c.py
+++ b/python/ray/rllib/a3c/a3c.py
@@ -73,8 +73,13 @@ class Runner(object):
         return completed
 
     def start(self):
+        logdir = self.logdir
+        if logdir.startswith("s3"):
+            print("WARNING: TensorFlow logging to S3 not supported by TensorFlow,"
+                  " logging to /tmp/ instead")
+            logdir = "/tmp/"
         summary_writer = tf.summary.FileWriter(
-            os.path.join(self.logdir, "agent_%d" % self.id))
+            os.path.join(logdir, "agent_%d" % self.id))
         self.summary_writer = summary_writer
         self.runner.start_runner(self.policy.sess, summary_writer)
 

--- a/python/ray/rllib/a3c/a3c.py
+++ b/python/ray/rllib/a3c/a3c.py
@@ -11,7 +11,7 @@ import os
 import ray
 from ray.rllib.a3c.runner import RunnerThread, process_rollout
 from ray.rllib.a3c.envs import create_env
-from ray.rllib.common import Agent, TrainingResult
+from ray.rllib.common import Agent, TrainingResult, get_tensorflow_log_dir
 from ray.rllib.a3c.shared_model import SharedModel
 from ray.rllib.a3c.shared_model_lstm import SharedModelLSTM
 
@@ -73,11 +73,7 @@ class Runner(object):
         return completed
 
     def start(self):
-        logdir = self.logdir
-        if logdir.startswith("s3"):
-            print("WARNING: TensorFlow logging to S3 not supported by TensorFlow,"
-                  " logging to /tmp/ instead")
-            logdir = "/tmp/"
+        logdir = get_tensorflow_log_dir(self.logdir)
         summary_writer = tf.summary.FileWriter(
             os.path.join(logdir, "agent_%d" % self.id))
         self.summary_writer = summary_writer

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -99,8 +99,13 @@ class PPOAgent(Agent):
             for _ in range(self.config["num_workers"])]
         self.start_time = time.time()
         if self.config["write_logs"]:
+            logdir = self.logdir
+            if logdir.startswith("s3"):
+                print("WARNING: TensorFlow logging to S3 not supported by TensorFlow,"
+                      " logging to /tmp/ instead")
+                logdir = "/tmp/"
             self.file_writer = tf.summary.FileWriter(
-                self.logdir, self.model.sess.graph)
+                logdir, self.model.sess.graph)
         else:
             self.file_writer = None
         self.saver = tf.train.Saver(max_to_keep=None)

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -11,7 +11,7 @@ import tensorflow as tf
 from tensorflow.python import debug as tf_debug
 
 import ray
-from ray.rllib.common import Agent, TrainingResult
+from ray.rllib.common import Agent, TrainingResult, get_tensorflow_log_dir
 from ray.rllib.ppo.runner import Runner, RemoteRunner
 from ray.rllib.ppo.rollout import collect_samples
 from ray.rllib.ppo.utils import shuffle
@@ -99,11 +99,7 @@ class PPOAgent(Agent):
             for _ in range(self.config["num_workers"])]
         self.start_time = time.time()
         if self.config["write_logs"]:
-            logdir = self.logdir
-            if logdir.startswith("s3"):
-                print("WARNING: TensorFlow logging to S3 not supported by TensorFlow,"
-                      " logging to /tmp/ instead")
-                logdir = "/tmp/"
+            logdir = get_tensorflow_log_dir(self.logdir)
             self.file_writer = tf.summary.FileWriter(
                 logdir, self.model.sess.graph)
         else:


### PR DESCRIPTION
This fixes two problems the came up when writing logs to Athena:

1. TensorFlow doesn't support logging to S3 (we are falling back to /tmp now)
2. There were NaNs that were floats and not np.float so our JSONEncoder didn't catch them (it is only invoked for unknown objects)