### PR TITLE
[tune] using None as the parameter default value instead of mutable dict

### DIFF
--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -63,7 +63,7 @@ class Agent(Trainable):
     _allow_unknown_subkeys = []
 
     def __init__(
-            self, config={}, env=None, registry=get_registry(),
+            self, config=None, env=None, registry=get_registry(),
             logger_creator=None):
         """Initialize an RLLib agent.
 
@@ -76,6 +76,8 @@ class Agent(Trainable):
             logger_creator (func): Function that creates a ray.tune.Logger
                 object. If unspecified, a default logger is created.
         """
+
+        config = config or {}
 
         # Agents allow env ids to be passed directly to the constructor.
         self._env_id = env or config.get("env")

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -48,7 +48,7 @@ class Trainable(object):
             classes and objects by name.
     """
 
-    def __init__(self, config={}, registry=None, logger_creator=None):
+    def __init__(self, config=None, registry=None, logger_creator=None):
         """Initialize an Trainable.
 
         Subclasses should prefer defining ``_setup()`` instead of overriding
@@ -68,7 +68,7 @@ class Trainable(object):
 
         self._initialize_ok = False
         self._experiment_id = uuid.uuid4().hex
-        self.config = config
+        self.config = config or {}
         self.registry = registry
 
         if logger_creator:

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -75,9 +75,9 @@ class Trial(object):
     ERROR = "ERROR"
 
     def __init__(
-            self, trainable_name, config={}, local_dir=DEFAULT_RESULTS_DIR,
+            self, trainable_name, config=None, local_dir=DEFAULT_RESULTS_DIR,
             experiment_tag=None, resources=Resources(cpu=1, gpu=0),
-            stopping_criterion={}, checkpoint_freq=0,
+            stopping_criterion=None, checkpoint_freq=0,
             restore_path=None, upload_dir=None):
         """Initialize a new trial.
 
@@ -97,11 +97,11 @@ class Trial(object):
 
         # Immutable config
         self.trainable_name = trainable_name
-        self.config = config
+        self.config = config or {}
         self.local_dir = local_dir
         self.experiment_tag = experiment_tag
         self.resources = resources
-        self.stopping_criterion = stopping_criterion
+        self.stopping_criterion = stopping_criterion or {}
         self.checkpoint_freq = checkpoint_freq
         self.upload_dir = upload_dir
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -89,11 +89,12 @@ class Trial(object):
                 TRAINABLE_CLASS, trainable_name):
             raise TuneError("Unknown trainable: " + trainable_name)
 
-        for k in stopping_criterion:
-            if k not in TrainingResult._fields:
-                raise TuneError(
-                    "Stopping condition key `{}` must be one of {}".format(
-                        k, TrainingResult._fields))
+        if stopping_criterion:
+            for k in stopping_criterion:
+                if k not in TrainingResult._fields:
+                    raise TuneError(
+                        "Stopping condition key `{}` must be one of {}".format(
+                            k, TrainingResult._fields))
 
         # Immutable config
         self.trainable_name = trainable_name


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

if we use dict as the init method default value, we have side effect like below:

``` python
class A(object):
    def __init__(self, config={}):
        self.config = config


a = A()
a.config['env'] = "gym"

b = A()
print(b.config)
```
the console will output `{'env': 'gym'}`, all instance objects of class A will share the same default dict object. This will cause some potential problems, not easy to find.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
