### PR TITLE
Allow setting redis shard ports through ray start (also object store memory).

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -52,11 +52,11 @@ def cli():
 @click.option("--redis-max-clients", required=False, type=int,
               help=("If provided, attempt to configure Redis with this "
                     "maximum number of clients."))
-@click.option("--object-manager-port", required=False, type=int,
-              help="the port to use for starting the object manager")
 @click.option("--redis-shard-ports", required=False, type=str,
               help="the port to use for the Redis shards other than the "
                    "primary Redis shard")
+@click.option("--object-manager-port", required=False, type=int,
+              help="the port to use for starting the object manager")
 @click.option("--object-store-memory", required=False, type=int,
               help="the maximum amount of memory (in bytes) to allow the "
                    "object store to use")
@@ -86,13 +86,18 @@ def cli():
 @click.option("--autoscaling-config", required=False, type=str,
               help="the file that contains the autoscaling config")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
-          redis_max_clients, object_manager_port, redis_shard_ports,
+          redis_max_clients, redis_shard_ports, object_manager_port,
           object_store_memory, num_workers, num_cpus, num_gpus, resources,
           head, no_ui, block, plasma_directory, huge_pages,
           autoscaling_config):
     if redis_shard_ports is not None:
         redis_shard_ports = redis_shard_ports.split(",")
-        if len(redis_shard_ports) != (num_redis_shards or 1):
+        # Infer the number of Redis shards from the ports if the number is not
+        # provided.
+        if num_redis_shards is None:
+            num_redis_shards = len(redis_shard_ports)
+        # Check that the arguments match.
+        if len(redis_shard_ports) != num_redis_shards:
             raise Exception("If --redis-shard-ports is provided, it must have "
                             "the form '6380,6381,6382', and the number of "
                             "ports provided must equal --num-redis-shards "

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -54,6 +54,9 @@ def cli():
                     "maximum number of clients."))
 @click.option("--object-manager-port", required=False, type=int,
               help="the port to use for starting the object manager")
+@click.option("--object-store-memory", required=False, type=int,
+              help="the maximum amount of memory (in bytes) to allow the "
+                   "object store to use")
 @click.option("--num-workers", required=False, type=int,
               help=("The initial number of workers to start on this node, "
                     "note that the local scheduler may start additional "
@@ -80,9 +83,9 @@ def cli():
 @click.option("--autoscaling-config", required=False, type=str,
               help="the file that contains the autoscaling config")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
-          redis_max_clients, object_manager_port, num_workers, num_cpus,
-          num_gpus, resources, head, no_ui, block, plasma_directory,
-          huge_pages, autoscaling_config):
+          redis_max_clients, object_manager_port, object_store_memory,
+          num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
+          plasma_directory, huge_pages, autoscaling_config):
     # Note that we redirect stdout and stderr to /dev/null because otherwise
     # attempts to print may cause exceptions if a process is started inside of
     # an SSH connection and the SSH connection dies. TODO(rkn): This is a
@@ -133,6 +136,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             address_info=address_info,
             node_ip_address=node_ip_address,
             redis_port=redis_port,
+            object_store_memory=object_store_memory,
             num_workers=num_workers,
             cleanup=False,
             redirect_output=True,
@@ -199,6 +203,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redis_address=redis_address,
             object_manager_ports=[object_manager_port],
             num_workers=num_workers,
+            object_store_memory=object_store_memory,
             cleanup=False,
             redirect_output=True,
             resources=resources,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -90,19 +90,6 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           object_store_memory, num_workers, num_cpus, num_gpus, resources,
           head, no_ui, block, plasma_directory, huge_pages,
           autoscaling_config):
-    if redis_shard_ports is not None:
-        redis_shard_ports = redis_shard_ports.split(",")
-        # Infer the number of Redis shards from the ports if the number is not
-        # provided.
-        if num_redis_shards is None:
-            num_redis_shards = len(redis_shard_ports)
-        # Check that the arguments match.
-        if len(redis_shard_ports) != num_redis_shards:
-            raise Exception("If --redis-shard-ports is provided, it must have "
-                            "the form '6380,6381,6382', and the number of "
-                            "ports provided must equal --num-redis-shards "
-                            "(which is 1 if not provided)")
-
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -126,6 +113,20 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
 
     if head:
         # Start Ray on the head node.
+        if redis_shard_ports is not None:
+            redis_shard_ports = redis_shard_ports.split(",")
+            # Infer the number of Redis shards from the ports if the number is
+            # not provided.
+            if num_redis_shards is None:
+                num_redis_shards = len(redis_shard_ports)
+            # Check that the arguments match.
+            if len(redis_shard_ports) != num_redis_shards:
+                raise Exception("If --redis-shard-ports is provided, it must "
+                                "have the form '6380,6381,6382', and the "
+                                "number of ports provided must equal "
+                                "--num-redis-shards (which is 1 if not "
+                                "provided)")
+
         if redis_address is not None:
             raise Exception("If --head is passed in, a Redis server will be "
                             "started, so a Redis address should not be "

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1202,6 +1202,7 @@ def start_ray_node(node_ip_address,
                    object_manager_ports=None,
                    num_workers=0,
                    num_local_schedulers=1,
+                   object_store_memory=None,
                    worker_path=None,
                    cleanup=True,
                    redirect_output=False,
@@ -1223,6 +1224,8 @@ def start_ray_node(node_ip_address,
         num_local_schedulers (int): The number of local schedulers to start.
             This is also the number of plasma stores and plasma managers to
             start.
+        object_store_memory (int): The maximum amount of memory (in bytes) to
+            let the plasma store use.
         worker_path (str): The path of the source code that will be run by the
             worker.
         cleanup (bool): If cleanup is true, then the processes started here
@@ -1247,6 +1250,7 @@ def start_ray_node(node_ip_address,
                                node_ip_address=node_ip_address,
                                num_workers=num_workers,
                                num_local_schedulers=num_local_schedulers,
+                               object_store_memory=object_store_memory,
                                worker_path=worker_path,
                                include_log_monitor=True,
                                cleanup=cleanup,

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -216,6 +216,11 @@ class StartRayScriptTest(unittest.TestCase):
                                  "--redis-port", "6379"])
         subprocess.Popen(["ray", "stop"]).wait()
 
+        # Test starting Ray with redis shard ports specified.
+        subprocess.check_output(["ray", "start", "--head",
+                                 "--redis-shard-ports", "6380,6381,6382"])
+        subprocess.Popen(["ray", "stop"]).wait()
+
         # Test starting Ray with a node IP address specified.
         subprocess.check_output(["ray", "start", "--head",
                                  "--node-ip-address", "127.0.0.1"])
@@ -245,6 +250,7 @@ class StartRayScriptTest(unittest.TestCase):
         subprocess.check_output(["ray", "start", "--head",
                                  "--num-workers", "20",
                                  "--redis-port", "6379",
+                                 "--redis-shard-ports", "6380,6381,6382",
                                  "--object-manager-port", "12345",
                                  "--num-cpus", "100",
                                  "--num-gpus", "0",


### PR DESCRIPTION
With this PR, it should be possible to set all of the ports used by Ray in the `ray start` command via

Head node
```
ray start --head \
          --redis-port=6379 \
          --num-redis-shards=2 \
          --redis-shard-ports=6380,6381  \
          --object-manager-port=2384
```

Other nodes (need to fill in the head node IP)
```
ray start --redis-address=<head-node-ip>:6379 \
          --object-manager-port=2384
```

See related discussion in https://github.com/ray-project/ray/issues/1013#issuecomment-367455016.

cc @abrahamrhoffman

Unrelated: In this PR, I also allow passing in `--object-store-memory` to `ray start`, which is a fairly minor change (see https://github.com/ray-project/ray/pull/1529#issuecomment-367473499). 