### PR TITLE
fixes default type for product of empty shape.

### DIFF
--- a/python/ray/experimental/tfutils.py
+++ b/python/ray/experimental/tfutils.py
@@ -9,7 +9,7 @@ def unflatten(vector, shapes):
     i = 0
     arrays = []
     for shape in shapes:
-        size = np.prod(shape)
+        size = np.prod(shape, dtype=np.int)
         array = vector[i:(i + size)].reshape(shape)
         arrays.append(array)
         i += size


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

When shapes is empty, size is of type float, which breaks indexing on vector.

## Related issue number

