### PR TITLE
[DataFrame] Inherit documentation from Pandas

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -32,7 +32,8 @@ from .utils import (
     to_pandas,
     _blocks_to_col,
     _blocks_to_row,
-    _create_block_partitions)
+    _create_block_partitions,
+    _inherit_docstrings)
 from . import get_npartitions
 from .index_metadata import _IndexMetadata
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -37,6 +37,7 @@ from . import get_npartitions
 from .index_metadata import _IndexMetadata
 
 
+@_inherit_docstrings(pd.DataFrame)
 class DataFrame(object):
 
     def __init__(self, data=None, index=None, columns=None, dtype=None,

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -2,7 +2,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pandas.core.groupby
 
+from .utils import _inherit_docstrings
+
+
+@_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy)
 class DataFrameGroupBy(object):
 
     def __init__(self, partitions, columns, index):

--- a/python/ray/dataframe/series.py
+++ b/python/ray/dataframe/series.py
@@ -3,6 +3,9 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import pandas as pd
+
+from .utils import _inherit_docstrings
 
 
 def na_op():
@@ -11,6 +14,7 @@ def na_op():
     raise NotImplementedError("Not Yet implemented.")
 
 
+@_inherit_docstrings(pd.Series)
 class Series(object):
 
     def __init__(self, series_oids):

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3020,6 +3020,8 @@ def test__doc__():
     assert rdf.DataFrame.__doc__ != pd.DataFrame.__doc__
     assert rdf.DataFrame.__init__ != pd.DataFrame.__init__
     for attr, obj in rdf.DataFrame.__dict__.items():
-        if callable(obj) and hasattr(pd.DataFrame, attr) \
+        if (callable(obj) or isinstance(obj, property)) \
                 and attr != "__init__":
-            assert obj.__doc__ == getattr(pd.DataFrame, attr).__doc__
+            pd_obj = getattr(pd.DataFrame, attr, None)
+            if callable(pd_obj) or isinstance(pd_obj, property):
+                assert obj.__doc__ == pd_obj.__doc__

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3014,3 +3014,11 @@ def test_iloc(ray_df, pd_df):
     assert ray_df.iloc[1:, 0].equals(pd_df.iloc[1:, 0])
     assert ray_df.iloc[1:2, 0].equals(pd_df.iloc[1:2, 0])
     assert ray_df.iloc[1:2, 0:2].equals(pd_df.iloc[1:2, 0:2])
+
+def test__doc__():
+    assert rdf.DataFrame.__doc__ != pd.DataFrame.__doc__
+    assert rdf.DataFrame.__init__ != pd.DataFrame.__init__
+    for attr, obj in rdf.DataFrame.__dict__.items():
+        if callable(obj) and hasattr(pd.DataFrame, attr) \
+                and attr != "__init__":
+            assert obj.__doc__ == getattr(pd.DataFrame, attr).__doc__

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3015,6 +3015,7 @@ def test_iloc(ray_df, pd_df):
     assert ray_df.iloc[1:2, 0].equals(pd_df.iloc[1:2, 0])
     assert ray_df.iloc[1:2, 0:2].equals(pd_df.iloc[1:2, 0:2])
 
+
 def test__doc__():
     assert rdf.DataFrame.__doc__ != pd.DataFrame.__doc__
     assert rdf.DataFrame.__init__ != pd.DataFrame.__init__

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -247,8 +247,8 @@ def _blocks_to_row(*partition):
 def _inherit_docstrings(parent):
     """Creates a decorator which overwrites a decorated class' __doc__
     attribute with parent's __doc__ attribute. Also overwrites __doc__ of
-    methods defined in the class with the __doc__ of matching methods in
-    parent.
+    methods and properties defined in the class with the __doc__ of matching
+    methods in parent.
 
     Args:
         parent (object): Class from which the decorated class inherits __doc__.
@@ -261,15 +261,17 @@ def _inherit_docstrings(parent):
             __init__ method matches pandas.DataFrame's __init__ method.
 
     Returns:
-        function: decorator which replaces a decorated class' __doc__  with
-            parent's __doc__.
+        function: decorator which replaces the decorated class' documentation
+            parent's documentation.
     """
     def decorator(cls):
-        # cls.__doc = parent.__doc__
+        # cls.__doc__ = parent.__doc__
         for attr, obj in cls.__dict__.items():
-            if callable(obj) and hasattr(parent, attr) \
+            if (callable(obj) or isinstance(obj, property)) \
                     and attr != "__init__":
-                obj.__doc__ = getattr(parent, attr).__doc__
+                parent_obj = getattr(parent, attr, None)
+                if callable(parent_obj) or isinstance(parent_obj, property):
+                    obj.__doc__ = parent_obj.__doc__
         return cls
 
     return decorator

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -267,10 +267,9 @@ def _inherit_docstrings(parent):
     def decorator(cls):
         # cls.__doc__ = parent.__doc__
         for attr, obj in cls.__dict__.items():
-            if (callable(obj) or isinstance(obj, property)) \
-                    and attr != "__init__":
-                parent_obj = getattr(parent, attr, None)
-                if callable(parent_obj) or isinstance(parent_obj, property):
+            if callable(obj) and attr != "__init__":
+                parent_obj =getattr(parent, attr, None)
+                if callable(parent_obj):
                     obj.__doc__ = parent_obj.__doc__
         return cls
 

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -242,3 +242,33 @@ def _blocks_to_row(*partition):
     # columns), this change is needed to ensure correctness.
     row_part.columns = pd.RangeIndex(0, len(row_part.columns))
     return row_part
+
+
+def _inherit_docstrings(parent):
+    """Creates a decorator which overwrites a decorated class' __doc__
+    attribute with parent's __doc__ attribute. Also overwrites __doc__ of
+    methods defined in the class with the __doc__ of matching methods in parent.
+
+    Args:
+        parent (object): Class from which the decorated class inherits __doc__.
+
+    Note:
+        Currently does not override class' __doc__ or __init__'s __doc__.
+
+    Todo:
+        Override the class' __doc__ and __init__'s __doc__  once DataFrame's
+            __init__ method matches pandas.DataFrame's __init__ method.
+
+    Returns:
+        function: decorator which replaces a decorated class' __doc__  with
+            parent's __doc__.
+    """
+    def decorator(cls):
+        # cls.__doc = parent.__doc__
+        for attr, obj in cls.__dict__.items():
+            if callable(obj) and hasattr(parent, attr) \
+                    and attr != "__init__":
+                obj.__doc__ = getattr(parent, attr).__doc__
+        return cls
+
+    return decorator

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -267,10 +267,18 @@ def _inherit_docstrings(parent):
     def decorator(cls):
         # cls.__doc__ = parent.__doc__
         for attr, obj in cls.__dict__.items():
-            if callable(obj) and attr != "__init__":
-                parent_obj =getattr(parent, attr, None)
-                if callable(parent_obj):
-                    obj.__doc__ = parent_obj.__doc__
+            if attr == "__init__":
+                continue
+            parent_obj = getattr(parent, attr, None)
+            if not callable(parent_obj) and \
+                    not isinstance(parent_obj, property):
+                continue
+            if callable(obj):
+                obj.__doc__ = parent_obj.__doc__
+            elif isinstance(obj, property) and obj.fget is not None:
+                p = property(obj.fget, obj.fset, obj.fdel, parent_obj.__doc__)
+                setattr(cls, attr, p)
+
         return cls
 
     return decorator

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -247,7 +247,8 @@ def _blocks_to_row(*partition):
 def _inherit_docstrings(parent):
     """Creates a decorator which overwrites a decorated class' __doc__
     attribute with parent's __doc__ attribute. Also overwrites __doc__ of
-    methods defined in the class with the __doc__ of matching methods in parent.
+    methods defined in the class with the __doc__ of matching methods in
+    parent.
 
     Args:
         parent (object): Class from which the decorated class inherits __doc__.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Ray DataFrame class inherits documentation from identical methods present in the Pandas DataFrame class.

Note that Ray DataFrame does **not** inherit documentation for itself or `DataFrame.__init__`. Currently, these have different definitions. This will need to be changed once the `__init__` is the same for Ray and Pandas dataframes. 
