### PR TITLE
Allow setting INCLUDE_UI=0 to disable building the UI.

### DIFF
--- a/src/thirdparty/build_ui.sh
+++ b/src/thirdparty/build_ui.sh
@@ -16,6 +16,11 @@ CATAPULT_FILES=$TP_DIR/../../python/ray/core/src/catapult_files
 # This is where we will copy the files that need to be packaged with the wheels.
 mkdir -p $CATAPULT_FILES
 
+if [[ "$INCLUDE_UI" == "0" ]]; then
+  # Let installation continue without building the UI.
+  exit 0
+fi
+
 if ! type python2 > /dev/null; then
   echo "cannot properly set up UI without a python2 executable"
   if [[ "$INCLUDE_UI" == "1" ]]; then


### PR DESCRIPTION
This allows you to work around #1611 by building Ray without the UI via

```
cd ray/python
INCLUDE_UI=0 pip install -e . --verbose
```

It doesn't completely fix the problem in #1611, as I am running into another unicode error.