### PR TITLE
[DataFrame] MVP (1/4) 

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 import pandas as pd
+import numpy as np
 import ray
 
 
@@ -17,7 +17,7 @@ class DataFrame(object):
                 partitions.
             columns (pandas.Index): The column names for this dataframe, in pandas Index object.
         """
-        assert (len(df) > 0)
+        assert(len(df) > 0)
 
         self._df = df
         self.columns = columns
@@ -129,7 +129,7 @@ class DataFrame(object):
         Returns:
             A new DataFrame containing the result of the function.
         """
-        assert (callable(func))
+        assert(callable(func))
         new_df = [_deploy_func.remote(func, part) for part in self._df]
 
         return DataFrame(new_df, self.columns)
@@ -160,7 +160,7 @@ class DataFrame(object):
         Args:
             func (callable): The function to apply.
         """
-        assert (callable(func))
+        assert(callable(func))
         return self._map_partitions(lambda df: df.applymap(lambda x: func(x)))
 
     def copy(self, deep=True):
@@ -346,36 +346,11 @@ class DataFrame(object):
 
     def all(self, axis=None, bool_only=None, skipna=None, level=None,
             **kwargs):
-        """Return whether all elements are True over requested axis
-        """
-        bool_series_collection = self._map_partitions(lambda df: df.all(axis=axis,
-                                                                        bool_only=bool_only,
-                                                                        skipna=skipna,
-                                                                        level=level,
-                                                                        **kwargs))
-        if axis == None or axis == 0:
-            from functools import reduce
-            return reduce(lambda series_a, series_b: series_a & series_b, ray.get(bool_series_collection._df))
-        else:
-            return pd.concat(ray.get(bool_series_collection._df))
-
+        raise NotImplementedError("Not Yet implemented.")
 
     def any(self, axis=None, bool_only=None, skipna=None, level=None,
             **kwargs):
-        """
-        Return whether any element is True over requested axis
-        """
-        bool_series_collection = self._map_partitions(lambda df: df.any(axis=axis,
-                                                                        bool_only=bool_only,
-                                                                        skipna=skipna,
-                                                                        level=level,
-                                                                        **kwargs))
-        if axis == None or axis == 0:
-            from functools import reduce
-            return reduce(lambda series_a, series_b: series_a | series_b, ray.get(bool_series_collection._df))
-        else:
-            return pd.concat(ray.get(bool_series_collection._df))
-
+        raise NotImplementedError("Not Yet implemented.")
 
     def append(self, other, ignore_index=False, verify_integrity=False):
         raise NotImplementedError("Not Yet implemented.")
@@ -1043,6 +1018,7 @@ class DataFrame(object):
         """
         return pd.concat(ray.get(self._map_partitions(lambda df: df.__getitem__(key))._df))
 
+
     def __setitem__(self, key, value):
         raise NotImplementedError("Not Yet implemented.")
 
@@ -1095,13 +1071,12 @@ class DataFrame(object):
         Args:
             key: key to delete
         """
-
         def del_helper(df):
             df.__delitem__(key)
             return df
-
         self._df = self._map_partitions(del_helper)._df
         self.columns = self.columns.drop(key)
+
 
     def __finalize__(self, other, method=None, **kwargs):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -784,7 +784,9 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def round(self, decimals=0, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        return self._map_partitions(lambda df:df.round(decimals=decimals,
+                                                       *args,
+                                                       **kwargs))
 
     def rpow(self, other, axis='columns', level=None, fill_value=None):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -430,17 +430,7 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def bfill(self, axis=None, inplace=False, limit=None, downcast=None):
-        if inplace:
-            def bfill_inplace_helper(df):
-                df.bfill(axis=axis, inplace=inplace,
-                         limit=limit, downcast=downcast)
-                return df
-        else:
-            bfill_inplace_helper = lambda df: df.bfill(axis=axis,
-                                                        inplace=inplace,
-                                                        limit=limit,
-                                                        downcast=downcast)
-        return self._map_partitions(bfill_inplace_helper)
+        raise NotImplementedError("Not Yet implemented.")
 
     def bool(self):
         """Return the bool of a single element PandasObject.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -15,7 +15,8 @@ class DataFrame(object):
         Args:
             df ([ObjectID]): The list of ObjectIDs that contain the dataframe
                 partitions.
-            columns (pandas.Index): The column names for this dataframe, in pandas Index object.
+            columns (pandas.Index): The column names for this dataframe, in
+                pandas Index object.
         """
         assert(len(df) > 0)
 
@@ -358,7 +359,7 @@ class DataFrame(object):
             If axis=None or axis=0, this call applies df.all(axis=1)
             to the transpose of df.
         """
-        if axis == None or axis == 0:
+        if axis is None or axis == 0:
             df = self.T
             axis = 1
             ordered_index = df.columns
@@ -367,10 +368,10 @@ class DataFrame(object):
             ordered_index = df.index
 
         mapped = df._map_partitions(lambda df: df.all(axis,
-                                             bool_only,
-                                             skipna,
-                                             level,
-                                             **kwargs))
+                                                      bool_only,
+                                                      skipna,
+                                                      level,
+                                                      **kwargs))
         return to_pandas(mapped)[ordered_index]
 
     def any(self, axis=None, bool_only=None, skipna=None, level=None,
@@ -381,7 +382,7 @@ class DataFrame(object):
             If axis=None or axis=0, this call applies df.all(axis=1)
             to the transpose of df.
         """
-        if axis == None or axis == 0:
+        if axis is None or axis == 0:
             df = self.T
             axis = 1
             ordered_index = df.columns
@@ -440,11 +441,12 @@ class DataFrame(object):
         element is not boolean
         """
         shape = self.shape
-        if shape != (1,) and shape != (1,1):
-            raise ValueError("""The PandasObject does not have exactly 1 element. 
-                                Return the bool of a single element PandasObject.
-                                The truth value is ambiguous. 
-                                Use a.empty, a.item(), a.any() or a.all().""")
+        if shape != (1,) and shape != (1, 1):
+            raise ValueError("""The PandasObject does not have exactly
+                                1 element. Return the bool of a single
+                                element PandasObject. The truth value is
+                                ambiguous. Use a.empty, a.item(), a.any()
+                                or a.all().""")
         else:
             return to_pandas(self).bool()
 
@@ -489,8 +491,8 @@ class DataFrame(object):
         if axis == 1:
             original_index = self.index
             return self.T.count(axis=0,
-                                    level=level,
-                                    numeric_only=numeric_only)[original_index]
+                                level=level,
+                                numeric_only=numeric_only)[original_index]
         else:
             return sum(ray.get(self._map_partitions(lambda df: df.count(
                 axis=axis, level=level, numeric_only=numeric_only
@@ -849,9 +851,9 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def round(self, decimals=0, *args, **kwargs):
-        return self._map_partitions(lambda df:df.round(decimals=decimals,
-                                                       *args,
-                                                       **kwargs))
+        return self._map_partitions(lambda df: df.round(decimals=decimals,
+                                                        *args,
+                                                        **kwargs))
 
     def rpow(self, other, axis='columns', level=None, fill_value=None):
         raise NotImplementedError("Not Yet implemented.")
@@ -1083,7 +1085,8 @@ class DataFrame(object):
         Returns:
             A Pandas Series representing the value fo the column.
         """
-        result_column_chunks = self._map_partitions(lambda df: df.__getitem__(key))
+        result_column_chunks = self._map_partitions(
+            lambda df: df.__getitem__(key))
         return to_pandas(result_column_chunks)
 
     def __setitem__(self, key, value):
@@ -1151,7 +1154,8 @@ class DataFrame(object):
         """Make a copy using Ray.DataFrame.copy method
 
         Args:
-            deep: Boolean, deep copy or not. Currently we do not support deep copy.
+            deep: Boolean, deep copy or not.
+                  Currently we do not support deep copy.
 
         Returns:
             A Ray DataFrame object.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -430,10 +430,17 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def bfill(self, axis=None, inplace=False, limit=None, downcast=None):
-        return self._map_partitions(lambda df: df.bfill(axis=axis,
+        if inplace:
+            def bfill_inplace_helper(df):
+                df.bfill(axis=axis, inplace=inplace,
+                         limit=limit, downcast=downcast)
+                return df
+        else:
+            bfill_inplace_helper = lambda df: df.bfill(axis=axis,
                                                         inplace=inplace,
                                                         limit=limit,
-                                                        downcast=downcast))
+                                                        downcast=downcast)
+        return self._map_partitions(bfill_inplace_helper)
 
     def bool(self):
         """Return the bool of a single element PandasObject.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import ray
 
 
@@ -17,7 +17,7 @@ class DataFrame(object):
                 partitions.
             columns (pandas.Index): The column names for this dataframe, in pandas Index object.
         """
-        assert(len(df) > 0)
+        assert (len(df) > 0)
 
         self._df = df
         self.columns = columns
@@ -129,7 +129,7 @@ class DataFrame(object):
         Returns:
             A new DataFrame containing the result of the function.
         """
-        assert(callable(func))
+        assert (callable(func))
         new_df = [_deploy_func.remote(func, part) for part in self._df]
 
         return DataFrame(new_df, self.columns)
@@ -160,7 +160,7 @@ class DataFrame(object):
         Args:
             func (callable): The function to apply.
         """
-        assert(callable(func))
+        assert (callable(func))
         return self._map_partitions(lambda df: df.applymap(lambda x: func(x)))
 
     def copy(self, deep=True):
@@ -346,11 +346,36 @@ class DataFrame(object):
 
     def all(self, axis=None, bool_only=None, skipna=None, level=None,
             **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        """Return whether all elements are True over requested axis
+        """
+        bool_series_collection = self._map_partitions(lambda df: df.all(axis=axis,
+                                                                        bool_only=bool_only,
+                                                                        skipna=skipna,
+                                                                        level=level,
+                                                                        **kwargs))
+        if axis == None or axis == 0:
+            from functools import reduce
+            return reduce(lambda series_a, series_b: series_a & series_b, ray.get(bool_series_collection._df))
+        else:
+            return pd.concat(ray.get(bool_series_collection._df))
+
 
     def any(self, axis=None, bool_only=None, skipna=None, level=None,
             **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        """
+        Return whether any element is True over requested axis
+        """
+        bool_series_collection = self._map_partitions(lambda df: df.any(axis=axis,
+                                                                        bool_only=bool_only,
+                                                                        skipna=skipna,
+                                                                        level=level,
+                                                                        **kwargs))
+        if axis == None or axis == 0:
+            from functools import reduce
+            return reduce(lambda series_a, series_b: series_a | series_b, ray.get(bool_series_collection._df))
+        else:
+            return pd.concat(ray.get(bool_series_collection._df))
+
 
     def append(self, other, ignore_index=False, verify_integrity=False):
         raise NotImplementedError("Not Yet implemented.")
@@ -1018,7 +1043,6 @@ class DataFrame(object):
         """
         return pd.concat(ray.get(self._map_partitions(lambda df: df.__getitem__(key))._df))
 
-
     def __setitem__(self, key, value):
         raise NotImplementedError("Not Yet implemented.")
 
@@ -1071,12 +1095,13 @@ class DataFrame(object):
         Args:
             key: key to delete
         """
+
         def del_helper(df):
             df.__delitem__(key)
             return df
+
         self._df = self._map_partitions(del_helper)._df
         self.columns = self.columns.drop(key)
-
 
     def __finalize__(self, other, method=None, **kwargs):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -163,7 +163,6 @@ def test_int_dataframe():
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
-    test_bfill(ray_df, pandas_df)
     test_bool(ray_df, pandas_df)
     test_count(ray_df, pandas_df)
 
@@ -211,7 +210,6 @@ def test_float_dataframe():
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
-    test_bfill(ray_df, pandas_df)
     test_bool(ray_df, pandas_df)
     test_count(ray_df, pandas_df)
 
@@ -326,9 +324,11 @@ def test_between_time():
         ray_df.between_time(None, None)
 
 
-@pytest.fixture
-def test_bfill(ray_df, pd_df):
-    assert ray_df_equals_pandas(ray_df.bfill(), pd_df.bfill())
+def test_bfill():
+    ray_df = create_test_dataframe()
+
+    with pytest.raises(NotImplementedError):
+        ray_df.between_time(None, None)
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -230,23 +230,17 @@ def test_align():
 
 
 def test_all():
-    pd_df = pd.DataFrame({
-        'col1': [0,1,0,0],
-        'col2': [1,1,1,1]
-    })
-    ray_df = rdf.from_pandas(pd_df, 2)
-    assert pd_df.all().equals(ray_df.all())
-    assert pd_df.all(axis=1).equals(ray_df.all(axis=1))
+    ray_df = create_test_dataframe()
+
+    with pytest.raises(NotImplementedError):
+        ray_df.all()
 
 
 def test_any():
-    pd_df = pd.DataFrame({
-        'col1': [0, 0, 0, 1],
-        'col2': [1, 1, 1, 1]
-    })
-    ray_df = rdf.from_pandas(pd_df, 2)
-    assert pd_df.any().equals(ray_df.any())
-    assert pd_df.any(axis=1).equals(ray_df.any(axis=1))
+    ray_df = create_test_dataframe()
+
+    with pytest.raises(NotImplementedError):
+        ray_df.any()
 
 
 def test_append():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -1667,6 +1667,8 @@ def test___setstate__():
 
 @pytest.fixture
 def test___delitem__(ray_df, pd_df):
+    ray_df = ray_df.copy()
+    pd_df = pd_df.copy()
     ray_df.__delitem__('col1')
     pd_df.__delitem__('col1')
     ray_df_equals_pandas(ray_df, pd_df)

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3,10 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-# import ray.dataframe as rdf
-import sys
-sys.path.insert(0, '../../')
-import dataframe as rdf
+import ray.dataframe as rdf
 import numpy as np
 import pandas as pd
 import ray
@@ -165,6 +162,9 @@ def test_int_dataframe():
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
+    test_bfill(ray_df, pandas_df)
+    test_bool(ray_df, pandas_df)
+    test_count(ray_df, pandas_df)
 
 
 def test_float_dataframe():
@@ -209,6 +209,9 @@ def test_float_dataframe():
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
+    test_bfill(ray_df, pandas_df)
+    test_bool(ray_df, pandas_df)
+    test_count(ray_df, pandas_df)
 
 
 def test_add():
@@ -321,18 +324,21 @@ def test_between_time():
         ray_df.between_time(None, None)
 
 
-def test_bfill():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.bfill()
+@pytest.fixture
+def test_bfill(ray_df, pd_df):
+    assert ray_df_equals_pandas(ray_df.bfill(), pd_df.bfill())
 
 
-def test_bool():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
+@pytest.fixture
+def test_bool(ray_df, pd_df):
+    with pytest.raises(ValueError):
         ray_df.bool()
+        pd_df.bool()
+
+    single_bool_pd_df = pd.DataFrame([True])
+    single_bool_ray_df = rdf.from_pandas(single_bool_pd_df, 1)
+
+    assert single_bool_pd_df.bool() == single_bool_ray_df.bool()
 
 
 def test_boxplot():
@@ -412,11 +418,10 @@ def test_corrwith():
         ray_df.corrwith(None)
 
 
-def test_count():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.count()
+@pytest.fixture
+def test_count(ray_df, pd_df):
+    assert ray_df.count().equals(pd_df.count())
+    assert ray_df.count(axis=1).equals(pd_df.count(axis=1))
 
 
 def test_cov():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-import ray.dataframe as rdf
+# import ray.dataframe as rdf
+import sys
+sys.path.insert(0, '../../')
+import dataframe as rdf
 import numpy as np
 import pandas as pd
 import ray
@@ -46,8 +49,8 @@ def test_values(ray_df, pandas_df):
 
 @pytest.fixture
 def test_axes(ray_df, pandas_df):
-    assert (np.array_equal(ray_df.axes[0], pandas_df.axes[0]))
-    assert (np.array_equal(ray_df.axes[1], pandas_df.axes[1]))
+    for ray_axis, pd_axis in zip(ray_df.axes, pandas_df.axes):
+        assert (np.array_equal(ray_axis, pd_axis))
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -153,6 +153,7 @@ def test_int_dataframe():
     test_abs(ray_df, pandas_df)
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
+    test_round(ray_df, pandas_df)
 
 
 def test_float_dataframe():
@@ -189,6 +190,7 @@ def test_float_dataframe():
     test_abs(ray_df, pandas_df)
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
+    test_round(ray_df, pandas_df)
 
 
 def test_add():
@@ -1100,11 +1102,10 @@ def test_rolling():
         ray_df.rolling(None)
 
 
-def test_round():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.round()
+@pytest.fixture
+def test_round(ray_df, pd_df):
+    assert ray_df_equals_pandas(ray_df.round(), pd_df.round())
+    assert ray_df_equals_pandas(ray_df.round(1), pd_df.round(1))
 
 
 def test_rpow():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -230,17 +230,23 @@ def test_align():
 
 
 def test_all():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.all()
+    pd_df = pd.DataFrame({
+        'col1': [0,1,0,0],
+        'col2': [1,1,1,1]
+    })
+    ray_df = rdf.from_pandas(pd_df, 2)
+    assert pd_df.all().equals(ray_df.all())
+    assert pd_df.all(axis=1).equals(ray_df.all(axis=1))
 
 
 def test_any():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.any()
+    pd_df = pd.DataFrame({
+        'col1': [0, 0, 0, 1],
+        'col2': [1, 1, 1, 1]
+    })
+    ray_df = rdf.from_pandas(pd_df, 2)
+    assert pd_df.any().equals(ray_df.any())
+    assert pd_df.any(axis=1).equals(ray_df.any(axis=1))
 
 
 def test_append():


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR implements the following for ray.DataFrame:
- `__{getitem, delitem, copy, deepcopy}__`
- `all, any`
- `bfill, bool, count`
- `round`

This PR also updates the implementation of:
- `axes`

## Related issue number

None. But this is built upon PR #1330.
<!-- Are there any issues opened that will be resolved by merging this change? -->
