### PR TITLE
Fix bugs in plasma manager transfer

### DIFF
--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -538,6 +538,9 @@ void fetch_missing_dependency(LocalSchedulerState *state,
       auto arrow_status = state->plasma_conn->Fetch(1, &obj_id);
       if (!arrow_status.ok()) {
         LocalSchedulerState_free(state);
+        /* TODO(swang): Local scheduler should also exit even if there are no
+         * pending fetches. This could be done by subscribing to the db_client
+         * table, or pinging the plasma manager in the heartbeat handler. */
         LOG_FATAL(
             "Lost connection to the plasma manager, local scheduler is "
             "exiting. Error: %s",

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -296,6 +296,12 @@ bool ClientConnection_request_finished(ClientConnection *client_conn) {
   return client_conn->cursor == -1;
 }
 
+/**
+ * Mark the current request as finished.
+ *
+ * @param conn The connection on which the request is being sent.
+ * @return Void.
+ */
 void ClientConnection_finish_request(ClientConnection *client_conn) {
   client_conn->cursor = -1;
 }

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -224,7 +224,23 @@ int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 int write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 
 /**
- * Check whether the current request is finished.
+ * Start a new request on this connection.
+ *
+ * @param conn The connection on which the request is being sent.
+ * @return Void.
+ */
+void ClientConnection_start_request(ClientConnection *client_conn) {
+
+/**
+ * Finish the current request on this connection.
+ *
+ * @param conn The connection on which the request is being sent.
+ * @return Void.
+ */
+void ClientConnection_finish_request(ClientConnection *client_conn) {
+
+/**
+ * Check whether the current request on this connection is finished.
  *
  * @param conn The connection on which the request is being sent.
  * @return Whether the request has finished.

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -224,6 +224,14 @@ int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 int write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 
 /**
+ * Check whether the current request is finished.
+ *
+ * @param conn The connection on which the request is being sent.
+ * @return Whether the request has finished.
+ */
+bool ClientConnection_request_finished(ClientConnection *client_conn);
+
+/**
  * Get the event loop of the given plasma manager state.
  *
  * @param state The state of the plasma manager whose loop we want.

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -203,11 +203,11 @@ ClientConnection *get_manager_connection(PlasmaManagerState *state,
  * Reads an object chunk sent by the given client into a buffer. This is the
  * complement to write_object_chunk.
  *
- * @param conn The connection to the client who's sending the data.
+ * @param conn The connection to the client who's sending the data. The
+ *        connection's cursor will be reset if this is the last read for the
+ *        current object.
  * @param buf The buffer to write the data into.
- * @return An integer representing whether the client is done sending this
- *         object. 1 means that the client has sent all the data, 0 means there
- *         is more.
+ * @return The errno set, if the read wasn't successful.
  */
 int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
 
@@ -215,7 +215,9 @@ int read_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
  * Writes an object chunk from a buffer to the given client. This is the
  * complement to read_object_chunk.
  *
- * @param conn The connection to the client who's receiving the data.
+ * @param conn The connection to the client who's receiving the data. The
+ *        connection's cursor will be reset if this is the last write for the
+ *        current object.
  * @param buf The buffer to read data from.
  * @return The errno set, if the write wasn't successful.
  */

--- a/src/plasma/plasma_manager.h
+++ b/src/plasma/plasma_manager.h
@@ -229,7 +229,7 @@ int write_object_chunk(ClientConnection *conn, PlasmaRequestBuffer *buf);
  * @param conn The connection on which the request is being sent.
  * @return Void.
  */
-void ClientConnection_start_request(ClientConnection *client_conn) {
+void ClientConnection_start_request(ClientConnection *client_conn);
 
 /**
  * Finish the current request on this connection.
@@ -237,7 +237,7 @@ void ClientConnection_start_request(ClientConnection *client_conn) {
  * @param conn The connection on which the request is being sent.
  * @return Void.
  */
-void ClientConnection_finish_request(ClientConnection *client_conn) {
+void ClientConnection_finish_request(ClientConnection *client_conn);
 
 /**
  * Check whether the current request on this connection is finished.

--- a/src/plasma/test/client_tests.cc
+++ b/src/plasma/test/client_tests.cc
@@ -125,48 +125,6 @@ bool is_equal_data_123(uint8_t *data1, uint8_t *data2, uint64_t size) {
   return true;
 }
 
-TEST plasma_abort_test(void) {
-  PlasmaClient client;
-  ARROW_CHECK_OK(client.Connect("/tmp/store1", "/tmp/manager1",
-                                PLASMA_DEFAULT_RELEASE_DELAY));
-  ObjectID oid = ObjectID::from_random();
-  ObjectID oid_array[1] = {oid};
-  ObjectBuffer obj_buffer;
-
-  /* Test for object non-existence. */
-  ARROW_CHECK_OK(client.Get(oid_array, 1, 0, &obj_buffer));
-  ASSERT(obj_buffer.data_size == -1);
-
-  /* Test for the object being in local Plasma store. */
-  /* First create object. */
-  int64_t data_size = 4;
-  uint8_t metadata[] = {5};
-  int64_t metadata_size = sizeof(metadata);
-  uint8_t *data;
-  ARROW_CHECK_OK(client.Create(oid, data_size, metadata, metadata_size, &data));
-  init_data_123(data, data_size, 0);
-  Status status = client.Abort(oid);
-  ASSERT(status.IsInvalid());
-  ARROW_CHECK_OK(client.Release(oid));
-  ARROW_CHECK_OK(client.Abort(oid));
-
-  ARROW_CHECK_OK(client.Get(oid_array, 1, 0, &obj_buffer));
-  ASSERT(obj_buffer.data_size == -1);
-
-  ARROW_CHECK_OK(client.Create(oid, data_size, metadata, metadata_size, &data));
-  init_data_123(data, data_size, 0);
-  ARROW_CHECK_OK(client.Seal(oid));
-
-  sleep(1);
-  ARROW_CHECK_OK(client.Get(oid_array, 1, 0, &obj_buffer));
-  ASSERT(is_equal_data_123(data, obj_buffer.data, data_size) == true);
-
-  sleep(1);
-  ARROW_CHECK_OK(client.Disconnect());
-
-  PASS();
-}
-
 TEST plasma_nonblocking_get_tests(void) {
   PlasmaClient client;
   ARROW_CHECK_OK(client.Connect("/tmp/store1", "/tmp/manager1",
@@ -364,7 +322,6 @@ SUITE(plasma_client_tests) {
   RUN_TEST(plasma_wait_for_objects_tests);
   RUN_TEST(plasma_get_tests);
   RUN_TEST(plasma_get_multiple_tests);
-  RUN_TEST(plasma_abort_test);
 }
 
 GREATEST_MAIN_DEFS();

--- a/src/plasma/test/manager_tests.cc
+++ b/src/plasma/test/manager_tests.cc
@@ -227,7 +227,9 @@ TEST read_write_object_chunk_test(void) {
    * - Read the object data on the local manager.
    * - Check that the data matches.
    */
+  ClientConnection_start_request(remote_mock->write_conn);
   write_object_chunk(remote_mock->write_conn, &remote_buf);
+  ASSERT(ClientConnection_request_finished(remote_mock->write_conn));
   /* Wait until the data is ready to be read. */
   wait_for_pollin(get_client_sock(remote_mock->read_conn));
   /* Read the data. */

--- a/src/plasma/test/manager_tests.cc
+++ b/src/plasma/test/manager_tests.cc
@@ -231,8 +231,9 @@ TEST read_write_object_chunk_test(void) {
   /* Wait until the data is ready to be read. */
   wait_for_pollin(get_client_sock(remote_mock->read_conn));
   /* Read the data. */
-  int done = read_object_chunk(remote_mock->read_conn, &local_buf);
-  ASSERT(done);
+  int err = read_object_chunk(remote_mock->read_conn, &local_buf);
+  ASSERT_EQ(err, 0);
+  ASSERT(ClientConnection_request_finished(remote_mock->read_conn));
   ASSERT_EQ(memcmp(remote_buf.data, local_buf.data, data_size), 0);
   /* Clean up. */
   free(local_buf.data);

--- a/src/plasma/test/manager_tests.cc
+++ b/src/plasma/test/manager_tests.cc
@@ -231,6 +231,7 @@ TEST read_write_object_chunk_test(void) {
   /* Wait until the data is ready to be read. */
   wait_for_pollin(get_client_sock(remote_mock->read_conn));
   /* Read the data. */
+  ClientConnection_start_request(remote_mock->read_conn);
   int err = read_object_chunk(remote_mock->read_conn, &local_buf);
   ASSERT_EQ(err, 0);
   ASSERT(ClientConnection_request_finished(remote_mock->read_conn));

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,4 +13,6 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git checkout 05788d035f4aa918d80c9db7a1bf74fe38309c60
+git remote add ray-arrow git@github.com:ray-project/arrow.git || true
+git fetch ray-arrow
+git checkout ray-arrow/abort-objects

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,6 +13,4 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git remote add ray-arrow git@github.com:ray-project/arrow.git || true
-git fetch ray-arrow
-git checkout ray-arrow/abort-objects
+git checkout dffa486c86d1d09c16e4c52ad0ff78bbee22c4e1

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,4 +13,6 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git checkout dffa486c86d1d09c16e4c52ad0ff78bbee22c4e1
+git remote add ray-arrow git@github.com:ray-project/arrow.git || true
+git fetch ray-arrow
+git checkout ray-arrow/plasma-client-disconnect-bug

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,4 +13,4 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git checkout 2d34f34dc81966f3e186055dc0b962699c98b236
+git checkout 837150e245823c6f0cd9e16dba89b6d1a0396aa7

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,6 +13,4 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git remote add ray-arrow git@github.com:ray-project/arrow.git || true
-git fetch ray-arrow
-git checkout ray-arrow/plasma-client-disconnect-bug
+git checkout 2d34f34dc81966f3e186055dc0b962699c98b236


### PR DESCRIPTION
This fixes error handling between plasma managers when one manager dies during a transfer. Previously, we were not detecting and handling errors on the receiving end. This detects the error by looking for an EOF returned by `read`, and aborts the object that was being received so that we can later recreate the object. This also refactors the send and receive code (in `write_object_chunk` and `read_object_chunk`, respectively) to be more similar.