### PR TITLE
Retry if wget redis fails, also don't check certificate.

### DIFF
--- a/src/common/thirdparty/build-redis.sh
+++ b/src/common/thirdparty/build-redis.sh
@@ -9,7 +9,15 @@ if [ ! -f redis/src/redis-server ]; then
   # relevant bit about redis/utils/whatisdoing.sh is that it is one of the last
   # files in the tarball.
   if [ ! -f redis/utils/whatisdoing.sh ]; then
-    mkdir -p "./redis" && wget -O- "https://github.com/antirez/redis/archive/$redis_vname.tar.gz" | tar xvz --strip-components=1 -C "./redis"
+    mkdir -p "./redis"
+    # The wget command frequently fails, so retry up to 20 times.
+    for COUNT in {1..20}; do
+      wget -O- "https://github.com/antirez/redis/archive/$redis_vname.tar.gz" | tar xvz --strip-components=1 -C "./redis"
+    done
+    # If none of the retries succeeded at getting Redis, then fail.
+    if [[ $COUNT == 20 ]]; then
+      exit 1
+    fi
   fi
   cd redis
   make


### PR DESCRIPTION
Recently I've been seeing the following error when building Linux wheels on Travis.

```
+ bash build-redis.sh
--2018-02-22 20:56:50--  https://github.com/antirez/redis/archive/4.0-rc2.tar.gz
Resolving github.com... 192.30.253.112, 192.30.253.113
Connecting to github.com|192.30.253.112|:443... connected.
OpenSSL: error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version
Unable to establish SSL connection.
```

I'm hoping this will fix it.