### PR TITLE
'buffer' and 'file' are undefined names in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq clang-format-3.8
       install: []
+      before_script:
+        - pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       script:
         - .travis/check-git-clang-format-output.sh
         # Try generating Sphinx documentation. To do this, we need to install


### PR DESCRIPTION
__cloudpickle.py__ refers to:
* __buffer__ which was removed from Python 3 in favor of [memoryview](https://docs.python.org/2/c-api/buffer.html)
* __file__ which was removed from Python 3 in favor of [open](http://python-future.org/compatible_idioms.html#file)

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
