### PR TITLE
Replace UT string in redis tests

### DIFF
--- a/src/common/test/redis_tests.cc
+++ b/src/common/test/redis_tests.cc
@@ -21,16 +21,15 @@ const char *test_value = "bar";
 std::vector<int> connections;
 
 void write_formatted_log_message(int socket_fd, const char *format, ...) {
-  UT_string *cmd;
   va_list ap;
 
-  utstring_new(cmd);
   va_start(ap, format);
-  utstring_printf_va(cmd, format, ap);
+  size_t cmd_size = vsnprintf(nullptr, 0, format, ap) + 1;
+  char cmd[cmd_size];
+  vsnprintf(cmd, cmd_size, format, ap);
   va_end(ap);
 
-  write_log_message(socket_fd, utstring_body(cmd));
-  utstring_free(cmd);
+  write_log_message(socket_fd, cmd);
 }
 
 int async_redis_socket_test_callback_called = 0;

--- a/src/common/test/redis_tests.cc
+++ b/src/common/test/redis_tests.cc
@@ -23,9 +23,14 @@ std::vector<int> connections;
 void write_formatted_log_message(int socket_fd, const char *format, ...) {
   va_list ap;
 
+  /* Get cmd size */
   va_start(ap, format);
   size_t cmd_size = vsnprintf(nullptr, 0, format, ap) + 1;
+  va_end(ap);
+
+  /* Print va to cmd */
   char cmd[cmd_size];
+  va_start(ap, format);
   vsnprintf(cmd, cmd_size, format, ap);
   va_end(ap);
 


### PR DESCRIPTION
- Use `vsnprintf` instead of `utstring_printf_va`
- Makes progress on #404 