### PR TITLE
Local scheduler detects plasma manager death

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -103,7 +103,7 @@ void kill_worker(LocalSchedulerState *state,
       /* If we're exiting the local scheduler anyway, it's okay to force kill
        * the worker immediately. Wait for the process to exit. */
       kill(worker->pid, SIGKILL);
-      waitpid(worker->pid, NULL, 0);
+      waitpid(worker->pid, NULL, WNOHANG);
       close(worker->sock);
     } else {
       /* If we're just cleaning up a single worker, allow it some time to clean
@@ -164,7 +164,7 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   /* Kill any child processes that didn't register as a worker yet. */
   for (auto const &worker_pid : state->child_pids) {
     kill(worker_pid, SIGKILL);
-    waitpid(worker_pid, NULL, 0);
+    waitpid(worker_pid, NULL, WNOHANG);
     LOG_INFO("Killed worker pid %d which hadn't started yet.", worker_pid);
   }
 

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -103,7 +103,11 @@ void kill_worker(LocalSchedulerState *state,
       /* If we're exiting the local scheduler anyway, it's okay to force kill
        * the worker immediately. Wait for the process to exit. */
       kill(worker->pid, SIGKILL);
+#ifdef __APPLE__
       waitpid(worker->pid, NULL, WNOHANG);
+#else
+      waitpid(worker->pid, NULL, 0);
+#endif
       close(worker->sock);
     } else {
       /* If we're just cleaning up a single worker, allow it some time to clean
@@ -164,7 +168,11 @@ void LocalSchedulerState_free(LocalSchedulerState *state) {
   /* Kill any child processes that didn't register as a worker yet. */
   for (auto const &worker_pid : state->child_pids) {
     kill(worker_pid, SIGKILL);
+#ifdef __APPLE__
     waitpid(worker_pid, NULL, WNOHANG);
+#else
+    waitpid(worker_pid, NULL, 0);
+#endif
     LOG_INFO("Killed worker pid %d which hadn't started yet.", worker_pid);
   }
 


### PR DESCRIPTION
Previously, the local scheduler detected plasma manager death when it sent a request to fetch objects. However, if the local scheduler didn't have any missing dependencies, no request would be sent. Then, if the plasma manager died, an attached local scheduler would not detect it.

Changes:
`test/component_failures_test.py`: Add a test that demonstrates the bug.
`local_scheduler/local_scheduler_algorithm.cc`: Local scheduler sends an empty fetch request to the plasma manager if there are no objects to fetch.

Fixes #1270.