### PR TITLE
[docs] Add backlinks from hyperopt / rl algorithm examples to the built-on Ray libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /src/common/format/*_generated.h
 /src/plasma/format/*_generated.h
 /src/local_scheduler/format/*_generated.h
+/src/ray/gcs/format/*_generated.h
 
 # Redis temporary files
 *dump.rdb

--- a/doc/source/example-a3c.rst
+++ b/doc/source/example-a3c.rst
@@ -11,6 +11,10 @@ View the `code for this example`_.
 .. _`Universe Starter Agent`: https://github.com/openai/universe-starter-agent
 .. _`code for this example`: https://github.com/ray-project/ray/tree/master/python/ray/rllib/a3c
 
+.. note::
+
+    For a more comprehensive framework of reinforcement learning in Ray, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
+
 To run the application, first install **ray** and then some dependencies:
 
 .. code-block:: bash

--- a/doc/source/example-a3c.rst
+++ b/doc/source/example-a3c.rst
@@ -13,7 +13,7 @@ View the `code for this example`_.
 
 .. note::
 
-    For a more comprehensive framework of reinforcement learning in Ray, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
+    For an overview of Ray's reinforcement learning library, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
 
 To run the application, first install **ray** and then some dependencies:
 

--- a/doc/source/example-hyperopt.rst
+++ b/doc/source/example-hyperopt.rst
@@ -2,6 +2,11 @@ Hyperparameter Optimization
 ===========================
 
 This document provides a walkthrough of the hyperparameter optimization example.
+
+.. note::
+
+     To learn about Ray's built-in hyperparameter optimization framework, see `Ray.tune <http://ray.readthedocs.io/en/latest/tune.html>`__.
+
 To run the application, first install some dependencies.
 
 .. code-block:: bash

--- a/doc/source/example-policy-gradient.rst
+++ b/doc/source/example-policy-gradient.rst
@@ -6,7 +6,7 @@ View the `code for this example`_.
 
 .. note::
 
-    For a more comprehensive framework of reinforcement learning in Ray, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
+    For an overview of Ray's reinforcement learning library, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
 
 
 To run this example, you will need to install `TensorFlow with GPU support`_ (at

--- a/doc/source/example-policy-gradient.rst
+++ b/doc/source/example-policy-gradient.rst
@@ -4,6 +4,11 @@ Policy Gradient Methods
 This code shows how to do reinforcement learning with policy gradient methods.
 View the `code for this example`_.
 
+.. note::
+
+    For a more comprehensive framework of reinforcement learning in Ray, see `Ray RLlib <http://ray.readthedocs.io/en/latest/rllib.html>`__.
+
+
 To run this example, you will need to install `TensorFlow with GPU support`_ (at
 least version ``1.0.0``) and a few other dependencies.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Seems like a lot of visitors land on those pages, but now that we have libraries we should link them there.