### PR TITLE
Add a distributed Dataframe API to Ray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ script:
   - python test/trial_runner_test.py
   - python test/trial_scheduler_test.py
   - python test/cython_test.py
+  - python -m pytest test/dataframe.py
 
   - python -m pytest python/ray/rllib/test/test_catalog.py
 

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -24,7 +24,7 @@ if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml
+  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml pandas
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake pkg-config python-dev python-numpy build-essential autoconf curl libtool unzip
@@ -32,7 +32,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml
+  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml pandas
 elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -48,7 +48,7 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml
+  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml pandas
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -64,7 +64,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
-  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml
+  pip install -q numpy cloudpickle==0.5.2 cython cmake funcsigs click colorama psutil redis tensorflow gym flatbuffers opencv-python pyyaml pandas
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake build-essential autoconf curl libtool unzip

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -12,3 +12,4 @@ recommonmark
 redis
 sphinx
 sphinx_rtd_theme
+pandas

--- a/python/ray/dataframe.py
+++ b/python/ray/dataframe.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import ray
 
+ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
+
 class DataFrame:
     def __init__(self, df, columns):
         """
@@ -11,6 +13,8 @@ class DataFrame:
                 partitions.
             columns ([str]): The list of column names for this dataframe.
         """
+        assert(len(df) > 0)
+
         self.df = df
         self.columns = columns
 
@@ -20,27 +24,30 @@ class DataFrame:
     def __repr__(self):
         return str(pd.concat(ray.get(self.df)))
 
-    def map_partitions(self, fn, *args):
+    def map_partitions(self, func, *args):
         """
-        Perform a function on each partition.
+        Apply a function on each partition.
 
         Args:
-            fn (callable): The function to perform.
+            func (callable): The function to Apply.
 
         Returns:
             A new DataFrame containing the result of the function.
         """
-        assert(callable(fn))
-
-        new_df = []
-        for partition in range(len(self.df)):
-            # self.df[partition] = _deploy_fn.remote(fn, self.df[partition], *args)
-
-            if len(args) == 0:
-                new_df.append(ray.put(fn(ray.get(self.df[partition]))))
-            else:
-                new_df.append(ray.put(fn(ray.get(self.df[partition]), *args)))
+        assert(callable(func))
+        new_df = [_deploy_func.remote(func, partition) for partition in self.df]
+        
         return DataFrame(new_df, self.columns)
+
+    def applymap(self, func):
+        """
+        Apply a function to a DataFrame elementwise.
+
+        Args:
+            func (callable): The function to apply.
+        """
+        assert(callable(func))
+        return self.map_partitions(lambda df: df.applymap(lambda x: func(x)))
 
     def copy(self):
         """
@@ -50,6 +57,37 @@ class DataFrame:
             A new DataFrame pointing to the same partitions as this one.
         """
         return DataFrame(self.df, self.columns)
+
+    def groupby(self, by=None, axis=0, level=None, as_index=True, group_keys=True, squeeze=False):
+        """
+        Apply a groupby to this DataFrame. See _groupby() remote task.
+
+        Args:
+            by
+            axis
+            level
+            as_index
+            group_keys
+            squeeze
+
+        Returns:
+            A new DataFrame resulting from the groupby.
+        """
+        return DataFrame(ray.get(_groupby.remote(self)), self.columns)
+
+    def reduce_by_index(self, func):
+        """
+        Perform a reduction based on the row index and perform a predicate on
+        the result.
+
+        Args:
+            func (callable): The function to call on the partition
+                after the reduction.
+
+        Returns:
+            A new DataFrame with the result of the reduction.
+        """
+        return DataFrame(ray.get(_reduce_by_index.remote(self, func)), self.columns)
 
     def sum(self, axis=None, skipna=True):
         """
@@ -62,112 +100,197 @@ class DataFrame:
         Returns:
             The sum of the DataFrame.
         """
-        sum_partitions = self.map_partitions(lambda df: df.sum(axis=axis, skipna=skipna))
-        return sum_partitions.reduce_by_index(lambda df: df.sum(axis=axis, skipna=skipna))
+        return self.map_partitions(lambda df: df.sum(axis=axis, skipna=skipna)
+            ).reduce_by_index(lambda df: df.sum(axis=axis, skipna=skipna))
 
-    def reduce_by_index(self, predicate_fn):
+    def abs(self):
         """
-        Perform a reduction based on the row index and perform a predicate on
-        the result.
-
-        Args:
-            predicate_fn (callable): The function to call on the partition
-                after the reduction.
+        Apply an absolute value function to all numberic columns.
 
         Returns:
-            A new DataFrame with the result of the reduction.
+            A new DataFrame with the applied absolute value.
         """
-        ray_df = self
+        return self.map_partitions(lambda df: df.abs())
 
-        indices = set()
-        for df in ray.get(ray_df.df):
-            indices.update(set(list(df.index)))
-        # indices = list(set(index for index in [list(df.index) for df in ray.get(ray_df.df)]))
-        indices = list(indices)
+    def isin(self, values):
+        """
+        Create a DataFrame filled with booleans representing whether or not the
+        cell is contained in values.
 
-        chunksize = int(len(indices) / len(ray_df.df))
-        partitions = [[] for _ in range(len(ray_df.df))]
-        
-        indices_copy = indices
-        for df in ray_df.df:
-            i = 0
-            indices = indices_copy
-            while len(indices) > chunksize:
-                #oids = _shuffle(df, indices[:chunksize])
-                oids = ray.put(ray.get(df).reindex(indices[:chunksize]).dropna())
-                partitions[i].append(oids)
-                indices = indices[chunksize:]
-                i += 1
-            else:
-                # oids = _shuffle(df, indices)
-                oids = ray.put(ray.get(df).reindex(indices).dropna())
-                partitions[i].append(oids)
+        Args:
+            values (iterable, DataFrame, Series, or dict): The values to find.
 
-        # return [_local_reduce(partition) for partition in partitions]
-        x = []
-        for partition in partitions:
-            combined_df = pd.concat(ray.get(partition))
-            x.append(ray.put(predicate_fn(combined_df.groupby(combined_df.index))))
-        return DataFrame(x, self.columns)
+        Returns:
+            A new DataFrame with booleans representing whether or not a cell is in values.
+            True: cell is contained in values.
+            False: otherwise
+        """
+        return self.map_partitions(lambda df: df.isin(values))
 
-        return DataFrame([ray.put(predicate_fn(ray.get(partition).groupby(ray.get(partition).index))) for partition in partitions], self.columns)
-        #TODO Use this once pandas can be used in remote functions
-        # return DataFrame(ray.get(_reduce_by_index.remote(self)), self.columns)
+    def isna(self):
+        """
+        Create a DataFrame filled with booleans representing whether or not the
+        cell contains NA.
 
+        Returns:
+            A new DataFrame with booleans representing whether or not a cell is NA.
+            True: cell contains NA.
+            False: otherwise.
+        """
+        return self.map_partitions(lambda df: df.isna())
+
+    def isnull(self):
+        """
+        Create a DataFrame filled with booleans representing whether or not the
+        cell contains a null value.
+
+        Returns:
+            A new DataFrame with booleans representing whether or not a cell
+                is null.
+            True: cell contains null.
+            False: otherwise.
+        """
+        return self.map_partitions(lambda df: df.isnull)
+
+    def keys(self):
+        """
+        Get the info axis for the DataFrame.
+
+        Returns:
+            A pandas Index for this DataFrame.
+        """
+        # Each partition should have the same index, so we'll use 0's
+        return ray.get(_deploy_func.remote(lambda df: df.keys(), self.df[0]))
+
+    def transpose(self, *args, **kwargs):
+        """
+        Transpose columns and rows for the DataFrame. Triggers a shuffle.
+
+        Returns:
+            A new DataFrame transposed from this DataFrame.
+        """
+        return self.map_partitions(lambda df: df.transpose(*args, **kwargs)
+            ).reduce_by_index(lambda df: df.sum())
+
+    # This breaks it all
+    T = property(transpose)
+
+    def dropna(self, axis, how, thresh=None, subset=[], inplace=False):
+        """
+        Create a new DataFrame from the removed NA values from this one.
+
+        Args:
+            axis (int, tuple, or list): The axis to apply the drop.
+            how (str): How to drop the NA values.
+                'all': drop the label if all values are NA.
+                'any': drop the label if any values are NA.
+            thresh (int): The minimum number of NAs to require.
+            subset ([label]): Labels to consider from other axis.
+            inplace (bool): Change this DataFrame or return a new DataFrame.
+                True: Modify the data for this DataFrame, return None.
+                False: Create a new DataFrame and return it.
+
+        Returns:
+            If inplace is set to True, returns None, otherwise returns a new
+            DataFrame with the dropna applied.
+        """
+        raise NotImplementedError("Not yet")
+        if how != 'any' and how != 'all':
+            raise ValueError("<how> not correctly set.")
 
 @ray.remote
-def _reduce_by_index(ray_df):
+def _reduce_by_index(ray_df, func):
     """
+    Perform a groupby and a function on the result.
 
+    Args:
+        ray_df (ray.DataFrame): The DataFrame to apply to.
+        func (callable): The function to apply after the groupby.
+
+    Returns:
+        A list of partitions, each containing a pandas DataFrame with the
+        result of the groupby and function provided.
     """
+    return [_deploy_func.remote(func, partition) for partition in ray.get(_groupby.remote(ray_df))]
 
-    indices = list(set([index for index in list(ray.get(ray_df.df).index)]))
+@ray.remote
+def _groupby(ray_df):
+    """
+    Group by the index (in current implementation) and return a list of
+    partitions. The groupby triggers a shuffle to ensure correctness.
+
+    Args:
+        ray_df (ray.DataFrame): The DataFrame to groupby.
+
+    Returns:
+        A list of partitions, each containing a pandas DataFrame with the
+        result of the groupby.
+    """
+    indices = list(set([index for df in ray.get(ray_df.df) for index in list(df.index)]))
 
     chunksize = int(len(indices) / len(ray_df.df))
-
-    # partitions = [[] for _ in range(len(ray_df))]
     partitions = []
     
     indices_copy = indices
     for df in ray_df.df:
-        indices = indices_copy
-        i = 0
-        while len(indices) > chunksize:
-            #oids = _shuffle(df, indices[:chunksize])
-            oids = ray.get(df).reindex(indices[:chunksize]).dropna()
-            if not partitions[i]:
-                partitions[i] = [oids]
-            else:
-                partitions[i].append(oids)
-            indices = indices[chunksize:]
-            i += 1
-        else:
-            # oids = _shuffle(df, indices)
-            oids = ray.get(df).reindex(indices).dropna()
-            partitions[i].append(oids)
-
-
-    # return [_local_reduce(partition) for partition in partitions]
-    return [pd.concat(ray.get(partition)) for partition in partitions]
-
+        partitions.append(_shuffle.remote(df, indices, chunksize))
     
+    partitions = ray.get(partitions)
+    
+    # Transpose the list of dataframes
+    # TODO find a better way
+    new_partitions = []
+    for i in range(len(partitions[0])):
+        new_partitions.append([])
+        for j in range(len(partitions)):
+            new_partitions[i].append(partitions[j][i])
+    
+    return [_local_groupby.remote(partition) for partition in new_partitions]
 
 @ray.remote
-def _shuffle(df, indices):
-    return df.reindex(indices).dropna()
-
-@ray.remote
-def _local_reduce(df_rows):
+def _shuffle(df, indices, chunksize):
     """
+    Sends data in blocks defined by the chunksize provided to the Ray object
+    store. This serves as the shuffle function.
 
+    Args:
+        df (pd.DataFrame): The pandas DataFrame to shuffle.
+        indices ([any]): The list of indices for the DataFrame.
+        chunksize (int): The number of indices to send.
+
+    Returns:
+        The list of pd.DataFrame objects in order of their assignment. This
+        order is important because it determines which task will get the data.
     """
-    concat_df = pd.concat(ray.get(df_rows))
-    return concat_df
-    # return predicate_fn(concat_df, *args)
-
+    i = 0
+    partition = []
+    while len(indices) > chunksize:
+        oids = df.reindex(indices[:chunksize]).dropna()
+        partition.append(oids)
+        indices = indices[chunksize:]
+        i += 1
+    else:
+        oids = df.reindex(indices).dropna()
+        partition.append(oids)
+    return partition
 
 @ray.remote
-def _deploy_fn(fn, dataframe, *args):
+def _local_groupby(df_rows):
+    """
+    Apply a groupby on this partition for the blocks sent to it.
+
+    Args:
+        df_rows ([pd.DataFrame]): A list of dataframes for this partition. Goes
+            through the Ray object store.
+
+    Returns:
+        A DataFrameGroupBy object from the resulting groupby.
+    """
+    concat_df = pd.concat(df_rows)
+    return concat_df.groupby(concat_df.index)
+
+@ray.remote
+def _deploy_func(func, dataframe, *args):
     """
     Deploys a function for the map_partitions call.
 
@@ -179,49 +302,58 @@ def _deploy_fn(fn, dataframe, *args):
         provided.
     """
     if len(args) == 0:
-        return fn(dataframe)
+        return func(dataframe)
     else:
-        return fn(dataframe, *args)
+        return func(dataframe, *args)
 
-def from_pandas(data, npartitions=None, chunksize=None, sort=True):
+def from_pandas(df, npartitions=None, chunksize=None, sort=True):
     """
     Converts a pandas DataFrame to a Ray DataFrame. It splits the DataFrame
     across the Ray Object Store.
 
     Args:
-        data (pandas.DataFrame): The pandas DataFrame to convert.
+        df (pandas.DataFrame): The pandas DataFrame to convert.
         npartitions (int): The number of partitions to split the DataFrame
             into. Has priority over chunksize.
         chunksize (int): The number of rows to put in each partition.
-        sort (bool): Whether or not to sort the data as it is being converted.
+        sort (bool): Whether or not to sort the df as it is being converted.
 
     Returns:
         A new Ray DataFrame object.
     """
-    if sort and not data.index.is_monotonic_increasing:
-        data = data.sort_index(ascending=True)
+    if sort and not df.index.is_monotonic_increasing:
+        df = df.sort_index(ascending=True)
     
     if npartitions is not None:
-        chunksize = int(len(data) / npartitions)
+        chunksize = int(len(df) / npartitions)
     elif chunksize is None:
         raise ValueError("The number of partitions or chunksize must be set.")
     
-    #TODO stop reassigning data
+    #TODO stop reassigning df
     dataframes = []
-    while len(data) > chunksize:
+    while len(df) > chunksize:
         top = ray.put(data[:chunksize])
         dataframes.append(top)
-        data = data[chunksize:]
+        df = df[chunksize:]
     else:
-        dataframes.append(ray.put(data))
+        dataframes.append(ray.put(df))
 
-    return DataFrame(dataframes, list(data.columns.values))
+    return DataFrame(dataframes, list(df.columns.values))
 
-@ray.remote
-def do_nothing(df):
-    return df
+def to_pandas(df):
+    """
+    Converts a Ray DataFrame to a pandas DataFrame.
 
-# data = pd.DataFrame(data={'col1': [1, 2, 3, 4], 'col2': [3, 4, 5, 6]})
-# ray.init()
-# ray_df = from_pandas(data, 2)
-# do_nothing.remote(ray_df)
+    Args:
+        df (ray.DataFrame): The Ray DataFrame to convert.
+
+    Returns:
+        A new pandas DataFrame.
+    """
+    return pd.concat(ray.get(df.df))
+
+data = pd.DataFrame(data={'col1': [1, 2, 3, 4], 'col2': [3, 4, 5, 6]})
+ray.init()
+ray_df = from_pandas(data, 2)
+sums = ray_df.map_partitions(lambda df: df.sum()).reduce_by_index(lambda df: df.sum())
+print(ray_df.T)

--- a/python/ray/dataframe.py
+++ b/python/ray/dataframe.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import ray
+
+class DataFrame():
+    def __init__(self, df, columns):
+        """
+        Distributed DataFrame object backed by Pandas dataframes.
+
+        Args:
+            df ([ObjectID]): The list of ObjectIDs that contain the dataframe
+                partitions.
+            columns ([str]): The list of column names for this dataframe.
+        """
+        self.df = df
+        self.columns = columns
+
+    def map_partitions(self, fn, *args):
+        assert(callable(fn))
+
+        new_df = []
+        for partition in range(len(self.df)):
+            # self.df[partition] = _deploy_fn.remote(fn, self.df[partition], *args)
+
+            if len(args) == 0:
+                new_df.append(ray.put(fn(ray.get(self.df[partition]))))
+            else:
+                new_df.append(ray.put(fn(ray.get(self.df[partition]), *args)))
+        return DataFrame(new_df, self.columns)
+
+@ray.remote
+def _deploy_fn(fn, dataframe, *args):
+    """
+    Deploys a function for the map_partitions call.
+
+    Args:
+        dataframe (pandas.DataFrame): The pandas DataFrame for this partition.
+
+    Returns:
+        A futures object representing the return value of the function
+        provided.
+    """
+    if len(args) == 0:
+        return fn(dataframe)
+    else:
+        return fn(dataframe, *args)
+
+def from_pandas(data, npartitions=None, chunksize=None, sort=True):
+    """
+    Converts a pandas DataFrame to a Ray DataFrame. It splits the DataFrame
+    across the Ray Object Store.
+
+    Args:
+        data (pandas.DataFrame): The pandas DataFrame to convert.
+        npartitions (int): The number of partitions to split the DataFrame
+            into. Has priority over chunksize.
+        chunksize (int): The number of rows to put in each partition.
+        sort (bool): Whether or not to sort the data as it is being converted.
+
+    Returns:
+        A new Ray DataFrame object.
+    """
+    if sort and not data.index.is_monotonic_increasing:
+        data = data.sort_index(ascending=True)
+    
+    if npartitions is not None:
+        chunksize = int(len(data) / npartitions)
+    elif chunksize is None:
+        raise ValueError("The number of partitions or chunksize must be set.")
+    
+    #TODO stop reassigning data
+    dataframes = []
+    while len(data) > chunksize:
+        top = ray.put(data[:chunksize])
+        dataframes.append(top)
+        data = data[chunksize:]
+    else:
+        dataframes.append(ray.put(data))
+
+    return DataFrame(dataframes, list(data.columns.values))

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -8,5 +8,7 @@ from .dataframe import to_pandas
 import ray
 import pandas as pd
 
+__all__ = ["DataFrame", "from_pandas", "to_pandas"]
+
 ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
 ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from .dataframe import DataFrame
 from .dataframe import from_pandas
 from .dataframe import to_pandas

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -2,6 +2,7 @@ from .dataframe import DataFrame
 from .dataframe import from_pandas
 from .dataframe import to_pandas
 import ray
+import pandas as pd
 
 ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
 ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -1,0 +1,5 @@
+# from .dataframe import DataFrame
+from .dataframe import *
+
+ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
+ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -1,6 +1,7 @@
 from .dataframe import DataFrame
 from .dataframe import from_pandas
 from .dataframe import to_pandas
+import ray
 
 ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
 ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -1,5 +1,6 @@
-# from .dataframe import DataFrame
-from .dataframe import *
+from .dataframe import DataFrame
+from .dataframe import from_pandas
+from .dataframe import to_pandas
 
 ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
 ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -6,9 +6,6 @@ import pandas as pd
 import numpy as np
 import ray
 
-ray.register_custom_serializer(pd.DataFrame, use_pickle=True)
-ray.register_custom_serializer(pd.core.indexes.base.Index, use_pickle=True)
-
 
 class DataFrame(object):
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -196,7 +196,7 @@ class DataFrame(object):
         """
 
         indices = list(set(
-        [index for df in ray.get(self.df) for index in list(df.index)]))
+            [index for df in ray.get(self.df) for index in list(df.index)]))
 
         chunksize = int(len(indices) / len(self.df))
         partitions = []
@@ -208,15 +208,15 @@ class DataFrame(object):
 
         # Transpose the list of dataframes
         # TODO find a better way
-        new_partitions = []
+        shuffle = []
         for i in range(len(partitions[0])):
-            new_partitions.append([])
+            shuffle.append([])
             for j in range(len(partitions)):
-                new_partitions[i].append(partitions[j][i])
+                shuffle[i].append(partitions[j][i])
 
-        new_partitions = [_local_groupby.remote(partition, axis=axis) for partition in new_partitions]
+        new_dfs = [_local_groupby.remote(part, axis=axis) for part in shuffle]
 
-        return DataFrame(new_partitions, self.columns)
+        return DataFrame(new_dfs, self.columns)
 
     def reduce_by_index(self, func, axis=0):
         """Perform a reduction based on the row index.

--- a/test/dataframe.py
+++ b/test/dataframe.py
@@ -1,0 +1,159 @@
+import pytest
+import ray.dataframe as rdf
+import numpy as np
+import pandas as pd
+import ray
+
+@pytest.fixture
+def ray_df_equals_pandas(ray_df, pandas_df):
+    return rdf.to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
+
+@pytest.fixture
+def test_roundtrip(ray_df, pandas_df):
+    assert(ray_df_equals_pandas(ray_df, pandas_df))
+
+@pytest.fixture
+def test_index(ray_df, pandas_df):
+    assert(ray_df.index.equals(pandas_df.index))
+
+@pytest.fixture
+def test_size(ray_df, pandas_df):
+    assert(ray_df.size == pandas_df.size)
+
+@pytest.fixture
+def test_ndim(ray_df, pandas_df):
+    assert(ray_df.ndim == pandas_df.ndim)
+
+@pytest.fixture
+def test_ftypes(ray_df, pandas_df):
+    assert(ray_df.ftypes.equals(pandas_df.ftypes))
+
+@pytest.fixture
+def test_values(ray_df, pandas_df):
+    assert(np.array_equal(ray_df.values, pandas_df.values))
+
+@pytest.fixture
+def test_axes(ray_df, pandas_df):
+    assert(np.array_equal(ray_df.axes, pandas_df.axes))
+
+@pytest.fixture
+def test_shape(ray_df, pandas_df):
+    assert(ray_df.shape == pandas_df.shape)
+
+@pytest.fixture
+def test_add_prefix(ray_df, pandas_df):
+    test_prefix = "TEST"
+    new_ray_df = ray_df.add_prefix(test_prefix)
+    new_pandas_df = pandas_df.add_prefix(test_prefix)
+    assert(new_ray_df.columns.equals(new_pandas_df.columns))
+
+@pytest.fixture
+def test_add_suffix(ray_df, pandas_df):
+    test_suffix = "TEST"
+    new_ray_df = ray_df.add_suffix(test_suffix)
+    new_pandas_df = pandas_df.add_suffix(test_suffix)
+    
+    assert(new_ray_df.columns.equals(new_pandas_df.columns))
+
+@pytest.fixture
+def test_applymap(ray_df, pandas_df, testfunc):
+    new_ray_df = ray_df.applymap(testfunc)
+    new_pandas_df = pandas_df.applymap(testfunc)
+
+    assert(ray_df_equals_pandas(new_ray_df, new_pandas_df))
+
+@pytest.fixture
+def test_copy(ray_df):
+    new_ray_df = ray_df.copy()
+
+    assert(new_ray_df is not ray_df)
+    assert(new_ray_df.df == ray_df.df)
+
+@pytest.fixture
+def test_sum(ray_df, pandas_df):
+    assert(ray_df_equals_pandas(ray_df.sum(), pandas_df.sum()))
+
+@pytest.fixture
+def test_abs(ray_df, pandas_df):
+    assert(ray_df_equals_pandas(ray_df.abs(), pandas_df.abs()))
+
+@pytest.fixture
+def test_keys(ray_df, pandas_df):
+    assert(ray_df.keys().equals(pandas_df.keys()))
+
+@pytest.fixture
+def test_transpose(ray_df, pandas_df):
+    assert(ray_df_equals_pandas(ray_df.T, pandas_df.T))
+    assert(ray_df_equals_pandas(ray_df.transpose(), pandas_df.transpose()))
+
+
+def test_int_dataframe():
+    ray.init()
+    
+    pandas_df = pd.DataFrame({'col1':[0,1,2,3], 
+                                 'col2':[4,5,6,7],
+                                 'col3':[8,9,10,11],
+                                 'col4':[12,13,14,15]})
+
+    ray_df = rdf.from_pandas(pandas_df, 2)
+
+    testfuncs = [lambda x: x + 1,
+                 lambda x: str(x),
+                 lambda x: x * x,
+                 lambda x: x,
+                 lambda x: False]
+
+    test_roundtrip(ray_df, pandas_df)
+    test_index(ray_df, pandas_df)
+    test_size(ray_df, pandas_df)
+    test_ndim(ray_df, pandas_df)
+    test_ftypes(ray_df, pandas_df)
+    test_values(ray_df, pandas_df)
+    test_axes(ray_df, pandas_df)
+    test_shape(ray_df, pandas_df)
+    test_add_prefix(ray_df, pandas_df)
+    test_add_suffix(ray_df, pandas_df)
+
+    for testfunc in testfuncs:
+        test_applymap(ray_df, pandas_df, testfunc)
+
+    test_copy(ray_df)
+    test_sum(ray_df, pandas_df)
+    test_abs(ray_df, pandas_df)
+    test_keys(ray_df, pandas_df)
+    test_transpose(ray_df, pandas_df)
+
+def test_float_dataframe():
+    
+    pandas_df = pd.DataFrame({'col1':[0.0,1.0,2.0,3.0], 
+                                 'col2':[4.0,5.0,6.0,7.0],
+                                 'col3':[8.0,9.0,10.0,11.0],
+                                 'col4':[12.0,13.0,14.0,15.0]})
+
+    ray_df = rdf.from_pandas(pandas_df, 2)
+
+    testfuncs = [lambda x: x + 1,
+                 lambda x: str(x),
+                 lambda x: x * x,
+                 lambda x: x,
+                 lambda x: False]
+
+    test_roundtrip(ray_df, pandas_df)
+    test_index(ray_df, pandas_df)
+    test_size(ray_df, pandas_df)
+    test_ndim(ray_df, pandas_df)
+    test_ftypes(ray_df, pandas_df)
+    test_values(ray_df, pandas_df)
+    test_axes(ray_df, pandas_df)
+    test_shape(ray_df, pandas_df)
+    test_add_prefix(ray_df, pandas_df)
+    test_add_suffix(ray_df, pandas_df)
+
+    for testfunc in testfuncs:
+        test_applymap(ray_df, pandas_df, testfunc)
+
+    test_copy(ray_df)
+    test_sum(ray_df, pandas_df)
+    test_abs(ray_df, pandas_df)
+    test_keys(ray_df, pandas_df)
+    test_transpose(ray_df, pandas_df)

--- a/test/dataframe.py
+++ b/test/dataframe.py
@@ -4,41 +4,51 @@ import numpy as np
 import pandas as pd
 import ray
 
+
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
     return rdf.to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
+
 
 @pytest.fixture
 def test_roundtrip(ray_df, pandas_df):
     assert(ray_df_equals_pandas(ray_df, pandas_df))
 
+
 @pytest.fixture
 def test_index(ray_df, pandas_df):
     assert(ray_df.index.equals(pandas_df.index))
+
 
 @pytest.fixture
 def test_size(ray_df, pandas_df):
     assert(ray_df.size == pandas_df.size)
 
+
 @pytest.fixture
 def test_ndim(ray_df, pandas_df):
     assert(ray_df.ndim == pandas_df.ndim)
+
 
 @pytest.fixture
 def test_ftypes(ray_df, pandas_df):
     assert(ray_df.ftypes.equals(pandas_df.ftypes))
 
+
 @pytest.fixture
 def test_values(ray_df, pandas_df):
     assert(np.array_equal(ray_df.values, pandas_df.values))
+
 
 @pytest.fixture
 def test_axes(ray_df, pandas_df):
     assert(np.array_equal(ray_df.axes, pandas_df.axes))
 
+
 @pytest.fixture
 def test_shape(ray_df, pandas_df):
     assert(ray_df.shape == pandas_df.shape)
+
 
 @pytest.fixture
 def test_add_prefix(ray_df, pandas_df):
@@ -47,13 +57,15 @@ def test_add_prefix(ray_df, pandas_df):
     new_pandas_df = pandas_df.add_prefix(test_prefix)
     assert(new_ray_df.columns.equals(new_pandas_df.columns))
 
+
 @pytest.fixture
 def test_add_suffix(ray_df, pandas_df):
     test_suffix = "TEST"
     new_ray_df = ray_df.add_suffix(test_suffix)
     new_pandas_df = pandas_df.add_suffix(test_suffix)
-    
+
     assert(new_ray_df.columns.equals(new_pandas_df.columns))
+
 
 @pytest.fixture
 def test_applymap(ray_df, pandas_df, testfunc):
@@ -62,6 +74,7 @@ def test_applymap(ray_df, pandas_df, testfunc):
 
     assert(ray_df_equals_pandas(new_ray_df, new_pandas_df))
 
+
 @pytest.fixture
 def test_copy(ray_df):
     new_ray_df = ray_df.copy()
@@ -69,17 +82,21 @@ def test_copy(ray_df):
     assert(new_ray_df is not ray_df)
     assert(new_ray_df.df == ray_df.df)
 
+
 @pytest.fixture
 def test_sum(ray_df, pandas_df):
     assert(ray_df_equals_pandas(ray_df.sum(), pandas_df.sum()))
+
 
 @pytest.fixture
 def test_abs(ray_df, pandas_df):
     assert(ray_df_equals_pandas(ray_df.abs(), pandas_df.abs()))
 
+
 @pytest.fixture
 def test_keys(ray_df, pandas_df):
     assert(ray_df.keys().equals(pandas_df.keys()))
+
 
 @pytest.fixture
 def test_transpose(ray_df, pandas_df):
@@ -89,11 +106,11 @@ def test_transpose(ray_df, pandas_df):
 
 def test_int_dataframe():
     ray.init()
-    
-    pandas_df = pd.DataFrame({'col1':[0,1,2,3], 
-                                 'col2':[4,5,6,7],
-                                 'col3':[8,9,10,11],
-                                 'col4':[12,13,14,15]})
+
+    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
+                              'col2': [4, 5, 6, 7],
+                              'col3': [8, 9, 10, 11],
+                              'col4': [12, 13, 14, 15]})
 
     ray_df = rdf.from_pandas(pandas_df, 2)
 
@@ -123,12 +140,13 @@ def test_int_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
 
+
 def test_float_dataframe():
-    
-    pandas_df = pd.DataFrame({'col1':[0.0,1.0,2.0,3.0], 
-                                 'col2':[4.0,5.0,6.0,7.0],
-                                 'col3':[8.0,9.0,10.0,11.0],
-                                 'col4':[12.0,13.0,14.0,15.0]})
+
+    pandas_df = pd.DataFrame({'col1': [0.0, 1.0, 2.0, 3.0],
+                              'col2': [4.0, 5.0, 6.0, 7.0],
+                              'col3': [8.0, 9.0, 10.0, 11.0],
+                              'col4': [12.0, 13.0, 14.0, 15.0]})
 
     ray_df = rdf.from_pandas(pandas_df, 2)
 

--- a/test/dataframe.py
+++ b/test/dataframe.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import pytest
 import ray.dataframe as rdf
 import numpy as np


### PR DESCRIPTION
## What do these changes do?
Adds a Pandas DataFrame wrapper for use in Ray:

* Distributes the DataFrame.
* Operates on the DataFrame partitions in remote tasks.
* Currently provides some simple functionality.

## TODO
- [x] Add/Format unit tests in test/dataframe.py
- [x] Clean up a couple of quick hacks
- [ ] ~~Add skeleton for full API with `NotImplementedErrors`~~
- [ ] ~~Docs in doc/source~~
- [ ] ~~Benchmark~~

Push the last 3 to next PR.