### PR TITLE
Add an Append call to the GCS Log that checks for current length

### DIFF
--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -755,9 +755,7 @@ int TableRequestNotifications_RedisCommand(RedisModuleCtx *ctx,
   // Lookup the current value at the key.
   RedisModuleKey *table_key =
       OpenPrefixedKey(ctx, prefix_str, id, REDISMODULE_READ);
-  if (table_key == nullptr) {
-    RedisModule_ReplyWithNull(ctx);
-  } else {
+  if (table_key != nullptr) {
     // Publish the current value at the key to the client that is requesting
     // notifications.
     flatbuffers::FlatBufferBuilder fbb;

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -637,9 +637,8 @@ int TableAppend_RedisCommand(RedisModuleCtx *ctx,
 
 /// A helper function to create and finish a GcsTableEntry, based on the
 /// current value or values at the given key.
-void TableEntryToFlatbuf(flatbuffers::FlatBufferBuilder &fbb,
-                         RedisModuleKey *table_key,
-                         RedisModuleString *entry_id) {
+void TableEntryToFlatbuf(RedisModuleKey *table_key,
+                         RedisModuleString *entry_id, flatbuffers::FlatBufferBuilder &fbb) {
   auto key_type = RedisModule_KeyType(table_key);
   switch (key_type) {
   case REDISMODULE_KEYTYPE_STRING: {
@@ -703,7 +702,7 @@ int TableLookup_RedisCommand(RedisModuleCtx *ctx,
   } else {
     // Serialize the data to a flatbuffer to return to the client.
     flatbuffers::FlatBufferBuilder fbb;
-    TableEntryToFlatbuf(fbb, table_key, id);
+    TableEntryToFlatbuf(table_key, id, fbb);
     RedisModule_ReplyWithStringBuffer(
         ctx, reinterpret_cast<const char *>(fbb.GetBufferPointer()),
         fbb.GetSize());
@@ -759,7 +758,7 @@ int TableRequestNotifications_RedisCommand(RedisModuleCtx *ctx,
     // Publish the current value at the key to the client that is requesting
     // notifications.
     flatbuffers::FlatBufferBuilder fbb;
-    TableEntryToFlatbuf(fbb, table_key, id);
+    TableEntryToFlatbuf(table_key, id, fbb);
     RedisModule_Call(ctx, "PUBLISH", "sb", client_channel, reinterpret_cast<const char *>(fbb.GetBufferPointer()),
         fbb.GetSize());
   }

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -638,7 +638,8 @@ int TableAppend_RedisCommand(RedisModuleCtx *ctx,
 /// A helper function to create and finish a GcsTableEntry, based on the
 /// current value or values at the given key.
 void TableEntryToFlatbuf(RedisModuleKey *table_key,
-                         RedisModuleString *entry_id, flatbuffers::FlatBufferBuilder &fbb) {
+                         RedisModuleString *entry_id,
+                         flatbuffers::FlatBufferBuilder &fbb) {
   auto key_type = RedisModule_KeyType(table_key);
   switch (key_type) {
   case REDISMODULE_KEYTYPE_STRING: {

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -17,6 +17,7 @@ Status AsyncGcsClient::Connect(const std::string &address, int port,
   object_table_.reset(new ObjectTable(context_, this));
   task_table_.reset(new TaskTable(context_, this));
   raylet_task_table_.reset(new raylet::TaskTable(context_, this));
+  task_reconstruction_log_.reset(new TaskReconstructionLog(context_, this));
   client_table_.reset(new ClientTable(context_, this, client_info));
   // TODO(swang): Call the client table's Connect() method here. To do this,
   // we need to make sure that we are attached to an event loop first. This
@@ -43,6 +44,10 @@ ObjectTable &AsyncGcsClient::object_table() { return *object_table_; }
 TaskTable &AsyncGcsClient::task_table() { return *task_table_; }
 
 raylet::TaskTable &AsyncGcsClient::raylet_task_table() { return *raylet_task_table_; }
+
+TaskReconstructionLog &AsyncGcsClient::task_reconstruction_log() {
+  return *task_reconstruction_log_;
+}
 
 ClientTable &AsyncGcsClient::client_table() { return *client_table_; }
 

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -46,6 +46,7 @@ class RAY_EXPORT AsyncGcsClient {
   ObjectTable &object_table();
   TaskTable &task_table();
   raylet::TaskTable &raylet_task_table();
+  TaskReconstructionLog &task_reconstruction_log();
   ClientTable &client_table();
   inline ErrorTable &error_table();
 
@@ -65,6 +66,7 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<ObjectTable> object_table_;
   std::unique_ptr<TaskTable> task_table_;
   std::unique_ptr<raylet::TaskTable> raylet_task_table_;
+  std::unique_ptr<TaskReconstructionLog> task_reconstruction_log_;
   std::unique_ptr<ClientTable> client_table_;
   std::shared_ptr<RedisContext> context_;
   std::unique_ptr<RedisAsioClient> asio_async_client_;

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -420,9 +420,10 @@ TEST_F(TestGcsWithAsio, TestSubscribeCancel) {
   TestSubscribeCancel(job_id_, client_);
 }
 
-void ClientTableNotification(gcs::AsyncGcsClient *client, const UniqueID &id,
+void ClientTableNotification(gcs::AsyncGcsClient *client, const ClientID &client_id,
                              const ClientTableDataT &data, bool is_insertion) {
   ClientID added_id = client->client_table().GetLocalClientId();
+  ASSERT_EQ(client_id, added_id);
   ASSERT_EQ(ClientID::from_binary(data.client_id), added_id);
   ASSERT_EQ(data.is_insertion, is_insertion);
 

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -232,8 +232,8 @@ void TestLogAppendAt(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
     test->IncrementNumCallbacks();
   };
 
-  RAY_CHECK_OK(
-      client->task_reconstruction_log().Append(job_id, task_id, data_log[0], nullptr));
+  RAY_CHECK_OK(client->task_reconstruction_log().Append(job_id, task_id, data_log.front(),
+                                                        nullptr));
   RAY_CHECK_OK(client->task_reconstruction_log().AppendAt(job_id, task_id, data_log[1],
                                                           nullptr, failure_callback, 0));
   RAY_CHECK_OK(client->task_reconstruction_log().AppendAt(job_id, task_id, data_log[1],

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -96,21 +96,27 @@ void TestTableLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
   auto data = std::make_shared<protocol::TaskT>();
   data->task_specification = "123";
 
-  auto add_callback = [data](gcs::AsyncGcsClient *client, const UniqueID &id,
-                             const std::shared_ptr<protocol::TaskT> d) {
+  // Check that we added the correct task.
+  auto add_callback = [task_id, data](gcs::AsyncGcsClient *client, const UniqueID &id,
+                                      const std::shared_ptr<protocol::TaskT> d) {
+    ASSERT_EQ(id, task_id);
     ASSERT_EQ(data->task_specification, d->task_specification);
   };
 
-  auto lookup_callback = [data](gcs::AsyncGcsClient *client, const UniqueID &id,
-                                const protocol::TaskT &d) {
+  // Check that the lookup returns the added task.
+  auto lookup_callback = [task_id, data](gcs::AsyncGcsClient *client, const TaskID &id,
+                                         const protocol::TaskT &d) {
+    ASSERT_EQ(id, task_id);
     ASSERT_EQ(data->task_specification, d.task_specification);
     test->Stop();
   };
 
+  // Check that the lookup does not return an empty entry.
   auto failure_callback = [](gcs::AsyncGcsClient *client, const UniqueID &id) {
     RAY_CHECK(false);
   };
 
+  // Add the task, then do a lookup.
   RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id, data, add_callback));
   RAY_CHECK_OK(client->raylet_task_table().Lookup(job_id, task_id, lookup_callback,
                                                   failure_callback));
@@ -129,16 +135,69 @@ TEST_F(TestGcsWithAsio, TestTableLookup) {
   TestTableLookup(job_id_, client_);
 }
 
-void TestLookupFailure(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
+void TestLogLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
+  // Append some entries to the log at an object ID.
+  ObjectID object_id = ObjectID::from_random();
+  std::vector<std::string> managers = {"abc", "def", "ghi"};
+  for (auto &manager : managers) {
+    auto data = std::make_shared<ObjectTableDataT>();
+    data->manager = manager;
+    // Check that we added the correct object entries.
+    auto add_callback = [object_id, data](gcs::AsyncGcsClient *client, const UniqueID &id,
+                                          const std::shared_ptr<ObjectTableDataT> d) {
+      ASSERT_EQ(id, object_id);
+      ASSERT_EQ(data->manager, d->manager);
+    };
+    RAY_CHECK_OK(client->object_table().Append(job_id, object_id, data, add_callback));
+  }
+
+  // Check that lookup returns the added object entries.
+  auto lookup_callback = [object_id, managers](
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
+    ASSERT_EQ(id, object_id);
+    for (const auto &entry : data) {
+      ASSERT_EQ(entry.manager, managers[test->NumCallbacks()]);
+      test->IncrementNumCallbacks();
+    }
+    if (test->NumCallbacks() == managers.size()) {
+      test->Stop();
+    }
+  };
+
+  // Do a lookup at the object ID.
+  RAY_CHECK_OK(client->object_table().Lookup(job_id, object_id, lookup_callback));
+  // Run the event loop. The loop will only stop if the Lookup callback is
+  // called (or an assertion failure).
+  test->Start();
+  ASSERT_EQ(test->NumCallbacks(), managers.size());
+}
+
+TEST_F(TestGcsWithAe, TestLogLookup) {
+  test = this;
+  TestLogLookup(job_id_, client_);
+}
+
+TEST_F(TestGcsWithAsio, TestLogLookup) {
+  test = this;
+  TestLogLookup(job_id_, client_);
+}
+
+void TestTableLookupFailure(const JobID &job_id,
+                            std::shared_ptr<gcs::AsyncGcsClient> client) {
   TaskID task_id = TaskID::from_random();
 
+  // Check that the lookup does not return data.
   auto lookup_callback = [](gcs::AsyncGcsClient *client, const UniqueID &id,
                             const protocol::TaskT &d) { RAY_CHECK(false); };
 
-  auto failure_callback = [](gcs::AsyncGcsClient *client, const UniqueID &id) {
+  // Check that the lookup returns an empty entry.
+  auto failure_callback = [task_id](gcs::AsyncGcsClient *client, const UniqueID &id) {
+    ASSERT_EQ(id, task_id);
     test->Stop();
   };
 
+  // Lookup the task. We have not done any writes, so the key should be empty.
   RAY_CHECK_OK(client->raylet_task_table().Lookup(job_id, task_id, lookup_callback,
                                                   failure_callback));
   // Run the event loop. The loop will only stop if the failure callback is
@@ -146,14 +205,14 @@ void TestLookupFailure(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient>
   test->Start();
 }
 
-TEST_F(TestGcsWithAe, TestLookupFailure) {
+TEST_F(TestGcsWithAe, TestTableLookupFailure) {
   test = this;
-  TestLookupFailure(job_id_, client_);
+  TestTableLookupFailure(job_id_, client_);
 }
 
-TEST_F(TestGcsWithAsio, TestLookupFailure) {
+TEST_F(TestGcsWithAsio, TestTableLookupFailure) {
   test = this;
-  TestLookupFailure(job_id_, client_);
+  TestTableLookupFailure(job_id_, client_);
 }
 
 void TaskAdded(gcs::AsyncGcsClient *client, const TaskID &id,
@@ -227,7 +286,7 @@ void TestTableSubscribeAll(const JobID &job_id,
   auto notification_callback = [task_id, task_specs](
       gcs::AsyncGcsClient *client, const UniqueID &id, const protocol::TaskT &data) {
     ASSERT_EQ(id, task_id);
-    // Check that the task entry was added.
+    // Check that we get notifications in the same order as the writes.
     ASSERT_EQ(data.task_specification, task_specs[test->NumCallbacks()]);
     test->IncrementNumCallbacks();
     if (test->NumCallbacks() == task_specs.size()) {
@@ -235,9 +294,10 @@ void TestTableSubscribeAll(const JobID &job_id,
     }
   };
 
-  // Callback for subscription success. This should only be called once.
+  // Callback for subscription success. We are guaranteed to receive
+  // notifications after this is called.
   auto subscribe_callback = [job_id, task_id, task_specs](gcs::AsyncGcsClient *client) {
-    // We have subscribed. Add an task table entry.
+    // We have subscribed. Do the writes to the table.
     for (const auto &task_spec : task_specs) {
       auto data = std::make_shared<protocol::TaskT>();
       data->task_specification = task_spec;
@@ -246,16 +306,14 @@ void TestTableSubscribeAll(const JobID &job_id,
   };
 
   // Subscribe to all task table notifications. Once we have successfully
-  // subscribed, we will add an task and check that we get notified of the
-  // operation.
+  // subscribed, we will write the key several times and check that we get
+  // notified for each.
   RAY_CHECK_OK(client->raylet_task_table().Subscribe(
       job_id, ClientID::nil(), notification_callback, subscribe_callback));
-
   // Run the event loop. The loop will only stop if the registered subscription
   // callback is called (or an assertion failure).
   test->Start();
-  // Check that we received one callback for subscription success and one for
-  // the Add notification.
+  // Check that we received one notification callback for each write.
   ASSERT_EQ(test->NumCallbacks(), task_specs.size());
 }
 
@@ -269,74 +327,85 @@ TEST_F(TestGcsWithAsio, TestTableSubscribeAll) {
   TestTableSubscribeAll(job_id_, client_);
 }
 
-void TestSubscribeAll(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
-  ObjectID object_id = ObjectID::from_random();
+void TestLogSubscribeAll(const JobID &job_id,
+                         std::shared_ptr<gcs::AsyncGcsClient> client) {
+  std::vector<std::string> managers = {"abc", "def", "ghi"};
+  std::vector<ObjectID> object_ids;
+  for (size_t i = 0; i < managers.size(); i++) {
+    object_ids.push_back(ObjectID::from_random());
+  }
   // Callback for a notification.
-  auto notification_callback = [object_id](
-      gcs::AsyncGcsClient *client, const UniqueID &id, const ObjectTableDataT &data) {
-    ASSERT_EQ(id, object_id);
-    // Check that the object entry was added.
-    ASSERT_EQ(data.managers, std::vector<std::string>({"A", "B"}));
-    test->IncrementNumCallbacks();
-    test->Stop();
+  auto notification_callback = [object_ids, managers](
+      gcs::AsyncGcsClient *client, const UniqueID &id,
+      const std::vector<ObjectTableDataT> data) {
+    ASSERT_EQ(id, object_ids[test->NumCallbacks()]);
+    // Check that we get notifications in the same order as the writes.
+    for (const auto &entry : data) {
+      ASSERT_EQ(entry.manager, managers[test->NumCallbacks()]);
+      test->IncrementNumCallbacks();
+    }
+    if (test->NumCallbacks() == managers.size()) {
+      test->Stop();
+    }
   };
 
-  // Callback for subscription success. This should only be called once.
-  auto subscribe_callback = [job_id, object_id](gcs::AsyncGcsClient *client) {
-    test->IncrementNumCallbacks();
-    // We have subscribed. Add an object table entry.
-    auto data = std::make_shared<ObjectTableDataT>();
-    data->managers.push_back("A");
-    data->managers.push_back("B");
-    RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
+  // Callback for subscription success. We are guaranteed to receive
+  // notifications after this is called.
+  auto subscribe_callback = [job_id, object_ids, managers](gcs::AsyncGcsClient *client) {
+    // We have subscribed. Do the writes to the table.
+    for (size_t i = 0; i < object_ids.size(); i++) {
+      auto data = std::make_shared<ObjectTableDataT>();
+      data->manager = managers[i];
+      RAY_CHECK_OK(client->object_table().Append(job_id, object_ids[i], data, nullptr));
+    }
   };
 
-  // Subscribe to all object table notifications. Once we have successfully
-  // subscribed, we will add an object and check that we get notified of the
-  // operation.
+  // Subscribe to all task table notifications. Once we have successfully
+  // subscribed, we will append to the key several times and check that we get
+  // notified for each.
   RAY_CHECK_OK(client->object_table().Subscribe(
       job_id, ClientID::nil(), notification_callback, subscribe_callback));
 
   // Run the event loop. The loop will only stop if the registered subscription
   // callback is called (or an assertion failure).
   test->Start();
-  // Check that we received one callback for subscription success and one for
-  // the Add notification.
-  ASSERT_EQ(test->NumCallbacks(), 2);
+  // Check that we received one notification callback for each write.
+  ASSERT_EQ(test->NumCallbacks(), managers.size());
 }
 
-TEST_F(TestGcsWithAe, TestSubscribeAll) {
+TEST_F(TestGcsWithAe, TestLogSubscribeAll) {
   test = this;
-  TestSubscribeAll(job_id_, client_);
+  TestLogSubscribeAll(job_id_, client_);
 }
 
-TEST_F(TestGcsWithAsio, TestSubscribeAll) {
+TEST_F(TestGcsWithAsio, TestLogSubscribeAll) {
   test = this;
-  TestSubscribeAll(job_id_, client_);
+  TestLogSubscribeAll(job_id_, client_);
 }
 
 void TestTableSubscribeId(const JobID &job_id,
                           std::shared_ptr<gcs::AsyncGcsClient> client) {
-  // Add an object table entry.
+  // Add a table entry.
   TaskID task_id1 = TaskID::from_random();
   std::vector<std::string> task_specs1 = {"abc", "def", "ghi"};
   auto data1 = std::make_shared<protocol::TaskT>();
   data1->task_specification = task_specs1[0];
   RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id1, data1, nullptr));
 
-  // Add a second object table entry.
+  // Add a table entry at a second key.
   TaskID task_id2 = TaskID::from_random();
   std::vector<std::string> task_specs2 = {"jkl", "mno", "pqr"};
   auto data2 = std::make_shared<protocol::TaskT>();
   data2->task_specification = task_specs2[0];
   RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id2, data2, nullptr));
 
-  // The callback for a notification from the object table. This should only be
-  // received for the object that we requested notifications for.
+  // The callback for a notification from the table. This should only be
+  // received for keys that we requested notifications for.
   auto notification_callback = [task_id2, task_specs2](
       gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
+    // Check that we only get notifications for the requested key.
     ASSERT_EQ(id, task_id2);
-    // Check that the task entry was added.
+    // Check that we get notifications in the same order as the writes.
     ASSERT_EQ(data.task_specification, task_specs2[test->NumCallbacks()]);
     test->IncrementNumCallbacks();
     if (test->NumCallbacks() == task_specs2.size()) {
@@ -345,16 +414,14 @@ void TestTableSubscribeId(const JobID &job_id,
   };
 
   // The callback for subscription success. Once we've subscribed, request
-  // notifications for the second object that was added.
+  // notifications for only one of the keys, then write to both keys.
   auto subscribe_callback = [job_id, task_id1, task_id2, task_specs1,
                              task_specs2](gcs::AsyncGcsClient *client) {
-    // Request notifications for the second object. Since we already added the
-    // entry to the table, we should receive an initial notification for its
-    // current value.
+    // Request notifications for one of the keys.
     RAY_CHECK_OK(client->raylet_task_table().RequestNotifications(
         job_id, task_id2, client->client_table().GetLocalClientId()));
-    // Overwrite the entry for the object. We should receive a second
-    // notification for its new value.
+    // Write both keys. We should only receive notifications for the key that
+    // we requested them for.
     auto remaining = std::vector<std::string>(++task_specs1.begin(), task_specs1.end());
     for (const auto &task_spec : remaining) {
       auto data = std::make_shared<protocol::TaskT>();
@@ -369,15 +436,16 @@ void TestTableSubscribeId(const JobID &job_id,
     }
   };
 
+  // Subscribe to notifications for this client. This allows us to request and
+  // receive notifications for specific keys.
   RAY_CHECK_OK(client->raylet_task_table().Subscribe(
       job_id, client->client_table().GetLocalClientId(), notification_callback,
       subscribe_callback));
-
   // Run the event loop. The loop will only stop if the registered subscription
-  // callback is called for both writes to the object key.
+  // callback is called for the requested key.
   test->Start();
-  // Check that we received one callback for subscription success and two
-  // callbacks for the Add notifications.
+  // Check that we received one notification callback for each write to the
+  // requested key.
   ASSERT_EQ(test->NumCallbacks(), task_specs2.size());
 }
 
@@ -391,89 +459,101 @@ TEST_F(TestGcsWithAsio, TestTableSubscribeId) {
   TestTableSubscribeId(job_id_, client_);
 }
 
-void TestSubscribeId(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
-  // Add an object table entry.
+void TestLogSubscribeId(const JobID &job_id,
+                        std::shared_ptr<gcs::AsyncGcsClient> client) {
+  // Add a log entry.
   ObjectID object_id1 = ObjectID::from_random();
+  std::vector<std::string> managers1 = {"abc", "def", "ghi"};
   auto data1 = std::make_shared<ObjectTableDataT>();
-  data1->managers.push_back("A");
-  data1->managers.push_back("B");
-  RAY_CHECK_OK(client->object_table().Add(job_id, object_id1, data1, nullptr));
+  data1->manager = managers1[0];
+  RAY_CHECK_OK(client->object_table().Append(job_id, object_id1, data1, nullptr));
 
-  // Add a second object table entry.
+  // Add a log entry at a second key.
   ObjectID object_id2 = ObjectID::from_random();
+  std::vector<std::string> managers2 = {"jkl", "mno", "pqr"};
   auto data2 = std::make_shared<ObjectTableDataT>();
-  data2->managers.push_back("C");
-  RAY_CHECK_OK(client->object_table().Add(job_id, object_id2, data2, nullptr));
+  data2->manager = managers2[0];
+  RAY_CHECK_OK(client->object_table().Append(job_id, object_id2, data2, nullptr));
 
-  // The callback for subscription success. Once we've subscribed, request
-  // notifications for the second object that was added.
-  auto subscribe_callback = [job_id, object_id2](gcs::AsyncGcsClient *client) {
-    test->IncrementNumCallbacks();
-    // Request notifications for the second object. Since we already added the
-    // entry to the table, we should receive an initial notification for its
-    // current value.
-    RAY_CHECK_OK(client->object_table().RequestNotifications(
-        job_id, object_id2, client->client_table().GetLocalClientId()));
-    // Overwrite the entry for the object. We should receive a second
-    // notification for its new value.
-    auto data = std::make_shared<ObjectTableDataT>();
-    data->managers.push_back("C");
-    data->managers.push_back("D");
-    RAY_CHECK_OK(client->object_table().Add(job_id, object_id2, data, nullptr));
-  };
-
-  // The callback for a notification from the object table. This should only be
-  // received for the object that we requested notifications for.
-  auto notification_callback = [data2, object_id2](
-      gcs::AsyncGcsClient *client, const UniqueID &id, const ObjectTableDataT &data) {
+  // The callback for a notification from the table. This should only be
+  // received for keys that we requested notifications for.
+  auto notification_callback = [object_id2, managers2](
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
+    // Check that we only get notifications for the requested key.
     ASSERT_EQ(id, object_id2);
-    // Check that we got a notification for the correct object.
-    ASSERT_EQ(data.managers.front(), "C");
-    test->IncrementNumCallbacks();
-    // Stop the loop once we've received notifications for both writes to the
-    // object key.
-    if (test->NumCallbacks() == 3) {
+    // Check that we get notifications in the same order as the writes.
+    for (const auto &entry : data) {
+      ASSERT_EQ(entry.manager, managers2[test->NumCallbacks()]);
+      test->IncrementNumCallbacks();
+    }
+    if (test->NumCallbacks() == managers2.size()) {
       test->Stop();
     }
   };
 
+  // The callback for subscription success. Once we've subscribed, request
+  // notifications for only one of the keys, then write to both keys.
+  auto subscribe_callback = [job_id, object_id1, object_id2, managers1,
+                             managers2](gcs::AsyncGcsClient *client) {
+    // Request notifications for one of the keys.
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id2, client->client_table().GetLocalClientId()));
+    // Write both keys. We should only receive notifications for the key that
+    // we requested them for.
+    auto remaining = std::vector<std::string>(++managers1.begin(), managers1.end());
+    for (const auto &manager : remaining) {
+      auto data = std::make_shared<ObjectTableDataT>();
+      data->manager = manager;
+      RAY_CHECK_OK(client->object_table().Append(job_id, object_id1, data, nullptr));
+    }
+    remaining = std::vector<std::string>(++managers2.begin(), managers2.end());
+    for (const auto &manager : remaining) {
+      auto data = std::make_shared<ObjectTableDataT>();
+      data->manager = manager;
+      RAY_CHECK_OK(client->object_table().Append(job_id, object_id2, data, nullptr));
+    }
+  };
+
+  // Subscribe to notifications for this client. This allows us to request and
+  // receive notifications for specific keys.
   RAY_CHECK_OK(
       client->object_table().Subscribe(job_id, client->client_table().GetLocalClientId(),
                                        notification_callback, subscribe_callback));
-
   // Run the event loop. The loop will only stop if the registered subscription
-  // callback is called for both writes to the object key.
+  // callback is called for the requested key.
   test->Start();
-  // Check that we received one callback for subscription success and two
-  // callbacks for the Add notifications.
-  ASSERT_EQ(test->NumCallbacks(), 3);
+  // Check that we received one notification callback for each write to the
+  // requested key.
+  ASSERT_EQ(test->NumCallbacks(), managers2.size());
 }
 
-TEST_F(TestGcsWithAe, TestSubscribeId) {
+TEST_F(TestGcsWithAe, TestLogSubscribeId) {
   test = this;
-  TestSubscribeId(job_id_, client_);
+  TestLogSubscribeId(job_id_, client_);
 }
 
-TEST_F(TestGcsWithAsio, TestSubscribeId) {
+TEST_F(TestGcsWithAsio, TestLogSubscribeId) {
   test = this;
-  TestSubscribeId(job_id_, client_);
+  TestLogSubscribeId(job_id_, client_);
 }
 
 void TestTableSubscribeCancel(const JobID &job_id,
                               std::shared_ptr<gcs::AsyncGcsClient> client) {
-  // Add a task table entry.
+  // Add a table entry.
   TaskID task_id = TaskID::from_random();
   std::vector<std::string> task_specs = {"jkl", "mno", "pqr"};
   auto data = std::make_shared<protocol::TaskT>();
   data->task_specification = task_specs[0];
   RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id, data, nullptr));
 
-  // The callback for a notification from the object table. This should only be
-  // received for the object that we requested notifications for.
+  // The callback for a notification from the table. This should only be
+  // received for keys that we requested notifications for.
   auto notification_callback = [task_id, task_specs](
       gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
     ASSERT_EQ(id, task_id);
-    // Check that the task entry was added.
+    // Check that we only get notifications for the first and last writes,
+    // since notifications are canceled in between.
     if (test->NumCallbacks() == 0) {
       ASSERT_EQ(data.task_specification, task_specs.front());
     } else {
@@ -485,37 +565,39 @@ void TestTableSubscribeCancel(const JobID &job_id,
     }
   };
 
-  // The callback for subscription success. Once we've subscribed, request
-  // notifications for the second object that was added.
+  // The callback for a notification from the table. This should only be
+  // received for keys that we requested notifications for.
   auto subscribe_callback = [job_id, task_id, task_specs](gcs::AsyncGcsClient *client) {
-    // Request notifications for the second object. Since we already added the
-    // entry to the table, we should receive an initial notification for its
-    // current value.
+    // Request notifications, then cancel immediately. We should receive a
+    // notification for the current value at the key.
     RAY_CHECK_OK(client->raylet_task_table().RequestNotifications(
         job_id, task_id, client->client_table().GetLocalClientId()));
     RAY_CHECK_OK(client->raylet_task_table().CancelNotifications(
         job_id, task_id, client->client_table().GetLocalClientId()));
-    // Overwrite the entry for the object. We should receive a second
-    // notification for its new value.
+    // Write to the key. Since we canceled notifications, we should not receive
+    // a notification for these writes.
     auto remaining = std::vector<std::string>(++task_specs.begin(), task_specs.end());
     for (const auto &task_spec : remaining) {
       auto data = std::make_shared<protocol::TaskT>();
       data->task_specification = task_spec;
       RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id, data, nullptr));
     }
+    // Request notifications again. We should receive a notification for the
+    // current value at the key.
     RAY_CHECK_OK(client->raylet_task_table().RequestNotifications(
         job_id, task_id, client->client_table().GetLocalClientId()));
   };
 
+  // Subscribe to notifications for this client. This allows us to request and
+  // receive notifications for specific keys.
   RAY_CHECK_OK(client->raylet_task_table().Subscribe(
       job_id, client->client_table().GetLocalClientId(), notification_callback,
       subscribe_callback));
-
   // Run the event loop. The loop will only stop if the registered subscription
-  // callback is called for both writes to the object key.
+  // callback is called for the requested key.
   test->Start();
-  // Check that we received one callback for subscription success and two
-  // callbacks for the Add notifications.
+  // Check that we received a notification callback for the first and least
+  // writes to the key, since notifications are canceled in between.
   ASSERT_EQ(test->NumCallbacks(), 2);
 }
 
@@ -529,77 +611,80 @@ TEST_F(TestGcsWithAsio, TestTableSubscribeCancel) {
   TestTableSubscribeCancel(job_id_, client_);
 }
 
-void TestSubscribeCancel(const JobID &job_id,
-                         std::shared_ptr<gcs::AsyncGcsClient> client) {
-  // Write the object table once.
+void TestLogSubscribeCancel(const JobID &job_id,
+                            std::shared_ptr<gcs::AsyncGcsClient> client) {
+  // Add a log entry.
   ObjectID object_id = ObjectID::from_random();
+  std::vector<std::string> managers = {"jkl", "mno", "pqr"};
   auto data = std::make_shared<ObjectTableDataT>();
-  data->managers.push_back("A");
-  RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
+  data->manager = managers[0];
+  RAY_CHECK_OK(client->object_table().Append(job_id, object_id, data, nullptr));
 
-  // The callback for subscription success. Once we've subscribed, request
-  // notifications for the second object that was added.
-  auto subscribe_callback = [job_id, object_id](gcs::AsyncGcsClient *client) {
-    test->IncrementNumCallbacks();
-    // Request notifications for the object. We should receive a notification
-    // for the current value at the key.
-    RAY_CHECK_OK(client->object_table().RequestNotifications(
-        job_id, object_id, client->client_table().GetLocalClientId()));
-    // Cancel notifications.
-    RAY_CHECK_OK(client->object_table().CancelNotifications(
-        job_id, object_id, client->client_table().GetLocalClientId()));
-    // Write the object table entry twice. Since we canceled notifications, we
-    // should not get notifications for either of these writes.
-    auto data = std::make_shared<ObjectTableDataT>();
-    data->managers.push_back("B");
-    RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
-    data = std::make_shared<ObjectTableDataT>();
-    data->managers.push_back("C");
-    RAY_CHECK_OK(client->object_table().Add(job_id, object_id, data, nullptr));
-    // Request notifications for the object again. We should only receive a
-    // notification for the current value at the key.
-    RAY_CHECK_OK(client->object_table().RequestNotifications(
-        job_id, object_id, client->client_table().GetLocalClientId()));
-  };
-
-  // The callback for a notification from the object table.
-  auto notification_callback = [object_id](
-      gcs::AsyncGcsClient *client, const UniqueID &id, const ObjectTableDataT &data) {
+  // The callback for a notification from the object table. This should only be
+  // received for the object that we requested notifications for.
+  auto notification_callback = [object_id, managers](
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     ASSERT_EQ(id, object_id);
-    // Check that we only receive notifications for the key when we have
-    // requested notifications for it. We should not get a notification for the
-    // entry that began with "B" since we canceled notifications then.
-    if (test->NumCallbacks() == 1) {
-      ASSERT_EQ(data.managers.front(), "A");
-    } else {
-      ASSERT_EQ(data.managers.front(), "C");
+    // Check that we get a duplicate notification for the first write. We get a
+    // duplicate notification because the log is append-only and notifications
+    // are canceled after the first write, then requested again.
+    auto managers_copy = managers;
+    managers_copy.insert(managers_copy.begin(), managers_copy.front());
+    for (const auto &entry : data) {
+      ASSERT_EQ(entry.manager, managers_copy[test->NumCallbacks()]);
+      test->IncrementNumCallbacks();
     }
-    test->IncrementNumCallbacks();
-    if (test->NumCallbacks() == 3) {
+    if (test->NumCallbacks() == managers_copy.size()) {
       test->Stop();
     }
   };
 
+  // The callback for a notification from the table. This should only be
+  // received for keys that we requested notifications for.
+  auto subscribe_callback = [job_id, object_id, managers](gcs::AsyncGcsClient *client) {
+    // Request notifications, then cancel immediately. We should receive a
+    // notification for the current value at the key.
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
+    RAY_CHECK_OK(client->object_table().CancelNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
+    // Append to the key. Since we canceled notifications, we should not
+    // receive a notification for these writes.
+    auto remaining = std::vector<std::string>(++managers.begin(), managers.end());
+    for (const auto &manager : remaining) {
+      auto data = std::make_shared<ObjectTableDataT>();
+      data->manager = manager;
+      RAY_CHECK_OK(client->object_table().Append(job_id, object_id, data, nullptr));
+    }
+    // Request notifications again. We should receive a notification for the
+    // current values at the key.
+    RAY_CHECK_OK(client->object_table().RequestNotifications(
+        job_id, object_id, client->client_table().GetLocalClientId()));
+  };
+
+  // Subscribe to notifications for this client. This allows us to request and
+  // receive notifications for specific keys.
   RAY_CHECK_OK(
       client->object_table().Subscribe(job_id, client->client_table().GetLocalClientId(),
                                        notification_callback, subscribe_callback));
-
   // Run the event loop. The loop will only stop if the registered subscription
-  // callback is called (or an assertion failure).
+  // callback is called for the requested key.
   test->Start();
-  // Check that we received one callback for subscription success and two
-  // callbacks for the Add notifications.
-  ASSERT_EQ(test->NumCallbacks(), 3);
+  // Check that we received a notification callback for the first append to the
+  // key, then a notification for all of the appends, because we cancel
+  // notifications in between.
+  ASSERT_EQ(test->NumCallbacks(), managers.size() + 1);
 }
 
-TEST_F(TestGcsWithAe, TestSubscribeCancel) {
+TEST_F(TestGcsWithAe, TestLogSubscribeCancel) {
   test = this;
-  TestSubscribeCancel(job_id_, client_);
+  TestLogSubscribeCancel(job_id_, client_);
 }
 
-TEST_F(TestGcsWithAsio, TestSubscribeCancel) {
+TEST_F(TestGcsWithAsio, TestLogSubscribeCancel) {
   test = this;
-  TestSubscribeCancel(job_id_, client_);
+  TestLogSubscribeCancel(job_id_, client_);
 }
 
 void ClientTableNotification(gcs::AsyncGcsClient *client, const UniqueID &id,

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -10,7 +10,8 @@ enum TablePrefix:int {
   RAYLET_TASK,
   CLIENT,
   OBJECT,
-  FUNCTION
+  FUNCTION,
+  TASK_RECONSTRUCTION
 }
 
 // The channel that Add operations to the Table should be published on, if any.
@@ -38,6 +39,11 @@ table ObjectTableData {
   object_size: long;
   manager: string;
   is_eviction: bool;
+}
+
+table TaskReconstructionData {
+  num_executions: int;
+  node_manager_id: string;
 }
 
 enum SchedulingState:int {

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -36,9 +36,14 @@ table FunctionTableData {
 }
 
 table ObjectTableData {
+  // The size of the object.
   object_size: long;
+  // The node manager ID that this object appeared on or was evicted by.
   manager: string;
+  // Whether this entry is an addition or a deletion.
   is_eviction: bool;
+  // The number of times this object has been evicted from this node so far.
+  num_evictions: int;
 }
 
 table TaskReconstructionData {

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -35,11 +35,9 @@ table FunctionTableData {
 }
 
 table ObjectTableData {
-  task_id: string;
   object_size: long;
-  is_put: bool;
-  never_created: bool;
-  managers: [string];
+  manager: string;
+  is_eviction: bool;
 }
 
 enum SchedulingState:int {

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -23,9 +23,9 @@ enum TablePubsub:int {
   ACTOR
 }
 
-table GcsNotification {
+table GcsTableEntry {
   id: string;
-  data: string;
+  entries: [string];
 }
 
 table FunctionTableData {

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -183,14 +183,14 @@ Status RedisContext::AttachToEventLoop(aeEventLoop *loop) {
 Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
                               const uint8_t *data, int64_t length,
                               const TablePrefix prefix, const TablePubsub pubsub_channel,
-                              int64_t callback_index, int log_index) {
+                              int64_t callback_index, int log_length) {
   if (length > 0) {
-    if (log_index >= 0) {
+    if (log_length >= 0) {
       std::string redis_command = command + " %d %d %b %b %d";
       int status = redisAsyncCommand(
           async_context_, reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
           reinterpret_cast<void *>(callback_index), redis_command.c_str(), prefix,
-          pubsub_channel, id.data(), id.size(), data, length, log_index);
+          pubsub_channel, id.data(), id.size(), data, length, log_length);
       if (status == REDIS_ERR) {
         return Status::RedisError(std::string(async_context_->errstr));
       }
@@ -205,7 +205,7 @@ Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
       }
     }
   } else {
-    RAY_CHECK(log_index == -1);
+    RAY_CHECK(log_length == -1);
     std::string redis_command = command + " %d %d %b";
     int status = redisAsyncCommand(
         async_context_, reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -24,7 +24,7 @@ class RedisCallbackManager {
   /// Every callback should take in a vector of the results from the Redis
   /// operation and return a bool indicating whether the callback should be
   /// deleted once called.
-  using RedisCallback = std::function<bool(const std::vector<std::string> &)>;
+  using RedisCallback = std::function<bool(const std::string &)>;
 
   static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -53,9 +53,25 @@ class RedisContext {
   ~RedisContext();
   Status Connect(const std::string &address, int port);
   Status AttachToEventLoop(aeEventLoop *loop);
+
+  /// Run an operation on some table key.
+  ///
+  /// \param command The command to run. This must match a registered Ray Redis
+  ///        command. These are strings of the format "RAY.TABLE_*".
+  /// \param id The table key to run the operation at.
+  /// \param data The data to add to the table key, if any.
+  /// \param length The length of the data to be added, if data is provided.
+  /// \param prefix
+  /// \param pubsub_channel
+  /// \param callback_index
+  /// \param log_index The RAY.TABLE_APPEND command takes in an optional index
+  ///        at which the data must be appended. For all other commands, this
+  ///        is unused. If this set, then data must be provided.
   Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
-                  int64_t length, int index, const TablePrefix prefix,
-                  const TablePubsub pubsub_channel, int64_t callback_index);
+                  int64_t length, const TablePrefix prefix,
+                  const TablePubsub pubsub_channel, int64_t callback_index,
+                  int log_index = 1);
+
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         int64_t callback_index);
   redisAsyncContext *async_context() { return async_context_; }

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -54,7 +54,7 @@ class RedisContext {
   Status Connect(const std::string &address, int port);
   Status AttachToEventLoop(aeEventLoop *loop);
   Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
-                  int64_t length, const TablePrefix prefix,
+                  int64_t length, int index, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, int64_t callback_index);
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         int64_t callback_index);

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -65,12 +65,12 @@ class RedisContext {
   /// \param pubsub_channel
   /// \param callback_index
   /// \param log_index The RAY.TABLE_APPEND command takes in an optional index
-  ///        at which the data must be appended. For all other commands, this
-  ///        is unused. If this set, then data must be provided.
+  ///        at which the data must be appended. For all other commands, set to
+  ///        -1 for unused. If set, then data must be provided.
   Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
                   int64_t length, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, int64_t callback_index,
-                  int log_index = 1);
+                  int log_index = -1);
 
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         int64_t callback_index);

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -64,13 +64,13 @@ class RedisContext {
   /// \param prefix
   /// \param pubsub_channel
   /// \param callback_index
-  /// \param log_index The RAY.TABLE_APPEND command takes in an optional index
+  /// \param log_length The RAY.TABLE_APPEND command takes in an optional index
   ///        at which the data must be appended. For all other commands, set to
   ///        -1 for unused. If set, then data must be provided.
   Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
                   int64_t length, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, int64_t callback_index,
-                  int log_index = -1);
+                  int log_length = -1);
 
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         int64_t callback_index);

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -24,7 +24,7 @@ Status Log<ID, Data>::Append(const JobID &job_id, const ID &id,
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, data.get()));
   return context_->RunAsync("RAY.TABLE_APPEND", id, fbb.GetBufferPointer(), fbb.GetSize(),
-                            -1, prefix_, pubsub_channel_, callback_index);
+                            prefix_, pubsub_channel_, callback_index);
 }
 
 template <typename ID, typename Data>
@@ -50,7 +50,7 @@ Status Log<ID, Data>::AppendAt(const JobID &job_id, const ID &id,
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, data.get()));
   return context_->RunAsync("RAY.TABLE_APPEND", id, fbb.GetBufferPointer(), fbb.GetSize(),
-                            index, prefix_, pubsub_channel_, callback_index);
+                            prefix_, pubsub_channel_, callback_index, index);
 }
 
 template <typename ID, typename Data>
@@ -77,7 +77,7 @@ Status Log<ID, Data>::Lookup(const JobID &job_id, const ID &id, const Callback &
         return true;
       });
   std::vector<uint8_t> nil;
-  return context_->RunAsync("RAY.TABLE_LOOKUP", id, nil.data(), nil.size(), -1, prefix_,
+  return context_->RunAsync("RAY.TABLE_LOOKUP", id, nil.data(), nil.size(), prefix_,
                             pubsub_channel_, callback_index);
 }
 
@@ -131,7 +131,7 @@ Status Log<ID, Data>::RequestNotifications(const JobID &job_id, const ID &id,
   RAY_CHECK(subscribe_callback_index_ >= 0)
       << "Client requested notifications on a key before Subscribe completed";
   return context_->RunAsync("RAY.TABLE_REQUEST_NOTIFICATIONS", id, client_id.data(),
-                            client_id.size(), -1, prefix_, pubsub_channel_,
+                            client_id.size(), prefix_, pubsub_channel_,
                             /*callback_index=*/-1);
 }
 
@@ -141,7 +141,7 @@ Status Log<ID, Data>::CancelNotifications(const JobID &job_id, const ID &id,
   RAY_CHECK(subscribe_callback_index_ >= 0)
       << "Client canceled notifications on a key before Subscribe completed";
   return context_->RunAsync("RAY.TABLE_CANCEL_NOTIFICATIONS", id, client_id.data(),
-                            client_id.size(), -1, prefix_, pubsub_channel_,
+                            client_id.size(), prefix_, pubsub_channel_,
                             /*callback_index=*/-1);
 }
 
@@ -161,7 +161,7 @@ Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, data.get()));
   return context_->RunAsync("RAY.TABLE_ADD", id, fbb.GetBufferPointer(), fbb.GetSize(),
-                            -1, prefix_, pubsub_channel_, callback_index);
+                            prefix_, pubsub_channel_, callback_index);
 }
 
 template <typename ID, typename Data>

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -335,6 +335,7 @@ template class Log<ObjectID, ObjectTableData>;
 template class Log<TaskID, ray::protocol::Task>;
 template class Table<TaskID, ray::protocol::Task>;
 template class Table<TaskID, TaskTableData>;
+template class Log<TaskID, TaskReconstructionData>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -308,7 +308,6 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) {
 template class Log<ObjectID, ObjectTableData>;
 template class Table<TaskID, ray::protocol::Task>;
 template class Table<TaskID, TaskTableData>;
-template class Table<ObjectID, ObjectTableData>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -42,7 +42,7 @@ Status Log<ID, Data>::Lookup(const JobID &job_id, const ID &id, const Callback &
               auto data_root =
                   flatbuffers::GetRoot<Data>(root->entries()->Get(i)->data());
               data_root->UnPackTo(&result);
-              results.push_back(result);
+              results.emplace_back(std::move(result));
             }
           }
           (d->callback)(d->client, d->id, results);
@@ -85,7 +85,7 @@ Status Log<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id,
               auto data_root =
                   flatbuffers::GetRoot<Data>(root->entries()->Get(i)->data());
               data_root->UnPackTo(&result);
-              results.push_back(result);
+              results.emplace_back(std::move(result));
             }
             (d->callback)(d->client, id, results);
             }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -9,13 +9,13 @@ namespace gcs {
 
 template <typename ID, typename Data>
 Status Log<ID, Data>::Append(const JobID &job_id, const ID &id,
-                             std::shared_ptr<DataT> data, const Callback &done) {
+                             std::shared_ptr<DataT> data, const WriteCallback &done) {
   auto d = std::shared_ptr<CallbackData>(
-      new CallbackData({id, data, done, nullptr, this, client_}));
+      new CallbackData({id, data, nullptr, nullptr, this, client_}));
   int64_t callback_index =
-      RedisCallbackManager::instance().add([d](const std::string &data) {
-        if (d->callback != nullptr) {
-          (d->callback)(d->client, d->id, {*d->data});
+      RedisCallbackManager::instance().add([d, done](const std::string &data) {
+        if (done != nullptr) {
+          (done)(d->client, d->id, d->data);
         }
         return true;
       });
@@ -120,13 +120,13 @@ Status Log<ID, Data>::CancelNotifications(const JobID &job_id, const ID &id,
 
 template <typename ID, typename Data>
 Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
-                            std::shared_ptr<DataT> data, const Callback &done) {
+                            std::shared_ptr<DataT> data, const WriteCallback &done) {
   auto d = std::shared_ptr<CallbackData>(
-      new CallbackData({id, data, done, nullptr, this, client_}));
+      new CallbackData({id, data, nullptr, nullptr, this, client_}));
   int64_t callback_index =
-      RedisCallbackManager::instance().add([d](const std::string &data) {
-        if (d->callback != nullptr) {
-          (d->callback)(d->client, d->id, *d->data);
+      RedisCallbackManager::instance().add([d, done](const std::string &data) {
+        if (done != nullptr) {
+          (done)(d->client, d->id, d->data);
         }
         return true;
       });
@@ -232,8 +232,9 @@ void ClientTable::HandleNotification(AsyncGcsClient *client,
   }
 }
 
-void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientTableDataT &data) {
-  auto connected_client_id = ClientID::from_binary(data.client_id);
+void ClientTable::HandleConnected(AsyncGcsClient *client,
+                                  const std::shared_ptr<ClientTableDataT> data) {
+  auto connected_client_id = ClientID::from_binary(data->client_id);
   RAY_CHECK(client_id_ == connected_client_id) << connected_client_id.hex() << " "
                                                << client_id_.hex();
 }
@@ -259,10 +260,9 @@ Status ClientTable::Connect() {
   // Callback to handle our own successful connection once we've added
   // ourselves.
   auto add_callback = [this](AsyncGcsClient *client, const UniqueID &log_key,
-                             const std::vector<ClientTableDataT> &data) {
+                             std::shared_ptr<ClientTableDataT> data) {
     RAY_CHECK(log_key == client_log_key_);
-    RAY_CHECK(data.size() == 1);
-    HandleConnected(client, data[0]);
+    HandleConnected(client, data);
   };
   // Callback to add ourselves once we've successfully subscribed.
   auto subscription_callback = [this, data, add_callback](AsyncGcsClient *c) {
@@ -282,9 +282,8 @@ Status ClientTable::Disconnect() {
   auto data = std::make_shared<ClientTableDataT>(local_client_);
   data->is_insertion = true;
   auto add_callback = [this](AsyncGcsClient *client, const ClientID &id,
-                             const std::vector<ClientTableDataT> &data) {
-    RAY_CHECK(data.size() == 1);
-    HandleConnected(client, data[0]);
+                             std::shared_ptr<ClientTableDataT> data) {
+    HandleConnected(client, data);
     RAY_CHECK_OK(CancelNotifications(JobID::nil(), client_log_key_, id));
   };
   RAY_RETURN_NOT_OK(Append(JobID::nil(), client_log_key_, data, add_callback));
@@ -306,6 +305,8 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) {
 }
 
 template class Log<ObjectID, ObjectTableData>;
+template class Table<ObjectID, ObjectTableData>;
+template class Log<TaskID, ray::protocol::Task>;
 template class Table<TaskID, ray::protocol::Task>;
 template class Table<TaskID, TaskTableData>;
 

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -30,7 +30,7 @@ Status Log<ID, Data>::Append(const JobID &job_id, const ID &id,
 template <typename ID, typename Data>
 Status Log<ID, Data>::AppendAt(const JobID &job_id, const ID &id,
                                std::shared_ptr<DataT> data, const WriteCallback &done,
-                               const WriteCallback &failure, int index) {
+                               const WriteCallback &failure, int log_length) {
   auto d = std::shared_ptr<CallbackData>(
       new CallbackData({id, data, nullptr, nullptr, this, client_}));
   int64_t callback_index =
@@ -50,7 +50,7 @@ Status Log<ID, Data>::AppendAt(const JobID &job_id, const ID &id,
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, data.get()));
   return context_->RunAsync("RAY.TABLE_APPEND", id, fbb.GetBufferPointer(), fbb.GetSize(),
-                            prefix_, pubsub_channel_, callback_index, index);
+                            prefix_, pubsub_channel_, callback_index, log_length);
 }
 
 template <typename ID, typename Data>

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -305,7 +305,6 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) {
 }
 
 template class Log<ObjectID, ObjectTableData>;
-template class Table<ObjectID, ObjectTableData>;
 template class Log<TaskID, ray::protocol::Task>;
 template class Table<TaskID, ray::protocol::Task>;
 template class Table<TaskID, TaskTableData>;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -77,8 +77,22 @@ class Log {
   Status Append(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
                 const WriteCallback &done);
 
+  /// Append a log entry to a key if and only if the log has the given number
+  /// of entries.
+  ///
+  /// \param job_id The ID of the job (= driver).
+  /// \param id The ID of the data that is added to the GCS.
+  /// \param data Data to append to the log.
+  /// \param done Callback that is called if the data was appended to the log.
+  /// \param failure Callback that is called if the data was not appended to
+  ///        the log because the log length did not match the given
+  ///        `log_length`.
+  /// \param log_length The number of entries that the log must have for the
+  ///        append to succeed.
+  /// \return Status
   Status AppendAt(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
-                  const WriteCallback &done, const WriteCallback &failure, int index);
+                  const WriteCallback &done, const WriteCallback &failure,
+                  int log_length);
 
   /// Lookup the log values at a key asynchronously.
   ///

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -298,8 +298,8 @@ class TaskTable : public Table<TaskID, TaskTableData> {
     flatbuffers::FlatBufferBuilder fbb;
     fbb.Finish(TaskTableTestAndUpdate::Pack(fbb, data.get()));
     RAY_RETURN_NOT_OK(context_->RunAsync("RAY.TABLE_TEST_AND_UPDATE", id,
-                                         fbb.GetBufferPointer(), fbb.GetSize(), -1,
-                                         prefix_, pubsub_channel_, callback_index));
+                                         fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
+                                         pubsub_channel_, callback_index));
     return Status::OK();
   }
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -210,10 +210,9 @@ class TaskTable : public Table<TaskID, TaskTableData> {
                        std::shared_ptr<TaskTableTestAndUpdateT> data,
                        const TestAndUpdateCallback &callback) {
     int64_t callback_index = RedisCallbackManager::instance().add(
-        [this, callback, id](const std::vector<std::string> &data) {
-          RAY_CHECK(data.size() == 1);
+        [this, callback, id](const std::string &data) {
           auto result = std::make_shared<TaskTableDataT>();
-          auto root = flatbuffers::GetRoot<TaskTableData>(data[0].data());
+          auto root = flatbuffers::GetRoot<TaskTableData>(data.data());
           root->UnPackTo(result.get());
           callback(client_, id, *result, root->updated());
           return true;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -218,10 +218,10 @@ class Table : private Log<ID, Data> {
   using Log<ID, Data>::prefix_;
 };
 
-class ObjectTable : public Table<ObjectID, ObjectTableData> {
+class ObjectTable : public Log<ObjectID, ObjectTableData> {
  public:
   ObjectTable(const std::shared_ptr<RedisContext> &context, AsyncGcsClient *client)
-      : Table(context, client) {
+      : Log(context, client) {
     pubsub_channel_ = TablePubsub_OBJECT;
     prefix_ = TablePrefix_OBJECT;
   };

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -41,6 +41,9 @@ class Log {
   using DataT = typename Data::NativeTableType;
   using Callback = std::function<void(AsyncGcsClient *client, const ID &id,
                                       const std::vector<DataT> &data)>;
+  /// The callback to call when a write to a key succeeds.
+  using WriteCallback = std::function<void(AsyncGcsClient *client, const ID &id,
+                                           std::shared_ptr<DataT> data)>;
   /// The callback to call when a SUBSCRIBE call completes and we are ready to
   /// request and receive notifications.
   using SubscriptionCallback = std::function<void(AsyncGcsClient *client)>;
@@ -72,7 +75,7 @@ class Log {
   ///        GCS.
   /// \return Status
   Status Append(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
-                const Callback &done);
+                const WriteCallback &done);
 
   /// Lookup the log values at a key asynchronously.
   ///
@@ -158,6 +161,7 @@ class Table : private Log<ID, Data> {
   using DataT = typename Log<ID, Data>::DataT;
   using Callback =
       std::function<void(AsyncGcsClient *client, const ID &id, const DataT &data)>;
+  using WriteCallback = typename Log<ID, Data>::WriteCallback;
   /// The callback to call when a Lookup call returns an empty entry.
   using FailureCallback = std::function<void(AsyncGcsClient *client, const ID &id)>;
   /// The callback to call when a Subscribe call completes and we are ready to
@@ -190,7 +194,7 @@ class Table : private Log<ID, Data> {
   ///        GCS.
   /// \return Status
   Status Add(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
-             const Callback &done);
+             const WriteCallback &done);
 
   /// Lookup an entry asynchronously.
   ///
@@ -409,7 +413,8 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   /// Handle a client table notification.
   void HandleNotification(AsyncGcsClient *client, const ClientTableDataT &notifications);
   /// Handle this client's successful connection to the GCS.
-  void HandleConnected(AsyncGcsClient *client, const ClientTableDataT &notifications);
+  void HandleConnected(AsyncGcsClient *client,
+                       const std::shared_ptr<ClientTableDataT> client_data);
 
   /// The key at which the log of client information is stored. This key must
   /// be kept the same across all instances of the ClientTable, so that all

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -244,6 +244,15 @@ using ClassTable = Table<ClassID, ClassTableData>;
 // TODO(swang): Set the pubsub channel for the actor table.
 using ActorTable = Table<ActorID, ActorTableData>;
 
+class TaskReconstructionLog : public Log<TaskID, TaskReconstructionData> {
+ public:
+  TaskReconstructionLog(const std::shared_ptr<RedisContext> &context,
+                        AsyncGcsClient *client)
+      : Log(context, client) {
+    prefix_ = TablePrefix_TASK_RECONSTRUCTION;
+  }
+};
+
 namespace raylet {
 
 class TaskTable : public Table<TaskID, ray::protocol::Task> {

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -77,6 +77,9 @@ class Log {
   Status Append(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
                 const WriteCallback &done);
 
+  Status AppendAt(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
+                  const WriteCallback &done, const WriteCallback &failure, int index);
+
   /// Lookup the log values at a key asynchronously.
   ///
   /// \param job_id The ID of the job (= driver).
@@ -295,8 +298,8 @@ class TaskTable : public Table<TaskID, TaskTableData> {
     flatbuffers::FlatBufferBuilder fbb;
     fbb.Finish(TaskTableTestAndUpdate::Pack(fbb, data.get()));
     RAY_RETURN_NOT_OK(context_->RunAsync("RAY.TABLE_TEST_AND_UPDATE", id,
-                                         fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
-                                         pubsub_channel_, callback_index));
+                                         fbb.GetBufferPointer(), fbb.GetSize(), -1,
+                                         prefix_, pubsub_channel_, callback_index));
     return Status::OK();
   }
 

--- a/src/ray/gcs/task_table.cc
+++ b/src/ray/gcs/task_table.cc
@@ -44,9 +44,9 @@ Status TaskTableAdd(AsyncGcsClient *gcs_client, Task *task) {
   TaskSpec *spec = execution_spec.Spec();
   auto data = MakeTaskTableData(execution_spec, Task_local_scheduler(task),
                                 static_cast<SchedulingState>(Task_state(task)));
-  return gcs_client->task_table().Add(
-      ray::JobID::nil(), TaskSpec_task_id(spec), data,
-      [](gcs::AsyncGcsClient *client, const TaskID &id, const TaskTableDataT &data) {});
+  return gcs_client->task_table().Add(ray::JobID::nil(), TaskSpec_task_id(spec), data,
+                                      [](gcs::AsyncGcsClient *client, const TaskID &id,
+                                         std::shared_ptr<TaskTableDataT> data) {});
 }
 
 // TODO(pcm): This is a helper method that should go away once we get rid of


### PR DESCRIPTION
## What do these changes do?

This adds a version of the `Append` operation on the GCS `Log` interface that takes in a `log_length`. The command fails if the requested `log_length` does not match the current length of the log. This allows us to use Redis as a centralized point for atomic operations (replacing the legacy test-and-set functionality).