### PR TITLE
[DataFrame] Implementation for head, idxmax, idxmin, pop, tail, and Ray Index

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -643,8 +643,7 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def idxmax(self, axis=0, skipna=True):
-        """Get the index of the first occurrence of the maximum value of the
-        axis.
+        """Get the index of the first occurrence of the max value of the axis.
 
         Args:
             axis (int): Identify the max over the rows (1) or columns (0).
@@ -652,7 +651,7 @@ class DataFrame(object):
 
         Returns:
             A Series with the index for each maximum value for the axis
-            specified.
+                specified.
         """
         if axis == 1:
             return to_pandas(self._map_partitions(
@@ -661,8 +660,7 @@ class DataFrame(object):
             return self.T.idxmax(axis=1, skipna=skipna)
 
     def idxmin(self, axis=0, skipna=True):
-        """Get the index of the first occurrence of the minimum value of the
-        axis.
+        """Get the index of the first occurrence of the min value of the axis.
 
         Args:
             axis (int): Identify the min over the rows (1) or columns (0).
@@ -670,7 +668,7 @@ class DataFrame(object):
 
         Returns:
             A Series with the index for each minimum value for the axis
-            specified.
+                specified.
         """
         if axis == 1:
             return to_pandas(self._map_partitions(

--- a/python/ray/dataframe/index.py
+++ b/python/ray/dataframe/index.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pandas as pd
+
+
+class Index(object):
+
+    def __init__(self, idx):
+        self.idx = idx
+
+    @classmethod
+    def to_pandas(indices):
+        if isinstance(indices[0], pd.RangeIndex):
+            merged = indices[0]
+            for index in indices[1:]:
+                merged = merged.union(index)
+            return merged
+        else:
+            return indices[0].append(indices[1:])

--- a/python/ray/dataframe/series.py
+++ b/python/ray/dataframe/series.py
@@ -13,6 +13,14 @@ def na_op():
 
 class Series(object):
 
+    def __init__(self, series_oids):
+        """Constructor for a Series object.
+
+        Args:
+            series_oids ([ObjectID]): The list of remote Series objects.
+        """
+        self.series_oids = series_oids
+
     @property
     def T(self):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -666,8 +666,8 @@ def test_gt():
 def test_head():
     ray_df = create_test_dataframe()
 
-    with pytest.raises(NotImplementedError):
-        ray_df.head()
+    ray_df_equals_pandas(ray_df.head(),
+        rdf.to_pandas(ray_df).head())
 
 
 def test_hist():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -165,6 +165,11 @@ def test_int_dataframe():
     test___deepcopy__(ray_df, pandas_df)
     test_bool(ray_df, pandas_df)
     test_count(ray_df, pandas_df)
+    test_head(ray_df, pandas_df)
+    test_tail(ray_df, pandas_df)
+    test_idxmax(ray_df, pandas_df)
+    test_idxmin(ray_df, pandas_df)
+    test_pop(ray_df, pandas_df)
 
 
 def test_float_dataframe():
@@ -212,6 +217,11 @@ def test_float_dataframe():
     test___deepcopy__(ray_df, pandas_df)
     test_bool(ray_df, pandas_df)
     test_count(ray_df, pandas_df)
+    test_head(ray_df, pandas_df)
+    test_tail(ray_df, pandas_df)
+    test_idxmax(ray_df, pandas_df)
+    test_idxmin(ray_df, pandas_df)
+    test_pop(ray_df, pandas_df)
 
 
 def test_add():
@@ -663,11 +673,9 @@ def test_gt():
         ray_df.gt(None)
 
 
-def test_head():
-    ray_df = create_test_dataframe()
-
-    ray_df_equals_pandas(ray_df.head(),
-        rdf.to_pandas(ray_df).head())
+@pytest.fixture
+def test_head(ray_df, pandas_df):
+    ray_df_equals_pandas(ray_df.head(), pandas_df.head())
 
 
 def test_hist():
@@ -677,18 +685,16 @@ def test_hist():
         ray_df.hist(None)
 
 
-def test_idxmax():
-    ray_df = create_test_dataframe()
+@pytest.fixture
+def test_idxmax(ray_df, pandas_df):
+    assert \
+        ray_df.idxmax().sort_index().equals(pandas_df.idxmax().sort_index())
 
-    with pytest.raises(NotImplementedError):
-        ray_df.idxmax()
 
-
-def test_idxmin():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.idxmin()
+@pytest.fixture
+def test_idxmin(ray_df, pandas_df):
+    assert \
+        ray_df.idxmin().sort_index().equals(pandas_df.idxmin().sort_index())
 
 
 def test_infer_objects():
@@ -971,11 +977,14 @@ def test_plot():
         ray_df.plot()
 
 
-def test_pop():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.pop(None)
+@pytest.fixture
+def test_pop(ray_df, pandas_df):
+    temp_ray_df = ray_df._map_partitions(lambda df: df)
+    temp_pandas_df = pandas_df.copy()
+    ray_popped = temp_ray_df.pop('col2')
+    pandas_popped = temp_pandas_df.pop('col2')
+    assert ray_popped.sort_index().equals(pandas_popped.sort_index())
+    ray_df_equals_pandas(temp_ray_df, temp_pandas_df)
 
 
 def test_pow():
@@ -1292,11 +1301,9 @@ def test_swaplevel():
         ray_df.swaplevel()
 
 
-def test_tail():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.tail()
+@pytest.fixture
+def test_tail(ray_df, pandas_df):
+    ray_df_equals_pandas(ray_df.tail(), pandas_df.tail())
 
 
 def test_take():

--- a/python/ray/dataframe/test/test_series.py
+++ b/python/ray/dataframe/test/test_series.py
@@ -11,7 +11,7 @@ ray.init()
 
 @pytest.fixture
 def create_test_series():
-    return rdf.Series()
+    return rdf.Series(None)
 
 
 def test_T():


### PR DESCRIPTION
Continuing to add functionality.

Ray Index will be needed to implement methods such as `__getitem__()` and will be extremely useful going forward. We cannot rely on the Pandas Index globally because we have a different structure overall. We can, however use the Pandas Index locally to access the item we need.

Index structure: `key -> (partition, key)`. The second `key` is the Pandas Index key.

Edit: Additional work is needed to integrate the new Index structure, but we at least have the skeleton in this PR.