### PR TITLE
Switch to monotonic clock

### DIFF
--- a/src/common/common.cc
+++ b/src/common/common.cc
@@ -71,6 +71,6 @@ char *ObjectID_to_string(ObjectID obj_id, char *id_string, int id_length) {
 int64_t current_time_ms() {
   std::chrono::milliseconds ms_since_epoch =
       std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::system_clock::now().time_since_epoch());
+          std::chrono::steady_clock::now().time_since_epoch());
   return ms_since_epoch.count();
 }


### PR DESCRIPTION
This PR switches from `std::chrono::system_clock` to `std::chrono::steady_clock`, so that `current_time` will always be monotonically increasing. This should fix these occasional Travis errors:
```
[FATAL] (/home/travis/build/ray-project/ray/src/plasma/plasma_manager.cc:1476: errno: Operation now in progress) Check failure: current_time >= state->previous_heartbeat_time 

/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x4041ac]
/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x421084]
/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x42131b]
/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x408a56]
/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x403a02]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7f1712ffdf45]
/home/travis/.local/lib/python2.7/site-packages/ray-0.2.1-py2.7-linux-x86_64.egg/ray/plasma/../core/src/plasma/plasma_manager[0x403fe7]
[FATAL] (/home/travis/build/ray-project/ray/src/local_scheduler/local_scheduler.cc:1218: errno: Operation now in progress) Check failure: current_time >= state->previous_heartbeat_time 
```