### PR TITLE
Fix Arrow's repository URL

### DIFF
--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -8,7 +8,7 @@ set -e
 TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 if [ ! -d $TP_DIR/arrow ]; then
-  git clone https://github.com/apache/arrow/ "$TP_DIR/arrow"
+  git clone https://github.com/apache/arrow.git "$TP_DIR/arrow"
 fi
 cd $TP_DIR/arrow
 git fetch origin master


### PR DESCRIPTION
Otherwise we are getting the following error in our CI:

```
root@0c7866a490b6:~# git clone https://github.com/apache/arrow/
Cloning into 'arrow'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
root@0c7866a490b6:~# git clone https://github.com/apache/arrow.git
Cloning into 'arrow'...
remote: Counting objects: 17102, done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 17102 (delta 17), reused 37 (delta 14), pack-reused 17051
Receiving objects: 100% (17102/17102), 7.47 MiB | 0 bytes/s, done.
Resolving deltas: 100% (11599/11599), done.
Checking connectivity... done.
root@0c7866a490b6:~# git --version
git version 2.7.4
```

Not sure why. It works locally for me. Maybe an older git version or something.