### PR TITLE
[DataFrame] Implemented __getattr__

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2746,6 +2746,22 @@ class DataFrame(object):
             lambda df: df.__getitem__(key))
         return to_pandas(result_column_chunks)
 
+    def __getattr__(self, key):
+        """After regular attribute access, looks up the name in the columns
+
+        Args:
+            key (str): Attribute name.
+
+        Returns:
+            The value of the attribute.
+        """
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError as e:
+            if key in self.columns:
+                return self[key]
+            raise e
+
     def __setitem__(self, key, value):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -2742,6 +2742,23 @@ def test___getitem__(ray_df, pd_df):
     assert pd_col.equals(ray_col)
 
 
+def test___getattr__():
+    df = create_test_dataframe()
+
+    col = df.__getattr__("col1")
+    assert isinstance(col, pd.Series)
+
+    col = getattr(df, "col1")
+    assert isinstance(col, pd.Series)
+
+    col = df.col1
+    assert isinstance(col, pd.Series)
+
+    # Check that lookup in column doesn't override other attributes
+    df2 = df.rename(index=str, columns={"col5": "columns"})
+    assert isinstance(df2.columns, pd.Index)
+
+
 def test___setitem__():
     ray_df = create_test_dataframe()
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Modifies `DataFrame.__getattr__` return a column if a column matching the attribute name exists.

Column lookup does not override normal attribute access. In other words, `df.columns` will return an `Index` even if `df["columns"]` exists.