### PR TITLE
Request and cancel notifications in the new GCS API

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -54,7 +54,7 @@ static const char *table_prefixes[] = {
 };
 
 /// Parse a Redis string into a TablePubsub channel.
-TablePubsub ParseTablePubsub(RedisModuleString *pubsub_channel_str) {
+TablePubsub ParseTablePubsub(const RedisModuleString *pubsub_channel_str) {
   long long pubsub_channel_long;
   RAY_CHECK(RedisModule_StringToLongLong(
                 pubsub_channel_str, &pubsub_channel_long) == REDISMODULE_OK)
@@ -68,9 +68,10 @@ TablePubsub ParseTablePubsub(RedisModuleString *pubsub_channel_str) {
 
 /// Format a pubsub channel for a specific key. pubsub_channel_str should
 /// contain a valid TablePubsub.
-RedisModuleString *FormatPubsubChannel(RedisModuleCtx *ctx,
-                                       RedisModuleString *pubsub_channel_str,
-                                       RedisModuleString *id) {
+RedisModuleString *FormatPubsubChannel(
+    RedisModuleCtx *ctx,
+    const RedisModuleString *pubsub_channel_str,
+    const RedisModuleString *id) {
   // Format the pubsub channel enum to a string. TablePubsub_MAX should be more
   // than enough digits, but add 1 just in case for the null terminator.
   char pubsub_channel[TablePubsub_MAX + 1];

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -631,10 +631,15 @@ int TableAdd_RedisCommand(RedisModuleCtx *ctx,
   // Publish a message on the requested pubsub channel if necessary.
   TablePubsub pubsub_channel = ParseTablePubsub(pubsub_channel_str);
   if (pubsub_channel == TablePubsub_TASK) {
+    // Publish the task to its subscribers.
+    // TODO(swang): This is only necessary for legacy Ray and should be removed
+    // once we switch to using the new GCS API for the task table.
     return TaskTableAdd(ctx, id, data);
   } else if (pubsub_channel == TablePubsub_CLIENT) {
+    // Publish all previous client table additions to the new client.
     return ClientTableAdd(ctx, pubsub_channel_str, data);
   } else if (pubsub_channel != TablePubsub_NO_PUBLISH) {
+    // All other pubsub channels write the data back directly onto the channel.
     return PublishTableAdd(ctx, pubsub_channel_str, id, data);
   } else {
     return RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -62,7 +62,9 @@ RedisModuleString *FormatPubsubChannel(RedisModuleCtx *ctx,
   RAY_CHECK(RedisModule_StringToLongLong(
                 pubsub_channel_str, &pubsub_channel_long) == REDISMODULE_OK)
       << "Prefix must be a valid TablePrefix";
-  char pubsub_channel[sizeof(TablePubsub) + 1];
+  // Format the pubsub channel enum to a string. TablePubsub_MAX should be more
+  // than enough digits, but add 1 just in case for the null terminator.
+  char pubsub_channel[TablePubsub_MAX + 1];
   sprintf(pubsub_channel, "%lld", pubsub_channel_long);
   return RedisString_Format(ctx, "%s:%S", pubsub_channel, id);
 }
@@ -581,7 +583,7 @@ int TableAdd_RedisCommand(RedisModuleCtx *ctx,
             RedisModule_Call(ctx, "PUBLISH", "ss", client_channel, data);
         if (reply == NULL) {
           RedisModule_CloseKey(notification_key);
-          RedisModule_ReplyWithError(ctx, "error during PUBLISH");
+          return RedisModule_ReplyWithError(ctx, "error during PUBLISH");
         }
       }
     }

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1332,15 +1332,16 @@ void log_object_hash_mismatch_error_result_callback(ObjectID object_id,
   RAY_CHECK_OK(state->gcs_client.task_table().Lookup(
       ray::JobID::nil(), task_id,
       [user_context](gcs::AsyncGcsClient *, const TaskID &,
-                     std::shared_ptr<TaskTableDataT> t) {
-        Task *task = Task_alloc(
-            t->task_info.data(), t->task_info.size(), t->scheduling_state,
-            DBClientID::from_binary(t->scheduler_id), std::vector<ObjectID>());
+                     const std::vector<TaskTableDataT> &data) {
+        RAY_CHECK(data.size() == 1);
+        TaskTableDataT task_data = data[0];
+        Task *task =
+            Task_alloc(task_data.task_info.data(), task_data.task_info.size(),
+                       task_data.scheduling_state,
+                       DBClientID::from_binary(task_data.scheduler_id),
+                       std::vector<ObjectID>());
         log_object_hash_mismatch_error_task_callback(task, user_context);
         Task_free(task);
-      },
-      [user_context](gcs::AsyncGcsClient *, const TaskID &) {
-        // TODO(pcmoritz): Handle failure.
       }));
 #endif
 }

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1332,10 +1332,10 @@ void log_object_hash_mismatch_error_result_callback(ObjectID object_id,
   RAY_CHECK_OK(state->gcs_client.task_table().Lookup(
       ray::JobID::nil(), task_id,
       [user_context](gcs::AsyncGcsClient *, const TaskID &,
-                     std::shared_ptr<TaskTableDataT> t) {
+                     const TaskTableDataT &t) {
         Task *task = Task_alloc(
-            t->task_info.data(), t->task_info.size(), t->scheduling_state,
-            DBClientID::from_binary(t->scheduler_id), std::vector<ObjectID>());
+            t.task_info.data(), t.task_info.size(), t.scheduling_state,
+            DBClientID::from_binary(t.scheduler_id), std::vector<ObjectID>());
         log_object_hash_mismatch_error_task_callback(task, user_context);
         Task_free(task);
       },

--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1332,16 +1332,15 @@ void log_object_hash_mismatch_error_result_callback(ObjectID object_id,
   RAY_CHECK_OK(state->gcs_client.task_table().Lookup(
       ray::JobID::nil(), task_id,
       [user_context](gcs::AsyncGcsClient *, const TaskID &,
-                     const std::vector<TaskTableDataT> &data) {
-        RAY_CHECK(data.size() == 1);
-        TaskTableDataT task_data = data[0];
-        Task *task =
-            Task_alloc(task_data.task_info.data(), task_data.task_info.size(),
-                       task_data.scheduling_state,
-                       DBClientID::from_binary(task_data.scheduler_id),
-                       std::vector<ObjectID>());
+                     std::shared_ptr<TaskTableDataT> t) {
+        Task *task = Task_alloc(
+            t->task_info.data(), t->task_info.size(), t->scheduling_state,
+            DBClientID::from_binary(t->scheduler_id), std::vector<ObjectID>());
         log_object_hash_mismatch_error_task_callback(task, user_context);
         Task_free(task);
+      },
+      [user_context](gcs::AsyncGcsClient *, const TaskID &) {
+        // TODO(pcmoritz): Handle failure.
       }));
 #endif
 }

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -42,7 +42,7 @@ class TestGcs : public ::testing::Test {
 
   virtual void Stop() = 0;
 
-  int64_t NumCallbacks() { return num_callbacks_; }
+  int64_t NumCallbacks() const { return num_callbacks_; }
 
   void IncrementNumCallbacks() { num_callbacks_++; }
 

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -210,8 +210,7 @@ void TestSubscribeAll(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> 
   };
 
   // Callback for subscription success. This should only be called once.
-  auto subscribe_callback = [job_id](gcs::AsyncGcsClient *client, const UniqueID &id,
-                                     const std::vector<ObjectTableDataT> &d) {
+  auto subscribe_callback = [job_id](gcs::AsyncGcsClient *client) {
     test->IncrementNumCallbacks();
     // We have subscribed. Add an object table entry.
     auto data = std::make_shared<ObjectTableDataT>();
@@ -261,9 +260,7 @@ void TestSubscribeId(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
 
   // The callback for subscription success. Once we've subscribed, request
   // notifications for the second object that was added.
-  auto subscribe_callback = [job_id, object_id2](gcs::AsyncGcsClient *client,
-                                                 const UniqueID &id,
-                                                 const std::vector<ObjectTableDataT> &d) {
+  auto subscribe_callback = [job_id, object_id2](gcs::AsyncGcsClient *client) {
     test->IncrementNumCallbacks();
     // Request notifications for the second object. Since we already added the
     // entry to the table, we should receive an initial notification for its
@@ -325,9 +322,7 @@ void TestSubscribeCancel(const JobID &job_id,
 
   // The callback for subscription success. Once we've subscribed, request
   // notifications for the second object that was added.
-  auto subscribe_callback = [job_id, object_id](gcs::AsyncGcsClient *client,
-                                                const UniqueID &id,
-                                                const std::vector<ObjectTableDataT> &d) {
+  auto subscribe_callback = [job_id, object_id](gcs::AsyncGcsClient *client) {
     test->IncrementNumCallbacks();
     // Request notifications for the object. We should receive a notification
     // for the current value at the key.

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -131,6 +131,29 @@ TEST_F(TestGcsWithAsio, TestObjectTable) {
   TestObjectTable(job_id_, client_);
 }
 
+void TestLookupFailure(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
+  auto object_id = ObjectID::from_random();
+  // Looking up an empty object ID should call the failure callback.
+  auto failure_callback = [](gcs::AsyncGcsClient *client, const UniqueID &id) {
+    test->Stop();
+  };
+  RAY_CHECK_OK(
+      client->object_table().Lookup(job_id, object_id, nullptr, failure_callback));
+  // Run the event loop. The loop will only stop if the failure callback is
+  // called.
+  test->Start();
+}
+
+TEST_F(TestGcsWithAe, TestLookupFailure) {
+  test = this;
+  TestLookupFailure(job_id_, client_);
+}
+
+TEST_F(TestGcsWithAsio, TestLookupFailure) {
+  test = this;
+  TestLookupFailure(job_id_, client_);
+}
+
 void TaskAdded(gcs::AsyncGcsClient *client, const TaskID &id,
                std::shared_ptr<TaskTableDataT> data) {
   ASSERT_EQ(data->scheduling_state, SchedulingState_SCHEDULED);

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -283,8 +283,8 @@ void TestSubscribeId(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
     // Request notifications for the second object. Since we already added the
     // entry to the table, we should receive an initial notification for its
     // current value.
-    client->object_table().RequestNotifications(
-        job_id, object_id2, client->client_table().GetLocalClientId());
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id2, client->client_table().GetLocalClientId()));
     // Overwrite the entry for the object. We should receive a second
     // notification for its new value.
     auto data = std::make_shared<ObjectTableDataT>();
@@ -343,11 +343,11 @@ void TestSubscribeCancel(const JobID &job_id,
     test->IncrementNumCallbacks();
     // Request notifications for the object. We should receive a notification
     // for the current value at the key.
-    client->object_table().RequestNotifications(
-        job_id, object_id, client->client_table().GetLocalClientId());
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
     // Cancel notifications.
-    client->object_table().CancelNotifications(job_id, object_id,
-                                               client->client_table().GetLocalClientId());
+    RAY_CHECK_OK(client->object_table().CancelNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
     // Write the object table entry twice. Since we canceled notifications, we
     // should not get notifications for either of these writes.
     auto data = std::make_shared<ObjectTableDataT>();
@@ -358,8 +358,8 @@ void TestSubscribeCancel(const JobID &job_id,
     RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
     // Request notifications for the object again. We should only receive a
     // notification for the current value at the key.
-    client->object_table().RequestNotifications(
-        job_id, object_id, client->client_table().GetLocalClientId());
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
   };
 
   // The callback for a notification from the object table.

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -21,6 +21,11 @@ enum TablePubsub:int {
   ACTOR
 }
 
+table GcsNotification {
+  id: string;
+  data: string;
+}
+
 table FunctionTableData {
   language: Language;
   name: string;

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -39,9 +39,11 @@ void GlobalRedisCallback(void *c, void *r, void *privdata) {
     RAY_LOG(FATAL) << "Fatal redis error of type " << reply->type
                    << " and with string " << reply->str;
   }
-  RedisCallbackManager::instance().get(callback_index)(data);
-  // Delete the callback.
-  RedisCallbackManager::instance().remove(callback_index);
+  if (callback_index >= 0) {
+    RedisCallbackManager::instance().get(callback_index)(data);
+    // Delete the callback.
+    RedisCallbackManager::instance().remove(callback_index);
+  }
 }
 
 void SubscribeRedisCallback(void *c, void *r, void *privdata) {
@@ -161,8 +163,9 @@ Status RedisContext::AttachToEventLoop(aeEventLoop *loop) {
 }
 
 Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
-                              uint8_t *data, int64_t length, const TablePrefix prefix,
-                              const TablePubsub pubsub_channel, int64_t callback_index) {
+                              const uint8_t *data, int64_t length,
+                              const TablePrefix prefix, const TablePubsub pubsub_channel,
+                              int64_t callback_index) {
   if (length > 0) {
     std::string redis_command = command + " %d %d %b %b";
     int status = redisAsyncCommand(

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -203,7 +203,6 @@ Status RedisContext::SubscribeAsync(const ClientID &client_id,
         reinterpret_cast<void *>(callback_index), redis_command.c_str(), pubsub_channel);
   } else {
     // Subscribe only to messages sent to this client.
-    // TODO(swang): Nobody sends on this channel yet.
     std::string redis_command = "SUBSCRIBE %d:%b";
     status = redisAsyncCommand(
         subscribe_context_, reinterpret_cast<redisCallbackFn *>(&SubscribeRedisCallback),

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -1,7 +1,6 @@
 #ifndef RAY_GCS_REDIS_CONTEXT_H
 #define RAY_GCS_REDIS_CONTEXT_H
 
-#include <boost/optional.hpp>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -22,7 +21,7 @@ namespace gcs {
 
 class RedisCallbackManager {
  public:
-  using RedisCallback = std::function<bool(boost::optional<const std::string &>)>;
+  using RedisCallback = std::function<bool(const std::vector<std::string> &)>;
 
   static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -1,6 +1,7 @@
 #ifndef RAY_GCS_REDIS_CONTEXT_H
 #define RAY_GCS_REDIS_CONTEXT_H
 
+#include <boost/optional.hpp>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -21,7 +22,7 @@ namespace gcs {
 
 class RedisCallbackManager {
  public:
-  using RedisCallback = std::function<void(const std::string &)>;
+  using RedisCallback = std::function<bool(boost::optional<const std::string &>)>;
 
   static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -50,7 +50,7 @@ class RedisContext {
   ~RedisContext();
   Status Connect(const std::string &address, int port);
   Status AttachToEventLoop(aeEventLoop *loop);
-  Status RunAsync(const std::string &command, const UniqueID &id, uint8_t *data,
+  Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
                   int64_t length, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, int64_t callback_index);
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -21,6 +21,9 @@ namespace gcs {
 
 class RedisCallbackManager {
  public:
+  /// Every callback should take in a vector of the results from the Redis
+  /// operation and return a bool indicating whether the callback should be
+  /// deleted once called.
   using RedisCallback = std::function<bool(const std::vector<std::string> &)>;
 
   static RedisCallbackManager &instance() {

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -23,7 +23,6 @@ Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
   fbb.Finish(Data::Pack(fbb, data.get()));
   return context_->RunAsync("RAY.TABLE_ADD", id, fbb.GetBufferPointer(), fbb.GetSize(),
                             prefix_, pubsub_channel_, callback_index);
-  return Status::OK();
 }
 
 template <typename ID, typename Data>
@@ -51,7 +50,6 @@ Status Table<ID, Data>::Lookup(const JobID &job_id, const ID &id, const Callback
   std::vector<uint8_t> nil;
   return context_->RunAsync("RAY.TABLE_LOOKUP", id, nil.data(), nil.size(), prefix_,
                             pubsub_channel_, callback_index);
-  return Status::OK();
 }
 
 template <typename ID, typename Data>

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -99,8 +99,7 @@ Status ClientTable::Connect() {
     HandleConnected(client, id, data);
   };
   // Callback to add ourselves once we've successfully subscribed.
-  auto subscription_callback = [this, data, add_callback](
-      AsyncGcsClient *c, const ClientID &id, const std::vector<ClientTableDataT> &d) {
+  auto subscription_callback = [this, data, add_callback](AsyncGcsClient *c) {
     // Mark ourselves as deleted if we called Disconnect() since the last
     // Connect() call.
     if (disconnected_) {

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -10,11 +10,11 @@ template <typename ID, typename Data>
 Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
                             std::shared_ptr<DataT> data, const Callback &done) {
   auto d = std::shared_ptr<CallbackData>(
-      new CallbackData({id, data, done, nullptr, this, client_}));
+      new CallbackData({id, data, done, nullptr, nullptr, this, client_}));
   int64_t callback_index =
       RedisCallbackManager::instance().add([d](const std::vector<std::string> &data) {
         if (d->callback != nullptr) {
-          (d->callback)(d->client, d->id, {*d->data});
+          (d->callback)(d->client, d->id, *d->data);
         }
         return true;
       });
@@ -27,21 +27,24 @@ Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
 }
 
 template <typename ID, typename Data>
-Status Table<ID, Data>::Lookup(const JobID &job_id, const ID &id,
-                               const Callback &lookup) {
+Status Table<ID, Data>::Lookup(const JobID &job_id, const ID &id, const Callback &lookup,
+                               const FailureCallback &failure) {
   auto d = std::shared_ptr<CallbackData>(
-      new CallbackData({id, nullptr, lookup, nullptr, this, client_}));
+      new CallbackData({id, nullptr, lookup, failure, nullptr, this, client_}));
   int64_t callback_index =
       RedisCallbackManager::instance().add([d](const std::vector<std::string> &data) {
-        if (d->callback != nullptr) {
-          std::vector<DataT> results;
-          for (auto &item : data) {
-            DataT result;
-            auto root = flatbuffers::GetRoot<Data>(item.data());
-            root->UnPackTo(&result);
-            results.push_back(result);
+        if (data.empty()) {
+          if (d->failure != nullptr) {
+            (d->failure)(d->client, d->id);
           }
-          (d->callback)(d->client, d->id, results);
+        } else {
+          RAY_CHECK(data.size() == 1);
+          if (d->callback != nullptr) {
+            DataT result;
+            auto root = flatbuffers::GetRoot<Data>(data[0].data());
+            root->UnPackTo(&result);
+            (d->callback)(d->client, d->id, result);
+          }
         }
         return true;
       });
@@ -58,7 +61,7 @@ Status Table<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id
   RAY_CHECK(subscribe_callback_index_ == -1)
       << "Client called Subscribe twice on the same table";
   auto d = std::shared_ptr<CallbackData>(
-      new CallbackData({client_id, nullptr, subscribe, done, this, client_}));
+      new CallbackData({client_id, nullptr, subscribe, nullptr, done, this, client_}));
   int64_t callback_index = RedisCallbackManager::instance().add(
       [this, d](const std::vector<std::string> &data) {
         if (data.size() == 1 && data[0] == "") {
@@ -69,15 +72,12 @@ Status Table<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id
           }
         } else {
           // Data is provided. This is the callback for a message.
+          RAY_CHECK(data.size() == 1);
           if (d->callback != nullptr) {
-            std::vector<DataT> results;
-            for (auto &item : data) {
-              DataT result;
-              auto root = flatbuffers::GetRoot<Data>(item.data());
-              root->UnPackTo(&result);
-              results.push_back(result);
-            }
-            (d->callback)(d->client, d->id, results);
+            DataT result;
+            auto root = flatbuffers::GetRoot<Data>(data[0].data());
+            root->UnPackTo(&result);
+            (d->callback)(d->client, d->id, result);
           }
         }
         // We do not delete the callback after calling it since there may be
@@ -129,52 +129,50 @@ void ClientTable::RegisterClientRemovedCallback(const ClientTableCallback &callb
 }
 
 void ClientTable::HandleNotification(AsyncGcsClient *client, const ClientID &channel_id,
-                                     const std::vector<ClientTableDataT> &notifications) {
-  for (const auto &data : notifications) {
-    ClientID client_id = ClientID::from_binary(data.client_id);
-    // It's possible to get duplicate notifications from the client table, so
-    // check whether this notification is new.
-    auto entry = client_cache_.find(client_id);
-    bool is_new;
-    if (entry == client_cache_.end()) {
-      // If the entry is not in the cache, then the notification is new.
-      is_new = true;
-    } else {
-      // If the entry is in the cache, then the notification is new if the client
-      // was alive and is now dead.
-      bool was_inserted = entry->second.is_insertion;
-      bool is_deleted = !data.is_insertion;
-      is_new = (was_inserted && is_deleted);
-      // Once a client with a given ID has been removed, it should never be added
-      // again. If the entry was in the cache and the client was deleted, check
-      // that this new notification is not an insertion.
-      if (!entry->second.is_insertion) {
-        RAY_CHECK(!data.is_insertion)
-            << "Notification for addition of a client that was already removed:"
-            << client_id.hex();
-      }
+                                     const ClientTableDataT &data) {
+  ClientID client_id = ClientID::from_binary(data.client_id);
+  // It's possible to get duplicate notifications from the client table, so
+  // check whether this notification is new.
+  auto entry = client_cache_.find(client_id);
+  bool is_new;
+  if (entry == client_cache_.end()) {
+    // If the entry is not in the cache, then the notification is new.
+    is_new = true;
+  } else {
+    // If the entry is in the cache, then the notification is new if the client
+    // was alive and is now dead.
+    bool was_inserted = entry->second.is_insertion;
+    bool is_deleted = !data.is_insertion;
+    is_new = (was_inserted && is_deleted);
+    // Once a client with a given ID has been removed, it should never be added
+    // again. If the entry was in the cache and the client was deleted, check
+    // that this new notification is not an insertion.
+    if (!entry->second.is_insertion) {
+      RAY_CHECK(!data.is_insertion)
+          << "Notification for addition of a client that was already removed:"
+          << client_id.hex();
     }
+  }
 
-    // Add the notification to our cache. Notifications are idempotent.
-    client_cache_[client_id] = data;
+  // Add the notification to our cache. Notifications are idempotent.
+  client_cache_[client_id] = data;
 
-    // If the notification is new, call any registered callbacks.
-    if (is_new) {
-      if (data.is_insertion) {
-        if (client_added_callback_ != nullptr) {
-          client_added_callback_(client, client_id, data);
-        }
-      } else {
-        if (client_removed_callback_ != nullptr) {
-          client_removed_callback_(client, client_id, data);
-        }
+  // If the notification is new, call any registered callbacks.
+  if (is_new) {
+    if (data.is_insertion) {
+      if (client_added_callback_ != nullptr) {
+        client_added_callback_(client, client_id, data);
+      }
+    } else {
+      if (client_removed_callback_ != nullptr) {
+        client_removed_callback_(client, client_id, data);
       }
     }
   }
 }
 
 void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientID &client_id,
-                                  const std::vector<ClientTableDataT> &data) {
+                                  const ClientTableDataT &data) {
   RAY_CHECK(client_id == client_id_) << client_id.hex() << " " << client_id_.hex();
 }
 
@@ -189,13 +187,13 @@ Status ClientTable::Connect() {
   data->is_insertion = true;
   // Callback for a notification from the client table.
   auto notification_callback = [this](AsyncGcsClient *client, const ClientID &channel_id,
-                                      const std::vector<ClientTableDataT> &data) {
+                                      const ClientTableDataT &data) {
     return HandleNotification(client, channel_id, data);
   };
   // Callback to handle our own successful connection once we've added
   // ourselves.
   auto add_callback = [this](AsyncGcsClient *client, const ClientID &id,
-                             const std::vector<ClientTableDataT> &data) {
+                             const ClientTableDataT &data) {
     HandleConnected(client, id, data);
   };
   // Callback to add ourselves once we've successfully subscribed.
@@ -215,7 +213,7 @@ Status ClientTable::Disconnect() {
   auto data = std::make_shared<ClientTableDataT>(local_client_);
   data->is_insertion = true;
   auto add_callback = [this](AsyncGcsClient *client, const ClientID &id,
-                             const std::vector<ClientTableDataT> &data) {
+                             const ClientTableDataT &data) {
     HandleConnected(client, id, data);
   };
   RAY_RETURN_NOT_OK(Add(JobID::nil(), client_id_, data, add_callback));

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -63,27 +63,7 @@ class Table {
   ///        GCS.
   /// \return Status
   Status Add(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
-             const Callback &done) {
-    auto d = std::shared_ptr<CallbackData>(
-        new CallbackData({id, data, done, nullptr, this, client_}));
-    int64_t callback_index =
-        RedisCallbackManager::instance().add([d](const std::vector<std::string> &data) {
-          if (d->callback != nullptr) {
-            (d->callback)(d->client, d->id, {*d->data});
-          }
-          return true;
-        });
-    flatbuffers::FlatBufferBuilder fbb;
-    fbb.ForceDefaults(true);
-    fbb.Finish(Data::Pack(fbb, data.get()));
-    RAY_RETURN_NOT_OK(context_->RunAsync("RAY.TABLE_ADD", id, fbb.GetBufferPointer(),
-                                         fbb.GetSize(), prefix_, pubsub_channel_,
-                                         callback_index));
-    return Status::OK();
-  }
-
-  /// Remove an entry from the table.
-  Status Remove(const JobID &job_id, const ID &id, const Callback &done);
+             const Callback &done);
 
   /// Lookup an entry asynchronously.
   ///
@@ -92,28 +72,7 @@ class Table {
   /// \param lookup Callback that is called after lookup. If the callback is
   ///        called with an empty vector, then there was no data at the key.
   /// \return Status
-  Status Lookup(const JobID &job_id, const ID &id, const Callback &lookup) {
-    auto d = std::shared_ptr<CallbackData>(
-        new CallbackData({id, nullptr, lookup, nullptr, this, client_}));
-    int64_t callback_index =
-        RedisCallbackManager::instance().add([d](const std::vector<std::string> &data) {
-          if (d->callback != nullptr) {
-            std::vector<DataT> results;
-            for (auto &item : data) {
-              DataT result;
-              auto root = flatbuffers::GetRoot<Data>(item.data());
-              root->UnPackTo(&result);
-              results.push_back(result);
-            }
-            (d->callback)(d->client, d->id, results);
-          }
-          return true;
-        });
-    std::vector<uint8_t> nil;
-    RAY_RETURN_NOT_OK(context_->RunAsync("RAY.TABLE_LOOKUP", id, nil.data(), nil.size(),
-                                         prefix_, pubsub_channel_, callback_index));
-    return Status::OK();
-  }
+  Status Lookup(const JobID &job_id, const ID &id, const Callback &lookup);
 
   /// Subscribe to any Add operations to this table. The caller may choose to
   /// subscribe to all Adds, or to subscribe only to keys that it requests
@@ -132,40 +91,7 @@ class Table {
   ///        are ready to receive messages.
   /// \return Status
   Status Subscribe(const JobID &job_id, const ClientID &client_id,
-                   const Callback &subscribe, const SubscriptionCallback &done) {
-    RAY_CHECK(subscribe_callback_index_ == -1)
-        << "Client called Subscribe twice on the same table";
-    auto d = std::shared_ptr<CallbackData>(
-        new CallbackData({client_id, nullptr, subscribe, done, this, client_}));
-    int64_t callback_index = RedisCallbackManager::instance().add(
-        [this, d](const std::vector<std::string> &data) {
-          if (data.size() == 1 && data[0] == "") {
-            // No notification data is provided. This is the callback for the
-            // initial subscription request.
-            if (d->subscription_callback != nullptr) {
-              (d->subscription_callback)(d->client);
-            }
-          } else {
-            // Data is provided. This is the callback for a message.
-            if (d->callback != nullptr) {
-              std::vector<DataT> results;
-              for (auto &item : data) {
-                DataT result;
-                auto root = flatbuffers::GetRoot<Data>(item.data());
-                root->UnPackTo(&result);
-                results.push_back(result);
-              }
-              (d->callback)(d->client, d->id, results);
-            }
-          }
-          // We do not delete the callback after calling it since there may be
-          // more subscription messages.
-          return false;
-        });
-    subscribe_callback_index_ = callback_index;
-    std::vector<uint8_t> nil;
-    return context_->SubscribeAsync(client_id, pubsub_channel_, callback_index);
-  }
+                   const Callback &subscribe, const SubscriptionCallback &done);
 
   /// Request notifications about a key in this table.
   ///
@@ -183,13 +109,7 @@ class Table {
   ///        table with the same `client_id` must complete successfully.
   /// \return Status
   Status RequestNotifications(const JobID &job_id, const ID &id,
-                              const ClientID &client_id) {
-    RAY_CHECK(subscribe_callback_index_ >= 0)
-        << "Client requested notifications on a key before Subscribe completed";
-    return context_->RunAsync("RAY.TABLE_REQUEST_NOTIFICATIONS", id, client_id.data(),
-                              client_id.size(), prefix_, pubsub_channel_,
-                              subscribe_callback_index_);
-  }
+                              const ClientID &client_id);
 
   /// Cancel notifications about a key in this table.
   ///
@@ -198,12 +118,7 @@ class Table {
   /// \param client_id The client who originally requested notifications.
   /// \return Status
   Status CancelNotifications(const JobID &job_id, const ID &id,
-                             const ClientID &client_id) {
-    RAY_CHECK(subscribe_callback_index_ >= 0)
-        << "Client canceled notifications on a key before Subscribe completed";
-    return context_->RunAsync("RAY.TABLE_CANCEL_NOTIFICATIONS", id, client_id.data(),
-                              client_id.size(), prefix_, pubsub_channel_, -1);
-  }
+                             const ClientID &client_id);
 
  protected:
   /// The connection to the GCS.

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -131,8 +131,9 @@ class Table {
   TablePubsub pubsub_channel_;
   /// The prefix to use for keys in this table.
   TablePrefix prefix_;
-  /// Whether we have subscribed to the table yet. Each client may only
-  /// subscribe to a table once.
+  /// The index in the RedisCallbackManager for the callback that is called
+  /// when we receive notifications. This is >= 0 iff we have subscribed to the
+  /// table, otherwise -1.
   int64_t subscribe_callback_index_;
 };
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -225,26 +225,6 @@ class ObjectTable : public Table<ObjectID, ObjectTableData> {
     pubsub_channel_ = TablePubsub_OBJECT;
     prefix_ = TablePrefix_OBJECT;
   };
-
-  /// Set up a client-specific channel for receiving notifications about
-  /// available
-  /// objects from the object table. The callback will be called once per
-  /// notification received on this channel.
-  ///
-  /// \param subscribe_all
-  /// \param object_available_callback Callback to be called when new object
-  ///        becomes available.
-  /// \param done_callback Callback to be called when subscription is installed.
-  ///        This is only used for the tests.
-  /// \return Status
-  Status SubscribeToNotifications(const JobID &job_id, bool subscribe_all,
-                                  const Callback &object_available, const Callback &done);
-
-  /////
-  ///// \param object_ids The object IDs to receive notifications about.
-  ///// \return Status
-  // Status RequestNotifications(const JobID &job_id,
-  //                            const std::vector<ObjectID> &object_ids);
 };
 
 class FunctionTable : public Table<ObjectID, FunctionTableData> {

--- a/src/ray/gcs/task_table.cc
+++ b/src/ray/gcs/task_table.cc
@@ -46,7 +46,7 @@ Status TaskTableAdd(AsyncGcsClient *gcs_client, Task *task) {
                                 static_cast<SchedulingState>(Task_state(task)));
   return gcs_client->task_table().Add(ray::JobID::nil(), TaskSpec_task_id(spec), data,
                                       [](gcs::AsyncGcsClient *client, const TaskID &id,
-                                         std::shared_ptr<TaskTableDataT> data) {});
+                                         const std::vector<TaskTableDataT> &data) {});
 }
 
 // TODO(pcm): This is a helper method that should go away once we get rid of

--- a/src/ray/gcs/task_table.cc
+++ b/src/ray/gcs/task_table.cc
@@ -44,9 +44,9 @@ Status TaskTableAdd(AsyncGcsClient *gcs_client, Task *task) {
   TaskSpec *spec = execution_spec.Spec();
   auto data = MakeTaskTableData(execution_spec, Task_local_scheduler(task),
                                 static_cast<SchedulingState>(Task_state(task)));
-  return gcs_client->task_table().Add(ray::JobID::nil(), TaskSpec_task_id(spec), data,
-                                      [](gcs::AsyncGcsClient *client, const TaskID &id,
-                                         const std::vector<TaskTableDataT> &data) {});
+  return gcs_client->task_table().Add(
+      ray::JobID::nil(), TaskSpec_task_id(spec), data,
+      [](gcs::AsyncGcsClient *client, const TaskID &id, const TaskTableDataT &data) {});
 }
 
 // TODO(pcm): This is a helper method that should go away once we get rid of


### PR DESCRIPTION
## What do these changes do?

This allows a caller to request and cancel notifications about a specific key in a GCS table.