### PR TITLE
[DataFrame] Added Implementations for equals, query, and some other operations

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -35,7 +35,7 @@ class DataFrame(object):
         assert(len(df) > 0)
 
         self._df = df
-        self._update_lengths()
+        self._gths()
         self.columns = columns
 
         # this _index object is a pd.DataFrame
@@ -55,7 +55,7 @@ class DataFrame(object):
         """Get the index for this DataFrame.
 
         Returns:
-            The union of all indexes across the partitions.
+            The union  all indexes across the partitions.
         """
         return self._index.index
 
@@ -84,6 +84,8 @@ class DataFrame(object):
     index = property(_get_index, _set_index)
 
     def _update_lengths(self):
+        """Updates the stored lengths of DataFrame partions
+        """
         self._lengths = [_deploy_func.remote(_get_lengths, d)
                          for d in self._df]
 
@@ -208,6 +210,8 @@ class DataFrame(object):
         return DataFrame(new_df, self.columns, index=index)
 
     def _update_inplace(self, new_dfs):
+        """Updates the current DataFrame inplace
+        """
         assert(len(new_dfs) > 0)
 
         self._df = new_dfs
@@ -625,6 +629,12 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def equals(self, other):
+        """
+        Checks if other DataFrame is elementwise equal to the current one
+
+        Returns:
+            Boolean: True if equal, otherwise False
+        """
         def helper(df, index, other_series):
             return df.iloc[index['index_within_partition']].equals(other_series)
 
@@ -1154,6 +1164,11 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def query(self, expr, inplace=False, **kwargs):
+        """Queries the Dataframe with a boolean expression
+
+        Returns:
+            A new DataFrame if inplace=False
+        """
         new_dfs = [_deploy_func.remote(lambda df: df.query(expr, **kwargs),
                                        part) for part in self._df]
 
@@ -1726,6 +1741,11 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __abs__(self):
+        """Creates a modified DataFrame by elementwise taking the absolute value
+
+        Returns:
+            A modified DataFrame
+        """
         return self.abs()
 
     def __round__(self, decimals=0):
@@ -1805,9 +1825,19 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __eq__(self, other):
+        """Computes the equality of this DataFrame with another
+
+        Returns:
+            True, if the DataFrames are equal. False otherwise.
+        """
         return self.equals(other)
 
     def __ne__(self, other):
+        """Checks that this DataFrame is not equal to another
+
+        Returns:
+            True, if the DataFrames are not equal. False otherwise.
+        """
         return not self.equals(other)
 
     def __add__(self, other):
@@ -1835,6 +1865,11 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __neg__(self):
+        """Computes an element wise negative DataFrame
+
+        Returns:
+            A modified DataFrame where every element is the negation of before
+        """
         for t in self.dtypes:
             if not (is_bool_dtype(t)
                     or is_numeric_dtype(t)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1805,10 +1805,10 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __eq__(self, other):
-        raise NotImplementedError("Not Yet implemented.")
+        return self.equals(other)
 
     def __ne__(self, other):
-        raise NotImplementedError("Not Yet implemented.")
+        return not self.equals(other)
 
     def __add__(self, other):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -35,7 +35,7 @@ class DataFrame(object):
         assert(len(df) > 0)
 
         self._df = df
-        self._update_lengths()
+        self._compute_lengths()
         self.columns = columns
 
         # this _index object is a pd.DataFrame
@@ -83,7 +83,7 @@ class DataFrame(object):
 
     index = property(_get_index, _set_index)
 
-    def _update_lengths(self):
+    def _compute_lengths(self):
         """Updates the stored lengths of DataFrame partions
         """
         self._lengths = [_deploy_func.remote(_get_lengths, d)
@@ -209,13 +209,19 @@ class DataFrame(object):
 
         return DataFrame(new_df, self.columns, index=index)
 
-    def _update_inplace(self, new_dfs):
+    def _update_inplace(self, df=None, columns=None, index=None):
         """Updates the current DataFrame inplace
         """
-        assert(len(new_dfs) > 0)
+        assert(len(df) > 0)
 
-        self._df = new_dfs
-        self._update_lengths()
+        if df:
+            self._df = df
+        if columns:
+            self.columns = columns
+        if index:
+            self.index = index
+
+        self._compute_lengths()
         self._index = self._default_index()
 
     def add_prefix(self, prefix):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1669,7 +1669,12 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __iter__(self):
-        raise NotImplementedError("Not Yet implemented.")
+        """Iterate over the columns
+
+        Returns:
+            An Iterator over the columns of the dataframe.
+        """
+        return iter(self.columns)
 
     def __contains__(self, key):
         return key in self.columns
@@ -1681,7 +1686,7 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __abs__(self):
-        raise NotImplementedError("Not Yet implemented.")
+        return self.abs()
 
     def __round__(self, decimals=0):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -9,6 +9,10 @@ from pandas.core.index import _ensure_index_from_sequences
 from pandas._libs import lib
 from pandas.core.dtypes.cast import maybe_upcast_putmask
 from pandas.compat import lzip
+from pandas.core.dtypes.common import (
+    is_bool_dtype,
+    is_numeric_dtype,
+    is_timedelta64_dtype)
 
 import warnings
 import numpy as np
@@ -1795,7 +1799,14 @@ class DataFrame(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def __neg__(self):
-        raise NotImplementedError("Not Yet implemented.")
+        for t in self.dtypes:
+            if not (is_bool_dtype(t)
+                    or is_numeric_dtype(t)
+                    or is_timedelta64_dtype(t)):
+                raise TypeError("Unary negative expects numeric dtype, not {}"
+                                .format(t))
+
+        return self._map_partitions(lambda df: df.__neg__())
 
     def __floordiv__(self, other):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -189,6 +189,7 @@ def test_int_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___neg__(ray_df, pandas_df)
     test___iter__(ray_df, pandas_df)
     test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
@@ -287,6 +288,7 @@ def test_float_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___neg__(ray_df, pandas_df)
     test___iter__(ray_df, pandas_df)
     test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
@@ -383,6 +385,10 @@ def test_mixed_dtype_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+
+    with pytest.raises(TypeError):
+        test___neg__(ray_df, pandas_df)
+
     test___iter__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
@@ -477,6 +483,7 @@ def test_nan_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___neg__(ray_df, pandas_df)
     test___iter__(ray_df, pandas_df)
     test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
@@ -1893,11 +1900,10 @@ def test___unicode__():
         ray_df.__unicode__()
 
 
-def test___neg__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__neg__()
+@pytest.fixture
+def test___neg__(ray_df, pd_df):
+    ray_df_neg = ray_df.__neg__()
+    assert pd_df.__neg__().equals(rdf.to_pandas(ray_df_neg))
 
 
 def test___invert__():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -1322,10 +1322,33 @@ def test_quantile():
 
 
 def test_query():
-    ray_df = create_test_dataframe()
+    def generate_data():
+        pandas_df = pd.DataFrame({'a': [0, 1, 2, 3],
+                                  'b': [8, 9, 1, 11],
+                                  'c': [4, 3, 2, 1]})
+        ray_df = rdf.from_pandas(pandas_df, 2)
 
-    with pytest.raises(NotImplementedError):
-        ray_df.query(None)
+        return pandas_df, ray_df
+
+    funcs = ['a < b', 'a > b', 'a == c', '(a > c) and (a < b)']
+
+    pandas_df, ray_df = generate_data()
+    pandas_df.query(funcs[0], inplace=True)
+    ray_df.query(funcs[0], inplace=True)
+    pandas_df.equals(rdf.to_pandas(ray_df))
+
+    pandas_df, ray_df = generate_data()
+    pandas_df.query(funcs[1], inplace=True)
+    ray_df.query(funcs[1], inplace=True)
+    pandas_df.equals(rdf.to_pandas(ray_df))
+
+    pandas_df, ray_df = generate_data()
+    pandas_df_2, ray_df_2 = pandas_df.query(funcs[2]), ray_df.query(funcs[2])
+    pandas_df_2.equals(rdf.to_pandas(ray_df_2))
+
+    pandas_df, ray_df = generate_data()
+    pandas_df_3, ray_df_3 = pandas_df.query(funcs[3]), ray_df.query(funcs[3])
+    pandas_df_3.equals(rdf.to_pandas(ray_df_3))
 
 
 def test_radd():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -843,10 +843,19 @@ def test_eq():
 
 
 def test_equals():
-    ray_df = create_test_dataframe()
+    pandas_df1 = pd.DataFrame({'col1': [2.9, 3, 3, 3],
+                              'col2': [2, 3, 4, 1]})
+    ray_df1 = rdf.from_pandas(pandas_df1, 2)
+    ray_df2 = rdf.from_pandas(pandas_df1, 3)
 
-    with pytest.raises(NotImplementedError):
-        ray_df.equals(None)
+    assert ray_df1.equals(ray_df2)
+
+    pandas_df2 = pd.DataFrame({'col1': [2.9, 3, 3, 3],
+                              'col2': [2, 3, 5, 1]})
+    ray_df3 = rdf.from_pandas(pandas_df2, 4)
+
+    assert not ray_df3.equals(ray_df1)
+    assert not ray_df3.equals(ray_df2)
 
 
 def test_eval():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -189,6 +189,8 @@ def test_int_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___iter__(ray_df, pandas_df)
+    test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
@@ -285,6 +287,8 @@ def test_float_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___iter__(ray_df, pandas_df)
+    test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
@@ -370,6 +374,7 @@ def test_mixed_dtype_dataframe():
 
     with pytest.raises(TypeError):
         test_abs(ray_df, pandas_df)
+        test___abs__(ray_df, pandas_df)
 
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
@@ -378,6 +383,7 @@ def test_mixed_dtype_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___iter__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
@@ -471,6 +477,8 @@ def test_nan_dataframe():
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
     test___getitem__(ray_df, pandas_df)
+    test___iter__(ray_df, pandas_df)
+    test___abs__(ray_df, pandas_df)
     test___delitem__(ray_df, pandas_df)
     test___copy__(ray_df, pandas_df)
     test___deepcopy__(ray_df, pandas_df)
@@ -1906,11 +1914,16 @@ def test___hash__():
         ray_df.__hash__()
 
 
-def test___iter__():
-    ray_df = create_test_dataframe()
+@pytest.fixture
+def test___iter__(ray_df, pd_df):
+    ray_iterator = ray_df.__iter__()
 
-    with pytest.raises(NotImplementedError):
-        ray_df.__iter__()
+    # Check that ray_iterator implements the iterator interface
+    assert hasattr(ray_iterator, '__iter__')
+    assert hasattr(ray_iterator, 'next') or hasattr(ray_iterator, '__next__')
+
+    pd_iterator = pd_df.__iter__()
+    assert list(ray_iterator) == list(pd_iterator)
 
 
 @pytest.fixture
@@ -1933,11 +1946,9 @@ def test___bool__():
         ray_df.__bool__()
 
 
-def test___abs__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__abs__()
+@pytest.fixture
+def test___abs__(ray_df, pandas_df):
+    assert(ray_df_equals_pandas(abs(ray_df), abs(pandas_df)))
 
 
 def test___round__():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -160,6 +160,9 @@ def test_int_dataframe():
                  lambda x: x,
                  lambda x: False]
 
+    query_funcs = ['col1 < col2', 'col3 > col4', 'col1 == col2',
+                   '(col2 > col1) and (col1 < col3)']
+
     keys = ['col1',
             'col2',
             'col3',
@@ -185,6 +188,7 @@ def test_int_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
@@ -259,6 +263,9 @@ def test_float_dataframe():
                  lambda x: x,
                  lambda x: False]
 
+    query_funcs = ['col1 < col2', 'col3 > col4', 'col1 == col2',
+                   '(col2 > col1) and (col1 < col3)']
+
     keys = ['col1',
             'col2',
             'col3',
@@ -284,6 +291,7 @@ def test_float_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
@@ -352,6 +360,9 @@ def test_mixed_dtype_dataframe():
                  lambda x: x,
                  lambda x: False]
 
+    query_funcs = ['col1 < col2', 'col1 == col2',
+                   '(col2 > col1) and (col1 < col3)']
+
     keys = ['col1',
             'col2',
             'col3',
@@ -381,6 +392,7 @@ def test_mixed_dtype_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
@@ -454,6 +466,9 @@ def test_nan_dataframe():
                  lambda x: x,
                  lambda x: False]
 
+    query_funcs = ['col1 < col2', 'col3 > col4', 'col1 == col2',
+                   '(col2 > col1) and (col1 < col3)']
+
     keys = ['col1',
             'col2',
             'col3',
@@ -479,6 +494,7 @@ def test_nan_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_all(ray_df, pandas_df)
     test_any(ray_df, pandas_df)
@@ -1330,34 +1346,12 @@ def test_quantile():
         ray_df.quantile()
 
 
-def test_query():
-    def generate_data():
-        pandas_df = pd.DataFrame({'a': [0, 1, 2, 3],
-                                  'b': [8, 9, 1, 11],
-                                  'c': [4, 3, 2, 1]})
-        ray_df = rdf.from_pandas(pandas_df, 2)
+@pytest.fixture
+def test_query(ray_df, pandas_df, funcs):
 
-        return pandas_df, ray_df
-
-    funcs = ['a < b', 'a > b', 'a == c', '(a > c) and (a < b)']
-
-    pandas_df, ray_df = generate_data()
-    pandas_df.query(funcs[0], inplace=True)
-    ray_df.query(funcs[0], inplace=True)
-    pandas_df.equals(rdf.to_pandas(ray_df))
-
-    pandas_df, ray_df = generate_data()
-    pandas_df.query(funcs[1], inplace=True)
-    ray_df.query(funcs[1], inplace=True)
-    pandas_df.equals(rdf.to_pandas(ray_df))
-
-    pandas_df, ray_df = generate_data()
-    pandas_df_2, ray_df_2 = pandas_df.query(funcs[2]), ray_df.query(funcs[2])
-    pandas_df_2.equals(rdf.to_pandas(ray_df_2))
-
-    pandas_df, ray_df = generate_data()
-    pandas_df_3, ray_df_3 = pandas_df.query(funcs[3]), ray_df.query(funcs[3])
-    pandas_df_3.equals(rdf.to_pandas(ray_df_3))
+    for f in funcs:
+        pandas_df_new, ray_df_new = pandas_df.query(f), ray_df.query(f)
+        assert pandas_df_new.equals(rdf.to_pandas(ray_df_new))
 
 
 def test_radd():


### PR DESCRIPTION
## What do these changes do?

The APIs for these implementations conform to that of pandas, many of the other operators rely on mapped calls to pandas functions. 

This PR implements:

1. equals
2. query
3. __ iter__
4. __ abs__
5. __ eq__
6. __ ne__
7. __ neg__
