### PR TITLE
Pass --allow-root into jupyter notebook.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -653,6 +653,7 @@ def start_ui(redis_address, stdout_file=None, stderr_file=None, cleanup=True):
     # querying the jupyter server.
     token = binascii.hexlify(os.urandom(24)).decode("ascii")
     command = ["jupyter", "notebook", "--no-browser",
+               "--allow-root",
                "--port={}".format(port),
                "--NotebookApp.iopub_data_rate_limit=10000000000",
                "--NotebookApp.open_browser=False",


### PR DESCRIPTION
If running Ray as root on a cluster, the web UI will fail to start because. E.g.,

```
root@123.45.67.89$ jupyter notebook
[C 05:13:20.987 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.
```

Could this cause security issues? We could enable this via a flag if we don't want it on by default.