### PR TITLE
Build MacOS wheels in separate Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,39 @@ matrix:
       install:
         - ./.travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./python/build-wheel-macos.sh
+        - ./python/build-wheel-macos.sh -p 2.7
       script:
-        - ./.travis/test-wheels.sh
+        - ./.travis/test-wheels.sh -p 2.7
+
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1
+      install:
+        - ./.travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./python/build-wheel-macos.sh -p 3.4
+      script:
+        - ./.travis/test-wheels.sh -p 3.4
+
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1
+      install:
+        - ./.travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./python/build-wheel-macos.sh -p 3.5
+      script:
+        - ./.travis/test-wheels.sh -p 3.5
+
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1
+      install:
+        - ./.travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./python/build-wheel-macos.sh -p 3.6
+      script:
+        - ./.travis/test-wheels.sh -p 2.6
 
 install:
   - ./.travis/install-dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
         # This command should be kept in sync with ray/python/README-building-wheels.md.
         - ./python/build-wheel-macos.sh -p 3.6
       script:
-        - ./.travis/test-wheels.sh -p 2.6
+        - ./.travis/test-wheels.sh -p 3.6
 
 install:
   - ./.travis/install-dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,43 +79,43 @@ matrix:
     # Build MacOS wheels.
     - os: osx
       osx_image: xcode7
-      env: MAC_WHEELS=1
+      env: MAC_WHEELS=1 PYTHON=2.7
       install:
         - ./.travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./python/build-wheel-macos.sh -p 2.7
+        - ./python/build-wheel-macos.sh -p $PYTHON
       script:
-        - ./.travis/test-wheels.sh -p 2.7
+        - ./.travis/test-wheels.sh -p $PYTHON
 
     - os: osx
       osx_image: xcode7
-      env: MAC_WHEELS=1
+      env: MAC_WHEELS=1 PYTHON=3.4
       install:
         - ./.travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./python/build-wheel-macos.sh -p 3.4
+        - ./python/build-wheel-macos.sh -p $PYTHON
       script:
-        - ./.travis/test-wheels.sh -p 3.4
+        - ./.travis/test-wheels.sh -p $PYTHON
 
     - os: osx
       osx_image: xcode7
-      env: MAC_WHEELS=1
+      env: MAC_WHEELS=1 PYTHON=3.5
       install:
         - ./.travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./python/build-wheel-macos.sh -p 3.5
+        - ./python/build-wheel-macos.sh -p $PYTHON
       script:
-        - ./.travis/test-wheels.sh -p 3.5
+        - ./.travis/test-wheels.sh -p $PYTHON
 
     - os: osx
       osx_image: xcode7
-      env: MAC_WHEELS=1
+      env: MAC_WHEELS=1 PYTHON=3.6
       install:
         - ./.travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./python/build-wheel-macos.sh -p 3.6
+        - ./python/build-wheel-macos.sh -p $PYTHON
       script:
-        - ./.travis/test-wheels.sh -p 3.6
+        - ./.travis/test-wheels.sh -p $PYTHON
 
 install:
   - ./.travis/install-dependencies.sh

--- a/.travis/test-wheels.sh
+++ b/.travis/test-wheels.sh
@@ -63,6 +63,22 @@ if [[ "$platform" == "linux" ]]; then
   fi
 
 elif [[ "$platform" == "macosx" ]]; then
+  # There are a few ways around this duplicate code (e.g., environment variable, 
+  # bash function), but each with their own downsides
+  PY_ARG=''
+  while getopts 'p:' flag; do
+    case "${flag}" in
+      p) PY_ARG="${OPTARG}" ;;
+      *) error "Unexpected option ${flag}" ;;
+    esac
+  done
+
+  # Check if the requested Python version is supported
+  if [[ ! -z "$PY_ARG" ]] && [[ ! " ${PY_MMS[@]} " =~ " ${PY_ARG} " ]]; then
+    echo "Unexpected Python version $PY_ARG"
+    exit 1
+  fi
+
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
   PY_MMS=("2.7"
           "3.4"
@@ -77,6 +93,11 @@ elif [[ "$platform" == "macosx" ]]; then
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM=${PY_MMS[i]}
     PY_WHEEL_VERSION=${PY_WHEEL_VERSIONS[i]}
+
+    if [[ ! -z "$PY_ARG" ]] && [[ "$PY_ARG" != "$PY_MM" ]]; then
+      echo "Skipping Python version $PY_MM"
+      continue
+    fi
 
     PYTHON_EXE=$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM
     PIP_CMD="$(dirname $PYTHON_EXE)/pip$PY_MM"

--- a/.travis/test-wheels.sh
+++ b/.travis/test-wheels.sh
@@ -63,21 +63,6 @@ if [[ "$platform" == "linux" ]]; then
   fi
 
 elif [[ "$platform" == "macosx" ]]; then
-  # There are a few ways around this duplicate code (e.g., environment variable, 
-  # bash function), but each with their own downsides
-  PY_ARG=''
-  while getopts 'p:' flag; do
-    case "${flag}" in
-      p) PY_ARG="${OPTARG}" ;;
-      *) error "Unexpected option ${flag}" ;;
-    esac
-  done
-
-  # Check if the requested Python version is supported
-  if [[ ! -z "$PY_ARG" ]] && [[ ! " ${PY_MMS[@]} " =~ " ${PY_ARG} " ]]; then
-    echo "Unexpected Python version $PY_ARG"
-    exit 1
-  fi
 
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
   PY_MMS=("2.7"
@@ -89,6 +74,21 @@ elif [[ "$platform" == "macosx" ]]; then
                      "34"
                      "35"
                      "36")
+   # There are a few ways around this duplicate code (e.g., environment variable, 
+   # bash function), but each with their own downsides
+   PY_ARG=''
+   while getopts 'p:' flag; do
+     case "${flag}" in
+       p) PY_ARG="${OPTARG}" ;;
+       *) error "Unexpected option ${flag}" ;;
+     esac
+   done
+
+   # Check if the requested Python version is supported
+   if [[ ! -z "$PY_ARG" ]] && [[ ! " ${PY_MMS[@]} " =~ " ${PY_ARG} " ]]; then
+     echo "Unexpected Python version $PY_ARG"
+     exit 1
+   fi
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM=${PY_MMS[i]}

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -26,6 +26,22 @@ PY_MMS=("2.7"
         "3.5"
         "3.6")
 
+# If Python version is given as an argument, run just that version. This could be
+# more advanced (e.g., accept multiple arguments).
+PY_ARG=''
+while getopts 'p:' flag; do
+  case "${flag}" in
+    p) PY_ARG="${OPTARG}" ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+# Check if the requested Python version is supported
+if [[ ! -z "$PY_ARG" ]] && [[ ! " ${PY_MMS[@]} " =~ " ${PY_ARG} " ]]; then
+  echo "Unexpected Python version $PY_ARG"
+  exit 1
+fi
+
 mkdir -p $DOWNLOAD_DIR
 mkdir -p .whl
 
@@ -33,6 +49,11 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
   PY_VERSION=${PY_VERSIONS[i]}
   PY_INST=${PY_INSTS[i]}
   PY_MM=${PY_MMS[i]}
+
+  if [[ ! -z "$PY_ARG" ]] && [[ "$PY_ARG" != "$PY_MM" ]]; then
+    echo "Skipping Python version $PY_MM"
+    continue
+  fi
 
   # The -f flag is passed twice to also run git clean in the arrow subdirectory.
   # The -d flag removes directories. The -x flag ignores the .gitignore file,


### PR DESCRIPTION
Python 2.7, 3.4, 3.5, and 3.6 wheels all build in their own Travis jobs now.

Notes:
- A lot of duplicate code. We discuss generating ```.travis.yml``` in #1110 as a possible solution.
- Can't check the upload to S3 to make sure ```$TRAVIS_COMMIT/.whl``` doesn't get overwritten in some bad way
- Total build time is ~40 minutes (see [here](https://travis-ci.org/danielsuo/ray/builds/300005929))
- Left Python 3.7 commented out. Made some notes in #1115