### PR TITLE
Implement the Subscribe call for the new GCS API

### DIFF
--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -152,7 +152,7 @@ TEST_F(TestGcsWithAsio, TestTaskTable) {
   TestTaskTable(job_id_, client_);
 }
 
-void objectTableSubscribed(gcs::AsyncGcsClient *client,
+void ObjectTableSubscribed(gcs::AsyncGcsClient *client,
                            const UniqueID &id,
                            std::shared_ptr<ObjectTableDataT> data) {
   aeStop(loop);
@@ -162,7 +162,7 @@ void TestSubscribeAll(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   // Subscribe to all object table notifications. The registered callback for
   // notifications will check whether the object below is added.
   RAY_CHECK_OK(client_.object_table().Subscribe(
-      job_id_, ClientID::nil(), &Lookup, &objectTableSubscribed));
+      job_id_, ClientID::nil(), &Lookup, &ObjectTableSubscribed));
   // Run the event loop. The loop will only stop if the subscription succeeds.
   test->Start();
 

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -145,4 +145,30 @@ TEST_F(TestGcsWithAsio, TestTaskTable) {
   TestTaskTable(job_id_, client_);
 }
 
+void objectTableSubscribed(gcs::AsyncGcsClient *client,
+                           const UniqueID &id,
+                           std::shared_ptr<ObjectTableDataT> data) {
+  aeStop(loop);
+}
+
+TEST_F(TestGcs, TestSubscribeAll) {
+  loop = aeCreateEventLoop(1024);
+  RAY_CHECK_OK(client_.context()->AttachToEventLoop(loop));
+  // Subscribe to all object table notifications.
+  RAY_CHECK_OK(client_.object_table().Subscribe(
+      job_id_, ClientID::nil(), &Lookup, &objectTableSubscribed));
+  aeMain(loop);
+
+  // We have subscribed. Add an object table entry and make sure the registered
+  // subscription callback gets called.
+  auto data = std::make_shared<ObjectTableDataT>();
+  data->managers.push_back("A");
+  data->managers.push_back("B");
+  ObjectID object_id = ObjectID::from_random();
+  RAY_CHECK_OK(
+      client_.object_table().Add(job_id_, object_id, data, &ObjectAdded));
+  aeMain(loop);
+  aeDeleteEventLoop(loop);
+}
+
 }  // namespace

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -155,14 +155,14 @@ TEST_F(TestGcsWithAsio, TestTaskTable) {
 void ObjectTableSubscribed(gcs::AsyncGcsClient *client,
                            const UniqueID &id,
                            std::shared_ptr<ObjectTableDataT> data) {
-  aeStop(loop);
+  test->Stop();
 }
 
 void TestSubscribeAll(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   // Subscribe to all object table notifications. The registered callback for
   // notifications will check whether the object below is added.
-  RAY_CHECK_OK(client_.object_table().Subscribe(
-      job_id_, ClientID::nil(), &Lookup, &ObjectTableSubscribed));
+  RAY_CHECK_OK(client.object_table().Subscribe(
+      job_id, ClientID::nil(), &Lookup, &ObjectTableSubscribed));
   // Run the event loop. The loop will only stop if the subscription succeeds.
   test->Start();
 
@@ -172,7 +172,7 @@ void TestSubscribeAll(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   data->managers.push_back("B");
   ObjectID object_id = ObjectID::from_random();
   RAY_CHECK_OK(
-      client_.object_table().Add(job_id_, object_id, data, &ObjectAdded));
+      client.object_table().Add(job_id, object_id, data, &ObjectAdded));
   // Run the event loop. The loop will only stop if the registered subscription
   // callback is called (or an assertion failure).
   test->Start();

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -161,8 +161,8 @@ void ObjectTableSubscribed(gcs::AsyncGcsClient *client,
 void TestSubscribeAll(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   // Subscribe to all object table notifications. The registered callback for
   // notifications will check whether the object below is added.
-  RAY_CHECK_OK(client.object_table().Subscribe(
-      job_id, ClientID::nil(), &Lookup, &ObjectTableSubscribed));
+  RAY_CHECK_OK(client.object_table().Subscribe(job_id, ClientID::nil(), &Lookup,
+                                               &ObjectTableSubscribed));
   // Run the event loop. The loop will only stop if the subscription succeeds.
   test->Start();
 

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -65,6 +65,7 @@ void ObjectAdded(gcs::AsyncGcsClient *client,
 void Lookup(gcs::AsyncGcsClient *client,
             const UniqueID &id,
             std::shared_ptr<ObjectTableDataT> data) {
+  // Check that the object entry was added.
   ASSERT_EQ(data->managers, std::vector<std::string>({"A", "B"}));
   test->Stop();
 }
@@ -77,6 +78,8 @@ void TestObjectTable(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   RAY_CHECK_OK(
       client.object_table().Add(job_id, object_id, data, &ObjectAdded));
   RAY_CHECK_OK(client.object_table().Lookup(job_id, object_id, &Lookup));
+  // Run the event loop. The loop will only stop if the Lookup callback is
+  // called (or an assertion failure).
   test->Start();
 }
 
@@ -130,8 +133,12 @@ void TestTaskTable(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
   update->test_scheduler_id = local_scheduler_id.binary();
   update->test_state_bitmask = SchedulingState_SCHEDULED;
   update->update_state = SchedulingState_LOST;
+  // After test-and-setting, the callback will lookup the current state of the
+  // task.
   RAY_CHECK_OK(client.task_table().TestAndUpdate(job_id, task_id, update,
                                                  &TaskUpdateCallback));
+  // Run the event loop. The loop will only stop if the lookup after the
+  // test-and-set succeeds (or an assertion failure).
   test->Start();
 }
 
@@ -151,24 +158,34 @@ void objectTableSubscribed(gcs::AsyncGcsClient *client,
   aeStop(loop);
 }
 
-TEST_F(TestGcs, TestSubscribeAll) {
-  loop = aeCreateEventLoop(1024);
-  RAY_CHECK_OK(client_.context()->AttachToEventLoop(loop));
-  // Subscribe to all object table notifications.
+void TestSubscribeAll(const UniqueID &job_id, gcs::AsyncGcsClient &client) {
+  // Subscribe to all object table notifications. The registered callback for
+  // notifications will check whether the object below is added.
   RAY_CHECK_OK(client_.object_table().Subscribe(
       job_id_, ClientID::nil(), &Lookup, &objectTableSubscribed));
-  aeMain(loop);
+  // Run the event loop. The loop will only stop if the subscription succeeds.
+  test->Start();
 
-  // We have subscribed. Add an object table entry and make sure the registered
-  // subscription callback gets called.
+  // We have subscribed. Add an object table entry.
   auto data = std::make_shared<ObjectTableDataT>();
   data->managers.push_back("A");
   data->managers.push_back("B");
   ObjectID object_id = ObjectID::from_random();
   RAY_CHECK_OK(
       client_.object_table().Add(job_id_, object_id, data, &ObjectAdded));
-  aeMain(loop);
-  aeDeleteEventLoop(loop);
+  // Run the event loop. The loop will only stop if the registered subscription
+  // callback is called (or an assertion failure).
+  test->Start();
+}
+
+TEST_F(TestGcsWithAe, TestSubscribeAll) {
+  test = this;
+  TestSubscribeAll(job_id_, client_);
+}
+
+TEST_F(TestGcsWithAsio, TestSubscribeAll) {
+  test = this;
+  TestSubscribeAll(job_id_, client_);
 }
 
 }  // namespace

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -4,6 +4,15 @@ enum Language:int {
   JAVA = 2
 }
 
+// The channel that Add operations to the Table should be published on, if any.
+enum TablePubsub:int {
+  NO_PUBLISH = 0,
+  TASK,
+  CLIENT,
+  OBJECT,
+  ACTOR
+}
+
 table FunctionTableData {
   language: Language;
   name: string;

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -28,6 +28,9 @@ void GlobalRedisCallback(void *c, void *r, void *privdata) {
   if (reply->type == REDIS_REPLY_NIL) {
   } else if (reply->type == REDIS_REPLY_STRING) {
     data = std::string(reply->str, reply->len);
+  } else if (reply->type == REDIS_REPLY_ARRAY) {
+    reply = reply->element[reply->elements - 1];
+    data = std::string(reply->str, reply->len);
   } else if (reply->type == REDIS_REPLY_STATUS) {
   } else if (reply->type == REDIS_REPLY_ERROR) {
     RAY_LOG(ERROR) << "Redis error " << reply->str;
@@ -36,6 +39,42 @@ void GlobalRedisCallback(void *c, void *r, void *privdata) {
                    << " and with string " << reply->str;
   }
   RedisCallbackManager::instance().get(callback_index)(data);
+  // Delete the callback.
+  RedisCallbackManager::instance().remove(callback_index);
+}
+
+void SubscribeRedisCallback(void *c, void *r, void *privdata) {
+  if (r == NULL) {
+    return;
+  }
+  int64_t callback_index = reinterpret_cast<int64_t>(privdata);
+  redisReply *reply = reinterpret_cast<redisReply *>(r);
+  std::string data = "";
+  if (reply->type == REDIS_REPLY_ARRAY) {
+    // Parse the message.
+    redisReply *message_type = reply->element[0];
+    if (strcmp(message_type->str, "subscribe") == 0) {
+      // If the message is for the initial subscription call, do not fill in
+      // data.
+    } else if (strcmp(message_type->str, "message") == 0) {
+      // If the message is from a PUBLISH, make sure the data is nonempty.
+      redisReply *message = reply->element[reply->elements - 1];
+      data = std::string(message->str, message->len);
+      RAY_CHECK(!data.empty()) << "Empty message received on subscribe channel";
+    } else {
+      RAY_LOG(FATAL) << "Fatal redis error during subscribe"
+                     << message_type->str;
+    }
+
+    // NOTE(swang): We do not delete the callback after calling it since there
+    // may be more subscription messages.
+    RedisCallbackManager::instance().get(callback_index)(data);
+  } else if (reply->type == REDIS_REPLY_ERROR) {
+    RAY_LOG(ERROR) << "Redis error " << reply->str;
+  } else {
+    RAY_LOG(FATAL) << "Fatal redis error of type " << reply->type
+                   << " and with string " << reply->str;
+  }
 }
 
 int64_t RedisCallbackManager::add(const RedisCallback &function) {
@@ -49,6 +88,10 @@ RedisCallbackManager::RedisCallback &RedisCallbackManager::get(
   return *callbacks_[callback_index];
 }
 
+void RedisCallbackManager::remove(int64_t callback_index) {
+  callbacks_.erase(callback_index);
+}
+
 #define REDIS_CHECK_ERROR(CONTEXT, REPLY)                     \
   if (REPLY == nullptr || REPLY->type == REDIS_REPLY_ERROR) { \
     return Status::RedisError(CONTEXT->errstr);               \
@@ -60,6 +103,9 @@ RedisContext::~RedisContext() {
   }
   if (async_context_) {
     redisAsyncFree(async_context_);
+  }
+  if (subscribe_context_) {
+    redisAsyncFree(subscribe_context_);
   }
 }
 
@@ -95,11 +141,18 @@ Status RedisContext::Connect(const std::string &address, int port) {
     RAY_LOG(FATAL) << "Could not establish connection to redis " << address
                    << ":" << port;
   }
+  // Connect to subscribe context
+  subscribe_context_ = redisAsyncConnect(address.c_str(), port);
+  if (subscribe_context_ == nullptr || subscribe_context_->err) {
+    RAY_LOG(FATAL) << "Could not establish subscribe connection to redis "
+                   << address << ":" << port;
+  }
   return Status::OK();
 }
 
 Status RedisContext::AttachToEventLoop(aeEventLoop *loop) {
-  if (redisAeAttach(loop, async_context_) != REDIS_OK) {
+  if (redisAeAttach(loop, async_context_) != REDIS_OK ||
+      redisAeAttach(loop, subscribe_context_) != REDIS_OK) {
     return Status::RedisError("could not attach redis event loop");
   } else {
     return Status::OK();
@@ -110,27 +163,60 @@ Status RedisContext::RunAsync(const std::string &command,
                               const UniqueID &id,
                               uint8_t *data,
                               int64_t length,
+                              const TablePubsub pubsub_channel,
                               int64_t callback_index) {
   if (length > 0) {
-    std::string redis_command = command + " %b %b";
+    std::string redis_command = command + " %d %b %b";
     int status = redisAsyncCommand(
         async_context_,
         reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
         reinterpret_cast<void *>(callback_index), redis_command.c_str(),
-        id.data(), id.size(), data, length);
+        pubsub_channel, id.data(), id.size(), data, length);
     if (status == REDIS_ERR) {
       return Status::RedisError(std::string(async_context_->errstr));
     }
   } else {
-    std::string redis_command = command + " %b";
+    std::string redis_command = command + " %d %b";
     int status = redisAsyncCommand(
         async_context_,
         reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
         reinterpret_cast<void *>(callback_index), redis_command.c_str(),
-        id.data(), id.size());
+        pubsub_channel, id.data(), id.size());
     if (status == REDIS_ERR) {
       return Status::RedisError(std::string(async_context_->errstr));
     }
+  }
+  return Status::OK();
+}
+
+Status RedisContext::SubscribeAsync(const ClientID &client_id,
+                                    const TablePubsub pubsub_channel,
+                                    int64_t callback_index) {
+  RAY_CHECK(pubsub_channel != TablePubsub_NO_PUBLISH)
+      << "Client requested subscribe on a table that does not support pubsub";
+
+  int status = 0;
+  if (client_id.is_nil()) {
+    // Subscribe to all messages.
+    std::string redis_command = "SUBSCRIBE %d";
+    status = redisAsyncCommand(
+        subscribe_context_,
+        reinterpret_cast<redisCallbackFn *>(&SubscribeRedisCallback),
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(),
+        pubsub_channel);
+  } else {
+    // Subscribe only to messages sent to this client.
+    // TODO(swang): Nobody sends on this channel yet.
+    std::string redis_command = "SUBSCRIBE %d:%b";
+    status = redisAsyncCommand(
+        subscribe_context_,
+        reinterpret_cast<redisCallbackFn *>(&SubscribeRedisCallback),
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(),
+        pubsub_channel, client_id.data(), client_id.size());
+  }
+
+  if (status == REDIS_ERR) {
+    return Status::RedisError(std::string(subscribe_context_->errstr));
   }
   return Status::OK();
 }

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -9,6 +9,8 @@
 #include "ray/status.h"
 #include "ray/util/logging.h"
 
+#include "ray/gcs/format/gcs_generated.h"
+
 struct redisContext;
 struct redisAsyncContext;
 struct aeEventLoop;
@@ -30,6 +32,9 @@ class RedisCallbackManager {
 
   RedisCallback &get(int64_t callback_index);
 
+  /// Remove a callback.
+  void remove(int64_t callback_index);
+
  private:
   RedisCallbackManager() : num_callbacks(0){};
 
@@ -49,12 +54,17 @@ class RedisContext {
                   const UniqueID &id,
                   uint8_t *data,
                   int64_t length,
+                  const TablePubsub pubsub_channel,
                   int64_t callback_index);
+  Status SubscribeAsync(const ClientID &client_id,
+                        const TablePubsub pubsub_channel,
+                        int64_t callback_index);
   redisAsyncContext *async_context() { return async_context_; }
 
  private:
   redisContext *context_;
   redisAsyncContext *async_context_;
+  redisAsyncContext *subscribe_context_;
 };
 
 }  // namespace gcs

--- a/src/ray/id.h
+++ b/src/ray/id.h
@@ -55,7 +55,9 @@ typedef UniqueID ActorID;
 typedef UniqueID ActorHandleID;
 typedef UniqueID WorkerID;
 typedef UniqueID DriverID;
+// TODO(swang): Replace this with ClientID.
 typedef UniqueID DBClientID;
+typedef UniqueID ClientID;
 typedef UniqueID ConfigID;
 
 }  // namespace ray


### PR DESCRIPTION
## What do these changes do?

This implements `Subscribe` for the new GCS. The client has the option to subscribe to all `Add` operations, or only to `Add` operations for a particular client. On the server, if an `Add` operation is made to a table with a registered pubsub channel, then a `PUBLISH` message with the added data will be sent to all clients. This does not yet send publications to a particular client (e.g., for requested object notifications).