### PR TITLE
[rllib] Switch to use lz4 instead of snappy

### DIFF
--- a/python/ray/rllib/utils/compression.py
+++ b/python/ray/rllib/utils/compression.py
@@ -11,7 +11,9 @@ try:
     import lz4.frame
     LZ4_ENABLED = True
 except ImportError:
-    print("WARNING: lz4 not available, disabling sample compression")
+    print(
+        "WARNING: lz4 not available, disabling sample compression. "
+        "This will significantly degrade RLlib performance.")
     LZ4_ENABLED = False
 
 

--- a/python/ray/rllib/utils/compression.py
+++ b/python/ray/rllib/utils/compression.py
@@ -13,7 +13,8 @@ try:
 except ImportError:
     print(
         "WARNING: lz4 not available, disabling sample compression. "
-        "This will significantly degrade RLlib performance.")
+        "This will significantly impact RLlib performance. "
+        "To install lz4, run `pip install lz4`.")
     LZ4_ENABLED = False
 
 

--- a/python/ray/rllib/utils/compression.py
+++ b/python/ray/rllib/utils/compression.py
@@ -2,31 +2,57 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import time
 import base64
+import numpy as np
 import pyarrow
 
 try:
-    import snappy
-    SNAPPY_ENABLED = True
+    import lz4.frame
+    LZ4_ENABLED = True
 except ImportError:
-    print("WARNING: python-snappy not available, disabling sample compression")
-    SNAPPY_ENABLED = False
+    print("WARNING: lz4 not available, disabling sample compression")
+    LZ4_ENABLED = False
 
 
 def pack(data):
-    if SNAPPY_ENABLED:
-        data = snappy.compress(
-            pyarrow.serialize(data).to_buffer().to_pybytes())
+    if LZ4_ENABLED:
+        data = pyarrow.serialize(data).to_buffer().to_pybytes()
+        data = lz4.frame.compress(data)
         # TODO(ekl) we shouldn't need to base64 encode this data, but this
         # seems to not survive a transfer through the object store if we don't.
-        return base64.b64encode(data)
-    else:
-        return data
+        data = base64.b64encode(data)
+    return data
 
 
 def unpack(data):
-    if SNAPPY_ENABLED:
+    if LZ4_ENABLED:
         data = base64.b64decode(data)
-        return pyarrow.deserialize(snappy.decompress(data))
-    else:
-        return data
+        data = lz4.frame.decompress(data)
+        data = pyarrow.deserialize(data)
+    return data
+
+
+# Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
+# Compression speed: 753.664 MB/s
+# Compression ratio: 87.4839812046
+# Decompression speed: 910.9504 MB/s
+if __name__ == "__main__":
+    size = 32 * 80 * 80 * 4
+    data = np.ones(size).reshape((32, 80, 80, 4))
+
+    count = 0
+    start = time.time()
+    while time.time() - start < 1:
+        pack(data)
+        count += 1
+    compressed = pack(data)
+    print("Compression speed: {} MB/s".format(count * size * 4 / 1e6))
+    print("Compression ratio: {}".format(round(size * 4 / len(compressed), 2)))
+
+    count = 0
+    start = time.time()
+    while time.time() - start < 1:
+        unpack(compressed)
+        count += 1
+    print("Decompression speed: {} MB/s".format(count * size * 4 / 1e6))

--- a/python/setup.py
+++ b/python/setup.py
@@ -54,7 +54,7 @@ optional_ray_files += ray_autoscaler_files
 extras = {
     "rllib": [
         "tensorflow", "pyyaml", "gym[atari]", "opencv-python",
-        "python-snappy", "scipy"]
+        "lz4", "scipy"]
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Lz4 is easier to install, and hence is preferable over snappy. Performance seems similar. LZ4 is slightly slower at decompression but compresses better.

```
Using snappy
Compression speed: 566.8864 MB/s
Compression ratio: 7.96600445365
Decompression speed: 1176.3712 MB/s

Using lz4
Compression speed: 753.664 MB/s
Compression ratio: 87.4839812046
Decompression speed: 910.9504 MB/s
```
## Related issue number
https://github.com/ray-project/ray/issues/1781