### PR TITLE
[tune] not share registry objects between default registry and other registry instances

### DIFF
--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -8,7 +8,7 @@ import os
 import pickle
 
 import tensorflow as tf
-from ray.tune.registry import ENV_CREATOR, get_registry
+from ray.tune.registry import ENV_CREATOR
 from ray.tune.result import TrainingResult
 from ray.tune.trainable import Trainable
 
@@ -63,7 +63,7 @@ class Agent(Trainable):
     _allow_unknown_subkeys = []
 
     def __init__(
-            self, config=None, env=None, registry=get_registry(),
+            self, config=None, env=None, registry=None,
             logger_creator=None):
         """Initialize an RLLib agent.
 

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -77,8 +77,8 @@ def _from_pinnable(obj):
 
 
 class _Registry(object):
-    def __init__(self, objs={}):
-        self._all_objects = objs
+    def __init__(self, objs=None):
+        self._all_objects = {} if objs is None else objs.copy()
         self._refs = []  # hard refs that prevent eviction of objects
 
     def register(self, category, key, value):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
<!-- Please give a short brief about these changes. -->

Before this PR, field `_all_objects` in all the _Registry instances will share the same dict instance.

``` python
import gym

import ray
from ray.tune.registry import register_env, get_registry, ENV_CREATOR

ray.init()

# create a registry before registry env in default registry
# bug we can also read the env in registry
registry = get_registry()
register_env("CartPole", lambda env_config: gym.make("CartPole-v0"))

# the result is True
print(registry.contains(ENV_CREATOR, "CartPole"))

# register an env in an old registry object, 
# but we can read the value in newly created registry object
registry.register(ENV_CREATOR, "CartPole2", lambda env_config: gym.make("CartPole-v0"))
registry_new = get_registry()

# the result is True
print(registry_new.contains(ENV_CREATOR, "CartPole2"))
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
