### PR TITLE
Switch to using pandas serialization context.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1038,12 +1038,10 @@ def _initialize_serialization(worker=global_worker):
     This defines a custom serializer for object IDs and also tells ray to
     serialize several exception classes that we define for error handling.
     """
-    worker.serialization_context = pyarrow.SerializationContext()
+    worker.serialization_context = pyarrow.pandas_serialization_context()
     # Tell the serialization context to use the cloudpickle version that we
     # ship with Ray.
     worker.serialization_context.set_pickle(pickle.dumps, pickle.loads)
-    pyarrow.register_default_serialization_handlers(
-        worker.serialization_context)
     pyarrow.register_torch_serialization_handlers(worker.serialization_context)
 
     # Define a custom serializer and deserializer for handling Object IDs.


### PR DESCRIPTION
This switches to from the pyarrow `default_serialization_context` to the pyarrow `pandas_serialization_context`. The difference between these two serialization contexts is that numpy object arrays are serialized with pickle instead of cloudpickle.

The benefit is that serialization of dataframes that contain strings should be faster. The downside is that Ray will not be able to handle numpy arrays of custom objects (at least not unless a custom serializer is registered for that object).

The tradeoff is probably reasonable for now (and we can see if people run into problems).

cc @pcmoritz @devin-petersohn 

Opening this for discussion. Any thoughts about this?