### PR TITLE
Keep track of which workers have never been used.

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -582,6 +582,7 @@ void finish_task(LocalSchedulerState *state,
                  LocalSchedulerClient *worker,
                  bool actor_checkpoint_failed) {
   if (worker->task_in_progress != NULL) {
+    CHECK(!worker->unused);
     TaskSpec *spec = Task_task_execution_spec(worker->task_in_progress)->Spec();
     /* Return dynamic resources back for the task in progress. */
     CHECK(worker->resources_in_use["CPU"] ==
@@ -858,6 +859,7 @@ void handle_client_register(LocalSchedulerState *state,
   /* Make sure this worker hasn't already registered. */
   CHECK(!worker->registered);
   worker->registered = true;
+  worker->unused = true;
   worker->is_worker = message->is_worker();
   CHECK(WorkerID_equal(worker->client_id, NIL_WORKER_ID));
   worker->client_id = from_flatbuf(*message->client_id());

--- a/src/local_scheduler/local_scheduler_shared.h
+++ b/src/local_scheduler/local_scheduler_shared.h
@@ -87,6 +87,8 @@ struct LocalSchedulerClient {
   int sock;
   /** True if the client has registered and false otherwise. */
   bool registered;
+  /// True if the worker has never been used and false otherwise.
+  bool unused;
   /** True if the client has sent a disconnect message to the local scheduler
    *  and false otherwise. If this is true, then the local scheduler will not
    *  propagate an error message to the driver when the client exits. */


### PR DESCRIPTION
This is in preparation for converting unused workers into actors (instead of having to start new workers for actors) to help with simplifying the process of treating actor creation as a regular task (happening in #1351).