### PR TITLE
Always redirect redis stdout/stderr.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -878,7 +878,7 @@ def start_ray_processes(address_info=None,
         redis_address, redis_shards = start_redis(
             node_ip_address, port=redis_port,
             num_redis_shards=num_redis_shards,
-            redirect_output=redirect_output,
+            redirect_output=True,
             redirect_worker_output=redirect_output, cleanup=cleanup)
         address_info["redis_address"] = redis_address
         time.sleep(0.1)


### PR DESCRIPTION
This is intended to address #1135.

Are there situations where we actually want to see the output of starting the redis servers?