### PR TITLE
Bump version to 0.4.0.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -61,7 +61,7 @@ from ray.actor import method  # noqa: E402
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 __all__ = ["error_info", "init", "connect", "disconnect", "get", "put", "wait",
            "remote", "log_event", "log_span", "flush_log", "actor", "method",

--- a/python/setup.py
+++ b/python/setup.py
@@ -114,7 +114,7 @@ class BinaryDistribution(Distribution):
 
 setup(name="ray",
       # The version string is also in __init__.py. TODO(pcm): Fix this.
-      version="0.3.1",
+      version="0.4.0",
       packages=find_packages(),
       cmdclass={"build_ext": build_ext},
       # The BinaryDistribution argument triggers build_ext.


### PR DESCRIPTION
Do not merge this yet.

**Release blockers before merging.**

- [x] Actor hanging issue #1734
- [x] Web UI issue #1741
- [x] Remove all the warnings that occur when a script exits like `Disconnecting client on fd 9`
- [x] Test scale
- [ ] Test fault tolerance
- [ ] Test tune
- [ ] Test rllib
- [ ] test Pandas on Ray
- [x] Tune documentation #1681 (Richard)
- [x] Fix resource bookkeeping when actors are blocked in `ray.get` (should be fixed by #1766)