### PR TITLE
Local scheduler filters out dead clients during reconstruction

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -353,9 +353,9 @@ class GlobalState(object):
                 "Deleted": bool(int(decode(client_info[b"deleted"]))),
                 "DBClientID": binary_to_hex(client_info[b"ray_client_id"])
             }
-            if b"aux_address" in client_info:
+            if b"manager_address" in client_info:
                 client_info_parsed["AuxAddress"] = decode(
-                    client_info[b"aux_address"])
+                    client_info[b"manager_address"])
             if b"num_cpus" in client_info:
                 client_info_parsed["NumCPUs"] = float(
                     decode(client_info[b"num_cpus"]))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1095,7 +1095,7 @@ def get_address_info_from_redis_helper(redis_address, node_ip_address):
     # Build the address information.
     object_store_addresses = []
     for manager in plasma_managers:
-        address = manager[b"address"].decode("ascii")
+        address = manager[b"aux_address"].decode("ascii")
         port = services.get_port(address)
         object_store_addresses.append(
             services.ObjectStoreAddress(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1095,7 +1095,7 @@ def get_address_info_from_redis_helper(redis_address, node_ip_address):
     # Build the address information.
     object_store_addresses = []
     for manager in plasma_managers:
-        address = manager[b"aux_address"].decode("ascii")
+        address = manager[b"manager_address"].decode("ascii")
         port = services.get_port(address)
         object_store_addresses.append(
             services.ObjectStoreAddress(

--- a/src/common/common.cc
+++ b/src/common/common.cc
@@ -44,6 +44,10 @@ bool DBClientID_equal(DBClientID first_id, DBClientID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }
 
+bool DBClientID_is_nil(DBClientID id) {
+  return IS_NIL_ID(id);
+}
+
 bool WorkerID_equal(WorkerID first_id, WorkerID second_id) {
   return UNIQUE_ID_EQ(first_id, second_id);
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -218,6 +218,14 @@ typedef UniqueID DBClientID;
  */
 bool DBClientID_equal(DBClientID first_id, DBClientID second_id);
 
+/**
+ * Compare a db client ID to the nil ID.
+ *
+ * @param id The db client ID to compare to nil.
+ * @return True if the db client ID is equal to nil.
+ */
+bool DBClientID_is_nil(ObjectID id);
+
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
 #define MIN(x, y) ((x) <= (y) ? (x) : (y))
 

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -107,8 +107,6 @@ root_type TaskReply;
 table SubscribeToDBClientTableReply {
   // The db client ID of the client that the message is about.
   db_client_id: string;
-  // The IP address of the client.
-  node_ip_address: string;
   // The type of the client.
   client_type: string;
   // If the client is a local scheduler, this is the address of the plasma

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -107,6 +107,8 @@ root_type TaskReply;
 table SubscribeToDBClientTableReply {
   // The db client ID of the client that the message is about.
   db_client_id: string;
+  // The IP address of the client.
+  node_ip_address: string;
   // The type of the client.
   client_type: string;
   // If the client is a local scheduler, this is the address of the plasma

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -111,7 +111,7 @@ table SubscribeToDBClientTableReply {
   client_type: string;
   // If the client is a local scheduler, this is the address of the plasma
   // manager that the local scheduler is connected to. Otherwise, it is empty.
-  aux_address: string;
+  manager_address: string;
   // True if the message is about the addition of a client and false if it is
   // about the deletion of a client.
   is_insertion: bool;

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -280,50 +280,6 @@ int Disconnect_RedisCommand(RedisModuleCtx *ctx,
 }
 
 /**
- * Get the address of a client from its db client ID. This is called from a
- * client with the command:
- *
- *     RAY.GET_CLIENT_ADDRESS <ray client id>
- *
- * @param ray_client_id The db client ID of the client.
- * @return The address of the client if the operation was successful.
- */
-int GetClientAddress_RedisCommand(RedisModuleCtx *ctx,
-                                  RedisModuleString **argv,
-                                  int argc) {
-  if (argc != 2) {
-    return RedisModule_WrongArity(ctx);
-  }
-
-  RedisModuleString *ray_client_id = argv[1];
-  /* Get the request client address from the db client table. */
-  RedisModuleKey *db_client_table_key =
-      OpenPrefixedKey(ctx, DB_CLIENT_PREFIX, ray_client_id, REDISMODULE_READ);
-  if (db_client_table_key == NULL) {
-    /* There is no client with this ID. */
-    RedisModule_CloseKey(db_client_table_key);
-    return RedisModule_ReplyWithError(ctx, "invalid client ID");
-  }
-  RedisModuleString *address;
-  RedisModule_HashGet(db_client_table_key, REDISMODULE_HASH_CFIELDS,
-                      "manager_address", &address, NULL);
-  if (address == NULL) {
-    /* The key did not exist. This should not happen. */
-    RedisModule_CloseKey(db_client_table_key);
-    return RedisModule_ReplyWithError(
-        ctx, "Client does not have an address field. This shouldn't happen.");
-  }
-
-  RedisModule_ReplyWithString(ctx, address);
-
-  /* Cleanup. */
-  RedisModule_CloseKey(db_client_table_key);
-  RedisModule_FreeString(ctx, address);
-
-  return REDISMODULE_OK;
-}
-
-/**
  * Lookup an entry in the object table.
  *
  * This is called from a client with the command:
@@ -1190,12 +1146,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx,
 
   if (RedisModule_CreateCommand(ctx, "ray.disconnect", Disconnect_RedisCommand,
                                 "write pubsub", 0, 0, 0) == REDISMODULE_ERR) {
-    return REDISMODULE_ERR;
-  }
-
-  if (RedisModule_CreateCommand(ctx, "ray.get_client_address",
-                                GetClientAddress_RedisCommand, "write", 0, 0,
-                                0) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
 

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -99,7 +99,6 @@ flatbuffers::Offset<flatbuffers::String> RedisStringToFlatbuf(
  */
 bool PublishDBClientNotification(RedisModuleCtx *ctx,
                                  RedisModuleString *ray_client_id,
-                                 RedisModuleString *node_ip_address,
                                  RedisModuleString *client_type,
                                  RedisModuleString *aux_address,
                                  bool is_insertion) {
@@ -118,7 +117,6 @@ bool PublishDBClientNotification(RedisModuleCtx *ctx,
   /* Create the flatbuffers message. */
   auto message = CreateSubscribeToDBClientTableReply(
       fbb, RedisStringToFlatbuf(fbb, ray_client_id),
-      RedisStringToFlatbuf(fbb, node_ip_address),
       RedisStringToFlatbuf(fbb, client_type), aux_address_str, is_insertion);
   fbb.Finish(message);
   /* Create a Redis string to publish by serializing the flatbuffers object. */
@@ -203,8 +201,8 @@ int Connect_RedisCommand(RedisModuleCtx *ctx,
   RedisModule_FreeString(ctx, deleted);
   RedisModule_FreeString(ctx, aux_address_key);
   RedisModule_CloseKey(db_client_table_key);
-  if (!PublishDBClientNotification(ctx, ray_client_id, node_ip_address,
-                                   client_type, aux_address, true)) {
+  if (!PublishDBClientNotification(ctx, ray_client_id, client_type, aux_address,
+                                   true)) {
     return RedisModule_ReplyWithError(ctx, "PUBLISH unsuccessful");
   }
 
@@ -257,16 +255,15 @@ int Disconnect_RedisCommand(RedisModuleCtx *ctx,
                         "deleted", deleted, NULL);
     RedisModule_FreeString(ctx, deleted);
 
-    RedisModuleString *node_ip_address;
     RedisModuleString *client_type;
     RedisModuleString *aux_address;
     RedisModule_HashGet(db_client_table_key, REDISMODULE_HASH_CFIELDS,
-                        "node_ip_address", &node_ip_address, "client_type",
-                        &client_type, "aux_address", &aux_address, NULL);
+                        "client_type", &client_type, "aux_address",
+                        &aux_address, NULL);
 
     /* Publish the deletion notification on the db client channel. */
-    published = PublishDBClientNotification(ctx, ray_client_id, node_ip_address,
-                                            client_type, aux_address, false);
+    published = PublishDBClientNotification(ctx, ray_client_id, client_type,
+                                            aux_address, false);
     if (aux_address != NULL) {
       RedisModule_FreeString(ctx, aux_address);
     }
@@ -311,8 +308,8 @@ int GetClientAddress_RedisCommand(RedisModuleCtx *ctx,
     return RedisModule_ReplyWithError(ctx, "invalid client ID");
   }
   RedisModuleString *address;
-  RedisModule_HashGet(db_client_table_key, REDISMODULE_HASH_CFIELDS, "address",
-                      &address, NULL);
+  RedisModule_HashGet(db_client_table_key, REDISMODULE_HASH_CFIELDS,
+                      "aux_address", &address, NULL);
   if (address == NULL) {
     /* The key did not exist. This should not happen. */
     RedisModule_CloseKey(db_client_table_key);

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -42,7 +42,8 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
 
   for (auto const &manager_id : manager_ids) {
     DBClient client = redis_cache_get_db_client(db_handle, manager_id);
-    manager_vector.push_back(client.node_ip_address);
+    CHECK(!client.aux_address.empty());
+    manager_vector.push_back(client.aux_address);
   }
 
   int64_t end_time = current_time_ms();

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -62,9 +62,14 @@ void db_client_table_update_cache_callback(DBClient *db_client,
   redis_cache_set_db_client(db_handle, *db_client);
 }
 
-void db_client_table_init_cache(DBHandle *db_handle) {
+void db_client_table_cache_init(DBHandle *db_handle) {
   db_client_table_subscribe(db_handle, db_client_table_update_cache_callback,
                             db_handle, NULL, NULL, NULL);
+}
+
+DBClient db_client_table_cache_get(DBHandle *db_handle, DBClientID client_id) {
+  CHECK(!ObjectID_is_nil(client_id));
+  return redis_cache_get_db_client(db_handle, client_id);
 }
 
 void plasma_manager_send_heartbeat(DBHandle *db_handle) {

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -41,9 +41,8 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
   std::vector<std::string> manager_vector;
 
   for (auto const &manager_id : manager_ids) {
-    const std::string manager_address =
-        redis_get_cached_db_client(db_handle, manager_id);
-    manager_vector.push_back(manager_address);
+    DBClient client = redis_cache_get_db_client(db_handle, manager_id);
+    manager_vector.push_back(client.node_ip_address);
   }
 
   int64_t end_time = current_time_ms();

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -56,6 +56,17 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
   return manager_vector;
 }
 
+void db_client_table_update_cache_callback(DBClient *db_client,
+                                           void *user_context) {
+  DBHandle *db_handle = (DBHandle *) user_context;
+  redis_cache_set_db_client(db_handle, *db_client);
+}
+
+void db_client_table_init_cache(DBHandle *db_handle) {
+  db_client_table_subscribe(db_handle, db_client_table_update_cache_callback,
+                            db_handle, NULL, NULL, NULL);
+}
+
 void plasma_manager_send_heartbeat(DBHandle *db_handle) {
   RetryInfo heartbeat_retry;
   heartbeat_retry.num_retries = 0;

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -42,8 +42,8 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
 
   for (auto const &manager_id : manager_ids) {
     DBClient client = redis_cache_get_db_client(db_handle, manager_id);
-    CHECK(!client.aux_address.empty());
-    manager_vector.push_back(client.aux_address);
+    CHECK(!client.manager_address.empty());
+    manager_vector.push_back(client.manager_address);
   }
 
   int64_t end_time = current_time_ms();
@@ -69,7 +69,7 @@ void db_client_table_cache_init(DBHandle *db_handle) {
 }
 
 DBClient db_client_table_cache_get(DBHandle *db_handle, DBClientID client_id) {
-  CHECK(!ObjectID_is_nil(client_id));
+  CHECK(!DBClientID_is_nil(client_id));
   return redis_cache_get_db_client(db_handle, client_id);
 }
 

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -1,6 +1,8 @@
 #ifndef DB_CLIENT_TABLE_H
 #define DB_CLIENT_TABLE_H
 
+#include <vector>
+
 #include "db.h"
 #include "table.h"
 
@@ -75,6 +77,10 @@ typedef struct {
   db_client_table_subscribe_callback subscribe_callback;
   void *subscribe_context;
 } DBClientTableSubscribeData;
+
+const std::vector<std::string> db_client_table_get_ip_addresses(
+    DBHandle *db,
+    const std::vector<DBClientID> &manager_ids);
 
 /*
  * ==== Plasma manager heartbeats ====

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -84,6 +84,8 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
     DBHandle *db,
     const std::vector<DBClientID> &manager_ids);
 
+void db_client_table_init_cache(DBHandle *db_handle);
+
 /*
  * ==== Plasma manager heartbeats ====
  */

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -35,6 +35,8 @@ void db_client_table_remove(DBHandle *db_handle,
 typedef struct {
   /** The database client ID. */
   DBClientID id;
+  /** The database client's IP address. */
+  const char *node_ip_address;
   /** The database client type. */
   const char *client_type;
   /** An optional auxiliary address for an associated database client on the

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -84,7 +84,24 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
     DBHandle *db,
     const std::vector<DBClientID> &manager_ids);
 
-void db_client_table_init_cache(DBHandle *db_handle);
+/**
+ * Initialize the db client cache. The cache is updated with each notification
+ * from the db client table.
+ *
+ * @param db_handle Database handle.
+ * @return Void.
+ */
+void db_client_table_cache_init(DBHandle *db_handle);
+
+/**
+ * Get a db client from the cache. If the requested client is not there,
+ * request the latest entry from the db client table.
+ *
+ * @param db_handle Database handle.
+ * @param client_id The ID of the client to look up in the cache.
+ * @return The database client in the cache.
+ */
+DBClient db_client_table_cache_get(DBHandle *db_handle, DBClientID client_id);
 
 /*
  * ==== Plasma manager heartbeats ====

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -37,12 +37,12 @@ typedef struct {
   DBClientID id;
   /** The database client type. */
   std::string client_type;
-  /** An optional auxiliary address for an associated database client on the
-   *  same node. */
-  std::string aux_address;
+  /** An optional auxiliary address for the plasma manager associated with this
+   *  database client. */
+  std::string manager_address;
   /** Whether or not the database client exists. If this is false for an entry,
    *  then it will never again be true. */
-  bool is_insertion;
+  bool is_alive;
 } DBClient;
 
 /* Callback for subscribing to the db client table. */

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -35,8 +35,6 @@ void db_client_table_remove(DBHandle *db_handle,
 typedef struct {
   /** The database client ID. */
   DBClientID id;
-  /** The database client's IP address. */
-  std::string node_ip_address;
   /** The database client type. */
   std::string client_type;
   /** An optional auxiliary address for an associated database client on the

--- a/src/common/state/db_client_table.h
+++ b/src/common/state/db_client_table.h
@@ -36,12 +36,12 @@ typedef struct {
   /** The database client ID. */
   DBClientID id;
   /** The database client's IP address. */
-  const char *node_ip_address;
+  std::string node_ip_address;
   /** The database client type. */
-  const char *client_type;
+  std::string client_type;
   /** An optional auxiliary address for an associated database client on the
    *  same node. */
-  const char *aux_address;
+  std::string aux_address;
   /** Whether or not the database client exists. If this is false for an entry,
    *  then it will never again be true. */
   bool is_insertion;

--- a/src/common/state/object_table.h
+++ b/src/common/state/object_table.h
@@ -18,14 +18,14 @@
 typedef void (*object_table_lookup_done_callback)(
     ObjectID object_id,
     bool never_created,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_ids,
     void *user_context);
 
 /* Callback called when object ObjectID is available. */
 typedef void (*object_table_object_available_callback)(
     ObjectID object_id,
     int64_t data_size,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_ids,
     void *user_context);
 
 /**

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -589,6 +589,10 @@ void redis_result_table_lookup(TableCallbackData *callback_data) {
   }
 }
 
+void redis_cache_set_db_client(DBHandle *db, DBClient client) {
+  db->db_client_cache[client.id] = client;
+}
+
 /**
  * Get an entry from the plasma manager table in redis.
  *

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -613,7 +613,7 @@ DBClient redis_cache_get_db_client(DBHandle *db, DBClientID db_client_id) {
            reply->type, reply->str);
     DBClient client;
     client.id = db_client_id;
-    client.node_ip_address = std::string(reply->str);
+    client.aux_address = std::string(reply->str);
     freeReplyObject(reply);
     db->db_client_cache[db_client_id] = client;
     it = db->db_client_cache.find(db_client_id);
@@ -1177,9 +1177,6 @@ void redis_db_client_table_scan(DBHandle *db,
       if (strcmp(key, "ray_client_id") == 0) {
         memcpy(db_client.id.id, value, sizeof(db_client.id));
         num_fields++;
-      } else if (strcmp(key, "node_ip_address") == 0) {
-        db_client.node_ip_address = std::string(value);
-        num_fields++;
       } else if (strcmp(key, "client_type") == 0) {
         db_client.client_type = std::string(value);
         num_fields++;
@@ -1193,9 +1190,9 @@ void redis_db_client_table_scan(DBHandle *db,
       }
     }
     freeReplyObject(client_reply);
-    /* The client ID, IP address, type, and whether it is deleted are all
+    /* The client ID, type, and whether it is deleted are all
      * mandatory fields. Auxiliary address is optional. */
-    CHECK(num_fields >= 4);
+    CHECK(num_fields >= 3);
     db_clients.push_back(db_client);
   }
   freeReplyObject(reply);
@@ -1246,7 +1243,6 @@ void redis_db_client_table_subscribe_callback(redisAsyncContext *c,
    * only client type, then the update was a delete. */
   DBClient db_client;
   db_client.id = from_flatbuf(message->db_client_id());
-  db_client.node_ip_address = std::string(message->node_ip_address()->data());
   db_client.client_type = std::string(message->client_type()->data());
   db_client.aux_address = std::string(message->aux_address()->data());
   db_client.is_insertion = message->is_insertion();

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -609,12 +609,12 @@ DBClient redis_db_client_table_get(DBHandle *db,
     } else if (strcmp(key, "client_type") == 0) {
       db_client.client_type = std::string(value);
       num_fields++;
-    } else if (strcmp(key, "aux_address") == 0) {
-      db_client.aux_address = std::string(value);
+    } else if (strcmp(key, "manager_address") == 0) {
+      db_client.manager_address = std::string(value);
       num_fields++;
     } else if (strcmp(key, "deleted") == 0) {
       bool is_deleted = atoi(value);
-      db_client.is_insertion = !is_deleted;
+      db_client.is_alive = !is_deleted;
       num_fields++;
     }
   }
@@ -1247,8 +1247,8 @@ void redis_db_client_table_subscribe_callback(redisAsyncContext *c,
   DBClient db_client;
   db_client.id = from_flatbuf(message->db_client_id());
   db_client.client_type = std::string(message->client_type()->data());
-  db_client.aux_address = std::string(message->aux_address()->data());
-  db_client.is_insertion = message->is_insertion();
+  db_client.manager_address = std::string(message->manager_address()->data());
+  db_client.is_alive = message->is_insertion();
 
   /* Call the subscription callback. */
   DBClientTableSubscribeData *data =

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -1167,6 +1167,8 @@ void redis_db_client_table_scan(DBHandle *db,
       if (strcmp(key, "ray_client_id") == 0) {
         memcpy(db_client.id.id, value, sizeof(db_client.id));
         num_fields++;
+      } else if (strcmp(key, "node_ip_address") == 0) {
+        db_client.node_ip_address = strdup(value);
       } else if (strcmp(key, "client_type") == 0) {
         db_client.client_type = strdup(value);
         num_fields++;
@@ -1180,9 +1182,9 @@ void redis_db_client_table_scan(DBHandle *db,
       }
     }
     freeReplyObject(client_reply);
-    /* The client ID, type, and whether it is deleted are all mandatory fields.
-     * Auxiliary address is optional. */
-    CHECK(num_fields >= 3);
+    /* The client ID, IP address, type, and whether it is deleted are all
+     * mandatory fields. Auxiliary address is optional. */
+    CHECK(num_fields >= 4);
     db_clients.push_back(db_client);
   }
   freeReplyObject(reply);
@@ -1239,6 +1241,7 @@ void redis_db_client_table_subscribe_callback(redisAsyncContext *c,
    * only client type, then the update was a delete. */
   DBClient db_client;
   db_client.id = from_flatbuf(message->db_client_id());
+  db_client.node_ip_address = (char *) message->node_ip_address()->data();
   db_client.client_type = (char *) message->client_type()->data();
   db_client.aux_address = message->aux_address()->data();
   db_client.is_insertion = message->is_insertion();

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -596,8 +596,7 @@ void redis_result_table_lookup(TableCallbackData *callback_data) {
  * @param index The index of the plasma manager.
  * @return The IP address and port of the manager.
  */
-const std::string redis_get_cached_db_client(DBHandle *db,
-                                             DBClientID db_client_id) {
+DBClient redis_cache_get_db_client(DBHandle *db, DBClientID db_client_id) {
   auto it = db->db_client_cache.find(db_client_id);
 
   std::string manager_address;
@@ -609,14 +608,13 @@ const std::string redis_get_cached_db_client(DBHandle *db,
     CHECKM(reply->type == REDIS_REPLY_STRING, "REDIS reply type=%d, str=%s",
            reply->type, reply->str);
     DBClient client;
+    client.id = db_client_id;
     client.node_ip_address = std::string(reply->str);
     freeReplyObject(reply);
     db->db_client_cache[db_client_id] = client;
-    manager_address = client.node_ip_address;
-  } else {
-    manager_address = it->second.node_ip_address;
+    it = db->db_client_cache.find(db_client_id);
   }
-  return manager_address;
+  return it->second;
 }
 
 void redis_object_table_lookup_callback(redisAsyncContext *c,

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -86,6 +86,8 @@ void get_redis_shards(redisContext *context,
                       std::vector<std::string> &db_shards_addresses,
                       std::vector<int> &db_shards_ports);
 
+void redis_cache_set_db_client(DBHandle *db, DBClient client);
+
 DBClient redis_cache_get_db_client(DBHandle *db, DBClientID db_client_id);
 
 void redis_object_table_get_entry(redisAsyncContext *c,

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "db.h"
+#include "db_client_table.h"
 #include "object_table.h"
 #include "task_table.h"
 
@@ -45,7 +46,7 @@ struct DBHandle {
   int64_t db_index;
   /** Cache for the IP addresses of db clients. This is an unordered map mapping
    *  client IDs to addresses. */
-  std::unordered_map<DBClientID, char *, UniqueIDHasher> db_client_cache;
+  std::unordered_map<DBClientID, DBClient, UniqueIDHasher> db_client_cache;
   /** Redis context for synchronous connections. This should only be used very
    *  rarely, it is not asynchronous. */
   redisContext *sync_context;

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -86,8 +86,7 @@ void get_redis_shards(redisContext *context,
                       std::vector<std::string> &db_shards_addresses,
                       std::vector<int> &db_shards_ports);
 
-const std::string redis_get_cached_db_client(DBHandle *db,
-                                             DBClientID db_client_id);
+DBClient redis_cache_get_db_client(DBHandle *db, DBClientID db_client_id);
 
 void redis_object_table_get_entry(redisAsyncContext *c,
                                   void *r,

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -85,6 +85,9 @@ void get_redis_shards(redisContext *context,
                       std::vector<std::string> &db_shards_addresses,
                       std::vector<int> &db_shards_ports);
 
+const std::string redis_get_cached_db_client(DBHandle *db,
+                                             DBClientID db_client_id);
+
 void redis_object_table_get_entry(redisAsyncContext *c,
                                   void *r,
                                   void *privdata);

--- a/src/common/state/task_table.cc
+++ b/src/common/state/task_table.cc
@@ -36,6 +36,7 @@ void task_table_update(DBHandle *db_handle,
 void task_table_test_and_update(
     DBHandle *db_handle,
     TaskID task_id,
+    DBClientID test_local_scheduler_id,
     int test_state_bitmask,
     int update_state,
     RetryInfo *retry,
@@ -43,6 +44,7 @@ void task_table_test_and_update(
     void *user_context) {
   TaskTableTestAndUpdateData *update_data =
       (TaskTableTestAndUpdateData *) malloc(sizeof(TaskTableTestAndUpdateData));
+  update_data->test_local_scheduler_id = test_local_scheduler_id;
   update_data->test_state_bitmask = test_state_bitmask;
   update_data->update_state = update_state;
   /* Update the task entry's local scheduler with this client's ID. */

--- a/src/common/state/task_table.h
+++ b/src/common/state/task_table.h
@@ -103,9 +103,13 @@ void task_table_update(DBHandle *db_handle,
  *
  * @param db_handle Database handle.
  * @param task_id The task ID of the task entry to update.
+ * @param test_local_scheduler_id The local scheduler ID to test the current
+ *        local scheduler ID against. If not NIL_ID, and if the current local
+ *        scheduler ID does not match it, then the update will not happen.
  * @param test_state_bitmask The bitmask to apply to the task entry's current
  *        scheduling state.  The update happens if and only if the current
- *        scheduling state AND-ed with the bitmask is greater than 0.
+ *        scheduling state AND-ed with the bitmask is greater than 0 and the
+ *        local scheduler ID test passes.
  * @param update_state The value to update the task entry's scheduling state
  *        with, if the current state matches test_state_bitmask.
  * @param retry Information about retrying the request to the database.
@@ -117,6 +121,7 @@ void task_table_update(DBHandle *db_handle,
 void task_table_test_and_update(
     DBHandle *db_handle,
     TaskID task_id,
+    DBClientID test_local_scheduler_id,
     int test_state_bitmask,
     int update_state,
     RetryInfo *retry,
@@ -125,6 +130,9 @@ void task_table_test_and_update(
 
 /* Data that is needed to test and set the task's scheduling state. */
 typedef struct {
+  /** The value to test the current local scheduler ID against. This field is
+   *  ignored if equal to NIL_ID. */
+  DBClientID test_local_scheduler_id;
   int test_state_bitmask;
   int update_state;
   DBClientID local_scheduler_id;

--- a/src/common/test/db_tests.cc
+++ b/src/common/test/db_tests.cc
@@ -73,11 +73,11 @@ int64_t timeout_handler(event_loop *loop, int64_t id, void *context) {
 TEST object_table_lookup_test(void) {
   event_loop *loop = event_loop_create();
   /* This uses manager_port1. */
-  const char *db_connect_args1[] = {"address", "127.0.0.1:12345"};
+  const char *db_connect_args1[] = {"aux_address", "127.0.0.1:12345"};
   DBHandle *db1 = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                              manager_addr, 2, db_connect_args1);
   /* This uses manager_port2. */
-  const char *db_connect_args2[] = {"address", "127.0.0.1:12346"};
+  const char *db_connect_args2[] = {"aux_address", "127.0.0.1:12346"};
   DBHandle *db2 = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                              manager_addr, 2, db_connect_args2);
   db_attach(db1, loop, false);

--- a/src/common/test/db_tests.cc
+++ b/src/common/test/db_tests.cc
@@ -29,9 +29,9 @@ const char *manager_addr = "127.0.0.1";
 int manager_port1 = 12345;
 int manager_port2 = 12346;
 char received_addr1[16] = {0};
-char received_port1[6] = {0};
+int received_port1;
 char received_addr2[16] = {0};
-char received_port2[6] = {0};
+int received_port2;
 
 typedef struct { int test_number; } user_context;
 
@@ -47,10 +47,10 @@ void lookup_done_callback(ObjectID object_id,
   CHECK(manager_ids.size() == 2);
   const std::vector<std::string> managers =
       db_client_table_get_ip_addresses(db, manager_ids);
-  char addr[16];
-  int port;
-  CHECK(parse_ip_addr_port(managers.at(0).c_str(), addr, &port) == 0);
-  CHECK(parse_ip_addr_port(managers.at(1).c_str(), addr, &port) == 0);
+  CHECK(parse_ip_addr_port(managers.at(0).c_str(), received_addr1,
+                           &received_port1) == 0);
+  CHECK(parse_ip_addr_port(managers.at(1).c_str(), received_addr2,
+                           &received_port2) == 0);
 }
 
 /* Entry added to database successfully. */
@@ -96,11 +96,9 @@ TEST object_table_lookup_test(void) {
   event_loop_add_timer(loop, 200, (event_loop_timer_handler) timeout_handler,
                        NULL);
   event_loop_run(loop);
-  int port1 = atoi(received_port1);
-  int port2 = atoi(received_port2);
   ASSERT_STR_EQ(&received_addr1[0], manager_addr);
-  ASSERT((port1 == manager_port1 && port2 == manager_port2) ||
-         (port2 == manager_port1 && port1 == manager_port2));
+  ASSERT((received_port1 == manager_port1 && received_port2 == manager_port2) ||
+         (received_port2 == manager_port1 && received_port1 == manager_port2));
 
   db_disconnect(db1);
   db_disconnect(db2);

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -4,6 +4,7 @@
 #include "example_task.h"
 #include "test_common.h"
 #include "common.h"
+#include "state/db_client_table.h"
 #include "state/object_table.h"
 #include "state/redis.h"
 
@@ -146,7 +147,7 @@ int lookup_failed = 0;
 
 void lookup_done_callback(ObjectID object_id,
                           bool never_created,
-                          const std::vector<std::string> &manager_vector,
+                          const std::vector<DBClientID> &manager_vector,
                           void *context) {
   /* The done callback should not be called. */
   CHECK(0);
@@ -226,7 +227,7 @@ int subscribe_failed = 0;
 
 void subscribe_done_callback(ObjectID object_id,
                              int64_t data_size,
-                             const std::vector<std::string> &manager_vector,
+                             const std::vector<DBClientID> &manager_vector,
                              void *user_context) {
   /* The done callback should not be called. */
   CHECK(0);
@@ -308,11 +309,13 @@ int add_retry_succeeded = 0;
 
 void add_lookup_done_callback(ObjectID object_id,
                               bool never_created,
-                              const std::vector<std::string> &manager_vector,
+                              const std::vector<DBClientID> &manager_ids,
                               void *context) {
-  CHECK(context == (void *) lookup_retry_context);
-  CHECK(manager_vector.size() == 1);
-  CHECK(manager_vector.at(0) == "127.0.0.1:11235");
+  DBHandle *db = (DBHandle *) context;
+  CHECK(manager_ids.size() == 1);
+  const std::vector<std::string> managers =
+      db_client_table_get_ip_addresses(db, manager_ids);
+  CHECK(managers.at(0) == "127.0.0.1:11235");
   lookup_retry_succeeded = 1;
 }
 
@@ -325,7 +328,7 @@ void add_lookup_callback(ObjectID object_id, bool success, void *user_context) {
       .fail_callback = lookup_retry_fail_callback,
   };
   object_table_lookup(db, NIL_ID, &retry, add_lookup_done_callback,
-                      (void *) lookup_retry_context);
+                      (void *) db);
 }
 
 TEST add_lookup_test(void) {
@@ -359,7 +362,7 @@ TEST add_lookup_test(void) {
 void add_remove_lookup_done_callback(
     ObjectID object_id,
     bool never_created,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *context) {
   CHECK(context == (void *) lookup_retry_context);
   CHECK(manager_vector.size() == 0);
@@ -433,7 +436,7 @@ void lookup_late_fail_callback(UniqueID id,
 
 void lookup_late_done_callback(ObjectID object_id,
                                bool never_created,
-                               const std::vector<std::string> &manager_vector,
+                               const std::vector<DBClientID> &manager_vector,
                                void *context) {
   /* This function should never be called. */
   CHECK(0);
@@ -520,11 +523,10 @@ void subscribe_late_fail_callback(UniqueID id,
   subscribe_late_failed = 1;
 }
 
-void subscribe_late_done_callback(
-    ObjectID object_id,
-    bool never_created,
-    const std::vector<std::string> &manager_vector,
-    void *user_context) {
+void subscribe_late_done_callback(ObjectID object_id,
+                                  bool never_created,
+                                  const std::vector<DBClientID> &manager_vector,
+                                  void *user_context) {
   /* This function should never be called. */
   CHECK(0);
 }
@@ -574,7 +576,7 @@ void subscribe_success_fail_callback(UniqueID id,
 void subscribe_success_done_callback(
     ObjectID object_id,
     bool never_created,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *user_context) {
   RetryInfo retry = {
       .num_retries = 0, .timeout = 750, .fail_callback = NULL,
@@ -587,7 +589,7 @@ void subscribe_success_done_callback(
 void subscribe_success_object_available_callback(
     ObjectID object_id,
     int64_t data_size,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *user_context) {
   CHECK(user_context == (void *) subscribe_success_context);
   CHECK(ObjectID_equal(object_id, subscribe_id));
@@ -645,7 +647,7 @@ int subscribe_object_present_succeeded = 0;
 void subscribe_object_present_object_available_callback(
     ObjectID object_id,
     int64_t data_size,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *user_context) {
   subscribe_object_present_context_t *ctx =
       (subscribe_object_present_context_t *) user_context;
@@ -711,7 +713,7 @@ const char *subscribe_object_not_present_context =
 void subscribe_object_not_present_object_available_callback(
     ObjectID object_id,
     int64_t data_size,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *user_context) {
   /* This should not be called. */
   CHECK(0);
@@ -760,7 +762,7 @@ int subscribe_object_available_later_succeeded = 0;
 void subscribe_object_available_later_object_available_callback(
     ObjectID object_id,
     int64_t data_size,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_vector,
     void *user_context) {
   subscribe_object_present_context_t *myctx =
       (subscribe_object_present_context_t *) user_context;

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -335,7 +335,7 @@ TEST add_lookup_test(void) {
   g_loop = event_loop_create();
   lookup_retry_succeeded = 0;
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11235"};
+  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11235"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, true);
@@ -601,7 +601,7 @@ TEST subscribe_success_test(void) {
   g_loop = event_loop_create();
 
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -669,7 +669,7 @@ TEST subscribe_object_present_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -783,7 +783,7 @@ TEST subscribe_object_available_later_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -836,7 +836,7 @@ TEST subscribe_object_available_subscribe_all(void) {
       subscribe_object_available_later_context, data_size};
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -335,7 +335,7 @@ TEST add_lookup_test(void) {
   g_loop = event_loop_create();
   lookup_retry_succeeded = 0;
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"address", "127.0.0.1:11235"};
+  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11235"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, true);
@@ -601,7 +601,7 @@ TEST subscribe_success_test(void) {
   g_loop = event_loop_create();
 
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -669,7 +669,7 @@ TEST subscribe_object_present_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -783,7 +783,7 @@ TEST subscribe_object_available_later_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);
@@ -836,7 +836,7 @@ TEST subscribe_object_available_subscribe_all(void) {
       subscribe_object_available_later_context, data_size};
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"address", "127.0.0.1:11236"};
+  const char *db_connect_args[] = {"aux_address", "127.0.0.1:11236"};
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                             "127.0.0.1", 2, db_connect_args);
   db_attach(db, g_loop, false);

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -254,7 +254,7 @@ void process_new_db_client(DBClient *db_client, void *user_context) {
   LOG_DEBUG("db client table callback for db client = %s",
             ObjectID_to_string(db_client->id, id_string, ID_STRING_SIZE));
   ARROW_UNUSED(id_string);
-  if (strncmp(db_client->client_type, "local_scheduler",
+  if (strncmp(db_client->client_type.c_str(), "local_scheduler",
               strlen("local_scheduler")) == 0) {
     bool local_scheduler_present =
         (state->local_schedulers.find(db_client->id) !=
@@ -264,7 +264,8 @@ void process_new_db_client(DBClient *db_client, void *user_context) {
        * notifications since we read the entire table before processing
        * notifications. Filter out local schedulers that we already added. */
       if (!local_scheduler_present) {
-        add_local_scheduler(state, db_client->id, db_client->aux_address);
+        add_local_scheduler(state, db_client->id,
+                            db_client->aux_address.c_str());
       }
     } else {
       if (local_scheduler_present) {

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -734,9 +734,9 @@ void reconstruct_failed_result_lookup_callback(ObjectID reconstruct_object_id,
 void reconstruct_object_lookup_callback(
     ObjectID reconstruct_object_id,
     bool never_created,
-    const std::vector<std::string> &manager_vector,
+    const std::vector<DBClientID> &manager_ids,
     void *user_context) {
-  LOG_DEBUG("Manager count was %d", manager_count);
+  LOG_DEBUG("Manager count was %d", manager_ids.size());
   /* Only continue reconstruction if we find that the object doesn't exist on
    * any nodes. NOTE: This codepath is not responsible for checking if the
    * object table entry is up-to-date. */
@@ -748,7 +748,7 @@ void reconstruct_object_lookup_callback(
     result_table_lookup(state->db, reconstruct_object_id, NULL,
                         reconstruct_failed_result_lookup_callback,
                         (void *) state);
-  } else if (manager_vector.size() == 0) {
+  } else if (manager_ids.size() == 0) {
     /* If the object was created and later evicted, we reconstruct the object
      * if and only if there are no other instances of the task running. */
     result_table_lookup(state->db, reconstruct_object_id, NULL,

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -711,6 +711,14 @@ void reconstruct_put_task_update_callback(Task *task,
                    PUT_RECONSTRUCTION_ERROR_INDEX, sizeof(function),
                    function.id);
       }
+    } else {
+      /* (1) The task is still executing and it is the driver task. We cannot
+       * restart the driver task, so the workload will hang. Push an error to
+       * the appropriate driver. */
+      TaskSpec *spec = Task_task_spec(task);
+      FunctionID function = TaskSpec_function(spec);
+      push_error(state->db, TaskSpec_driver_id(spec),
+                 PUT_RECONSTRUCTION_ERROR_INDEX, sizeof(function), function.id);
     }
   } else {
     /* The update to TASK_STATUS_RECONSTRUCTING succeeded, so continue with

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -18,6 +18,7 @@
 #include "net.h"
 #include "state/actor_notification_table.h"
 #include "state/db.h"
+#include "state/db_client_table.h"
 #include "state/driver_table.h"
 #include "state/task_table.h"
 #include "state/object_table.h"
@@ -149,6 +150,11 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
    * local scheduler at most once. If a SIGTERM is caught afterwards, there is
    * the possibility of orphan worker processes. */
   signal(SIGTERM, SIG_DFL);
+  /* Send a null heartbeat that tells the global scheduler that we are dead to
+   * avoid waiting for the heartbeat timeout. */
+  if (state->db != NULL) {
+    local_scheduler_table_disconnect(state->db);
+  }
 
   /* Kill any child processes that didn't register as a worker yet. */
   for (auto const &worker_pid : state->child_pids) {
@@ -176,9 +182,6 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
    * responsible for deleting our entry from the db_client table, so do not
    * delete it here. */
   if (state->db != NULL) {
-    /* Send a null heartbeat that tells the global scheduler that we are dead
-     * to avoid waiting for the heartbeat timeout. */
-    local_scheduler_table_disconnect(state->db);
     DBHandle_free(state->db);
   }
 
@@ -635,16 +638,31 @@ void process_plasma_notification(event_loop *loop,
 void reconstruct_task_update_callback(Task *task,
                                       void *user_context,
                                       bool updated) {
+  LocalSchedulerState *state = (LocalSchedulerState *) user_context;
   if (!updated) {
-    /* The test-and-set of the task's scheduling state failed, so the task was
-     * either not finished yet, or it was already being reconstructed.
-     * Suppress the reconstruction request. */
+    /* The test-and-set failed. The task is either: (1) not finished yet, (2)
+     * lost, but not yet updated, or (3) already being reconstructed. */
+    DBClientID current_local_scheduler_id = Task_local_scheduler(task);
+    if (!ObjectID_is_nil(current_local_scheduler_id)) {
+      DBClient current_local_scheduler =
+          db_client_table_cache_get(state->db, current_local_scheduler_id);
+      if (!current_local_scheduler.is_insertion) {
+        /* (2) The current local scheduler for the task is dead. The task is
+         * lost, but the task table hasn't received the update yet. Retry the
+         * test-and-set. */
+        task_table_test_and_update(state->db, Task_task_id(task),
+                                   current_local_scheduler_id, Task_state(task),
+                                   TASK_STATUS_RECONSTRUCTING, NULL,
+                                   reconstruct_task_update_callback, state);
+      }
+    }
+    /* The test-and-set failed, so it is not safe to resubmit the task for
+     * execution. Suppress the request. */
     return;
   }
 
   /* Otherwise, the test-and-set succeeded, so resubmit the task for execution
    * to ensure that reconstruction will happen. */
-  LocalSchedulerState *state = (LocalSchedulerState *) user_context;
   TaskSpec *spec = Task_task_spec(task);
   if (ActorID_equal(TaskSpec_actor_id(spec), NIL_ACTOR_ID)) {
     handle_task_submitted(state, state->algorithm_state, Task_task_spec(task),
@@ -667,20 +685,38 @@ void reconstruct_task_update_callback(Task *task,
 void reconstruct_put_task_update_callback(Task *task,
                                           void *user_context,
                                           bool updated) {
-  if (updated) {
+  LocalSchedulerState *state = (LocalSchedulerState *) user_context;
+  if (!updated) {
+    /* The test-and-set failed. The task is either: (1) not finished yet, (2)
+     * lost, but not yet updated, or (3) already being reconstructed. */
+    DBClientID current_local_scheduler_id = Task_local_scheduler(task);
+    if (!ObjectID_is_nil(current_local_scheduler_id)) {
+      DBClient current_local_scheduler =
+          db_client_table_cache_get(state->db, current_local_scheduler_id);
+      if (!current_local_scheduler.is_insertion) {
+        /* (2) The current local scheduler for the task is dead. The task is
+         * lost, but the task table hasn't received the update yet. Retry the
+         * test-and-set. */
+        task_table_test_and_update(state->db, Task_task_id(task),
+                                   current_local_scheduler_id, Task_state(task),
+                                   TASK_STATUS_RECONSTRUCTING, NULL,
+                                   reconstruct_put_task_update_callback, state);
+      } else if (Task_state(task) == TASK_STATUS_RUNNING) {
+        /* (1) The task is still executing on a live node. The object created
+         * by `ray.put` was not able to be reconstructed, and the workload will
+         * likely hang. Push an error to the appropriate driver. */
+        TaskSpec *spec = Task_task_spec(task);
+        FunctionID function = TaskSpec_function(spec);
+        push_error(state->db, TaskSpec_driver_id(spec),
+                   PUT_RECONSTRUCTION_ERROR_INDEX, sizeof(function),
+                   function.id);
+      }
+    }
+  } else {
     /* The update to TASK_STATUS_RECONSTRUCTING succeeded, so continue with
      * reconstruction as usual. */
     reconstruct_task_update_callback(task, user_context, updated);
-    return;
   }
-
-  /* An object created by `ray.put` was not able to be reconstructed, and the
-   * workload will likely hang. Push an error to the appropriate driver. */
-  LocalSchedulerState *state = (LocalSchedulerState *) user_context;
-  TaskSpec *spec = Task_task_spec(task);
-  FunctionID function = TaskSpec_function(spec);
-  push_error(state->db, TaskSpec_driver_id(spec),
-             PUT_RECONSTRUCTION_ERROR_INDEX, sizeof(function), function.id);
 }
 
 void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
@@ -705,7 +741,7 @@ void reconstruct_evicted_result_lookup_callback(ObjectID reconstruct_object_id,
   /* If there are no other instances of the task running, it's safe for us to
    * claim responsibility for reconstruction. */
   task_table_test_and_update(
-      state->db, task_id, (TASK_STATUS_DONE | TASK_STATUS_LOST),
+      state->db, task_id, NIL_ID, (TASK_STATUS_DONE | TASK_STATUS_LOST),
       TASK_STATUS_RECONSTRUCTING, NULL, done_callback, state);
 }
 
@@ -726,7 +762,7 @@ void reconstruct_failed_result_lookup_callback(ObjectID reconstruct_object_id,
   LocalSchedulerState *state = (LocalSchedulerState *) user_context;
   /* If the task failed to finish, it's safe for us to claim responsibility for
    * reconstruction. */
-  task_table_test_and_update(state->db, task_id, TASK_STATUS_LOST,
+  task_table_test_and_update(state->db, task_id, NIL_ID, TASK_STATUS_LOST,
                              TASK_STATUS_RECONSTRUCTING, NULL,
                              reconstruct_task_update_callback, state);
 }
@@ -748,12 +784,24 @@ void reconstruct_object_lookup_callback(
     result_table_lookup(state->db, reconstruct_object_id, NULL,
                         reconstruct_failed_result_lookup_callback,
                         (void *) state);
-  } else if (manager_ids.size() == 0) {
-    /* If the object was created and later evicted, we reconstruct the object
-     * if and only if there are no other instances of the task running. */
-    result_table_lookup(state->db, reconstruct_object_id, NULL,
-                        reconstruct_evicted_result_lookup_callback,
-                        (void *) state);
+  } else {
+    /* If the object has been created, filter out the dead plasma managers that
+     * have it. */
+    size_t num_live_managers = 0;
+    for (auto manager_id : manager_ids) {
+      DBClient manager = db_client_table_cache_get(state->db, manager_id);
+      if (manager.is_insertion) {
+        num_live_managers++;
+      }
+    }
+    /* If the object was created, but all plasma managers that had the object
+     * either evicted it or failed, we reconstruct the object if and only if
+     * there are no other instances of the task running. */
+    if (num_live_managers == 0) {
+      result_table_lookup(state->db, reconstruct_object_id, NULL,
+                          reconstruct_evicted_result_lookup_callback,
+                          (void *) state);
+    }
   }
 }
 
@@ -1291,6 +1339,10 @@ void start_server(const char *node_ip_address,
     event_loop_add_timer(loop,
                          RayConfig::instance().heartbeat_timeout_milliseconds(),
                          heartbeat_handler, g_state);
+  }
+  /* Listen for new and deleted db clients. */
+  if (g_state->db != NULL) {
+    db_client_table_cache_init(g_state->db);
   }
   /* Create a timer for fetching queued tasks' missing object dependencies. */
   event_loop_add_timer(

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -426,7 +426,7 @@ TEST object_reconstruction_suppression_test(void) {
     exit(0);
   } else {
     /* Connect a plasma manager client so we can call object_table_add. */
-    const char *db_connect_args[] = {"address", "127.0.0.1:12346"};
+    const char *db_connect_args[] = {"aux_address", "127.0.0.1:12346"};
     DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                               "127.0.0.1", 2, db_connect_args);
     db_attach(db, local_scheduler->loop, false);

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -426,7 +426,7 @@ TEST object_reconstruction_suppression_test(void) {
     exit(0);
   } else {
     /* Connect a plasma manager client so we can call object_table_add. */
-    const char *db_connect_args[] = {"aux_address", "127.0.0.1:12346"};
+    const char *db_connect_args[] = {"manager_address", "127.0.0.1:12346"};
     DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
                               "127.0.0.1", 2, db_connect_args);
     db_attach(db, local_scheduler->loop, false);

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -458,7 +458,7 @@ PlasmaManagerState *PlasmaManagerState_init(const char *store_socket_name,
     db_connect_args[1] = store_socket_name;
     db_connect_args[2] = "manager_socket_name";
     db_connect_args[3] = manager_socket_name;
-    db_connect_args[4] = "aux_address";
+    db_connect_args[4] = "manager_address";
     db_connect_args[5] = manager_address_str.c_str();
     state->db =
         db_connect(std::string(redis_primary_addr), redis_primary_port,

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -458,7 +458,7 @@ PlasmaManagerState *PlasmaManagerState_init(const char *store_socket_name,
     db_connect_args[1] = store_socket_name;
     db_connect_args[2] = "manager_socket_name";
     db_connect_args[3] = manager_socket_name;
-    db_connect_args[4] = "address";
+    db_connect_args[4] = "aux_address";
     db_connect_args[5] = manager_address_str.c_str();
     state->db =
         db_connect(std::string(redis_primary_addr), redis_primary_port,


### PR DESCRIPTION
When there are many keys in Redis, monitor cleanup of the task and object tables is very slow. This leads to high latencies (minutes or more) during reconstruction.

This removes that latency by allowing the local scheduler to listen to notifications about dead clients from the db client table and filter out lost tasks/objects itself, instead of waiting for the monitor. This includes the following changes:
1. Expose a call to the `db_client_table` that allows a client to build a cache of the other database clients.
2. Add an option to specify a local scheduler ID in the `task_table_test_and_update` call. If this option is set, then the current local scheduler ID is tested before doing the task update.
2. During reconstruction, if the local scheduler is not able to update a task to `TASK_STATUS_RECONSTRUCTING` at first, then it checks if the currently assigned local scheduler is dead. If yes, then the local scheduler tries the `test_and_update` again.