### PR TITLE
[rllib] [minor] Re-enable mean std filter by default

### DIFF
--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -57,7 +57,7 @@ DEFAULT_CONFIG = {
     # Config params to pass to the model
     "model": {"free_log_std": False},
     # Which observation filter to apply to the observation
-    "observation_filter": "NoFilter",
+    "observation_filter": "MeanStdFilter",
     # If >1, adds frameskip
     "extra_frameskip": 1,
     # Number of timesteps collected in each outer loop

--- a/python/ray/rllib/ppo/runner.py
+++ b/python/ray/rllib/ppo/runner.py
@@ -145,7 +145,7 @@ class Runner(object):
         else:
             raise Exception("Unknown observation_filter: " +
                             str(config["observation_filter"]))
-        self.reward_filter = NoFilter()
+        self.reward_filter = MeanStdFilter((), clip=5.0)
         self.sess.run(tf.global_variables_initializer())
 
     def load_data(self, trajectories, full_trace):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

MeanStdFilter was disabled due to https://github.com/ray-project/ray/issues/1081, but that has since been fixed. Enable it again since the tuned examples were with it on.