### PR TITLE
Don't record event log on driver.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2095,7 +2095,10 @@ def log(event_type, kind, contents=None, worker=global_worker):
     assert isinstance(contents, dict)
     # Make sure all of the keys and values in the dictionary are strings.
     contents = {str(k): str(v) for k, v in contents.items()}
-    worker.events.append((time.time(), event_type, kind, contents))
+    # Log the event if this is a worker and not a driver, since the driver's
+    # event log never gets flushed.
+    if worker.mode == WORKER_MODE:
+        worker.events.append((time.time(), event_type, kind, contents))
 
 
 def flush_log(worker=global_worker):


### PR DESCRIPTION
This removes a memory leak on the driver. Basically, every time the driver did some operation (e.g., submit a task), the timestamp was recorded in a list. That list just grew and grew and was never flushed. This PR gets rid of that list (for drivers, but not for workers).

You can see the issue by watching top and running

```python
import ray

ray.worker._init(start_ray_local=True, object_store_memory=100000000)

@ray.remote
def f():
    return 1

i = 0
while True:
    print(i)
    i += 1
    ray.get([f.remote() for _ in range(10000)])
```