### PR TITLE
change int64_t to uint32_t used by flatbuffers for Ray event logging

### DIFF
--- a/src/common/logging.cc
+++ b/src/common/logging.cc
@@ -90,9 +90,9 @@ void RayLogger_log(RayLogger *logger,
 
 void RayLogger_log_event(DBHandle *db,
                          uint8_t *key,
-                         int64_t key_length,
+                         uint32_t key_length,
                          uint8_t *value,
-                         int64_t value_length,
+                         uint32_t value_length,
                          double timestamp) {
   std::string timestamp_string = std::to_string(timestamp);
   int status = redisAsyncCommand(db->context, NULL, NULL, "ZADD %b %s %b", key,

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -50,9 +50,9 @@ void RayLogger_log(RayLogger *logger,
  */
 void RayLogger_log_event(DBHandle *db,
                          uint8_t *key,
-                         int64_t key_length,
+                         uint32_t key_length,
                          uint8_t *value,
-                         int64_t value_length,
+                         uint32_t value_length,
                          double time);
 
 #endif /* LOGGING_H */


### PR DESCRIPTION
this PR addresses a local scheduler SIGSEGV on 32bit linux that occurs inside RayLogger_log_event due to the use of 64bit (long long) data types.

```
Program received signal SIGSEGV, Segmentation fault.
__strlen_sse2_bsf () at ../sysdeps/i386/i686/multiarch/strlen-sse2-bsf.S:50
50	../sysdeps/i386/i686/multiarch/strlen-sse2-bsf.S: No such file or directory.
(gdb) bt
#0  __strlen_sse2_bsf () at ../sysdeps/i386/i686/multiarch/strlen-sse2-bsf.S:50
#1  0x080a201e in redisvFormatCommand (target=0xbfeceb58, format=0x80ab841 "ZADD %b %s %b", ap=0xbfecebc8 "") at hiredis.c:262
#2  0x080a736c in redisvAsyncCommand (ac=0x90723f0, fn=0x0, privdata=0x0, format=0x80ab841 "ZADD %b %s %b", ap=0xbfecebc0 "xe\a\t\036") at async.c:654
#3  0x080a73ec in redisAsyncCommand (ac=0x90723f0, fn=0x0, privdata=0x0, format=0x80ab841 "ZADD %b %s %b") at async.c:669
#4  0x08078081 in RayLogger_log_event (db=0x9071e10, key=0x9076578 "event_log:\037\300\345\027v\r\300!>}\034\372\242\035}\376\320+^:", key_length=30,
    value=0x90761c8 "[[1507965381.056622, \"ray:get_task\", 1, {}], [1507965578.319059, \"ray:import_remote_function\", 1, {}], [1507965578.320148, \"ray:import_remote_function\", 2, {}], [1507965593.372685, \"ray:get_task\", 2, "..., value_length=938, timestamp=1507965593.3735039)
    at /home/atumanov/ray/src/common/logging.cc:100
#5  0x08062375 in process_message (loop=0x9068a38, client_sock=22, context=0x90738b8, events=1)
    at /home/atumanov/ray/src/local_scheduler/local_scheduler.cc:975
#6  0x0808770d in aeProcessEvents (eventLoop=0x9068a38, flags=3) at /home/atumanov/ray/src/common/thirdparty/ae/ae.c:412
#7  0x08087beb in aeMain (eventLoop=0x9068a38) at /home/atumanov/ray/src/common/thirdparty/ae/ae.c:455
#8  0x0806b408 in event_loop_run (loop=0x9068a38) at /home/atumanov/ray/src/common/event_loop.cc:58
#9  0x0806189e in start_server (node_ip_address=0xbfed1617 "127.0.0.1", socket_name=0xbfed15e0 "/tmp/scheduler17985046",
    redis_primary_addr=0xbfecf6ac "127.0.0.1", redis_primary_port=54774, plasma_store_socket_name=0xbfed15fa "/tmp/plasma_store75833613",
    plasma_manager_socket_name=0xbfed1629 "/tmp/plasma_manager4733243", plasma_manager_address=0xbfed1789 "127.0.0.1:25654", global_scheduler_exists=true,
    static_resource_conf=0xbfecf298,
    start_worker_command=0xbfed1647 "/home/atumanov/miniconda2/bin/python /home/atumanov/ray/python/ray/workers/default_worker.py --node-ip-address=127.0.0.1 --object-store-name=/tmp/plasma_store75833613 --object-store-manager-name=/tmp/"..., num_workers=2)
    at /home/atumanov/ray/src/local_scheduler/local_scheduler.cc:1298
#10 0x08057b09 in main (argc=19, argv=0xbfecf784) at /home/atumanov/ray/src/local_scheduler/local_scheduler.cc:1442
```