### PR TITLE
Register custom serializer for FunctionSignature objects.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1057,6 +1057,10 @@ def _initialize_serialization(worker=global_worker):
         # Ray can serialize actor handles that have been wrapped.
         register_custom_serializer(ray.actor.ActorHandleWrapper,
                                    use_dict=True)
+        # Tell Ray to serialize FunctionSignatures as dictionaries. This is
+        # used when passing around actor handles.
+        register_custom_serializer(ray.signature.FunctionSignature,
+                                   use_dict=True)
 
 
 def get_address_info_from_redis_helper(redis_address, node_ip_address):


### PR DESCRIPTION
This just removes the warning

```
WARNING: Serializing objects of type <class 'ray.signature.FunctionSignature'> by expanding them as dictionaries of their fields. This behavior may be incorrect in some cases.
```

which currently appears when passing actor handles around.