### PR TITLE
[rllib] Fix PPO parallelism

### DIFF
--- a/python/ray/rllib/ppo/rollout.py
+++ b/python/ray/rllib/ppo/rollout.py
@@ -25,8 +25,8 @@ def collect_samples(agents, config, local_evaluator):
         [fut_sample], _ = ray.wait(list(agent_dict))
         agent = agent_dict.pop(fut_sample)
         # Start task with next trajectory and record it in the dictionary.
-        fut_sample = agent.sample.remote()
-        agent_dict[fut_sample] = agent
+        fut_sample2 = agent.sample.remote()
+        agent_dict[fut_sample2] = agent
 
         next_sample = ray.get(fut_sample)
         num_timesteps_so_far += next_sample.count


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Seems like this limits PPO to one concurrent task (and drops all results from the first wave).