### PR TITLE
[rllib][minor] Fix Pong-PPO tuned example Config

### DIFF
--- a/python/ray/rllib/tuned_examples/pong-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/pong-ppo.yaml
@@ -5,11 +5,11 @@
 # - PPO_PongDeterministic-v4_0:  TERMINATED [pid=16387], 4984 s, 1117981 ts, 21 rew
 # - PPO_PongDeterministic-v4_0:  TERMINATED [pid=83606], 4592 s, 1068671 ts, 21 rew
 #
-pong-deterministic-dqn:
+pong-deterministic-ppo:
     env: PongDeterministic-v4
     run: PPO
     resources:
-        cpu: 1
+        cpu: 6
         gpu: 1
     stop:
         episode_reward_mean: 21


### PR DESCRIPTION
## What do these changes do?
Fixes this config file to title experiment correctly and allocate correct number of cores (6 cores for 5 workers and 1 driver)
