### PR TITLE
Integrate credis with Ray & route task table entries into credis.

### DIFF
--- a/python/ray/common/redis_module/runtest.py
+++ b/python/ray/common/redis_module/runtest.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import redis
 import sys
 import time
@@ -51,8 +52,10 @@ def get_next_message(pubsub_client, timeout_seconds=10):
 
 class TestGlobalStateStore(unittest.TestCase):
     def setUp(self):
-        redis_port, _ = ray.services.start_redis_instance()
-        self.redis = redis.StrictRedis(host="localhost", port=redis_port, db=0)
+        unused_primary_redis_addr, redis_shards = ray.services.start_redis(
+            "localhost", use_credis="RAY_USE_NEW_GCS" in os.environ)
+        self.redis = redis.StrictRedis(
+            host="localhost", port=redis_shards[0].split(":")[-1], db=0)
 
     def tearDown(self):
         ray.services.cleanup()

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -580,13 +580,11 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
     for module in modules:
         assert os.path.isfile(module)
     counter = 0
-    print('_start_redis_instance; modules:', modules, '; port', port)
     if port is not None:
         # If a port is specified, then try only once to connect.
         num_retries = 1
     else:
         port = new_port()
-    print(' port', port)
 
     load_module_args = []
     for module in modules:
@@ -606,11 +604,10 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
                 all_processes[PROCESS_TYPE_REDIS_SERVER].append(p)
             break
         port = new_port()
-        print(' port', port)
         counter += 1
     if counter == num_retries:
-        raise Exception("Couldn't start Redis. Check stdout file " +
-                        stdout_file.name)
+        raise Exception(
+            "Couldn't start Redis. Check stdout file {}".format(stdout_file))
 
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(host="127.0.0.1", port=port)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -580,21 +580,23 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
     for module in modules:
         assert os.path.isfile(module)
     counter = 0
+    print('_start_redis_instance; modules:', modules, '; port', port)
     if port is not None:
         # If a port is specified, then try only once to connect.
         num_retries = 1
     else:
         port = new_port()
+    print(' port', port)
 
     load_module_args = []
     for module in modules:
         load_module_args += ["--loadmodule", module]
-    command = [executable, "--port",
-               str(port), "--loglevel", "warning"] + load_module_args
 
     while counter < num_retries:
         if counter > 0:
             print("Redis failed to start, retrying now.")
+        command = [executable, "--port",
+                   str(port), "--loglevel", "warning"] + load_module_args
         p = subprocess.Popen(command, stdout=stdout_file, stderr=stderr_file)
         time.sleep(0.1)
         # Check if Redis successfully started (or at least if it the executable
@@ -604,10 +606,11 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
                 all_processes[PROCESS_TYPE_REDIS_SERVER].append(p)
             break
         port = new_port()
+        print(' port', port)
         counter += 1
     if counter == num_retries:
-        raise Exception("Couldn't start Redis. Check stderr file " +
-                        stderr_file.name)
+        raise Exception("Couldn't start Redis. Check stdout file " +
+                        stdout_file.name)
 
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(host="127.0.0.1", port=port)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -496,8 +496,8 @@ def start_redis(node_ip_address,
                 cleanup=cleanup)
         else:
             assert num_redis_shards == 1, \
-                "For now, RAY_USE_NEW_GCS supports 1 shard, and credis supports" \
-                " 1-node chain for that shard only."
+                "For now, RAY_USE_NEW_GCS supports 1 shard, and credis "\
+                "supports 1-node chain for that shard only."
             redis_shard_port, _ = start_redis_instance(
                 node_ip_address=node_ip_address,
                 port=redis_shard_ports[i],

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -401,7 +401,7 @@ def start_redis(node_ip_address,
                 redirect_output=False,
                 redirect_worker_output=False,
                 cleanup=True,
-                use_credis=("RAY_USE_NEW_GCS" in os.environ)):
+                use_credis=None):
     """Start the Redis global state store.
 
     Args:
@@ -425,9 +425,9 @@ def start_redis(node_ip_address,
             then all Redis processes started by this method will be killed by
             services.cleanup() when the Python process that imported services
             exits.
-        use_credis (bool): If True, additionally load the chain-replicated
-            libraries into the redis servers.  Controlled by the presence of
-            "RAY_USE_NEW_GCS" in os.environ.
+        use_credis: If True, additionally load the chain-replicated libraries
+            into the redis servers.  Defaults to None, which means its value is
+            set by the presence of "RAY_USE_NEW_GCS" in os.environ.
 
     Returns:
         A tuple of the address for the primary Redis shard and a list of
@@ -442,6 +442,8 @@ def start_redis(node_ip_address,
         raise Exception("The number of Redis shard ports does not match the "
                         "number of Redis shards.")
 
+    if use_credis is None:
+        use_credis = ("RAY_USE_NEW_GCS" in os.environ)
     if not use_credis:
         assigned_port, _ = _start_redis_instance(
             node_ip_address=node_ip_address,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import binascii
 import json
@@ -605,7 +607,7 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
         counter += 1
     if counter == num_retries:
         raise Exception("Couldn't start Redis. Check stderr file " +
-                        stderr_file)
+                        stderr_file.name)
 
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(host="127.0.0.1", port=port)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -580,7 +580,7 @@ def start_redis_instance(node_ip_address="127.0.0.1",
 
     load_module_args = []
     for module in modules:
-        load_module_args += ["--loadmodule", m]
+        load_module_args += ["--loadmodule", module]
     command = [executable, "--port",
                str(port), "--loglevel", "warning"] + load_module_args
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -541,7 +541,7 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
                           stderr_file=None,
                           cleanup=True,
                           executable=REDIS_EXECUTABLE,
-                          modules=[REDIS_MODULE]):
+                          modules=None):
     """Start a single Redis server.
 
     Args:
@@ -561,7 +561,8 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
             Python process that imported services exits.
         executable (str): Full path tho the redis-server executable.
         modules (list of str): A list of pathnames, pointing to the redis
-            module(s) that will be loaded in this redis server.
+            module(s) that will be loaded in this redis server.  If None, load
+            the default Ray redis module.
 
     Returns:
         A tuple of the port used by Redis and a handle to the process that was
@@ -572,6 +573,8 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
         Exception: An exception is raised if Redis could not be started.
     """
     assert os.path.isfile(executable)
+    if modules is None:
+        modules = [REDIS_MODULE]
     for module in modules:
         assert os.path.isfile(module)
     counter = 0
@@ -601,7 +604,8 @@ def _start_redis_instance(node_ip_address="127.0.0.1",
         port = new_port()
         counter += 1
     if counter == num_retries:
-        raise Exception("Couldn't start Redis.")
+        raise Exception("Couldn't start Redis. Check stderr file " +
+                        stderr_file)
 
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(host="127.0.0.1", port=port)

--- a/src/common/redis_module/chain_module.h
+++ b/src/common/redis_module/chain_module.h
@@ -1,0 +1,50 @@
+#ifndef RAY_CHAIN_MODULE_H_
+#define RAY_CHAIN_MODULE_H_
+
+#include <functional>
+
+#include "redismodule.h"
+
+// NOTE(zongheng): this duplicated declaration serves as forward-declaration
+// only.  The implementation is supposed to be linked in from credis.  In
+// principle, we can expose a header from credis and simple include that header.
+// This is left as future work.
+
+// Typical usage to make an existing redismodule command chain-compatible:
+//
+//   extern RedisChainModule module;
+//   int MyCmd_RedisModuleCmd(...) {
+//       return module.Mutate(..., NodeFunc, TailFunc);
+//   }
+//
+// See, for instance, ChainTableAdd_RedisCommand in ray_redis_module.cc.
+class RedisChainModule {
+ public:
+  // A function that runs on every node in the chain.  Type:
+  //   (context, argv, argc, (can be nullptr) mutated_key_str) -> int
+  //
+  // If the fourth arg is passed, NodeFunc must fill in the key being mutated.
+  // It is okay for this NodeFunc to call "RM_FreeString(mutated_key_str)" after
+  // assigning the fourth arg, since that call presumably only decrements a ref
+  // count.
+  using NodeFunc = std::function<
+      int(RedisModuleCtx *, RedisModuleString **, int, RedisModuleString **)>;
+
+  // A function that (1) runs only after all NodeFunc's have run, and (2) runs
+  // once on the tail.  A typical usage is to publish a write.
+  using TailFunc =
+      std::function<int(RedisModuleCtx *, RedisModuleString **, int)>;
+
+  // TODO(zongheng): document the RM_Reply semantics.
+
+  // Runs "node_func" on every node in the chain; after the tail node has run it
+  // too, finalizes the mutation by running "tail_func".
+  // TODO(zongheng): currently only supports 1-node chain.
+  int Mutate(RedisModuleCtx *ctx,
+             RedisModuleString **argv,
+             int argc,
+             NodeFunc node_func,
+             TailFunc tail_func);
+};
+
+#endif  // RAY_CHAIN_MODULE_H_

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -517,8 +517,8 @@ int PublishTaskTableAdd(RedisModuleCtx *ctx,
 
     /* See how many clients received this publish. */
     long long num_clients = RedisModule_CallReplyInteger(reply);
-    RAY_CHECK(num_clients <= 1)
-        << "Published to " << num_clients << " clients.";
+    RAY_CHECK(num_clients <= 1) << "Published to " << num_clients
+                                << " clients.";
   }
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
@@ -959,8 +959,9 @@ int TableTestAndUpdate_RedisCommand(RedisModuleCtx *ctx,
   bool do_update = data->scheduling_state() & update->test_state_bitmask();
 
   if (!is_nil(update->test_scheduler_id()->str())) {
-    do_update = do_update && update->test_scheduler_id()->str() ==
-                                 data->scheduler_id()->str();
+    do_update =
+        do_update &&
+        update->test_scheduler_id()->str() == data->scheduler_id()->str();
   }
 
   if (do_update) {
@@ -1494,8 +1495,8 @@ int TaskTableWrite(RedisModuleCtx *ctx,
 
     /* See how many clients received this publish. */
     long long num_clients = RedisModule_CallReplyInteger(reply);
-    RAY_CHECK(num_clients <= 1)
-        << "Published to " << num_clients << " clients.";
+    RAY_CHECK(num_clients <= 1) << "Published to " << num_clients
+                                << " clients.";
 
     if (reply == NULL) {
       return RedisModule_ReplyWithError(ctx, "PUBLISH unsuccessful");

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -636,8 +636,8 @@ int TableAdd_DoPublish(RedisModuleCtx *ctx,
 ///
 /// \param table_prefix The prefix string for keys in this table.
 /// \param pubsub_channel The pubsub channel name that notifications for
-///        this key should be published to. When publishing to a specific
-///        client, the channel name should be <pubsub_channel>:<client_id>.
+///  this key should be published to. When publishing to a specific
+///  client, the channel name should be <pubsub_channel>:<client_id>.
 /// \param id The ID of the key to set.
 /// \param data The data to insert at the key.
 /// \return The current value at the key, or OK if there is no value.

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -653,8 +653,8 @@ int TableAdd_RedisCommand(RedisModuleCtx *ctx,
 int ChainTableAdd_RedisCommand(RedisModuleCtx *ctx,
                                RedisModuleString **argv,
                                int argc) {
-  return module.Mutate(ctx, argv, argc, /*node_func=*/TableAdd_DoWrite,
-                       /*tail_func=*/TableAdd_DoPublish);
+  return module.ChainReplicate(ctx, argv, argc, /*node_func=*/TableAdd_DoWrite,
+                               /*tail_func=*/TableAdd_DoPublish);
 }
 #endif
 

--- a/src/common/redis_module/redis_string.h
+++ b/src/common/redis_module/redis_string.h
@@ -1,6 +1,11 @@
+#ifndef RAY_REDIS_STRING_H_
+#define RAY_REDIS_STRING_H_
+
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
+
+#include "redismodule.h"
 
 /* Format a RedisModuleString.
  *
@@ -65,3 +70,5 @@ RedisModuleString *RedisString_Format(RedisModuleCtx *ctx,
   va_end(ap);
   return result;
 }
+
+#endif  // RAY_REDIS_STRING_H_

--- a/src/common/test/run_tests.sh
+++ b/src/common/test/run_tests.sh
@@ -3,12 +3,29 @@
 # This needs to be run in the build tree, which is normally ray/build
 
 # Cause the script to exit if a single command fails.
-set -e
+set -ex
+
+LaunchRedis() {
+    port=$1
+    if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+        ./src/credis/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/credis/build/src/libmember.so \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    else
+        ./src/common/thirdparty/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    fi
+    sleep 1s
+}
+
 
 # Start the Redis shards.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
-sleep 1s
+LaunchRedis 6379
+LaunchRedis 6380
 # Register the shard location with the primary shard.
 ./src/common/thirdparty/redis/src/redis-cli set NumRedisShards 1
 ./src/common/thirdparty/redis/src/redis-cli rpush RedisShards 127.0.0.1:6380

--- a/src/common/test/run_valgrind.sh
+++ b/src/common/test/run_valgrind.sh
@@ -7,22 +7,21 @@ set -x
 # Cause the script to exit if a single command fails.
 set -e
 
-# Start the Redis shards.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
-sleep 1s
-# Register the shard location with the primary shard.
-./src/common/thirdparty/redis/src/redis-cli set NumRedisShards 1
-./src/common/thirdparty/redis/src/redis-cli rpush RedisShards 127.0.0.1:6380
-
 if [ -z "$RAY_USE_NEW_GCS" ]; then
+    # Start the Redis shards.
+    ./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
+    ./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
+    sleep 1s
+    # Register the shard location with the primary shard.
+    ./src/common/thirdparty/redis/src/redis-cli set NumRedisShards 1
+    ./src/common/thirdparty/redis/src/redis-cli rpush RedisShards 127.0.0.1:6380
+
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/db_tests
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/io_tests
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/task_tests
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/redis_tests
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/task_table_tests
   valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1 ./src/common/object_table_tests
+  ./src/common/thirdparty/redis/src/redis-cli shutdown
+  ./src/common/thirdparty/redis/src/redis-cli -p 6380 shutdown
 fi
-
-./src/common/thirdparty/redis/src/redis-cli shutdown
-./src/common/thirdparty/redis/src/redis-cli -p 6380 shutdown

--- a/src/local_scheduler/test/run_tests.sh
+++ b/src/local_scheduler/test/run_tests.sh
@@ -5,9 +5,26 @@
 # Cause the script to exit if a single command fails.
 set -e
 
+LaunchRedis() {
+    port=$1
+    if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+        ./src/credis/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/credis/build/src/libmember.so \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    else
+        ./src/common/thirdparty/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    fi
+}
+
+
 # Start the Redis shards.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
+LaunchRedis 6379
+LaunchRedis 6380
 sleep 1s
 # Register the shard location with the primary shard.
 ./src/common/thirdparty/redis/src/redis-cli set NumRedisShards 1

--- a/src/local_scheduler/test/run_valgrind.sh
+++ b/src/local_scheduler/test/run_valgrind.sh
@@ -7,10 +7,28 @@ set -x
 # Cause the script to exit if a single command fails.
 set -e
 
+LaunchRedis() {
+    port=$1
+    if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+        ./src/credis/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/credis/build/src/libmember.so \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    else
+        ./src/common/thirdparty/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    fi
+}
+
+
 # Start the Redis shards.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
+LaunchRedis 6379
+LaunchRedis 6380
 sleep 1s
+
 # Register the shard location with the primary shard.
 ./src/common/thirdparty/redis/src/redis-cli set NumRedisShards 1
 ./src/common/thirdparty/redis/src/redis-cli rpush RedisShards 127.0.0.1:6380

--- a/src/plasma/test/run_tests.sh
+++ b/src/plasma/test/run_tests.sh
@@ -8,12 +8,28 @@ sleep 1
 ./src/plasma/manager_tests
 killall plasma_store
 
+LaunchRedis() {
+    port=$1
+    if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+        ./src/credis/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/credis/build/src/libmember.so \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    else
+        ./src/common/thirdparty/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port &
+    fi
+}
+
 # Start the Redis shards.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
+LaunchRedis 6379
 redis_pid1=$!
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6380 &
+LaunchRedis 6380
 redis_pid2=$!
-sleep 1
+sleep 1s
 
 # Flush the redis server
 ./src/common/thirdparty/redis/src/redis-cli flushall

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -6,20 +6,25 @@ namespace ray {
 
 namespace gcs {
 
-AsyncGcsClient::AsyncGcsClient(const ClientID &client_id) {
+AsyncGcsClient::AsyncGcsClient(const ClientID &client_id, CommandType command_type) {
   context_ = std::make_shared<RedisContext>();
   client_table_.reset(new ClientTable(context_, this, client_id));
   object_table_.reset(new ObjectTable(context_, this));
   actor_table_.reset(new ActorTable(context_, this));
-  task_table_.reset(new TaskTable(context_, this));
-  raylet_task_table_.reset(new raylet::TaskTable(context_, this));
+  task_table_.reset(new TaskTable(context_, this, command_type));
+  raylet_task_table_.reset(new raylet::TaskTable(context_, this, command_type));
   task_reconstruction_log_.reset(new TaskReconstructionLog(context_, this));
   heartbeat_table_.reset(new HeartbeatTable(context_, this));
+  command_type_ = command_type;
 }
 
-AsyncGcsClient::AsyncGcsClient() : AsyncGcsClient(ClientID::from_random()) {}
+AsyncGcsClient::AsyncGcsClient(const ClientID &client_id)
+    : AsyncGcsClient(client_id, CommandType::kRegular) {}
 
-AsyncGcsClient::~AsyncGcsClient() {}
+AsyncGcsClient::AsyncGcsClient(CommandType command_type)
+    : AsyncGcsClient(ClientID::from_random(), command_type) {}
+
+AsyncGcsClient::AsyncGcsClient() : AsyncGcsClient(ClientID::from_random()) {}
 
 Status AsyncGcsClient::Connect(const std::string &address, int port) {
   RAY_RETURN_NOT_OK(context_->Connect(address, port));

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -19,15 +19,18 @@ class RedisContext;
 
 class RAY_EXPORT AsyncGcsClient {
  public:
-  /// Start a GCS client with the given client ID. To read from the GCS tables,
-  /// Connect and then Attach must be called. To read and write from the GCS
-  /// tables requires a further call to Connect to the client table.
+  /// Start a GCS client with the given client ID and command type (regular or
+  /// chain-replicated). To read from the GCS tables, Connect() and then
+  /// Attach() must be called. To read and write from the GCS tables requires a
+  /// further call to Connect() to the client table.
   ///
   /// \param client_id The ID to assign to the client.
+  /// \param command_type GCS command type.  If CommandType::kChain, chain-replicated
+  /// versions of the tables might be used, if available.
+  AsyncGcsClient(const ClientID &client_id, CommandType command_type);
   AsyncGcsClient(const ClientID &client_id);
-  /// Start a GCS client with a random client ID.
+  AsyncGcsClient(CommandType command_type);
   AsyncGcsClient();
-  ~AsyncGcsClient();
 
   /// Connect to the GCS.
   ///
@@ -79,6 +82,8 @@ class RAY_EXPORT AsyncGcsClient {
   std::shared_ptr<RedisContext> context_;
   std::unique_ptr<RedisAsioClient> asio_async_client_;
   std::unique_ptr<RedisAsioClient> asio_subscribe_client_;
+
+  CommandType command_type_;
 };
 
 class SyncGcsClient {

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -15,7 +15,7 @@ namespace ray {
 namespace gcs {
 
 namespace {
-const char *const kRandomId = "abcdefghijklmnopqrst";
+constexpr char kRandomId[] = "abcdefghijklmnopqrst";
 }  // namespace
 
 /* Flush redis. */

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -177,8 +177,8 @@ void TestLogLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> cli
 
   // Check that lookup returns the added object entries.
   auto lookup_callback = [object_id, managers](
-                             gcs::AsyncGcsClient *client, const ObjectID &id,
-                             const std::vector<ObjectTableDataT> &data) {
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     ASSERT_EQ(id, object_id);
     for (const auto &entry : data) {
       ASSERT_EQ(entry.manager, managers[test->NumCallbacks()]);
@@ -377,9 +377,8 @@ void TestTableSubscribeAll(const JobID &job_id,
   TaskID task_id = TaskID::from_random();
   std::vector<std::string> task_specs = {"abc", "def", "ghi"};
   // Callback for a notification.
-  auto notification_callback = [task_id, task_specs](gcs::AsyncGcsClient *client,
-                                                     const UniqueID &id,
-                                                     const protocol::TaskT &data) {
+  auto notification_callback = [task_id, task_specs](
+      gcs::AsyncGcsClient *client, const UniqueID &id, const protocol::TaskT &data) {
     ASSERT_EQ(id, task_id);
     // Check that we get notifications in the same order as the writes.
     ASSERT_EQ(data.task_specification, task_specs[test->NumCallbacks()]);
@@ -428,8 +427,8 @@ void TestLogSubscribeAll(const JobID &job_id,
   }
   // Callback for a notification.
   auto notification_callback = [object_ids, managers](
-                                   gcs::AsyncGcsClient *client, const UniqueID &id,
-                                   const std::vector<ObjectTableDataT> data) {
+      gcs::AsyncGcsClient *client, const UniqueID &id,
+      const std::vector<ObjectTableDataT> data) {
     ASSERT_EQ(id, object_ids[test->NumCallbacks()]);
     // Check that we get notifications in the same order as the writes.
     for (const auto &entry : data) {
@@ -493,9 +492,8 @@ void TestTableSubscribeId(const JobID &job_id,
 
   // The callback for a notification from the table. This should only be
   // received for keys that we requested notifications for.
-  auto notification_callback = [task_id2, task_specs2](gcs::AsyncGcsClient *client,
-                                                       const TaskID &id,
-                                                       const protocol::TaskT &data) {
+  auto notification_callback = [task_id2, task_specs2](
+      gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
     // Check that we only get notifications for the requested key.
     ASSERT_EQ(id, task_id2);
     // Check that we get notifications in the same order as the writes.
@@ -568,8 +566,8 @@ void TestLogSubscribeId(const JobID &job_id,
   // The callback for a notification from the table. This should only be
   // received for keys that we requested notifications for.
   auto notification_callback = [object_id2, managers2](
-                                   gcs::AsyncGcsClient *client, const ObjectID &id,
-                                   const std::vector<ObjectTableDataT> &data) {
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     // Check that we only get notifications for the requested key.
     ASSERT_EQ(id, object_id2);
     // Check that we get notifications in the same order as the writes.
@@ -639,9 +637,8 @@ void TestTableSubscribeCancel(const JobID &job_id,
 
   // The callback for a notification from the table. This should only be
   // received for keys that we requested notifications for.
-  auto notification_callback = [task_id, task_specs](gcs::AsyncGcsClient *client,
-                                                     const TaskID &id,
-                                                     const protocol::TaskT &data) {
+  auto notification_callback = [task_id, task_specs](
+      gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
     ASSERT_EQ(id, task_id);
     // Check that we only get notifications for the first and last writes,
     // since notifications are canceled in between.
@@ -711,8 +708,8 @@ void TestLogSubscribeCancel(const JobID &job_id,
   // The callback for a notification from the object table. This should only be
   // received for the object that we requested notifications for.
   auto notification_callback = [object_id, managers](
-                                   gcs::AsyncGcsClient *client, const ObjectID &id,
-                                   const std::vector<ObjectTableDataT> &data) {
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     ASSERT_EQ(id, object_id);
     // Check that we get a duplicate notification for the first write. We get a
     // duplicate notification because the log is append-only and notifications
@@ -886,12 +883,11 @@ void TestClientTableMarkDisconnected(const JobID &job_id,
   RAY_CHECK_OK(client->client_table().MarkDisconnected(dead_client_id));
   // Make sure we only get a notification for the removal of the client we
   // marked as dead.
-  client->client_table().RegisterClientRemovedCallback(
-      [dead_client_id](gcs::AsyncGcsClient *client, const UniqueID &id,
-                       const ClientTableDataT &data) {
-        ASSERT_EQ(ClientID::from_binary(data.client_id), dead_client_id);
-        test->Stop();
-      });
+  client->client_table().RegisterClientRemovedCallback([dead_client_id](
+      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
+    ASSERT_EQ(ClientID::from_binary(data.client_id), dead_client_id);
+    test->Stop();
+  });
   test->Start();
 }
 

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -144,18 +144,19 @@ void TestTableLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> c
   test->Start();
 }
 
-#define TEST_TABLE_LOOKUP(FIXTURE)     \
-  TEST_F(FIXTURE, TestTableLookup) {   \
-    test = this;                       \
-    TestTableLookup(job_id_, client_); \
+// Convenient macro to test across {ae, asio} x {regular, chain} x {the tests}.
+// Undefined at the end.
+#define TEST_MACRO(FIXTURE, TEST) \
+  TEST_F(FIXTURE, TEST) {         \
+    test = this;                  \
+    TEST(job_id_, client_);       \
   }
 
-TEST_TABLE_LOOKUP(TestGcsWithAe);
-TEST_TABLE_LOOKUP(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTableLookup);
+TEST_MACRO(TestGcsWithAsio, TestTableLookup);
 #if RAY_USE_NEW_GCS
-TEST_TABLE_LOOKUP(TestGcsWithChainAe);
-TEST_TABLE_LOOKUP(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTableLookup);
+TEST_MACRO(TestGcsWithChainAsio, TestTableLookup);
 #endif
 
 void TestLogLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
@@ -228,18 +229,11 @@ void TestTableLookupFailure(const JobID &job_id,
   test->Start();
 }
 
-#define TEST_TABLE_LOOKUP_FAILURE(FIXTURE)    \
-  TEST_F(FIXTURE, TestTableLookupFailure) {   \
-    test = this;                              \
-    TestTableLookupFailure(job_id_, client_); \
-  }
-
-TEST_TABLE_LOOKUP_FAILURE(TestGcsWithAe);
-TEST_TABLE_LOOKUP_FAILURE(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTableLookupFailure);
+TEST_MACRO(TestGcsWithAsio, TestTableLookupFailure);
 #if RAY_USE_NEW_GCS
-TEST_TABLE_LOOKUP_FAILURE(TestGcsWithChainAe);
-TEST_TABLE_LOOKUP_FAILURE(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTableLookupFailure);
+TEST_MACRO(TestGcsWithChainAsio, TestTableLookupFailure);
 #endif
 
 void TestLogAppendAt(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
@@ -371,18 +365,11 @@ void TestTaskTable(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> cli
   test->Start();
 }
 
-#define TEST_TASK_TABLE(FIXTURE)     \
-  TEST_F(FIXTURE, TestTaskTable) {   \
-    test = this;                     \
-    TestTaskTable(job_id_, client_); \
-  }
-
-TEST_TASK_TABLE(TestGcsWithAe);
-TEST_TASK_TABLE(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTaskTable);
+TEST_MACRO(TestGcsWithAsio, TestTaskTable);
 #if RAY_USE_NEW_GCS
-TEST_TASK_TABLE(TestGcsWithChainAe);
-TEST_TASK_TABLE(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTaskTable);
+TEST_MACRO(TestGcsWithChainAsio, TestTaskTable);
 #endif
 
 void TestTableSubscribeAll(const JobID &job_id,
@@ -425,18 +412,11 @@ void TestTableSubscribeAll(const JobID &job_id,
   ASSERT_EQ(test->NumCallbacks(), task_specs.size());
 }
 
-#define TEST_TABLE_SUBSCRIBE_ALL(FIXTURE)    \
-  TEST_F(FIXTURE, TestTableSubscribeAll) {   \
-    test = this;                             \
-    TestTableSubscribeAll(job_id_, client_); \
-  }
-
-TEST_TABLE_SUBSCRIBE_ALL(TestGcsWithAe);
-TEST_TABLE_SUBSCRIBE_ALL(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTableSubscribeAll);
+TEST_MACRO(TestGcsWithAsio, TestTableSubscribeAll);
 #if RAY_USE_NEW_GCS
-TEST_TABLE_SUBSCRIBE_ALL(TestGcsWithChainAe);
-TEST_TABLE_SUBSCRIBE_ALL(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTableSubscribeAll);
+TEST_MACRO(TestGcsWithChainAsio, TestTableSubscribeAll);
 #endif
 
 void TestLogSubscribeAll(const JobID &job_id,
@@ -562,18 +542,11 @@ void TestTableSubscribeId(const JobID &job_id,
   ASSERT_EQ(test->NumCallbacks(), task_specs2.size());
 }
 
-#define TEST_TABLE_SUBSCRIBE_ID(FIXTURE)    \
-  TEST_F(FIXTURE, TestTableSubscribeId) {   \
-    test = this;                            \
-    TestTableSubscribeId(job_id_, client_); \
-  }
-
-TEST_TABLE_SUBSCRIBE_ID(TestGcsWithAe);
-TEST_TABLE_SUBSCRIBE_ID(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTableSubscribeId);
+TEST_MACRO(TestGcsWithAsio, TestTableSubscribeId);
 #if RAY_USE_NEW_GCS
-TEST_TABLE_SUBSCRIBE_ID(TestGcsWithChainAe);
-TEST_TABLE_SUBSCRIBE_ID(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTableSubscribeId);
+TEST_MACRO(TestGcsWithChainAsio, TestTableSubscribeId);
 #endif
 
 void TestLogSubscribeId(const JobID &job_id,
@@ -719,18 +692,11 @@ void TestTableSubscribeCancel(const JobID &job_id,
   ASSERT_EQ(test->NumCallbacks(), 2);
 }
 
-#define TEST_TABLE_SUBSCRIBE_CANCEL(FIXTURE)    \
-  TEST_F(FIXTURE, TestTableSubscribeCancel) {   \
-    test = this;                                \
-    TestTableSubscribeCancel(job_id_, client_); \
-  }
-
-TEST_TABLE_SUBSCRIBE_CANCEL(TestGcsWithAe);
-TEST_TABLE_SUBSCRIBE_CANCEL(TestGcsWithAsio);
-
+TEST_MACRO(TestGcsWithAe, TestTableSubscribeCancel);
+TEST_MACRO(TestGcsWithAsio, TestTableSubscribeCancel);
 #if RAY_USE_NEW_GCS
-TEST_TABLE_SUBSCRIBE_CANCEL(TestGcsWithChainAe);
-TEST_TABLE_SUBSCRIBE_CANCEL(TestGcsWithChainAsio);
+TEST_MACRO(TestGcsWithChainAe, TestTableSubscribeCancel);
+TEST_MACRO(TestGcsWithChainAsio, TestTableSubscribeCancel);
 #endif
 
 void TestLogSubscribeCancel(const JobID &job_id,
@@ -933,6 +899,8 @@ TEST_F(TestGcsWithAsio, TestClientTableMarkDisconnected) {
   test = this;
   TestClientTableMarkDisconnected(job_id_, client_);
 }
+
+#undef TEST_MACRO
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -12,6 +12,8 @@ extern "C" {
 
 namespace ray {
 
+namespace gcs {
+
 namespace {
 const char *const kRandomId = "abcdefghijklmnopqrst";
 }  // namespace
@@ -131,20 +133,22 @@ TEST_F(TestGcsWithAe, TestTableLookup) {
   TestTableLookup(job_id_, client_, gcs::CommandType::kRegular);
 }
 
-TEST_F(TestGcsWithAe, TestTableLookupWithChain) {
-  test = this;
-  TestTableLookup(job_id_, client_, gcs::CommandType::kChain);
-}
-
 TEST_F(TestGcsWithAsio, TestTableLookup) {
   test = this;
   TestTableLookup(job_id_, client_, gcs::CommandType::kRegular);
+}
+
+#if RAY_USE_NEW_GCS
+TEST_F(TestGcsWithAe, TestTableLookupWithChain) {
+  test = this;
+  TestTableLookup(job_id_, client_, gcs::CommandType::kChain);
 }
 
 TEST_F(TestGcsWithAsio, TestTableLookupWithChain) {
   test = this;
   TestTableLookup(job_id_, client_, gcs::CommandType::kChain);
 }
+#endif
 
 void TestLogLookup(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> client) {
   // Append some entries to the log at an object ID.
@@ -361,20 +365,22 @@ TEST_F(TestGcsWithAe, TestTaskTable) {
   TestTaskTable(job_id_, client_, gcs::CommandType::kRegular);
 }
 
-TEST_F(TestGcsWithAe, TestTaskTableWithChain) {
-  test = this;
-  TestTaskTable(job_id_, client_, gcs::CommandType::kChain);
-}
-
 TEST_F(TestGcsWithAsio, TestTaskTable) {
   test = this;
   TestTaskTable(job_id_, client_, gcs::CommandType::kRegular);
+}
+
+#if RAY_USE_NEW_GCS
+TEST_F(TestGcsWithAe, TestTaskTableWithChain) {
+  test = this;
+  TestTaskTable(job_id_, client_, gcs::CommandType::kChain);
 }
 
 TEST_F(TestGcsWithAsio, TestTaskTableWithChain) {
   test = this;
   TestTaskTable(job_id_, client_, gcs::CommandType::kChain);
 }
+#endif
 
 void TestTableSubscribeAll(const JobID &job_id,
                            std::shared_ptr<gcs::AsyncGcsClient> client,
@@ -423,19 +429,23 @@ TEST_F(TestGcsWithAe, TestTableSubscribeAll) {
   test = this;
   TestTableSubscribeAll(job_id_, client_, gcs::CommandType::kRegular);
 }
-TEST_F(TestGcsWithAe, TestTableSubscribeAllWithChain) {
-  test = this;
-  TestTableSubscribeAll(job_id_, client_, gcs::CommandType::kChain);
-}
 
 TEST_F(TestGcsWithAsio, TestTableSubscribeAll) {
   test = this;
   TestTableSubscribeAll(job_id_, client_, gcs::CommandType::kRegular);
 }
+
+#if RAY_USE_NEW_GCS
+TEST_F(TestGcsWithAe, TestTableSubscribeAllWithChain) {
+  test = this;
+  TestTableSubscribeAll(job_id_, client_, gcs::CommandType::kChain);
+}
+
 TEST_F(TestGcsWithAsio, TestTableSubscribeAllWithChain) {
   test = this;
   TestTableSubscribeAll(job_id_, client_, gcs::CommandType::kChain);
 }
+#endif
 
 void TestLogSubscribeAll(const JobID &job_id,
                          std::shared_ptr<gcs::AsyncGcsClient> client) {
@@ -569,19 +579,23 @@ TEST_F(TestGcsWithAe, TestTableSubscribeId) {
   test = this;
   TestTableSubscribeId(job_id_, client_, gcs::CommandType::kRegular);
 }
-TEST_F(TestGcsWithAe, TestTableSubscribeIdWithChain) {
-  test = this;
-  TestTableSubscribeId(job_id_, client_, gcs::CommandType::kChain);
-}
 
 TEST_F(TestGcsWithAsio, TestTableSubscribeId) {
   test = this;
   TestTableSubscribeId(job_id_, client_, gcs::CommandType::kRegular);
 }
+
+#if RAY_USE_NEW_GCS
+TEST_F(TestGcsWithAe, TestTableSubscribeIdWithChain) {
+  test = this;
+  TestTableSubscribeId(job_id_, client_, gcs::CommandType::kChain);
+}
+
 TEST_F(TestGcsWithAsio, TestTableSubscribeIdWithChain) {
   test = this;
   TestTableSubscribeId(job_id_, client_, gcs::CommandType::kChain);
 }
+#endif
 
 void TestLogSubscribeId(const JobID &job_id,
                         std::shared_ptr<gcs::AsyncGcsClient> client) {
@@ -734,19 +748,23 @@ TEST_F(TestGcsWithAe, TestTableSubscribeCancel) {
   test = this;
   TestTableSubscribeCancel(job_id_, client_, gcs::CommandType::kRegular);
 }
-TEST_F(TestGcsWithAe, TestTableSubscribeCancelWithChain) {
-  test = this;
-  TestTableSubscribeCancel(job_id_, client_, gcs::CommandType::kChain);
-}
 
 TEST_F(TestGcsWithAsio, TestTableSubscribeCancel) {
   test = this;
   TestTableSubscribeCancel(job_id_, client_, gcs::CommandType::kRegular);
 }
+
+#if RAY_USE_NEW_GCS
+TEST_F(TestGcsWithAe, TestTableSubscribeCancelWithChain) {
+  test = this;
+  TestTableSubscribeCancel(job_id_, client_, gcs::CommandType::kChain);
+}
+
 TEST_F(TestGcsWithAsio, TestTableSubscribeCancelWithChain) {
   test = this;
   TestTableSubscribeCancel(job_id_, client_, gcs::CommandType::kChain);
 }
+#endif
 
 void TestLogSubscribeCancel(const JobID &job_id,
                             std::shared_ptr<gcs::AsyncGcsClient> client) {
@@ -949,4 +967,5 @@ TEST_F(TestGcsWithAsio, TestClientTableMarkDisconnected) {
   TestClientTableMarkDisconnected(job_id_, client_);
 }
 
+}  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -25,7 +25,6 @@ using RedisCallback = std::function<bool(const std::string &)>;
 
 class RedisCallbackManager {
  public:
-
   static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;
     return instance;
@@ -43,7 +42,7 @@ class RedisCallbackManager {
 
   ~RedisCallbackManager() { printf("shut down callback manager\n"); }
 
-  int64_t num_callbacks;
+  int64_t num_callbacks_ = 0;
   std::unordered_map<int64_t, RedisCallback> callbacks_;
 };
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -38,7 +38,7 @@ class RedisCallbackManager {
   void remove(int64_t callback_index);
 
  private:
-  RedisCallbackManager() : num_callbacks(0){};
+  RedisCallbackManager() : num_callbacks_(0){};
 
   ~RedisCallbackManager() { printf("shut down callback manager\n"); }
 

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -145,7 +145,7 @@ Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
                               prefix_, pubsub_channel_, callback_index,
                               std::move(callback));
   } else {
-    RAY_CHECK(command_type == CommandType::kChain);
+    RAY_CHECK(command_type_ == CommandType::kChain);
     return context_->RunAsync("RAY.CHAIN.TABLE_ADD", id, fbb.GetBufferPointer(),
                               fbb.GetSize(), prefix_, pubsub_channel_,
                               std::move(callback));

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -140,10 +140,9 @@ Status Table<ID, Data>::Add(const JobID &job_id, const ID &id,
   flatbuffers::FlatBufferBuilder fbb;
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, dataT.get()));
-  if (command_type == CommandType::kRegular) {
+  if (command_type_ == CommandType::kRegular) {
     return context_->RunAsync("RAY.TABLE_ADD", id, fbb.GetBufferPointer(), fbb.GetSize(),
-                              prefix_, pubsub_channel_, callback_index,
-                              std::move(callback));
+                              prefix_, pubsub_channel_, std::move(callback));
   } else {
     RAY_CHECK(command_type_ == CommandType::kChain);
     return context_->RunAsync("RAY.CHAIN.TABLE_ADD", id, fbb.GetBufferPointer(),

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -248,8 +248,8 @@ void ClientTable::HandleNotification(AsyncGcsClient *client,
 
 void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientTableDataT &data) {
   auto connected_client_id = ClientID::from_binary(data.client_id);
-  RAY_CHECK(client_id_ == connected_client_id)
-      << connected_client_id << " " << client_id_;
+  RAY_CHECK(client_id_ == connected_client_id) << connected_client_id << " "
+                                               << client_id_;
 }
 
 const ClientID &ClientTable::GetLocalClientId() { return client_id_; }
@@ -274,8 +274,8 @@ Status ClientTable::Connect(const ClientTableDataT &local_client) {
 
     // Callback for a notification from the client table.
     auto notification_callback = [this](
-                                     AsyncGcsClient *client, const UniqueID &log_key,
-                                     const std::vector<ClientTableDataT> &notifications) {
+        AsyncGcsClient *client, const UniqueID &log_key,
+        const std::vector<ClientTableDataT> &notifications) {
       RAY_CHECK(log_key == client_log_key_);
       for (auto &notification : notifications) {
         HandleNotification(client, notification);

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -27,6 +27,9 @@ class RedisContext;
 
 class AsyncGcsClient;
 
+/// If kChain, chain-replicated versions of commands will be used, when available.
+enum class CommandType { kRegular, kChain };
+
 /// \class PubsubInterface
 ///
 /// The interface for a pubsub storage system. The client of a storage system
@@ -238,6 +241,10 @@ class Table : private Log<ID, Data>,
   /// \return Status
   Status Add(const JobID &job_id, const ID &id, std::shared_ptr<DataT> &data,
              const WriteCallback &done);
+
+  /// A general version of Add() that supports different CommandType's.
+  Status Add(const JobID &job_id, const ID &id, std::shared_ptr<DataT> data,
+             const WriteCallback &done, CommandType command_type);
 
   /// Lookup an entry asynchronously.
   ///

--- a/src/ray/test/run_gcs_tests.sh
+++ b/src/ray/test/run_gcs_tests.sh
@@ -7,7 +7,18 @@ set -e
 set -x
 
 # Start Redis.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 &
+if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+    ./src/credis/redis/src/redis-server \
+        --loglevel warning \
+        --loadmodule ./src/credis/build/src/libmember.so \
+        --loadmodule ./src/common/redis_module/libray_redis_module.so \
+        --port 6379 &
+else
+    ./src/common/thirdparty/redis/src/redis-server \
+        --loglevel warning \
+        --loadmodule ./src/common/redis_module/libray_redis_module.so \
+        --port 6379 &
+fi
 sleep 1s
 
 ./src/ray/gcs/client_test

--- a/src/ray/test/run_object_manager_tests.sh
+++ b/src/ray/test/run_object_manager_tests.sh
@@ -36,10 +36,6 @@ fi
 
 STORE_EXEC="$CORE_DIR/src/plasma/plasma_store"
 
-# echo "$STORE_EXEC"
-# echo "$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379"
-# echo "$REDIS_DIR/redis-cli -p 6379 shutdown"
-
 # Allow cleanup commands to fail.
 $REDIS_DIR/redis-cli -p 6379 shutdown || true
 sleep 1s

--- a/src/ray/test/run_object_manager_tests.sh
+++ b/src/ray/test/run_object_manager_tests.sh
@@ -21,18 +21,29 @@ if [ ! -d "$RAY_ROOT/python" ]; then
 fi
 
 CORE_DIR="$RAY_ROOT/python/ray/core"
-REDIS_DIR="$CORE_DIR/src/common/thirdparty/redis/src"
 REDIS_MODULE="$CORE_DIR/src/common/redis_module/libray_redis_module.so"
+REDIS_DIR="$CORE_DIR/src/common/thirdparty/redis/src"
+
+if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+    REDIS_SERVER="$CORE_DIR/src/credis/redis/src/redis-server"
+
+    CREDIS_MODULE="$CORE_DIR/src/credis/build/src/libmember.so"
+    LOAD_MODULE_ARGS="--loadmodule ${CREDIS_MODULE} --loadmodule ${REDIS_MODULE}"
+else
+    REDIS_SERVER="${REDIS_DIR}/redis-server"
+    LOAD_MODULE_ARGS="--loadmodule ${REDIS_MODULE}"
+fi
+
 STORE_EXEC="$CORE_DIR/src/plasma/plasma_store"
 
-echo "$STORE_EXEC"
-echo "$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379"
-echo "$REDIS_DIR/redis-cli -p 6379 shutdown"
+# echo "$STORE_EXEC"
+# echo "$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379"
+# echo "$REDIS_DIR/redis-cli -p 6379 shutdown"
 
 # Allow cleanup commands to fail.
 $REDIS_DIR/redis-cli -p 6379 shutdown || true
 sleep 1s
-$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379 &
+${REDIS_SERVER} --loglevel warning ${LOAD_MODULE_ARGS} --port 6379 &
 sleep 1s
 # Run tests.
 $CORE_DIR/src/ray/object_manager/object_manager_stress_test $STORE_EXEC

--- a/src/ray/test/run_object_manager_valgrind.sh
+++ b/src/ray/test/run_object_manager_valgrind.sh
@@ -26,15 +26,25 @@ REDIS_MODULE="$CORE_DIR/src/common/redis_module/libray_redis_module.so"
 STORE_EXEC="$CORE_DIR/src/plasma/plasma_store"
 VALGRIND_CMD="valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all --leak-check-heuristics=stdstring --error-exitcode=1"
 
+if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+    REDIS_SERVER="$CORE_DIR/src/credis/redis/src/redis-server"
+
+    CREDIS_MODULE="$CORE_DIR/src/credis/build/src/libmember.so"
+    LOAD_MODULE_ARGS="--loadmodule ${CREDIS_MODULE} --loadmodule ${REDIS_MODULE}"
+else
+    REDIS_SERVER="${REDIS_DIR}/redis-server"
+    LOAD_MODULE_ARGS="--loadmodule ${REDIS_MODULE}"
+fi
+
 echo "$STORE_EXEC"
-echo "$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379"
+echo "${REDIS_SERVER} --loglevel warning ${LOAD_MODULE_ARGS} --port 6379"
 echo "$REDIS_DIR/redis-cli -p 6379 shutdown"
 
 # Allow cleanup commands to fail.
 killall plasma_store || true
 $REDIS_DIR/redis-cli -p 6379 shutdown || true
 sleep 1s
-$REDIS_DIR/redis-server --loglevel warning --loadmodule $REDIS_MODULE --port 6379 &
+${REDIS_SERVER} --loglevel warning ${LOAD_MODULE_ARGS} --port 6379 &
 sleep 1s
 
 # Run tests.

--- a/src/ray/test/start_raylets.sh
+++ b/src/ray/test/start_raylets.sh
@@ -5,8 +5,24 @@
 # Cause the script to exit if a single command fails.
 set -e
 
+LaunchRedis() {
+    port=$1
+    if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
+        ./src/credis/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/credis/build/src/libmember.so \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port >/dev/null &
+    else
+        ./src/common/thirdparty/redis/src/redis-server \
+            --loglevel warning \
+            --loadmodule ./src/common/redis_module/libray_redis_module.so \
+            --port $port >/dev/null &
+    fi
+}
+
 # Start the GCS.
-./src/common/thirdparty/redis/src/redis-server --loglevel warning --loadmodule ./src/common/redis_module/libray_redis_module.so --port 6379 >/dev/null &
+LaunchRedis 6379
 sleep 1s
 
 if [[ $1 ]]; then

--- a/test/credis_test.py
+++ b/test/credis_test.py
@@ -8,7 +8,7 @@ import redis
 import ray
 
 
-def ParseClient(addr_port_str):
+def parse_client(addr_port_str):
     redis_address, redis_port = addr_port_str.split(":")
     return redis.StrictRedis(host=redis_address, port=redis_port)
 
@@ -24,7 +24,7 @@ class CredisTest(unittest.TestCase):
 
     def test_credis_started(self):
         assert "redis_address" in self.config
-        primary = ParseClient(self.config['redis_address'])
+        primary = parse_client(self.config['redis_address'])
         assert primary.ping() is True
 
         # Check that primary has loaded credis' master module.
@@ -34,7 +34,7 @@ class CredisTest(unittest.TestCase):
         # Check that the shard has loaded credis' member module.
         member = primary.lrange('RedisShards', 0, -1)[0]
         assert chain[0] == member
-        shard = ParseClient(member.decode())
+        shard = parse_client(member.decode())
         assert shard.execute_command('MEMBER.SN') == -1
 
 

--- a/test/credis_test.py
+++ b/test/credis_test.py
@@ -1,12 +1,16 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
-import redis
 import unittest
 
+import redis
+
 import ray
+
+
+def ParseClient(addr_port_str):
+    redis_address, redis_port = addr_port_str.split(":")
+    return redis.StrictRedis(host=redis_address, port=redis_port)
 
 
 @unittest.skipIf(not os.environ.get('RAY_USE_NEW_GCS', False),
@@ -19,15 +23,19 @@ class CredisTest(unittest.TestCase):
         ray.worker.cleanup()
 
     def test_credis_started(self):
-        assert "credis_address" in self.config
-        credis_address, credis_port = self.config["credis_address"].split(":")
-        credis_client = redis.StrictRedis(
-            host=credis_address, port=credis_port)
-        assert credis_client.ping() is True
+        assert "redis_address" in self.config
+        primary = ParseClient(self.config['redis_address'])
+        assert primary.ping() is True
 
-        redis_client = ray.worker.global_state.redis_client
-        addr = redis_client.get("credis_address").decode("ascii")
-        assert addr == self.config["credis_address"]
+        # Check that primary has loaded credis' master module.
+        chain = primary.execute_command('MASTER.GET_CHAIN')
+        assert len(chain) == 1
+
+        # Check that the shard has loaded credis' member module.
+        member = primary.lrange('RedisShards', 0, -1)[0]
+        assert chain[0] == member
+        shard = ParseClient(member.decode())
+        assert shard.execute_command('MEMBER.SN') == -1
 
 
 if __name__ == "__main__":

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
-import ray
 import subprocess
 import sys
 import tempfile
 import time
 import unittest
 
+import ray
 from ray.test.test_utils import run_and_get_output
 
 
@@ -215,12 +213,6 @@ class StartRayScriptTest(unittest.TestCase):
         run_and_get_output(["ray", "start", "--head", "--redis-port", "6379"])
         subprocess.Popen(["ray", "stop"]).wait()
 
-        # Test starting Ray with redis shard ports specified.
-        run_and_get_output([
-            "ray", "start", "--head", "--redis-shard-ports", "6380,6381,6382"
-        ])
-        subprocess.Popen(["ray", "stop"]).wait()
-
         # Test starting Ray with a node IP address specified.
         run_and_get_output(
             ["ray", "start", "--head", "--node-ip-address", "127.0.0.1"])
@@ -244,15 +236,23 @@ class StartRayScriptTest(unittest.TestCase):
             ["ray", "start", "--head", "--redis-max-clients", "100"])
         subprocess.Popen(["ray", "stop"]).wait()
 
-        # Test starting Ray with all arguments specified.
-        run_and_get_output([
-            "ray", "start", "--head", "--num-workers", "20", "--redis-port",
-            "6379", "--redis-shard-ports", "6380,6381,6382",
-            "--object-manager-port", "12345", "--num-cpus", "100",
-            "--num-gpus", "0", "--redis-max-clients", "100", "--resources",
-            "{\"Custom\": 1}"
-        ])
-        subprocess.Popen(["ray", "stop"]).wait()
+        if "RAY_USE_NEW_GCS" not in os.environ:
+            # Test starting Ray with redis shard ports specified.
+            run_and_get_output([
+                "ray", "start", "--head", "--redis-shard-ports",
+                "6380,6381,6382"
+            ])
+            subprocess.Popen(["ray", "stop"]).wait()
+
+            # Test starting Ray with all arguments specified.
+            run_and_get_output([
+                "ray", "start", "--head", "--num-workers", "20",
+                "--redis-port", "6379", "--redis-shard-ports",
+                "6380,6381,6382", "--object-manager-port", "12345",
+                "--num-cpus", "100", "--num-gpus", "0", "--redis-max-clients",
+                "100", "--resources", "{\"Custom\": 1}"
+            ])
+            subprocess.Popen(["ray", "stop"]).wait()
 
         # Test starting Ray with invalid arguments.
         with self.assertRaises(Exception):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1066,6 +1066,10 @@ class APITest(unittest.TestCase):
             ray.get(3)
 
 
+@unittest.skipIf(
+    os.environ.get('RAY_USE_NEW_GCS', False),
+    "For now, RAY_USE_NEW_GCS supports 1 shard, and credis "
+    "supports 1-node chain for that shard only.")
 class APITestSharded(APITest):
     def init_ray(self, **kwargs):
         if kwargs is None:

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -19,48 +19,46 @@ TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)/../
 ROOT_DIR=$TP_DIR/..
 
 if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
-  if [ ! -d $TP_DIR/pkg/credis ]; then
-    pushd "$TP_DIR/pkg/"
-      rm -rf credis
-      git clone --recursive https://github.com/ray-project/credis
+  pushd "$TP_DIR/pkg/"
+    rm -rf credis
+    git clone --recursive https://github.com/ray-project/credis
+  popd
+
+  pushd "$TP_DIR/pkg/credis"
+    # git checkout 6be4a739ab5e795c98402b27c2e254f86e3524ea
+
+    # 4/10/2018 credis/integrate branch.  With updated redis hacks.
+    git checkout cbe8ade35d2278b1d94684fa5d00010cb015ef82
+
+    # If the above commit points to different submodules' commits than
+    # origin's head, this updates the submodules.
+    git submodule update
+
+    # TODO(pcm): Get the build environment for tcmalloc set up and compile redis
+    # with tcmalloc.
+    # NOTE(zongheng): if we don't specify MALLOC=jemalloc, then build behiavors
+    # differ between Mac (libc) and Linux (jemalloc)... This breaks our CMake
+    # rules.
+    if [[ "${CREDIS_TCMALLOC}" = 1 ]]; then
+        echo "CREDIS_MALLOC is set, using tcmalloc to build redis"
+        pushd redis && env USE_TCMALLOC=yes make -j && popd
+    else
+        pushd redis && make -j MALLOC=jemalloc && popd
+    fi
+    pushd glog && cmake -DWITH_GFLAGS=off . && make -j && popd
+    # NOTE(zongheng): DO NOT USE -j parallel build for leveldb as it's incorrect!
+    pushd leveldb && CXXFLAGS="$CXXFLAGS -fPIC" make && popd
+
+    mkdir build
+    pushd build
+      cmake ..
+      make -j
     popd
 
-    pushd "$TP_DIR/pkg/credis"
-      # git checkout 6be4a739ab5e795c98402b27c2e254f86e3524ea
-
-      # 4/10/2018 credis/integrate branch.  With updated redis hacks.
-      git checkout cbe8ade35d2278b1d94684fa5d00010cb015ef82
-
-      # If the above commit points to different submodules' commits than
-      # origin's head, this updates the submodules.
-      git submodule update
-
-      # TODO(pcm): Get the build environment for tcmalloc set up and compile redis
-      # with tcmalloc.
-      # NOTE(zongheng): if we don't specify MALLOC=jemalloc, then build behiavors
-      # differ between Mac (libc) and Linux (jemalloc)... This breaks our CMake
-      # rules.
-      if [[ "${CREDIS_TCMALLOC}" = 1 ]]; then
-          echo "CREDIS_MALLOC is set, using tcmalloc to build redis"
-          pushd redis && env USE_TCMALLOC=yes make -j && popd
-      else
-          pushd redis && make -j MALLOC=jemalloc && popd
-      fi
-      pushd glog && cmake -DWITH_GFLAGS=off . && make -j && popd
-      # NOTE(zongheng): DO NOT USE -j parallel build for leveldb as it's incorrect!
-      pushd leveldb && CXXFLAGS="$CXXFLAGS -fPIC" make && popd
-
-      mkdir build
-      pushd build
-        cmake ..
-        make -j
-      popd
-
-      mkdir -p $ROOT_DIR/python/ray/core/src/credis/redis/src/
-      cp redis/src/redis-server $ROOT_DIR/python/ray/core/src/credis/redis/src/redis-server
-      mkdir -p $ROOT_DIR/python/ray/core/src/credis/build/src/
-      cp build/src/libmaster.so $ROOT_DIR/python/ray/core/src/credis/build/src/libmaster.so
-      cp build/src/libmember.so $ROOT_DIR/python/ray/core/src/credis/build/src/libmember.so
-    popd
-  fi
+    mkdir -p $ROOT_DIR/python/ray/core/src/credis/redis/src/
+    cp redis/src/redis-server $ROOT_DIR/python/ray/core/src/credis/redis/src/redis-server
+    mkdir -p $ROOT_DIR/python/ray/core/src/credis/build/src/
+    cp build/src/libmaster.so $ROOT_DIR/python/ray/core/src/credis/build/src/libmaster.so
+    cp build/src/libmember.so $ROOT_DIR/python/ray/core/src/credis/build/src/libmember.so
+  popd
 fi

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -28,8 +28,8 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
     pushd "$TP_DIR/pkg/credis"
       # git checkout 6be4a739ab5e795c98402b27c2e254f86e3524ea
 
-      # 4/5/2018 credis/integrate branch.  With updated redis hacks.
-      git checkout 7eae7f2e58d16dfa1a95b5dfab02549f54b94e5d
+      # 4/10/2018 credis/integrate branch.  With updated redis hacks.
+      git checkout cbe8ade35d2278b1d94684fa5d00010cb015ef82
 
       # If the above commit points to different submodules' commits than
       # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -25,8 +25,6 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    # git checkout 6be4a739ab5e795c98402b27c2e254f86e3524ea
-
     # 4/10/2018 credis/integrate branch.  With updated redis hacks.
     git checkout cbe8ade35d2278b1d94684fa5d00010cb015ef82
 


### PR DESCRIPTION
Quick overview of this change. 

**How credis is loaded**.  Previously credis servers were separate from redis servers.  With this change, the primary additionally loads credis' `libmaster.so`, and the (assumed to be only 1) redis shard loads credis' `libmember.so`, acting as the singleton node in a 1-node chain.

**Changes to ray_redis_module.cc**.  `TableAdd` gets a new variant, `ChainTableAdd`.  I believe _this should serve as a good example if others wish to port other commands_ in the future ;)

**Testing**.  All tests related to adding entries to legacy / raylet task tables in `client_test.cc` have been augmented to test with credis.

**To build and launch manually.** To build, `RAY_USE_NEW_GCS=on pip install -e . --verbose`.  To launch, `RAY_USE_NEW_GCS=on ipython`.