### PR TITLE
[tune] Recover experiments from last checkpoint

### DIFF
--- a/doc/source/tune.rst
+++ b/doc/source/tune.rst
@@ -198,6 +198,20 @@ Trial Checkpointing
 
 To enable checkpoint / resume, you must subclass ``Trainable`` and implement its ``_train``, ``_save``, and ``_restore`` abstract methods `(example) <https://github.com/ray-project/ray/blob/master/python/ray/tune/examples/hyperband_example.py>`__: Implementing this interface is required to support resource multiplexing in schedulers such as HyperBand and PBT.
 
+Additionally, checkpointing can be used to provide fault-tolerance for experiments. This can be enabled by setting ``checkpoint_freq: N`` and ``max_failures: M`` to checkpoint trials every *N* iterations and recover from up to *M* crashes per trial, e.g.:
+
+.. code-block:: python
+
+    run_experiments({
+        "my_experiment": {
+            ...
+            "checkpoint_freq": 10,
+            "max_failures": 5,
+        },
+    })
+
+The class interface that must be implemented to enable checkpointing is as follows:
+
 .. autoclass:: ray.tune.trainable.Trainable
 
 Resource Allocation

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -139,12 +139,19 @@ class _MockAgent(Agent):
     """Mock agent for use in tests"""
 
     _agent_name = "MockAgent"
-    _default_config = {}
+    _default_config = {
+        "mock_error": False,
+        "persistent_error": False,
+    }
 
     def _init(self):
         self.info = None
+        self.restored = False
 
     def _train(self):
+        if self.config["mock_error"] and self.iteration == 1 \
+                and (self.config["persistent_error"] or not self.restored):
+            raise Exception("mock error")
         return TrainingResult(
             episode_reward_mean=10, episode_len_mean=10,
             timesteps_this_iter=10, info={})
@@ -159,6 +166,7 @@ class _MockAgent(Agent):
         with open(checkpoint_path, 'rb') as f:
             info = pickle.load(f)
         self.info = info
+        self.restored = True
 
     def set_info(self, info):
         self.info = info

--- a/python/ray/rllib/dqn/dqn_evaluator.py
+++ b/python/ray/rllib/dqn/dqn_evaluator.py
@@ -174,7 +174,9 @@ class DQNEvaluator(TFMultiGPUSupport):
             self.episode_rewards,
             self.episode_lengths,
             self.saved_mean_reward,
-            self.obs]
+            self.obs,
+            self.global_timestep,
+            self.local_timestep]
 
     def restore(self, data):
         self.exploration = data[0]
@@ -182,3 +184,5 @@ class DQNEvaluator(TFMultiGPUSupport):
         self.episode_lengths = data[2]
         self.saved_mean_reward = data[3]
         self.obs = data[4]
+        self.global_timestep = data[5]
+        self.local_timestep = data[6]

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -76,7 +76,7 @@ def make_parser(**kwargs):
         "A value of 0 (default) disables checkpointing.")
     parser.add_argument(
         "--max-failures", default=3, type=int,
-        help="Try to recover a trial from the last checkpoint at least this "
+        help="Try to recover a trial from its last checkpoint at least this "
         "many times. Only applies if checkpointing is enabled.")
     parser.add_argument(
         "--scheduler", default="FIFO", type=str,

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -75,6 +75,10 @@ def make_parser(**kwargs):
         help="How many training iterations between checkpoints. "
         "A value of 0 (default) disables checkpointing.")
     parser.add_argument(
+        "--max-failures", default=3, type=int,
+        help="Try to recover a trial from the last checkpoint at least this "
+        "many times. Only applies if checkpointing is enabled.")
+    parser.add_argument(
         "--scheduler", default="FIFO", type=str,
         help="FIFO (default), MedianStopping, or HyperBand.")
     parser.add_argument(

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -208,6 +208,7 @@ class VariantGeneratorTest(unittest.TestCase):
         trials = generate_trials({
             "run": "PPO",
             "repeat": 2,
+            "max_failures": 5,
             "config": {
                 "env": "Pong-v0",
                 "foo": "bar"
@@ -219,6 +220,7 @@ class VariantGeneratorTest(unittest.TestCase):
         self.assertEqual(trials[0].config, {"foo": "bar", "env": "Pong-v0"})
         self.assertEqual(trials[0].trainable_name, "PPO")
         self.assertEqual(trials[0].experiment_tag, "0")
+        self.assertEqual(trials[0].max_failures, 5)
         self.assertEqual(
             trials[0].local_dir,
             os.path.join(DEFAULT_RESULTS_DIR, "tune-pong"))
@@ -456,6 +458,81 @@ class TrialRunnerTest(unittest.TestCase):
         runner.step()
         self.assertEqual(trials[0].status, Trial.ERROR)
         self.assertEqual(trials[1].status, Trial.RUNNING)
+
+    def testFailureRecoveryDisabled(self):
+        ray.init(num_cpus=1, num_gpus=1)
+        runner = TrialRunner()
+        kwargs = {
+            "resources": Resources(cpu=1, gpu=1),
+            "checkpoint_freq": 1,
+            "max_failures": 0,
+            "config": {
+                "mock_error": True,
+            },
+        }
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.ERROR)
+        self.assertEqual(trials[0].num_failures, 1)
+
+    def testFailureRecoveryEnabled(self):
+        ray.init(num_cpus=1, num_gpus=1)
+        runner = TrialRunner()
+        kwargs = {
+            "resources": Resources(cpu=1, gpu=1),
+            "checkpoint_freq": 1,
+            "max_failures": 1,
+            "config": {
+                "mock_error": True,
+            },
+        }
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        self.assertEqual(trials[0].num_failures, 1)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+
+    def testFailureRecoveryMaxFailures(self):
+        ray.init(num_cpus=1, num_gpus=1)
+        runner = TrialRunner()
+        kwargs = {
+            "resources": Resources(cpu=1, gpu=1),
+            "checkpoint_freq": 1,
+            "max_failures": 2,
+            "config": {
+                "mock_error": True,
+                "persistent_error": True,
+            },
+        }
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        self.assertEqual(trials[0].num_failures, 1)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        self.assertEqual(trials[0].num_failures, 2)
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.ERROR)
+        self.assertEqual(trials[0].num_failures, 3)
 
     def testCheckpointing(self):
         ray.init(num_cpus=1, num_gpus=1)

--- a/python/ray/tune/variant_generator.py
+++ b/python/ray/tune/variant_generator.py
@@ -62,7 +62,8 @@ def generate_trials(unresolved_spec, output_path=''):
                 stopping_criterion=spec.get("stop", {}),
                 checkpoint_freq=args.checkpoint_freq,
                 restore_path=spec.get("restore"),
-                upload_dir=args.upload_dir)
+                upload_dir=args.upload_dir,
+                max_failures=args.max_failures)
 
 
 def generate_variants(unresolved_spec):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

If a trial crashes, attempt to recover it from the last checkpoint up to ``max_failures`` times. This is automatically enabled with max_failures=3 if checkpoint_freq is set.

cc @eugenevinitsky 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
