### PR TITLE
Update arrow, and pass memcopy_threads into put.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -234,6 +234,9 @@ class Worker(object):
         # dummy objects. Once we allow object pinning in the store, we may
         # remove this variable.
         self.actor_pinned_objects = None
+        # The number of threads Plasma should use when putting an object in the
+        # object store.
+        self.memcopy_threads = 12
 
     def set_mode(self, mode):
         """Set the mode of the worker.
@@ -283,8 +286,11 @@ class Worker(object):
                                 "type {}.".format(type(value)))
             counter += 1
             try:
-                self.plasma_client.put(value, pyarrow.plasma.ObjectID(
-                    object_id.id()), self.serialization_context)
+                self.plasma_client.put(
+                    value,
+                    object_id=pyarrow.plasma.ObjectID(object_id.id()),
+                    memcopy_threads=self.memcopy_threads,
+                    serialization_context=self.serialization_context)
                 break
             except pyarrow.SerializationCallbackError as e:
                 try:

--- a/src/thirdparty/download_thirdparty.sh
+++ b/src/thirdparty/download_thirdparty.sh
@@ -13,4 +13,4 @@ fi
 cd $TP_DIR/arrow
 git fetch origin master
 
-git checkout 65f5add61829bd413aa8175ad2644cdd362d0c50
+git checkout 16c79cc94e2440321bcad1ebbef53ea1266b94e8


### PR DESCRIPTION
I've actually seen speedups by using up to 20 threads, although that seems like a lot.