### PR TITLE
Define string prefixes for all tables in the new GCS API

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -78,6 +78,8 @@ RedisModuleKey *OpenPrefixedKey(RedisModuleCtx *ctx,
   auto prefix = static_cast<TablePrefix>(prefix_long);
   RAY_CHECK(prefix != TablePrefix_UNUSED)
       << "This table has no prefix registered";
+  RAY_CHECK(prefix >= TablePrefix_MIN && prefix <= TablePrefix_MAX)
+      << "Prefix must be a valid TablePrefix";
   return OpenPrefixedKey(ctx, table_prefixes[prefix], keyname, mode);
 }
 

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -4,6 +4,14 @@ enum Language:int {
   JAVA = 2
 }
 
+enum TablePrefix:int {
+  UNUSED = 0,
+  TASK,
+  CLIENT,
+  OBJECT,
+  FUNCTION
+}
+
 // The channel that Add operations to the Table should be published on, if any.
 enum TablePubsub:int {
   NO_PUBLISH = 0,

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -161,23 +161,23 @@ Status RedisContext::AttachToEventLoop(aeEventLoop *loop) {
 }
 
 Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
-                              uint8_t *data, int64_t length,
+                              uint8_t *data, int64_t length, const TablePrefix prefix,
                               const TablePubsub pubsub_channel, int64_t callback_index) {
   if (length > 0) {
-    std::string redis_command = command + " %d %b %b";
+    std::string redis_command = command + " %d %d %b %b";
     int status = redisAsyncCommand(
         async_context_, reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
-        reinterpret_cast<void *>(callback_index), redis_command.c_str(), pubsub_channel,
-        id.data(), id.size(), data, length);
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
+        pubsub_channel, id.data(), id.size(), data, length);
     if (status == REDIS_ERR) {
       return Status::RedisError(std::string(async_context_->errstr));
     }
   } else {
-    std::string redis_command = command + " %d %b";
+    std::string redis_command = command + " %d %d %b";
     int status = redisAsyncCommand(
         async_context_, reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
-        reinterpret_cast<void *>(callback_index), redis_command.c_str(), pubsub_channel,
-        id.data(), id.size());
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
+        pubsub_channel, id.data(), id.size());
     if (status == REDIS_ERR) {
       return Status::RedisError(std::string(async_context_->errstr));
     }

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -51,8 +51,8 @@ class RedisContext {
   Status Connect(const std::string &address, int port);
   Status AttachToEventLoop(aeEventLoop *loop);
   Status RunAsync(const std::string &command, const UniqueID &id, uint8_t *data,
-                  int64_t length, const TablePubsub pubsub_channel,
-                  int64_t callback_index);
+                  int64_t length, const TablePrefix prefix,
+                  const TablePubsub pubsub_channel, int64_t callback_index);
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         int64_t callback_index);
   redisAsyncContext *async_context() { return async_context_; }

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -148,10 +148,15 @@ class Table {
   Status Remove(const JobID &job_id, const ID &id, const Callback &done);
 
  protected:
-  std::unordered_map<ID, std::unique_ptr<CallbackData>, UniqueIDHasher> callback_data_;
+  /// The connection to the GCS.
   std::shared_ptr<RedisContext> context_;
+  /// The GCS client.
   AsyncGcsClient *client_;
+  /// The pubsub channel to subscribe to for notifications about keys in this
+  /// table. If no notifications are required, this may be set to
+  /// TablePubsub_NO_PUBLISH.
   TablePubsub pubsub_channel_;
+  /// The prefix to use for keys in this table.
   TablePrefix prefix_;
 };
 


### PR DESCRIPTION
## What do these changes do?

This defines key prefixes for all tables in the new GCS API.