### PR TITLE
Allow scheduling with arbitrary user-defined resource labels.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -70,6 +70,7 @@ Example Program
    serialization.rst
    fault-tolerance.rst
    plasma-object-store.rst
+   resources.rst
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/resources.rst
+++ b/doc/source/resources.rst
@@ -1,0 +1,123 @@
+Resource (CPUs, GPUs)
+=====================
+
+This document describes how resources are managed in Ray. Each node in a Ray
+cluster knows its own resource capacities, and each task specifies its resource
+requirements.
+
+CPUs and GPUs
+-------------
+
+The Ray backend includes built-in support for CPUs and GPUs.
+
+Specifying a node's resource requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To specify a node's resource requirements from the command line, pass the
+``--num-cpus`` and ``--num-cpus`` flags into ``ray start``.
+
+.. code-block:: bash
+
+  # To start a head node.
+  ray start --head --num-cpus=8 --num-gpus=1
+
+  # To start a non-head node.
+  ray start --redis-address=<redis-address> --num-cpus=4 --num-gpus=2
+
+To specify a node's resource requirements when the Ray processes are all started
+through ``ray.init``, do the following.
+
+.. code-block:: python
+
+  ray.init(num_cpus=8, num_gpus=1)
+
+If the number of CPUs is unspecified, Ray will automatically determine the
+number by running ``psutil.cpu_count()``. If the number of GPUs is unspecified,
+Ray will default to 0 GPUs.
+
+Specifying a task's CPU and GPU requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To specify a task's CPU and GPU requirements, pass the ``num_cpus`` and
+``num_gpus`` arguments into the remote decorator.
+
+.. code-block:: python
+
+  @ray.remote(num_cpus=4, num_gpus=2)
+  def f():
+      return 1
+
+When ``f`` tasks will be scheduled on machines that have at least 4 CPUs and 2
+GPUs, and when one of the ``f`` tasks executes, 4 CPUs and 2 GPUs will be
+reserved for that task. The IDs of the GPUs that are reserved for the task can
+be accessed with ``ray.get_gpu_ids()``. Ray will automatically set the
+environment variable ``CUDA_VISIBLE_DEVICES`` for that process. These resources
+will be released when the task finishes executing.
+
+However, if the task gets blocked in a call to ``ray.get``. For example,
+consider the following remote function.
+
+.. code-block:: python
+
+  @ray.remote(num_cpus=1, num_gpus=1)
+  def g():
+      return ray.get(f.remote())
+
+When a ``g`` task is executing, it will release its CPU resources when it gets
+blocked in the call to ``ray.get``. It will reacquire the CPU resources when
+``ray.get`` returns. It will retain its GPU resources throughout the lifetime of
+the task because the task will most likely continue to use GPU memory.
+
+To specify that an **actor** requires GPUs, do the following.
+
+.. code-block:: python
+
+  @ray.remote(num_gpus=1)
+  class Actor(object):
+      pass
+
+When an ``Actor`` instance is created, it will be placed on a node that has at
+least 1 GPU, and the GPU will be reserved for the actor for the duration of the
+actor's lifetime (even if the actor is not executing tasks). The GPU resources
+will be released when the actor terminates. Note that currently **only GPU
+resources are used for actor placement**.
+
+Custom Resources
+----------------
+
+While Ray has built-in support for CPUs and GPUs, nodes can be started with
+arbitrary custom resources. **All custom resources behave like GPUs.**
+
+A node can be started with some custom resources as follows.
+
+.. code-block:: bash
+
+  ray start --head --resources='{"Resource1": 4, "Resource2": 16}'
+
+It can be done through ``ray.init`` as follows.
+
+.. code-block:: python
+
+  ray.init(resources={'Resource1': 4, 'Resource2': 16})
+
+To require custom resources in a task, specify the requirements in the remote
+decorator.
+
+.. code-block:: python
+
+  @ray.remote(resources={'Resource2': 1})
+  def f():
+      return 1
+
+Current Limitations
+-------------------
+
+We are working to remove the following limitations.
+
+- **Actor Resource Requirements:** Currently only GPUs are used to determine
+  actor placement.
+- **Recovering from Bad Scheduling:** Currently Ray does not recover from poor
+  scheduling decisions. For example, suppose there are two GPUs (on separate
+  machines) in the cluster and we wish to run two GPU tasks. There are scenarios
+  in which both tasks can be accidentally scheduled on the same machine, which
+  will result in poor load balancing.

--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -585,8 +585,8 @@ def cpu_usage():
     client_table = ray.global_state.client_table()
     for node_ip, client_list in client_table.items():
         for client in client_list:
-            if "NumCPUs" in client:
-                num_cpus += client["NumCPUs"]
+            if "CPU" in client:
+                num_cpus += client["CPU"]
 
     # Update the plot based on the sliders
     def plot_utilization():

--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -98,7 +98,7 @@ class TestGlobalScheduler(unittest.TestCase):
                 plasma_manager_name=plasma_manager_name,
                 plasma_address=plasma_address,
                 redis_address=redis_address,
-                static_resource_list=[10, 0])
+                static_resources={"CPU": 10})
             # Connect to the scheduler.
             local_scheduler_client = local_scheduler.LocalSchedulerClient(
                 local_scheduler_name, NIL_WORKER_ID, NIL_ACTOR_ID, False, 0)
@@ -166,13 +166,13 @@ class TestGlobalScheduler(unittest.TestCase):
         task1 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
                                      0)
-        self.assertEqual(task1.required_resources(), [1.0, 0.0, 0.0])
+        self.assertEqual(task1.required_resources(), {"CPU": 1})
         task2 = local_scheduler.Task(random_driver_id(), random_function_id(),
                                      [random_object_id()], 0, random_task_id(),
                                      0, local_scheduler.ObjectID(NIL_ACTOR_ID),
                                      local_scheduler.ObjectID(NIL_ACTOR_ID),
-                                     0, 0, [1.0, 2.0, 0.0])
-        self.assertEqual(task2.required_resources(), [1.0, 2.0, 0.0])
+                                     0, 0, {"CPU": 1, "GPU": 2})
+        self.assertEqual(task2.required_resources(), {"CPU": 1, "GPU": 2})
 
     def test_redis_only_single_task(self):
         # Tests global scheduler functionality by interacting with Redis and

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -429,20 +429,15 @@ class Monitor(object):
         log.info(
             "Driver {} has been removed.".format(binary_to_hex(driver_id)))
 
-        # Get a list of the local schedulers.
-        client_table = ray.global_state.client_table()
-        local_schedulers = []
-        for ip_address, clients in client_table.items():
-            for client in clients:
-                if client["ClientType"] == "local_scheduler":
-                    local_schedulers.append(client)
+        # Get a list of the local schedulers that have not been deleted.
+        local_schedulers = ray.global_state.local_schedulers()
 
         self._clean_up_entries_for_driver(driver_id)
 
         # Release any GPU resources that have been reserved for this driver in
         # Redis.
         for local_scheduler in local_schedulers:
-            if int(local_scheduler["NumGPUs"]) > 0:
+            if int(local_scheduler["GPU"]) > 0:
                 local_scheduler_id = local_scheduler["DBClientID"]
 
                 num_gpus_returned = 0

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -437,7 +437,7 @@ class Monitor(object):
         # Release any GPU resources that have been reserved for this driver in
         # Redis.
         for local_scheduler in local_schedulers:
-            if int(local_scheduler["GPU"]) > 0:
+            if local_scheduler.get("GPU", 0) > 0:
                 local_scheduler_id = local_scheduler["DBClientID"]
 
                 num_gpus_returned = 0

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -78,8 +78,8 @@ def cli():
               help="enable support for huge pages in the object store")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, object_manager_port, num_workers, num_cpus,
-          num_gpus, resources, num_custom_resource, head, no_ui, block,
-          plasma_directory, huge_pages):
+          num_gpus, resources, head, no_ui, block, plasma_directory,
+          huge_pages):
     # Note that we redirect stdout and stderr to /dev/null because otherwise
     # attempts to print may cause exceptions if a process is started inside of
     # an SSH connection and the SSH connection dies. TODO(rkn): This is a

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -230,7 +230,7 @@ class TrialRunner(object):
             if (entry['ClientType'] == 'local_scheduler' and not
                 entry['Deleted'])
         ]
-        num_cpus = sum(ls['NumCPUs'] for ls in local_schedulers)
-        num_gpus = sum(ls['NumGPUs'] for ls in local_schedulers)
+        num_cpus = sum(ls['CPU'] for ls in local_schedulers)
+        num_gpus = sum(ls.get('GPU', 0) for ls in local_schedulers)
         self._avail_resources = Resources(int(num_cpus), int(num_gpus))
         self._resources_initialized = True

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -109,9 +109,7 @@ def hex_to_binary(hex_identifier):
 
 FunctionProperties = collections.namedtuple("FunctionProperties",
                                             ["num_return_vals",
-                                             "num_cpus",
-                                             "num_gpus",
-                                             "num_custom_resource",
+                                             "resources",
                                              "max_calls"])
 """FunctionProperties: A named tuple storing remote functions information."""
 
@@ -131,7 +129,7 @@ def attempt_to_reserve_gpus(num_gpus, driver_id, local_scheduler,
     """
     assert num_gpus != 0
     local_scheduler_id = local_scheduler["DBClientID"]
-    local_scheduler_total_gpus = int(local_scheduler["NumGPUs"])
+    local_scheduler_total_gpus = int(local_scheduler["GPU"])
 
     success = False
 
@@ -253,9 +251,9 @@ def select_local_scheduler(driver_id, local_schedulers, num_gpus,
     # Loop through all of the local schedulers in a random order.
     local_schedulers = np.random.permutation(local_schedulers)
     for local_scheduler in local_schedulers:
-        if local_scheduler["NumCPUs"] < 1:
+        if local_scheduler["CPU"] < 1:
             continue
-        if local_scheduler["NumGPUs"] < num_gpus:
+        if local_scheduler.get("GPU", 0) < num_gpus:
             continue
         if num_gpus == 0:
             local_scheduler_id = hex_to_binary(local_scheduler["DBClientID"])

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -543,8 +543,7 @@ class Worker(object):
                 actor_handle_id,
                 actor_counter,
                 is_actor_checkpoint_method,
-                [function_properties.num_cpus, function_properties.num_gpus,
-                 function_properties.num_custom_resource])
+                function_properties.resources)
             # Increment the worker's task index to track how many tasks have
             # been submitted by the current task so far.
             self.task_index += 1
@@ -1133,6 +1132,44 @@ def get_address_info_from_redis(redis_address, node_ip_address, num_retries=5):
         counter += 1
 
 
+def _normalize_resource_arguments(num_cpus, num_gpus, resources,
+                                  num_local_schedulers):
+    """Stick the CPU and GPU arguments into the resources dictionary.
+
+    This also checks that the arguments are well-formed.
+
+    Args:
+        num_cpus: Either a number of CPUs or a list of numbers of CPUs.
+        num_gpus: Either a number of CPUs or a list of numbers of CPUs.
+        resources: Either a dictionary of resource mappings or a list of
+            dictionaries of resource mappings.
+        num_local_schedulers: The number of local schedulers.
+
+    Returns:
+        A list of dictionaries of resources of length num_local_schedulers.
+    """
+    if resources is None:
+        resources = {}
+    if not isinstance(num_cpus, list):
+        num_cpus = num_local_schedulers * [num_cpus]
+    if not isinstance(num_gpus, list):
+        num_gpus = num_local_schedulers * [num_gpus]
+    if not isinstance(resources, list):
+        resources = num_local_schedulers * [resources]
+
+    new_resources = [r.copy() for r in resources]
+
+    for i in range(num_local_schedulers):
+        assert "CPU" not in new_resources[i], "Use the 'num_cpus' argument."
+        assert "GPU" not in new_resources[i], "Use the 'num_gpus' argument."
+        if num_cpus[i] is not None:
+            new_resources[i]["CPU"] = num_cpus[i]
+        if num_gpus[i] is not None:
+            new_resources[i]["GPU"] = num_gpus[i]
+
+    return new_resources
+
+
 def _init(address_info=None,
           start_ray_local=False,
           object_id_seed=None,
@@ -1144,7 +1181,7 @@ def _init(address_info=None,
           start_workers_from_local_scheduler=True,
           num_cpus=None,
           num_gpus=None,
-          num_custom_resource=None,
+          resources=None,
           num_redis_shards=None,
           redis_max_clients=None,
           plasma_directory=None,
@@ -1183,13 +1220,12 @@ def _init(address_info=None,
         start_workers_from_local_scheduler (bool): If this flag is True, then
             start the initial workers from the local scheduler. Else, start
             them from Python. The latter case is for debugging purposes only.
-        num_cpus: A list containing the number of CPUs the local schedulers
-            should be configured with.
-        num_gpus: A list containing the number of GPUs the local schedulers
-            should be configured with.
-        num_custom_resource: A list containing the quantity of a user-defined
-            custom resource that the local schedulers should be configured
-            with.
+        num_cpus (int): Number of cpus the user wishes all local schedulers to
+            be configured with.
+        num_gpus (int): Number of gpus the user wishes all local schedulers to
+            be configured with.
+        resources: A dictionary mapping resource names to the quantity of that
+            resource available.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
         redis_max_clients: If provided, attempt to configure Redis with this
@@ -1241,6 +1277,12 @@ def _init(address_info=None,
                 num_local_schedulers = 1
         # Use 1 additional redis shard if num_redis_shards is not provided.
         num_redis_shards = 1 if num_redis_shards is None else num_redis_shards
+
+        # Stick the CPU and GPU resources into the resource dictionary.
+        resources = _normalize_resource_arguments(num_cpus, num_gpus,
+                                                  resources,
+                                                  num_local_schedulers)
+
         # Start the scheduler, object store, and some workers. These will be
         # killed by the call to cleanup(), which happens when the Python script
         # exits.
@@ -1253,9 +1295,7 @@ def _init(address_info=None,
             redirect_output=redirect_output,
             start_workers_from_local_scheduler=(
                 start_workers_from_local_scheduler),
-            num_cpus=num_cpus,
-            num_gpus=num_gpus,
-            num_custom_resource=num_custom_resource,
+            resources=resources,
             num_redis_shards=num_redis_shards,
             redis_max_clients=redis_max_clients,
             plasma_directory=plasma_directory,
@@ -1270,11 +1310,12 @@ def _init(address_info=None,
         if num_local_schedulers is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_local_schedulers must not be provided.")
-        if (num_cpus is not None or num_gpus is not None or
-                num_custom_resource is not None):
-            raise Exception("When connecting to an existing cluster, resource "
-                            "labels (e.g., num_gpus, num_cpus, "
-                            "num_custom_resource) must not be provided.")
+        if num_cpus is not None or num_gpus is not None:
+            raise Exception("When connecting to an existing cluster, num_cpus "
+                            "and num_gpus must not be provided.")
+        if resources is not None:
+            raise Exception("When connecting to an existing cluster, "
+                            "resources must not be provided.")
         if num_redis_shards is not None:
             raise Exception("When connecting to an existing cluster, "
                             "num_redis_shards must not be provided.")
@@ -1321,9 +1362,9 @@ def _init(address_info=None,
 
 def init(redis_address=None, node_ip_address=None, object_id_seed=None,
          num_workers=None, driver_mode=SCRIPT_MODE, redirect_output=False,
-         num_cpus=None, num_gpus=None, num_custom_resource=None,
-         num_redis_shards=None, redis_max_clients=None,
-         plasma_directory=None, huge_pages=False):
+         num_cpus=None, num_gpus=None, resources=None,
+         num_custom_resource=None, num_redis_shards=None,
+         redis_max_clients=None, plasma_directory=None, huge_pages=False):
     """Connect to an existing Ray cluster or start one and connect to it.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1351,9 +1392,8 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
             be configured with.
         num_gpus (int): Number of gpus the user wishes all local schedulers to
             be configured with.
-        num_custom_resource (int): The quantity of a user-defined custom
-            resource that the local scheduler should be configured with. This
-            flag is experimental and is subject to changes in the future.
+        resources: A dictionary mapping the name of a resource to the quantity
+            of that resource available.
         num_redis_shards: The number of Redis shards to start in addition to
             the primary Redis shard.
         redis_max_clients: If provided, attempt to configure Redis with this
@@ -1381,7 +1421,7 @@ def init(redis_address=None, node_ip_address=None, object_id_seed=None,
     return _init(address_info=info, start_ray_local=(redis_address is None),
                  num_workers=num_workers, driver_mode=driver_mode,
                  redirect_output=redirect_output, num_cpus=num_cpus,
-                 num_gpus=num_gpus, num_custom_resource=num_custom_resource,
+                 num_gpus=num_gpus, resources=resources,
                  num_redis_shards=num_redis_shards,
                  redis_max_clients=redis_max_clients,
                  plasma_directory=plasma_directory,
@@ -1498,25 +1538,21 @@ def print_error_messages(worker):
 def fetch_and_register_remote_function(key, worker=global_worker):
     """Import a remote function."""
     (driver_id, function_id_str, function_name,
-     serialized_function, num_return_vals, module, num_cpus,
-     num_gpus, num_custom_resource, max_calls) = worker.redis_client.hmget(
+     serialized_function, num_return_vals, module, resources,
+     max_calls) = worker.redis_client.hmget(
         key, ["driver_id",
               "function_id",
               "name",
               "function",
               "num_return_vals",
               "module",
-              "num_cpus",
-              "num_gpus",
-              "num_custom_resource",
+              "resources",
               "max_calls"])
     function_id = ray.local_scheduler.ObjectID(function_id_str)
     function_name = function_name.decode("ascii")
     function_properties = FunctionProperties(
         num_return_vals=int(num_return_vals),
-        num_cpus=int(num_cpus),
-        num_gpus=int(num_gpus),
-        num_custom_resource=int(num_custom_resource),
+        resources=json.loads(resources.decode("ascii")),
         max_calls=int(max_calls))
     module = module.decode("ascii")
 
@@ -1835,7 +1871,7 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
             ray.local_scheduler.ObjectID(NIL_ACTOR_ID),
             nil_actor_counter,
             False,
-            [0, 0, 0])
+            {"CPU": 0})
         global_state._execute_command(
             driver_task.task_id(),
             "RAY.TASK_TABLE_ADD",
@@ -2345,9 +2381,7 @@ def export_remote_function(function_id, func_name, func, func_invoker,
         "module": func.__module__,
         "function": pickled_func,
         "num_return_vals": function_properties.num_return_vals,
-        "num_cpus": function_properties.num_cpus,
-        "num_gpus": function_properties.num_gpus,
-        "num_custom_resource": function_properties.num_custom_resource,
+        "resources": json.dumps(function_properties.resources),
         "max_calls": function_properties.max_calls})
     worker.redis_client.rpush("Exports", key)
 
@@ -2399,9 +2433,8 @@ def remote(*args, **kwargs):
             function should return.
         num_cpus (int): The number of CPUs needed to execute this function.
         num_gpus (int): The number of GPUs needed to execute this function.
-        num_custom_resource (int): The quantity of a user-defined custom
-            resource that is needed to execute this function. This flag is
-            experimental and is subject to changes in the future.
+        resources: A dictionary mapping resource name to the required quantity
+            of that resource.
         max_calls (int): The maximum number of tasks of this kind that can be
             run on a worker before the worker needs to be restarted.
         checkpoint_interval (int): The number of tasks to run between
@@ -2409,21 +2442,18 @@ def remote(*args, **kwargs):
     """
     worker = global_worker
 
-    def make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                              num_custom_resource, max_calls,
+    def make_remote_decorator(num_return_vals, resources, max_calls,
                               checkpoint_interval, func_id=None):
         def remote_decorator(func_or_class):
             if inspect.isfunction(func_or_class) or is_cython(func_or_class):
                 function_properties = FunctionProperties(
                     num_return_vals=num_return_vals,
-                    num_cpus=num_cpus,
-                    num_gpus=num_gpus,
-                    num_custom_resource=num_custom_resource,
+                    resources=resources,
                     max_calls=max_calls)
                 return remote_function_decorator(func_or_class,
                                                  function_properties)
             if inspect.isclass(func_or_class):
-                return worker.make_actor(func_or_class, num_cpus, num_gpus,
+                return worker.make_actor(func_or_class, resources,
                                          checkpoint_interval)
             raise Exception("The @ray.remote decorator must be applied to "
                             "either a function or to a class.")
@@ -2489,12 +2519,21 @@ def remote(*args, **kwargs):
 
         return remote_decorator
 
-    num_return_vals = (kwargs["num_return_vals"] if "num_return_vals"
-                       in kwargs else 1)
+    # Handle resource arguments
     num_cpus = kwargs["num_cpus"] if "num_cpus" in kwargs else 1
     num_gpus = kwargs["num_gpus"] if "num_gpus" in kwargs else 0
-    num_custom_resource = (kwargs["num_custom_resource"]
-                           if "num_custom_resource" in kwargs else 0)
+    resources = kwargs.get("resources", {})
+    if not isinstance(resources, dict):
+        raise Exception("The 'resources' keyword argument must be a "
+                        "dictionary, but received type {}."
+                        .format(type(resources)))
+    assert "CPU" not in resources, "Use the 'num_cpus' argument."
+    assert "GPU" not in resources, "Use the 'num_gpus' argument."
+    resources["CPU"] = num_cpus
+    resources["GPU"] = num_gpus
+    # Handle other arguments.
+    num_return_vals = (kwargs["num_return_vals"] if "num_return_vals"
+                       in kwargs else 1)
     max_calls = kwargs["max_calls"] if "max_calls" in kwargs else 0
     checkpoint_interval = (kwargs["checkpoint_interval"]
                            if "checkpoint_interval" in kwargs else -1)
@@ -2502,15 +2541,13 @@ def remote(*args, **kwargs):
     if _mode() == WORKER_MODE:
         if "function_id" in kwargs:
             function_id = kwargs["function_id"]
-            return make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                                         num_custom_resource, max_calls,
+            return make_remote_decorator(num_return_vals, resources, max_calls,
                                          checkpoint_interval, function_id)
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # This is the case where the decorator is just @ray.remote.
         return make_remote_decorator(
-            num_return_vals, num_cpus,
-            num_gpus, num_custom_resource,
+            num_return_vals, resources,
             max_calls, checkpoint_interval)(args[0])
     else:
         # This is the case where the decorator is something like
@@ -2518,21 +2555,15 @@ def remote(*args, **kwargs):
         error_string = ("The @ray.remote decorator must be applied either "
                         "with no arguments and no parentheses, for example "
                         "'@ray.remote', or it must be applied using some of "
-                        "the arguments 'num_return_vals', 'num_cpus', "
-                        "'num_gpus', num_custom_resource, or 'max_calls', "
-                        "like '@ray.remote(num_return_vals=2)'.")
-        assert (len(args) == 0 and
-                ("num_return_vals" in kwargs or
-                 "num_cpus" in kwargs or
-                 "num_gpus" in kwargs or
-                 "num_custom_resource" in kwargs or
-                 "max_calls" in kwargs or
-                 "checkpoint_interval" in kwargs)), error_string
+                        "the arguments 'num_return_vals', 'resources', "
+                        "or 'max_calls', like "
+                        "'@ray.remote(num_return_vals=2, "
+                        "resources={\"GPU\": 1})'.")
+        assert len(args) == 0 and len(kwargs) > 0, error_string
         for key in kwargs:
-            assert key in ["num_return_vals", "num_cpus",
-                           "num_gpus", "num_custom_resource", "max_calls",
+            assert key in ["num_return_vals", "num_cpus", "num_gpus",
+                           "resources", "max_calls",
                            "checkpoint_interval"], error_string
         assert "function_id" not in kwargs
-        return make_remote_decorator(num_return_vals, num_cpus, num_gpus,
-                                     num_custom_resource, max_calls,
+        return make_remote_decorator(num_return_vals, resources, max_calls,
                                      checkpoint_interval)

--- a/src/common/common_protocol.cc
+++ b/src/common/common_protocol.cc
@@ -6,10 +6,10 @@ flatbuffers::Offset<flatbuffers::String> to_flatbuf(
   return fbb.CreateString((char *) &object_id.id[0], sizeof(object_id.id));
 }
 
-ObjectID from_flatbuf(const flatbuffers::String *string) {
+ObjectID from_flatbuf(const flatbuffers::String &string) {
   ObjectID object_id;
-  CHECK(string->size() == sizeof(object_id.id));
-  memcpy(&object_id.id[0], string->data(), sizeof(object_id.id));
+  CHECK(string.size() == sizeof(object_id.id));
+  memcpy(&object_id.id[0], string.data(), sizeof(object_id.id));
   return object_id;
 }
 
@@ -23,4 +23,31 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
     results.push_back(to_flatbuf(fbb, object_ids[i]));
   }
   return fbb.CreateVector(results);
+}
+
+std::string string_from_flatbuf(const flatbuffers::String &string) {
+  return std::string(string.data(), string.size());
+}
+
+const std::unordered_map<std::string, double> map_from_flatbuf(
+    const flatbuffers::Vector<flatbuffers::Offset<ResourcePair>>
+        &resource_vector) {
+  std::unordered_map<std::string, double> required_resources;
+  for (int64_t i = 0; i < resource_vector.size(); i++) {
+    const ResourcePair *resource_pair = resource_vector.Get(i);
+    required_resources[string_from_flatbuf(*resource_pair->key())] =
+        resource_pair->value();
+  }
+  return required_resources;
+}
+
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ResourcePair>>>
+map_to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
+               const std::unordered_map<std::string, double> &resource_map) {
+  std::vector<flatbuffers::Offset<ResourcePair>> resource_vector;
+  for (auto const &resource_pair : resource_map) {
+    resource_vector.push_back(CreateResourcePair(
+        fbb, fbb.CreateString(resource_pair.first), resource_pair.second));
+  }
+  return fbb.CreateVector(resource_vector);
 }

--- a/src/common/common_protocol.h
+++ b/src/common/common_protocol.h
@@ -3,41 +3,63 @@
 
 #include "format/common_generated.h"
 
+#include <unordered_map>
+
 #include "common.h"
 
 #define DB_CLIENT_PREFIX "CL:"
 
-/**
- * Convert an object ID to a flatbuffer string.
- *
- * @param fbb Reference to the flatbuffer builder.
- * @param object_id The object ID to be converted.
- * @return The flatbuffer string contining the object ID.
- */
+/// Convert an object ID to a flatbuffer string.
+///
+/// @param fbb Reference to the flatbuffer builder.
+/// @param object_id The object ID to be converted.
+/// @return The flatbuffer string contining the object ID.
 flatbuffers::Offset<flatbuffers::String> to_flatbuf(
     flatbuffers::FlatBufferBuilder &fbb,
     ObjectID object_id);
 
-/**
- * Convert a flatbuffer string to an object ID.
- *
- * @param string The flatbuffer string.
- * @return The object ID.
- */
-ObjectID from_flatbuf(const flatbuffers::String *string);
+/// Convert a flatbuffer string to an object ID.
+///
+/// @param string The flatbuffer string.
+/// @return The object ID.
+ObjectID from_flatbuf(const flatbuffers::String &string);
 
-/**
- * Convert an array of object IDs to a flatbuffer vector of strings.
- *
- * @param fbb Reference to the flatbuffer builder.
- * @param object_ids Array of object IDs.
- * @param num_objects Number of elements in the array.
- * @return Flatbuffer vector of strings.
- */
+/// Convert an array of object IDs to a flatbuffer vector of strings.
+///
+/// @param fbb Reference to the flatbuffer builder.
+/// @param object_ids Array of object IDs.
+/// @param num_objects Number of elements in the array.
+/// @return Flatbuffer vector of strings.
 flatbuffers::Offset<
     flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
 to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
            ObjectID object_ids[],
            int64_t num_objects);
+
+/// Convert a flatbuffer string to a std::string.
+///
+/// @param fbb Reference to the flatbuffer builder.
+/// @param string A flatbuffers string.
+/// @return The std::string version of the flatbuffer string.
+std::string string_from_flatbuf(const flatbuffers::String &string);
+
+/// Convert a std::unordered_map to a flatbuffer vector of pairs.
+///
+/// @param fbb Reference to the flatbuffer builder.
+/// @param resource_map A mapping from resource name to resource quantity.
+/// @return A flatbuffer vector of ResourcePair objects.
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ResourcePair>>>
+map_to_flatbuf(flatbuffers::FlatBufferBuilder &fbb,
+               const std::unordered_map<std::string, double> &resource_map);
+
+/// Convert a flatbuffer vector of ResourcePair objects to a std::unordered map
+/// from resource name to resource quantity.
+///
+/// @param fbb Reference to the flatbuffer builder.
+/// @param resource_vector The flatbuffer object.
+/// @return A map from resource name to resource quantity.
+const std::unordered_map<std::string, double> map_from_flatbuf(
+    const flatbuffers::Vector<flatbuffers::Offset<ResourcePair>>
+        &resource_vector);
 
 #endif

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -3,19 +3,6 @@
 // A resource vector maps a resource index to the number
 // of units of that resource required.
 
-// The total length of the resource vector is ResourceIndex_MAX.
-enum ResourceIndex:int {
-  // A central processing unit.
-  CPU = 0,
-  // A graphics processing unit.
-  GPU = 1,
-  // A user-defined custom resource.
-  CustomResource = 2,
-  // A dummy entry to make ResourceIndex_MAX equal to the length of
-  // a resource vector.
-  DUMMY = 3
-}
-
 table Arg {
   // Object ID for pass-by-reference arguments. Normally there is only one
   // object ID in this list which represents the object that is being passed.
@@ -24,6 +11,13 @@ table Arg {
   object_ids: [string];
   // Data for pass-by-value arguments.
   data: string;
+}
+
+table ResourcePair {
+  // The name of the resource.
+  key: string;
+  // The quantity of the resource.
+  value: double;
 }
 
 table TaskInfo {
@@ -52,11 +46,8 @@ table TaskInfo {
   // Object IDs of return values.
   returns: [string];
   // The required_resources vector indicates the quantities of the different
-  // resources required by this task. The index in this vector corresponds to
-  // the resource type defined in the ResourceIndex enum. For example,
-  // required_resources[0] is the number of CPUs required, and
-  // required_resources[1] is the number of GPUs required.
-  required_resources: [double];
+  // resources required by this task.
+  required_resources: [ResourcePair];
 }
 
 // Object information data structure.
@@ -131,12 +122,10 @@ table LocalSchedulerInfoMessage {
   task_queue_length: long;
   // The number of workers that are available and waiting for tasks.
   available_workers: long;
-  // The resource vector of resources generally available to this local
-  // scheduler.
-  static_resources: [double];
-  // The resource vector of resources currently available to this local
-  // scheduler.
-  dynamic_resources: [double];
+  // The resources generally available to this local scheduler.
+  static_resources: [ResourcePair];
+  // The resources currently available to this local scheduler.
+  dynamic_resources: [ResourcePair];
   // Whether the local scheduler is dead. If true, then all other fields
   // besides `db_client_id` will not be set.
   is_dead: bool;

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -446,16 +446,16 @@ static PyObject *PyTask_required_resources(PyObject *self) {
   for (auto const &resource_pair : TaskSpec_get_required_resources(task)) {
     std::string resource_name = resource_pair.first;
 #if PY_MAJOR_VERSION >= 3
-    PyDict_SetItem(required_resources,
-                   PyUnicode_FromStringAndSize(resource_name.c_str(),
-                                               resource_name.size()),
-                   PyFloat_FromDouble(resource_pair.second));
+    PyObject *key = PyUnicode_FromStringAndSize(resource_name.c_str(),
+                                                resource_name.size());
 #else
-    PyDict_SetItem(
-        required_resources,
-        PyBytes_FromStringAndSize(resource_name.c_str(), resource_name.size()),
-        PyFloat_FromDouble(resource_pair.second));
+    PyObject *key = PyBytes_FromStringAndSize(resource_name.c_str(),
+                                              resource_name.size());
 #endif
+    PyObject *value = PyFloat_FromDouble(resource_pair.second);
+    PyDict_SetItem(required_resources, key, value);
+    Py_DECREF(key);
+    Py_DECREF(value);
   }
   return required_resources;
 }

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -446,8 +446,8 @@ static PyObject *PyTask_required_resources(PyObject *self) {
   for (auto const &resource_pair : TaskSpec_get_required_resources(task)) {
     std::string resource_name = resource_pair.first;
 #if PY_MAJOR_VERSION >= 3
-    PyObject *key = PyUnicode_FromStringAndSize(resource_name.data(),
-                                                resource_name.size());
+    PyObject *key =
+        PyUnicode_FromStringAndSize(resource_name.data(), resource_name.size());
 #else
     PyObject *key =
         PyBytes_FromStringAndSize(resource_name.data(), resource_name.size());

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -446,11 +446,11 @@ static PyObject *PyTask_required_resources(PyObject *self) {
   for (auto const &resource_pair : TaskSpec_get_required_resources(task)) {
     std::string resource_name = resource_pair.first;
 #if PY_MAJOR_VERSION >= 3
-    PyObject *key = PyUnicode_FromStringAndSize(resource_name.c_str(),
+    PyObject *key = PyUnicode_FromStringAndSize(resource_name.data(),
                                                 resource_name.size());
 #else
     PyObject *key =
-        PyBytes_FromStringAndSize(resource_name.c_str(), resource_name.size());
+        PyBytes_FromStringAndSize(resource_name.data(), resource_name.size());
 #endif
     PyObject *value = PyFloat_FromDouble(resource_pair.second);
     PyDict_SetItem(required_resources, key, value);

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -8,6 +8,10 @@
 
 #include <string>
 
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_Check PyLong_Check
+#endif
+
 PyObject *CommonError;
 
 /* Initialize pickle module. */
@@ -284,15 +288,14 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   TaskID parent_task_id;
   /* The number of tasks that the parent task has called prior to this one. */
   int parent_counter;
-  /* Resource vector of the required resources to execute this task. */
-  PyObject *resource_vector = NULL;
-  if (!PyArg_ParseTuple(args, "O&O&OiO&i|O&O&iOO", &PyObjectToUniqueID,
-                        &driver_id, &PyObjectToUniqueID, &function_id,
-                        &arguments, &num_returns, &PyObjectToUniqueID,
-                        &parent_task_id, &parent_counter, &PyObjectToUniqueID,
-                        &actor_id, &PyObjectToUniqueID, &actor_handle_id,
-                        &actor_counter, &is_actor_checkpoint_method_object,
-                        &resource_vector)) {
+  /* Dictionary of resource requirements for this task. */
+  PyObject *resource_map = NULL;
+  if (!PyArg_ParseTuple(
+          args, "O&O&OiO&i|O&O&iOO", &PyObjectToUniqueID, &driver_id,
+          &PyObjectToUniqueID, &function_id, &arguments, &num_returns,
+          &PyObjectToUniqueID, &parent_task_id, &parent_counter,
+          &PyObjectToUniqueID, &actor_id, &PyObjectToUniqueID, &actor_handle_id,
+          &actor_counter, &is_actor_checkpoint_method_object, &resource_map)) {
     return -1;
   }
 
@@ -318,25 +321,54 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
       /* We do this check because we cast a signed int to an unsigned int. */
       PyObject *data = PyObject_CallMethodObjArgs(pickle_module, pickle_dumps,
                                                   arg, pickle_protocol, NULL);
-      TaskSpec_args_add_val(g_task_builder, (uint8_t *) PyBytes_AS_STRING(data),
-                            PyBytes_GET_SIZE(data));
+      TaskSpec_args_add_val(g_task_builder, (uint8_t *) PyBytes_AsString(data),
+                            PyBytes_Size(data));
       Py_DECREF(data);
     }
   }
-  /* Set the resource vector of the task. */
-  if (resource_vector != NULL) {
-    CHECK(PyList_Size(resource_vector) == ResourceIndex_MAX);
-    for (int i = 0; i < ResourceIndex_MAX; ++i) {
-      PyObject *resource_entry = PyList_GetItem(resource_vector, i);
-      TaskSpec_set_required_resource(g_task_builder, i,
-                                     PyFloat_AsDouble(resource_entry));
+  /* Set the resource requirements for the task. */
+  bool found_CPU_requirements = false;
+  PyObject *key, *value;
+  Py_ssize_t position = 0;
+  if (resource_map != NULL) {
+    if (!PyDict_Check(resource_map)) {
+      PyErr_SetString(PyExc_TypeError, "resource_map must be a dictionary");
+      return -1;
     }
-  } else {
-    for (int i = 0; i < ResourceIndex_MAX; ++i) {
-      TaskSpec_set_required_resource(g_task_builder, i,
-                                     i == ResourceIndex_CPU ? 1.0 : 0.0);
+    while (PyDict_Next(resource_map, &position, &key, &value)) {
+      if (!(PyBytes_Check(key) || PyUnicode_Check(key))) {
+        PyErr_SetString(PyExc_TypeError,
+                        "the keys in resource_map must be strings");
+        return -1;
+      }
+      if (!(PyFloat_Check(value) || PyInt_Check(value) ||
+            PyLong_Check(value))) {
+        PyErr_SetString(PyExc_TypeError,
+                        "the values in resource_map must be floats");
+        return -1;
+      }
+      // Handle the case where the key is a bytes object and the case where it
+      // is a unicode object.
+      std::string resource_name;
+      if (PyUnicode_Check(key)) {
+        PyObject *ascii_key = PyUnicode_AsASCIIString(key);
+        resource_name =
+            std::string(PyBytes_AsString(ascii_key), PyBytes_Size(ascii_key));
+        Py_DECREF(ascii_key);
+      } else {
+        resource_name = std::string(PyBytes_AsString(key), PyBytes_Size(key));
+      }
+      if (resource_name == std::string("CPU")) {
+        found_CPU_requirements = true;
+      }
+      TaskSpec_set_required_resource(g_task_builder, resource_name,
+                                     PyFloat_AsDouble(value));
     }
   }
+  if (!found_CPU_requirements) {
+    TaskSpec_set_required_resource(g_task_builder, "CPU", 1.0);
+  }
+
   /* Compute the task ID and the return object IDs. */
   self->spec = TaskSpec_finish_construct(g_task_builder, &self->size);
   return 0;
@@ -410,10 +442,20 @@ static PyObject *PyTask_arguments(PyObject *self) {
 
 static PyObject *PyTask_required_resources(PyObject *self) {
   TaskSpec *task = ((PyTask *) self)->spec;
-  PyObject *required_resources = PyList_New((Py_ssize_t) ResourceIndex_MAX);
-  for (int i = 0; i < ResourceIndex_MAX; ++i) {
-    double r = TaskSpec_get_required_resource(task, i);
-    PyList_SetItem(required_resources, i, PyFloat_FromDouble(r));
+  PyObject *required_resources = PyDict_New();
+  for (auto const &resource_pair : TaskSpec_get_required_resources(task)) {
+    std::string resource_name = resource_pair.first;
+#if PY_MAJOR_VERSION >= 3
+    PyDict_SetItem(required_resources,
+                   PyUnicode_FromStringAndSize(resource_name.c_str(),
+                                               resource_name.size()),
+                   PyFloat_FromDouble(resource_pair.second));
+#else
+    PyDict_SetItem(
+        required_resources,
+        PyBytes_FromStringAndSize(resource_name.c_str(), resource_name.size()),
+        PyFloat_FromDouble(resource_pair.second));
+#endif
   }
   return required_resources;
 }
@@ -505,10 +547,6 @@ PyObject *PyTask_make(TaskSpec *task_spec, int64_t task_size) {
 }
 
 /* Define the methods for the module. */
-
-#if PY_MAJOR_VERSION >= 3
-#define PyInt_Check PyLong_Check
-#endif
 
 /**
  * This method checks if a Python object is sufficiently simple that it can be

--- a/src/common/lib/python/common_extension.cc
+++ b/src/common/lib/python/common_extension.cc
@@ -449,8 +449,8 @@ static PyObject *PyTask_required_resources(PyObject *self) {
     PyObject *key = PyUnicode_FromStringAndSize(resource_name.c_str(),
                                                 resource_name.size());
 #else
-    PyObject *key = PyBytes_FromStringAndSize(resource_name.c_str(),
-                                              resource_name.size());
+    PyObject *key =
+        PyBytes_FromStringAndSize(resource_name.c_str(), resource_name.size());
 #endif
     PyObject *value = PyFloat_FromDouble(resource_pair.second);
     PyDict_SetItem(required_resources, key, value);

--- a/src/common/lib/python/config_extension.cc
+++ b/src/common/lib/python/config_extension.cc
@@ -75,19 +75,6 @@ PyObject *PyRayConfig_kill_worker_timeout_milliseconds(PyObject *self) {
       RayConfig::instance().kill_worker_timeout_milliseconds());
 }
 
-PyObject *PyRayConfig_default_num_CPUs(PyObject *self) {
-  return PyFloat_FromDouble(RayConfig::instance().default_num_CPUs());
-}
-
-PyObject *PyRayConfig_default_num_GPUs(PyObject *self) {
-  return PyFloat_FromDouble(RayConfig::instance().default_num_GPUs());
-}
-
-PyObject *PyRayConfig_default_num_custom_resource(PyObject *self) {
-  return PyFloat_FromDouble(
-      RayConfig::instance().default_num_custom_resource());
-}
-
 PyObject *PyRayConfig_manager_timeout_milliseconds(PyObject *self) {
   return PyLong_FromLongLong(
       RayConfig::instance().manager_timeout_milliseconds());
@@ -172,13 +159,6 @@ static PyMethodDef PyRayConfig_methods[] = {
     {"kill_worker_timeout_milliseconds",
      (PyCFunction) PyRayConfig_kill_worker_timeout_milliseconds, METH_NOARGS,
      "Return kill_worker_timeout_milliseconds"},
-    {"default_num_CPUs", (PyCFunction) PyRayConfig_default_num_CPUs,
-     METH_NOARGS, "Return default_num_CPUs"},
-    {"default_num_GPUs", (PyCFunction) PyRayConfig_default_num_GPUs,
-     METH_NOARGS, "Return default_num_GPUs"},
-    {"default_num_custom_resource",
-     (PyCFunction) PyRayConfig_default_num_custom_resource, METH_NOARGS,
-     "Return default_num_custom_resource"},
     {"manager_timeout_milliseconds",
      (PyCFunction) PyRayConfig_manager_timeout_milliseconds, METH_NOARGS,
      "Return manager_timeout_milliseconds"},

--- a/src/common/lib/python/config_extension.h
+++ b/src/common/lib/python/config_extension.h
@@ -32,9 +32,6 @@ PyObject *PyRayConfig_local_scheduler_reconstruction_timeout_milliseconds(
 PyObject *PyRayConfig_max_num_to_reconstruct(PyObject *self);
 PyObject *PyRayConfig_local_scheduler_fetch_request_size(PyObject *self);
 PyObject *PyRayConfig_kill_worker_timeout_milliseconds(PyObject *self);
-PyObject *PyRayConfig_default_num_CPUs(PyObject *self);
-PyObject *PyRayConfig_default_num_GPUs(PyObject *self);
-PyObject *PyRayConfig_default_num_custom_resource(PyObject *self);
 PyObject *PyRayConfig_manager_timeout_milliseconds(PyObject *self);
 PyObject *PyRayConfig_buf_size(PyObject *self);
 PyObject *PyRayConfig_max_time_for_handler_milliseconds(PyObject *self);

--- a/src/common/state/db.h
+++ b/src/common/state/db.h
@@ -1,6 +1,8 @@
 #ifndef DB_H
 #define DB_H
 
+#include <vector>
+
 #include "common.h"
 #include "event_loop.h"
 
@@ -16,11 +18,10 @@ typedef struct DBHandle DBHandle;
  *        as db_shards_addresses.
  * @param client_type The type of this client.
  * @param node_ip_address The hostname of the client that is connecting.
- * @param num_args The number of extra arguments that should be supplied. This
- *        should be an even number.
- * @param args An array of extra arguments strings. They should alternate
+ * @param args A vector of extra arguments strings. They should alternate
  *        between the name of the argument and the value of the argument. For
- *        examples: "port", "1234", "socket_name", "/tmp/s1".
+ *        examples: "port", "1234", "socket_name", "/tmp/s1". This vector should
+ *        have an even length.
  * @return This returns a handle to the database, which must be freed with
  *         db_disconnect after use.
  */
@@ -28,8 +29,7 @@ DBHandle *db_connect(const std::string &db_primary_address,
                      int db_primary_port,
                      const char *client_type,
                      const char *node_ip_address,
-                     int num_args,
-                     const char **args);
+                     const std::vector<std::string> &args);
 
 /**
  * Attach global system store connection to an event loop. Callbacks from

--- a/src/common/state/local_scheduler_table.h
+++ b/src/common/state/local_scheduler_table.h
@@ -1,6 +1,8 @@
 #ifndef LOCAL_SCHEDULER_TABLE_H
 #define LOCAL_SCHEDULER_TABLE_H
 
+#include <unordered_map>
+
 #include "db.h"
 #include "table.h"
 #include "task.h"
@@ -17,10 +19,10 @@ typedef struct {
   int available_workers;
   /** The resource vector of resources generally available to this local
    *  scheduler. */
-  double static_resources[ResourceIndex_MAX];
+  std::unordered_map<std::string, double> static_resources;
   /** The resource vector of resources currently available to this local
    *  scheduler. */
-  double dynamic_resources[ResourceIndex_MAX];
+  std::unordered_map<std::string, double> dynamic_resources;
   /** Whether the local scheduler is dead. If true, then all other fields
    *  should be ignored. */
   bool is_dead;
@@ -77,8 +79,10 @@ void local_scheduler_table_send_info(DBHandle *db_handle,
 /* Data that is needed to publish local scheduler heartbeats to the local
  * scheduler table. */
 typedef struct {
+  /* The size of the flatbuffer object. */
+  int64_t size;
   /* The information to be sent. */
-  LocalSchedulerInfo info;
+  uint8_t flatbuffer_data[0];
 } LocalSchedulerTableSendInfoData;
 
 /**

--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -1,7 +1,6 @@
 #ifndef RAY_CONFIG_H
 #define RAY_CONFIG_H
 
-#include <math.h>
 #include <stdint.h>
 
 class RayConfig {
@@ -53,14 +52,6 @@ class RayConfig {
     return kill_worker_timeout_milliseconds_;
   }
 
-  double default_num_CPUs() const { return default_num_CPUs_; }
-
-  double default_num_GPUs() const { return default_num_GPUs_; }
-
-  double default_num_custom_resource() const {
-    return default_num_custom_resource_;
-  }
-
   int64_t manager_timeout_milliseconds() const {
     return manager_timeout_milliseconds_;
   }
@@ -105,9 +96,6 @@ class RayConfig {
         max_num_to_reconstruct_(10000),
         local_scheduler_fetch_request_size_(10000),
         kill_worker_timeout_milliseconds_(100),
-        default_num_CPUs_(INT16_MAX),
-        default_num_GPUs_(0),
-        default_num_custom_resource_(INFINITY),
         manager_timeout_milliseconds_(1000),
         buf_size_(4096),
         max_time_for_handler_milliseconds_(1000),
@@ -166,12 +154,6 @@ class RayConfig {
   /// The duration that we wait after sending a worker SIGTERM before sending
   /// the worker SIGKILL.
   int64_t kill_worker_timeout_milliseconds_;
-
-  /// These are used to determine the local scheduler's behavior with respect to
-  /// different types of resources.
-  double default_num_CPUs_;
-  double default_num_GPUs_;
-  double default_num_custom_resource_;
 
   /// These are used by the plasma manager.
   int64_t manager_timeout_milliseconds_;

--- a/src/common/task.cc
+++ b/src/common/task.cc
@@ -79,14 +79,9 @@ class TaskBuilder {
     sha256_update(&ctx, (BYTE *) value, length);
   }
 
-  void SetRequiredResource(int64_t resource_index, double value) {
-    if (static_cast<size_t>(resource_index) >= resource_vector_.size()) {
-      /* Make sure the resource vector is constructed entry by entry,
-       * in order. */
-      CHECK(static_cast<size_t>(resource_index) == resource_vector_.size());
-      resource_vector_.resize(resource_index + 1);
-    }
-    resource_vector_[resource_index] = value;
+  void SetRequiredResource(const std::string &resource_name, double value) {
+    CHECK(resource_map_.count(resource_name) == 0);
+    resource_map_[resource_name] = value;
   }
 
   uint8_t *Finish(int64_t *size) {
@@ -105,16 +100,13 @@ class TaskBuilder {
       returns.push_back(to_flatbuf(fbb, return_id));
     }
     /* Create TaskInfo. */
-    for (int64_t i = resource_vector_.size(); i < ResourceIndex_MAX; ++i) {
-      resource_vector_.push_back(0.0);
-    }
     auto message = CreateTaskInfo(
         fbb, to_flatbuf(fbb, driver_id_), to_flatbuf(fbb, task_id),
         to_flatbuf(fbb, parent_task_id_), parent_counter_,
         to_flatbuf(fbb, actor_id_), to_flatbuf(fbb, actor_handle_id_),
         actor_counter_, is_actor_checkpoint_method_,
         to_flatbuf(fbb, function_id_), arguments, fbb.CreateVector(returns),
-        fbb.CreateVector(resource_vector_));
+        map_to_flatbuf(fbb, resource_map_));
     /* Finish the TaskInfo. */
     fbb.Finish(message);
     *size = fbb.GetSize();
@@ -122,6 +114,7 @@ class TaskBuilder {
     memcpy(result, fbb.GetBufferPointer(), *size);
     fbb.Clear();
     args.clear();
+    resource_map_.clear();
     return result;
   }
 
@@ -140,7 +133,7 @@ class TaskBuilder {
   bool is_actor_checkpoint_method_;
   FunctionID function_id_;
   int64_t num_returns_;
-  std::vector<double> resource_vector_;
+  std::unordered_map<std::string, double> resource_map_;
 };
 
 TaskBuilder *make_task_builder(void) {
@@ -205,9 +198,9 @@ void TaskSpec_args_add_val(TaskBuilder *builder,
 }
 
 void TaskSpec_set_required_resource(TaskBuilder *builder,
-                                    int64_t resource_index,
+                                    const std::string &resource_name,
                                     double value) {
-  builder->SetRequiredResource(resource_index, value);
+  builder->SetRequiredResource(resource_name, value);
 }
 
 /* Functions for reading tasks. */
@@ -215,25 +208,25 @@ void TaskSpec_set_required_resource(TaskBuilder *builder,
 TaskID TaskSpec_task_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->task_id());
+  return from_flatbuf(*message->task_id());
 }
 
 FunctionID TaskSpec_function(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->function_id());
+  return from_flatbuf(*message->function_id());
 }
 
 ActorID TaskSpec_actor_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->actor_id());
+  return from_flatbuf(*message->actor_id());
 }
 
 ActorID TaskSpec_actor_handle_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->actor_handle_id());
+  return from_flatbuf(*message->actor_handle_id());
 }
 
 bool TaskSpec_is_actor_task(TaskSpec *spec) {
@@ -268,13 +261,13 @@ bool TaskSpec_arg_is_actor_dummy_object(TaskSpec *spec, int64_t arg_index) {
 UniqueID TaskSpec_driver_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->driver_id());
+  return from_flatbuf(*message->driver_id());
 }
 
 TaskID TaskSpec_parent_task_id(TaskSpec *spec) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->parent_task_id());
+  return from_flatbuf(*message->parent_task_id());
 }
 
 int64_t TaskSpec_parent_counter(TaskSpec *spec) {
@@ -300,7 +293,7 @@ ObjectID TaskSpec_arg_id(TaskSpec *spec, int64_t arg_index, int64_t id_index) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
   return from_flatbuf(
-      message->args()->Get(arg_index)->object_ids()->Get(id_index));
+      *message->args()->Get(arg_index)->object_ids()->Get(id_index));
 }
 
 const uint8_t *TaskSpec_arg_val(TaskSpec *spec, int64_t arg_index) {
@@ -330,14 +323,29 @@ bool TaskSpec_arg_by_ref(TaskSpec *spec, int64_t arg_index) {
 ObjectID TaskSpec_return(TaskSpec *spec, int64_t return_index) {
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return from_flatbuf(message->returns()->Get(return_index));
+  return from_flatbuf(*message->returns()->Get(return_index));
 }
 
 double TaskSpec_get_required_resource(const TaskSpec *spec,
-                                      int64_t resource_index) {
+                                      const std::string &resource_name) {
+  // This is a bit ugly. However it shouldn't be much of a performance issue
+  // because there shouldn't be many distinct resources in a single task spec.
   CHECK(spec);
   auto message = flatbuffers::GetRoot<TaskInfo>(spec);
-  return message->required_resources()->Get(resource_index);
+  for (size_t i = 0; i < message->required_resources()->size(); i++) {
+    const ResourcePair *resource_pair = message->required_resources()->Get(i);
+    if (string_from_flatbuf(*resource_pair->key()) == resource_name) {
+      return resource_pair->value();
+    }
+  }
+  return 0;
+}
+
+const std::unordered_map<std::string, double> TaskSpec_get_required_resources(
+    const TaskSpec *spec) {
+  CHECK(spec);
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec);
+  return map_from_flatbuf(*message->required_resources());
 }
 
 bool TaskSpec_is_dependent_on(TaskSpec *spec, ObjectID object_id) {

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -1,6 +1,8 @@
 #ifndef TASK_H
 #define TASK_H
 
+#include <unordered_map>
+
 #include <stddef.h>
 #include <stdint.h>
 #include "common.h"
@@ -310,13 +312,13 @@ void TaskSpec_args_add_val(TaskBuilder *builder,
  * Set the value associated to a resource index.
  *
  * @param spec Task specification.
- * @param resource_index Index of the resource in the resource vector.
+ * @param resource_name Name of the resource in the resource vector.
  * @param value Value for the resource. This can be a quantity of this resource
  *        this task needs or a value for an attribute this task requires.
  * @return Void.
  */
 void TaskSpec_set_required_resource(TaskBuilder *builder,
-                                    int64_t resource_index,
+                                    const std::string &resource_name,
                                     double value);
 
 /**
@@ -329,14 +331,20 @@ void TaskSpec_set_required_resource(TaskBuilder *builder,
 ObjectID TaskSpec_return(TaskSpec *data, int64_t return_index);
 
 /**
- * Get the value associated to a resource index.
+ * Get the value associated to a resource name.
  *
  * @param spec Task specification.
- * @param resource_index Index of the resource.
+ * @param resource_name Name of the resource.
  * @return How many of this resource the task needs to execute.
  */
 double TaskSpec_get_required_resource(const TaskSpec *spec,
-                                      int64_t resource_index);
+                                      const std::string &resource_name);
+
+/**
+ *
+ */
+const std::unordered_map<std::string, double> TaskSpec_get_required_resources(
+    const TaskSpec *spec);
 
 /**
  * Compute whether the task is dependent on an object ID.

--- a/src/common/test/db_tests.cc
+++ b/src/common/test/db_tests.cc
@@ -68,13 +68,17 @@ int64_t timeout_handler(event_loop *loop, int64_t id, void *context) {
 TEST object_table_lookup_test(void) {
   event_loop *loop = event_loop_create();
   /* This uses manager_port1. */
-  const char *db_connect_args1[] = {"manager_address", "127.0.0.1:12345"};
+  std::vector<std::string> db_connect_args1;
+  db_connect_args1.push_back("manager_address");
+  db_connect_args1.push_back("127.0.0.1:12345");
   DBHandle *db1 = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                             manager_addr, 2, db_connect_args1);
+                             manager_addr, db_connect_args1);
   /* This uses manager_port2. */
-  const char *db_connect_args2[] = {"manager_address", "127.0.0.1:12346"};
+  std::vector<std::string> db_connect_args2;
+  db_connect_args2.push_back("manager_address");
+  db_connect_args2.push_back("127.0.0.1:12346");
   DBHandle *db2 = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                             manager_addr, 2, db_connect_args2);
+                             manager_addr, db_connect_args2);
   db_attach(db1, loop, false);
   db_attach(db2, loop, false);
   UniqueID id = globally_unique_id();
@@ -144,7 +148,7 @@ TEST task_table_test(void) {
   task_table_test_callback_called = 0;
   event_loop *loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "local_scheduler",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, loop, false);
   DBClientID local_scheduler_id = globally_unique_id();
   int64_t task_spec_size;
@@ -180,7 +184,7 @@ void task_table_all_test_callback(Task *task, void *user_data) {
 TEST task_table_all_test(void) {
   event_loop *loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "local_scheduler",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, loop, false);
   int64_t task_spec_size;
   TaskSpec *spec = example_task_spec(1, 1, &task_spec_size);
@@ -218,7 +222,7 @@ TEST unique_client_id_test(void) {
   DBHandle *db;
   for (int i = 0; i < num_conns; ++i) {
     db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                    "127.0.0.1", 0, NULL);
+                    "127.0.0.1", std::vector<std::string>());
     ids[i] = get_db_client_id(db);
     db_disconnect(db);
   }

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -84,7 +84,7 @@ TEST new_object_test(void) {
   new_object_task_id = TaskSpec_task_id(new_object_task_spec);
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -120,7 +120,7 @@ TEST new_object_no_task_test(void) {
   new_object_task_id = globally_unique_id();
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -162,7 +162,7 @@ void lookup_fail_callback(UniqueID id, void *user_context, void *user_data) {
 TEST lookup_timeout_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = lookup_fail_callback,
@@ -201,7 +201,7 @@ void add_fail_callback(UniqueID id, void *user_context, void *user_data) {
 TEST add_timeout_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5, .timeout = 100, .fail_callback = add_fail_callback,
@@ -241,7 +241,7 @@ void subscribe_fail_callback(UniqueID id, void *user_context, void *user_data) {
 TEST subscribe_timeout_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -335,9 +335,11 @@ TEST add_lookup_test(void) {
   g_loop = event_loop_create();
   lookup_retry_succeeded = 0;
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11235"};
+  std::vector<std::string> db_connect_args;
+  db_connect_args.push_back("manager_address");
+  db_connect_args.push_back("127.0.0.1:11235");
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 2, db_connect_args);
+                            "127.0.0.1", db_connect_args);
   db_attach(db, g_loop, true);
   RetryInfo retry = {
       .num_retries = 5,
@@ -399,7 +401,7 @@ TEST add_remove_lookup_test(void) {
   g_loop = event_loop_create();
   lookup_retry_succeeded = 0;
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, true);
   RetryInfo retry = {
       .num_retries = 5,
@@ -445,7 +447,7 @@ void lookup_late_done_callback(ObjectID object_id,
 TEST lookup_late_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 0,
@@ -489,7 +491,7 @@ void add_late_done_callback(ObjectID object_id,
 TEST add_late_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 0, .timeout = 0, .fail_callback = add_late_fail_callback,
@@ -534,7 +536,7 @@ void subscribe_late_done_callback(ObjectID object_id,
 TEST subscribe_late_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 0,
@@ -601,9 +603,11 @@ TEST subscribe_success_test(void) {
   g_loop = event_loop_create();
 
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
+  std::vector<std::string> db_connect_args;
+  db_connect_args.push_back("manager_address");
+  db_connect_args.push_back("127.0.0.1:11236");
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 2, db_connect_args);
+                            "127.0.0.1", db_connect_args);
   db_attach(db, g_loop, false);
   subscribe_id = globally_unique_id();
 
@@ -669,9 +673,11 @@ TEST subscribe_object_present_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
+  std::vector<std::string> db_connect_args;
+  db_connect_args.push_back("manager_address");
+  db_connect_args.push_back("127.0.0.1:11236");
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 2, db_connect_args);
+                            "127.0.0.1", db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {
@@ -722,7 +728,7 @@ void subscribe_object_not_present_object_available_callback(
 TEST subscribe_object_not_present_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {
@@ -783,9 +789,11 @@ TEST subscribe_object_available_later_test(void) {
 
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
+  std::vector<std::string> db_connect_args;
+  db_connect_args.push_back("manager_address");
+  db_connect_args.push_back("127.0.0.1:11236");
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 2, db_connect_args);
+                            "127.0.0.1", db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {
@@ -836,9 +844,11 @@ TEST subscribe_object_available_subscribe_all(void) {
       subscribe_object_available_later_context, data_size};
   g_loop = event_loop_create();
   /* Construct the arguments to db_connect. */
-  const char *db_connect_args[] = {"manager_address", "127.0.0.1:11236"};
+  std::vector<std::string> db_connect_args;
+  db_connect_args.push_back("manager_address");
+  db_connect_args.push_back("127.0.0.1:11236");
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 2, db_connect_args);
+                            "127.0.0.1", db_connect_args);
   db_attach(db, g_loop, false);
   UniqueID id = globally_unique_id();
   RetryInfo retry = {

--- a/src/common/test/redis_tests.cc
+++ b/src/common/test/redis_tests.cc
@@ -119,7 +119,7 @@ TEST async_redis_socket_test(void) {
 
   /* Start connection to Redis. */
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "test_process",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, loop, false);
 
   /* Send a command to the Redis process. */
@@ -193,7 +193,7 @@ TEST logging_test(void) {
 
   /* Start connection to Redis. */
   DBHandle *conn = db_connect(std::string("127.0.0.1"), 6379, "test_process",
-                              "127.0.0.1", 0, NULL);
+                              "127.0.0.1", std::vector<std::string>());
   db_attach(conn, loop, false);
 
   /* Send a command to the Redis process. */

--- a/src/common/test/task_table_tests.cc
+++ b/src/common/test/task_table_tests.cc
@@ -41,7 +41,7 @@ TEST lookup_nil_test(void) {
   lookup_nil_id = globally_unique_id();
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -108,7 +108,7 @@ TEST add_lookup_test(void) {
   add_lookup_task = example_task(1, 1, TASK_STATUS_WAITING);
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -149,7 +149,7 @@ void subscribe_fail_callback(UniqueID id, void *user_context, void *user_data) {
 TEST subscribe_timeout_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -192,7 +192,7 @@ void publish_fail_callback(UniqueID id, void *user_context, void *user_data) {
 TEST publish_timeout_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   RetryInfo retry = {
@@ -263,7 +263,7 @@ void subscribe_retry_fail_callback(UniqueID id,
 TEST subscribe_retry_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 5,
@@ -313,7 +313,7 @@ void publish_retry_fail_callback(UniqueID id,
 TEST publish_retry_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   RetryInfo retry = {
@@ -367,7 +367,7 @@ void subscribe_late_done_callback(TaskID task_id, void *user_context) {
 TEST subscribe_late_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   RetryInfo retry = {
       .num_retries = 0,
@@ -412,7 +412,7 @@ void publish_late_done_callback(TaskID task_id, void *user_context) {
 TEST publish_late_test(void) {
   g_loop = event_loop_create();
   DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                            "127.0.0.1", 0, NULL);
+                            "127.0.0.1", std::vector<std::string>());
   db_attach(db, g_loop, false);
   Task *task = example_task(1, 1, TASK_STATUS_WAITING);
   RetryInfo retry = {

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -23,7 +23,6 @@ typedef enum {
 struct GlobalSchedulerPolicyState {
   /** The index of the next local scheduler to assign a task to. */
   int64_t round_robin_index;
-  double resource_attribute_weight[ResourceIndex_MAX + 1];
 };
 
 /**

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -124,29 +124,25 @@ void start_worker(LocalSchedulerState *state,
  * is 0, we ignore the dynamic number of available CPUs (which may be negative).
  *
  * @param state The state of the local scheduler.
- * @param num_cpus Check if this many CPUs are available.
- * @param num_gpus Check if this many GPUs are available.
+ * @param resources The resources to check.
  * @return True if there are enough CPUs and GPUs and false otherwise.
  */
-bool check_dynamic_resources(LocalSchedulerState *state,
-                             double num_cpus,
-                             double num_gpus,
-                             double num_custom_resource);
+bool check_dynamic_resources(
+    LocalSchedulerState *state,
+    const std::unordered_map<std::string, double> &resources);
 
 /**
  * Acquire additional resources (CPUs and GPUs) for a worker.
  *
  * @param state The local scheduler state.
  * @param worker The worker who is acquiring resources.
- * @param num_cpus The number of CPU resources to acquire.
- * @param num_gpus The number of GPU resources to acquire.
+ * @param resources The resources to acquire.
  * @return Void.
  */
-void acquire_resources(LocalSchedulerState *state,
-                       LocalSchedulerClient *worker,
-                       double num_cpus,
-                       double num_gpus,
-                       double num_custom_resource);
+void acquire_resources(
+    LocalSchedulerState *state,
+    LocalSchedulerClient *worker,
+    const std::unordered_map<std::string, double> &resources);
 
 /**
  * Return resources (CPUs and GPUs) being used by a worker to the local
@@ -154,15 +150,13 @@ void acquire_resources(LocalSchedulerState *state,
  *
  * @param state The local scheduler state.
  * @param worker The worker who is returning resources.
- * @param num_cpus The number of CPU resources to return.
- * @param num_gpus The number of GPU resources to return.
+ * @param resources The resources to release.
  * @return Void.
  */
-void release_resources(LocalSchedulerState *state,
-                       LocalSchedulerClient *worker,
-                       double num_cpus,
-                       double num_gpus,
-                       double num_custom_resource);
+void release_resources(
+    LocalSchedulerState *state,
+    LocalSchedulerClient *worker,
+    const std::unordered_map<std::string, double> &resources);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST
@@ -176,7 +170,7 @@ LocalSchedulerState *LocalSchedulerState_init(
     const char *plasma_store_socket_name,
     const char *plasma_manager_address,
     bool global_scheduler_exists,
-    const double static_resource_vector[],
+    const std::unordered_map<std::string, double> &static_resource_vector,
     const char *worker_path,
     int num_workers);
 

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -68,10 +68,10 @@ struct LocalSchedulerState {
   std::vector<uint8_t> input_buffer;
   /** Vector of static attributes associated with the node owned by this local
    *  scheduler. */
-  double static_resources[ResourceIndex_MAX];
+  std::unordered_map<std::string, double> static_resources;
   /** Vector of dynamic attributes associated with the node owned by this local
    *  scheduler. */
-  double dynamic_resources[ResourceIndex_MAX];
+  std::unordered_map<std::string, double> dynamic_resources;
   /** The IDs of the available GPUs. There is redundancy here in that
    *  available_gpus.size() == dynamic_resources[ResourceIndex_GPU] should
    *  always be true. */
@@ -101,7 +101,7 @@ struct LocalSchedulerClient {
    *  update the task table. */
   Task *task_in_progress;
   /** An array of resource counts currently in use by the worker.  */
-  double resources_in_use[ResourceIndex_MAX];
+  std::unordered_map<std::string, double> resources_in_use;
   /** A vector of the IDs of the GPUs that the worker is currently using. If the
    *  worker is an actor, this will be constant throughout the lifetime of the
    *  actor (and will be equal to the number of GPUs requested by the actor). If

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -77,9 +77,9 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   const char *node_ip_address = "127.0.0.1";
   const char *redis_addr = node_ip_address;
   int redis_port = 6379;
-  const double static_resource_conf[ResourceIndex_MAX] = {
-      RayConfig::instance().default_num_CPUs(),
-      RayConfig::instance().default_num_GPUs()};
+  std::unordered_map<std::string, double> static_resource_conf;
+  static_resource_conf["CPU"] = INT16_MAX;
+  static_resource_conf["GPU"] = 0;
   LocalSchedulerMock *mock =
       (LocalSchedulerMock *) malloc(sizeof(LocalSchedulerMock));
   memset(mock, 0, sizeof(LocalSchedulerMock));
@@ -424,9 +424,11 @@ TEST object_reconstruction_suppression_test(void) {
     exit(0);
   } else {
     /* Connect a plasma manager client so we can call object_table_add. */
-    const char *db_connect_args[] = {"manager_address", "127.0.0.1:12346"};
+    std::vector<std::string> db_connect_args;
+    db_connect_args.push_back("manager_address");
+    db_connect_args.push_back("127.0.0.1:12346");
     DBHandle *db = db_connect(std::string("127.0.0.1"), 6379, "plasma_manager",
-                              "127.0.0.1", 2, db_connect_args);
+                              "127.0.0.1", db_connect_args);
     db_attach(db, local_scheduler->loop, false);
     /* Add the object to the object table. */
     object_table_add(db, return_id, 1, (unsigned char *) NIL_DIGEST, NULL,

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -463,19 +463,15 @@ PlasmaManagerState *PlasmaManagerState_init(const char *store_socket_name,
     std::string manager_address_str =
         std::string(manager_addr) + ":" + std::to_string(manager_port);
 
-    int num_args = 6;
-    const char **db_connect_args =
-        (const char **) malloc(sizeof(char *) * num_args);
-    db_connect_args[0] = "store_socket_name";
-    db_connect_args[1] = store_socket_name;
-    db_connect_args[2] = "manager_socket_name";
-    db_connect_args[3] = manager_socket_name;
-    db_connect_args[4] = "manager_address";
-    db_connect_args[5] = manager_address_str.c_str();
-    state->db =
-        db_connect(std::string(redis_primary_addr), redis_primary_port,
-                   "plasma_manager", manager_addr, num_args, db_connect_args);
-    free(db_connect_args);
+    std::vector<std::string> db_connect_args;
+    db_connect_args.push_back("store_socket_name");
+    db_connect_args.push_back(store_socket_name);
+    db_connect_args.push_back("manager_socket_name");
+    db_connect_args.push_back(manager_socket_name);
+    db_connect_args.push_back("manager_address");
+    db_connect_args.push_back(manager_address_str);
+    state->db = db_connect(std::string(redis_primary_addr), redis_primary_port,
+                           "plasma_manager", manager_addr, db_connect_args);
     db_attach(state->db, state->loop, false);
   } else {
     state->db = NULL;
@@ -1330,7 +1326,7 @@ void process_object_notification(event_loop *loop,
   }
   auto object_info = flatbuffers::GetRoot<ObjectInfo>(notification);
   /* Add object to locally available object. */
-  ObjectID object_id = from_flatbuf(object_info->object_id());
+  ObjectID object_id = from_flatbuf(*object_info->object_id());
   if (object_info->is_deletion()) {
     process_delete_object_notification(state, object_id);
   } else {

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -205,7 +205,8 @@ class StartRayScriptTest(unittest.TestCase):
                                  "--object-manager-port", "12345",
                                  "--num-cpus", "100",
                                  "--num-gpus", "0",
-                                 "--redis-max-clients", "100"])
+                                 "--redis-max-clients", "100",
+                                 "--resources", "{\"Custom\": 1}"])
         subprocess.Popen(["ray", "stop"]).wait()
 
         # Test starting Ray with invalid arguments.

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1275,6 +1275,7 @@ class ResourcesTest(unittest.TestCase):
         # Wait for all workers to start up.
         @ray.remote
         def f():
+            time.sleep(0.1)
             return os.getpid()
 
         start_time = time.time()

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1272,6 +1272,19 @@ class ResourcesTest(unittest.TestCase):
                 assert gpu_id in range(num_gpus)
             return gpu_ids
 
+        # Wait for all workers to start up.
+        @ray.remote
+        def f():
+            return os.getpid()
+
+        start_time = time.time()
+        while True:
+            if len(set(ray.get([f.remote() for _ in range(10)]))) == 10:
+                break
+            if time.time() > start_time + 10:
+                raise Exception("Timed out while waiting for workers to start "
+                                "up.")
+
         list_of_ids = ray.get([f0.remote() for _ in range(10)])
         self.assertEqual(list_of_ids, 10 * [[]])
 


### PR DESCRIPTION
This is intended to address #695.

This PR introduces the following API changes. Note that **all custom resources behave like GPUs**.

**Starting Ray from the command line.**

```
# The --resources argument is a JSON encoded dictionary.
ray start --head --num-cpus=64 --num-gpus=4 --resources='{"CustomLabel": 1}'
```

**Starting Ray from Python.**

```python
ray.init(num_cpus=64, num_gpus=4, resources={"CustomLabel": 1})
```

**Defining remote functions and actors.**

```python
@ray.remote(num_gpus=1, resources={"CustomLabel": 1})
def f():
    pass

@ray.remote(num_gpus=1, resources={"CustomLabel": 1})
class Actor(object):
    pass
```

**TODO in this PR:**
- [x] Add tests for the new functionality.
- [x] Fix remaining bugs.
- [x] Update all documentation.
- [x] Decide on API.
- [x] Add skipped test for actor placement with custom resources.
- [x] Add test to `multi_node_test.py`.
- [x] Double check handling when resource names are bytes versus unicode.
- [x] Maybe we really want GPU-like resources, not CPU-like resources. Figure out what to do about this.
- [x] Check for performance regressions.

**Not done in this PR:**
- Actor placement needs to be changed to take into account non-GPU resources.