### PR TITLE
Ray scheduler spillback plumbing + mechanism

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -273,6 +273,8 @@ class GlobalState(object):
                     task_table_message.LocalSchedulerId()),
                 "ExecutionDependenciesString":
                     task_table_message.ExecutionDependencies(),
+                "SpillbackCount":
+                    task_table_message.SpillbackCount(),
                 "TaskSpec": task_spec_info}
 
     def task_table(self, task_id=None):

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -198,7 +198,8 @@ class Monitor(object):
                 key, "RAY.TASK_TABLE_UPDATE",
                 hex_to_binary(task_id),
                 ray.experimental.state.TASK_STATUS_LOST, NIL_ID,
-                task["ExecutionDependenciesString"])
+                task["ExecutionDependenciesString"],
+                task["SpillbackCount"])
             if ok != b"OK":
                 log.warn("Failed to update lost task for dead scheduler.")
             num_tasks_updated += 1

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1906,6 +1906,7 @@ def connect(info, object_id_seed=None, mode=WORKER_MODE, worker=global_worker,
             TASK_STATUS_RUNNING,
             NIL_LOCAL_SCHEDULER_ID,
             driver_task.execution_dependencies_string(),
+            0,
             ray.local_scheduler.task_to_string(driver_task))
         # Set the driver's current task ID to the task ID assigned to the
         # driver task.

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -101,6 +101,8 @@ table TaskReply {
   execution_dependencies: string;
   // A string of bytes representing the task specification.
   task_spec: string;
+  // The number of times the task was spilled back by local schedulers.
+  spillback_count: long;
   // A boolean representing whether the update was successful. This field
   // should only be used for test-and-set operations.
   updated: bool;

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -779,9 +779,11 @@ int ReplyWithTask(RedisModuleCtx *ctx,
     long long state_integer;
     long long spillback_count_val;
     if ((RedisModule_StringToLongLong(state, &state_integer) !=
-         REDISMODULE_OK) || (state_integer < 0) ||
+         REDISMODULE_OK) ||
+        (state_integer < 0) ||
         (RedisModule_StringToLongLong(spillback_count, &spillback_count_val) !=
-         REDISMODULE_OK) || (spillback_count_val < 0)) {
+         REDISMODULE_OK) ||
+        (spillback_count_val < 0)) {
       RedisModule_CloseKey(key);
       RedisModule_FreeString(ctx, state);
       RedisModule_FreeString(ctx, local_scheduler_id);

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -762,12 +762,14 @@ int ReplyWithTask(RedisModuleCtx *ctx,
     RedisModuleString *local_scheduler_id = NULL;
     RedisModuleString *execution_dependencies = NULL;
     RedisModuleString *task_spec = NULL;
-    RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS, "state", &state,
-                        "local_scheduler_id", &local_scheduler_id,
-                        "execution_dependencies", &execution_dependencies,
-                        "TaskSpec", &task_spec, NULL);
+    RedisModuleString *spillback_count = NULL;
+    RedisModule_HashGet(
+        key, REDISMODULE_HASH_CFIELDS, "state", &state, "local_scheduler_id",
+        &local_scheduler_id, "execution_dependencies", &execution_dependencies,
+        "TaskSpec", &task_spec, "spillback_count", &spillback_count, NULL);
     if (state == NULL || local_scheduler_id == NULL ||
-        execution_dependencies == NULL || task_spec == NULL) {
+        execution_dependencies == NULL || task_spec == NULL ||
+        spillback_count == NULL) {
       /* We must have either all fields or no fields. */
       RedisModule_CloseKey(key);
       return RedisModule_ReplyWithError(
@@ -775,22 +777,27 @@ int ReplyWithTask(RedisModuleCtx *ctx,
     }
 
     long long state_integer;
-    if (RedisModule_StringToLongLong(state, &state_integer) != REDISMODULE_OK ||
-        state_integer < 0) {
+    long long spillback_count_val;
+    if ((RedisModule_StringToLongLong(state, &state_integer) !=
+         REDISMODULE_OK) || (state_integer < 0) ||
+        (RedisModule_StringToLongLong(spillback_count, &spillback_count_val) !=
+         REDISMODULE_OK) || (spillback_count_val < 0)) {
       RedisModule_CloseKey(key);
       RedisModule_FreeString(ctx, state);
       RedisModule_FreeString(ctx, local_scheduler_id);
       RedisModule_FreeString(ctx, execution_dependencies);
       RedisModule_FreeString(ctx, task_spec);
-      return RedisModule_ReplyWithError(ctx, "Found invalid scheduling state.");
+      RedisModule_FreeString(ctx, spillback_count);
+      return RedisModule_ReplyWithError(
+          ctx, "Found invalid scheduling state or spillback count.");
     }
 
     flatbuffers::FlatBufferBuilder fbb;
-    auto message =
-        CreateTaskReply(fbb, RedisStringToFlatbuf(fbb, task_id), state_integer,
-                        RedisStringToFlatbuf(fbb, local_scheduler_id),
-                        RedisStringToFlatbuf(fbb, execution_dependencies),
-                        RedisStringToFlatbuf(fbb, task_spec), updated);
+    auto message = CreateTaskReply(
+        fbb, RedisStringToFlatbuf(fbb, task_id), state_integer,
+        RedisStringToFlatbuf(fbb, local_scheduler_id),
+        RedisStringToFlatbuf(fbb, execution_dependencies),
+        RedisStringToFlatbuf(fbb, task_spec), spillback_count_val, updated);
     fbb.Finish(message);
 
     RedisModuleString *reply = RedisModule_CreateString(
@@ -801,6 +808,7 @@ int ReplyWithTask(RedisModuleCtx *ctx,
     RedisModule_FreeString(ctx, local_scheduler_id);
     RedisModule_FreeString(ctx, execution_dependencies);
     RedisModule_FreeString(ctx, task_spec);
+    RedisModule_FreeString(ctx, spillback_count);
   } else {
     /* If the key does not exist, return nil. */
     RedisModule_ReplyWithNull(ctx);
@@ -911,11 +919,18 @@ int TaskTableWrite(RedisModuleCtx *ctx,
                    RedisModuleString *state,
                    RedisModuleString *local_scheduler_id,
                    RedisModuleString *execution_dependencies,
+                   RedisModuleString *spillback_count,
                    RedisModuleString *task_spec) {
   /* Extract the scheduling state. */
   long long state_value;
   if (RedisModule_StringToLongLong(state, &state_value) != REDISMODULE_OK) {
     return RedisModule_ReplyWithError(ctx, "scheduling state must be integer");
+  }
+
+  long long spillback_count_value;
+  if (RedisModule_StringToLongLong(spillback_count, &spillback_count_value) !=
+      REDISMODULE_OK) {
+    return RedisModule_ReplyWithError(ctx, "spillback count must be integer");
   }
   /* Add the task to the task table. If no spec was provided, get the existing
    * spec out of the task table so we can publish it. */
@@ -925,7 +940,8 @@ int TaskTableWrite(RedisModuleCtx *ctx,
   if (task_spec == NULL) {
     RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "state", state,
                         "local_scheduler_id", local_scheduler_id,
-                        "execution_dependencies", execution_dependencies, NULL);
+                        "execution_dependencies", execution_dependencies,
+                        "spillback_count", spillback_count, NULL);
     RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS, "TaskSpec",
                         &existing_task_spec, NULL);
     if (existing_task_spec == NULL) {
@@ -934,10 +950,10 @@ int TaskTableWrite(RedisModuleCtx *ctx,
           ctx, "Cannot update a task that doesn't exist yet");
     }
   } else {
-    RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "state", state,
-                        "local_scheduler_id", local_scheduler_id,
-                        "execution_dependencies", execution_dependencies,
-                        "TaskSpec", task_spec, NULL);
+    RedisModule_HashSet(
+        key, REDISMODULE_HASH_CFIELDS, "state", state, "local_scheduler_id",
+        local_scheduler_id, "execution_dependencies", execution_dependencies,
+        "TaskSpec", task_spec, "spillback_count", spillback_count, NULL);
   }
   RedisModule_CloseKey(key);
 
@@ -959,11 +975,12 @@ int TaskTableWrite(RedisModuleCtx *ctx,
       task_spec_to_use = existing_task_spec;
     }
     /* Create the flatbuffers message. */
-    auto message =
-        CreateTaskReply(fbb, RedisStringToFlatbuf(fbb, task_id), state_value,
-                        RedisStringToFlatbuf(fbb, local_scheduler_id),
-                        RedisStringToFlatbuf(fbb, execution_dependencies),
-                        RedisStringToFlatbuf(fbb, task_spec_to_use));
+    auto message = CreateTaskReply(
+        fbb, RedisStringToFlatbuf(fbb, task_id), state_value,
+        RedisStringToFlatbuf(fbb, local_scheduler_id),
+        RedisStringToFlatbuf(fbb, execution_dependencies),
+        RedisStringToFlatbuf(fbb, task_spec_to_use), spillback_count_value,
+        true);  // The updated field is not used.
     fbb.Finish(message);
 
     RedisModuleString *publish_message = RedisModule_CreateString(
@@ -1023,11 +1040,12 @@ int TaskTableWrite(RedisModuleCtx *ctx,
 int TaskTableAddTask_RedisCommand(RedisModuleCtx *ctx,
                                   RedisModuleString **argv,
                                   int argc) {
-  if (argc != 6) {
+  if (argc != 7) {
     return RedisModule_WrongArity(ctx);
   }
 
-  return TaskTableWrite(ctx, argv[1], argv[2], argv[3], argv[4], argv[5]);
+  return TaskTableWrite(ctx, argv[1], argv[2], argv[3], argv[4], argv[5],
+                        argv[6]);
 }
 
 /**
@@ -1051,11 +1069,11 @@ int TaskTableAddTask_RedisCommand(RedisModuleCtx *ctx,
 int TaskTableUpdate_RedisCommand(RedisModuleCtx *ctx,
                                  RedisModuleString **argv,
                                  int argc) {
-  if (argc != 5) {
+  if (argc != 6) {
     return RedisModule_WrongArity(ctx);
   }
 
-  return TaskTableWrite(ctx, argv[1], argv[2], argv[3], argv[4], NULL);
+  return TaskTableWrite(ctx, argv[1], argv[2], argv[3], argv[4], argv[5], NULL);
 }
 
 /**

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -23,7 +23,7 @@ class TaskExecutionSpec {
   TaskExecutionSpec(const std::vector<ObjectID> &execution_dependencies,
                     TaskSpec *spec,
                     int64_t task_spec_size,
-                    int spillover_count);
+                    int spillback_count);
   TaskExecutionSpec(TaskExecutionSpec *execution_spec);
 
   /// Get the task's execution dependencies.

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -20,6 +20,10 @@ class TaskExecutionSpec {
   TaskExecutionSpec(const std::vector<ObjectID> &execution_dependencies,
                     TaskSpec *spec,
                     int64_t task_spec_size);
+  TaskExecutionSpec(const std::vector<ObjectID> &execution_dependencies,
+                    TaskSpec *spec,
+                    int64_t task_spec_size,
+                    int spillover_count);
   TaskExecutionSpec(TaskExecutionSpec *execution_spec);
 
   /// Get the task's execution dependencies.
@@ -37,7 +41,27 @@ class TaskExecutionSpec {
   /// Get the task spec size.
   ///
   /// @return The size of the immutable task spec.
-  int64_t SpecSize();
+  int64_t SpecSize() const;
+
+  /// Get the task's spillback count.
+  ///
+  /// @return The spillback count for this task.
+  int SpillbackCount() const;
+
+  void IncrementSpillbackCount();
+
+  /// Get the task's last timestamp.
+  ///
+  /// @return The timestamp when this task was last received for scheduling.
+  int64_t LastTimeStamp() const;
+
+  /// Set the task's last timestamp to the specified value.
+  ///
+  /// @param new_timestamp The new timestamp in millisecond to set the task's
+  ///        time stamp to. Tracks the last time this task entered a local
+  ///        scheduler.
+  /// @return Void.
+  void SetLastTimeStamp(int64_t new_timestamp);
 
   /// Get the task spec.
   ///
@@ -84,6 +108,10 @@ class TaskExecutionSpec {
   std::vector<ObjectID> execution_dependencies_;
   /** The size of the task specification for this task. */
   int64_t task_spec_size_;
+  /** Last time this task was received for scheduling. */
+  int64_t last_timestamp_;
+  /** Number of times this task was spilled back by local schedulers. */
+  int spillback_count_;
   /** The task specification for this task. */
   std::unique_ptr<TaskSpec[]> spec_;
 };

--- a/src/common/task.h
+++ b/src/common/task.h
@@ -43,11 +43,15 @@ class TaskExecutionSpec {
   /// @return The size of the immutable task spec.
   int64_t SpecSize() const;
 
-  /// Get the task's spillback count.
+  /// Get the task's spillback count, which tracks the number of times
+  /// this task was spilled back from local to the global scheduler.
   ///
   /// @return The spillback count for this task.
   int SpillbackCount() const;
 
+  /// Increment the spillback count for this task.
+  ///
+  /// @return Void.
   void IncrementSpillbackCount();
 
   /// Get the task's last timestamp.

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1007,6 +1007,8 @@ void process_message(event_loop *loop,
         TaskExecutionSpec(from_flatbuf(*message->execution_dependencies()),
                           (TaskSpec *) message->task_spec()->data(),
                           message->task_spec()->size());
+    /* Set the tasks's local scheduler entrypoint time. */
+    execution_spec.SetLastTimeStamp(current_time_ms());
     TaskSpec *spec = execution_spec.Spec();
     /* Update the result table, which holds mappings of object ID -> ID of the
      * task that created it. */
@@ -1196,6 +1198,9 @@ void handle_task_scheduled_callback(Task *original_task,
   LocalSchedulerState *state = (LocalSchedulerState *) subscribe_context;
   TaskExecutionSpec *execution_spec = Task_task_execution_spec(original_task);
   TaskSpec *spec = execution_spec->Spec();
+
+  /* Set the tasks's local scheduler entrypoint time. */
+  execution_spec->SetLastTimeStamp(current_time_ms());
 
   /* If the driver for this task has been removed, then don't bother telling the
    * scheduling algorithm. */

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1067,6 +1067,10 @@ void give_task_to_global_scheduler(LocalSchedulerState *state,
   }
   /* Pass on the task to the global scheduler. */
   DCHECK(state->config.global_scheduler_exists);
+  /* Increment the task's spillback count before forwarding it to the global
+   * scheduler.
+   */
+  execution_spec.IncrementSpillbackCount();
   Task *task =
       Task_alloc(execution_spec, TASK_STATUS_WAITING, DBClientID::nil());
   DCHECK(state->db != NULL);


### PR DESCRIPTION
## What do these changes do?
This PR adds support for the task spillback mechanism that will allow local schedulers to spill back tasks to the global scheduler and keep track of the tasks' spillback accounting. In this PR we provide support for all the plumbing and data structure support necessary for the flow of the spillback data between the local and global schedulers through Redis. Some simple spillback functionality is already working : 
```
import ray
import time
ray.init(num_cpus = 1)

@ray.remote
def f(i):
  time.sleep(1)
  return i

time.sleep(1)
oids = [f.remote(i) for i in range(3)]
ray.get(oids)

tt = ray.global_state.task_table()
[(tt[t]['State'], tt[t]['SpillbackCount']) for t in tt if tt[t]['State'] == ray.experimental.state.TASK_STATUS_DONE]
```
You should see one task being taken by the local scheduler (and have spillback count of 0), while the other two -- be spilled back to the global scheduler and make their way back to the original local scheduler, with a spillback count of 1.

Output:
```
Out[1]: [(16, 1), (16, 0), (16, 1)]
```