### PR TITLE
Allow actor methods to return multiple object IDs.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -51,13 +51,14 @@ from ray.worker import global_state  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
 import ray.actor  # noqa: F401
+from ray.actor import method  # noqa: E402
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.
 __version__ = "0.3.0"
 
 __all__ = ["error_info", "init", "connect", "disconnect", "get", "put", "wait",
-           "remote", "log_event", "log_span", "flush_log", "actor",
+           "remote", "log_event", "log_span", "flush_log", "actor", "method",
            "get_gpu_ids", "get_webui_url", "register_custom_serializer",
            "SCRIPT_MODE", "WORKER_MODE", "PYTHON_MODE", "SILENT_MODE",
            "global_state", "_config", "__version__"]

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -311,7 +311,6 @@ def register_actor_signatures(worker, driver_id, class_name,
         # problem.
         function_id = compute_actor_method_function_id(class_name,
                                                        actor_method_name).id()
-        # For now, all actor methods have 1 return value.
         worker.function_properties[driver_id][function_id] = (
             FunctionProperties(num_return_vals=num_return_vals + 1,
                                resources={"CPU": 1},

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -303,7 +303,7 @@ def register_actor_signatures(worker, driver_id, class_name,
         actor_method_num_return_vals: A list of the number of return values for
             each of the actor's methods.
     """
-
+    assert len(actor_method_names) == len(actor_method_num_return_vals)
     for actor_method_name, num_return_vals in zip(
             actor_method_names, actor_method_num_return_vals):
         # TODO(rkn): When we create a second actor, we are probably overwriting
@@ -312,6 +312,7 @@ def register_actor_signatures(worker, driver_id, class_name,
         function_id = compute_actor_method_function_id(class_name,
                                                        actor_method_name).id()
         worker.function_properties[driver_id][function_id] = (
+            # The extra return value is an actor dummy object.
             FunctionProperties(num_return_vals=num_return_vals + 1,
                                resources={"CPU": 1},
                                max_calls=0))

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -468,13 +468,14 @@ class ActorHandleWrapper(object):
     can tell that an argument is an ActorHandle.
     """
     def __init__(self, actor_id, actor_handle_id, actor_cursor, actor_counter,
-                 actor_method_names, method_signatures, checkpoint_interval,
-                 class_name):
+                 actor_method_names, actor_method_num_return_vals,
+                 method_signatures, checkpoint_interval, class_name):
         self.actor_id = actor_id
         self.actor_handle_id = actor_handle_id
         self.actor_cursor = actor_cursor
         self.actor_counter = actor_counter
         self.actor_method_names = actor_method_names
+        self.actor_method_num_return_vals = actor_method_num_return_vals
         # TODO(swang): Fetch this information from Redis so that we don't have
         # to fall back to pickle.
         self.method_signatures = method_signatures
@@ -501,10 +502,10 @@ def wrap_actor_handle(actor_handle):
         actor_handle._ray_actor_cursor,
         0,  # Reset the actor counter.
         actor_handle._ray_actor_method_names,
+        actor_handle._ray_actor_method_num_return_vals,
         actor_handle._ray_method_signatures,
         actor_handle._ray_checkpoint_interval,
-        actor_handle._ray_class_name,
-        actor_handle._ray_actor_method_num_return_vals)
+        actor_handle._ray_class_name)
     actor_handle._ray_actor_forks += 1
     return wrapper
 
@@ -532,6 +533,7 @@ def unwrap_actor_handle(worker, wrapper):
         wrapper.actor_cursor,
         wrapper.actor_counter,
         wrapper.actor_method_names,
+        wrapper.actor_method_num_return_vals,
         wrapper.method_signatures,
         wrapper.checkpoint_interval)
     return actor_object


### PR DESCRIPTION
Addresses #750.

This PR allows you to do

```python
@ray.remote
class Foo(object):
    def method1(self):
        return 1

    @ray.method(num_return_vals=2)
    def method2(self):
        return 1, 2
```

**TODO before merging:**
- [x] add test