### PR TITLE
[tune] Fixing up Hyperband

### DIFF
--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -178,7 +178,7 @@ class HyperBandScheduler(FIFOScheduler):
         Bracket information will only be cleaned up after the trialrunner has
         finished its bookkeeping."""
         bracket, _ = self._trial_info[trial]
-        self._cleanup_trial(t, bracket)
+        self._cleanup_trial(trial, bracket)
 
     def on_trial_error(self, trial_runner, trial):
         """Cleans up trial info from bracket if trial errored early.
@@ -186,7 +186,7 @@ class HyperBandScheduler(FIFOScheduler):
         Bracket information will only be cleaned up after the trialrunner has
         finished its bookkeeping."""
         bracket, _ = self._trial_info[trial]
-        self._cleanup_trial(t, bracket)
+        self._cleanup_trial(trial, bracket)
 
     def choose_trial_to_run(self, trial_runner, *args):
         """Fair scheduling within iteration by completion percentage.

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -219,7 +219,8 @@ class HyperBandScheduler(FIFOScheduler):
 
     def debug_string(self):
         brackets = [
-            "({0} / {1})".format(len(band._live_trials), band._all_trials)
+            "({0}/{1})".format(
+                len(bracket._live_trials), len(bracket._all_trials))
             for band in self._hyperbands for bracket in band]
         return " ".join([
             "Using HyperBand:",

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -36,7 +36,6 @@ class HyperBandScheduler(FIFOScheduler):
         """
         args:
             max_iter (int): maximum iterations per configuration
-            max_hours (float): hours for tuning to run
             eta (int): # defines downsampling rate (default=3)
         """
         assert max_iter > 0, "Max Iterations not valid!"

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -145,6 +145,8 @@ class HyperBandScheduler(FIFOScheduler):
                     trial_runner._stop_trial(t)
                 elif t is trial:
                     signal = TrialScheduler.STOP
+                else:
+                    raise Exception("Trial with unexpected status encountered")
                 self._cleanup_trial(t, bracket)
 
             # ready the good trials

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -218,10 +218,16 @@ class HyperBandScheduler(FIFOScheduler):
         return None
 
     def debug_string(self):
+        brackets = [
+            "({0} / {1})".format(len(band._live_trials), band._all_trials)
+            for band in self._hyperbands for bracket in band]
         return " ".join([
             "Using HyperBand:",
             "num_stopped={}".format(self._num_stopped),
-            "brackets={}".format(sum(len(band) for band in self._hyperbands))])
+            "total_brackets={}".format(
+                sum(len(band) for band in self._hyperbands)),
+            " ".join(brackets)
+            ])
 
 
 class Bracket():

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -64,7 +64,7 @@ class HyperBandScheduler(FIFOScheduler):
 
     def time_finished(self):
         return (self._max_hours
-            and self.max_hours * 3600.0 > (time.time() - self._start_time))
+            and self._max_hours * 3600.0 < (time.time() - self._start_time))
 
     def on_trial_add(self, trial_runner, trial):
         """On a new trial add, if current bracket is not filled,

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -86,9 +86,9 @@ class HyperBandScheduler(FIFOScheduler):
                 self._hyperbands.append(cur_band)
                 self._state["band_idx"] += 1
 
-            # cur_band will always be less than s_max or else filled
-            s = self._s_max_1 - len(cur_band) - 1
-            assert s >= 0, "Current band is filled but adding bracket!"
+            # cur_band will always be less than s_max_1 or else filled
+            s = len(cur_band)
+            assert s < self._s_max_1, "Current band is filled!"
 
             # create new bracket
             cur_bracket = Bracket(self._get_n0(s),

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -63,8 +63,8 @@ class HyperBandScheduler(FIFOScheduler):
         self._num_stopped = 0
 
     def time_finished(self):
-        return (self._max_hours
-            and self._max_hours * 3600.0 < (time.time() - self._start_time))
+        return (self._max_hours and
+                self._max_hours * 3600.0 < (time.time() - self._start_time))
 
     def on_trial_add(self, trial_runner, trial):
         """On a new trial add, if current bracket is not filled,

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -186,7 +186,6 @@ class HyperbandSuite(unittest.TestCase):
         self.assertNotEqual(trial.status, Trial.TERMINATED)
         mock_runner._stop_trial(trial)
 
-
     def testSuccessiveHalving(self):
         """Setup full band, then iterate through last bracket (n=9)
         to make sure successive halving is correct."""
@@ -206,7 +205,7 @@ class HyperbandSuite(unittest.TestCase):
             elif status == TrialScheduler.PAUSE:
                 mock_runner._pause_trial(trl)
             elif status == TrialScheduler.STOP:
-                self.assertNotEqual(trial.status, Trial.TERMINATED)
+                self.assertNotEqual(trl.status, Trial.TERMINATED)
                 self.stopTrial(trl, mock_runner)
 
         current_length = len(big_bracket.current_trials())

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
-import time
 
 from ray.tune.result import TrainingResult
 from ray.tune.trial import Trial
@@ -319,6 +318,7 @@ class HyperbandSuite(unittest.TestCase):
         t = Trial("t%d" % 5, "__fake")
         sched.on_trial_add(None, t)
         self.assertEqual(3 + 1, sched._state["bracket"]._live_trials[t][1])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -320,23 +320,5 @@ class HyperbandSuite(unittest.TestCase):
         sched.on_trial_add(None, t)
         self.assertEqual(3 + 1, sched._state["bracket"]._live_trials[t][1])
 
-    def testTiming(self):
-        sched = HyperBandScheduler(3, max_hours=10/3600, eta=3)
-        mock_runner = _MockTrialRunner()
-        trials = [Trial("t%d" % i, "__fake") for i in range(2)]
-        for t in trials:
-            sched.on_trial_add(None, t)
-        filled_band = sched._hyperbands[0]
-        brack = filled_band[0]
-        bracket_trials = brack.current_trials()
-        for t in bracket_trials:
-            mock_runner._launch_trial(t)
-        time.sleep(10)
-        self.assertEqual(TrialScheduler.STOP, sched.on_trial_result(
-                mock_runner, bracket_trials[-1], result(1, 10)))
-        self.assertIsNone(sched.choose_trial_to_run(mock_runner))
-        self.assertIsNone(sched.on_trial_add(None, Trial("t6", "__fake")))
-
-
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -245,8 +245,6 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(status, TrialScheduler.STOP)
         self.assertEqual(len(big_bracket.current_trials()), 0)
         self.assertEqual(sched._num_stopped, 9)
-        # TODO(rliaw): check
-
 
     def testBasicRun(self):
         sched = self.advancedSetup()


### PR DESCRIPTION
## What do these changes do?

1. Cleans up bookkeeping for HyperBand. Previously, bookkeeping was missed when running trials were stopped.
1a. Launches task in order of long-running bracket first. (Previously, short-running bracket was filled first and would cause severe slowdowns when launching small number of trials)
2. Provides a full test for successive halving per HyperBand iteration.
2a. Cleans up tests.
3.  [OPEN TO FEEDBACK] ~Introduces time limit for HyperBand as a more intuitive specification.~

~NOTE: It would also make sense to put this at a higher level so that all trial schedulers can utilize this.~
~NOTE 2: One other option for intuitive configuration is to **have default constant number of brackets and trials**. 
We can automatically translate `max_iters` of each trial into `max_iterations` in the HyperBand context. For example, the default `max_iterations` for HyperBand can be 81. Then, one can specify `5000` iterations for A3C, and 60 A3C iterations would count as 1 iteration in the HyperBand context.~

## TODO:
 - [x] One last test to take care of case where an errored task is the final one of the band iteration.