### PR TITLE
[DataFrame] Implement ray.DataFrame.drop w/ tests

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -134,6 +134,19 @@ class DataFrame(object):
 
         return DataFrame(new_df, self.columns)
 
+    def _map_partitions_to_values(self, func, *args):
+        """Apply a function on each partition.
+
+        Args:
+            func (callable): The function to Apply.
+
+        Returns:
+            A new list containing the result of the function called
+            onto each partition.
+        """
+        assert(callable(func))
+        return [_deploy_func.remote(func, part) for part in self._df]
+
     def add_prefix(self, prefix):
         """Add a prefix to each of the column names.
 
@@ -463,7 +476,47 @@ class DataFrame(object):
 
     def drop(self, labels=None, axis=0, index=None, columns=None, level=None,
              inplace=False, errors='raise'):
-        raise NotImplementedError("Not Yet implemented.")
+        if errors == 'raise':
+            def check_values_exist(selector, values):
+                if isinstance(values, pd.Index):
+                    values = set(values.tolist())
+                else:
+                    if not isinstance(values, list):
+                        values = [values]
+                    values = set(values)
+                    existing_values = self._map_partitions_to_values(
+                        lambda df: set([value for value in values if selector(df).contains(value)])
+                    )
+                    # TODO: parallize reduction
+                    merged_existing_values = set()
+                    for label in existing_values:
+                        merged_existing_values |= ray.get(label)
+                    if len(values) != len(merged_existing_values):
+                        raise ValueError("labels {} not contained in axis".format(
+                            list(values - merged_existing_values)
+                        ))
+            if labels is not None:
+                if index is not None or columns is not None:
+                    raise ValueError("Cannot specify both 'labels' and "
+                                     "'index'/'columns'")
+                if axis == 0:
+                    check_values_exist(lambda df: df.index, labels)
+                elif axis == 1:
+                    check_values_exist(lambda df: df.columns, labels)
+            elif index is None and columns is None:
+                raise ValueError("Need to specify at least one of 'labels', "
+                                 "'index' or 'columns'")
+            if columns is not None:
+                check_values_exist(lambda df: df.columns, columns)
+            if index is not None:
+                check_values_exist(lambda df: df.index, index)
+        new_df = self._map_partitions(lambda df: df.drop(labels=labels, axis=axis, index=index,
+                columns=columns, level=level, inplace=False, errors='ignore'))
+        if inplace:
+            self._df = new_df._df
+            self.columns = new_df.columns
+        else:
+            return new_df
 
     def drop_duplicates(self, subset=None, keep='first', inplace=False):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -484,10 +484,11 @@ def test_drop():
     ray_simple = rdf.from_pandas(simple, 2)
     assert ray_df_equals_pandas(ray_simple.drop("A", axis=1), simple[['B']])
     assert ray_df_equals_pandas(ray_simple.drop(["A", "B"], axis='columns'),
-        simple[[]])
-    assert ray_df_equals_pandas(ray_simple.drop([0, 1, 3], axis=0), simple.loc[[2], :])
+                                simple[[]])
+    assert ray_df_equals_pandas(ray_simple.drop([0, 1, 3], axis=0),
+                                simple.loc[[2], :])
     assert ray_df_equals_pandas(ray_simple.drop([0, 3], axis='index'),
-        simple.loc[[1, 2], :])
+                                simple.loc[[1, 2], :])
 
     pytest.raises(ValueError, ray_simple.drop, 5)
     pytest.raises(ValueError, ray_simple.drop, 'C', 1)
@@ -497,24 +498,28 @@ def test_drop():
     # errors = 'ignore'
     assert ray_df_equals_pandas(ray_simple.drop(5, errors='ignore'), simple)
     assert ray_df_equals_pandas(ray_simple.drop([0, 5], errors='ignore'),
-                       simple.loc[[1, 2, 3], :])
-    assert ray_df_equals_pandas(ray_simple.drop('C', axis=1, errors='ignore'), simple)
-    assert ray_df_equals_pandas(ray_simple.drop(['A', 'C'], axis=1, errors='ignore'),
-                       simple[['B']])
+                                simple.loc[[1, 2, 3], :])
+    assert ray_df_equals_pandas(ray_simple.drop('C', axis=1, errors='ignore'),
+                                simple)
+    assert ray_df_equals_pandas(ray_simple.drop(['A', 'C'], axis=1,
+                                errors='ignore'), simple[['B']])
 
     # non-unique - wheee!
     nu_df = pd.DataFrame(pd.compat.lzip(range(3), range(-3, 1), list('abc')),
-                      columns=['a', 'a', 'b'])
+                         columns=['a', 'a', 'b'])
     ray_nu_df = rdf.from_pandas(nu_df, 3)
     assert ray_df_equals_pandas(ray_nu_df.drop('a', axis=1), nu_df[['b']])
-    assert ray_df_equals_pandas(ray_nu_df.drop('b', axis='columns'), nu_df['a'])
+    assert ray_df_equals_pandas(ray_nu_df.drop('b', axis='columns'),
+                                nu_df['a'])
     assert ray_df_equals_pandas(ray_nu_df.drop([]), nu_df)  # GH 16398
 
     nu_df = nu_df.set_index(pd.Index(['X', 'Y', 'X']))
     nu_df.columns = list('abc')
     ray_nu_df = rdf.from_pandas(nu_df, 3)
-    assert ray_df_equals_pandas(ray_nu_df.drop('X', axis='rows'), nu_df.loc[["Y"], :])
-    assert ray_df_equals_pandas(ray_nu_df.drop(['X', 'Y'], axis=0), nu_df.loc[[], :])
+    assert ray_df_equals_pandas(ray_nu_df.drop('X', axis='rows'),
+                                nu_df.loc[["Y"], :])
+    assert ray_df_equals_pandas(ray_nu_df.drop(['X', 'Y'], axis=0),
+                                nu_df.loc[[], :])
 
     # inplace cache issue
     # GH 5628
@@ -528,8 +533,7 @@ def test_drop():
 def test_drop_api_equivalence():
     # equivalence of the labels/axis and index/columns API's (GH12392)
     df = pd.DataFrame([[1, 2, 3], [3, 4, 5], [5, 6, 7]],
-                   index=['a', 'b', 'c'],
-                   columns=['d', 'e', 'f'])
+                      index=['a', 'b', 'c'], columns=['d', 'e', 'f'])
     ray_df = rdf.from_pandas(df, 3)
 
     res1 = ray_df.drop('a')


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Implements the ray.Dataframe.drop method. Checks if values of labels, index or columns exist in the pandas DataFrame partitions, if the errors flag is set in order to raise the same errors that pandas does. @devin-petersohn 
