### PR TITLE
fetching task table fails for some task_ids.

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -543,23 +543,26 @@ class GlobalState(object):
                 should be included in the trace.
         """
         workers = self.workers()
+
+        task_info = task_info.copy()
+        task_table = {}
+        # TODO(ekl) reduce the number of RPCs here with MGET
+        for task_id, _ in task_info.items():
+            try:
+                # TODO (hme): do something to correct slider here,
+                # slider should be correct to begin with, though.
+                task_table[task_id] = self.task_table(task_id)
+            except Exception as e:
+                print("Warning:" + str(e))
+
+        # filter out tasks not in task_table
+        task_info = {k: v for k, v in task_info.items() if k in task_table}
+
         start_time = None
         for info in task_info.values():
             task_start = min(self._get_times(info))
             if not start_time or task_start < start_time:
                 start_time = task_start
-
-        def micros(ts):
-            return int(1e6 * ts)
-
-        def micros_rel(ts):
-            return micros(ts - start_time)
-
-        task_table = {}
-        # TODO(ekl) reduce the number of RPCs here with MGET
-        for task_id, _ in task_info.items():
-            task_table[task_id] = self.task_table(task_id)
-        seen_obj = {}
 
         full_trace = []
         for task_id, info in task_info.items():

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -544,7 +544,6 @@ class GlobalState(object):
         """
         workers = self.workers()
 
-        task_info = task_info.copy()
         task_table = {}
         # TODO(ekl) reduce the number of RPCs here with MGET
         for task_id, _ in task_info.items():
@@ -553,7 +552,7 @@ class GlobalState(object):
                 # slider should be correct to begin with, though.
                 task_table[task_id] = self.task_table(task_id)
             except Exception as e:
-                print("Warning:" + str(e))
+                print("Could not find task {}".format(task_id))
 
         # filter out tasks not in task_table
         task_info = {k: v for k, v in task_info.items() if k in task_table}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Sometimes the timeline view fails to render anything because the call to `self.task_table` fails. This issue continues to happen after the first occurrence, leaving the timeline view unusable.

This was debugged with @ericl a few weeks ago.

## Related issue number

