### PR TITLE
Dispatch all tasks on a timer.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1279,6 +1279,9 @@ void start_server(const char *node_ip_address,
     event_loop_add_timer(loop, HEARTBEAT_TIMEOUT_MILLISECONDS,
                          heartbeat_handler, g_state);
   }
+  /* Create a timer for dispatching tasks. */
+  event_loop_add_timer(loop, kLocalSchedulerDispatchTimeoutMilliseconds,
+                       dispatch_tasks_handler, g_state);
   /* Create a timer for fetching queued tasks' missing object dependencies. */
   event_loop_add_timer(loop, kLocalSchedulerFetchTimeoutMilliseconds,
                        fetch_object_timeout_handler, g_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -763,6 +763,12 @@ void dispatch_all_tasks(LocalSchedulerState *state,
   }
 }
 
+int dispatch_tasks_handler(event_loop *loop, timer_id id, void *context) {
+  LocalSchedulerState *state = (LocalSchedulerState *) context;
+  dispatch_all_tasks(state, state->algorithm_state);
+  return kLocalSchedulerDispatchTimeoutMilliseconds;
+}
+
 /**
  * A helper function to allocate a queue entry for a task specification and
  * push it onto a generic queue.

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -5,6 +5,9 @@
 #include "common/task.h"
 #include "state/local_scheduler_table.h"
 
+/* The duration that the local scheduler will wait between dispatching queued
+ * tasks. Tasks are also dispatched at other times. */
+constexpr int64_t kLocalSchedulerDispatchTimeoutMilliseconds = 10;
 /* The duration that the local scheduler will wait before reinitiating a fetch
  * request for a missing task dependency. This time may adapt based on the
  * number of missing task dependencies. */
@@ -276,6 +279,18 @@ void handle_actor_worker_unblocked(LocalSchedulerState *state,
 void handle_driver_removed(LocalSchedulerState *state,
                            SchedulingAlgorithmState *algorithm_state,
                            WorkerID driver_id);
+
+/**
+ * This function attempts to dispatch all tasks. It is called every
+ * kLocalSchedulerDispatchTimeoutMilliseconds milliseconds.
+ *
+ * @param loop The local scheduler's event loop.
+ * @param id the ID of the timer that triggers this function.
+ * @param context The function's context.
+ * @return An integer representing the time interval in seconds before the
+ *         next invocation of the function.
+ */
+int dispatch_tasks_handler(event_loop *loop, timer_id id, void *context);
 
 /**
  * This function fetches queued task's missing object dependencies. It is


### PR DESCRIPTION
I'm **not necessarily suggesting that we merge this**. Just opening this PR so that we can start a discussion about it.

Currently, the local scheduler manually calls `dispatch_all_tasks` (as well as more fine-grained dispatch methods) whenever there is the possibility of assigning some tasks to workers (e.g., when a worker becomes available, when an object arrives, when a task is submitted, etc).

**Considerations:**
- There are a lot of cases to keep track of, and it's easy to miss some, we've had bugs (e.g., https://github.com/ray-project/ray/pull/1064/commits/a685f0ebab841873828450d099662978a7493993) where we forgot a case or two.
- We can still dispatch tasks whenever we feel like it, but having a timer in the background frees us up to remove a bunch of the calls, potentially improving performance.
- What is the right duration for the timer? 1ms? 5ms? This could hurt latency.

cc @atumanov 