### PR TITLE
Implement simple random spillback policy.

### DIFF
--- a/python/ray/global_scheduler/test/test.py
+++ b/python/ray/global_scheduler/test/test.py
@@ -302,7 +302,9 @@ class TestGlobalScheduler(unittest.TestCase):
             num_retries -= 1
             time.sleep(0.1)
 
-        self.assertEqual(num_tasks_done, num_tasks)
+        # Tasks can either be queued or in the global scheduler due to
+        # spillback.
+        self.assertEqual(num_tasks_done + num_tasks_waiting, num_tasks)
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False),

--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -80,17 +80,7 @@ class RayConfig {
 
   int64_t L3_cache_size_bytes() const { return L3_cache_size_bytes_; }
 
-  int64_t spillback_allowed_min() const {
-    return spillback_allowed_min_;
-  }
-
-  int64_t spillback_allowed_max() const {
-    return spillback_allowed_max_;
-  }
-
-  int64_t spillback_period() const {
-    return spillback_period_;
-  }
+  int64_t max_tasks_to_spillback() const { return max_tasks_to_spillback_; }
 
  private:
   RayConfig()
@@ -118,9 +108,7 @@ class RayConfig {
         redis_db_connect_wait_milliseconds_(100),
         plasma_default_release_delay_(64),
         L3_cache_size_bytes_(100000000),
-        spillback_allowed_min_(32),    // ms
-        spillback_allowed_max_(1025),  // ms
-        spillback_period_(100) {}      // ms
+        max_tasks_to_spillback_(10) {}
 
   ~RayConfig() {}
 
@@ -195,11 +183,8 @@ class RayConfig {
   int64_t plasma_default_release_delay_;
   int64_t L3_cache_size_bytes_;
 
-  /// Spillback constants that define the base allowed queueing delay and the
-  /// maximum allowed threshold after which task will no longer be spilled back.
-  int64_t spillback_allowed_min_;
-  int64_t spillback_allowed_max_;
-  int64_t spillback_period_;
+  /// Constants for the spillback scheduling policy.
+  int64_t max_tasks_to_spillback_;
 };
 
 #endif  // RAY_CONFIG_H

--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -80,6 +80,18 @@ class RayConfig {
 
   int64_t L3_cache_size_bytes() const { return L3_cache_size_bytes_; }
 
+  int64_t spillback_allowed_min() const {
+    return spillback_allowed_min_;
+  }
+
+  int64_t spillback_allowed_max() const {
+    return spillback_allowed_max_;
+  }
+
+  int64_t spillback_period() const {
+    return spillback_period_;
+  }
+
  private:
   RayConfig()
       : ray_protocol_version_(0x0000000000000000),
@@ -105,7 +117,10 @@ class RayConfig {
         redis_db_connect_retries_(50),
         redis_db_connect_wait_milliseconds_(100),
         plasma_default_release_delay_(64),
-        L3_cache_size_bytes_(100000000) {}
+        L3_cache_size_bytes_(100000000),
+        spillback_allowed_min_(32),    // ms
+        spillback_allowed_max_(1025),  // ms
+        spillback_period_(100) {}      // ms
 
   ~RayConfig() {}
 
@@ -179,6 +194,12 @@ class RayConfig {
   /// TODO(rkn): These constants are currently unused.
   int64_t plasma_default_release_delay_;
   int64_t L3_cache_size_bytes_;
+
+  /// Spillback constants that define the base allowed queueing delay and the
+  /// maximum allowed threshold after which task will no longer be spilled back.
+  int64_t spillback_allowed_min_;
+  int64_t spillback_allowed_max_;
+  int64_t spillback_period_;
 };
 
 #endif  // RAY_CONFIG_H

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -348,6 +348,7 @@ void local_scheduler_table_handler(DBClientID client_id,
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
   ARROW_UNUSED(state);
   std::string id_string = client_id.hex();
+  int64_t curtime = current_time_ms();
   LOG_DEBUG("Local scheduler heartbeat from db_client_id %s",
             id_string.c_str());
   LOG_DEBUG(
@@ -368,6 +369,7 @@ void local_scheduler_table_handler(DBClientID client_id,
       LocalScheduler &local_scheduler = it->second;
       local_scheduler.num_heartbeats_missed = 0;
       local_scheduler.num_recent_tasks_sent = 0;
+      local_scheduler.last_heartbeat = curtime;
       local_scheduler.info = info;
     }
   } else {

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -348,7 +348,6 @@ void local_scheduler_table_handler(DBClientID client_id,
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
   ARROW_UNUSED(state);
   std::string id_string = client_id.hex();
-  int64_t curtime = current_time_ms();
   LOG_DEBUG("Local scheduler heartbeat from db_client_id %s",
             id_string.c_str());
   LOG_DEBUG(
@@ -369,7 +368,6 @@ void local_scheduler_table_handler(DBClientID client_id,
       LocalScheduler &local_scheduler = it->second;
       local_scheduler.num_heartbeats_missed = 0;
       local_scheduler.num_recent_tasks_sent = 0;
-      local_scheduler.last_heartbeat = curtime;
       local_scheduler.info = info;
     }
   } else {

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -26,10 +26,6 @@ typedef struct {
   /** The number of tasks sent from the global scheduler to this local scheduler
    *  since the last heartbeat arrived. */
   int64_t num_recent_tasks_sent;
-  /** Last time this global scheduler received a heartbeat for this local
-   *  scheduler.
-   */
-  int64_t last_heartbeat;
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
   LocalSchedulerInfo info;

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -35,7 +35,7 @@ typedef struct {
   LocalSchedulerInfo info;
 } LocalScheduler;
 
-typedef struct GlobalSchedulerPolicyState GlobalSchedulerPolicyState;
+typedef class GlobalSchedulerPolicyState GlobalSchedulerPolicyState;
 
 /**
  * This defines a hash table used to cache information about different objects.

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -26,6 +26,10 @@ typedef struct {
   /** The number of tasks sent from the global scheduler to this local scheduler
    *  since the last heartbeat arrived. */
   int64_t num_recent_tasks_sent;
+  /** Last time this global scheduler received a heartbeat for this local
+   *  scheduler.
+   */
+  int64_t last_heartbeat;
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
   LocalSchedulerInfo info;

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -111,7 +111,8 @@ double calculate_cost_pending(const GlobalSchedulerState *state,
   /* TODO(rkn): This logic does not load balance properly when the different
    * machines have different sizes. Fix this. */
   double cost_pending = scheduler->num_recent_tasks_sent +
-      scheduler->info.task_queue_length - scheduler->info.available_workers;
+                        scheduler->info.task_queue_length -
+                        scheduler->info.available_workers;
   return cost_pending;
 }
 
@@ -119,39 +120,22 @@ bool handle_task_waiting_random(GlobalSchedulerState *state,
                                 GlobalSchedulerPolicyState *policy_state,
                                 Task *task) {
   TaskSpec *task_spec = Task_task_execution_spec(task)->Spec();
-  int64_t curtime = current_time_ms();
-
   CHECKM(task_spec != NULL,
          "task wait handler encounted a task with NULL spec");
 
-  std::string id_string_fromlocalsched = task->local_scheduler_id.hex();
-  LOG_INFO("ct[%" PRId64 "] task from %s spillback %d", curtime,
-      id_string_fromlocalsched.c_str(), task->execution_spec->SpillbackCount());
-
-  bool task_feasible = false;
   std::vector<DBClientID> feasible_nodes;
-  feasible_nodes.reserve(state->local_schedulers.size());
 
-  for (const auto &kvpair: state->local_schedulers) {
-    /* Local scheduler map iterator yields <DBClientID, LocalScheduler> pairs.
-     */
-    const LocalScheduler &local_scheduler = kvpair.second;
+  for (const auto &it : state->local_schedulers) {
+    // Local scheduler map iterator yields <DBClientID, LocalScheduler> pairs.
+    const LocalScheduler &local_scheduler = it.second;
     if (!constraints_satisfied_hard(&local_scheduler, task_spec)) {
       continue;
     }
-    /* Skip the local scheduler the task came from. */
-    if (task->local_scheduler_id == local_scheduler.id) {
-      continue;
-    }
-    /* Add this local scheduler as a candidate for random selection.
-     */
-    feasible_nodes.push_back(kvpair.first);
-    task_feasible = true;
+    // Add this local scheduler as a candidate for random selection.
+    feasible_nodes.push_back(it.first);
   }
 
-  if (!task_feasible) {
-    /* TODO(atumanov): try the last local scheduler the task came from before
-     * giving up. */
+  if (feasible_nodes.size() == 0) {
     std::string id_string = Task_task_id(task).hex();
     LOG_ERROR(
         "Infeasible task. No nodes satisfy hard constraints for task = %s",
@@ -159,70 +143,71 @@ bool handle_task_waiting_random(GlobalSchedulerState *state,
     return false;
   }
 
-  /* Randomly select the local scheduler. */
-  /* TODO(atumanov): replace with std::discrete_distribution<int>. */
-  std::uniform_int_distribution<> dis(0, feasible_nodes.size()-1);
-  DBClientID best_local_scheduler_id =
+  // Randomly select the local scheduler. TODO(atumanov): replace with
+  // std::discrete_distribution<int>.
+  std::uniform_int_distribution<> dis(0, feasible_nodes.size() - 1);
+  DBClientID local_scheduler_id =
       feasible_nodes[dis(policy_state->getRandomGenerator())];
-  CHECKM(!best_local_scheduler_id.is_nil(),
+  CHECKM(!local_scheduler_id.is_nil(),
          "Task is feasible, but doesn't have a local scheduler assigned.");
-  /* A local scheduler ID was found, so assign the task. */
-  assign_task_to_local_scheduler(state, task, best_local_scheduler_id);
+  // A local scheduler ID was found, so assign the task.
+  assign_task_to_local_scheduler(state, task, local_scheduler_id);
   return true;
 }
 
 bool handle_task_waiting_cost(GlobalSchedulerState *state,
-                         GlobalSchedulerPolicyState *policy_state,
-                         Task *task) {
+                              GlobalSchedulerPolicyState *policy_state,
+                              Task *task) {
   TaskSpec *task_spec = Task_task_execution_spec(task)->Spec();
   int64_t curtime = current_time_ms();
 
   CHECKM(task_spec != NULL,
          "task wait handler encounted a task with NULL spec");
 
-  /* For tasks already seen by the global scheduler (spillback > 1),
-   * adjust scheduled task counts for the source local scheduler.
-   */
+  // For tasks already seen by the global scheduler (spillback > 1),
+  // adjust scheduled task counts for the source local scheduler.
   if (task->execution_spec->SpillbackCount() > 1) {
     auto it = state->local_schedulers.find(task->local_scheduler_id);
-    /* Task's previous local scheduler must be present and known. */
+    // Task's previous local scheduler must be present and known.
     CHECK(it != state->local_schedulers.end());
     LocalScheduler &src_local_scheduler = it->second;
-    src_local_scheduler.num_recent_tasks_sent -=1;
+    src_local_scheduler.num_recent_tasks_sent -= 1;
   }
 
   bool task_feasible = false;
 
-  /* Go through all the nodes, calculate the score for each, pick max score. */
+  // Go through all the nodes, calculate the score for each, pick max score.
   double best_local_scheduler_score = INT32_MIN;
   CHECKM(best_local_scheduler_score < 0,
          "We might have a floating point underflow");
   std::string id_string_fromlocalsched = task->local_scheduler_id.hex();
   LOG_INFO("ct[%" PRId64 "] task from %s spillback %d", curtime,
-      id_string_fromlocalsched.c_str(), task->execution_spec->SpillbackCount());
+           id_string_fromlocalsched.c_str(),
+           task->execution_spec->SpillbackCount());
 
-  DBClientID best_local_scheduler_id =
-      DBClientID::nil(); /* best node to send this task */
+  // The best node to send this task.
+  DBClientID best_local_scheduler_id = DBClientID::nil();
+
   for (auto it = state->local_schedulers.begin();
        it != state->local_schedulers.end(); it++) {
-    /* For each local scheduler, calculate its score. Check hard constraints
-     * first. */
+    // For each local scheduler, calculate its score. Check hard constraints
+    // first.
     LocalScheduler *scheduler = &(it->second);
     if (!constraints_satisfied_hard(scheduler, task_spec)) {
       continue;
     }
-    /* Skip the local scheduler the task came from. */
+    // Skip the local scheduler the task came from.
     if (task->local_scheduler_id == scheduler->id) {
       continue;
     }
     std::string id_string = scheduler->id.hex();
     task_feasible = true;
-    /* This node satisfies the hard capacity constraint. Calculate its score. */
+    // This node satisfies the hard capacity constraint. Calculate its score.
     double score = -1 * calculate_cost_pending(state, scheduler, task_spec);
-    LOG_INFO("ct[%" PRId64 "][%s][dt%" PRId64 "][q%d][w%d]: score %f bestscore %f\n",
-             curtime, id_string.c_str(), curtime - scheduler->last_heartbeat,
-             scheduler->info.task_queue_length, scheduler->info.available_workers,
-             score, best_local_scheduler_score);
+    LOG_INFO("ct[%" PRId64 "][%s][q%d][w%d]: score %f bestscore %f\n", curtime,
+             id_string.c_str(), scheduler->info.task_queue_length,
+             scheduler->info.available_workers, score,
+             best_local_scheduler_score);
     if (score >= best_local_scheduler_score) {
       best_local_scheduler_score = score;
       best_local_scheduler_id = scheduler->id;
@@ -234,13 +219,13 @@ bool handle_task_waiting_cost(GlobalSchedulerState *state,
     LOG_ERROR(
         "Infeasible task. No nodes satisfy hard constraints for task = %s",
         id_string.c_str());
-    /* TODO(atumanov): propagate this error to the task's driver and/or
-     * cache the task in case new local schedulers satisfy it in the future. */
+    // TODO(atumanov): propagate this error to the task's driver and/or
+    // cache the task in case new local schedulers satisfy it in the future.
     return false;
   }
   CHECKM(!best_local_scheduler_id.is_nil(),
          "Task is feasible, but doesn't have a local scheduler assigned.");
-  /* A local scheduler ID was found, so assign the task. */
+  // A local scheduler ID was found, so assign the task.
   assign_task_to_local_scheduler(state, task, best_local_scheduler_id);
   return true;
 }

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -1,5 +1,4 @@
 #include <limits.h>
-#include <random>
 
 #include "task.h"
 #include "state/task_table.h"
@@ -8,7 +7,6 @@
 
 GlobalSchedulerPolicyState *GlobalSchedulerPolicyState_init(void) {
   GlobalSchedulerPolicyState *policy_state = new GlobalSchedulerPolicyState();
-  policy_state->round_robin_index = 0;
   return policy_state;
 }
 
@@ -162,10 +160,10 @@ bool handle_task_waiting_random(GlobalSchedulerState *state,
   }
 
   /* Randomly select the local scheduler. */
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  /* TODO(atumanov): replace with std::discrete_distribution<int>. */
   std::uniform_int_distribution<> dis(0, feasible_nodes.size()-1);
-  DBClientID best_local_scheduler_id = feasible_nodes[dis(gen)];
+  DBClientID best_local_scheduler_id =
+      feasible_nodes[dis(policy_state->getRandomGenerator())];
   CHECKM(!best_local_scheduler_id.is_nil(),
          "Task is feasible, but doesn't have a local scheduler assigned.");
   /* A local scheduler ID was found, so assign the task. */

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -1,4 +1,5 @@
 #include <limits.h>
+#include <random>
 
 #include "task.h"
 #include "state/task_table.h"
@@ -111,16 +112,86 @@ double calculate_cost_pending(const GlobalSchedulerState *state,
   locally_available_data_size(state, scheduler->id, task_spec);
   /* TODO(rkn): This logic does not load balance properly when the different
    * machines have different sizes. Fix this. */
-  return scheduler->num_recent_tasks_sent + scheduler->info.task_queue_length;
+  double cost_pending = scheduler->num_recent_tasks_sent +
+      scheduler->info.task_queue_length - scheduler->info.available_workers;
+  return cost_pending;
 }
 
-bool handle_task_waiting(GlobalSchedulerState *state,
-                         GlobalSchedulerPolicyState *policy_state,
-                         Task *task) {
+bool handle_task_waiting_random(GlobalSchedulerState *state,
+                                GlobalSchedulerPolicyState *policy_state,
+                                Task *task) {
   TaskSpec *task_spec = Task_task_execution_spec(task)->Spec();
+  int64_t curtime = current_time_ms();
 
   CHECKM(task_spec != NULL,
          "task wait handler encounted a task with NULL spec");
+
+  std::string id_string_fromlocalsched = task->local_scheduler_id.hex();
+  LOG_INFO("ct[%" PRId64 "] task from %s spillback %d", curtime,
+      id_string_fromlocalsched.c_str(), task->execution_spec->SpillbackCount());
+
+  bool task_feasible = false;
+  std::vector<DBClientID> feasible_nodes;
+  feasible_nodes.reserve(state->local_schedulers.size());
+
+  for (const auto &kvpair: state->local_schedulers) {
+    /* Local scheduler map iterator yields <DBClientID, LocalScheduler> pairs.
+     */
+    const LocalScheduler &local_scheduler = kvpair.second;
+    if (!constraints_satisfied_hard(&local_scheduler, task_spec)) {
+      continue;
+    }
+    /* Skip the local scheduler the task came from. */
+    if (task->local_scheduler_id == local_scheduler.id) {
+      continue;
+    }
+    /* Add this local scheduler as a candidate for random selection.
+     */
+    feasible_nodes.push_back(kvpair.first);
+    task_feasible = true;
+  }
+
+  if (!task_feasible) {
+    /* TODO(atumanov): try the last local scheduler the task came from before
+     * giving up. */
+    std::string id_string = Task_task_id(task).hex();
+    LOG_ERROR(
+        "Infeasible task. No nodes satisfy hard constraints for task = %s",
+        id_string.c_str());
+    return false;
+  }
+
+  /* Randomly select the local scheduler. */
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, feasible_nodes.size()-1);
+  DBClientID best_local_scheduler_id = feasible_nodes[dis(gen)];
+  CHECKM(!best_local_scheduler_id.is_nil(),
+         "Task is feasible, but doesn't have a local scheduler assigned.");
+  /* A local scheduler ID was found, so assign the task. */
+  assign_task_to_local_scheduler(state, task, best_local_scheduler_id);
+  return true;
+}
+
+bool handle_task_waiting_cost(GlobalSchedulerState *state,
+                         GlobalSchedulerPolicyState *policy_state,
+                         Task *task) {
+  TaskSpec *task_spec = Task_task_execution_spec(task)->Spec();
+  int64_t curtime = current_time_ms();
+
+  CHECKM(task_spec != NULL,
+         "task wait handler encounted a task with NULL spec");
+
+  /* For tasks already seen by the global scheduler (spillback > 1),
+   * adjust scheduled task counts for the source local scheduler.
+   */
+  if (task->execution_spec->SpillbackCount() > 1) {
+    auto it = state->local_schedulers.find(task->local_scheduler_id);
+    /* Task's previous local scheduler must be present and known. */
+    CHECK(it != state->local_schedulers.end());
+    LocalScheduler &src_local_scheduler = it->second;
+    src_local_scheduler.num_recent_tasks_sent -=1;
+  }
 
   bool task_feasible = false;
 
@@ -128,6 +199,10 @@ bool handle_task_waiting(GlobalSchedulerState *state,
   double best_local_scheduler_score = INT32_MIN;
   CHECKM(best_local_scheduler_score < 0,
          "We might have a floating point underflow");
+  std::string id_string_fromlocalsched = task->local_scheduler_id.hex();
+  LOG_INFO("ct[%" PRId64 "] task from %s spillback %d", curtime,
+      id_string_fromlocalsched.c_str(), task->execution_spec->SpillbackCount());
+
   DBClientID best_local_scheduler_id =
       DBClientID::nil(); /* best node to send this task */
   for (auto it = state->local_schedulers.begin();
@@ -138,10 +213,19 @@ bool handle_task_waiting(GlobalSchedulerState *state,
     if (!constraints_satisfied_hard(scheduler, task_spec)) {
       continue;
     }
+    /* Skip the local scheduler the task came from. */
+    if (task->local_scheduler_id == scheduler->id) {
+      continue;
+    }
+    std::string id_string = scheduler->id.hex();
     task_feasible = true;
     /* This node satisfies the hard capacity constraint. Calculate its score. */
     double score = -1 * calculate_cost_pending(state, scheduler, task_spec);
-    if (score > best_local_scheduler_score) {
+    LOG_INFO("ct[%" PRId64 "][%s][dt%" PRId64 "][q%d][w%d]: score %f bestscore %f\n",
+             curtime, id_string.c_str(), curtime - scheduler->last_heartbeat,
+             scheduler->info.task_queue_length, scheduler->info.available_workers,
+             score, best_local_scheduler_score);
+    if (score >= best_local_scheduler_score) {
       best_local_scheduler_score = score;
       best_local_scheduler_id = scheduler->id;
     }
@@ -161,6 +245,12 @@ bool handle_task_waiting(GlobalSchedulerState *state,
   /* A local scheduler ID was found, so assign the task. */
   assign_task_to_local_scheduler(state, task, best_local_scheduler_id);
   return true;
+}
+
+bool handle_task_waiting(GlobalSchedulerState *state,
+                         GlobalSchedulerPolicyState *policy_state,
+                         Task *task) {
+  return handle_task_waiting_random(state, policy_state, task);
 }
 
 void handle_object_available(GlobalSchedulerState *state,

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -21,38 +21,30 @@ typedef enum {
   SCHED_ALGORITHM_MAX
 } global_scheduler_algorithm;
 
-/** The class encapsulating state managed by the global scheduling policy. */
+/// The class encapsulating state managed by the global scheduling policy.
 class GlobalSchedulerPolicyState {
-public:
-  GlobalSchedulerPolicyState(int64_t round_robin_index):
-    round_robin_index_(round_robin_index), gen_(rd_()) {}
+ public:
+  GlobalSchedulerPolicyState(int64_t round_robin_index)
+      : round_robin_index_(round_robin_index), gen_(rd_()) {}
 
-  GlobalSchedulerPolicyState(): round_robin_index_(0), gen_(rd_()) {}
+  GlobalSchedulerPolicyState() : round_robin_index_(0), gen_(rd_()) {}
 
-  /**
-   * Return a constant reference to the random number generator.
-   *
-   * @param None.
-   */
-  std::mt19937_64 &getRandomGenerator() {
-    return gen_;
-  }
+  /// Return the policy's random number generator.
+  ///
+  /// @return The policy's random number generator.
+  std::mt19937_64 &getRandomGenerator() { return gen_; }
 
-  /**
-   * Return the round robin index maintained by policy state.
-   *
-   * @param None.
-   */
-  int64_t getRoundRobinIndex() const {
-    return round_robin_index_;
-  }
+  /// Return the round robin index maintained by policy state.
+  ///
+  /// @return The round robin index.
+  int64_t getRoundRobinIndex() const { return round_robin_index_; }
 
-private:
-  /** The index of the next local scheduler to assign a task to. */
+ private:
+  /// The index of the next local scheduler to assign a task to.
   int64_t round_robin_index_;
-  /** Internally maintained random number engine device. */
+  /// Internally maintained random number engine device.
   std::random_device rd_;
-  /** Internally maintained random number generator. */
+  /// Internally maintained random number generator.
   std::mt19937_64 gen_;
 };
 

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -1,6 +1,8 @@
 #ifndef GLOBAL_SCHEDULER_ALGORITHM_H
 #define GLOBAL_SCHEDULER_ALGORITHM_H
 
+#include <random>
+
 #include "common.h"
 #include "global_scheduler.h"
 #include "task.h"
@@ -19,10 +21,39 @@ typedef enum {
   SCHED_ALGORITHM_MAX
 } global_scheduler_algorithm;
 
-/** The state managed by the global scheduling policy. */
-struct GlobalSchedulerPolicyState {
+/** The class encapsulating state managed by the global scheduling policy. */
+class GlobalSchedulerPolicyState {
+public:
+  GlobalSchedulerPolicyState(int64_t round_robin_index):
+    round_robin_index_(round_robin_index), gen_(rd_()) {}
+
+  GlobalSchedulerPolicyState(): round_robin_index_(0), gen_(rd_()) {}
+
+  /**
+   * Return a constant reference to the random number generator.
+   *
+   * @param None.
+   */
+  std::mt19937_64 &getRandomGenerator() {
+    return gen_;
+  }
+
+  /**
+   * Return the round robin index maintained by policy state.
+   *
+   * @param None.
+   */
+  int64_t getRoundRobinIndex() const {
+    return round_robin_index_;
+  }
+
+private:
   /** The index of the next local scheduler to assign a task to. */
-  int64_t round_robin_index;
+  int64_t round_robin_index_;
+  /** Internally maintained random number engine device. */
+  std::random_device rd_;
+  /** Internally maintained random number generator. */
+  std::mt19937_64 gen_;
 };
 
 /**

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1423,8 +1423,8 @@ int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerState *state = (LocalSchedulerState *) context;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
 
-  /* Spillback policy invocation is synchronized with the heartbeats. */
-  spillback_tasks_handler(loop, id, context);
+  // Spillback policy invocation is synchronized with the heartbeats.
+  spillback_tasks_handler(state);
 
   /* Check that the last heartbeat was not sent too long ago. */
   int64_t current_time = current_time_ms();
@@ -1515,10 +1515,6 @@ void start_server(
       loop, RayConfig::instance()
                 .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
-  /* Create a timer for periodically invoking the spillback policy. */
-//  event_loop_add_timer(
-//      loop, RayConfig::instance().spillback_period(),
-//      spillback_tasks_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);
 }

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1423,6 +1423,9 @@ int heartbeat_handler(event_loop *loop, timer_id id, void *context) {
   LocalSchedulerState *state = (LocalSchedulerState *) context;
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
 
+  /* Spillback policy invocation is synchronized with the heartbeats. */
+  spillback_tasks_handler(loop, id, context);
+
   /* Check that the last heartbeat was not sent too long ago. */
   int64_t current_time = current_time_ms();
   CHECK(current_time >= state->previous_heartbeat_time);
@@ -1512,6 +1515,10 @@ void start_server(
       loop, RayConfig::instance()
                 .local_scheduler_reconstruction_timeout_milliseconds(),
       reconstruct_object_timeout_handler, g_state);
+  /* Create a timer for periodically invoking the spillback policy. */
+//  event_loop_add_timer(
+//      loop, RayConfig::instance().spillback_period(),
+//      spillback_tasks_handler, g_state);
   /* Run event loop. */
   event_loop_run(loop);
 }

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -820,44 +820,24 @@ bool resources_available(LocalSchedulerState *state) {
   return resources_available;
 }
 
-/**
- * Prune and spillback all tasks that exceeded allowed queueing delay.
- * This function implements the spillback policy.
- *
- * @param state The scheduler state.
- * @return Void.
- */
-int spillback_tasks_handler(event_loop *loop, timer_id id, void * context) {
-
-  LocalSchedulerState *state = reinterpret_cast<LocalSchedulerState *>(context);
+void spillback_tasks_handler(LocalSchedulerState *state) {
   SchedulingAlgorithmState *algorithm_state = state->algorithm_state;
-  const int64_t delay_max_ms = RayConfig::instance().spillback_allowed_max();
 
-  /* Traverse all tasks in the queue and spillback tasks that exceeded their
-   * allowed queueing delay but not the maximum allowed queueing delay. */
-  for (auto it = algorithm_state->dispatch_task_queue->begin();
-       it != algorithm_state->dispatch_task_queue->end();) {
-    int64_t delay_cur_ms = current_time_ms() - it->LastTimeStamp();
-    int64_t delay_allowed_ms =
-        RayConfig::instance().spillback_allowed_min() << it->SpillbackCount();
+  int64_t num_to_spillback = std::min(
+      static_cast<int64_t>(algorithm_state->dispatch_task_queue->size()),
+      RayConfig::instance().max_tasks_to_spillback());
 
-//    LOG_INFO("[spillback]: allowed %" PRId64 " cur %" PRId64 "max %" PRId64
-//             ", spillback %d\n", delay_allowed_ms, delay_cur_ms, delay_max_ms,
-//             it->SpillbackCount());
-
-    if (delay_allowed_ms < delay_cur_ms && delay_allowed_ms < delay_max_ms) {
-      /* If the task's queueing delay is more than allowed and still under
-       * the maximum threshold, forward this task to the global scheduler and
-       * deque it from the pending queue. */
-      it->IncrementSpillbackCount();
-      give_task_to_global_scheduler(state, algorithm_state, *it);
-      /* Dequeue the task. */
-      it = algorithm_state->dispatch_task_queue->erase(it);
-    } else {
-      ++it;
-    }
+  auto it = algorithm_state->dispatch_task_queue->end();
+  for (int64_t i = 0; i < num_to_spillback; i++) {
+    it--;
   }
-  return RayConfig::instance().spillback_period();
+
+  for (int64_t i = 0; i < num_to_spillback; i++) {
+    it->IncrementSpillbackCount();
+    give_task_to_global_scheduler(state, algorithm_state, *it);
+    // Dequeue the task.
+    it = algorithm_state->dispatch_task_queue->erase(it);
+  }
 }
 
 /**
@@ -873,7 +853,6 @@ void dispatch_tasks(LocalSchedulerState *state,
   for (auto it = algorithm_state->dispatch_task_queue->begin();
        it != algorithm_state->dispatch_task_queue->end();) {
     TaskSpec *spec = it->Spec();
-
     /* If there is a task to assign, but there are no more available workers in
      * the worker pool, then exit. Ensure that there will be an available
      * worker during a future invocation of dispatch_tasks. */
@@ -883,12 +862,12 @@ void dispatch_tasks(LocalSchedulerState *state,
          * then we must start a new one to replenish the worker pool. */
         start_worker(state, ActorID::nil(), false);
       }
-      break;
+      return;
     }
 
     /* Terminate early if there are no more resources available. */
     if (!resources_available(state)) {
-      break;
+      return;
     }
 
     /* Skip to the next task if this task cannot currently be satisfied. */
@@ -1187,7 +1166,7 @@ void give_task_to_global_scheduler(LocalSchedulerState *state,
   }
   /* Pass on the task to the global scheduler. */
   DCHECK(state->config.global_scheduler_exists);
-  Task *task = Task_alloc(execution_spec, TASK_STATUS_WAITING, 
+  Task *task = Task_alloc(execution_spec, TASK_STATUS_WAITING,
                           get_db_client_id(state->db));
 #if !RAY_USE_NEW_GCS
   DCHECK(state->db != NULL);
@@ -1201,19 +1180,6 @@ void give_task_to_global_scheduler(LocalSchedulerState *state,
   RAY_CHECK_OK(TaskTableAdd(&state->gcs_client, task));
   Task_free(task);
 #endif
-}
-
-bool static_resource_constraints_satisfied(LocalSchedulerState *state,
-                                           TaskSpec *spec) {
-  /* At the local scheduler, if required resource vector exceeds static
-   * resource vector, the static resource constraint is not satisfied. */
-  for (const auto &resource_pair : TaskSpec_get_required_resources(spec)) {
-    double required_resource = resource_pair.second;
-    if (required_resource > state->static_resources[resource_pair.first]) {
-      return false;
-    }
-  }
-  return true;
 }
 
 bool resource_constraints_satisfied(LocalSchedulerState *state,
@@ -1242,8 +1208,10 @@ void handle_task_submitted(LocalSchedulerState *state,
    * locally, and there is an available worker, then enqueue the task in the
    * dispatch queue and trigger task dispatch. Otherwise, pass the task along to
    * the global scheduler if there is one. */
-  if (static_resource_constraints_satisfied(state, spec)) {
-    queue_task_locally(state, algorithm_state, execution_spec, false);
+  if (resource_constraints_satisfied(state, spec) &&
+      (algorithm_state->available_workers.size() > 0) &&
+      can_run(algorithm_state, execution_spec)) {
+    queue_dispatch_task(state, algorithm_state, execution_spec, false);
   } else {
     /* Give the task to the global scheduler to schedule, if it exists. */
     give_task_to_global_scheduler(state, algorithm_state, execution_spec);

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -303,18 +303,12 @@ int reconstruct_object_timeout_handler(event_loop *loop,
 bool object_locally_available(SchedulingAlgorithmState *algorithm_state,
                               ObjectID object_id);
 
-/**
- * This function implements a periodically invoked spillback policy.
- *
- * @param loop The local scheduler's event loop.
- * @param id The ID of the timer that triggers this function.
- * @param context The function's context.
- * @return An integer representing the time interval in seconds before the
- *         next invocation of the function.
- */
-int spillback_tasks_handler(event_loop *loop,
-                            timer_id id,
-                            void *context);
+/// Spill some tasks back to the global scheduler. This function implements the
+/// spillback policy.
+///
+/// @param state The scheduler state.
+/// @return Void.
+void spillback_tasks_handler(LocalSchedulerState *state);
 
 /**
  * A helper function to print debug information about the current state and

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -304,6 +304,19 @@ bool object_locally_available(SchedulingAlgorithmState *algorithm_state,
                               ObjectID object_id);
 
 /**
+ * This function implements a periodically invoked spillback policy.
+ *
+ * @param loop The local scheduler's event loop.
+ * @param id The ID of the timer that triggers this function.
+ * @param context The function's context.
+ * @return An integer representing the time interval in seconds before the
+ *         next invocation of the function.
+ */
+int spillback_tasks_handler(event_loop *loop,
+                            timer_id id,
+                            void *context);
+
+/**
  * A helper function to print debug information about the current state and
  * number of workers.
  *

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1702,7 +1702,7 @@ class SchedulingAlgorithm(unittest.TestCase):
                                 total_tasks,
                                 num_local_schedulers,
                                 minimum_count,
-                                num_attempts=20):
+                                num_attempts=100):
         attempts = 0
         while attempts < num_attempts:
             locations = ray.get(
@@ -1728,11 +1728,11 @@ class SchedulingAlgorithm(unittest.TestCase):
 
         @ray.remote
         def f():
-            time.sleep(0.001)
+            time.sleep(0.01)
             return ray.worker.global_worker.plasma_client.store_socket_name
 
-        self.attempt_to_load_balance(f, [], 100, num_local_schedulers, 25)
-        self.attempt_to_load_balance(f, [], 1000, num_local_schedulers, 250)
+        self.attempt_to_load_balance(f, [], 100, num_local_schedulers, 10)
+        self.attempt_to_load_balance(f, [], 1000, num_local_schedulers, 100)
 
     def testLoadBalancingWithDependencies(self):
         # This test ensures that tasks are being assigned to all local


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR adds spillback policy to the local scheduler. Tasks are pushed back to the global scheduler when their currently accumulated queueing delay is greater than the allowed (to be defined) and less than the maximum specified threshold (100ms). The "allowed" queueing delay is exponentially increased each time the task is spilled back. It is calculated as 2^(spillback_count + 1). 

### Example
```
import ray
import time
ray.init(num_cpus=1, num_workers=1)
@ray.remote
def f(i):
  return i

time.sleep(1) #let the system warm up
oids = [f.remote(i) for i in range(100)]
ray.get(oids)
```

## Related issue number
This is related to (and enabled by) the spillback plumbing and mechanism PR #1362 .


