### PR TITLE
Add external module as a node scaler.

### DIFF
--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -157,7 +157,25 @@ with GPU worker nodes instead.
             MarketType: spot
         InstanceType: p2.xlarge
 
+
+External Node Provider
+--------------------------
+
+Ray also supports external node providers (check `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`__ implementation).
+You can specify the external node provider using the yaml config:
+
+.. code-block:: yaml
+
+    provider:
+        type: external
+        module: mypackage.myclass
+
 Additional Cloud providers
 --------------------------
 
 To use Ray autoscaling on other Cloud providers or cluster management systems, you can implement the ``NodeProvider`` interface (~100 LOC) and register it in `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`__. Contributions are welcome!
+
+"provider"] = {
+            "type": "external",
+            "module": "does-not-exist",
+            }

--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -174,8 +174,3 @@ Additional Cloud providers
 --------------------------
 
 To use Ray autoscaling on other Cloud providers or cluster management systems, you can implement the ``NodeProvider`` interface (~100 LOC) and register it in `node_provider.py <https://github.com/ray-project/ray/tree/master/python/ray/autoscaler/node_provider.py>`__. Contributions are welcome!
-
-"provider"] = {
-            "type": "external",
-            "module": "does-not-exist",
-            }

--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -170,6 +170,8 @@ You can specify the external node provider using the yaml config:
         type: external
         module: mypackage.myclass
 
+The module needs to be in the format `package.provider_class` or `package.sub_package.provider_class`.
+
 Additional Cloud providers
 --------------------------
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -55,7 +55,7 @@ CLUSTER_CONFIG_SCHEMA = {
         "type": (str, REQUIRED),  # e.g. aws
         "region": (str, OPTIONAL),  # e.g. us-east-1
         "availability_zone": (str, OPTIONAL),  # e.g. us-east-1a
-        "module": (str, OPTIONAL),  # e.g. module to import
+        "module": (str, OPTIONAL),  # module, if using external node provider
     }, REQUIRED),
 
     # How Ray will authenticate with newly launched nodes.

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -53,8 +53,9 @@ CLUSTER_CONFIG_SCHEMA = {
     # Cloud-provider specific configuration.
     "provider": ({
         "type": (str, REQUIRED),  # e.g. aws
-        "region": (str, REQUIRED),  # e.g. us-east-1
-        "availability_zone": (str, REQUIRED),  # e.g. us-east-1a
+        "region": (str, OPTIONAL),  # e.g. us-east-1
+        "availability_zone": (str, OPTIONAL),  # e.g. us-east-1a
+        "module": (str, OPTIONAL),  # e.g. module to import and use as scaler implementation
     }, REQUIRED),
 
     # How Ray will authenticate with newly launched nodes.

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -55,7 +55,7 @@ CLUSTER_CONFIG_SCHEMA = {
         "type": (str, REQUIRED),  # e.g. aws
         "region": (str, OPTIONAL),  # e.g. us-east-1
         "availability_zone": (str, OPTIONAL),  # e.g. us-east-1a
-        "module": (str, OPTIONAL),  # e.g. module to import and use as scaler implementation
+        "module": (str, OPTIONAL),  # e.g. module to import
     }, REQUIRED),
 
     # How Ray will authenticate with newly launched nodes.

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -49,10 +49,9 @@ def load_class(path):
     class_data = path.split(".")
     module_path = ".".join(class_data[:-1])
     class_str = class_data[-1]
-    module = importlib.import_module(module_path)
-    print(module)
     print(module_path)
     print(class_str)
+    module = importlib.import_module(module_path)
 
     return getattr(module, class_str)
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -39,11 +39,22 @@ DEFAULT_CONFIGS = {
 }
 
 
+def load_class(path):
+    """
+    Load a class at runtime given a full path.
+
+    Example of the path: mypkg.mysubpkg.myclass
+    """
+    class_data = path.split(".")
+    module_path = ".".join(class_data[:-1])
+    class_str = class_data[-1]
+    module = importlib.import_module(module_path)
+    return getattr(module, class_str)
+
+
 def get_node_provider(provider_config, cluster_name):
     if provider_config["type"] == "external":
-        provider_cls = importlib.import_module(
-            name=provider_config["module"]
-            )
+        provider_cls = load_class(path=provider_config["module"])
         return provider_cls(provider_config, cluster_name)
 
     importer = NODE_PROVIDERS.get(provider_config["type"])

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -45,14 +45,19 @@ def load_class(path):
 
     Example of the path: mypkg.mysubpkg.myclass
     """
+    print(path)
     class_data = path.split(".")
     module_path = ".".join(class_data[:-1])
     class_str = class_data[-1]
     module = importlib.import_module(module_path)
+    print(module)
+    print(module_path)
+    print(class_str)
     return getattr(module, class_str)
 
 
 def get_node_provider(provider_config, cluster_name):
+    print(provider_config)
     if provider_config["type"] == "external":
         provider_cls = load_class(path=provider_config["module"])
         return provider_cls(provider_config, cluster_name)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -45,20 +45,18 @@ def load_class(path):
 
     Example of the path: mypkg.mysubpkg.myclass
     """
-    print(path)
     class_data = path.split(".")
     if len(class_data) < 2:
-        raise ValueError("You need to pass a valid path: mymodule.provider_class")
+        raise ValueError(
+            "You need to pass a valid path like mymodule.provider_class"
+            )
     module_path = ".".join(class_data[:-1])
     class_str = class_data[-1]
-    print(module_path)
-    print(class_str)
     module = importlib.import_module(module_path)
     return getattr(module, class_str)
 
 
 def get_node_provider(provider_config, cluster_name):
-    print(provider_config)
     if provider_config["type"] == "external":
         provider_cls = load_class(path=provider_config["module"])
         return provider_cls(provider_config, cluster_name)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -47,12 +47,13 @@ def load_class(path):
     """
     print(path)
     class_data = path.split(".")
+    if len(class_data) < 2:
+        raise ValueError("You need to pass a valid path: mymodule.provider_class")
     module_path = ".".join(class_data[:-1])
     class_str = class_data[-1]
     print(module_path)
     print(class_str)
     module = importlib.import_module(module_path)
-
     return getattr(module, class_str)
 
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import importlib
+import os
 import yaml
 
 
@@ -40,7 +40,7 @@ DEFAULT_CONFIGS = {
 
 
 def get_node_provider(provider_config, cluster_name):
-    if provider_config["type"] == 'external':
+    if provider_config["type"] == "external":
         provider_cls = importlib.import_module(name=provider_config["module"])
         return provider_cls(provider_config, cluster_name)
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -53,6 +53,7 @@ def load_class(path):
     print(module)
     print(module_path)
     print(class_str)
+
     return getattr(module, class_str)
 
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import importlib
 import yaml
 
 
@@ -25,6 +26,7 @@ NODE_PROVIDERS = {
     "kubernetes": None,
     "docker": None,
     "local_cluster": None,
+    "external": None,  # Import an external module
 }
 
 DEFAULT_CONFIGS = {
@@ -38,7 +40,12 @@ DEFAULT_CONFIGS = {
 
 
 def get_node_provider(provider_config, cluster_name):
+    if provider_config["type"] == 'external':
+        provider_cls = importlib.import_module(name=provider_config["module"])
+        return provider_cls(provider_config, cluster_name)
+
     importer = NODE_PROVIDERS.get(provider_config["type"])
+
     if importer is None:
         raise NotImplementedError(
             "Unsupported node provider: {}".format(provider_config["type"]))

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -41,7 +41,9 @@ DEFAULT_CONFIGS = {
 
 def get_node_provider(provider_config, cluster_name):
     if provider_config["type"] == "external":
-        provider_cls = importlib.import_module(name=provider_config["module"])
+        provider_cls = importlib.import_module(
+            name=provider_config["module"]
+            )
         return provider_cls(provider_config, cluster_name)
 
     importer = NODE_PROVIDERS.get(provider_config["type"])

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -519,7 +519,7 @@ class AutoscalingTest(unittest.TestCase):
     def testExternalNodeScaler(self):
         EXTERNAL_PROVIDER["provider"] = {
             "type": "external",
-            "path": "test.autoscaler_test.MockProvider",
+            "module": "test.autoscaler_test.MockProvider",
             },
         config_path = self.write_config(EXTERNAL_PROVIDER)
         self.provider = MockProvider()
@@ -531,12 +531,12 @@ class AutoscalingTest(unittest.TestCase):
     def testExternalNodeScalerWrongImport(self):
         EXTERNAL_PROVIDER["provider"] = {
             "type": "external",
-            "path": "does-not-exist",
+            "module": "does-not-exist",
             },
         invalid_provider = self.write_config(EXTERNAL_PROVIDER)
         self.provider = MockProvider()
         self.assertRaises(
-            ValueError,
+            ImportError,
             lambda: StandardAutoscaler(
                 invalid_provider, LoadMetrics(), update_interval_s=0))
 

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -511,10 +511,9 @@ class AutoscalingTest(unittest.TestCase):
         config = SMALL_CLUSTER.copy()
         config["provider"] = {
             "type": "external",
-            "module": "ray.test.autoscaler_test.MockProvider",
+            "module": "test.autoscaler_test.MockProvider",
             }
         config_path = self.write_config(config)
-        self.provider = MockProvider()
         autoscaler = StandardAutoscaler(
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
 
@@ -527,7 +526,6 @@ class AutoscalingTest(unittest.TestCase):
             "module": "does-not-exist",
             }
         invalid_provider = self.write_config(config)
-        self.provider = MockProvider()
         self.assertRaises(
             ImportError,
             lambda: StandardAutoscaler(

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -511,7 +511,7 @@ class AutoscalingTest(unittest.TestCase):
         config = SMALL_CLUSTER.copy()
         config["provider"] = {
             "type": "external",
-            "module": "test.autoscaler_test.MockProvider",
+            "module": "ray.test.autoscaler_test.MockProvider",
             }
         config_path = self.write_config(config)
         self.provider = MockProvider()

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -121,15 +121,6 @@ SMALL_CLUSTER = {
     "worker_start_ray_commands": ["start_ray_worker"],
 }
 
-EXTERNAL_PROVIDER = {
-    "cluster_name": "default",
-    "max_workers": 2,
-    "auth": {
-        "ssh_user": "ubuntu",
-        "ssh_private_key": "/dev/null",
-    },
-}
-
 
 class LoadMetricsTest(unittest.TestCase):
     def testUpdate(self):
@@ -517,11 +508,12 @@ class AutoscalingTest(unittest.TestCase):
         self.waitFor(lambda: len(runner.calls) > num_calls)
 
     def testExternalNodeScaler(self):
-        EXTERNAL_PROVIDER["provider"] = {
+        config = SMALL_CLUSTER.copy()
+        config["provider"] = {
             "type": "external",
             "module": "test.autoscaler_test.MockProvider",
-            },
-        config_path = self.write_config(EXTERNAL_PROVIDER)
+            }
+        config_path = self.write_config(config)
         self.provider = MockProvider()
         autoscaler = StandardAutoscaler(
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
@@ -529,11 +521,12 @@ class AutoscalingTest(unittest.TestCase):
         self.assertIsInstance(autoscaler.provider, MockProvider)
 
     def testExternalNodeScalerWrongImport(self):
-        EXTERNAL_PROVIDER["provider"] = {
+        config = SMALL_CLUSTER.copy()
+        config["provider"] = {
             "type": "external",
             "module": "does-not-exist",
-            },
-        invalid_provider = self.write_config(EXTERNAL_PROVIDER)
+            }
+        invalid_provider = self.write_config(config)
         self.provider = MockProvider()
         self.assertRaises(
             ImportError,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
These changes add the possibility to specify an external module as autoscaler.

```yaml
provider:
    type: external
    module: this.is.my.module
```

`module` will be loaded and used a nodescaler.

More about the origin of this PR [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ray-dev/uhtE5D05Q5s/jcLut7GeBgAJ).
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
