### PR TITLE
[DataFrame] Update groupby and add shuffle with Actors

### DIFF
--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import pandas as pd
 import threading
 
+<<<<<<< HEAD
 pd_version = pd.__version__
 pd_major = int(pd_version.split(".")[0])
 pd_minor = int(pd_version.split(".")[1])

--- a/python/ray/dataframe/__init__.py
+++ b/python/ray/dataframe/__init__.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import pandas as pd
 import threading
 
-<<<<<<< HEAD
 pd_version = pd.__version__
 pd_major = int(pd_version.split(".")[0])
 pd_minor = int(pd_version.split(".")[1])

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -25,7 +25,8 @@ from .utils import (
     _local_groupby,
     _deploy_func,
     _compute_length_and_index,
-    _prepend_partitions)
+    _prepend_partitions,
+    assign_partitions)
 from .shuffle import ShuffleActor
 from .groupby import DataFrameGroupBy
 
@@ -303,26 +304,6 @@ class DataFrame(object):
         Returns:
             A new DataFrame resulting from the groupby.
         """
-        @ray.remote
-        def assign_partitions(index_df, num_partitions):
-            uniques = index_df.index.unique()
-
-            if len(uniques) % num_partitions == 0:
-                chunksize = int(len(uniques) / num_partitions)
-            else:
-                chunksize = int(len(uniques) / num_partitions) + 1
-
-            assignments = []
-
-            while len(uniques) > chunksize:
-                temp_df = uniques[:chunksize]
-                assignments.append(temp_df)
-                uniques = uniques[chunksize:]
-            else:
-                assignments.append(uniques)
-
-            return assignments
-
         if by is None:
             raise TypeError("You have to supply one of 'by' and 'level'")
         elif axis != 0 and axis != 1:
@@ -330,7 +311,8 @@ class DataFrame(object):
         elif not as_index and axis == 1 or axis == 'columns':
             raise ValueError("as_index=False only valid for axis=0")
 
-        # The easy one. Everything for columns can be handled by the partitions.
+        # The easy one. Everything for columns can be handled by the
+        # partitions.
         if axis == 1 or axis == 'columns':
             if sort:
                 new_cols = sorted(self.columns)
@@ -400,10 +382,10 @@ class DataFrame(object):
             The sum of the DataFrame.
         """
         if axis == 1:
-            return self._map_partitions(lambda df: df.sum(axis=axis,
-                                                          skipna=skipna,
-                                                          level=level,
-                                                          numeric_only=numeric_only))
+            return self._map_partitions(
+                lambda df: df.sum(axis=axis, skipna=skipna, level=level,
+                                  numeric_only=numeric_only))
+
         elif axis == 0 or axis is None:
             return self.T.sum(axis=1, skipna=skipna, level=level,
                               numeric_only=numeric_only)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -332,7 +332,8 @@ class DataFrame(object):
         [shufflers[i].shuffle.remote(self._index[self._index['partition'] == i],
                                      partition_assignments, i, *shufflers)
          for i in range(len(shufflers))]
-
+        import time
+        time.sleep(2)
         return DataFrameGroupBy([shuffler.apply_func.remote(
             lambda df: df.groupby(by=df.index,
                                   axis=axis,

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -21,8 +21,6 @@ import itertools
 from .utils import (
     _get_lengths,
     to_pandas,
-    _shuffle,
-    _local_groupby,
     _deploy_func,
     _compute_length_and_index,
     _prepend_partitions,

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -318,7 +318,7 @@ class DataFrame(object):
                 new_cols = sorted(self.columns)
             else:
                 new_cols = self.columns
-            return DataFrameGroupBy([self._map_partitions(
+            return DataFrameGroupBy(self._map_partitions(
                 lambda df: df.groupby(by=by,
                                       axis=axis,
                                       level=level,
@@ -326,7 +326,7 @@ class DataFrame(object):
                                       sort=sort,
                                       group_keys=group_keys,
                                       squeeze=squeeze,
-                                      **kwargs))._df],
+                                      **kwargs))._df,
                                     new_cols, self.index)
 
         # Begin groupby for rows. Requires shuffle.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -13,11 +13,11 @@ from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_numeric_dtype,
     is_timedelta64_dtype)
-
 import warnings
 import numpy as np
 import ray
 import itertools
+
 from .utils import (
     _get_lengths,
     to_pandas,
@@ -26,6 +26,7 @@ from .utils import (
     _deploy_func,
     _compute_length_and_index,
     _prepend_partitions)
+from .shuffle import ShuffleActor
 
 
 class DataFrame(object):
@@ -301,23 +302,51 @@ class DataFrame(object):
             A new DataFrame resulting from the groupby.
         """
 
-        indices = self.index.unique()
+        @ray.remote
+        def assign_partitions(index_df, num_partitions):
+            chunksize = int(len(index_df) / num_partitions) + 1
 
-        chunksize = int(len(indices) / len(self._df))
-        partitions = [_shuffle.remote(df, indices, chunksize)
-                      for df in self._df]
-        partitions = ray.get(partitions)
+            assignments = []
 
-        # Transpose the list of dataframes
-        # TODO find a better way
-        shuffle = []
-        for i in range(len(partitions[0])):
-            shuffle.append([])
-            for j in range(len(partitions)):
-                shuffle[i].append(partitions[j][i])
-        new_dfs = [_local_groupby.remote(part, axis=axis) for part in shuffle]
+            while len(index_df) > chunksize:
+                temp_df = index_df[:chunksize]
+                assignments.append(temp_df)
+                index_df = index_df[chunksize:]
+            else:
+                assignments.append(index_df)
 
-        return DataFrame(new_dfs, self.columns, index=indices)
+            return assignments
+
+        partition_assignments = ray.get(assign_partitions.remote(self._index,
+                                                         len(self._df)))
+        print(partition_assignments)
+        shufflers = [ShuffleActor.remote(self._df[i])
+                     for i in range(len(self._df))]
+
+        print(shufflers)
+
+        shuffled = [shufflers[i].shuffle.remote(partition_assignments, i, *shufflers)
+                    for i in range(len(shufflers))]
+
+        print(shuffled)
+        return shufflers
+        # indices = self.index.unique()
+        #
+        # chunksize = int(len(indices) / len(self._df))
+        # partitions = [_shuffle.remote(df, indices, chunksize)
+        #               for df in self._df]
+        # partitions = ray.get(partitions)
+        #
+        # # Transpose the list of dataframes
+        # # TODO find a better way
+        # shuffle = []
+        # for i in range(len(partitions[0])):
+        #     shuffle.append([])
+        #     for j in range(len(partitions)):
+        #         shuffle[i].append(partitions[j][i])
+        # new_dfs = [_local_groupby.remote(part, axis=axis) for part in shuffle]
+        #
+        # return DataFrame(new_dfs, self.columns, index=indices)
 
     def reduce_by_index(self, func, axis=0):
         """Perform a reduction based on the row index.

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -373,6 +373,8 @@ class DataFrame(object):
         else:
             new_index = self.index
 
+        # TODO Remove once the actor joining is merged:
+        # https://github.com/ray-project/ray/pull/1536
         import time
         time.sleep(2)
         return DataFrameGroupBy([shuffler.apply_func.remote(

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -25,7 +25,9 @@ class DataFrameGroupBy(object):
         from .dataframe import _deploy_func
 
         assert(callable(func))
-        new_df = [_deploy_func.remote(func, part) for part in self._partitions]
+        new_df = [_deploy_func.remote(lambda df: df.apply(func), part)
+                  for part in self._partitions]
+
         if index is None:
             index = self._index
 

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -182,7 +182,7 @@ class DataFrameGroupBy(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def sum(self, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        self._map_partitions(lambda df: df.sum())
 
     def __unicode__(self):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -7,8 +7,29 @@ import pandas as pd
 
 class DataFrameGroupBy(object):
 
-    def __init__(self, partitions):
+    def __init__(self, partitions, columns, index):
         self._partitions = partitions
+        self._columns = columns
+        self._index = index
+
+    def _map_partitions(self, func, index=None):
+        """Apply a function on each partition.
+
+        Args:
+            func (callable): The function to Apply.
+
+        Returns:
+            A new DataFrame containing the result of the function.
+        """
+        from .dataframe import DataFrame
+        from .dataframe import _deploy_func
+
+        assert(callable(func))
+        new_df = [_deploy_func.remote(func, part) for part in self._partitions]
+        if index is None:
+            index = self._index
+
+        return DataFrame(new_df, self._columns, index=index)
 
     @property
     def ngroups(self):
@@ -84,7 +105,7 @@ class DataFrameGroupBy(object):
         raise NotImplementedError("Not Yet implemented.")
 
     def apply(self, func, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        return self._map_partitions(func)
 
     def rolling(self, *args, **kwargs):
         raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -1,0 +1,242 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pandas as pd
+
+
+class DataFrameGroupBy(object):
+
+    def __init__(self, partitions):
+        self._partitions = partitions
+
+    @property
+    def ngroups(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def skew(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def ffill(self, limit=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def sem(self, ddof=1):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def mean(self, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def any(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def plot(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def ohlc(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def __bytes__(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def tshift(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def groups(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def min(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def idxmax(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def ndim(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def shift(self, periods=1, freq=None, axis=0):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def nth(self, n, dropna=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def cumsum(self, axis=0, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def indices(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def pct_change(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def filter(self, func, dropna=True, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def cummax(self, axis=0, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def apply(self, func, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def rolling(self, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def dtypes(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def first(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def backfill(self, limit=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def __getitem__(self, key):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def cummin(self, axis=0, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def bfill(self, limit=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def idxmin(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def prod(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def std(self, ddof=1, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def aggregate(self, arg, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def last(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def mad(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def rank(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def corrwith(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def pad(self, limit=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def max(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def var(self, ddof=1, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def get_group(self, name, obj=None):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def __len__(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def all(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def size(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def sum(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def __unicode__(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def describe(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def boxplot(grouped, subplots=True, column=None, fontsize=None, rot=0, grid=True, ax=None, figsize=None,
+                layout=None, **kwds):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def ngroup(self, ascending=True):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def nunique(self, dropna=True):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def resample(self, rule, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def median(self, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def head(self, n=5):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def cumprod(self, axis=0, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def __iter__(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def agg(self, arg, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def cov(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def transform(self, func, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def corr(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def fillna(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def count(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def pipe(self, func, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def cumcount(self, ascending=True):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def tail(self, n=5):
+        raise NotImplementedError("Not Yet implemented.")
+
+    def expanding(self, *args, **kwargs):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def hist(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def quantile(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def diff(self):
+        raise NotImplementedError("Not Yet implemented.")
+
+    @property
+    def take(self):
+        raise NotImplementedError("Not Yet implemented.")

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pandas as pd
-
 
 class DataFrameGroupBy(object):
 
@@ -190,8 +188,8 @@ class DataFrameGroupBy(object):
     def describe(self, **kwargs):
         raise NotImplementedError("Not Yet implemented.")
 
-    def boxplot(grouped, subplots=True, column=None, fontsize=None, rot=0, grid=True, ax=None, figsize=None,
-                layout=None, **kwds):
+    def boxplot(grouped, subplots=True, column=None, fontsize=None, rot=0,
+                grid=True, ax=None, figsize=None, layout=None, **kwds):
         raise NotImplementedError("Not Yet implemented.")
 
     def ngroup(self, ascending=True):

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -15,28 +15,37 @@ class ShuffleActor(object):
         self.partition_data = partition_data
         self.index_of_self = None
 
-    def shuffle(self, partition_assignments, index_of_self, *list_of_partitions):
+    def shuffle(self, index, partition_assignments, index_of_self, *list_of_partitions):
         assert(len(partition_assignments) == len(list(list_of_partitions)))
         self.index_of_self = index_of_self
-        self.assign_and_send_data(partition_assignments, list(list_of_partitions))
+        self.assign_and_send_data(index, partition_assignments, list(list_of_partitions))
 
-    def assign_and_send_data(self, partition_assignments, list_of_partitions):
+    def assign_and_send_data(self, index, partition_assignments, list_of_partitions):
         num_partitions = len(partition_assignments)
 
         for i in range(num_partitions):
             if i == self.index_of_self:
                 continue
-
-            data_to_send = \
-                self.partition_data[partition_assignments[i][partition_assignments[i]['partition'] == self.index_of_self]['index_within_partition']]
-            self.partition_data.drop(
-                data_to_send)
-            list_of_partitions[i].add_to_incoming.remote(data_to_send)
+            try:
+                indices_to_send = [idx
+                                   for idx in partition_assignments[i]
+                                   if idx in index.index]
+                data_to_send = \
+                    self.partition_data.loc[index.loc[indices_to_send]['index_within_partition']]
+                # raise ValueError(str(data_to_send))
+                self.partition_data.drop(data_to_send.index)
+                list_of_partitions[i].add_to_incoming.remote(data_to_send)
+            except KeyError:
+                pass
 
     def add_to_incoming(self, data):
         self.incoming.append(data)
 
-    def groupby(self):
+    def apply_func(self, func, *args):
         self.incoming.append(self.partition_data)
         data = pd.concat(self.incoming)
-        return data.groupby(by=data.index)
+
+        if len(args) == 0:
+            return func(data)
+        else:
+            return func(data, *args)

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -22,7 +22,7 @@ class ShuffleActor(object):
 
     def assign_and_send_data(self, index, partition_assignments, list_of_partitions):
         num_partitions = len(partition_assignments)
-
+        self.partition_data.index = index.index
         for i in range(num_partitions):
             if i == self.index_of_self:
                 continue
@@ -31,9 +31,11 @@ class ShuffleActor(object):
                                    for idx in partition_assignments[i]
                                    if idx in index.index]
                 data_to_send = \
-                    self.partition_data.loc[index.loc[indices_to_send]['index_within_partition']]
-                # raise ValueError(str(data_to_send))
-                self.partition_data.drop(data_to_send.index)
+                    self.partition_data.loc[indices_to_send]
+
+                # raise ValueError(str(self.partition_data))
+                self.partition_data = \
+                    self.partition_data.drop(data_to_send.index)
                 list_of_partitions[i].add_to_incoming.remote(data_to_send)
             except KeyError:
                 pass

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -23,6 +23,7 @@ class ShuffleActor(object):
     def assign_and_send_data(self, index, partition_assignments, list_of_partitions):
         num_partitions = len(partition_assignments)
         self.partition_data.index = index.index
+
         for i in range(num_partitions):
             if i == self.index_of_self:
                 continue

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -17,7 +17,9 @@ class ShuffleActor(object):
 
     def shuffle(self, index, partition_assignments, index_of_self, *list_of_partitions):
         self.index_of_self = index_of_self
-        self.assign_and_send_data(index, partition_assignments, list(list_of_partitions))
+        return self.assign_and_send_data(index,
+                                         partition_assignments,
+                                         list(list_of_partitions))
 
     def assign_and_send_data(self, index, partition_assignments, list_of_partitions):
 
@@ -52,6 +54,9 @@ class ShuffleActor(object):
                     self.partition_data.drop(indices_to_send[i])
             except KeyError:
                 pass
+
+        # Returning here to guarantee scheduling consistency.
+        return None
 
     def add_to_incoming(self, data):
         self.incoming.append(data)

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pandas as pd
+import ray
+from multiprocessing.pool import ThreadPool
+
+
+@ray.remote(num_cpus=2)
+class ShuffleActor(object):
+
+    def __init__(self, partition_data):
+        self.incoming = []
+        self.partition_data = partition_data
+        self.index_of_self = None
+
+    def shuffle(self, partition_assignments, index_of_self, *list_of_partitions):
+        assert(len(partition_assignments) == len(list(list_of_partitions)))
+        self.index_of_self = index_of_self
+        self.assign_and_send_data(partition_assignments, list(list_of_partitions))
+
+    def assign_and_send_data(self, partition_assignments, list_of_partitions):
+        num_partitions = len(partition_assignments)
+
+        for i in range(num_partitions):
+            if i == self.index_of_self:
+                continue
+
+            data_to_send = \
+                self.partition_data[partition_assignments[i][partition_assignments[i]['partition'] == self.index_of_self]['index_within_partition']]
+            self.partition_data.drop(
+                data_to_send)
+            list_of_partitions[i].add_to_incoming.remote(data_to_send)
+
+    def add_to_incoming(self, data):
+        self.incoming.append(data)
+
+    def groupby(self):
+        self.incoming.append(self.partition_data)
+        data = pd.concat(self.incoming)
+        return data.groupby(by=data.index)

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -15,20 +15,54 @@ class ShuffleActor(object):
         self.partition_data = partition_data
         self.index_of_self = None
 
-    def shuffle(self, index, partition_assignments, index_of_self, *list_of_partitions):
+    def shuffle(self, index, partition_assignments, index_of_self,
+                *list_of_partitions):
+        """Shuffle the data between ShuffleActors given partition assignments.
+
+        Args:
+
+            index: The pd.Index object being used to shuffle the data.
+            partition_assignments: A pd.DataFrame object of assignments.
+            index_of_self: The integer index of this ShuffleActor in the
+                list_of_partitions object.
+            list_of_partitions: The list of all ShuffleActor objects being
+                used.
+
+        Returns:
+            A value to be used with ray.get() to ensure proper scheduling
+            order.
+        """
         self.index_of_self = index_of_self
         return self.assign_and_send_data(index,
                                          partition_assignments,
                                          list(list_of_partitions))
 
-    def assign_and_send_data(self, index, partition_assignments, list_of_partitions):
+    def assign_and_send_data(self, index, partition_assignments,
+                             list_of_partitions):
+        """Sends data to the necessary ShuffleActors based on assignments.
+
+        Args:
+            index:
+            partition_assignments:
+            list_of_partitions:
+
+        Returns:
+             A value to be used with ray.get() to ensure proper scheduling
+             order.
+        """
 
         def calc_send(i, indices_to_send, data_to_send):
+            """Separates the data to send into 
+
+            :param i:
+            :param indices_to_send:
+            :param data_to_send:
+            :return:
+            """
             indices_to_send[i] = [idx
                                   for idx in partition_assignments[i]
                                   if idx in index.index]
-            data_to_send[i] = \
-                self.partition_data.loc[indices_to_send[i]]
+            data_to_send[i] = self.partition_data.loc[indices_to_send[i]]
 
         num_partitions = len(partition_assignments)
         self.partition_data.index = index.index
@@ -36,7 +70,8 @@ class ShuffleActor(object):
         indices_to_send = [None] * num_partitions
         data_to_send = [None] * num_partitions
 
-        threads = [Thread(target=calc_send, args=(i, indices_to_send, data_to_send))
+        threads = [Thread(target=calc_send, args=(i, indices_to_send,
+                                                  data_to_send))
                    for i in range(num_partitions)]
         for t in threads:
             t.start()
@@ -48,10 +83,10 @@ class ShuffleActor(object):
             if i == self.index_of_self:
                 continue
             try:
-                list_of_partitions[i].add_to_incoming.remote((self.index_of_self, data_to_send[i]))
+                list_of_partitions[i].add_to_incoming.remote((
+                    self.index_of_self, data_to_send[i]))
 
-                self.partition_data = \
-                    self.partition_data.drop(indices_to_send[i])
+                self.partition_data.drop(indices_to_send[i], inplace=True)
             except KeyError:
                 pass
 

--- a/python/ray/dataframe/shuffle.py
+++ b/python/ray/dataframe/shuffle.py
@@ -10,10 +10,11 @@ from threading import Thread
 @ray.remote(num_cpus=2)
 class ShuffleActor(object):
 
-    def __init__(self, partition_data):
+    def __init__(self, partition_data, axis=1):
         self.incoming = []
         self.partition_data = partition_data
         self.index_of_self = None
+        self.axis = axis
 
     def shuffle(self, index, partition_assignments, index_of_self,
                 *list_of_partitions):
@@ -22,7 +23,7 @@ class ShuffleActor(object):
         Args:
 
             index: The pd.Index object being used to shuffle the data.
-            partition_assignments: A pd.DataFrame object of assignments.
+            partition_assignments: A list of pd.Index objects of assignments.
             index_of_self: The integer index of this ShuffleActor in the
                 list_of_partitions object.
             list_of_partitions: The list of all ShuffleActor objects being
@@ -52,24 +53,28 @@ class ShuffleActor(object):
         """
 
         def calc_send(i, indices_to_send, data_to_send):
-            """Separates the data to send into 
+            """Separates the data to send into a list based on assignments.
 
-            :param i:
-            :param indices_to_send:
-            :param data_to_send:
-            :return:
+            Args:
+                i: The index within the list of Threads generated.
+                indices_to_send: The indices containing data to send.
+                data_to_send: An empty list to fill with the destination data
+                    for a given index (i).
             """
+
             indices_to_send[i] = [idx
                                   for idx in partition_assignments[i]
                                   if idx in index.index]
             data_to_send[i] = self.partition_data.loc[indices_to_send[i]]
 
         num_partitions = len(partition_assignments)
+        # Reindexing here to properly drop the data.
         self.partition_data.index = index.index
 
         indices_to_send = [None] * num_partitions
         data_to_send = [None] * num_partitions
 
+        # Fill the above two lists with relevant data.
         threads = [Thread(target=calc_send, args=(i, indices_to_send,
                                                   data_to_send))
                    for i in range(num_partitions)]
@@ -85,7 +90,7 @@ class ShuffleActor(object):
             try:
                 list_of_partitions[i].add_to_incoming.remote((
                     self.index_of_self, data_to_send[i]))
-
+                # Drop the data once it's been sent.
                 self.partition_data.drop(indices_to_send[i], inplace=True)
             except KeyError:
                 pass
@@ -97,10 +102,27 @@ class ShuffleActor(object):
         self.incoming.append(data)
 
     def apply_func(self, func, *args):
+        """Perform some post-processing on the result of the shuffle.
+
+        Note: This function guarantees the order of data is preserved as it was
+        sent i.e. Data sent from partition 0 will come before partition 1..n,
+        etc.
+
+        Args:
+            func: A function to perform on the data.
+            args: The args to the function
+
+        Returns:
+            The result of the function on the data.
+        """
         self.incoming.append((self.index_of_self, self.partition_data))
+        # x[0] in the lambda is the partition index, which was sent in the call
+        # to shuffle.
         self.incoming.sort(key=lambda x: x[0])
+        # After we drop the partition indices we use pd.concat with the axis
+        # provided in the constructor.
         self.incoming = [x[1] for x in self.incoming]
-        data = pd.concat(self.incoming, axis=1)
+        data = pd.concat(self.incoming, axis=self.axis)
 
         if len(args) == 0:
             return func(data)

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -80,47 +80,6 @@ def to_pandas(df):
 
 
 @ray.remote
-def _shuffle(df, indices, chunksize):
-    """Shuffle data by sending it through the Ray Store.
-
-    Args:
-        df (pd.DataFrame): The pandas DataFrame to shuffle.
-        indices ([any]): The list of indices for the DataFrame.
-        chunksize (int): The number of indices to send.
-
-    Returns:
-        The list of pd.DataFrame objects in order of their assignment. This
-        order is important because it determines which task will get the data.
-    """
-    i = 0
-    partition = []
-    while len(indices) > chunksize:
-        oids = df.reindex(indices[:chunksize])
-        partition.append(oids)
-        indices = indices[chunksize:]
-        i += 1
-    else:
-        oids = df.reindex(indices)
-        partition.append(oids)
-    return partition
-
-
-@ray.remote
-def _local_groupby(df_rows, axis=0):
-    """Apply a groupby on this partition for the blocks sent to it.
-
-    Args:
-        df_rows ([pd.DataFrame]): A list of dataframes for this partition. Goes
-            through the Ray object store.
-
-    Returns:
-        A DataFrameGroupBy object from the resulting groupby.
-    """
-    concat_df = pd.concat(df_rows, axis=axis)
-    return concat_df.groupby(concat_df.index)
-
-
-@ray.remote
 def _deploy_func(func, dataframe, *args):
     """Deploys a function for the _map_partitions call.
 

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -162,3 +162,24 @@ def _prepend_partitions(last_vals, index, partition, func):
     appended_df = last_vals[:index].append(partition)
     cum_df = func(appended_df)
     return cum_df[index:]
+
+
+@ray.remote
+def assign_partitions(index_df, num_partitions):
+    uniques = index_df.index.unique()
+
+    if len(uniques) % num_partitions == 0:
+        chunksize = int(len(uniques) / num_partitions)
+    else:
+        chunksize = int(len(uniques) / num_partitions) + 1
+
+    assignments = []
+
+    while len(uniques) > chunksize:
+        temp_df = uniques[:chunksize]
+        assignments.append(temp_df)
+        uniques = uniques[chunksize:]
+    else:
+        assignments.append(uniques)
+
+    return assignments

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -39,7 +39,8 @@ def from_pandas(df, npartitions=None, chunksize=None):
     from .dataframe import DataFrame
 
     if npartitions is not None:
-        chunksize = int(len(df) / npartitions)
+        chunksize = len(df) // npartitions if len(df) % npartitions == 0 \
+            else len(df) // npartitions + 1
     elif chunksize is None:
         raise ValueError("The number of partitions or chunksize must be set.")
 


### PR DESCRIPTION
The current groupby/shuffle does not scale well. This at least allows it to scale. The performance of groupby is not yet good, but this is at least correct and gives us a good checkpoint to go back to in the case that things go wrong with the optimizations.

@robertnishihara and I sketched out a way to do this without Actors, and it will probably be superior but it takes an addition to the ray API. I would prefer to do it without Actors.