### PR TITLE
Fix MNIST downloading problems in parameter server examples.

### DIFF
--- a/examples/parameter_server/async_parameter_server.py
+++ b/examples/parameter_server/async_parameter_server.py
@@ -3,11 +3,9 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-from tensorflow.examples.tutorials.mnist import input_data
 import time
 
 import ray
-
 import model
 
 parser = argparse.ArgumentParser(description="Run the asynchronous parameter "
@@ -68,7 +66,7 @@ if __name__ == "__main__":
     worker_tasks = [worker_task.remote(ps, i) for i in range(args.num_workers)]
 
     # Download MNIST.
-    mnist = input_data.read_data_sets("MNIST_data", one_hot=True)
+    mnist = model.download_mnist_retry()
 
     i = 0
     while True:

--- a/examples/parameter_server/async_parameter_server.py
+++ b/examples/parameter_server/async_parameter_server.py
@@ -35,10 +35,7 @@ class ParameterServer(object):
 
 
 @ray.remote
-def worker_task(ps, batch_size=50):
-    # Download MNIST.
-    mnist = input_data.read_data_sets("MNIST_data", one_hot=True)
-
+def worker_task(ps, mnist, batch_size=50):
     # Initialize the model.
     net = model.SimpleCNN()
     keys = net.get_weights()[0]
@@ -64,11 +61,12 @@ if __name__ == "__main__":
     all_keys, all_values = net.get_weights()
     ps = ParameterServer.remote(all_keys, all_values)
 
-    # Start some training tasks.
-    worker_tasks = [worker_task.remote(ps) for _ in range(args.num_workers)]
-
     # Download MNIST.
     mnist = input_data.read_data_sets("MNIST_data", one_hot=True)
+
+    # Start some training tasks.
+    worker_tasks = [worker_task.remote(ps, mnist)
+                    for _ in range(args.num_workers)]
 
     i = 0
     while True:

--- a/examples/parameter_server/model.py
+++ b/examples/parameter_server/model.py
@@ -8,6 +8,18 @@ from __future__ import print_function
 
 import ray
 import tensorflow as tf
+from tensorflow.examples.tutorials.mnist import input_data
+import time
+
+
+def download_mnist_retry(seed=0, max_num_retries=20):
+    for _ in range(max_num_retries):
+        try:
+            return input_data.read_data_sets("MNIST_data", one_hot=True,
+                                             seed=seed)
+        except tf.errors.AlreadyExistsError:
+            time.sleep(1)
+    raise Exception("Failed to download MNIST.")
 
 
 class SimpleCNN(object):

--- a/examples/parameter_server/sync_parameter_server.py
+++ b/examples/parameter_server/sync_parameter_server.py
@@ -5,9 +5,6 @@ from __future__ import print_function
 import argparse
 
 import numpy as np
-import tensorflow as tf
-from tensorflow.examples.tutorials.mnist import input_data
-import time
 
 import ray
 import model
@@ -18,16 +15,6 @@ parser.add_argument("--num-workers", default=4, type=int,
                     help="The number of workers to use.")
 parser.add_argument("--redis-address", default=None, type=str,
                     help="The Redis address of the cluster.")
-
-
-def download_mnist_retry(seed=0, max_num_retries=20):
-    for _ in range(max_num_retries):
-        try:
-            return input_data.read_data_sets("MNIST_data", one_hot=True,
-                                             seed=seed)
-        except tf.errors.AlreadyExistsError:
-            time.sleep(1)
-    raise Exception("Failed to download MNIST.")
 
 
 @ray.remote
@@ -48,7 +35,7 @@ class Worker(object):
     def __init__(self, worker_index, batch_size=50):
         self.worker_index = worker_index
         self.batch_size = batch_size
-        self.mnist = download_mnist_retry(seed=worker_index)
+        self.mnist = model.download_mnist_retry(seed=worker_index)
         self.net = model.SimpleCNN()
 
     def compute_gradients(self, weights):
@@ -71,7 +58,7 @@ if __name__ == "__main__":
                for worker_index in range(args.num_workers)]
 
     # Download MNIST.
-    mnist = download_mnist_retry()
+    mnist = model.download_mnist_retry()
 
     i = 0
     current_weights = ps.get_weights.remote()

--- a/examples/parameter_server/sync_parameter_server.py
+++ b/examples/parameter_server/sync_parameter_server.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-
 import numpy as np
 
 import ray


### PR DESCRIPTION
This fixes #1398. The problem was that multiple workers were attempting to download the MNIST data set at the same time (on the same machine), which cause an exception sometimes.