### PR TITLE
Prototype distributed actor handles

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -393,6 +393,8 @@ class ActorHandleWrapper(object):
         self.actor_cursor = actor_cursor
         self.actor_counter = actor_counter
         self.actor_method_names = actor_method_names
+        # TODO(swang): Fetch this information from Redis so that we don't have
+        # to fall back to pickle.
         self.method_signatures = method_signatures
         self.checkpoint_interval = checkpoint_interval
         self.class_name = class_name

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -342,8 +342,15 @@ def export_actor_class(class_id, Class, actor_method_names,
         assert worker.cached_remote_functions_and_actors is not None
         worker.cached_remote_functions_and_actors.append(
             ("actor", (key, actor_class_info)))
+        # This caching code path is currently not used because we only export
+        # actor class definitions lazily when we instantiate the actor for the
+        # first time.
+        assert False, "This should be unreachable."
     else:
         publish_actor_class_to_key(key, actor_class_info, worker)
+    # TODO(rkn): Currently we allow actor classes to be defined within tasks.
+    # I tried to disable this, but it may be necessary because of
+    # https://github.com/ray-project/ray/issues/1146.
 
 
 def export_actor(actor_id, class_id, class_name, actor_method_names, num_cpus,

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -820,13 +820,14 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
     class_id = random_actor_class_id()
 
     # Export the actor class.
-    ray_actor_methods = inspect.getmembers(
-        Class, predicate=(lambda x: (inspect.isfunction(x) or
-                                     inspect.ismethod(x))))
-    export_actor_class(class_id, Class,
-                       [method_name for method_name, _ in ray_actor_methods],
-                       checkpoint_interval,
-                       ray.worker.global_worker)
+    if ray.worker.global_worker.mode != ray.PYTHON_MODE:
+        ray_actor_methods = inspect.getmembers(
+            Class, predicate=(lambda x: (inspect.isfunction(x) or
+                                         inspect.ismethod(x))))
+        export_actor_class(class_id, Class,
+                           [method_name for method_name, _ in ray_actor_methods],
+                           checkpoint_interval,
+                           ray.worker.global_worker)
 
     return actor_handle_from_class(Class, class_id, num_cpus, num_gpus,
                                    checkpoint_interval)

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -409,6 +409,9 @@ def wrap_actor_handle(actor_handle):
     Returns:
         An ActorHandleWrapper instance that stores the ActorHandle's fields.
     """
+    if actor_handle._ray_checkpoint_interval > 0:
+        raise Exception("Checkpointing not yet supported for distributed "
+                        "actor handles.")
     return ActorHandleWrapper(
         actor_handle._ray_actor_id,
         random_actor_handle_id(),  # Generate a new handle ID.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -430,7 +430,8 @@ def actor_handle_from_fields(worker, actor_id, actor_handle_id, actor_counter,
             self._ray_actor_id = actor_id
             #self._ray_actor_handle_id = actor_handle_id
             self._ray_actor_handle_id = random_actor_handle_id()#Should probably be computed as a hash.
-            self._ray_actor_counter = actor_counter
+            #self._ray_actor_counter = actor_counter
+            self._ray_actor_counter = 0#Should we just ignore the counter?
             self._ray_actor_cursor = None #TODO(rkn): This should probably be a different value.
             self._ray_actor_methods = actor_methods
             self._ray_method_signatures = method_signatures
@@ -541,11 +542,12 @@ def actor_handle_from_fields(worker, actor_id, actor_handle_id, actor_counter,
         def __reduce__(self):
             raise Exception("Actor objects cannot be pickled.")
 
-        def __del__(self):
-            """Kill the worker that is running this actor."""
-            if ray.worker.global_worker.connected:
-                self._actor_method_call("__ray_terminate__",
-                                        args=[self._ray_actor_id.id()])
+        # def __del__(self):
+        #     """Kill the worker that is running this actor."""
+        #     if ray.worker.global_worker.connected:
+        #         self._actor_method_call("__ray_terminate__",
+        #                                 args=[self._ray_actor_id.id()])
+        #TODO(rkn): We can't just never clean up actors!!!
 
     actor_object = ActorHandle.__new__(ActorHandle)
     actor_object._manual_init_from_fields(actor_id, actor_handle_id,
@@ -734,11 +736,12 @@ def actor_handle_from_class(Class, class_id, num_cpus, num_gpus,
         def __reduce__(self):
             raise Exception("Actor objects cannot be pickled.")
 
-        def __del__(self):
-            """Kill the worker that is running this actor."""
-            if ray.worker.global_worker.connected:
-                self._actor_method_call("__ray_terminate__",
-                                        args=[self._ray_actor_id.id()])
+        # def __del__(self):
+        #     """Kill the worker that is running this actor."""
+        #     if ray.worker.global_worker.connected:
+        #         self._actor_method_call("__ray_terminate__",
+        #                                 args=[self._ray_actor_id.id()])
+        #TODO(rkn): We can't just never clean up actors!!!
 
     return ActorHandle
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -652,10 +652,12 @@ def actor_handle_from_class(Class, class_id, num_cpus, num_gpus,
                                       actor_counter, actor_method_names,
                                       method_signatures, checkpoint_interval)
 
-            # Call __init__ as a remote function. This throws an exception if
-            # there is no __init__ method defined.
-            actor_object._actor_method_call("__init__", args=args,
-                                            kwargs=kwargs)
+            # Call __init__ as a remote function.
+            if "__init__" in actor_object._ray_actor_method_names:
+                actor_object._actor_method_call("__init__", args=args,
+                                                kwargs=kwargs)
+            else:
+                print("WARNING: this object has no __init__ method.")
 
             return actor_object
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -584,12 +584,15 @@ def make_actor_handle_class(class_name):
         def __reduce__(self):
             raise Exception("Actor objects cannot be pickled.")
 
-        # def __del__(self):
-        #     """Kill the worker that is running this actor."""
-        #     if ray.worker.global_worker.connected:
-        #         self._actor_method_call("__ray_terminate__",
-        #                                 args=[self._ray_actor_id.id()])
-        # TODO(rkn): We can't just never clean up actors!!!
+        def __del__(self):
+            """Kill the worker that is running this actor."""
+            # TODO(swang): Also clean up forked actor handles.
+            # Kill the worker if this is the original actor handle, created
+            # with Class.remote().
+            if (ray.worker.global_worker.connected and
+                    self._ray_actor_handle_id.id() == ray.worker.NIL_ACTOR_ID):
+                self._actor_method_call("__ray_terminate__",
+                                        args=[self._ray_actor_id.id()])
 
     return ActorHandle
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -824,10 +824,10 @@ def make_actor(cls, num_cpus, num_gpus, checkpoint_interval):
         ray_actor_methods = inspect.getmembers(
             Class, predicate=(lambda x: (inspect.isfunction(x) or
                                          inspect.ismethod(x))))
-        export_actor_class(class_id, Class,
-                           [method_name for method_name, _ in ray_actor_methods],
-                           checkpoint_interval,
-                           ray.worker.global_worker)
+        export_actor_class(
+            class_id, Class,
+            [method_name for method_name, _ in ray_actor_methods],
+            checkpoint_interval, ray.worker.global_worker)
 
     return actor_handle_from_class(Class, class_id, num_cpus, num_gpus,
                                    checkpoint_interval)

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -170,6 +170,7 @@ class TestGlobalScheduler(unittest.TestCase):
         task2 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
                                      0, local_scheduler.ObjectID(NIL_ACTOR_ID),
+                                     local_scheduler.ObjectID(NIL_ACTOR_ID),
                                      0, 0, [1.0, 2.0, 0.0])
         self.assertEqual(task2.required_resources(), [1.0, 2.0, 0.0])
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -487,6 +487,16 @@ class Worker(object):
             for arg in args:
                 if isinstance(arg, ray.local_scheduler.ObjectID):
                     args_for_local_scheduler.append(arg)
+                elif isinstance(arg, ray.actor.ActorHandleParent):
+                    args_for_local_scheduler.append(put(
+                        ray.actor.ActorHandleWrapper(
+                            arg._ray_actor_id,
+                            arg._ray_actor_handle_id,
+                            arg._ray_actor_counter,
+                            arg._ray_actor_methods,
+                            arg._ray_method_signatures,
+                            arg._ray_checkpoint_interval,
+                            arg._ray_class_name)))
                 elif ray.local_scheduler.check_simple_value(arg):
                     args_for_local_scheduler.append(arg)
                 else:
@@ -653,14 +663,29 @@ class Worker(object):
         """
         arguments = []
         for (i, arg) in enumerate(serialized_args):
+            print("YYY", arg)
             if isinstance(arg, ray.local_scheduler.ObjectID):
                 # get the object from the local object store
                 argument = self.get_object([arg])[0]
+                print("AAA", type(argument), id(type(argument)))
+                print("BBB", ray.actor.ActorHandleWrapper, id(ray.actor.ActorHandleWrapper))
                 if isinstance(argument, RayTaskError):
                     # If the result is a RayTaskError, then the task that
                     # created this object failed, and we should propagate the
                     # error message here.
                     raise RayGetArgumentError(function_name, i, arg, argument)
+                elif isinstance(argument, ray.actor.ActorHandleWrapper):
+                    print("XXXXXXXXXXXX")
+                    argument = ray.actor.actor_handle_from_fields(
+                        self,
+                        argument.actor_id,
+                        argument.actor_handle_id,
+                        argument.actor_counter,
+                        argument.actor_methods,
+                        argument.method_signatures,
+                        argument.checkpoint_interval,
+                        argument.class_name
+                    )
             else:
                 # pass the argument by value
                 argument = arg

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -35,6 +35,9 @@ table TaskInfo {
   // Actor ID of the task. This is the actor that this task is executed on
   // or NIL_ACTOR_ID if the task is just a normal task.
   actor_id: string;
+  // The ID of the handle that was used to submit the task. This should be
+  // unique across handles with the same actor_id.
+  actor_handle_id: string;
   // Number of tasks that have been submitted to this actor so far.
   actor_counter: int;
   // True if this task is an actor checkpoint task and false otherwise.

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -271,6 +271,8 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   UniqueID driver_id;
   /* ID of the actor this task should run on. */
   UniqueID actor_id = NIL_ACTOR_ID;
+  /* ID of the actor handle used to submit this task. */
+  UniqueID actor_handle_id = NIL_ACTOR_ID;
   /* How many tasks have been launched on the actor so far? */
   int actor_counter = 0;
   /* True if this is an actor checkpoint task and false otherwise. */
@@ -287,12 +289,13 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   int parent_counter;
   /* Resource vector of the required resources to execute this task. */
   PyObject *resource_vector = NULL;
-  if (!PyArg_ParseTuple(args, "O&O&OiO&i|O&iOO", &PyObjectToUniqueID,
+  if (!PyArg_ParseTuple(args, "O&O&OiO&i|O&O&iOO", &PyObjectToUniqueID,
                         &driver_id, &PyObjectToUniqueID, &function_id,
                         &arguments, &num_returns, &PyObjectToUniqueID,
                         &parent_task_id, &parent_counter, &PyObjectToUniqueID,
-                        &actor_id, &actor_counter,
-                        &is_actor_checkpoint_method_object, &resource_vector)) {
+                        &actor_id, &PyObjectToUniqueID, &actor_handle_id,
+                        &actor_counter, &is_actor_checkpoint_method_object,
+                        &resource_vector)) {
     return -1;
   }
 
@@ -304,9 +307,10 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
 
   Py_ssize_t size = PyList_Size(arguments);
   /* Construct the task specification. */
-  TaskSpec_start_construct(
-      g_task_builder, driver_id, parent_task_id, parent_counter, actor_id,
-      actor_counter, is_actor_checkpoint_method, function_id, num_returns);
+  TaskSpec_start_construct(g_task_builder, driver_id, parent_task_id,
+                           parent_counter, actor_id, actor_handle_id,
+                           actor_counter, is_actor_checkpoint_method,
+                           function_id, num_returns);
   /* Add the task arguments. */
   for (Py_ssize_t i = 0; i < size; ++i) {
     PyObject *arg = PyList_GetItem(arguments, i);

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -38,6 +38,7 @@ class TaskBuilder {
              TaskID parent_task_id,
              int64_t parent_counter,
              ActorID actor_id,
+             ActorID actor_handle_id,
              int64_t actor_counter,
              bool is_actor_checkpoint_method,
              FunctionID function_id,
@@ -46,6 +47,7 @@ class TaskBuilder {
     parent_task_id_ = parent_task_id;
     parent_counter_ = parent_counter;
     actor_id_ = actor_id;
+    actor_handle_id_ = actor_handle_id;
     actor_counter_ = actor_counter;
     is_actor_checkpoint_method_ = is_actor_checkpoint_method;
     function_id_ = function_id;
@@ -107,7 +109,8 @@ class TaskBuilder {
     auto message = CreateTaskInfo(
         fbb, to_flatbuf(fbb, driver_id_), to_flatbuf(fbb, task_id),
         to_flatbuf(fbb, parent_task_id_), parent_counter_,
-        to_flatbuf(fbb, actor_id_), actor_counter_, is_actor_checkpoint_method_,
+        to_flatbuf(fbb, actor_id_), to_flatbuf(fbb, actor_handle_id_),
+        actor_counter_, is_actor_checkpoint_method_,
         to_flatbuf(fbb, function_id_), arguments, fbb.CreateVector(returns),
         fbb.CreateVector(resource_vector_));
     /* Finish the TaskInfo. */
@@ -130,6 +133,7 @@ class TaskBuilder {
   TaskID parent_task_id_;
   int64_t parent_counter_;
   ActorID actor_id_;
+  ActorID actor_handle_id_;
   int64_t actor_counter_;
   bool is_actor_checkpoint_method_;
   FunctionID function_id_;
@@ -172,13 +176,14 @@ void TaskSpec_start_construct(TaskBuilder *builder,
                               TaskID parent_task_id,
                               int64_t parent_counter,
                               ActorID actor_id,
+                              ActorID actor_handle_id,
                               int64_t actor_counter,
                               bool is_actor_checkpoint_method,
                               FunctionID function_id,
                               int64_t num_returns) {
   builder->Start(driver_id, parent_task_id, parent_counter, actor_id,
-                 actor_counter, is_actor_checkpoint_method, function_id,
-                 num_returns);
+                 actor_handle_id, actor_counter, is_actor_checkpoint_method,
+                 function_id, num_returns);
 }
 
 uint8_t *TaskSpec_finish_construct(TaskBuilder *builder, int64_t *size) {
@@ -219,6 +224,12 @@ ActorID TaskSpec_actor_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
   return from_flatbuf(message->actor_id());
+}
+
+ActorID TaskSpec_actor_handle_id(TaskSpec *spec) {
+  CHECK(spec);
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec);
+  return from_flatbuf(message->actor_handle_id());
 }
 
 bool TaskSpec_is_actor_task(TaskSpec *spec) {

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -86,6 +86,9 @@ void free_task_builder(TaskBuilder *builder);
  *        the parent task prior to this one.
  * @param actor_id The ID of the actor that this task is for. If it is not an
  *        actor task, then this if NIL_ACTOR_ID.
+ * @param actor_handle_id The ID of the actor handle that this task was
+ *        submitted through. If it is not an actor task, or if this is the
+ *        original handle, then this is NIL_ACTOR_ID.
  * @param actor_counter A counter indicating how many tasks have been submitted
  *        to the same actor before this one.
  * @param is_actor_checkpoint_method True if this is an actor checkpoint method
@@ -102,6 +105,7 @@ void TaskSpec_start_construct(TaskBuilder *B,
                               TaskID parent_task_id,
                               int64_t parent_counter,
                               UniqueID actor_id,
+                              UniqueID actor_handle_id,
                               int64_t actor_counter,
                               bool is_actor_checkpoint_method,
                               FunctionID function_id,
@@ -132,6 +136,14 @@ FunctionID TaskSpec_function(TaskSpec *spec);
  * @return The actor ID of the actor the task is part of.
  */
 UniqueID TaskSpec_actor_id(TaskSpec *spec);
+
+/**
+ * Return the actor handle ID of the task.
+ *
+ * @param spec The task_spec in question.
+ * @return The ID of the actor handle that the task was submitted through.
+ */
+UniqueID TaskSpec_actor_handle_id(TaskSpec *spec);
 
 /**
  * Return whether this task is for an actor.

--- a/src/common/test/example_task.h
+++ b/src/common/test/example_task.h
@@ -14,7 +14,8 @@ static inline TaskSpec *example_task_spec_with_args(int64_t num_args,
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
   TaskSpec_start_construct(g_task_builder, NIL_ID, parent_task_id, 0,
-                           NIL_ACTOR_ID, 0, false, func_id, num_returns);
+                           NIL_ACTOR_ID, NIL_ACTOR_ID, 0, false, func_id,
+                           num_returns);
   for (int64_t i = 0; i < num_args; ++i) {
     ObjectID arg_id;
     if (arg_ids == NULL) {

--- a/src/common/test/task_tests.cc
+++ b/src/common/test/task_tests.cc
@@ -15,8 +15,8 @@ TEST task_test(void) {
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
   TaskBuilder *builder = make_task_builder();
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 2);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 2);
 
   UniqueID arg1 = globally_unique_id();
   TaskSpec_args_add_ref(builder, arg1);
@@ -54,16 +54,16 @@ TEST deterministic_ids_test(void) {
   uint8_t *arg2 = (uint8_t *) "hello world";
 
   /* Construct a first task. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size1;
   TaskSpec *spec1 = TaskSpec_finish_construct(builder, &size1);
 
   /* Construct a second identical task. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size2;
@@ -83,39 +83,39 @@ TEST deterministic_ids_test(void) {
 
   /* Construct a task with a different parent task ID. */
   TaskSpec_start_construct(builder, NIL_ID, globally_unique_id(), 0,
-                           NIL_ACTOR_ID, 0, false, func_id, 3);
+                           NIL_ACTOR_ID, NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size3;
   TaskSpec *spec3 = TaskSpec_finish_construct(builder, &size3);
 
   /* Construct a task with a different parent counter. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 1, NIL_ACTOR_ID, 0,
-                           false, func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 1, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size4;
   TaskSpec *spec4 = TaskSpec_finish_construct(builder, &size4);
 
   /* Construct a task with a different function ID. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, globally_unique_id(), 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, globally_unique_id(), 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size5;
   TaskSpec *spec5 = TaskSpec_finish_construct(builder, &size5);
 
   /* Construct a task with a different object ID argument. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, globally_unique_id());
   TaskSpec_args_add_val(builder, arg2, 11);
   int64_t size6;
   TaskSpec *spec6 = TaskSpec_finish_construct(builder, &size6);
 
   /* Construct a task with a different value argument. */
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 3);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 3);
   TaskSpec_args_add_ref(builder, arg1);
   TaskSpec_args_add_val(builder, (uint8_t *) "hello_world", 11);
   int64_t size7;
@@ -159,8 +159,8 @@ TEST send_task(void) {
   TaskBuilder *builder = make_task_builder();
   TaskID parent_task_id = globally_unique_id();
   FunctionID func_id = globally_unique_id();
-  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID, 0,
-                           false, func_id, 2);
+  TaskSpec_start_construct(builder, NIL_ID, parent_task_id, 0, NIL_ACTOR_ID,
+                           NIL_ACTOR_ID, 0, false, func_id, 2);
   TaskSpec_args_add_ref(builder, globally_unique_id());
   TaskSpec_args_add_val(builder, (uint8_t *) "Hello", 5);
   TaskSpec_args_add_val(builder, (uint8_t *) "World", 5);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -51,16 +51,16 @@ struct ObjectEntry {
 /** This struct contains information about a specific actor. This struct will be
  *  used inside of a hash table. */
 typedef struct {
-  /** The number of tasks that have been executed on this actor so far. This is
-   *  used to guarantee the in-order execution of tasks on actors (in the order
-   *  that the tasks were submitted). This is currently meaningful because we
-   *  restrict the submission of tasks on actors to the process that created the
-   *  actor. */
-  int64_t task_counter;
+  /** The number of tasks that have been executed on this actor so far, per
+   *  handle. This is used to guarantee execution of tasks on actors in the
+   *  order that the tasks were submitted, per handle. Tasks from different
+   *  handles to the same actor may be interleaved. */
+  std::unordered_map<ActorID, int64_t, UniqueIDHasher> task_counters;
   /** The index of the task assigned to this actor. Set to -1 if no task is
    *  currently assigned. If the actor process reports back success for the
    *  assigned task execution, task_counter should be set to this value. */
   int64_t assigned_task_counter;
+  ActorID assigned_task_handle_id;
   /** Whether the actor process has loaded yet. The actor counts as loaded once
    *  it has either executed its first task or successfully resumed from a
    *  checkpoint. Before the actor has loaded, we may dispatch the first task
@@ -247,8 +247,9 @@ void create_actor(SchedulingAlgorithmState *algorithm_state,
                   ActorID actor_id,
                   LocalSchedulerClient *worker) {
   LocalActorInfo entry;
-  entry.task_counter = 0;
+  entry.task_counters[NIL_ACTOR_ID] = 0;
   entry.assigned_task_counter = -1;
+  entry.assigned_task_handle_id = NIL_ACTOR_ID;
   entry.task_queue = new std::list<TaskQueueEntry>();
   entry.worker = worker;
   entry.worker_available = false;
@@ -333,16 +334,17 @@ bool dispatch_actor_task(LocalSchedulerState *state,
   /* Check whether we can execute the first task in the queue. */
   auto task = entry.task_queue->begin();
   int64_t next_task_counter = TaskSpec_actor_counter(task->spec);
+  ActorID next_task_handle_id = TaskSpec_actor_handle_id(task->spec);
   if (entry.loaded) {
     /* Once the actor has loaded, we can only execute tasks in order of
      * task_counter. */
-    if (next_task_counter != entry.task_counter) {
+    if (next_task_counter != entry.task_counters[next_task_handle_id]) {
       return false;
     }
   } else {
     /* If the actor has not yet loaded, we can only execute the task that
      * matches task_counter (the first task), or a checkpoint task. */
-    if (next_task_counter != entry.task_counter) {
+    if (next_task_counter != entry.task_counters[next_task_handle_id]) {
       /* No other task should be first in the queue. */
       CHECK(TaskSpec_is_actor_checkpoint_method(task->spec));
     }
@@ -361,6 +363,7 @@ bool dispatch_actor_task(LocalSchedulerState *state,
    * as unavailable. */
   assign_task_to_worker(state, task->spec, task->task_spec_size, entry.worker);
   entry.assigned_task_counter = next_task_counter;
+  entry.assigned_task_handle_id = next_task_handle_id;
   entry.worker_available = false;
   /* Free the task queue entry. */
   TaskQueueEntry_free(&(*task));
@@ -407,6 +410,8 @@ void insert_actor_task_queue(LocalSchedulerState *state,
                              TaskQueueEntry task_entry) {
   /* Get the local actor entry for this actor. */
   ActorID actor_id = TaskSpec_actor_id(task_entry.spec);
+  ActorID task_handle_id = TaskSpec_actor_handle_id(task_entry.spec);
+  int64_t task_counter = TaskSpec_actor_counter(task_entry.spec);
 
   /* Handle the case in which there is no LocalActorInfo struct yet. */
   if (algorithm_state->local_actor_infos.count(actor_id) == 0) {
@@ -418,40 +423,43 @@ void insert_actor_task_queue(LocalSchedulerState *state,
   }
   LocalActorInfo &entry =
       algorithm_state->local_actor_infos.find(actor_id)->second;
+  if (entry.task_counters.count(task_handle_id) == 0) {
+    entry.task_counters[task_handle_id] = 0;
+  }
 
-  int64_t task_counter = TaskSpec_actor_counter(task_entry.spec);
   /* As a sanity check, the counter of the new task should be greater than the
    * number of tasks that have executed on this actor so far (since we are
    * guaranteeing in-order execution of the tasks on the actor). TODO(rkn): This
    * check will fail if the fault-tolerance mechanism resubmits a task on an
    * actor. */
-  if (task_counter < entry.task_counter) {
+  if (task_counter < entry.task_counters[task_handle_id]) {
     LOG_INFO(
         "A task that has already been executed has been resubmitted, so we "
         "are ignoring it. This should only happen during reconstruction.");
     return;
   }
 
-  /* Add the task spec to the actor's task queue in a manner that preserves the
-   * order of the actor task counters. Iterate from the beginning of the queue
-   * to find the right place to insert the task queue entry. TODO(pcm): This
-   * makes submitting multiple actor tasks take quadratic time, which needs to
-   * be optimized. */
+  /* Insert the task spec to the actor's task queue in sorted order, per actor
+   * handle ID. Find the first task in the queue with a counter greater than
+   * the submitted task's and the same handle ID. */
   auto it = entry.task_queue->begin();
-  while (it != entry.task_queue->end() &&
-         (task_counter > TaskSpec_actor_counter(it->spec))) {
-    ++it;
+  for (; it != entry.task_queue->end(); it++) {
+    /* Skip tasks submitted by a different handle. */
+    if (!ActorID_equal(task_handle_id, TaskSpec_actor_handle_id(it->spec))) {
+      continue;
+    }
+    /* A duplicate task submitted by the same handle. */
+    if (task_counter == TaskSpec_actor_counter(it->spec)) {
+      LOG_INFO(
+          "A task was resubmitted, so we are ignoring it. This should only "
+          "happen during reconstruction.");
+      return;
+    }
+    /* We found a task with the same handle ID and a greater task counter. */
+    if (task_counter < TaskSpec_actor_counter(it->spec)) {
+      break;
+    }
   }
-  if (it != entry.task_queue->end() &&
-      task_counter == TaskSpec_actor_counter(it->spec)) {
-    LOG_INFO(
-        "A task was resubmitted, so we are ignoring it. This should only "
-        "happen during reconstruction.");
-    return;
-  }
-
-  /* The task has a counter that has not been executed or submitted before. Add
-   * it to the actor queue. */
   entry.task_queue->insert(it, task_entry);
 
   /* Record the fact that this actor has a task waiting to execute. */
@@ -1266,7 +1274,8 @@ void handle_actor_worker_available(LocalSchedulerState *state,
    * loaded the checkpoint successfully, then we update the actor's counter
    * to the assigned counter. */
   if (!actor_checkpoint_failed) {
-    entry.task_counter = entry.assigned_task_counter + 1;
+    entry.task_counters[entry.assigned_task_handle_id] =
+        entry.assigned_task_counter + 1;
     /* If a task was assigned to this actor and there was no checkpoint
      * failure, then it is now loaded. */
     if (entry.assigned_task_counter > -1) {
@@ -1274,6 +1283,7 @@ void handle_actor_worker_available(LocalSchedulerState *state,
     }
   }
   entry.assigned_task_counter = -1;
+  entry.assigned_task_handle_id = NIL_ACTOR_ID;
   entry.worker_available = true;
   /* Assign new tasks if possible. */
   dispatch_all_tasks(state, algorithm_state);

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -58,8 +58,13 @@ typedef struct {
   std::unordered_map<ActorID, int64_t, UniqueIDHasher> task_counters;
   /** The index of the task assigned to this actor. Set to -1 if no task is
    *  currently assigned. If the actor process reports back success for the
-   *  assigned task execution, task_counter should be set to this value. */
+   *  assigned task execution, then the corresponding task_counter should be
+   *  updated to this value. */
   int64_t assigned_task_counter;
+  /** The handle that the currently assigned task was submitted by. This field
+   *  is only valid if assigned_task_counter is set. If the actor process
+   *  reports back success for the assigned task execution, then the
+   *  task_counter corresponding to this handle should be updated. */
   ActorID assigned_task_handle_id;
   /** Whether the actor process has loaded yet. The actor counts as loaded once
    *  it has either executed its first task or successfully resumed from a

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -164,9 +164,27 @@ class ActorAPI(unittest.TestCase):
         self.assertEqual(results2[1].x, 2)
         self.assertEqual(results2[2].x, 3)
 
-    # def testCachingActors(self):
-    #   # TODO(rkn): Implement this.
-    #   pass
+    def testCachingActors(self):
+        # Test defining actors before ray.init() has been called.
+
+        @ray.remote
+        class Foo(object):
+            def __init__(self):
+                pass
+
+            def get_val(self):
+                return 3
+
+        # Check that we can't actually create actors before ray.init() has been
+        # called.
+        with self.assertRaises(Exception):
+            f = Foo.remote()
+
+        ray.init(num_workers=0)
+
+        f = Foo.remote()
+
+        self.assertEqual(ray.get(f.get_val.remote()), 3)
 
     def testDecoratorArgs(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)


### PR DESCRIPTION
Allow a task that creates an actor handle to pass it to another task. The passed handle will get forked, so that tasks that get submitted after the fork will get executed after tasks that were submitted before the fork. Tasks will also be serialized per fork of the actor handle. The actor is garbage-collected when the original handle goes out of scope.

The local scheduler schedules tasks FIFO by submission order, regardless of the actor handle it was submitted by.