### PR TITLE
Add missing availability_zone argument to development example.

### DIFF
--- a/python/ray/autoscaler/aws/development-example.yaml
+++ b/python/ray/autoscaler/aws/development-example.yaml
@@ -22,6 +22,7 @@ idle_timeout_minutes: 5
 provider:
     type: aws
     region: us-west-2
+    availability_zone: us-west-2a
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
`availability_zone` is a required field, see the discussion in #1407.

cc @ericl 