### PR TITLE
[rllib] Fix for gym version 0.9.5.

### DIFF
--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -78,7 +78,6 @@ class AtariRamPreprocessor(Preprocessor):
 
 class OneHotPreprocessor(Preprocessor):
     def _init(self):
-        assert self._obs_space.shape == ()
         self.shape = (self._obs_space.n,)
 
     def transform(self, observation):


### PR DESCRIPTION
This fixes #1470.

cc @ericl @richardliaw 

Not sure if this is the "right" fix, but I tried printing `self._obs_space.shape` and it takes on values like `(16,)`.