### PR TITLE
Compile with -rdynamic for better debugging symbols.

### DIFF
--- a/src/common/cmake/Common.cmake
+++ b/src/common/cmake/Common.cmake
@@ -3,7 +3,7 @@
 include(ExternalProject)
 include(CMakeParseArguments)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -Werror -Wall -Wno-error=unused-function -Wno-error=strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -rdynamic -Werror -Wall -Wno-error=unused-function -Wno-error=strict-aliasing")
 
 set(FLATBUFFERS_VERSION "1.7.1")
 

--- a/src/common/cmake/Common.cmake
+++ b/src/common/cmake/Common.cmake
@@ -5,6 +5,7 @@ include(CMakeParseArguments)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -Werror -Wall -Wno-error=unused-function -Wno-error=strict-aliasing")
 
+# The rdynamic flag is needed to produce better backtraces on Linux.
 if(UNIX AND NOT APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -rdynamic")
 endif()

--- a/src/common/cmake/Common.cmake
+++ b/src/common/cmake/Common.cmake
@@ -3,7 +3,11 @@
 include(ExternalProject)
 include(CMakeParseArguments)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -rdynamic -Werror -Wall -Wno-error=unused-function -Wno-error=strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -Werror -Wall -Wno-error=unused-function -Wno-error=strict-aliasing")
+
+if(UNIX AND NOT APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -rdynamic")
+endif()
 
 set(FLATBUFFERS_VERSION "1.7.1")
 


### PR DESCRIPTION
Looks like it shouldn't affect performance too much (or only the first time a symbol is used). https://stackoverflow.com/questions/12634114/will-adding-the-rdynamic-linker-option-to-gcc-g-impact-performance/12636790#12636790

Example backtrace on Ubuntu 16 **before** this PR.

```
[FATAL] (/home/ubuntu/ray/src/local_scheduler/local_scheduler.cc:557: errno: Operation now in progress) Check failure: false 

/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x409838]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x411f89]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x40de2a]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x431c70]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x43208b]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x403d24]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f3f87c5a830]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler[0x404469]
```

And after this PR.

```
[FATAL] (/home/ubuntu/ray/src/local_scheduler/local_scheduler.cc:557: errno: Operation now in progress) Check failure: false 

/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler9(_Z21assign_task_to_workerP19LocalSchedulerStatePhlP20LocalSchedulerClient
+0xa18)[0x417458]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(_Z14dispatch_tasksP19LocalSchedulerStateP24SchedulingAlgorithmState+0x109)[0x41fbd9]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(_Z15process_messageP11aeEventLoopiPvi+0x60a)[0x41ba7a]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(aeProcessEvents+0x130)[0x440080]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(aeMain+0x2b)[0x44049b]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(main+0x304)[0x411934]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f5c9ef34830]
/home/ubuntu/ray/python/ray/local_scheduler/../core/src/local_scheduler/local_scheduler(_start+0x29)[0x412079]
```

Still not perfect, e.g., there are no line numbers.