### PR TITLE
Don't use 127.0.0.1 for local ip address.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1285,9 +1285,8 @@ def _init(address_info=None,
         # In this case, we launch a scheduler, a new object store, and some
         # workers, and we connect to them. We do not launch any processes that
         # are already registered in address_info.
-        # Use the address 127.0.0.1 in local mode.
-        node_ip_address = ("127.0.0.1" if node_ip_address is None
-                           else node_ip_address)
+        if node_ip_address is None:
+            node_ip_address = ray.services.get_node_ip_address()
         # Use 1 local scheduler if num_local_schedulers is not provided. If
         # existing local schedulers are provided, use that count as
         # num_local_schedulers.

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1987,7 +1987,7 @@ class GlobalStateAPI(unittest.TestCase):
         worker_info = ray.global_state.workers()
         self.assertEqual(len(worker_info), num_workers)
         for worker_id, info in worker_info.items():
-            self.assertEqual(info["node_ip_address"], "127.0.0.1")
+            self.assertIn("node_ip_address", info)
             self.assertIn("local_scheduler_socket", info)
             self.assertIn("plasma_manager_socket", info)
             self.assertIn("plasma_store_socket", info)


### PR DESCRIPTION
This makes it a bit easier to connect to the webUI (through port forwarding) when I start Ray on a remote machine using `ray.init()`. This also makes `ray.init()` more consistent with the `ray start` codepath.