### PR TITLE
Fix pyarrow version check

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -350,14 +350,14 @@ def check_version_info(redis_client):
                         "    Ray location: " + true_version_info[1] + "\n"
                         "    Python: " + true_version_info[2] + "\n"
                         "    Cloudpickle: " + true_version_info[3] + "\n"
-                        "    Pyarrow: " + true_version_info[4] + "\n"
+                        "    Pyarrow: " + str(true_version_info[4]) + "\n"
                         "This process on node " + node_ip_address +
                         " was started with:" + "\n"
                         "    Ray: " + version_info[0] + "\n"
                         "    Ray location: " + version_info[1] + "\n"
                         "    Python: " + version_info[2] + "\n"
                         "    Cloudpickle: " + version_info[3] + "\n"
-                        "    Pyarrow: " + version_info[4])
+                        "    Pyarrow: " + str(version_info[4]))
 
 
 def start_redis(node_ip_address,


### PR DESCRIPTION
In certain situations, the version number of pyarrow can be `None`, see https://github.com/apache/arrow/blob/155bf076204dcb6bf1f68a556e9243556f5e4ebb/python/pyarrow/__init__.py#L29

In this case, constructing the error message didn't work.