### PR TITLE
[Dataframes] Call ray.init() on ray.dataframe import

### DIFF
--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -28,6 +28,9 @@ __all__ = [
     "read_parquet"
 ]
 
-if threading.current_thread().name == "MainThread":
-    import ray
-    ray.init()
+try:
+    if threading.current_thread().name == "MainThread":
+        import ray
+        ray.init()
+except AssertionError:
+    pass

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import threading
 
 DEFAULT_NPARTITIONS = 10
 
@@ -26,3 +27,7 @@ __all__ = [
     "DataFrame", "from_pandas", "to_pandas", "Series", "read_csv",
     "read_parquet"
 ]
+
+if threading.current_thread().name == "MainThread":
+    import ray
+    ray.init()

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -145,7 +145,6 @@ def create_test_dataframe():
 
 
 def test_int_dataframe():
-    ray.init()
 
     pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
                               'col2': [4, 5, 6, 7],

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import pytest
 import numpy as np
 import pandas as pd
-import ray
 import ray.dataframe as rdf
 
 

--- a/python/ray/dataframe/test/test_io.py
+++ b/python/ray/dataframe/test/test_io.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import pytest
 import numpy as np
 import pandas as pd
-import ray
 import ray.dataframe as rdf
 import ray.dataframe.io as io
 import os
@@ -58,7 +57,6 @@ def teardown_csv_file():
 
 
 def test_from_parquet_small():
-    ray.init()
 
     setup_parquet_file(SMALL_ROW_SIZE)
 

--- a/python/ray/dataframe/test/test_series.py
+++ b/python/ray/dataframe/test/test_series.py
@@ -4,9 +4,6 @@ from __future__ import print_function
 
 import pytest
 import ray.dataframe as rdf
-import ray
-
-ray.init()
 
 
 @pytest.fixture


### PR DESCRIPTION
Ensure ray is initialized when dataframes are imported.

The behavior here is interesting because the dataframe import is sent to all the workers. We need to ensure that the init is only run on the main thread.