### PR TITLE
Expose custom serializers through the API.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -43,7 +43,7 @@ except ImportError as e:
 from ray.worker import (error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
                         flush_log, get_gpu_ids, get_webui_url,
-                        register_custom_serializers)  # noqa: E402
+                        register_custom_serializer)  # noqa: E402
 from ray.worker import (SCRIPT_MODE, WORKER_MODE, PYTHON_MODE,
                         SILENT_MODE)  # noqa: E402
 from ray.worker import global_state  # noqa: E402
@@ -57,7 +57,7 @@ __version__ = "0.2.1"
 
 __all__ = ["error_info", "init", "connect", "disconnect", "get", "put", "wait",
            "remote", "log_event", "log_span", "flush_log", "actor",
-           "get_gpu_ids", "get_webui_url", "register_custom_serializers",
+           "get_gpu_ids", "get_webui_url", "register_custom_serializer",
            "SCRIPT_MODE", "WORKER_MODE", "PYTHON_MODE", "SILENT_MODE",
            "global_state", "__version__"]
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -40,9 +40,10 @@ except ImportError as e:
             e.args += (helpful_message,)
     raise
 
-from ray.worker import (register_class, error_info, init, connect, disconnect,
+from ray.worker import (error_info, init, connect, disconnect,
                         get, put, wait, remote, log_event, log_span,
-                        flush_log, get_gpu_ids, get_webui_url)  # noqa: E402
+                        flush_log, get_gpu_ids, get_webui_url,
+                        register_custom_serializers)  # noqa: E402
 from ray.worker import (SCRIPT_MODE, WORKER_MODE, PYTHON_MODE,
                         SILENT_MODE)  # noqa: E402
 from ray.worker import global_state  # noqa: E402
@@ -54,9 +55,9 @@ import ray.actor  # noqa: F401
 # Fix this.
 __version__ = "0.2.1"
 
-__all__ = ["register_class", "error_info", "init", "connect", "disconnect",
-           "get", "put", "wait", "remote", "log_event", "log_span",
-           "flush_log", "actor", "get_gpu_ids", "get_webui_url",
+__all__ = ["error_info", "init", "connect", "disconnect", "get", "put", "wait",
+           "remote", "log_event", "log_span", "flush_log", "actor",
+           "get_gpu_ids", "get_webui_url", "register_custom_serializers",
            "SCRIPT_MODE", "WORKER_MODE", "PYTHON_MODE", "SILENT_MODE",
            "global_state", "__version__"]
 

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -7,6 +7,12 @@ class RayNotDictionarySerializable(Exception):
     pass
 
 
+# This exception is used to represent situations where cloudpickle fails to
+# pickle an object (cloudpickle can fail in many different ways).
+class RayPicklingError(Exception):
+    pass
+
+
 def check_serializable(cls):
     """Throws an exception if Ray cannot serialize this class efficiently.
 

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -9,7 +9,7 @@ class RayNotDictionarySerializable(Exception):
 
 # This exception is used to represent situations where cloudpickle fails to
 # pickle an object (cloudpickle can fail in many different ways).
-class RayPicklingError(Exception):
+class CloudPickleError(Exception):
     pass
 
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1901,6 +1901,47 @@ def disconnect(worker=global_worker):
     worker.serialization_context = pyarrow.SerializationContext()
 
 
+def _try_to_compute_deterministic_class_id(cls, depth=5):
+    """Attempt to produce a deterministic class ID for a given class.
+
+    The goal here is for the class ID to be the same when this is run on
+    different worker processes. Pickling, loading, and pickling again seems to
+    produce more consistent results than simply pickling. This is a bit crazy
+    and could cause problems, in which case we should revert it and figure out
+    something better.
+
+    Args:
+        cls: The class to produce an ID for.
+        depth: The number of times to repeatedly try to load and dump the
+            string while trying to reach a fixed point.
+
+    Returns:
+        A class ID for this class. We attempt to make the class ID the same
+            when this function is run on different workers, but that is not
+            guaranteed.
+
+    Raises:
+        Exception: This could raise an exception if cloudpickle raises an
+            exception.
+    """
+    # Pickling, loading, and pickling again seems to produce more consistent
+    # results than simply pickling. This is a bit
+    class_id = pickle.dumps(cls)
+    for _ in range(depth):
+        new_class_id = pickle.dumps(pickle.loads(class_id))
+        if new_class_id == class_id:
+            # We appear to have reached a fix point, so use this as the ID.
+            return hashlib.sha1(new_class_id).digest()
+        class_id = new_class_id
+
+    # We have not reached a fixed point, so we may end up with a different
+    # class ID for this custom class on each worker, which could lead to the
+    # same class definition being exported many many times.
+    print("WARNING: Could not produce a deterministic class ID for class "
+          "{}".format(cls), file=sys.stderr)
+    return hashlib.sha1(new_class_id).digest()
+
+
 def register_custom_serializer(cls, use_pickle=False, use_dict=False,
                                serializer=None, deserializer=None,
                                local=False, worker=global_worker):
@@ -1958,7 +1999,10 @@ def register_custom_serializer(cls, use_pickle=False, use_dict=False,
         # that would run the risk of having collisions. TODO(rkn): We should
         # improve this.
         try:
-            class_id = hashlib.sha1(pickle.dumps(cls)).digest()
+            # Attempt to produce a class ID that will be the same on each
+            # worker. However, determinism is not guaranteed, and the result
+            # may be different on different workers.
+            class_id = _try_to_compute_deterministic_class_id(cls)
         except Exception as e:
             raise serialization.CloudPickleError("Failed to pickle class "
                                                  "'{}'".format(cls))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1970,22 +1970,16 @@ def register_custom_serializer(cls, use_pickle=False, use_dict=False,
             be efficiently serialized by Ray. This can also raise an exception
             if use_dict is true and cls is not pickleable.
     """
-    assert not (use_pickle and use_dict), ("If use_pickle is true, then "
-                                           "use_dict must be false.")
+    assert (serializer is None) == (deserializer is None), (
+        "The serializer/deserializer arguments must both be provided or "
+        "both not be provided."
+    )
+    use_custom_serializer = (serializer is not None)
 
-    if use_pickle or use_dict:
-        assert serializer is None, ("A serializer should not be provided if "
-                                    "use_pickle is true.")
-        assert deserializer is None, ("A deserializer should not be provided "
-                                      "if use_pickle is true.")
-
-    if not (use_pickle or use_dict):
-        assert serializer is not None, ("A custom serializer must be provided "
-                                        "if use_pickle and use_dict are "
-                                        "false.")
-        assert deserializer is not None, ("A custom deserializer must be "
-                                          "provided if use_pickle and "
-                                          "use_dict are false.")
+    assert use_custom_serializer + use_pickle + use_dict == 1, (
+        "Exactly one of use_pickle, use_dict, or serializer/deserializer must "
+        "be specified."
+    )
 
     if use_dict:
         # Raise an exception if cls cannot be serialized efficiently by Ray.

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -352,7 +352,7 @@ class APITest(unittest.TestCase):
                 self.x = 3
 
         def custom_serializer(obj):
-            return obj.x, "string1"
+            return 3, "string1", type(obj).__name__
 
         def custom_deserializer(serialized_obj):
             return serialized_obj, "string2"
@@ -360,7 +360,8 @@ class APITest(unittest.TestCase):
         ray.register_custom_serializer(Foo, serializer=custom_serializer,
                                        deserializer=custom_deserializer)
 
-        self.assertEqual(ray.get(ray.put(Foo())), ((3, "string1"), "string2"))
+        self.assertEqual(ray.get(ray.put(Foo())),
+                         ((3, "string1", Foo.__name__), "string2"))
 
         class Bar(object):
             def __init__(self):
@@ -374,7 +375,8 @@ class APITest(unittest.TestCase):
             return Bar()
 
         # The test below is commented out because it currently does not work.
-        # self.assertEqual(ray.get(f.remote()), ((3, "string1"), "string2"))
+        self.assertEqual(ray.get(f.remote()),
+                         ((3, "string1", Bar.__name__), "string2"))
 
     def testRegisterClass(self):
         self.init_ray({"num_workers": 2})

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -374,7 +374,6 @@ class APITest(unittest.TestCase):
         def f():
             return Bar()
 
-        # The test below is commented out because it currently does not work.
         self.assertEqual(ray.get(f.remote()),
                          ((3, "string1", Bar.__name__), "string2"))
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -357,8 +357,8 @@ class APITest(unittest.TestCase):
         def custom_deserializer(serialized_obj):
             return serialized_obj, "string2"
 
-        ray.register_custom_serializers(Foo, serializer=custom_serializer,
-                                        deserializer=custom_deserializer)
+        ray.register_custom_serializer(Foo, serializer=custom_serializer,
+                                       deserializer=custom_deserializer)
 
         self.assertEqual(ray.get(ray.put(Foo())), ((3, "string1"), "string2"))
 
@@ -366,8 +366,8 @@ class APITest(unittest.TestCase):
             def __init__(self):
                 self.x = 3
 
-        ray.register_custom_serializers(Bar, serializer=custom_serializer,
-                                        deserializer=custom_deserializer)
+        ray.register_custom_serializer(Bar, serializer=custom_serializer,
+                                       deserializer=custom_deserializer)
 
         @ray.remote
         def f():


### PR DESCRIPTION
This is intended to address #899. It still does not quite work in the case where the call to `ray.register_custom_serializers` happens on worker (e.g., the driver), and an object of the relevant type gets serialized on a different worker.