### PR TITLE
[DO NOT MERGE] Implement centralized scheduling.

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -941,8 +941,8 @@ int TaskTableWrite(RedisModuleCtx *ctx,
   }
   RedisModule_CloseKey(key);
 
-  if (state_value == TASK_STATUS_WAITING ||
-      state_value == TASK_STATUS_SCHEDULED) {
+  if (state_value & (TASK_STATUS_WAITING | TASK_STATUS_SCHEDULED |
+                     TASK_STATUS_DONE)) {
     /* Build the PUBLISH topic and message for task table subscribers. The topic
      * is a string in the format "TASK_PREFIX:<local scheduler ID>:<state>". The
      * message is a serialized SubscribeToTasksReply flatbuffer object. */

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -109,16 +109,18 @@ void assign_task_to_local_scheduler(GlobalSchedulerState *state,
   for (auto const &resource_pair : TaskSpec_get_required_resources(spec)) {
     std::string resource_name = resource_pair.first;
     double resource_quantity = resource_pair.second;
-    // The local scheduler must have this resource because otherwise we wouldn't
-    // be assigning the task to this local scheduler.
-    CHECK(local_scheduler.info.dynamic_resources.count(resource_name) == 1 ||
-          resource_quantity == 0);
-    // Subtract task's resource from the cached dynamic resource capacity for
-    // this local scheduler. This will be overwritten on the next heartbeat.
-    local_scheduler.info.dynamic_resources[resource_name] =
-        MAX(0, local_scheduler.info.dynamic_resources[resource_name] -
-                   resource_quantity);
+
+    if (local_scheduler.resources_in_use.count(resource_name) != 1) {
+      local_scheduler.resources_in_use[resource_name] = 0;
+    }
+
+    local_scheduler.resources_in_use[resource_name] += resource_quantity;
   }
+
+  // Keep track of which tasks this local scheduler is executing.
+  TaskID task_id = TaskSpec_task_id(spec);
+  CHECK(local_scheduler.tasks_in_progress.count(task_id) == 0);
+  local_scheduler.tasks_in_progress.insert(task_id);
 }
 
 GlobalSchedulerState *GlobalSchedulerState_init(event_loop *loop,
@@ -181,6 +183,31 @@ void signal_handler(int signal) {
 }
 
 /* End of the cleanup code. */
+
+void process_task_done(Task *waiting_task, void *user_context) {
+  GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
+  TaskSpec *task_spec = Task_task_execution_spec(waiting_task)->Spec();
+
+  DBClientID local_scheduler_id = Task_local_scheduler(waiting_task);
+  auto it = state->local_schedulers.find(local_scheduler_id);
+  CHECK(it != state->local_schedulers.end());
+  LocalScheduler &local_scheduler = it->second;
+
+  // Resource accounting update for this local scheduler.
+  for (auto const &resource_pair : TaskSpec_get_required_resources(task_spec)) {
+    std::string resource_name = resource_pair.first;
+    double resource_quantity = resource_pair.second;
+
+    CHECK(local_scheduler.resources_in_use.count(resource_name) == 1);
+    local_scheduler.resources_in_use[resource_name] -= resource_quantity;
+    CHECK(local_scheduler.resources_in_use[resource_name] >= 0);
+  }
+
+  // Keep track of which tasks this local scheduler is executing.
+  TaskID task_id = TaskSpec_task_id(task_spec);
+  CHECK(local_scheduler.tasks_in_progress.count(task_id) == 1);
+  local_scheduler.tasks_in_progress.erase(task_id);
+}
 
 void process_task_waiting(Task *waiting_task, void *user_context) {
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
@@ -431,9 +458,12 @@ void start_server(const char *node_ip_address,
    * submits tasks to the global scheduler before the global scheduler
    * successfully subscribes, then the local scheduler that submitted the tasks
    * will retry. */
-  task_table_subscribe(g_state->db, UniqueID::nil(), TASK_STATUS_WAITING,
-                       process_task_waiting, (void *) g_state, NULL, NULL,
-                       NULL);
+  task_table_subscribe(
+      g_state->db, UniqueID::nil(), TASK_STATUS_DONE,
+      process_task_done, (void *) g_state, NULL, NULL, NULL);
+  task_table_subscribe(
+      g_state->db, UniqueID::nil(), TASK_STATUS_WAITING,
+      process_task_waiting, (void *) g_state, NULL, NULL, NULL);
 
   object_table_subscribe_to_notifications(g_state->db, true,
                                           object_table_subscribe_callback,

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -4,6 +4,7 @@
 #include "task.h"
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "state/db.h"
 #include "state/local_scheduler_table.h"
@@ -28,6 +29,13 @@ typedef struct {
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
   LocalSchedulerInfo info;
+  /// The resources in use by the local scheduler. This is redundant with
+  /// info->dynamic_resources, but here the bookkeeping is done entirely by the
+  /// global scheduler.
+  std::unordered_map<std::string, double> resources_in_use;
+  /// The tasks currently being executed by this local scheduler. This is just
+  /// to check correctness of the code.
+  std::unordered_set<TaskID, UniqueIDHasher> tasks_in_progress;
 } LocalScheduler;
 
 typedef struct GlobalSchedulerPolicyState GlobalSchedulerPolicyState;

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1057,23 +1057,12 @@ bool resource_constraints_satisfied(LocalSchedulerState *state,
 void handle_task_submitted(LocalSchedulerState *state,
                            SchedulingAlgorithmState *algorithm_state,
                            TaskExecutionSpec &execution_spec) {
-  TaskSpec *spec = execution_spec.Spec();
   /* TODO(atumanov): if static is satisfied and local objects ready, but dynamic
    * resource is currently unavailable, then consider queueing task locally and
    * recheck dynamic next time. */
 
-  /* If this task's constraints are satisfied, dependencies are available
-   * locally, and there is an available worker, then enqueue the task in the
-   * dispatch queue and trigger task dispatch. Otherwise, pass the task along to
-   * the global scheduler if there is one. */
-  if (resource_constraints_satisfied(state, spec) &&
-      (algorithm_state->available_workers.size() > 0) &&
-      can_run(algorithm_state, execution_spec)) {
-    queue_dispatch_task(state, algorithm_state, execution_spec, false);
-  } else {
-    /* Give the task to the global scheduler to schedule, if it exists. */
-    give_task_to_global_scheduler(state, algorithm_state, execution_spec);
-  }
+  /* Give the task to the global scheduler to schedule, if it exists. */
+  give_task_to_global_scheduler(state, algorithm_state, execution_spec);
 
   /* Try to dispatch tasks, since we may have added one to the queue. */
   dispatch_tasks(state, algorithm_state);


### PR DESCRIPTION
This is a hack to workaround #1180 while we are implementing spillback scheduling.

**In this PR:**
- All tasks go through the global scheduler.
- The global scheduler keeps track of how much resources each local scheduler has available based on the tasks that the global scheduler assigns to the local schedulers
- The global scheduler gets notifications when tasks finish, which contributes to the bookkeeping
- The global scheduler ignores dynamic load information from local schedulers
- The global scheduler only assigns a task to a local scheduler when the local scheduler has enough resource capacity.

**Drawbacks:**
- Note that task submission is much slower now because there is no local scheduling.
- This probably won't work with fault tolerance at the moment
- This probably won't work well with tasks that submit tasks and block on them
- This does not work with **actors** (this can be easily fixed)
  