### PR TITLE
[tune] remove assert which sometimes trips when cluster is resizing

### DIFF
--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -13,7 +13,7 @@ def json_to_resources(data):
     if type(data) is str:
         data = json.loads(data)
     return Resources(
-        data.get("cpu", 0), data.get("gpu", 0),
+        data.get("cpu", 1), data.get("gpu", 0),
         data.get("driver_cpu_limit"), data.get("driver_gpu_limit"))
 
 

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -126,7 +126,6 @@ class TrialRunner(object):
 
         cpu_avail = self._avail_resources.cpu - self._committed_resources.cpu
         gpu_avail = self._avail_resources.gpu - self._committed_resources.gpu
-        assert cpu_avail >= 0 and gpu_avail >= 0
         return resources.cpu <= cpu_avail and resources.gpu <= gpu_avail
 
     def _can_launch_more(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

When a cluster is down-scaling, it is possible the number of committed resources briefly exceeds the number of available resources (if we haven't processed the actor deaths yet). This is fairly harmless, so we shouldn't assert. The user would see something like `cpus: 15/10` if this happens.

I also changed the default cpu allocation for trials to 1, since zero will launch all of them at once.

cc @richardliaw 

## Related issue number

https://github.com/ray-project/ray/issues/1233