### PR TITLE
Fix actor garbage collection by breaking cyclic references

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -8,6 +8,7 @@ import hashlib
 import inspect
 import json
 import traceback
+import weakref
 
 import ray.local_scheduler
 import ray.signature as signature
@@ -253,7 +254,10 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
 
     class ActorMethod(object):
         def __init__(self, actor, method_name, method_signature):
-            self.actor = actor
+            # NOTE(swang): We use a weak reference back to the actor handle so
+            # that garbage collection can safely collect this reference cycle
+            # once the actor handle goes out of scope.
+            self.actor = weakref.proxy(actor)
             self.method_name = method_name
             self.method_signature = method_signature
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -8,7 +8,6 @@ import hashlib
 import inspect
 import json
 import traceback
-import weakref
 
 import ray.local_scheduler
 import ray.signature as signature
@@ -252,12 +251,11 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
     # constructor.
     exported = []
 
+    # Create objects to wrap method invocations. This is done so that we can
+    # invoke methods with actor.method.remote() instead of actor.method().
     class ActorMethod(object):
         def __init__(self, actor, method_name, method_signature):
-            # NOTE(swang): We use a weak reference back to the actor handle so
-            # that garbage collection can safely collect this reference cycle
-            # once the actor handle goes out of scope.
-            self.actor = weakref.proxy(actor)
+            self.actor = actor
             self.method_name = method_name
             self.method_signature = method_signature
 
@@ -310,14 +308,6 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                 signature.check_signature_supported(v, warn=True)
                 self._ray_method_signatures[k] = signature.extract_signature(
                     v, ignore_first=True)
-
-            # Create objects to wrap method invocations. This is done so that
-            # we can invoke methods with actor.method.remote() instead of
-            # actor.method().
-            self._actor_method_invokers = dict()
-            for k, v in self._ray_actor_methods.items():
-                self._actor_method_invokers[k] = ActorMethod(
-                    self, k, self._ray_method_signatures[k])
 
             # Do not export the actor class or the actor if run in PYTHON_MODE
             # Instead, instantiate the actor locally and add it to
@@ -394,10 +384,17 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
                         "_actor_method_call"]:
                 return object.__getattribute__(self, attr)
             if attr in self._ray_actor_methods.keys():
-                return self._actor_method_invokers[attr]
-            # There is no method with this name, so raise an exception.
-            raise AttributeError("'{}' Actor object has no attribute '{}'"
-                                 .format(Class, attr))
+                # We create the ActorMethod on the fly here so that the
+                # ActorHandle doesn't need a reference to the ActorMethod. The
+                # ActorMethod has a reference to the ActorHandle and this was
+                # causing cyclic references which were prevent object
+                # deallocation from behaving in a predictable manner.
+                return ActorMethod(self, attr,
+                                   self._ray_method_signatures[attr])
+            else:
+                # There is no method with this name, so raise an exception.
+                raise AttributeError("'{}' Actor object has no attribute '{}'"
+                                     .format(Class, attr))
 
         def __repr__(self):
             return "Actor(" + self._ray_actor_id.hex() + ")"

--- a/python/ray/test/test_utils.py
+++ b/python/ray/test/test_utils.py
@@ -118,6 +118,7 @@ def _pid_alive(pid):
     """
     try:
         os.kill(pid, 0)
+        return True
     except OSError:
         return False
 

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -356,12 +356,6 @@ void handle_actor_worker_connect(LocalSchedulerState *state,
   dispatch_actor_task(state, algorithm_state, actor_id);
 }
 
-void handle_actor_worker_disconnect(LocalSchedulerState *state,
-                                    SchedulingAlgorithmState *algorithm_state,
-                                    ActorID actor_id) {
-  remove_actor(algorithm_state, actor_id);
-}
-
 /**
  * This will add a task to the task queue for an actor. If this is the first
  * task being processed for this actor, it is possible that the LocalActorInfo
@@ -1156,6 +1150,18 @@ void handle_worker_removed(LocalSchedulerState *state,
 
   /* Make sure we removed the worker at most once. */
   CHECK(num_times_removed <= 1);
+
+  /* Attempt to dispatch some tasks because some resources may have freed up. */
+  dispatch_all_tasks(state, algorithm_state);
+}
+
+void handle_actor_worker_disconnect(LocalSchedulerState *state,
+                                    SchedulingAlgorithmState *algorithm_state,
+                                    ActorID actor_id) {
+  remove_actor(algorithm_state, actor_id);
+
+  /* Attempt to dispatch some tasks because some resources may have freed up. */
+  dispatch_all_tasks(state, algorithm_state);
 }
 
 void handle_actor_worker_available(LocalSchedulerState *state,

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -302,6 +302,15 @@ class ActorMethods(unittest.TestCase):
         actors = None
         [ray.test.test_utils.wait_for_pid_to_exit(pid) for pid in pids]
 
+        @ray.remote
+        class Actor(object):
+            def method(self):
+                return 1
+
+        # Make sure that if we create an actor and call a method on it
+        # immediately, the actor does get killed before the method is called.
+        self.assertEqual(ray.get(Actor.remote().method.remote()), 1)
+
         ray.worker.cleanup()
 
     def testActorState(self):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -309,9 +309,9 @@ class ActorMethods(unittest.TestCase):
                 return 1
 
         # Make sure that if we create an actor and call a method on it
-        # immediately, the actor does get killed before the method is called.
-        with self.assertRaises(ReferenceError) as context:
-            ray.get(Actor.remote().method.remote())
+        # immediately, the actor doesn't get killed before the method is
+        # called.
+        self.assertEqual(ray.get(Actor.remote().method.remote()), 1)
 
         ray.worker.cleanup()
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -299,6 +299,7 @@ class ActorMethods(unittest.TestCase):
 
         actors = [Actor.remote() for _ in range(10)]
         pids = ray.get([a.getpid.remote() for a in actors])
+        a = None
         actors = None
         [ray.test.test_utils.wait_for_pid_to_exit(pid) for pid in pids]
 
@@ -309,7 +310,8 @@ class ActorMethods(unittest.TestCase):
 
         # Make sure that if we create an actor and call a method on it
         # immediately, the actor does get killed before the method is called.
-        self.assertEqual(ray.get(Actor.remote().method.remote()), 1)
+        with self.assertRaises(ReferenceError) as context:
+            ray.get(Actor.remote().method.remote())
 
         ray.worker.cleanup()
 

--- a/test/jenkins_tests/multi_node_tests/many_drivers_test.py
+++ b/test/jenkins_tests/multi_node_tests/many_drivers_test.py
@@ -30,10 +30,10 @@ class Actor1(object):
 
 
 def driver(redis_address, driver_index):
-    """The script for driver 0.
+    """The script for all drivers.
 
-    This driver should create five actors that each use one GPU and some actors
-    that use no GPUs. After a while, it should exit.
+    This driver should create five actors that each use one GPU. After a while,
+    it should exit.
     """
     ray.init(redis_address=redis_address)
 
@@ -44,7 +44,7 @@ def driver(redis_address, driver_index):
     for i in range(driver_index - max_concurrent_drivers + 1):
         _wait_for_event("DRIVER_{}_DONE".format(i), redis_address)
 
-    def try_to_create_actor(actor_class, timeout=100):
+    def try_to_create_actor(actor_class, timeout=500):
         # Try to create an actor, but allow failures while we wait for the
         # monitor to release the resources for the removed drivers.
         start_time = time.time()


### PR DESCRIPTION
#902 introduced a cyclic reference between an `ActorHandle` instance and its dictionary of `ActorMethod` instances. This replaces the backreference to the actor handle with a weak reference, so that the Python garbage collector can safely collect an `ActorHandle`.

Fixes #1060.