### PR TITLE
Resource capacity-based global scheduler policy

### DIFF
--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -80,6 +80,8 @@ class RayConfig {
 
   int64_t L3_cache_size_bytes() const { return L3_cache_size_bytes_; }
 
+  int64_t spillback_allowed_min() const { return spillback_allowed_min_; }
+
   int64_t max_tasks_to_spillback() const { return max_tasks_to_spillback_; }
 
  private:
@@ -108,6 +110,7 @@ class RayConfig {
         redis_db_connect_wait_milliseconds_(100),
         plasma_default_release_delay_(64),
         L3_cache_size_bytes_(100000000),
+        spillback_allowed_min_(32),    // ms
         max_tasks_to_spillback_(10) {}
 
   ~RayConfig() {}
@@ -183,7 +186,9 @@ class RayConfig {
   int64_t plasma_default_release_delay_;
   int64_t L3_cache_size_bytes_;
 
+
   /// Constants for the spillback scheduling policy.
+  int64_t spillback_allowed_min_;
   int64_t max_tasks_to_spillback_;
 };
 

--- a/src/global_scheduler/global_scheduler.h
+++ b/src/global_scheduler/global_scheduler.h
@@ -26,6 +26,14 @@ typedef struct {
   /** The number of tasks sent from the global scheduler to this local scheduler
    *  since the last heartbeat arrived. */
   int64_t num_recent_tasks_sent;
+  /** Last time this global scheduler received a heartbeat for this local
+   *  scheduler.
+   */
+  int64_t last_heartbeat;
+  /** The resource vector of resources expected to currently be available
+   * to this local scheduler.
+   */
+  std::unordered_map<std::string, double> expected_capacity;
   /** The latest information about the local scheduler capacity. This is updated
    *  every time a new local scheduler heartbeat arrives. */
   LocalSchedulerInfo info;

--- a/src/global_scheduler/global_scheduler_algorithm.cc
+++ b/src/global_scheduler/global_scheduler_algorithm.cc
@@ -249,7 +249,7 @@ bool handle_task_waiting_capacity(GlobalSchedulerState *state,
     return true;
   }
   // No nodes found with enough capacity.
-  LOG_INFO("No nodes found with enough capacity. Assign randomly.");
+  LOG_DEBUG("No nodes found with enough capacity. Assign randomly.");
   return handle_task_waiting_random(state, policy_state, task);
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->
## Summary of changes

This PR updates the global scheduler policy to consider expected resource capacity for scheduled tasks. If no nodes are found, which contain enough expected resource capacity for the scheduled task, the policy falls back to random.

In preliminary evaluation (on MacOSX), this PR significantly improves initial load distribution from a single driver for shorter tasks. For example, on 10 simulated local scheduler nodes, 10 cores each, 100 1sec tasks get perfect load distribution after a warmup (which ensures that all workers are up).

## Related issue number
https://github.com/ray-project/ray/issues/1180

<!-- Are there any issues opened that will be resolved by merging this change? -->
