### PR TITLE
Join consistency for distributed actor handles

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -823,6 +823,8 @@ class Worker(object):
         # the passed handles since we use a nested dictionary.
         for handles in ray.worker.global_worker.passed_actor_handles.values():
             assert len(handles) == 0
+        # TODO(swang): An actor may keep handles as part of its internal state
+        # across methods, so we should not clear the entire dictionary here.
         ray.worker.global_worker.passed_actor_handles.clear()
 
         # Get task arguments from the object store.

--- a/src/common/format/common.fbs
+++ b/src/common/format/common.fbs
@@ -82,6 +82,28 @@ table TaskExecutionDependencies {
 
 root_type TaskExecutionDependencies;
 
+// The ActorFrontier is used to represent the current frontier of tasks that
+// the local scheduler has marked as runnable for a particular actor. It is
+// used to save the point in an actor's lifetime at which a checkpoint was
+// taken, so that the same frontier of tasks can be made runnable again if the
+// actor is resumed from that checkpoint.
+table ActorFrontier {
+  // Actor ID of the actor whose frontier is described.
+  actor_id: string;
+  // A list of handle IDs, representing the callers of the actor that have
+  // submitted a runnable task to the local scheduler. A nil ID represents the
+  // creator of the actor.
+  handle_ids: [string];
+  // A list representing the number of tasks executed so far, per handle. Each
+  // count in task_counters corresponds to the handle at the same in index in
+  // handle_ids.
+  task_counters: [long];
+  // A list representing the execution dependency for the next runnable task,
+  // per handle. Each execution dependency in frontier_dependencies corresponds
+  // to the handle at the same in index in handle_ids.
+  frontier_dependencies: [TaskExecutionDependencies];
+}
+
 table SubscribeToNotificationsReply {
   // The object ID of the object that the notification is about.
   object_id: string;

--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -95,28 +95,6 @@ table PutObject {
   object_id: string;
 }
 
-// The ActorFrontier is used to represent the current frontier of tasks that
-// the local scheduler has marked as runnable for a particular actor. It is
-// used to save the point in an actor's lifetime at which a checkpoint was
-// taken, so that the same frontier of tasks can be made runnable again if the
-// actor is resumed from that checkpoint.
-table ActorFrontier {
-  // Actor ID of the actor whose frontier is described.
-  actor_id: string;
-  // A list of handle IDs, representing the callers of the actor that have
-  // submitted a runnable task to the local scheduler. A nil ID represents the
-  // creator of the actor.
-  handle_ids: [string];
-  // A list representing the number of tasks executed so far, per handle. Each
-  // count in task_counters corresponds to the handle at the same in index in
-  // handle_ids.
-  task_counters: [long];
-  // A list representing the execution dependency for the next runnable task,
-  // per handle. Each execution dependency in frontier_dependencies corresponds
-  // to the handle at the same in index in handle_ids.
-  frontier_dependencies: [string];
-}
-
 table GetActorFrontierRequest {
   actor_id: string;
 }

--- a/src/local_scheduler/local_scheduler_algorithm.h
+++ b/src/local_scheduler/local_scheduler_algorithm.h
@@ -364,7 +364,7 @@ void print_worker_info(const char *message,
  */
 std::unordered_map<ActorHandleID, int64_t, UniqueIDHasher>
 get_actor_task_counters(SchedulingAlgorithmState *algorithm_state,
-                        ActorID actor_id);
+                        const ActorID &actor_id);
 
 /**
  * Set the number of tasks, per actor handle, that have been executed on an
@@ -380,7 +380,7 @@ get_actor_task_counters(SchedulingAlgorithmState *algorithm_state,
  */
 void set_actor_task_counters(
     SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id,
+    const ActorID &actor_id,
     const std::unordered_map<ActorHandleID, int64_t, UniqueIDHasher>
         &task_counters);
 
@@ -392,12 +392,12 @@ void set_actor_task_counters(
  *
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @param actor_id The ID of the actor whose task counters are returned.
- * @return A map from handle ID to execution dependency for the earliest
- *         runnable task submitted through that handle.
+ * @return A map from handle ID to a list of execution dependencies for the
+ *         earliest runnable task submitted through that handle.
  */
-std::unordered_map<ActorHandleID, ObjectID, UniqueIDHasher> get_actor_frontier(
-    SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id);
+std::unordered_map<ActorHandleID, std::vector<ObjectID>, UniqueIDHasher>
+get_actor_frontier(SchedulingAlgorithmState *algorithm_state,
+                   const ActorID &actor_id);
 
 /**
  * Set the actor's frontier of task dependencies. The previous frontier will be
@@ -406,16 +406,18 @@ std::unordered_map<ActorHandleID, ObjectID, UniqueIDHasher> get_actor_frontier(
  *
  * @param algorithm_state State maintained by the scheduling algorithm.
  * @param actor_id The ID of the actor whose task counters are returned.
- * @param frontier_dependencies A map from handle ID to execution dependency
- *        for the earliest runnable task submitted through that handle.
+ * @param frontier_dependencies A map from handle ID to a list of execution
+ *        dependencies for the earliest runnable task submitted through that
+ *        handle.
  * @return Void.
  */
 void set_actor_frontier(
     LocalSchedulerState *state,
     SchedulingAlgorithmState *algorithm_state,
-    ActorID actor_id,
-    const std::unordered_map<ActorHandleID, ObjectID, UniqueIDHasher>
-        &frontier_dependencies);
+    const ActorID &actor_id,
+    const std::unordered_map<ActorHandleID,
+                             std::vector<ObjectID>,
+                             UniqueIDHasher> &frontier_dependencies);
 
 /** The following methods are for testing purposes only. */
 #ifdef LOCAL_SCHEDULER_TEST

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -104,28 +104,6 @@ table PutObject {
   object_id: string;
 }
 
-// The ActorFrontier is used to represent the current frontier of tasks that
-// the local scheduler has marked as runnable for a particular actor. It is
-// used to save the point in an actor's lifetime at which a checkpoint was
-// taken, so that the same frontier of tasks can be made runnable again if the
-// actor is resumed from that checkpoint.
-table ActorFrontier {
-  // Actor ID of the actor whose frontier is described.
-  actor_id: string;
-  // A list of handle IDs, representing the callers of the actor that have
-  // submitted a runnable task to the local scheduler. A nil ID represents the
-  // creator of the actor.
-  handle_ids: [string];
-  // A list representing the number of tasks executed so far, per handle. Each
-  // count in task_counters corresponds to the handle at the same in index in
-  // handle_ids.
-  task_counters: [long];
-  // A list representing the execution dependency for the next runnable task,
-  // per handle. Each execution dependency in frontier_dependencies corresponds
-  // to the handle at the same in index in handle_ids.
-  frontier_dependencies: [string];
-}
-
 table GetActorFrontierRequest {
   actor_id: string;
 }


### PR DESCRIPTION
## What do these changes do?

When an actor handle is passed into a remote task that calls methods on the actor, we guarantee the following execution ordering properties:
1. Methods called by the remote task execute after methods that were called by the original handle before calling the remote task.
2. Methods called on a handle will execute in order of submission.

However, we do not guarantee "join consistency", in which methods called by the original handle *after* waiting for the remote task to return will also execute after methods called by the remote task. This PR adds this guarantee by packing actor handles that were passed to a task into the return values of the task. Now, a user can synchronize forked handles by calling `ray.get` on tasks that were passed an actor handle.

**Note**: This does not work for `ray.wait`.


## Related issue number
#1286.