### PR TITLE
[rllib] Load evaluation configuration from checkpoint

### DIFF
--- a/python/ray/rllib/eval.py
+++ b/python/ray/rllib/eval.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import argparse
 import gym
 import json
+import os
 import ray
 
 from ray.rllib.agent import get_agent_class
@@ -42,10 +43,18 @@ parser.add_argument(
         help="Run evaluation of the agent forever.")
 parser.add_argument(
         "--config", default="{}", type=json.loads,
-        help="Algorithm-specific configuration (e.g. env, hyperparams), ")
+        help="Algorithm-specific configuration (e.g. env, hyperparams). "
+        "Surpresses loading of configuration from checkpoint.")
 
 if __name__ == "__main__":
     args = parser.parse_args()
+
+    if not args.config:
+        # Load configuration from file
+        config_dir = os.path.dirname(args.checkpoint)
+        config_path = os.path.join(config_dir, "params.json")
+        with open(config_path) as f:
+            args.config = json.load(f)
 
     if not args.env:
         if not args.config.get("env"):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- By default, loads configuration for evaluation from checkpoint (params.json).
- Supplying `--config` suppresses loading configuration from checkpoint.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#1386 