### PR TITLE
Add a GCS table for the xray task flatbuffer

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -50,7 +50,7 @@
   }
 
 static const char *table_prefixes[] = {
-    NULL, "TASK:", "CLIENT:", "OBJECT:", "FUNCTION:",
+    NULL, "TASK:", "TASK:", "CLIENT:", "OBJECT:", "FUNCTION:",
 };
 
 /// Parse a Redis string into a TablePubsub channel.

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -40,7 +40,7 @@ template <class T>
 void ClientConnection<T>::ProcessMessageHeader(const boost::system::error_code &error) {
   if (error) {
     // If there was an error, disconnect the client.
-    read_type_ = MessageType_DisconnectClient;
+    read_type_ = protocol::MessageType_DisconnectClient;
     read_length_ = 0;
     ProcessMessage(error);
     return;
@@ -81,7 +81,7 @@ template <class T>
 void ClientConnection<T>::ProcessMessage(const boost::system::error_code &error) {
   if (error) {
     // TODO(hme): Disconnect differently & remove dependency on node_manager_generated.h
-    read_type_ = MessageType_DisconnectClient;
+    read_type_ = protocol::MessageType_DisconnectClient;
   }
   manager_.ProcessClientMessage(this->shared_from_this(), read_type_,
                                 read_message_.data());

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -16,6 +16,7 @@ Status AsyncGcsClient::Connect(const std::string &address, int port,
   RAY_RETURN_NOT_OK(context_->Connect(address, port));
   object_table_.reset(new ObjectTable(context_, this));
   task_table_.reset(new TaskTable(context_, this));
+  raylet_task_table_.reset(new raylet::TaskTable(context_, this));
   client_table_.reset(new ClientTable(context_, this, client_info));
   // TODO(swang): Call the client table's Connect() method here. To do this,
   // we need to make sure that we are attached to an event loop first. This

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -41,6 +41,8 @@ ObjectTable &AsyncGcsClient::object_table() { return *object_table_; }
 
 TaskTable &AsyncGcsClient::task_table() { return *task_table_; }
 
+raylet::TaskTable &AsyncGcsClient::raylet_task_table() { return *raylet_task_table_; }
+
 ClientTable &AsyncGcsClient::client_table() { return *client_table_; }
 
 FunctionTable &AsyncGcsClient::function_table() { return *function_table_; }

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -45,6 +45,7 @@ class RAY_EXPORT AsyncGcsClient {
   inline ConfigTable &config_table();
   ObjectTable &object_table();
   TaskTable &task_table();
+  raylet::TaskTable &raylet_task_table();
   ClientTable &client_table();
   inline ErrorTable &error_table();
 
@@ -63,6 +64,7 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<ClassTable> class_table_;
   std::unique_ptr<ObjectTable> object_table_;
   std::unique_ptr<TaskTable> task_table_;
+  std::unique_ptr<raylet::TaskTable> raylet_task_table_;
   std::unique_ptr<ClientTable> client_table_;
   std::shared_ptr<RedisContext> context_;
   std::unique_ptr<RedisAsioClient> asio_async_client_;

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -7,6 +7,7 @@ enum Language:int {
 enum TablePrefix:int {
   UNUSED = 0,
   TASK,
+  RAYLET_TASK,
   CLIENT,
   OBJECT,
   FUNCTION
@@ -16,6 +17,7 @@ enum TablePrefix:int {
 enum TablePubsub:int {
   NO_PUBLISH = 0,
   TASK,
+  RAYLET_TASK,
   CLIENT,
   OBJECT,
   ACTOR

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -239,6 +239,7 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) {
   }
 }
 
+template class Table<TaskID, ray::protocol::Task>;
 template class Table<TaskID, TaskTableData>;
 template class Table<ObjectID, ObjectTableData>;
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -12,6 +12,7 @@
 
 #include "ray/gcs/format/gcs_generated.h"
 #include "ray/gcs/redis_context.h"
+#include "ray/raylet/format/node_manager_generated.h"
 
 // TODO(pcm): Remove this
 #include "task.h"
@@ -164,6 +165,10 @@ using ClassTable = Table<ClassID, ClassTableData>;
 
 // TODO(swang): Set the pubsub channel for the actor table.
 using ActorTable = Table<ActorID, ActorTableData>;
+
+namespace raylet {
+using TaskTable = Table<TaskID, ray::protocol::Task>;
+}
 
 class TaskTable : public Table<TaskID, TaskTableData> {
  public:

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -167,7 +167,15 @@ using ClassTable = Table<ClassID, ClassTableData>;
 using ActorTable = Table<ActorID, ActorTableData>;
 
 namespace raylet {
-using TaskTable = Table<TaskID, ray::protocol::Task>;
+
+class TaskTable : public Table<TaskID, ray::protocol::Task> {
+ public:
+  TaskTable(const std::shared_ptr<RedisContext> &context, AsyncGcsClient *client)
+      : Table(context, client) {
+    pubsub_channel_ = TablePubsub_RAYLET_TASK;
+    prefix_ = TablePrefix_RAYLET_TASK;
+  }
+};
 }
 
 class TaskTable : public Table<TaskID, TaskTableData> {

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -1,5 +1,9 @@
 // Local scheduler protocol specification
 
+// TODO(swang): We put the flatbuffer types in a separate namespace for now to
+// avoid conflicts with legacy Ray types.
+namespace ray.protocol;
+
 enum MessageType:int {
   // Task is submitted to the local scheduler. This is sent from a worker to a
   // local scheduler.
@@ -48,6 +52,21 @@ enum MessageType:int {
   // before the checkpoint, and make any tasks on the frontier runnable by
   // making their execution dependencies available.
   SetActorFrontier
+}
+
+table TaskExecutionSpecification {
+  // A list of object IDs representing the dependencies of this task that may
+  // change at execution time.
+  dependencies: [string];
+  // The last time this task was received for scheduling.
+  last_timestamp: double;
+  // The number of times this task was spilled back by local schedulers.
+  num_forwards: int;
+}
+
+table Task {
+  task_specification: string;
+  task_execution_spec: TaskExecutionSpecification;
 }
 
 table SubmitTaskRequest {


### PR DESCRIPTION
## What do these changes do?

This adds a `TaskTable` for the xray `Task` flatbuffer, which should eventually replace the legacy `TaskTable`. To handle naming conflicts between legacy Ray and xray, this also places the xray flatbuffer types into a separate `ray::protocol` namespace.