### PR TITLE
Slight changes to remove_driver_test.py.

### DIFF
--- a/test/jenkins_tests/multi_node_docker_test.py
+++ b/test/jenkins_tests/multi_node_docker_test.py
@@ -343,6 +343,7 @@ if __name__ == "__main__":
             any_failed = True
 
     if any_failed:
+        print("There was a failure in one of the drivers.")
         sys.exit(1)
     elif not successfully_stopped:
         print("There was a failure when attempting to stop the containers.")

--- a/test/jenkins_tests/multi_node_tests/remove_driver_test.py
+++ b/test/jenkins_tests/multi_node_tests/remove_driver_test.py
@@ -33,7 +33,7 @@ def long_running_task(driver_index, task_index, redis_address):
                      data=(ray.services.get_node_ip_address(), os.getpid()))
     # Loop forever.
     while True:
-        time.sleep(100)
+        time.sleep(1000)
 
 
 num_long_running_tasks_per_driver = 2
@@ -54,7 +54,7 @@ class Actor0(object):
     def long_running_method(self):
         # Loop forever.
         while True:
-            time.sleep(100)
+            time.sleep(1000)
 
 
 @ray.remote(num_gpus=1)
@@ -72,7 +72,7 @@ class Actor1(object):
     def long_running_method(self):
         # Loop forever.
         while True:
-            time.sleep(100)
+            time.sleep(1000)
 
 
 @ray.remote(num_gpus=2)
@@ -90,7 +90,7 @@ class Actor2(object):
     def long_running_method(self):
         # Loop forever.
         while True:
-            time.sleep(100)
+            time.sleep(1000)
 
 
 def driver_0(redis_address, driver_index):


### PR DESCRIPTION
Looking into #1436.

I'm curious to see if this increases the rate of failure within `remove_driver_test.py`.

I have seen `remove_driver_test.py` hang locally. There may just be something wrong with my docker installation.

Note, should look into whether some of this is related to #1462. Although our tests should be able to handle processes crashing.