### PR TITLE
[autoscaler] Increased head and worker storage to 25 GiB

### DIFF
--- a/python/ray/autoscaler/aws/development-example.yaml
+++ b/python/ray/autoscaler/aws/development-example.yaml
@@ -39,6 +39,12 @@ head_node:
     InstanceType: m4.16xlarge
     ImageId: ami-0def3275  # Default Ubuntu 16.04 AMI.
 
+    # Set primary volume to 25 GiB
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 25
+
     # Additional options in the boto docs.
 
 # Provider-specific config for worker nodes, e.g. instance type. By default
@@ -48,6 +54,12 @@ head_node:
 worker_nodes:
     InstanceType: m4.16xlarge
     ImageId: ami-0def3275  # Default Ubuntu 16.04 AMI.
+
+    # Set primary volume to 25 GiB
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 25
 
     # Run workers on spot by default. Comment this out to use on-demand.
     InstanceMarketOptions:

--- a/python/ray/autoscaler/aws/example.yaml
+++ b/python/ray/autoscaler/aws/example.yaml
@@ -39,6 +39,12 @@ head_node:
     InstanceType: m5.large
     ImageId: ami-3b6bce43  # Amazon Deep Learning AMI (Ubuntu)
 
+    # You can provision additional disk space with a conf as follows
+    # BlockDeviceMappings:
+    #     - DeviceName: /dev/sda1
+    #       Ebs:
+    #           VolumeSize: 100
+
     # Additional options in the boto docs.
 
 # Provider-specific config for worker nodes, e.g. instance type. By default


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- Increased head and worker storage to 25 GiB for development YAML configuration file.
