### PR TITLE
[rllib] Multi-gpu optimizer should do splits on CPU device to avoid GPU OOMs

### DIFF
--- a/python/ray/rllib/parallel.py
+++ b/python/ray/rllib/parallel.py
@@ -59,8 +59,12 @@ class LocalSyncParallelOptimizer(object):
 
         # Then setup the per-device loss graphs that use the shared weights
         self._batch_index = tf.placeholder(tf.int32)
-        data_splits = zip(
-            *[tf.split(ph, len(devices)) for ph in input_placeholders])
+
+        # Split on the CPU in case the data doesn't fit in GPU memory.
+        with tf.device("/cpu:0"):
+            data_splits = zip(
+                *[tf.split(ph, len(devices)) for ph in input_placeholders])
+
         self._towers = []
         for device, device_placeholders in zip(self.devices, data_splits):
             self._towers.append(self._setup_device(device,


### PR DESCRIPTION
Turns out these ops were getting auto-assigned to a random GPU. As a result, large data loads would OOM the single GPU, even if the data would fit on GPU memory in aggregate.

Before: PPO could only load <16k Pong-v0 samples regardless of the number of GPUs.

After: PPO can load 20k+ observations per GPU (so 16 GPUs can support 320k full observations).

cc @pcmoritz