### PR TITLE
Reduce size of Docker containers

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,14 +1,30 @@
-# The deploy Docker image build a self-contained Ray instance suitable
-# for end users.
+# The base-deps Docker image installs main libraries needed to run Ray
 
 FROM ubuntu:xenial
 RUN apt-get update \
-    && apt-get install -y vim git wget \
-    && apt-get install -y cmake pkg-config build-essential autoconf curl libtool unzip flex bison
-RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
-    && wget --quiet 'https://repo.continuum.io/archive/Anaconda2-4.2.0-Linux-x86_64.sh' -O /tmp/anaconda.sh \
+    && apt-get install -y \
+        git \
+        wget \
+        cmake \
+        pkg-config \
+        build-essential \
+        autoconf \
+        curl \
+        libtool \
+        unzip \
+        flex \
+        bison \
+    && apt-get clean \
+    && echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
+    && wget \
+        --quiet 'https://repo.continuum.io/archive/Anaconda2-4.2.0-Linux-x86_64.sh' \
+        -O /tmp/anaconda.sh \
     && /bin/bash /tmp/anaconda.sh -b -p /opt/conda \
-    && rm /tmp/anaconda.sh
+    && rm /tmp/anaconda.sh \
+    && /opt/conda/bin/conda install -y \
+        libgcc \
+    && /opt/conda/bin/conda clean -y --all \
+    && /opt/conda/bin/pip install \
+        flatbuffers
+
 ENV PATH "/opt/conda/bin:$PATH"
-RUN conda install -y libgcc
-RUN pip install flatbuffers


### PR DESCRIPTION
## What do these changes do?

Hello,

Thank you for this excellent project!

I've been reading through this repo trying to familiarize myself with the project, and saw something I may be able to help with. In this PR, I propose a few changes to the Dockerfiles in this repo to reduce container size and build time.

This PR reduces the size of `base-deps` by about 70 MB.

*Proposals related to build time / size:*

- chaining together run commands
    - less build layers --> smaller image
- removing `vim` from the dependencies
    - Users who want to run `vim` in the container to mess with files are welcome to add it in their own spin-off dockerfiles, but I believe the project should make the published container used to run Ray as small as possible

*Proposals related to style and administration:*

- Putting dependency installation (e.g. with `apt-get`) on one line makes the `git blame` more usable and the Dockerfile more human-readable

*Testing*

I can confirm I was able to build the `deploy` and `examples` containers.

To test, I built the `base-deps` container as follows and then changed the `deploy` container to look at `ray_new_deps` (which it found locally):

```
docker build -t ray_deps_new -f Dockerfile .
```

I built `deploy` and `examples` using `install-docker.sh` at the repo root.

*Future PR*

I also want to propose removing `git` from these containers (since it isn't used in the build process, AFAICT), but didn't want to put that in this PR since it would involve changing some of the example documentation. If you are open to that change, I will make it in a follow-up PR.

Thank you for your consideration,

-James

## Related issue number

This does not relate to any open issues.
