### PR TITLE
[autoscaler] Fix confirmation (y/N) for autoscaler for Python 2

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -174,7 +174,7 @@ def confirm(msg):
     if sys.version_info >= (3, 0):
         answer = input()
     else:
-        answer = raw_input() # noqa: F821
+        answer = raw_input()  # noqa: F821
     if answer.strip().lower() != "y":
         print("Abort.")
         exit(1)

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -171,7 +171,10 @@ def get_or_create_head_node(config, no_restart):
 
 def confirm(msg):
     print("{}. Do you want to continue [y/N]? ".format(msg), end="")
-    answer = input()
+    if sys.version_info[0] > 2:
+        answer = input()
+    else:
+        answer = raw_input()
     if answer.strip().lower() != "y":
         print("Abort.")
         exit(1)

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -171,7 +171,7 @@ def get_or_create_head_node(config, no_restart):
 
 def confirm(msg):
     print("{}. Do you want to continue [y/N]? ".format(msg), end="")
-    if sys.version_info[0] > 2:
+    if sys.version_info >= (3, 0):
         answer = input()
     else:
         answer = raw_input()

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -174,7 +174,7 @@ def confirm(msg):
     if sys.version_info >= (3, 0):
         answer = input()
     else:
-        answer = raw_input()
+        answer = raw_input() # noqa: F821
     if answer.strip().lower() != "y":
         print("Abort.")
         exit(1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This is a small fix to make the confirmation question work as expected in Python 2. There is a small inconsistency between Python 2 and Python 3 input (namely in Python 2 the result is evaled), which gives a "no such variable y" error in Python 2.

Without this fix, the user has to type 'y' instead of y to make sure the result of eval is a string.
