### PR TITLE
Allow custom destructor methods for user-passed callback data

### DIFF
--- a/src/common/state/actor_notification_table.cc
+++ b/src/common/state/actor_notification_table.cc
@@ -12,7 +12,8 @@ void actor_notification_table_subscribe(
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 
-  init_table_callback(db_handle, NIL_ID, __func__, sub_data, retry, NULL,
+  init_table_callback(db_handle, NIL_ID, __func__,
+                      new CommonCallbackData(sub_data), retry, NULL,
                       redis_actor_notification_table_subscribe, NULL);
 }
 

--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -6,7 +6,8 @@ void db_client_table_remove(DBHandle *db_handle,
                             RetryInfo *retry,
                             db_client_table_done_callback done_callback,
                             void *user_context) {
-  init_table_callback(db_handle, db_client_id, __func__, NULL, retry,
+  init_table_callback(db_handle, db_client_id, __func__,
+                      new CommonCallbackData(NULL), retry,
                       (table_done_callback) done_callback,
                       redis_db_client_table_remove, user_context);
 }
@@ -23,7 +24,8 @@ void db_client_table_subscribe(
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 
-  init_table_callback(db_handle, NIL_ID, __func__, sub_data, retry,
+  init_table_callback(db_handle, NIL_ID, __func__,
+                      new CommonCallbackData(sub_data), retry,
                       (table_done_callback) done_callback,
                       redis_db_client_table_subscribe, user_context);
 }
@@ -80,7 +82,7 @@ void plasma_manager_send_heartbeat(DBHandle *db_handle) {
       RayConfig::instance().heartbeat_timeout_milliseconds();
   heartbeat_retry.fail_callback = NULL;
 
-  init_table_callback(db_handle, NIL_ID, __func__, NULL,
+  init_table_callback(db_handle, NIL_ID, __func__, new CommonCallbackData(NULL),
                       (RetryInfo *) &heartbeat_retry, NULL,
                       redis_plasma_manager_send_heartbeat, NULL);
 }

--- a/src/common/state/driver_table.cc
+++ b/src/common/state/driver_table.cc
@@ -9,13 +9,15 @@ void driver_table_subscribe(DBHandle *db_handle,
       (DriverTableSubscribeData *) malloc(sizeof(DriverTableSubscribeData));
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
-  init_table_callback(db_handle, NIL_ID, __func__, sub_data, retry, NULL,
+  init_table_callback(db_handle, NIL_ID, __func__,
+                      new CommonCallbackData(sub_data), retry, NULL,
                       redis_driver_table_subscribe, NULL);
 }
 
 void driver_table_send_driver_death(DBHandle *db_handle,
                                     WorkerID driver_id,
                                     RetryInfo *retry) {
-  init_table_callback(db_handle, driver_id, __func__, NULL, retry, NULL,
+  init_table_callback(db_handle, driver_id, __func__,
+                      new CommonCallbackData(NULL), retry, NULL,
                       redis_driver_table_send_driver_death, NULL);
 }

--- a/src/common/state/error_table.cc
+++ b/src/common/state/error_table.cc
@@ -26,6 +26,6 @@ void push_error(DBHandle *db_handle,
   UniqueID error_key = globally_unique_id();
   memcpy(info->error_key, error_key.id, sizeof(info->error_key));
 
-  init_table_callback(db_handle, NIL_ID, __func__, info, NULL, NULL,
-                      redis_push_error, NULL);
+  init_table_callback(db_handle, NIL_ID, __func__, new CommonCallbackData(info),
+                      NULL, NULL, redis_push_error, NULL);
 }

--- a/src/common/state/local_scheduler_table.cc
+++ b/src/common/state/local_scheduler_table.cc
@@ -13,7 +13,8 @@ void local_scheduler_table_subscribe(
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 
-  init_table_callback(db_handle, NIL_ID, __func__, sub_data, retry, NULL,
+  init_table_callback(db_handle, NIL_ID, __func__,
+                      new CommonCallbackData(sub_data), retry, NULL,
                       redis_local_scheduler_table_subscribe, NULL);
 }
 
@@ -36,8 +37,8 @@ void local_scheduler_table_send_info(DBHandle *db_handle,
   data->size = fbb.GetSize();
   memcpy(&data->flatbuffer_data[0], fbb.GetBufferPointer(), fbb.GetSize());
 
-  init_table_callback(db_handle, NIL_ID, __func__, data, retry, NULL,
-                      redis_local_scheduler_table_send_info, NULL);
+  init_table_callback(db_handle, NIL_ID, __func__, new CommonCallbackData(data),
+                      retry, NULL, redis_local_scheduler_table_send_info, NULL);
 }
 
 void local_scheduler_table_disconnect(DBHandle *db_handle) {

--- a/src/common/state/object_table.cc
+++ b/src/common/state/object_table.cc
@@ -7,7 +7,8 @@ void object_table_lookup(DBHandle *db_handle,
                          object_table_lookup_done_callback done_callback,
                          void *user_context) {
   CHECK(db_handle != NULL);
-  init_table_callback(db_handle, object_id, __func__, NULL, retry,
+  init_table_callback(db_handle, object_id, __func__,
+                      new CommonCallbackData(NULL), retry,
                       (table_done_callback) done_callback,
                       redis_object_table_lookup, user_context);
 }
@@ -25,7 +26,8 @@ void object_table_add(DBHandle *db_handle,
       (ObjectTableAddData *) malloc(sizeof(ObjectTableAddData));
   info->object_size = object_size;
   memcpy(&info->digest[0], digest, DIGEST_SIZE);
-  init_table_callback(db_handle, object_id, __func__, info, retry,
+  init_table_callback(db_handle, object_id, __func__,
+                      new CommonCallbackData(info), retry,
                       (table_done_callback) done_callback,
                       redis_object_table_add, user_context);
 }
@@ -43,7 +45,8 @@ void object_table_remove(DBHandle *db_handle,
     client_id_copy = (DBClientID *) malloc(sizeof(DBClientID));
     *client_id_copy = *client_id;
   }
-  init_table_callback(db_handle, object_id, __func__, client_id_copy, retry,
+  init_table_callback(db_handle, object_id, __func__,
+                      new CommonCallbackData(client_id_copy), retry,
                       (table_done_callback) done_callback,
                       redis_object_table_remove, user_context);
 }
@@ -63,10 +66,10 @@ void object_table_subscribe_to_notifications(
   sub_data->subscribe_context = subscribe_context;
   sub_data->subscribe_all = subscribe_all;
 
-  init_table_callback(db_handle, NIL_OBJECT_ID, __func__, sub_data, retry,
-                      (table_done_callback) done_callback,
-                      redis_object_table_subscribe_to_notifications,
-                      user_context);
+  init_table_callback(
+      db_handle, NIL_OBJECT_ID, __func__, new CommonCallbackData(sub_data),
+      retry, (table_done_callback) done_callback,
+      redis_object_table_subscribe_to_notifications, user_context);
 }
 
 void object_table_request_notifications(DBHandle *db_handle,
@@ -82,7 +85,8 @@ void object_table_request_notifications(DBHandle *db_handle,
   data->num_object_ids = num_object_ids;
   memcpy(data->object_ids, object_ids, num_object_ids * sizeof(ObjectID));
 
-  init_table_callback(db_handle, NIL_OBJECT_ID, __func__, data, retry, NULL,
+  init_table_callback(db_handle, NIL_OBJECT_ID, __func__,
+                      new CommonCallbackData(data), retry, NULL,
                       redis_object_table_request_notifications, NULL);
 }
 
@@ -97,7 +101,8 @@ void object_info_subscribe(DBHandle *db_handle,
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 
-  init_table_callback(db_handle, NIL_OBJECT_ID, __func__, sub_data, retry,
+  init_table_callback(db_handle, NIL_OBJECT_ID, __func__,
+                      new CommonCallbackData(sub_data), retry,
                       (table_done_callback) done_callback,
                       redis_object_info_subscribe, user_context);
 }
@@ -113,7 +118,8 @@ void result_table_add(DBHandle *db_handle,
       (ResultTableAddInfo *) malloc(sizeof(ResultTableAddInfo));
   info->task_id = task_id;
   info->is_put = is_put;
-  init_table_callback(db_handle, object_id, __func__, info, retry,
+  init_table_callback(db_handle, object_id, __func__,
+                      new CommonCallbackData(info), retry,
                       (table_done_callback) done_callback,
                       redis_result_table_add, user_context);
 }
@@ -123,7 +129,8 @@ void result_table_lookup(DBHandle *db_handle,
                          RetryInfo *retry,
                          result_table_lookup_callback done_callback,
                          void *user_context) {
-  init_table_callback(db_handle, object_id, __func__, NULL, retry,
+  init_table_callback(db_handle, object_id, __func__,
+                      new CommonCallbackData(NULL), retry,
                       (table_done_callback) done_callback,
                       redis_result_table_lookup, user_context);
 }

--- a/src/common/state/task_table.cc
+++ b/src/common/state/task_table.cc
@@ -8,9 +8,9 @@ void task_table_get_task(DBHandle *db_handle,
                          RetryInfo *retry,
                          task_table_get_callback get_callback,
                          void *user_context) {
-  init_table_callback(db_handle, task_id, __func__, NULL, retry,
-                      (void *) get_callback, redis_task_table_get_task,
-                      user_context);
+  init_table_callback(
+      db_handle, task_id, __func__, new CommonCallbackData(NULL), retry,
+      (void *) get_callback, redis_task_table_get_task, user_context);
 }
 
 void task_table_add_task(DBHandle *db_handle,
@@ -18,7 +18,8 @@ void task_table_add_task(DBHandle *db_handle,
                          RetryInfo *retry,
                          task_table_done_callback done_callback,
                          void *user_context) {
-  init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
+  init_table_callback(db_handle, Task_task_id(task), __func__,
+                      new TaskCallbackData(task), retry,
                       (table_done_callback) done_callback,
                       redis_task_table_add_task, user_context);
 }
@@ -28,7 +29,8 @@ void task_table_update(DBHandle *db_handle,
                        RetryInfo *retry,
                        task_table_done_callback done_callback,
                        void *user_context) {
-  init_table_callback(db_handle, Task_task_id(task), __func__, task, retry,
+  init_table_callback(db_handle, Task_task_id(task), __func__,
+                      new TaskCallbackData(task), retry,
                       (table_done_callback) done_callback,
                       redis_task_table_update, user_context);
 }
@@ -49,7 +51,8 @@ void task_table_test_and_update(
   update_data->update_state = update_state;
   /* Update the task entry's local scheduler with this client's ID. */
   update_data->local_scheduler_id = db_handle->client;
-  init_table_callback(db_handle, task_id, __func__, update_data, retry,
+  init_table_callback(db_handle, task_id, __func__,
+                      new CommonCallbackData(update_data), retry,
                       (table_done_callback) done_callback,
                       redis_task_table_test_and_update, user_context);
 }
@@ -70,7 +73,8 @@ void task_table_subscribe(DBHandle *db_handle,
   sub_data->subscribe_callback = subscribe_callback;
   sub_data->subscribe_context = subscribe_context;
 
-  init_table_callback(db_handle, local_scheduler_id, __func__, sub_data, retry,
+  init_table_callback(db_handle, local_scheduler_id, __func__,
+                      new CommonCallbackData(sub_data), retry,
                       (table_done_callback) done_callback,
                       redis_task_table_subscribe, user_context);
 }


### PR DESCRIPTION
## What do these changes do?

Allows GCS table clients to specify a custom destructor for data passed into the table operation (e.g., a task for the `add_task` operation). Data pointers passed by the caller must be wrapped in a class that defines the destructor.
