### PR TITLE
Nondeterministic reconstruction for actors

### DIFF
--- a/src/common/task.h
+++ b/src/common/task.h
@@ -28,6 +28,12 @@ class TaskExecutionSpec {
   ///         dependencies.
   std::vector<ObjectID> ExecutionDependencies();
 
+  /// Set the task's execution dependencies.
+  ///
+  /// @param dependencies The value to set the execution dependencies to.
+  /// @return Void.
+  void SetExecutionDependencies(const std::vector<ObjectID> &dependencies);
+
   /// Get the task spec size.
   ///
   /// @return The size of the immutable task spec.
@@ -239,14 +245,15 @@ int64_t TaskSpec_actor_counter(TaskSpec *spec);
 bool TaskSpec_is_actor_checkpoint_method(TaskSpec *spec);
 
 /**
- * Return whether the task's argument is a dummy object. Dummy objects are used
- * to encode an actor's state dependencies in the task graph.
+ * Return an actor task's dummy return value. Dummy objects are used to
+ * encode an actor's state dependencies in the task graph. The dummy object
+ * is local if and only if the task that returned it has completed
+ * execution.
  *
  * @param spec The task_spec in question.
- * @param arg_index The index of the argument in question.
- * @return Whether the argument at arg_index is a dummy object.
+ * @return The dummy object ID that the actor task will return.
  */
-bool TaskSpec_arg_is_actor_dummy_object(TaskSpec *spec, int64_t arg_index);
+ObjectID TaskSpec_actor_dummy_object(TaskSpec *spec);
 
 /**
  * Return the driver ID of the task.

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1629,7 +1629,7 @@ class DistributedActorHandles(unittest.TestCase):
                                             num_items_per_fork,
                                             num_forks_to_wait):
         ray.worker._init(start_ray_local=True, num_local_schedulers=2,
-                         num_workers=0, redirect_output=False)
+                         num_workers=0, redirect_output=True)
 
         # Make a shared queue.
         @ray.remote

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1674,8 +1674,7 @@ class DistributedActorHandles(unittest.TestCase):
                 actor, [(fork, i) for i in range(num_items_per_fork)]))
         # Wait for the forks to complete their tasks.
         enqueue_tasks = ray.get(enqueue_tasks)
-        enqueue_tasks = [object_id for object_id_list in enqueue_tasks for
-                         object_id in object_id_list]
+        enqueue_tasks = [fork_ids[0] for fork_ids in enqueue_tasks]
         ray.get(enqueue_tasks)
 
         # Read the queue and make sure it has all items from all forks.


### PR DESCRIPTION
## What do these changes do?

Local scheduler asynchronously updates each actor task's execution dependencies upon dispatch so that each actor task is dependent on the task executed immediately before. Then, during actor reconstruction, the local scheduler automatically follows the initial order of execution (within some error bound due to message asynchrony).