### PR TITLE
[tune] Make HyperBand Usable

### DIFF
--- a/python/ray/rllib/tuned_examples/hyperband-cartpole.yaml
+++ b/python/ray/rllib/tuned_examples/hyperband-cartpole.yaml
@@ -1,7 +1,7 @@
 cartpole-ppo:
     env: CartPole-v0
     alg: PPO
-    num_trials: 20
+    repeat: 3
     stop:
         episode_reward_mean: 200
         time_total_s: 180

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -8,12 +8,10 @@ from ray.tune.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.trial import Trial
 
 
-def calculate_bracket_count(max_t_attr, eta):
-    return int(np.log(max_t_attr)/np.log(eta)) + 1
-
-
 class HyperBandScheduler(FIFOScheduler):
     """Implements HyperBand.
+
+    Blog post: https://people.eecs.berkeley.edu/~kjamieson/hyperband.html
 
     This implementation contains 3 logical levels.
     Each HyperBand iteration is a "band". There can be multiple
@@ -31,7 +29,11 @@ class HyperBandScheduler(FIFOScheduler):
     Trials added will be inserted into the most recent bracket
     and band and will spill over to new brackets/bands accordingly.
 
-    See https://people.eecs.berkeley.edu/~kjamieson/hyperband.html
+    This maintains the bracket size and max trial count per band
+    to 5 and 117 respectively, which correspond to that of
+    `max_attr=81, eta=3` from the blog post. Trials will fill up
+    from smallest bracket to largest, with largest
+    having the most rounds of successive halving.
 
     Args:
         time_attr (str): The TrainingResult attr to use for comparing time.
@@ -41,33 +43,24 @@ class HyperBandScheduler(FIFOScheduler):
         reward_attr (str): The TrainingResult objective value attribute. As
             with `time_attr`, this may refer to any objective value. Stopping
             procedures will use this attribute.
-        max_t_attr (int): maximum iterations per configuration. Altering
-            this with `eta=None` will not change the bracket count
-            nor size. If eta is changed to an int, then all will change.
-        eta (int): Default is None, This maintains the bracket size
-            and max trial count per band to 5 and 117 respectively, which
-            correspond to that of `max_t_attr=81, eta=3`. Trials do not
-            need to fill the band and will fill up from smallest bracket
-            to largest, with largest having the most rounds of successive
-            halving. If eta is changed, it will create trials and brackets
-            according to the default Hyperband formulation.
+        max_t (int): max time units per trial. Trials will be stopped after
+            max_t time units (determined by time_attr) have passed.
+            The HyperBand scheduler automatically tries to determine a
+            reasonable number of brackets based on this and eta.
     """
 
     def __init__(
             self, time_attr='training_iteration',
-            reward_attr='episode_reward_mean',
-            max_t_attr=81, eta=None):
-        assert max_t_attr > 0, "Max (time_attr) not valid!"
-        assert (eta is None or eta > 1), "Downsampling rate (eta) not valid!"
-
+            reward_attr='episode_reward_mean', max_t=81):
+        assert max_t > 0, "Max (time_attr) not valid!"
         FIFOScheduler.__init__(self)
-        self._eta = eta if eta else 3
-        self._s_max_1 = calculate_bracket_count(max_t_attr, eta) if eta else 5
+        self._eta = 3
+        self._s_max_1 = 5
         # bracket max trials
         self._get_n0 = lambda s: int(
             np.ceil(self._s_max_1/(s+1) * self._eta**s))
         # bracket initial iterations
-        self._get_r0 = lambda s: int((max_t_attr*self._eta**(-s)))
+        self._get_r0 = lambda s: int((max_t*self._eta**(-s)))
         self._hyperbands = [[]]  # list of hyperband iterations
         self._trial_info = {}  # Stores Trial -> Bracket, Band Iteration
 
@@ -153,7 +146,7 @@ class HyperBandScheduler(FIFOScheduler):
         if bracket.cur_iter_done():
             if bracket.finished():
                 self._cleanup_bracket(trial_runner, bracket)
-                return TrialScheduler.STOP
+                return TrialScheduler.CONTINUE
 
             good, bad = bracket.successive_halving(self._reward_attr)
             # kill bad trials
@@ -188,11 +181,14 @@ class HyperBandScheduler(FIFOScheduler):
         bracket.cleanup_trial(t)
 
     def _cleanup_bracket(self, trial_runner, bracket):
-        """Cleans up bracket after bracket is completely finished."""
+        """Cleans up bracket after bracket is completely finished.
+        Lets the last trial continue to run until termination condition
+        kicks in."""
         for trial in bracket.current_trials():
-            self._cleanup_trial(
-                trial_runner, trial, bracket,
-                hard=(trial.status == Trial.PAUSED))
+            if (trial.status == Trial.PAUSED):
+                self._cleanup_trial(
+                    trial_runner, trial, bracket,
+                    hard=True)
 
     def on_trial_complete(self, trial_runner, trial, result):
         """Cleans up trial info from bracket if trial completed early."""

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -35,8 +35,9 @@ class HyperBandScheduler(FIFOScheduler):
     def __init__(self, max_iter=81, eta=None):
         """
         args:
-            max_iter (int): maximum iterations per configuration. By default,
-                this will not change the bracket count nor size.
+            max_iter (int): maximum iterations per configuration. Altering
+                this with `eta=None` will not change the bracket count
+                nor size. If eta is changed to an int, then all will change.
             eta (int): Default is None, This maintains the bracket size
                 and trial count per band to 5 and 117 respectively, which
                 correspond to that of `max_iter=81, eta=3`. If eta is changed,
@@ -71,7 +72,7 @@ class HyperBandScheduler(FIFOScheduler):
         cur_bracket = self._state["bracket"]
         cur_band = self._hyperbands[self._state["band_idx"]]
         if cur_bracket is None or cur_bracket.filled():
-            retry = False
+            retry = True
             while retry:
                 # if current iteration is filled, create new iteration
                 if self._cur_band_filled():
@@ -83,15 +84,14 @@ class HyperBandScheduler(FIFOScheduler):
                 s = len(cur_band)
                 assert s < self._s_max_1, "Current band is filled!"
                 if self._get_r0(s) == 0:
-                    retry = True
                     print("Bracket too small - Retrying...")
                     cur_bracket = None
                 else:
-                    cur_bracket = Bracket(self._get_n0(s),
-                                      self._get_r0(s), self._eta, s)
+                    retry = False
+                    cur_bracket = Bracket(
+                        self._get_n0(s), self._get_r0(s), self._eta, s)
                 cur_band.append(cur_bracket)
                 self._state["bracket"] = cur_bracket
-
 
         self._state["bracket"].add_trial(trial)
         self._trial_info[trial] = cur_bracket, self._state["band_idx"]

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -200,7 +200,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertNotEqual(trial.status, Trial.TERMINATED)
         mock_runner._stop_trial(trial)
 
-    def testConfigEtaSame(self):
+    def testConfigSameEta(self):
         sched = HyperBandScheduler()
         i = 0
         while not sched._cur_band_filled():
@@ -225,7 +225,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(sched._hyperbands[0][-1]._n, 81)
         self.assertEqual(sched._hyperbands[0][-1]._r, 10)
 
-    def testConfigEtaSameSmall(self):
+    def testConfigSameEtaSmall(self):
         sched = HyperBandScheduler(max_iter=1)
         i = 0
         while len(sched._hyperbands) < 2:
@@ -253,8 +253,7 @@ class HyperbandSuite(unittest.TestCase):
             t = Trial("t%d" % (i), "__fake")
             sched.on_trial_add(None, t)
             i += 1
-        self.assertEqual(len(sched._hyperbands[0]), 5)
-        self.assertTrue(all(v is None for v in sched._hyperbands[0][1:]))
+        self.assertEqual(len(sched._hyperbands[0]), 1)
 
     def testSuccessiveHalving(self):
         """Setup full band, then iterate through last bracket (n=9)

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -397,7 +397,7 @@ class HyperbandSuite(unittest.TestCase):
                 mock_runner, t, result(stats[str(1)]["r"], 10))
 
         mock_runner._launch_trial(trials[-1])
-        sched.on_trial_complete(mock_runner, trials[-1], result(1, 12))
+        sched.on_trial_complete(mock_runner, trials[-1], result(100, 12))
         self.assertEqual(len(sched._state["bracket"].current_trials()),
                          self.downscale(stats[str(1)]["n"], sched))
 

--- a/test/trial_scheduler_test.py
+++ b/test/trial_scheduler_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
+import numpy as np
 
 from ray.tune.hyperband import HyperBandScheduler
 from ray.tune.median_stopping_rule import MedianStoppingRule
@@ -158,21 +159,46 @@ class HyperbandSuite(unittest.TestCase):
         """Setup a scheduler and Runner with max Iter = 9
 
         Bracketing is placed as follows:
-        (3, 9);
-        (5, 3) -> (2, 9);
-        (9, 1) -> (3, 3) -> (1, 9); """
-        sched = HyperBandScheduler(max_t_attr=9, eta=3)
+        (5, 81);
+        (8, 27) -> (3, 81);
+        (15, 9) -> (5, 27) -> (2, 81);
+        (34, 3) -> (12, 9) -> (4, 27) -> (2, 81);
+        (81, 1) -> (27, 3) -> (9, 9) -> (3, 27) -> (1, 81);"""
+        sched = HyperBandScheduler()
         for i in range(num_trials):
             t = Trial("t%d" % i, "__fake")
             sched.on_trial_add(None, t)
         runner = _MockTrialRunner()
         return sched, runner
 
+    def default_statistics(self):
+        """Default statistics for HyperBand"""
+        sched = HyperBandScheduler()
+        res = {
+            str(s): {"n": sched._get_n0(s), "r": sched._get_r0(s)}
+            for s in range(sched._s_max_1)
+        }
+        res["max_trials"] = sum(v["n"] for v in res.values())
+        res["brack_count"] = sched._s_max_1
+        res["s_max"] = sched._s_max_1 - 1
+        return res
+
+    def downscale(self, n, sched):
+        return int(np.ceil(n / sched._eta))
+
+    def process(self, trl, mock_runner, action):
+        if action == TrialScheduler.CONTINUE:
+            pass
+        elif action == TrialScheduler.PAUSE:
+            mock_runner._pause_trial(trl)
+        elif action == TrialScheduler.STOP:
+            self.stopTrial(trl, mock_runner)
+
     def basicSetup(self):
         """Setup and verify full band.
         """
-
-        sched, _ = self.schedulerSetup(17)
+        stats = self.default_statistics()
+        sched, _ = self.schedulerSetup(stats["max_trials"])
 
         self.assertEqual(len(sched._hyperbands), 1)
         self.assertEqual(sched._cur_band_filled(), True)
@@ -194,7 +220,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(len(unfilled_band), 2)
         bracket = unfilled_band[-1]
         self.assertEqual(bracket.filled(), False)
-        self.assertEqual(len(bracket.current_trials()), 1)
+        self.assertEqual(len(bracket.current_trials()), 7)
 
         return sched
 
@@ -215,7 +241,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(sched._hyperbands[0][-1]._n, 81)
         self.assertEqual(sched._hyperbands[0][-1]._r, 1)
 
-        sched = HyperBandScheduler(max_t_attr=810)
+        sched = HyperBandScheduler(max_t=810)
         i = 0
         while not sched._cur_band_filled():
             t = Trial("t%d" % (i), "__fake")
@@ -228,7 +254,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(sched._hyperbands[0][-1]._r, 10)
 
     def testConfigSameEtaSmall(self):
-        sched = HyperBandScheduler(max_t_attr=1)
+        sched = HyperBandScheduler(max_t=1)
         i = 0
         while len(sched._hyperbands) < 2:
             t = Trial("t%d" % (i), "__fake")
@@ -237,166 +263,171 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(len(sched._hyperbands[0]), 5)
         self.assertTrue(all(v is None for v in sched._hyperbands[0][1:]))
 
-    def testConfigDiffEta(self):
-        sched = HyperBandScheduler(max_t_attr=64, eta=2)
-        i = 0
-        while not sched._cur_band_filled():
-            t = Trial("t%d" % (i), "__fake")
-            sched.on_trial_add(None, t)
-            i += 1
-        self.assertEqual(len(sched._hyperbands[0]), 7)
-        self.assertEqual(sched._hyperbands[0][0]._n, 7)
-        self.assertEqual(sched._hyperbands[0][-1]._n, 64)
-
-    def testConfigDiffEtaSmall(self):
-        sched = HyperBandScheduler(max_t_attr=1, eta=2)
-        i = 0
-        while len(sched._hyperbands) < 2:
-            t = Trial("t%d" % (i), "__fake")
-            sched.on_trial_add(None, t)
-            i += 1
-        self.assertEqual(len(sched._hyperbands[0]), 1)
-
     def testSuccessiveHalving(self):
-        """Setup full band, then iterate through last bracket (n=9)
+        """Setup full band, then iterate through last bracket (n=81)
         to make sure successive halving is correct."""
+        stats = self.default_statistics()
+        sched, mock_runner = self.schedulerSetup(stats["max_trials"])
+        big_bracket = sched._state["bracket"]
+        cur_units = stats[str(stats["s_max"])]["r"]
+        # The last bracket will downscale 4 times
+        for x in range(stats["brack_count"] - 1):
+            trials = big_bracket.current_trials()
+            current_length = len(trials)
+            for trl in trials:
+                mock_runner._launch_trial(trl)
 
-        sched, mock_runner = self.schedulerSetup(17)
-        big_bracket = sched._hyperbands[0][-1]
+            # Provides results from 0 to 8 in order, keeping last one running
+            for i, trl in enumerate(trials):
+                action = sched.on_trial_result(
+                    mock_runner, trl, result(cur_units, i))
+                if i < current_length - 1:
+                    self.assertEqual(action, TrialScheduler.PAUSE)
+                self.process(trl, mock_runner, action)
 
+            self.assertEqual(action, TrialScheduler.CONTINUE)
+            new_length = len(big_bracket.current_trials())
+            self.assertEqual(new_length, self.downscale(current_length, sched))
+            cur_units += int(cur_units * sched._eta)
+        self.assertEqual(len(big_bracket.current_trials()), 1)
+
+    def testHalvingStop(self):
+        stats = self.default_statistics()
+        num_trials = stats[str(0)]["n"] + stats[str(1)]["n"]
+        sched, mock_runner = self.schedulerSetup(num_trials)
+        big_bracket = sched._state["bracket"]
         for trl in big_bracket.current_trials():
             mock_runner._launch_trial(trl)
 
-        # Provides results from 0 to 8 in order, keeping the last one running
-        for i, trl in enumerate(big_bracket.current_trials()):
-            status = sched.on_trial_result(mock_runner, trl, result(1, i))
-            if status == TrialScheduler.CONTINUE:
-                continue
-            elif status == TrialScheduler.PAUSE:
-                mock_runner._pause_trial(trl)
-            elif status == TrialScheduler.STOP:
-                self.assertNotEqual(trl.status, Trial.TERMINATED)
-                self.stopTrial(trl, mock_runner)
-
-        current_length = len(big_bracket.current_trials())
-        self.assertEqual(status, TrialScheduler.CONTINUE)
-        self.assertEqual(current_length, 3)
-
-        # Techincally only need to launch 2/3, as one is already running
-        for trl in big_bracket.current_trials():
-            mock_runner._launch_trial(trl)
-
-        # Provides results from 2 to 0 in order, killing the last one
+        # # Provides result in reverse order, killing the last one
+        cur_units = stats[str(1)]["r"]
         for i, trl in reversed(list(enumerate(big_bracket.current_trials()))):
-            for j in range(3):
-                status = sched.on_trial_result(
-                    mock_runner, trl, result(2 + j, i))
-            if status == TrialScheduler.CONTINUE:
-                continue
-            elif status == TrialScheduler.PAUSE:
-                mock_runner._pause_trial(trl)
-            elif status == TrialScheduler.STOP:
-                self.stopTrial(trl, mock_runner)
+            action = sched.on_trial_result(
+                mock_runner, trl, result(cur_units, i))
+            self.process(trl, mock_runner, action)
 
-        self.assertEqual(status, TrialScheduler.STOP)
-        trl = big_bracket.current_trials()[0]
-        for i in range(9):
-            status = sched.on_trial_result(mock_runner, trl, result(5 + i, i))
-        self.assertEqual(status, TrialScheduler.STOP)
-        self.assertEqual(len(big_bracket.current_trials()), 0)
-        self.assertEqual(sched._num_stopped, 9)
+        self.assertEqual(action, TrialScheduler.STOP)
 
-    def testScheduling(self):
-        """Setup two bands, then make sure all trials are running"""
-        sched = self.advancedSetup()
-        mock_runner = _MockTrialRunner()
-        trl = sched.choose_trial_to_run(mock_runner)
-        while trl:
-            # If band iteration > 0, make sure first band is all running
-            if sched._trial_info[trl][1] > 0:
-                first_band = sched._hyperbands[0]
-                trials = [t for b in first_band for t in b._live_trials]
-                self.assertEqual(
-                    all(t.status == Trial.RUNNING for t in trials),
-                    True)
+    def testContinueLastOne(self):
+        stats = self.default_statistics()
+        num_trials = stats[str(0)]["n"]
+        sched, mock_runner = self.schedulerSetup(num_trials)
+        big_bracket = sched._state["bracket"]
+        for trl in big_bracket.current_trials():
             mock_runner._launch_trial(trl)
-            res = sched.on_trial_result(mock_runner, trl, result(1, 10))
-            if res is TrialScheduler.PAUSE:
-                mock_runner._pause_trial(trl)
-            trl = sched.choose_trial_to_run(mock_runner)
 
-        self.assertEqual(
-                    all(t.status == Trial.RUNNING for t in trials), True)
+        # # Provides result in reverse order, killing the last one
+        cur_units = stats[str(0)]["r"]
+        for i, trl in enumerate(big_bracket.current_trials()):
+            action = sched.on_trial_result(
+                mock_runner, trl, result(cur_units, i))
+            self.process(trl, mock_runner, action)
+
+        self.assertEqual(action, TrialScheduler.CONTINUE)
+
+        for x in range(100):
+            action = sched.on_trial_result(
+                mock_runner, trl, result(cur_units + x, 10))
+            self.assertEqual(action, TrialScheduler.CONTINUE)
 
     def testTrialErrored(self):
-        sched, mock_runner = self.schedulerSetup(10)
-        t1, t2 = sched._state["bracket"].current_trials()
-        mock_runner._launch_trial(t1)
-        mock_runner._launch_trial(t2)
+        """If a trial errored, make sure successive halving still happens"""
+        stats = self.default_statistics()
+        trial_count = stats[str(0)]["n"] + 3
+        sched, mock_runner = self.schedulerSetup(trial_count)
+        t1, t2, t3 = sched._state["bracket"].current_trials()
+        for t in [t1, t2, t3]:
+            mock_runner._launch_trial(t)
 
-        sched.on_trial_error(mock_runner, t2)
+        sched.on_trial_error(mock_runner, t3)
+        self.assertEqual(
+            TrialScheduler.PAUSE,
+            sched.on_trial_result(
+                mock_runner, t1, result(stats[str(1)]["r"], 10)))
         self.assertEqual(
             TrialScheduler.CONTINUE,
-            sched.on_trial_result(mock_runner, t1, result(1, 10)))
+            sched.on_trial_result(
+                mock_runner, t2, result(stats[str(1)]["r"], 10)))
 
     def testTrialErrored2(self):
         """Check successive halving happened even when last trial failed"""
-        sched, mock_runner = self.schedulerSetup(17)
+        stats = self.default_statistics()
+        trial_count = stats[str(0)]["n"] + stats[str(1)]["n"]
+        sched, mock_runner = self.schedulerSetup(trial_count)
         trials = sched._state["bracket"].current_trials()
-        self.assertEqual(len(trials), 9)
         for t in trials[:-1]:
             mock_runner._launch_trial(t)
-            sched.on_trial_result(mock_runner, t, result(1, 10))
+            sched.on_trial_result(
+                mock_runner, t, result(stats[str(1)]["r"], 10))
 
         mock_runner._launch_trial(trials[-1])
         sched.on_trial_error(mock_runner, trials[-1])
-        self.assertEqual(len(sched._state["bracket"].current_trials()), 3)
+        self.assertEqual(len(sched._state["bracket"].current_trials()),
+                         self.downscale(stats[str(1)]["n"], sched))
 
     def testTrialEndedEarly(self):
-        sched, mock_runner = self.schedulerSetup(10)
-        trials = sched._state["bracket"].current_trials()
-        for t in trials:
+        """Check successive halving happened even when one trial failed"""
+        stats = self.default_statistics()
+        trial_count = stats[str(0)]["n"] + 3
+        sched, mock_runner = self.schedulerSetup(trial_count)
+
+        t1, t2, t3 = sched._state["bracket"].current_trials()
+        for t in [t1, t2, t3]:
             mock_runner._launch_trial(t)
 
-        sched.on_trial_complete(mock_runner, trials[-1], result(1, 12))
+        sched.on_trial_complete(mock_runner, t3, result(1, 12))
+        self.assertEqual(
+            TrialScheduler.PAUSE,
+            sched.on_trial_result(
+                mock_runner, t1, result(stats[str(1)]["r"], 10)))
         self.assertEqual(
             TrialScheduler.CONTINUE,
-            sched.on_trial_result(mock_runner, trials[0], result(1, 12)))
+            sched.on_trial_result(
+                mock_runner, t2, result(stats[str(1)]["r"], 10)))
 
     def testTrialEndedEarly2(self):
-        """Check successive halving happened even when last trial finished"""
-        sched, mock_runner = self.schedulerSetup(17)
+        """Check successive halving happened even when last trial failed"""
+        stats = self.default_statistics()
+        trial_count = stats[str(0)]["n"] + stats[str(1)]["n"]
+        sched, mock_runner = self.schedulerSetup(trial_count)
         trials = sched._state["bracket"].current_trials()
-        self.assertEqual(len(trials), 9)
         for t in trials[:-1]:
             mock_runner._launch_trial(t)
-            sched.on_trial_result(mock_runner, t, result(1, 10))
+            sched.on_trial_result(
+                mock_runner, t, result(stats[str(1)]["r"], 10))
 
         mock_runner._launch_trial(trials[-1])
         sched.on_trial_complete(mock_runner, trials[-1], result(1, 12))
-        self.assertEqual(len(sched._state["bracket"].current_trials()), 3)
+        self.assertEqual(len(sched._state["bracket"].current_trials()),
+                         self.downscale(stats[str(1)]["n"], sched))
 
     def testAddAfterHalving(self):
-        sched, mock_runner = self.schedulerSetup(10)
+        stats = self.default_statistics()
+        trial_count = stats[str(0)]["n"] + 1
+        sched, mock_runner = self.schedulerSetup(trial_count)
         bracket_trials = sched._state["bracket"].current_trials()
+        init_units = stats[str(1)]["r"]
 
         for t in bracket_trials:
             mock_runner._launch_trial(t)
 
         for i, t in enumerate(bracket_trials):
             status = sched.on_trial_result(
-                mock_runner, t, result(1, i))
+                mock_runner, t, result(init_units, i))
         self.assertEqual(status, TrialScheduler.CONTINUE)
-        t = Trial("t%d" % 5, "__fake")
+        t = Trial("t%d" % 100, "__fake")
         sched.on_trial_add(None, t)
         mock_runner._launch_trial(t)
-        for i in range(3):
-            self.assertEqual(
-                TrialScheduler.CONTINUE,
-                sched.on_trial_result(mock_runner, t, result(i + 1, 12)))
+        self.assertEqual(len(sched._state["bracket"].current_trials()), 2)
+
+        # Make sure that newly added trial gets fair computation (not just 1)
+        self.assertEqual(
+            TrialScheduler.CONTINUE,
+            sched.on_trial_result(mock_runner, t, result(init_units, 12)))
+        new_units = init_units + int(init_units * sched._eta)
         self.assertEqual(
             TrialScheduler.PAUSE,
-            sched.on_trial_result(mock_runner, t, result(4, 12)))
+            sched.on_trial_result(mock_runner, t, result(new_units, 12)))
 
     def testAlternateMetrics(self):
         """Checking that alternate metrics will pass."""
@@ -405,10 +436,10 @@ class HyperbandSuite(unittest.TestCase):
             return TrainingResult(time_total_s=t, neg_mean_loss=rew)
 
         sched = HyperBandScheduler(
-            time_attr='time_total_s', reward_attr='neg_mean_loss',
-            max_t_attr=9, eta=3)
+            time_attr='time_total_s', reward_attr='neg_mean_loss')
+        stats = self.default_statistics()
 
-        for i in range(17):
+        for i in range(stats["max_trials"]):
             t = Trial("t%d" % i, "__fake")
             sched.on_trial_add(None, t)
         runner = _MockTrialRunner()
@@ -417,6 +448,7 @@ class HyperbandSuite(unittest.TestCase):
 
         for trl in big_bracket.current_trials():
             runner._launch_trial(trl)
+        current_length = len(big_bracket.current_trials())
 
         # Provides results from 0 to 8 in order, keeping the last one running
         for i, trl in enumerate(big_bracket.current_trials()):
@@ -429,12 +461,12 @@ class HyperbandSuite(unittest.TestCase):
                 self.assertNotEqual(trl.status, Trial.TERMINATED)
                 self.stopTrial(trl, runner)
 
-        current_length = len(big_bracket.current_trials())
+        new_length = len(big_bracket.current_trials())
         self.assertEqual(status, TrialScheduler.CONTINUE)
-        self.assertEqual(current_length, 3)
+        self.assertEqual(new_length, self.downscale(current_length, sched))
 
     def testJumpingTime(self):
-        sched, mock_runner = self.schedulerSetup(17)
+        sched, mock_runner = self.schedulerSetup(81)
         big_bracket = sched._hyperbands[0][-1]
 
         for trl in big_bracket.current_trials():
@@ -457,7 +489,7 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(status, TrialScheduler.PAUSE)
 
         current_length = len(big_bracket.current_trials())
-        self.assertEqual(current_length, 3)
+        self.assertLess(current_length, 27)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What do these changes do?
Makes HyperBand usable.

Introduces a series of changes:
 - Defaults the number of brackets and trials per bracket. This allows users to enter their particular number of `max_iters` and will keep the logical structure user friendly. Power-users can specify `eta` and the actual hyperband parameters would be used.

 - Removes `ceil` from minimum iterations. This was problematic before because a user could specify `max_iter=1` and the bottom bracket with the most downsampling/scaling would run a trial for over 80 iterations. Now, brackets with `r = 0` indicating the minimum number of trials to run will automatically not be created.

 - Introduces tests for these fixes.

cc: @ericl  