### PR TITLE
Build valgrind 3.13.0 from source in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,16 @@ matrix:
       dist: trusty
       env: VALGRIND=1 PYTHON=2.7
       before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq valgrind
+        - cd ..
+        - wget ftp://sourceware.org/pub/valgrind/valgrind-3.13.0.tar.bz2
+        - tar xf valgrind-3.13.0.tar.bz2
+        - cd valgrind-3.13.0
+        - ./autogen.sh
+        - ./configure
+        - make -j8
+        - sudo make install
+        - cd ../ray
+
       install:
         - ./.travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Seeing if this addresses some of the valgrind failures that we've been seeing (e.g., in the global scheduler test).

cc @atumanov 