### PR TITLE
Allow Ray to be built without UI by setting INCLUDE_UI=0.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -23,11 +23,22 @@ ray_files = [
     "ray/core/src/local_scheduler/local_scheduler",
     "ray/core/src/local_scheduler/liblocal_scheduler_library.so",
     "ray/core/src/global_scheduler/global_scheduler",
-    "ray/core/src/catapult_files/index.html",
-    "ray/core/src/catapult_files/trace_viewer_full.html",
     "ray/WebUI.ipynb"
 ]
 
+optional_ray_files = []
+
+ray_ui_files = [
+    "ray/core/src/catapult_files/index.html",
+    "ray/core/src/catapult_files/trace_viewer_full.html"
+]
+
+# The UI files are mandatory if the INCLUDE_UI environment variable equals 1.
+# Otherwise, they are optional.
+if "INCLUDE_UI" in os.environ and os.environ["INCLUDE_UI"] == "1":
+    ray_files += ray_ui_files
+else:
+    optional_ray_files += ray_ui_files
 
 class build_ext(_build_ext.build_ext):
     def run(self):
@@ -55,6 +66,14 @@ class build_ext(_build_ext.build_ext):
             if filename[-3:] == ".py":
                 self.move_file(os.path.join(generated_python_directory,
                                             filename))
+
+        # Try to copy over the optional files.
+        for filename in optional_ray_files:
+            try:
+                self.move_file(filename)
+            except Exception as e:
+                print("Failed to copy optional file {}. This is ok."
+                      .format(filename))
 
     def move_file(self, filename):
         # TODO(rkn): This feels very brittle. It may not handle all cases. See

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,6 +40,7 @@ if "INCLUDE_UI" in os.environ and os.environ["INCLUDE_UI"] == "1":
 else:
     optional_ray_files += ray_ui_files
 
+
 class build_ext(_build_ext.build_ext):
     def run(self):
         # Note: We are passing in sys.executable so that we use the same

--- a/src/thirdparty/build_ui.sh
+++ b/src/thirdparty/build_ui.sh
@@ -16,7 +16,7 @@ CATAPULT_FILES=$TP_DIR/../../python/ray/core/src/catapult_files
 # This is where we will copy the files that need to be packaged with the wheels.
 mkdir -p $CATAPULT_FILES
 
-if [ ! type python2 > /dev/null ]; then
+if ! type python2 > /dev/null; then
   echo "cannot properly set up UI without a python2 executable"
   if [[ "$INCLUDE_UI" == "1" ]]; then
     # Since the UI is explicitly supposed to be included, fail here.


### PR DESCRIPTION
After this, `python setup.py install` should succeed and build Ray without the UI if there is no `python2` executable.

Fixes #1073.