### PR TITLE
Speed up actor creation task submission by generating IDs with uuid.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -16,22 +16,12 @@ from ray.utils import (FunctionProperties, random_string, is_cython,
                        push_error_to_driver)
 
 
-def random_actor_id(current_task_id, actor_id_counter):
-    actor_id_hash = hashlib.sha1()
-    actor_id_hash.update(current_task_id)
-    actor_id_hash.update(str(actor_id_counter).encode("ascii"))
-    actor_id = actor_id_hash.digest()
-    assert len(actor_id) == 20
-    return ray.local_scheduler.ObjectID(actor_id)
+def random_actor_id():
+    return ray.local_scheduler.ObjectID(random_string())
 
 
-def random_actor_class_id(current_task_id, actor_class_counter):
-    class_id_hash = hashlib.sha1()
-    class_id_hash.update(current_task_id)
-    class_id_hash.update(str(actor_class_counter).encode("ascii"))
-    class_id = class_id_hash.digest()
-    assert len(class_id) == 20
-    return class_id
+def random_actor_class_id():
+    return random_string()
 
 
 def compute_actor_handle_id(actor_handle_id, num_forks):
@@ -747,7 +737,7 @@ def make_actor_handle_class(class_name):
 
 
 def actor_handle_from_class(Class, class_id, actor_creation_resources,
-                            checkpoint_interval, actor_method_cpus, worker):
+                            checkpoint_interval, actor_method_cpus):
     class_name = Class.__name__.encode("ascii")
     actor_handle_class = make_actor_handle_class(class_name)
     exported = []
@@ -760,10 +750,7 @@ def actor_handle_from_class(Class, class_id, actor_creation_resources,
                 raise Exception("Actors cannot be created before ray.init() "
                                 "has been called.")
 
-            actor_id = random_actor_id(worker.current_task_id.id(),
-                                       worker.actor_id_counter)
-            worker.actor_id_counter += 1
-
+            actor_id = random_actor_id()
             # The ID for this instance of ActorHandle. These should be unique
             # across instances with the same _ray_actor_id.
             actor_handle_id = ray.local_scheduler.ObjectID(
@@ -847,7 +834,7 @@ def actor_handle_from_class(Class, class_id, actor_creation_resources,
     return ActorHandle
 
 
-def make_actor(cls, resources, checkpoint_interval, actor_method_cpus, worker):
+def make_actor(cls, resources, checkpoint_interval, actor_method_cpus):
     if checkpoint_interval == 0:
         raise Exception("checkpoint_interval must be greater than 0.")
 
@@ -943,13 +930,10 @@ def make_actor(cls, resources, checkpoint_interval, actor_method_cpus, worker):
     Class.__module__ = cls.__module__
     Class.__name__ = cls.__name__
 
-    class_id = random_actor_class_id(worker.current_task_id.id(),
-                                     worker.actor_class_counter)
-    worker.actor_class_counter += 1
+    class_id = random_actor_class_id()
 
     return actor_handle_from_class(Class, class_id, resources,
-                                   checkpoint_interval, actor_method_cpus,
-                                   worker)
+                                   checkpoint_interval, actor_method_cpus)
 
 
 ray.worker.global_worker.fetch_and_register_actor = fetch_and_register_actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -7,21 +7,29 @@ import hashlib
 import inspect
 import json
 import traceback
+import uuid
 
 import ray.cloudpickle as pickle
 import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
-from ray.utils import (FunctionProperties, random_string, is_cython,
-                       push_error_to_driver)
+from ray.utils import FunctionProperties, is_cython, push_error_to_driver
 
 
 def random_actor_id():
-    return ray.local_scheduler.ObjectID(random_string())
+    actor_id_hash = hashlib.sha1()
+    actor_id_hash.update(uuid.uuid4().bytes)
+    actor_id = actor_id_hash.digest()
+    assert len(actor_id) == 20
+    return ray.local_scheduler.ObjectID(actor_id)
 
 
 def random_actor_class_id():
-    return random_string()
+    class_id_hash = hashlib.sha1()
+    class_id_hash.update(uuid.uuid4().bytes)
+    class_id = class_id_hash.digest()
+    assert len(class_id) == 20
+    return class_id
 
 
 def compute_actor_handle_id(actor_handle_id, num_forks):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -7,29 +7,13 @@ import hashlib
 import inspect
 import json
 import traceback
-import uuid
 
 import ray.cloudpickle as pickle
 import ray.local_scheduler
 import ray.signature as signature
 import ray.worker
-from ray.utils import FunctionProperties, is_cython, push_error_to_driver
-
-
-def random_actor_id():
-    actor_id_hash = hashlib.sha1()
-    actor_id_hash.update(uuid.uuid4().bytes)
-    actor_id = actor_id_hash.digest()
-    assert len(actor_id) == 20
-    return ray.local_scheduler.ObjectID(actor_id)
-
-
-def random_actor_class_id():
-    class_id_hash = hashlib.sha1()
-    class_id_hash.update(uuid.uuid4().bytes)
-    class_id = class_id_hash.digest()
-    assert len(class_id) == 20
-    return class_id
+from ray.utils import (FunctionProperties, _random_string, is_cython,
+                       push_error_to_driver)
 
 
 def compute_actor_handle_id(actor_handle_id, num_forks):
@@ -758,7 +742,7 @@ def actor_handle_from_class(Class, class_id, actor_creation_resources,
                 raise Exception("Actors cannot be created before ray.init() "
                                 "has been called.")
 
-            actor_id = random_actor_id()
+            actor_id = ray.local_scheduler.ObjectID(_random_string())
             # The ID for this instance of ActorHandle. These should be unique
             # across instances with the same _ray_actor_id.
             actor_handle_id = ray.local_scheduler.ObjectID(
@@ -938,7 +922,7 @@ def make_actor(cls, resources, checkpoint_interval, actor_method_cpus):
     Class.__module__ = cls.__module__
     Class.__name__ = cls.__name__
 
-    class_id = random_actor_class_id()
+    class_id = _random_string()
 
     return actor_handle_from_class(Class, class_id, resources,
                                    checkpoint_interval, actor_method_cpus)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -4,9 +4,11 @@ from __future__ import print_function
 
 import binascii
 import collections
+import hashlib
 import numpy as np
 import os
 import sys
+import uuid
 
 import ray.local_scheduler
 
@@ -15,7 +17,11 @@ DRIVER_ID_LENGTH = 20
 
 
 def _random_string():
-    return np.random.bytes(20)
+    id_hash = hashlib.sha1()
+    id_hash.update(uuid.uuid4().bytes)
+    id_bytes = id_hash.digest()
+    assert len(id_bytes) == 20
+    return id_bytes
 
 
 def format_error_message(exception_message, task_exception=False):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -236,13 +236,6 @@ class Worker(object):
         self.make_actor = None
         self.actors = {}
         self.actor_task_counter = 0
-        # The number of actor classes that have been defined so far by this
-        # worker during this task. This is used to generate unique actor class
-        # IDs.
-        self.actor_class_counter = 0
-        # The number of actors that have been defined so far by this worker
-        # during this task. This is used to generate unique actor IDs.
-        self.actor_id_counter = 0
         # A set of all of the actor class keys that have been imported by the
         # import thread. It is safe to convert this worker into an actor of
         # these types.
@@ -773,8 +766,6 @@ class Worker(object):
         self.current_function_id = task.function_id().id()
         self.task_index = 0
         self.put_index = 0
-        self.actor_class_counter = 0
-        self.actor_id_counter = 0
         function_id = task.function_id()
         args = task.arguments()
         return_object_ids = task.returns()
@@ -2562,7 +2553,7 @@ def remote(*args, **kwargs):
 
                 return worker.make_actor(func_or_class, resources,
                                          checkpoint_interval,
-                                         actor_method_cpus, worker)
+                                         actor_method_cpus)
             raise Exception("The @ray.remote decorator must be applied to "
                             "either a function or to a class.")
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -236,6 +236,13 @@ class Worker(object):
         self.make_actor = None
         self.actors = {}
         self.actor_task_counter = 0
+        # The number of actor classes that have been defined so far by this
+        # worker during this task. This is used to generate unique actor class
+        # IDs.
+        self.actor_class_counter = 0
+        # The number of actors that have been defined so far by this worker
+        # during this task. This is used to generate unique actor IDs.
+        self.actor_id_counter = 0
         # A set of all of the actor class keys that have been imported by the
         # import thread. It is safe to convert this worker into an actor of
         # these types.
@@ -766,6 +773,8 @@ class Worker(object):
         self.current_function_id = task.function_id().id()
         self.task_index = 0
         self.put_index = 0
+        self.actor_class_counter = 0
+        self.actor_id_counter = 0
         function_id = task.function_id()
         args = task.arguments()
         return_object_ids = task.returns()
@@ -2553,7 +2562,7 @@ def remote(*args, **kwargs):
 
                 return worker.make_actor(func_or_class, resources,
                                          checkpoint_interval,
-                                         actor_method_cpus)
+                                         actor_method_cpus, worker)
             raise Exception("The @ray.remote decorator must be applied to "
                             "either a function or to a class.")
 


### PR DESCRIPTION
This speeds up actor creation (just the submission part) by 10x. See the explanation in #1698.

```python
import ray
ray.init()

@ray.remote
class Foo(object):
    pass

Foo.remote()  # The first time is a bit slower since the actor is exported here.
%time Foo.remote()  # This changes from 6ms to 0.6ms
```

Fixes #1698.