### PR TITLE
Replace UT strings in local scheduler

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1356,9 +1356,8 @@ void start_server(const char *node_ip_address,
   /* Create a timer for initiating the reconstruction of tasks' missing object
    * dependencies. */
   event_loop_add_timer(
-      loop,
-      RayConfig::instance()
-          .local_scheduler_reconstruction_timeout_milliseconds(),
+      loop, RayConfig::instance()
+                .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -349,7 +349,6 @@ LocalSchedulerState *LocalSchedulerState_init(
     std::string num_gpus = std::to_string(static_resource_conf[1]);
 
     /* Construct db_connect_args */
-    int num_args = 6;
     std::vector<const char *> db_connect_args;
     db_connect_args.push_back("local_scheduler_socket_name");
     db_connect_args.push_back(local_scheduler_socket_name);
@@ -359,14 +358,13 @@ LocalSchedulerState *LocalSchedulerState_init(
     db_connect_args.push_back(num_gpus.c_str());
 
     if (plasma_manager_address != NULL) {
-      num_args = 8;
       db_connect_args.push_back("manager_address");
       db_connect_args.push_back(plasma_manager_address);
     }
 
     state->db = db_connect(std::string(redis_primary_addr), redis_primary_port,
-                           "local_scheduler", node_ip_address, num_args,
-                           &db_connect_args[0]);
+                           "local_scheduler", node_ip_address,
+                           db_connect_args.size(), &db_connect_args[0]);
     db_attach(state->db, loop, false);
   } else {
     state->db = NULL;

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -344,36 +344,29 @@ LocalSchedulerState *LocalSchedulerState_init(
 
   /* Connect to Redis if a Redis address is provided. */
   if (redis_primary_addr != NULL) {
-    int num_args;
-    const char **db_connect_args = NULL;
     /* Use std::string to convert the resource value into a string. */
     std::string num_cpus = std::to_string(static_resource_conf[0]);
     std::string num_gpus = std::to_string(static_resource_conf[1]);
+
+    /* Construct db_connect_args */
+    int num_args = 6;
+    std::vector<const char *> db_connect_args;
+    db_connect_args.push_back("local_scheduler_socket_name");
+    db_connect_args.push_back(local_scheduler_socket_name);
+    db_connect_args.push_back("num_cpus");
+    db_connect_args.push_back(num_cpus.c_str());
+    db_connect_args.push_back("num_gpus");
+    db_connect_args.push_back(num_gpus.c_str());
+
     if (plasma_manager_address != NULL) {
       num_args = 8;
-      db_connect_args = (const char **) malloc(sizeof(char *) * num_args);
-      db_connect_args[0] = "local_scheduler_socket_name";
-      db_connect_args[1] = local_scheduler_socket_name;
-      db_connect_args[2] = "num_cpus";
-      db_connect_args[3] = num_cpus.c_str();
-      db_connect_args[4] = "num_gpus";
-      db_connect_args[5] = num_gpus.c_str();
-      db_connect_args[6] = "manager_address";
-      db_connect_args[7] = plasma_manager_address;
-    } else {
-      num_args = 6;
-      db_connect_args = (const char **) malloc(sizeof(char *) * num_args);
-      db_connect_args[0] = "local_scheduler_socket_name";
-      db_connect_args[1] = local_scheduler_socket_name;
-      db_connect_args[2] = "num_cpus";
-      db_connect_args[3] = num_cpus.c_str();
-      db_connect_args[4] = "num_gpus";
-      db_connect_args[5] = num_gpus.c_str();
+      db_connect_args.push_back("manager_address");
+      db_connect_args.push_back(plasma_manager_address);
     }
+
     state->db = db_connect(std::string(redis_primary_addr), redis_primary_port,
                            "local_scheduler", node_ip_address, num_args,
-                           db_connect_args);
-    free(db_connect_args);
+                           &db_connect_args[0]);
     db_attach(state->db, loop, false);
   } else {
     state->db = NULL;

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -6,6 +6,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <string>
+
 #include "common.h"
 #include "common_protocol.h"
 #include "event_loop.h"
@@ -344,22 +346,18 @@ LocalSchedulerState *LocalSchedulerState_init(
   if (redis_primary_addr != NULL) {
     int num_args;
     const char **db_connect_args = NULL;
-    /* Use UT_string to convert the resource value into a string. */
-    UT_string *num_cpus;
-    UT_string *num_gpus;
-    utstring_new(num_cpus);
-    utstring_new(num_gpus);
-    utstring_printf(num_cpus, "%f", static_resource_conf[0]);
-    utstring_printf(num_gpus, "%f", static_resource_conf[1]);
+    /* Use std::string to convert the resource value into a string. */
+    std::string num_cpus = std::to_string(static_resource_conf[0]);
+    std::string num_gpus = std::to_string(static_resource_conf[1]);
     if (plasma_manager_address != NULL) {
       num_args = 8;
       db_connect_args = (const char **) malloc(sizeof(char *) * num_args);
       db_connect_args[0] = "local_scheduler_socket_name";
       db_connect_args[1] = local_scheduler_socket_name;
       db_connect_args[2] = "num_cpus";
-      db_connect_args[3] = utstring_body(num_cpus);
+      db_connect_args[3] = num_cpus.c_str();
       db_connect_args[4] = "num_gpus";
-      db_connect_args[5] = utstring_body(num_gpus);
+      db_connect_args[5] = num_gpus.c_str();
       db_connect_args[6] = "manager_address";
       db_connect_args[7] = plasma_manager_address;
     } else {
@@ -368,15 +366,13 @@ LocalSchedulerState *LocalSchedulerState_init(
       db_connect_args[0] = "local_scheduler_socket_name";
       db_connect_args[1] = local_scheduler_socket_name;
       db_connect_args[2] = "num_cpus";
-      db_connect_args[3] = utstring_body(num_cpus);
+      db_connect_args[3] = num_cpus.c_str();
       db_connect_args[4] = "num_gpus";
-      db_connect_args[5] = utstring_body(num_gpus);
+      db_connect_args[5] = num_gpus.c_str();
     }
     state->db = db_connect(std::string(redis_primary_addr), redis_primary_port,
                            "local_scheduler", node_ip_address, num_args,
                            db_connect_args);
-    utstring_free(num_cpus);
-    utstring_free(num_gpus);
     free(db_connect_args);
     db_attach(state->db, loop, false);
   } else {
@@ -1360,8 +1356,9 @@ void start_server(const char *node_ip_address,
   /* Create a timer for initiating the reconstruction of tasks' missing object
    * dependencies. */
   event_loop_add_timer(
-      loop, RayConfig::instance()
-                .local_scheduler_reconstruction_timeout_milliseconds(),
+      loop,
+      RayConfig::instance()
+          .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1356,8 +1356,9 @@ void start_server(const char *node_ip_address,
   /* Create a timer for initiating the reconstruction of tasks' missing object
    * dependencies. */
   event_loop_add_timer(
-      loop, RayConfig::instance()
-                .local_scheduler_reconstruction_timeout_milliseconds(),
+      loop,
+      RayConfig::instance()
+          .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1347,9 +1347,8 @@ void start_server(const char *node_ip_address,
   /* Create a timer for initiating the reconstruction of tasks' missing object
    * dependencies. */
   event_loop_add_timer(
-      loop,
-      RayConfig::instance()
-          .local_scheduler_reconstruction_timeout_milliseconds(),
+      loop, RayConfig::instance()
+                .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
- Use `std::string` to parse `num_cpus` and `num_gpus`

<!-- Please give a short brief about these changes. -->

## Related issue number
- Makes progress on #404

<!-- Are there any issues opened that will be resolved by merging this change? -->
