### PR TITLE
Download Redis and flatbuffers differently.

### DIFF
--- a/src/common/thirdparty/build-redis.sh
+++ b/src/common/thirdparty/build-redis.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 # Cause the script to exit if a single command fails.
 set -e
 
@@ -9,7 +11,8 @@ if [ ! -f redis/src/redis-server ]; then
   # relevant bit about redis/utils/whatisdoing.sh is that it is one of the last
   # files in the tarball.
   if [ ! -f redis/utils/whatisdoing.sh ]; then
-    mkdir -p "./redis" && wget -O- "https://github.com/antirez/redis/archive/$redis_vname.tar.gz" | tar xvz --strip-components=1 -C "./redis"
+    mkdir -p "./redis"
+    curl -sL "https://github.com/antirez/redis/archive/$redis_vname.tar.gz" | tar xz --strip-components=1 -C "./redis"
   fi
   cd redis
   make

--- a/src/thirdparty/build_flatbuffers.sh
+++ b/src/thirdparty/build_flatbuffers.sh
@@ -12,7 +12,7 @@ FLATBUFFERS_VERSION=1.7.1
 # Download and compile flatbuffers if it isn't already present.
 if [ ! -d $TP_DIR/flatbuffers ]; then
   echo "building flatbuffers"
-  wget https://github.com/google/flatbuffers/archive/v$FLATBUFFERS_VERSION.tar.gz -O flatbuffers-$FLATBUFFERS_VERSION.tar.gz
+  curl -sL https://github.com/google/flatbuffers/archive/v$FLATBUFFERS_VERSION.tar.gz -o flatbuffers-$FLATBUFFERS_VERSION.tar.gz
   tar xf flatbuffers-$FLATBUFFERS_VERSION.tar.gz
   rm -rf flatbuffers-$FLATBUFFERS_VERSION.tar.gz
 


### PR DESCRIPTION
May need to make sure `curl` is installed?

Fixes #1587.