### PR TITLE
Introduce a log interface for the new GCS

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -755,9 +755,7 @@ int TableRequestNotifications_RedisCommand(RedisModuleCtx *ctx,
   // Lookup the current value at the key.
   RedisModuleKey *table_key =
       OpenPrefixedKey(ctx, prefix_str, id, REDISMODULE_READ);
-  if (table_key == nullptr) {
-    RedisModule_ReplyWithNull(ctx);
-  } else {
+  if (table_key != nullptr) {
     // Publish the current value at the key to the client that is requesting
     // notifications.
     flatbuffers::FlatBufferBuilder fbb;

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -637,9 +637,8 @@ int TableAppend_RedisCommand(RedisModuleCtx *ctx,
 
 /// A helper function to create and finish a GcsTableEntry, based on the
 /// current value or values at the given key.
-void TableEntryToFlatbuf(flatbuffers::FlatBufferBuilder &fbb,
-                         RedisModuleKey *table_key,
-                         RedisModuleString *entry_id) {
+void TableEntryToFlatbuf(RedisModuleKey *table_key,
+                         RedisModuleString *entry_id, flatbuffers::FlatBufferBuilder &fbb) {
   auto key_type = RedisModule_KeyType(table_key);
   switch (key_type) {
   case REDISMODULE_KEYTYPE_STRING: {
@@ -703,7 +702,7 @@ int TableLookup_RedisCommand(RedisModuleCtx *ctx,
   } else {
     // Serialize the data to a flatbuffer to return to the client.
     flatbuffers::FlatBufferBuilder fbb;
-    TableEntryToFlatbuf(fbb, table_key, id);
+    TableEntryToFlatbuf(table_key, id, fbb);
     RedisModule_ReplyWithStringBuffer(
         ctx, reinterpret_cast<const char *>(fbb.GetBufferPointer()),
         fbb.GetSize());
@@ -759,7 +758,7 @@ int TableRequestNotifications_RedisCommand(RedisModuleCtx *ctx,
     // Publish the current value at the key to the client that is requesting
     // notifications.
     flatbuffers::FlatBufferBuilder fbb;
-    TableEntryToFlatbuf(fbb, table_key, id);
+    TableEntryToFlatbuf(table_key, id, fbb);
     RedisModule_Call(ctx, "PUBLISH", "sb", client_channel, reinterpret_cast<const char *>(fbb.GetBufferPointer()),
         fbb.GetSize());
   }

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -638,7 +638,8 @@ int TableAppend_RedisCommand(RedisModuleCtx *ctx,
 /// A helper function to create and finish a GcsTableEntry, based on the
 /// current value or values at the given key.
 void TableEntryToFlatbuf(RedisModuleKey *table_key,
-                         RedisModuleString *entry_id, flatbuffers::FlatBufferBuilder &fbb) {
+                         RedisModuleString *entry_id,
+                         flatbuffers::FlatBufferBuilder &fbb) {
   auto key_type = RedisModule_KeyType(table_key);
   switch (key_type) {
   case REDISMODULE_KEYTYPE_STRING: {

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -420,9 +420,10 @@ TEST_F(TestGcsWithAsio, TestSubscribeCancel) {
   TestSubscribeCancel(job_id_, client_);
 }
 
-void ClientTableNotification(gcs::AsyncGcsClient *client, const UniqueID &id,
+void ClientTableNotification(gcs::AsyncGcsClient *client, const ClientID &client_id,
                              const ClientTableDataT &data, bool is_insertion) {
   ClientID added_id = client->client_table().GetLocalClientId();
+  ASSERT_EQ(client_id, added_id);
   ASSERT_EQ(ClientID::from_binary(data.client_id), added_id);
   ASSERT_EQ(data.is_insertion, is_insertion);
 

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -23,9 +23,9 @@ enum TablePubsub:int {
   ACTOR
 }
 
-table GcsNotification {
+table GcsTableEntry {
   id: string;
-  data: string;
+  entries: [string];
 }
 
 table FunctionTableData {

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -24,7 +24,7 @@ class RedisCallbackManager {
   /// Every callback should take in a vector of the results from the Redis
   /// operation and return a bool indicating whether the callback should be
   /// deleted once called.
-  using RedisCallback = std::function<bool(const std::vector<std::string> &)>;
+  using RedisCallback = std::function<bool(const std::string &)>;
 
   static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -42,7 +42,7 @@ Status Log<ID, Data>::Lookup(const JobID &job_id, const ID &id, const Callback &
               auto data_root =
                   flatbuffers::GetRoot<Data>(root->entries()->Get(i)->data());
               data_root->UnPackTo(&result);
-              results.push_back(result);
+              results.emplace_back(std::move(result));
             }
           }
           (d->callback)(d->client, d->id, results);
@@ -85,7 +85,7 @@ Status Log<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id,
               auto data_root =
                   flatbuffers::GetRoot<Data>(root->entries()->Get(i)->data());
               data_root->UnPackTo(&result);
-              results.push_back(result);
+              results.emplace_back(std::move(result));
             }
             (d->callback)(d->client, id, results);
             }

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -210,10 +210,9 @@ class TaskTable : public Table<TaskID, TaskTableData> {
                        std::shared_ptr<TaskTableTestAndUpdateT> data,
                        const TestAndUpdateCallback &callback) {
     int64_t callback_index = RedisCallbackManager::instance().add(
-        [this, callback, id](const std::vector<std::string> &data) {
-          RAY_CHECK(data.size() == 1);
+        [this, callback, id](const std::string &data) {
           auto result = std::make_shared<TaskTableDataT>();
-          auto root = flatbuffers::GetRoot<TaskTableData>(data[0].data());
+          auto root = flatbuffers::GetRoot<TaskTableData>(data.data());
           root->UnPackTo(result.get());
           callback(client_, id, *result, root->updated());
           return true;


### PR DESCRIPTION
## What do these changes do?

The `Table` interface for the GCS is a key-value store, which means that we can only add entries or overwrite existing ones. This PR adds an append-only `Log` interface to the GCS so that we can support concurrent appends to the same key. This also switches the client table implementation from a `Table` to a `Log`.