### PR TITLE
Minor, change NotImplemented -> NotImplementedError.

### DIFF
--- a/python/ray/rllib/a3c/tfpolicy.py
+++ b/python/ray/rllib/a3c/tfpolicy.py
@@ -38,7 +38,7 @@ class TFPolicy(Policy):
         elif isinstance(action_space, gym.spaces.Discrete):
             self.ac = tf.placeholder(tf.int64, [None], name="ac")
         else:
-            raise NotImplemented(
+            raise NotImplementedError(
                 "action space" + str(type(action_space)) +
                 "currently not supported")
         self.adv = tf.placeholder(tf.float32, [None], name="adv")


### PR DESCRIPTION
I'm seeing tons of error messages in Jenkins like the following. For some reason they are not failing the Jenkins build..

```
('=== Testing', 'A3C', [Box(5,), Box(5,)], Tuple(Discrete(10), Box(5,)), '===')
Observation shape is ((10,), (5,))
Using a TupleFlatteningPreprocessor
Creating sub-preprocessor for Discrete(10)
Observation shape is (10,)
Using one-hot preprocessor for discrete envs.
Creating sub-preprocessor for Box(5,)
Observation shape is (5,)
Not using any observation preprocessor.
Setting up loss
'NotImplementedType' object is not callable
Traceback (most recent call last):
  File "/ray/python/ray/rllib/test/test_supported_spaces.py", line 84, in check_support
    a = get_agent_class(alg)(config=config, env="stub_env")
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/agent.py", line 84, in __init__
    Trainable.__init__(self, config, registry, logger_creator)
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/tune/trainable.py", line 88, in __init__
    self._setup()
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/agent.py", line 107, in _setup
    self._init()
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/a3c/a3c.py", line 74, in _init
    start_sampler=False)
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/a3c/a3c_evaluator.py", line 37, in __init__
    registry, env.observation_space.shape, env.action_space, config)
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/a3c/shared_model.py", line 18, in __init__
    registry, ob_space, ac_space, config, **kwargs)
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/a3c/tfpolicy.py", line 27, in __init__
    self.setup_loss(action_space)
  File "/opt/conda/lib/python2.7/site-packages/ray-0.3.1-py2.7-linux-x86_64.egg/ray/rllib/a3c/tfpolicy.py", line 43, in setup_loss
    "currently not supported")
TypeError: 'NotImplementedType' object is not callable
```