### PR TITLE
Adding documentation for building from current master without cloning.

### DIFF
--- a/doc/source/install-on-macosx.rst
+++ b/doc/source/install-on-macosx.rst
@@ -48,6 +48,11 @@ Ray can be built from the repository as follows.
   cd ray/python
   python setup.py install  # Add --user if you see a permission denied error.
 
+Alternatively, Ray can be built from the repository without cloning with pip.
+
+.. code-block:: bash
+
+  pip install git+https://github.com/ray-project/ray.git#subdirectory=python
 
 Test if the installation succeeded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/install-on-macosx.rst
+++ b/doc/source/install-on-macosx.rst
@@ -48,7 +48,7 @@ Ray can be built from the repository as follows.
   cd ray/python
   python setup.py install  # Add --user if you see a permission denied error.
 
-Alternatively, Ray can be built from the repository without cloning with pip.
+Alternatively, Ray can be built from the repository without cloning using pip.
 
 .. code-block:: bash
 

--- a/doc/source/install-on-ubuntu.rst
+++ b/doc/source/install-on-ubuntu.rst
@@ -56,6 +56,11 @@ Ray can be built from the repository as follows.
   cd ray/python
   python setup.py install  # Add --user if you see a permission denied error.
 
+Alternatively, Ray can be built from the repository without cloning with pip.
+
+.. code-block:: bash
+
+    pip install git+https://github.com/ray-project/ray.git#subdirectory=python
 
 Test if the installation succeeded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/install-on-ubuntu.rst
+++ b/doc/source/install-on-ubuntu.rst
@@ -56,7 +56,7 @@ Ray can be built from the repository as follows.
   cd ray/python
   python setup.py install  # Add --user if you see a permission denied error.
 
-Alternatively, Ray can be built from the repository without cloning with pip.
+Alternatively, Ray can be built from the repository without cloning using pip.
 
 .. code-block:: bash
 


### PR DESCRIPTION
It might be useful for downstream projects to build from the current master without having to clone. This additional doc explains how.