### PR TITLE
Release GPU resources as soon as an actor exits.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -12,8 +12,8 @@ import traceback
 import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
-from ray.utils import (FunctionProperties, random_string,
-                       select_local_scheduler)
+from ray.utils import (binary_to_hex, FunctionProperties, random_string,
+                       release_gpus_in_use, select_local_scheduler)
 
 
 def random_actor_id():
@@ -112,7 +112,6 @@ def fetch_and_register_actor(actor_class_key, worker):
 
     try:
         unpickled_class = pickle.loads(pickled_class)
-        worker.actor_class = unpickled_class
     except Exception:
         # If an exception was thrown when the actor was imported, we record the
         # traceback and notify the scheduler of the failure.
@@ -120,6 +119,9 @@ def fetch_and_register_actor(actor_class_key, worker):
         # Log the error message.
         worker.push_error_to_driver(driver_id, "register_actor", traceback_str,
                                     data={"actor_id": actor_id_str})
+        # TODO(rkn): In the future, it might make sense to have the worker exit
+        # here. However, currently that would lead to hanging if someone calls
+        # ray.get on a method invoked on the actor.
     else:
         # TODO(pcm): Why is the below line necessary?
         unpickled_class.__module__ = module
@@ -132,6 +134,15 @@ def fetch_and_register_actor(actor_class_key, worker):
             # We do not set worker.function_properties[driver_id][function_id]
             # because we currently do need the actor worker to submit new tasks
             # for the actor.
+
+        # Store some extra information that will be used when the actor exits
+        # to release GPU resources.
+        worker.actors[actor_id_str].__ray_driver_id__ = (
+            binary_to_hex(driver_id))
+        local_scheduler_id = worker.redis_client.hget(
+            b"Actor:" + actor_id_str, "local_scheduler_id")
+        worker.actors[actor_id_str].__ray_local_scheduler_id__ = (
+            binary_to_hex(local_scheduler_id))
 
 
 def export_actor_class(class_id, Class, actor_method_names,
@@ -214,6 +225,12 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
             # remove the actor key from Redis here.
             ray.worker.global_worker.redis_client.hset(b"Actor:" + actor_id,
                                                        "removed", True)
+            # Release the GPUs that this worker was using.
+            if len(ray.get_gpu_ids()) > 0:
+                release_gpus_in_use(self.__ray_driver_id__,
+                                    self.__ray_local_scheduler_id__,
+                                    ray.get_gpu_ids(),
+                                    ray.worker.global_worker.redis_client)
             # Disconnect the worker from he local scheduler. The point of this
             # is so that when the worker kills itself below, the local
             # scheduler won't push an error message to the driver.

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -139,11 +139,16 @@ def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler,
 def release_gpus_in_use(driver_id, local_scheduler_id, gpu_ids, redis_client):
     """Release the GPUs that a given worker was using.
 
+    Note that this does not affect the local scheduler's bookkeeping. It only
+    affects the GPU allocations which are recorded in the primary Redis shard,
+    which are redundant with the local scheduler bookkeeping.
+
     Args:
-        driver_id:
-        local_scheduler_id:
-        gpu_ids:
-        redis_client:
+        driver_id: The ID of the driver that is releasing some GPUs.
+        local_scheduler_id: The ID of the local scheduler that owns the GPUs
+            being released.
+        gpu_ids: The IDs of the GPUs being released.
+        redis_client: A client for the primary Redis shard.
     """
     # Attempt to release GPU IDs atomically.
     with redis_client.pipeline() as pipe:

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -136,6 +136,49 @@ def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler,
     return success
 
 
+def release_gpus_in_use(driver_id, local_scheduler_id, gpu_ids, redis_client):
+    """Release the GPUs that a given worker was using.
+
+    Args:
+        driver_id:
+        local_scheduler_id:
+        gpu_ids:
+        redis_client:
+    """
+    # Attempt to release GPU IDs atomically.
+    with redis_client.pipeline() as pipe:
+        while True:
+            try:
+                # If this key is changed before the transaction below (the
+                # multi/exec block), then the transaction will not take place.
+                pipe.watch(local_scheduler_id)
+
+                # Figure out which GPUs are currently in use.
+                result = redis_client.hget(local_scheduler_id, "gpus_in_use")
+                gpus_in_use = dict() if result is None else json.loads(
+                    result.decode("ascii"))
+
+                assert driver_id in gpus_in_use
+                assert gpus_in_use[driver_id] >= len(gpu_ids)
+
+                gpus_in_use[driver_id] -= len(gpu_ids)
+
+                pipe.multi()
+
+                pipe.hset(local_scheduler_id, "gpus_in_use",
+                          json.dumps(gpus_in_use))
+
+                pipe.execute()
+                # If a WatchError is not raised, then the operations should
+                # have gone through atomically.
+                break
+            except redis.WatchError:
+                # Another client must have changed the watched key between the
+                # time we started WATCHing it and the pipeline's execution. We
+                # should just retry.
+                continue
+
+
 def select_local_scheduler(driver_id, local_schedulers, num_gpus,
                            redis_client):
     """Select a local scheduler to assign this actor to.


### PR DESCRIPTION
This fixes #1065.

GPU resource allocation is handled in part by the local schedulers and in part by Redis. The Redis part should be removed at some point.

**Before merging:**
- [x] Get rid of the `__ray_local_scheduler_id__` and `__ray_driver_id__` fields and put them somewhere else.
- [x] Add a test for this.