### PR TITLE
[tune] Tensorboard logger incorrectly reports training iteration as cur timestep value

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -115,7 +115,7 @@ class _TFLogger(Logger):
                     tag="ray/tune/{}".format(attr),
                     simple_value=getattr(result, attr)))
         train_stats = tf.Summary(value=values)
-        self._file_writer.add_summary(train_stats, result.training_iteration)
+        self._file_writer.add_summary(train_stats, result.timesteps_total)
 
     def close(self):
         self._file_writer.close()


### PR DESCRIPTION
This is a bug -- that field is supposed to be the timestep.