### PR TITLE
[DataFrame] Implement iteritems, items, itertuples, and iterrows.

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -724,7 +724,7 @@ class DataFrame(object):
     def iterrows(self):
         """Iterate over DataFrame rows as (index, Series) pairs.
 
-        NOTE:
+        Note:
             Generators can't be pickeled so from the remote function
             we expand the generator into a list before getting it.
             This is not that ideal.
@@ -740,7 +740,7 @@ class DataFrame(object):
     def items(self):
         """Iterator over (column name, Series) pairs.
 
-        NOTE:
+        Note:
             Generators can't be pickeled so from the remote function
             we expand the generator into a list before getting it.
             This is not that ideal.
@@ -753,11 +753,7 @@ class DataFrame(object):
 
         def concat_iters(iterables):
             for partitions in zip(*iterables):
-                to_concat = []
-                for items in partitions:
-                    index, _series = items
-                    to_concat.append(_series)
-                series = pd.concat(to_concat)
+                series = pd.concat([_series for _, _series in partitions])
                 yield (index, series)
 
         return concat_iters(iters)
@@ -765,7 +761,7 @@ class DataFrame(object):
     def iteritems(self):
         """Iterator over (column name, Series) pairs.
 
-        NOTE:
+        Note:
             Returns the same thing as .items()
 
         Returns:
@@ -774,15 +770,14 @@ class DataFrame(object):
         return self.items()
 
     def itertuples(self, index=True, name='Pandas'):
-        """Iterate over DataFrame rows as namedtuples, with index value as first
-        element of the tuple.
+        """Iterate over DataFrame rows as namedtuples, with index value as first element of the tuple.
 
         Args:
             index (boolean, default True): If True, return the index as the
                 first element of the tuple.
             name (string, default "Pandas"): The name of the returned
             namedtuples or None to return regular tuples.
-        NOTE:
+        Note:
             Generators can't be pickeled so from the remote function
             we expand the generator into a list before getting it.
             This is not that ideal.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -754,7 +754,7 @@ class DataFrame(object):
         def concat_iters(iterables):
             for partitions in zip(*iterables):
                 series = pd.concat([_series for _, _series in partitions])
-                yield (index, series)
+                yield (series.name, series)
 
         return concat_iters(iters)
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -722,10 +722,10 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def items(self):
+        transposed = self.transpose()
         func = lambda df: list(df.items())
-        iters = ray.get([_deploy_func.remote(func, part) for part in self._df])
-        return list(itertools.chain.from_iterable(iters))
-        # return [i for l in iters for i in l]
+        iters = ray.get([_deploy_func.remote(func, part) for part in transposed._df])
+        return itertools.chain.from_iterable(iters)
 
     def iteritems(self):
         func = lambda df: df.items()
@@ -733,8 +733,8 @@ class DataFrame(object):
         return itertools.chain.from_iterable(iters)
 
     def iterrows(self):
-        func = lambda df: df.items()
-        iters = [_deploy_func.remote(func, part) for part in self._df]
+        func = lambda df: list(df.iterrows())
+        iters = ray.get([_deploy_func.remote(func, part) for part in self._df])
         return itertools.chain.from_iterable(iters)
 
     def itertuples(self, index=True, name='Pandas'):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import pandas as pd
 import numpy as np
 import ray
+import itertools
 
 
 class DataFrame(object):
@@ -721,13 +722,19 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def items(self):
-        raise NotImplementedError("Not Yet implemented.")
+        func = lambda df: df.items()
+        iters = [_deploy_func.remote(func, part) for part in self._df]
+        return itertools.chain.from_iterable(iters)
 
     def iteritems(self):
-        raise NotImplementedError("Not Yet implemented.")
+        func = lambda df: df.items()
+        iters = [_deploy_func.remote(func, part) for part in self._df]
+        return itertools.chain.from_iterable(iters)
 
     def iterrows(self):
-        raise NotImplementedError("Not Yet implemented.")
+        func = lambda df: df.items()
+        iters = [_deploy_func.remote(func, part) for part in self._df]
+        return itertools.chain.from_iterable(iters)
 
     def itertuples(self, index=True, name='Pandas'):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -722,9 +722,10 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def items(self):
-        func = lambda df: df.items()
-        iters = [_deploy_func.remote(func, part) for part in self._df]
-        return itertools.chain.from_iterable(iters)
+        func = lambda df: list(df.items())
+        iters = ray.get([_deploy_func.remote(func, part) for part in self._df])
+        return list(itertools.chain.from_iterable(iters))
+        # return [i for l in iters for i in l]
 
     def iteritems(self):
         func = lambda df: df.items()

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -770,7 +770,7 @@ class DataFrame(object):
         return self.items()
 
     def itertuples(self, index=True, name='Pandas'):
-        """Iterate over DataFrame rows as namedtuples, with index value as first element of the tuple.
+        """Iterate over DataFrame rows as namedtuples.
 
         Args:
             index (boolean, default True): If True, return the index as the

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -193,6 +193,9 @@ def test_int_dataframe():
     test_idxmax(ray_df, pandas_df)
     test_idxmin(ray_df, pandas_df)
     test_pop(ray_df, pandas_df)
+    test_iterrows(ray_df, pandas_df)
+    test_items(ray_df, pandas_df)
+    test_iteritems(ray_df, pandas_df)
 
     for key in keys:
         test_get(ray_df, pandas_df, key)
@@ -311,6 +314,9 @@ def test_mixed_dtype_dataframe():
     test_get_ftype_counts(ray_df, pandas_df)
     test_items(ray_df, pandas_df)
     test_iterrows(ray_df, pandas_df)
+    test_items(ray_df, pandas_df)
+    test_iteritems(ray_df, pandas_df)
+
 
 def test_add():
     ray_df = create_test_dataframe()
@@ -791,27 +797,38 @@ def test_interpolate():
     with pytest.raises(NotImplementedError):
         ray_df.interpolate()
 
+
 @pytest.fixture
 def test_items(ray_df, pandas_df):
     ray_items = ray_df.items()
     pandas_items = pandas_df.items()
     for ray_item, pandas_item in zip(ray_items, pandas_items):
-        print(ray_item, '\n', pandas_item)
-        assert ray_item == pandas_item
+        ray_index, ray_series = ray_item
+        pandas_index, pandas_series = pandas_item
+        assert pandas_series.equals(ray_series)
+        assert pandas_index == ray_index
 
 
-# def test_iteritems():
-#     ray_df = create_test_dataframe()
+@pytest.fixture
+def test_iteritems(ray_df, pandas_df):
+    ray_items = ray_df.iteritems()
+    pandas_items = pandas_df.iteritems()
+    for ray_item, pandas_item in zip(ray_items, pandas_items):
+        ray_index, ray_series = ray_item
+        pandas_index, pandas_series = pandas_item
+        assert pandas_series.equals(ray_series)
+        assert pandas_index == ray_index
 
-#     with pytest.raises(NotImplementedError):
-#         ray_df.iteritems()
 
 @pytest.fixture
 def test_iterrows(ray_df, pandas_df):
     ray_iterrows = ray_df.iterrows()
     pandas_iterrows = pandas_df.iterrows()
     for ray_row, pandas_row in zip(ray_iterrows, pandas_iterrows):
-        assert ray_row.equals
+        ray_index, ray_series = ray_row
+        pandas_index, pandas_series = pandas_row
+        assert pandas_series.equals(ray_series)
+        assert pandas_index == ray_index
 
 
 def test_itertuples():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -193,16 +193,16 @@ def test_int_dataframe():
     test_idxmax(ray_df, pandas_df)
     test_idxmin(ray_df, pandas_df)
     test_pop(ray_df, pandas_df)
-    test_iterrows(ray_df, pandas_df)
-    test_items(ray_df, pandas_df)
-    test_iteritems(ray_df, pandas_df)
-    test_itertuples(ray_df, pandas_df)
 
     for key in keys:
         test_get(ray_df, pandas_df, key)
 
     test_get_dtype_counts(ray_df, pandas_df)
     test_get_ftype_counts(ray_df, pandas_df)
+    test_iterrows(ray_df, pandas_df)
+    test_items(ray_df, pandas_df)
+    test_iteritems(ray_df, pandas_df)
+    test_itertuples(ray_df, pandas_df)
 
 
 def test_float_dataframe():
@@ -260,14 +260,16 @@ def test_float_dataframe():
     test_idxmax(ray_df, pandas_df)
     test_idxmin(ray_df, pandas_df)
     test_pop(ray_df, pandas_df)
-<<<<<<< 5e981475ecceb7f01f0d60672c3a3fbee33de372
-<<<<<<< f86f3e9697190617224e805a84b3d127a3e16e03
 
     for key in keys:
         test_get(ray_df, pandas_df, key)
 
     test_get_dtype_counts(ray_df, pandas_df)
     test_get_ftype_counts(ray_df, pandas_df)
+    test_iterrows(ray_df, pandas_df)
+    test_items(ray_df, pandas_df)
+    test_iteritems(ray_df, pandas_df)
+    test_itertuples(ray_df, pandas_df)
 
 
 def test_mixed_dtype_dataframe():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -316,6 +316,7 @@ def test_mixed_dtype_dataframe():
     test_iterrows(ray_df, pandas_df)
     test_items(ray_df, pandas_df)
     test_iteritems(ray_df, pandas_df)
+    test_itertuples(ray_df, pandas_df)
 
 
 def test_add():
@@ -831,11 +832,24 @@ def test_iterrows(ray_df, pandas_df):
         assert pandas_index == ray_index
 
 
-def test_itertuples():
-    ray_df = create_test_dataframe()
+@pytest.fixture
+def test_itertuples(ray_df, pandas_df):
+    # test default
+    ray_it_default = ray_df.itertuples()
+    pandas_it_default = pandas_df.itertuples()
+    for ray_row, pandas_row in zip(ray_it_default, pandas_it_default):
+        assert ray_row == pandas_row
 
-    with pytest.raises(NotImplementedError):
-        ray_df.itertuples()
+    # test all combinations of custom params
+    indices = [True, False]
+    names = [None, 'NotPandas', 'Pandas']
+
+    for index in indices:
+        for name in names:
+            ray_it_custom = ray_df.itertuples(index=index, name=name)
+            pandas_it_custom = pandas_df.itertuples(index=index, name=name)
+            for ray_row, pandas_row in zip(ray_it_custom, pandas_it_custom):
+                assert ray_row == pandas_row
 
 
 def test_join():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -196,6 +196,7 @@ def test_int_dataframe():
     test_iterrows(ray_df, pandas_df)
     test_items(ray_df, pandas_df)
     test_iteritems(ray_df, pandas_df)
+    test_itertuples(ray_df, pandas_df)
 
     for key in keys:
         test_get(ray_df, pandas_df, key)

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -256,6 +256,7 @@ def test_float_dataframe():
     test_idxmax(ray_df, pandas_df)
     test_idxmin(ray_df, pandas_df)
     test_pop(ray_df, pandas_df)
+<<<<<<< 5e981475ecceb7f01f0d60672c3a3fbee33de372
 <<<<<<< f86f3e9697190617224e805a84b3d127a3e16e03
 
     for key in keys:
@@ -308,10 +309,8 @@ def test_mixed_dtype_dataframe():
 
     test_get_dtype_counts(ray_df, pandas_df)
     test_get_ftype_counts(ray_df, pandas_df)
-
-=======
     test_items(ray_df, pandas_df)
->>>>>>> Can't pickle generator so return list
+    test_iterrows(ray_df, pandas_df)
 
 def test_add():
     ray_df = create_test_dataframe()
@@ -807,12 +806,12 @@ def test_items(ray_df, pandas_df):
 #     with pytest.raises(NotImplementedError):
 #         ray_df.iteritems()
 
-
-# def test_iterrows():
-#     ray_df = create_test_dataframe()
-
-#     with pytest.raises(NotImplementedError):
-#         ray_df.iterrows()
+@pytest.fixture
+def test_iterrows(ray_df, pandas_df):
+    ray_iterrows = ray_df.iterrows()
+    pandas_iterrows = pandas_df.iterrows()
+    for ray_row, pandas_row in zip(ray_iterrows, pandas_iterrows):
+        assert ray_row.equals
 
 
 def test_itertuples():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -256,6 +256,7 @@ def test_float_dataframe():
     test_idxmax(ray_df, pandas_df)
     test_idxmin(ray_df, pandas_df)
     test_pop(ray_df, pandas_df)
+<<<<<<< f86f3e9697190617224e805a84b3d127a3e16e03
 
     for key in keys:
         test_get(ray_df, pandas_df, key)
@@ -308,6 +309,9 @@ def test_mixed_dtype_dataframe():
     test_get_dtype_counts(ray_df, pandas_df)
     test_get_ftype_counts(ray_df, pandas_df)
 
+=======
+    test_items(ray_df, pandas_df)
+>>>>>>> Can't pickle generator so return list
 
 def test_add():
     ray_df = create_test_dataframe()
@@ -788,26 +792,27 @@ def test_interpolate():
     with pytest.raises(NotImplementedError):
         ray_df.interpolate()
 
-
-def test_items():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.items()
-
-
-def test_iteritems():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.iteritems()
+@pytest.fixture
+def test_items(ray_df, pandas_df):
+    ray_items = ray_df.items()
+    pandas_items = pandas_df.items()
+    for ray_item, pandas_item in zip(ray_items, pandas_items):
+        print(ray_item, '\n', pandas_item)
+        assert ray_item == pandas_item
 
 
-def test_iterrows():
-    ray_df = create_test_dataframe()
+# def test_iteritems():
+#     ray_df = create_test_dataframe()
 
-    with pytest.raises(NotImplementedError):
-        ray_df.iterrows()
+#     with pytest.raises(NotImplementedError):
+#         ray_df.iteritems()
+
+
+# def test_iterrows():
+#     ray_df = create_test_dataframe()
+
+#     with pytest.raises(NotImplementedError):
+#         ray_df.iterrows()
 
 
 def test_itertuples():


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Implemented tests and methods for iteritems, items, itertuples, iterrows. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
