### PR TITLE
fix unused-lambda-capture on clang version 9.1

### DIFF
--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -236,7 +236,7 @@ void TestLogAppendAt(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
   RAY_CHECK_OK(client->task_reconstruction_log().AppendAt(job_id, task_id, data_log[1],
                                                           nullptr, failure_callback, 1));
 
-  auto lookup_callback = [task_id, managers](
+  auto lookup_callback = [managers](
       gcs::AsyncGcsClient *client, const UniqueID &id,
       const std::vector<TaskReconstructionDataT> &data) {
     std::vector<std::string> appended_managers;

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -236,9 +236,8 @@ void TestLogAppendAt(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
   RAY_CHECK_OK(client->task_reconstruction_log().AppendAt(job_id, task_id, data_log[1],
                                                           nullptr, failure_callback, 1));
 
-  auto lookup_callback = [managers](
-      gcs::AsyncGcsClient *client, const UniqueID &id,
-      const std::vector<TaskReconstructionDataT> &data) {
+  auto lookup_callback = [managers](gcs::AsyncGcsClient *client, const UniqueID &id,
+                                    const std::vector<TaskReconstructionDataT> &data) {
     std::vector<std::string> appended_managers;
     for (const auto &entry : data) {
       appended_managers.push_back(entry.node_manager_id);

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -90,7 +90,7 @@ Status Log<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id,
   auto d = std::shared_ptr<CallbackData>(
       new CallbackData({client_id, nullptr, subscribe, done, this, client_}));
   int64_t callback_index =
-      RedisCallbackManager::instance().add([this, d](const std::string &data) {
+      RedisCallbackManager::instance().add([d](const std::string &data) {
         if (data.empty()) {
           // No notification data is provided. This is the callback for the
           // initial subscription request.

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -60,9 +60,8 @@ ray::Status ObjectDirectory::ExecuteGetLocations(const ObjectID &object_id) {
   // Note: Lookup must be synchronous for thread-safe access.
   // For now, this is only accessed by the main thread.
   ray::Status status = gcs_client_->object_table().Lookup(
-      job_id, object_id,
-      [this](gcs::AsyncGcsClient *client, const ObjectID &object_id,
-                        const std::vector<ObjectTableDataT> &data) {
+      job_id, object_id, [this](gcs::AsyncGcsClient *client, const ObjectID &object_id,
+                                const std::vector<ObjectTableDataT> &data) {
         GetLocationsComplete(object_id, data);
       });
   return status;

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -61,7 +61,7 @@ ray::Status ObjectDirectory::ExecuteGetLocations(const ObjectID &object_id) {
   // For now, this is only accessed by the main thread.
   ray::Status status = gcs_client_->object_table().Lookup(
       job_id, object_id,
-      [this, object_id](gcs::AsyncGcsClient *client, const ObjectID &object_id,
+      [this](gcs::AsyncGcsClient *client, const ObjectID &object_id,
                         const std::vector<ObjectTableDataT> &data) {
         GetLocationsComplete(object_id, data);
       });

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -207,7 +207,7 @@ ray::Status ObjectManager::Push(const ObjectID &object_id, const ClientID &clien
           transfer_queue_.QueueSend(client_id, object_id, info);
           RAY_CHECK_OK(DequeueTransfers());
         },
-        [this](const Status &status) {
+        [](const Status &status) {
           // Push is best effort, so do nothing here.
         });
     RAY_CHECK_OK(status);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -92,7 +92,7 @@ void NodeManager::ClientAdded(gcs::AsyncGcsClient *client, const UniqueID &id,
     };
     ray::Status status = client->heartbeat_table().Subscribe(
         UniqueID::nil(), UniqueID::nil(), heartbeat_added,
-        [this](gcs::AsyncGcsClient *client) {
+        [](gcs::AsyncGcsClient *client) {
           RAY_LOG(DEBUG) << "heartbeat table subscription done callback called.";
         });
     RAY_CHECK_OK(status);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This fixes a compilation error on clang 9.1 complaining about an unused lambda capture. This could not be reproduced on clang 9.0 or clang 8.0.

## Related issue number

reported by @richardliaw 
