### PR TITLE
Add yapf as a Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,21 +29,21 @@ matrix:
         #- echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         - sudo apt-get update -qq
         - sudo apt-get install -qq clang-format-3.8
-        - pip install yapf
       install: []
       script:
         - .travis/check-git-clang-format-output.sh
-        - .travis/yapf.sh
         # Try generating Sphinx documentation. To do this, we need to install
         # Ray first.
         - ./.travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - cd doc
         - pip install -q -r requirements-doc.txt
+        - pip install yapf
         - sphinx-build -W -b html -d _build/doctrees source _build/html
         - cd ..
         # Run Python linting.
         - flake8 --exclude=python/ray/core/src/common/flatbuffers_ep-prefix/,python/ray/core/generated/,src/common/format/,doc/source/conf.py,python/ray/cloudpickle/
+        - .travis/yapf.sh
 
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,11 @@ matrix:
         #- echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         - sudo apt-get update -qq
         - sudo apt-get install -qq clang-format-3.8
+        - pip install yapf
       install: []
       script:
         - .travis/check-git-clang-format-output.sh
+        - .travis/yapf.sh
         # Try generating Sphinx documentation. To do this, we need to install
         # Ray first.
         - ./.travis/install-dependencies.sh

--- a/.travis/yapf.sh
+++ b/.travis/yapf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -x
 
 # Git pre-commit hook to check staged Python files for formatting issues with
 # yapf.
@@ -25,15 +25,14 @@ set -ex
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
   # Not in a pull request, so compare against parent commit
   base_commit="HEAD^"
-  echo "Running clang-format against parent commit $(git rev-parse $base_commit)"
+  echo "Running yapf against parent commit $(git rev-parse $base_commit)"
 else
   base_commit="$TRAVIS_BRANCH"
-  echo "Running clang-format against branch $base_commit, with hash $(git rev-parse $base_commit)"
+  echo "Running yapf against branch $base_commit, with hash $(git rev-parse $base_commit)"
 fi
 
 # Find all staged Python files, and exit early if there aren't any.
-PYTHON_FILES=(`git diff ${base_commit} --name-only --cached --diff-filter=AM | \
-  grep --color=never '.py$'`)
+PYTHON_FILES=(`git diff ${base_commit} --name-only --cached --diff-filter=AM | grep --color=never '.py$'`)
 if [ ! "$PYTHON_FILES" ]; then
   exit 0
 fi

--- a/.travis/yapf.sh
+++ b/.travis/yapf.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -ex
+
+# Git pre-commit hook to check staged Python files for formatting issues with
+# yapf.
+#
+# INSTALLING: Copy this script into `.git/hooks/pre-commit`, and mark it as
+# executable.
+#
+# This requires that yapf is installed and runnable in the environment running
+# the pre-commit hook.
+#
+# When running, this first checks for unstaged changes to staged files, and if
+# there are any, it will exit with an error. Files with unstaged changes will be
+# printed.
+#
+# If all staged files have no unstaged changes, it will run yapf against them,
+# leaving the formatting changes unstaged. Changed files will be printed.
+#
+# BUGS: This does not leave staged changes alone when used with the -a flag to
+# git commit, due to the fact that git stages ALL unstaged files when that flag
+# is used.
+
+# Copied from .travis/check-git-clang-format-output.sh.
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
+  # Not in a pull request, so compare against parent commit
+  base_commit="HEAD^"
+  echo "Running clang-format against parent commit $(git rev-parse $base_commit)"
+else
+  base_commit="$TRAVIS_BRANCH"
+  echo "Running clang-format against branch $base_commit, with hash $(git rev-parse $base_commit)"
+fi
+
+# Find all staged Python files, and exit early if there aren't any.
+PYTHON_FILES=(`git diff ${base_commit} --name-only --cached --diff-filter=AM | \
+  grep --color=never '.py$'`)
+if [ ! "$PYTHON_FILES" ]; then
+  exit 0
+fi
+
+# Verify that yapf is installed; if not, warn and exit.
+if [ -z $(which yapf) ]; then
+  echo 'yapf not on path; can not format. Please install yapf:'
+  echo '    pip install yapf'
+  exit 2
+fi
+
+# Check for unstaged changes to files in the index.
+CHANGED_FILES=(`git diff --name-only ${PYTHON_FILES[@]}`)
+if [ "$CHANGED_FILES" ]; then
+  echo 'You have unstaged changes to some files in your commit; skipping '
+  echo 'auto-format. Please stage, stash, or revert these changes. You may '
+  echo 'find `git stash -k` helpful here.'
+  echo
+  echo 'Files with unstaged changes:'
+  for file in ${CHANGED_FILES[@]}; do
+    echo "  $file"
+  done
+  exit 1
+fi
+# Format all staged files, then exit with an error code if any have uncommitted
+# changes.
+echo 'Formatting staged Python files . . .'
+yapf -i -r ${PYTHON_FILES[@]}
+CHANGED_FILES=(`git diff --name-only ${PYTHON_FILES[@]}`)
+if [ "$CHANGED_FILES" ]; then
+  echo 'Reformatted staged files. Please review and stage the changes.'
+  echo
+  echo 'Files updated:'
+  for file in ${CHANGED_FILES[@]}; do
+    echo "  $file"
+  done
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
This PR adds `yapf` as part of the Travis `LINT=1` build.  It only looks at **changed Python files** of the PR under Travis testing, and checks if running `yapf` against those files produces different results than the versions in the PR.

The script is adapted from https://github.com/google/yapf/blob/master/plugins/pre-commit.sh.