### PR TITLE
Only pass in --allow-root if the user is root.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -665,11 +665,14 @@ def start_ui(redis_address, stdout_file=None, stderr_file=None, cleanup=True):
     # querying the jupyter server.
     token = binascii.hexlify(os.urandom(24)).decode("ascii")
     command = ["jupyter", "notebook", "--no-browser",
-               "--allow-root",
                "--port={}".format(port),
                "--NotebookApp.iopub_data_rate_limit=10000000000",
                "--NotebookApp.open_browser=False",
                "--NotebookApp.token={}".format(token)]
+    # If the user is root, add the --allow-root flag.
+    if os.geteuid() == 0:
+        command.append("--allow-root")
+
     try:
         ui_process = subprocess.Popen(command, env=new_env,
                                       cwd=new_notebook_directory,


### PR DESCRIPTION
On some machines, I'm seeing

```
$ jupyter-notebook  --allow-root
The Jupyter HTML Notebook.

This launches a Tornado based HTML Notebook Server that serves up an
HTML5/Javascript Notebook client.

Subcommands
-----------

Subcommands are launched as `jupyter-notebook cmd [args]`. For information on
using subcommand 'cmd', do: `jupyter-notebook cmd -h`.

list
    List currently running notebook servers.

Options
-------

Arguments that take values are actually convenience aliases to full
Configurables, whose aliases are listed on the help line. For more information
on full configurables, see '--help-all'.

--pylab
    DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
--no-script
    DEPRECATED, IGNORED
-y
    Answer yes to any questions instead of prompting.
--debug
    set log level to logging.DEBUG (maximize logging output)
--generate-config
    generate default config file
--script
    DEPRECATED, IGNORED
--no-browser
    Don't open the notebook in a browser after startup.
--no-mathjax
    Disable MathJax
    
    MathJax is the javascript library Jupyter uses to render math/LaTeX. It is
    very large, so you may want to disable it if you have a slow internet
    connection, or for offline use of the notebook.
    
    When disabled, equations etc. will appear as their untransformed TeX source.
--pylab=<Unicode> (NotebookApp.pylab)
    Default: 'disabled'
    DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
--browser=<Unicode> (NotebookApp.browser)
    Default: ''
    Specify what command to use to invoke a web browser when opening the
    notebook. If not specified, the default browser will be determined by the
    `webbrowser` standard library module, which allows setting of the BROWSER
    environment variable to override it.
--transport=<CaselessStrEnum> (KernelManager.transport)
    Default: 'tcp'
    Choices: ['tcp', 'ipc']
--port-retries=<Int> (NotebookApp.port_retries)
    Default: 50
    The number of additional ports to try if the specified port is not
    available.
--log-level=<Enum> (Application.log_level)
    Default: 30
    Choices: (0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
    Set the log level by value or name.
--keyfile=<Unicode> (NotebookApp.keyfile)
    Default: ''
    The full path to a private key file for usage with SSL/TLS.
--config=<Unicode> (JupyterApp.config_file)
    Default: ''
    Full path of a config file.
--notebook-dir=<Unicode> (NotebookApp.notebook_dir)
    Default: ''
    The directory to use for notebooks and kernels.
--certfile=<Unicode> (NotebookApp.certfile)
    Default: ''
    The full path to an SSL/TLS certificate file.
--ip=<Unicode> (NotebookApp.ip)
    Default: 'localhost'
    The IP address the notebook server will listen on.
--client-ca=<Unicode> (NotebookApp.client_ca)
    Default: ''
    The full path to a certificate authority certificate for SSL/TLS client
    authentication.
--port=<Int> (NotebookApp.port)
    Default: 8888
    The port the notebook server will listen on.

To see all available configurables, use `--help-all`

Examples
--------

    jupyter notebook                       # start the notebook
    jupyter notebook --certfile=mycert.pem # use SSL/TLS certificate

[C 00:12:44.386 NotebookApp] Bad config encountered during initialization:
[C 00:12:44.386 NotebookApp] Unrecognized flag: '--allow-root'
```