### PR TITLE
[tune] [rllib] Automatically determine RLlib resources and add queueing mechanism for autoscaling

### DIFF
--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -287,7 +287,8 @@ Here is an example of using the command-line interface with RLlib:
     python ray/python/ray/rllib/train.py -f tuned_examples/cartpole-grid-search-example.yaml
 
 Here is an example using the Python API. The same config passed to ``Agents`` may be placed
-in the ``config`` section of the experiments.
+in the ``config`` section of the experiments. RLlib agents automatically declare their
+resources requirements (e.g., based on ``num_workers``) to Tune, so you don't have to.
 
 .. code-block:: python
 
@@ -300,10 +301,6 @@ in the ``config`` section of the experiments.
         'cartpole-ppo': {
             'run': 'PPO',
             'env': 'CartPole-v0',
-            'trial_resources': {
-                'cpu': 1,
-                'extra_cpu': 2,  # for workers
-            },
             'stop': {
                 'episode_reward_mean': 200,
                 'time_total_s': 180

--- a/python/ray/rllib/a3c/a3c.py
+++ b/python/ray/rllib/a3c/a3c.py
@@ -13,6 +13,7 @@ from ray.rllib.utils import FilterManager
 from ray.rllib.a3c.a3c_evaluator import A3CEvaluator, RemoteA3CEvaluator, \
     GPURemoteA3CEvaluator
 from ray.tune.result import TrainingResult
+from ray.tune.trial import Resources
 
 
 DEFAULT_CONFIG = {
@@ -67,6 +68,14 @@ class A3CAgent(Agent):
     _agent_name = "A3C"
     _default_config = DEFAULT_CONFIG
     _allow_unknown_subkeys = ["model", "optimizer", "env_config"]
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        return Resources(
+            cpu=1, gpu=0,
+            extra_cpu=cf["num_workers"],
+            extra_gpu=cf["use_gpu_for_workers"] and cf["num_workers"] or 0)
 
     def _init(self):
         self.local_evaluator = A3CEvaluator(

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -63,11 +63,12 @@ class Agent(Trainable):
     _allow_unknown_subkeys = []
 
     @classmethod
-    def resource_help(cls, _):
+    def resource_help(cls, config):
         return (
-            "You can adjust the resource requests of RLlib agents by setting "
-            "the `num_workers` and other configs. See the DEFAULT_CONFIG "
-            "defined by each agent for more info.")
+            "\n\nYou can adjust the resource requests of RLlib agents by "
+            "setting `num_workers` and other configs. See the "
+            "DEFAULT_CONFIG defined by each agent for more info.\n\n"
+            "The config of this agent is: " + str(config))
 
     def __init__(
             self, config=None, env=None, registry=None,

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -63,11 +63,11 @@ class Agent(Trainable):
     _allow_unknown_subkeys = []
 
     @classmethod
-    def resource_help(cls):
+    def resource_help(cls, _):
         return (
             "You can adjust the resource requests of RLlib agents by setting "
-            "the `num_workers` config. See the config variables available "
-            "for each agent for more info.")
+            "the `num_workers` and other configs. See the config variables "
+            "available for each agent for more info.")
 
     def __init__(
             self, config=None, env=None, registry=None,

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -64,8 +64,6 @@ class Agent(Trainable):
 
     @classmethod
     def resource_help(cls):
-        """Returns a help string for configuring this trial's resources."""
-
         return (
             "You can adjust the resource requests of RLlib agents by setting "
             "the `num_workers` config. See the config variables available "

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -66,8 +66,8 @@ class Agent(Trainable):
     def resource_help(cls, _):
         return (
             "You can adjust the resource requests of RLlib agents by setting "
-            "the `num_workers` and other configs. See the config variables "
-            "available for each agent for more info.")
+            "the `num_workers` and other configs. See the DEFAULT_CONFIG "
+            "defined by each agent for more info.")
 
     def __init__(
             self, config=None, env=None, registry=None,

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -62,6 +62,15 @@ class Agent(Trainable):
     _allow_unknown_configs = False
     _allow_unknown_subkeys = []
 
+    @classmethod
+    def resource_help(cls):
+        """Returns a help string for configuring this trial's resources."""
+
+        return (
+            "You can adjust the resource requests of RLlib agents by setting "
+            "the `num_workers` config. See the config variables available "
+            "for each agent for more info.")
+
     def __init__(
             self, config=None, env=None, registry=None,
             logger_creator=None):

--- a/python/ray/rllib/agent.py
+++ b/python/ray/rllib/agent.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import logging
 import numpy as np
+import json
 import os
 import pickle
 
@@ -68,7 +69,7 @@ class Agent(Trainable):
             "\n\nYou can adjust the resource requests of RLlib agents by "
             "setting `num_workers` and other configs. See the "
             "DEFAULT_CONFIG defined by each agent for more info.\n\n"
-            "The config of this agent is: " + str(config))
+            "The config of this agent is: " + json.dumps(config))
 
     def __init__(
             self, config=None, env=None, registry=None,

--- a/python/ray/rllib/bc/bc.py
+++ b/python/ray/rllib/bc/bc.py
@@ -8,16 +8,19 @@ from ray.rllib.bc.bc_evaluator import BCEvaluator, GPURemoteBCEvaluator, \
     RemoteBCEvaluator
 from ray.rllib.optimizers import AsyncOptimizer
 from ray.tune.result import TrainingResult
+from ray.tune.trial import Resources
 
 DEFAULT_CONFIG = {
     # Number of workers (excluding master)
-    "num_workers": 4,
+    "num_workers": 1,
     # Size of rollout batch
     "batch_size": 100,
     # Max global norm for each gradient calculated by worker
     "grad_clip": 40.0,
     # Learning rate
     "lr": 0.0001,
+    # Whether to use a GPU for local optimization.
+    "gpu": False,
     # Whether to place workers on GPUs
     "use_gpu_for_workers": False,
     # Model and preprocessor options
@@ -45,6 +48,18 @@ class BCAgent(Agent):
     _agent_name = "BC"
     _default_config = DEFAULT_CONFIG
     _allow_unknown_configs = True
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        if cf["use_gpu_for_workers"]:
+            num_gpus_per_worker = 1
+        else:
+            num_gpus_per_worker = 0
+        return Resources(
+            cpu=1, gpu=cf["gpu"] and 1 or 0,
+            extra_cpu=cf["num_workers"],
+            extra_gpu=num_gpus_per_worker * cf["num_workers"])
 
     def _init(self):
         self.local_evaluator = BCEvaluator(

--- a/python/ray/rllib/dqn/apex.py
+++ b/python/ray/rllib/dqn/apex.py
@@ -12,6 +12,7 @@ APEX_DEFAULT_CONFIG = dict(DQN_CONFIG, **dict(
         debug=False,
     )),
     n_step=3,
+    gpu=True,
     num_workers=32,
     buffer_size=2000000,
     learning_starts=50000,

--- a/python/ray/rllib/dqn/apex.py
+++ b/python/ray/rllib/dqn/apex.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 from ray.rllib.dqn.dqn import DQNAgent, DEFAULT_CONFIG as DQN_CONFIG
+from ray.tune.trial import Resources
 
 APEX_DEFAULT_CONFIG = dict(DQN_CONFIG, **dict(
     optimizer_class="ApexOptimizer",

--- a/python/ray/rllib/dqn/apex.py
+++ b/python/ray/rllib/dqn/apex.py
@@ -36,6 +36,15 @@ class ApexAgent(DQNAgent):
     _agent_name = "APEX"
     _default_config = APEX_DEFAULT_CONFIG
 
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        return Resources(
+            cpu=1 + cf["optimizer_config"]["num_replay_buffer_shards"],
+            gpu=cf["gpu"] and 1 or 0,
+            extra_cpu=cf["num_cpus_per_worker"] * cf["num_workers"],
+            extra_gpu=cf["num_gpus_per_worker"] * cf["num_workers"])
+
     def update_target_if_needed(self):
         # Ape-X updates based on num steps trained, not sampled
         if self.optimizer.num_steps_trained - self.last_target_update_ts > \

--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -136,7 +136,6 @@ class DQNAgent(Agent):
             extra_gpu=cf["num_gpus_per_worker"] * cf["num_workers"])
 
     def _init(self):
-        print("CREATED DQN")
         self.local_evaluator = DQNEvaluator(
             self.registry, self.env_creator, self.config, self.logdir, 0)
         remote_cls = ray.remote(
@@ -160,7 +159,6 @@ class DQNAgent(Agent):
         self.saver = tf.train.Saver(max_to_keep=None)
         self.last_target_update_ts = 0
         self.num_target_updates = 0
-        print("CREATED DQN OK")
 
     @property
     def global_timestep(self):

--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -13,6 +13,7 @@ from ray.rllib import optimizers
 from ray.rllib.dqn.dqn_evaluator import DQNEvaluator
 from ray.rllib.agent import Agent
 from ray.tune.result import TrainingResult
+from ray.tune.trial import Resources
 
 
 OPTIMIZER_SHARED_CONFIGS = [
@@ -100,14 +101,16 @@ DEFAULT_CONFIG = dict(
     },
 
     # === Parallelism ===
+    # Whether to use a GPU for local optimization.
+    gpu=False,
     # Number of workers for collecting samples with. This only makes sense
     # to increase if your environment is particularly slow to sample, or if
     # you're using the Async or Ape-X optimizers.
     num_workers=0,
     # Whether to allocate GPUs for workers (if > 0).
     num_gpus_per_worker=0,
-    # Whether to reserve CPUs for workers (if not None).
-    num_cpus_per_worker=None,
+    # Whether to allocate CPUs for workers (if > 0).
+    num_cpus_per_worker=1,
     # Optimizer class to use.
     optimizer_class="LocalSyncReplayOptimizer",
     # Config to pass to the optimizer.
@@ -123,6 +126,15 @@ class DQNAgent(Agent):
     _allow_unknown_subkeys = [
         "model", "optimizer", "tf_session_args", "env_config"]
     _default_config = DEFAULT_CONFIG
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        print("HI", cf)
+        return Resources(
+            cpu=1, gpu=cf["gpu"] and 1 or 0,
+            extra_cpu=cf["num_cpus_per_worker"] * cf["num_workers"],
+            extra_gpu=cf["num_gpus_per_worker"] * cf["num_workers"])
 
     def _init(self):
         self.local_evaluator = DQNEvaluator(

--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -130,7 +130,6 @@ class DQNAgent(Agent):
     @classmethod
     def default_resource_request(cls, config):
         cf = dict(cls._default_config, **config)
-        print("HI", cf)
         return Resources(
             cpu=1, gpu=cf["gpu"] and 1 or 0,
             extra_cpu=cf["num_cpus_per_worker"] * cf["num_workers"],

--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -136,6 +136,7 @@ class DQNAgent(Agent):
             extra_gpu=cf["num_gpus_per_worker"] * cf["num_workers"])
 
     def _init(self):
+        print("CREATED DQN")
         self.local_evaluator = DQNEvaluator(
             self.registry, self.env_creator, self.config, self.logdir, 0)
         remote_cls = ray.remote(
@@ -159,6 +160,7 @@ class DQNAgent(Agent):
         self.saver = tf.train.Saver(max_to_keep=None)
         self.last_target_update_ts = 0
         self.num_target_updates = 0
+        print("CREATED DQN OK")
 
     @property
     def global_timestep(self):

--- a/python/ray/rllib/es/es.py
+++ b/python/ray/rllib/es/es.py
@@ -13,6 +13,7 @@ import time
 
 import ray
 from ray.rllib import agent
+from ray.tune.trial import Resources
 
 from ray.rllib.es import optimizers
 from ray.rllib.es import policies
@@ -137,6 +138,11 @@ class ESAgent(agent.Agent):
     _agent_name = "ES"
     _default_config = DEFAULT_CONFIG
     _allow_unknown_subkeys = ["env_config"]
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        return Resources(cpu=1, gpu=0, extra_cpu=cf["num_workers"])
 
     def _init(self):
         policy_params = {

--- a/python/ray/rllib/optimizers/apex_optimizer.py
+++ b/python/ray/rllib/optimizers/apex_optimizer.py
@@ -18,7 +18,7 @@ import ray
 from ray.rllib.optimizers.policy_optimizer import PolicyOptimizer
 from ray.rllib.optimizers.replay_buffer import PrioritizedReplayBuffer
 from ray.rllib.optimizers.sample_batch import SampleBatch
-from ray.rllib.utils.actors import TaskPool
+from ray.rllib.utils.actors import TaskPool, create_colocated
 from ray.rllib.utils.timer import TimerStat
 from ray.rllib.utils.window_stat import WindowStat
 
@@ -163,15 +163,12 @@ class ApexOptimizer(PolicyOptimizer):
         self.learner = LearnerThread(self.local_evaluator)
         self.learner.start()
 
-        # TODO(ekl) use create_colocated() for these actors once
-        # https://github.com/ray-project/ray/issues/1734 is fixed
-        self.replay_actors = [
-            ReplayActor.remote(
-                num_replay_buffer_shards, learning_starts, buffer_size,
-                train_batch_size, prioritized_replay_alpha,
-                prioritized_replay_beta, prioritized_replay_eps, clip_rewards)
-            for _ in range(num_replay_buffer_shards)
-        ]
+        self.replay_actors = create_colocated(
+            ReplayActor,
+            [num_replay_buffer_shards, learning_starts, buffer_size,
+             train_batch_size, prioritized_replay_alpha,
+             prioritized_replay_beta, prioritized_replay_eps, clip_rewards],
+            num_replay_buffer_shards)
         assert len(self.remote_evaluators) > 0
 
         # Stats

--- a/python/ray/rllib/pg/pg.py
+++ b/python/ray/rllib/pg/pg.py
@@ -9,6 +9,8 @@ from ray.rllib.optimizers import LocalSyncOptimizer
 from ray.rllib.pg.pg_evaluator import PGEvaluator
 from ray.rllib.agent import Agent
 from ray.tune.result import TrainingResult
+from ray.tune.trial import Resources
+
 
 DEFAULT_CONFIG = {
     # Number of workers (excluding master)
@@ -40,6 +42,11 @@ class PGAgent(Agent):
 
     _agent_name = "PG"
     _default_config = DEFAULT_CONFIG
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        return Resources(cpu=1, gpu=0, extra_cpu=cf["num_workers"])
 
     def _init(self):
         self.optimizer = LocalSyncOptimizer.make(

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -92,8 +92,7 @@ DEFAULT_CONFIG = {
 
 class PPOAgent(Agent):
     _agent_name = "PPO"
-    _allow_unknown_subkeys = ["model", "tf_session_args", "env_config",
-                              "worker_resources"]
+    _allow_unknown_subkeys = ["model", "tf_session_args", "env_config"]
     _default_config = DEFAULT_CONFIG
 
     @classmethod
@@ -111,7 +110,8 @@ class PPOAgent(Agent):
         self.local_evaluator = PPOEvaluator(
             self.registry, self.env_creator, self.config, self.logdir, False)
         RemotePPOEvaluator = ray.remote(
-            **self.config["worker_resources"])(PPOEvaluator)
+            num_cpus=self.config["num_cpus_per_worker"],
+            num_gpus=self.config["num_gpus_per_worker"])(PPOEvaluator)
         self.remote_evaluators = [
             RemotePPOEvaluator.remote(
                 self.registry, self.env_creator, self.config, self.logdir,

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -12,6 +12,7 @@ from tensorflow.python import debug as tf_debug
 
 import ray
 from ray.tune.result import TrainingResult
+from ray.tune.trial import Resources
 from ray.rllib.agent import Agent
 from ray.rllib.utils import FilterManager
 from ray.rllib.ppo.ppo_evaluator import PPOEvaluator
@@ -69,8 +70,10 @@ DEFAULT_CONFIG = {
     "min_steps_per_task": 200,
     # Number of actors used to collect the rollouts
     "num_workers": 5,
-    # Resource requirements for remote actors
-    "worker_resources": {"num_cpus": None},
+    # Whether to allocate GPUs for workers (if > 0).
+    "num_gpus_per_worker": 0,
+    # Whether to allocate CPUs for workers (if > 0).
+    "num_cpus_per_worker": 1,
     # Dump TensorFlow timeline after this many SGD minibatches
     "full_trace_nth_sgd_batch": -1,
     # Whether to profile data loading
@@ -92,6 +95,15 @@ class PPOAgent(Agent):
     _allow_unknown_subkeys = ["model", "tf_session_args", "env_config",
                               "worker_resources"]
     _default_config = DEFAULT_CONFIG
+
+    @classmethod
+    def default_resource_request(cls, config):
+        cf = dict(cls._default_config, **config)
+        return Resources(
+            cpu=1,
+            gpu=len([d for d in cf["devices"] if "gpu" in d.lower()]),
+            extra_cpu=cf["num_cpus_per_worker"] * cf["num_workers"],
+            extra_gpu=cf["num_gpus_per_worker"] * cf["num_workers"])
 
     def _init(self):
         self.global_step = 0

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -34,6 +34,12 @@ parser.add_argument(
     "--redis-address", default=None, type=str,
     help="The Redis address of the cluster.")
 parser.add_argument(
+    "--fake-ray-cpus", default=None, type=int,
+    help="Number of CPUs to allocate to Ray. This only works in local mode.")
+parser.add_argument(
+    "--fake-ray-gpus", default=None, type=int,
+    help="Number of GPUs to allocate to Ray. This only works in local mode.")
+parser.add_argument(
     "--experiment-name", default="default", type=str,
     help="Name of the subdirectory under `local_dir` to put results in.")
 parser.add_argument(
@@ -73,5 +79,7 @@ if __name__ == "__main__":
         if not exp.get("env") and not exp.get("config", {}).get("env"):
             parser.error("the following arguments are required: --env")
 
-    ray.init(redis_address=args.redis_address)
+    ray.init(
+        redis_address=args.redis_address,
+        num_cpus=args.fake_ray_cpus, num_gpus=args.fake_ray_gpus)
     run_experiments(experiments, scheduler=_make_scheduler(args))

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -34,12 +34,6 @@ parser.add_argument(
     "--redis-address", default=None, type=str,
     help="The Redis address of the cluster.")
 parser.add_argument(
-    "--num-cpus", default=None, type=int,
-    help="Number of CPUs to allocate to Ray.")
-parser.add_argument(
-    "--num-gpus", default=None, type=int,
-    help="Number of GPUs to allocate to Ray.")
-parser.add_argument(
     "--experiment-name", default="default", type=str,
     help="Name of the subdirectory under `local_dir` to put results in.")
 parser.add_argument(
@@ -62,7 +56,9 @@ if __name__ == "__main__":
                 "run": args.run,
                 "checkpoint_freq": args.checkpoint_freq,
                 "local_dir": args.local_dir,
-                "trial_resources": resources_to_json(args.trial_resources),
+                "trial_resources": (
+                    args.trial_resources and
+                    resources_to_json(args.trial_resources)),
                 "stop": args.stop,
                 "config": dict(args.config, env=args.env),
                 "restore": args.restore,
@@ -77,7 +73,5 @@ if __name__ == "__main__":
         if not exp.get("env") and not exp.get("config", {}).get("env"):
             parser.error("the following arguments are required: --env")
 
-    ray.init(
-        redis_address=args.redis_address,
-        num_cpus=args.num_cpus, num_gpus=args.num_gpus)
+    ray.init(redis_address=args.redis_address)
     run_experiments(experiments, scheduler=_make_scheduler(args))

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -45,6 +45,12 @@ parser.add_argument(
 parser.add_argument(
     "--env", default=None, type=str, help="The gym environment to use.")
 parser.add_argument(
+    "--queue-trials", action='store_true',
+    help=(
+        "Whether to queue trials when the cluster does not currently have "
+        "enough resources to launch one. This should be set to True when "
+        "running on an autoscaling cluster to enable automatic scale-up."))
+parser.add_argument(
     "-f", "--config-file", default=None, type=str,
     help="If specified, use config options from this file. Note that this "
     "overrides any trial-specific options set via flags above.")
@@ -82,4 +88,6 @@ if __name__ == "__main__":
     ray.init(
         redis_address=args.redis_address,
         num_cpus=args.ray_num_cpus, num_gpus=args.ray_num_gpus)
-    run_experiments(experiments, scheduler=_make_scheduler(args))
+    run_experiments(
+        experiments, scheduler=_make_scheduler(args),
+        queue_trials=args.queue_trials)

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -34,11 +34,11 @@ parser.add_argument(
     "--redis-address", default=None, type=str,
     help="The Redis address of the cluster.")
 parser.add_argument(
-    "--fake-ray-cpus", default=None, type=int,
-    help="Number of CPUs to allocate to Ray. This only works in local mode.")
+    "--ray-num-cpus", default=None, type=int,
+    help="--num-cpus to pass to Ray. This only has an affect in local mode.")
 parser.add_argument(
-    "--fake-ray-gpus", default=None, type=int,
-    help="Number of GPUs to allocate to Ray. This only works in local mode.")
+    "--ray-num-gpus", default=None, type=int,
+    help="--num-gpus to pass to Ray. This only has an affect in local mode.")
 parser.add_argument(
     "--experiment-name", default="default", type=str,
     help="Name of the subdirectory under `local_dir` to put results in.")
@@ -81,5 +81,5 @@ if __name__ == "__main__":
 
     ray.init(
         redis_address=args.redis_address,
-        num_cpus=args.fake_ray_cpus, num_gpus=args.fake_ray_gpus)
+        num_cpus=args.ray_num_cpus, num_gpus=args.ray_num_gpus)
     run_experiments(experiments, scheduler=_make_scheduler(args))

--- a/python/ray/rllib/tuned_examples/cartpole-grid-search-example.yaml
+++ b/python/ray/rllib/tuned_examples/cartpole-grid-search-example.yaml
@@ -4,9 +4,6 @@ cartpole-ppo:
     stop:
         episode_reward_mean: 200
         time_total_s: 180
-    trial_resources:
-        cpu: 1
-        extra_cpu: 1
     config:
         num_workers: 2
         num_sgd_iter:

--- a/python/ray/rllib/tuned_examples/hopper-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/hopper-ppo.yaml
@@ -1,8 +1,4 @@
 hopper-ppo:
     env: Hopper-v1
     run: PPO
-    trial_resources:
-        cpu: 1
-        gpu: 4
-        extra_cpu: 64
     config: {"gamma": 0.995, "kl_coeff": 1.0, "num_sgd_iter": 20, "sgd_stepsize": .0001, "sgd_batchsize": 32768, "devices": ["/gpu:0", "/gpu:1", "/gpu:2", "/gpu:3"], "tf_session_args": {"device_count": {"GPU": 4}, "log_device_placement": false, "allow_soft_placement": true}, "timesteps_per_batch": 160000, "num_workers": 64}

--- a/python/ray/rllib/tuned_examples/humanoid-es.yaml
+++ b/python/ray/rllib/tuned_examples/humanoid-es.yaml
@@ -1,9 +1,6 @@
 humanoid-es:
     env: Humanoid-v1
     run: ES
-    trial_resources:
-        cpu: 1
-        extra_cpu: 100
     stop:
         episode_reward_mean: 6000
     config:

--- a/python/ray/rllib/tuned_examples/humanoid-ppo-gae.yaml
+++ b/python/ray/rllib/tuned_examples/humanoid-ppo-gae.yaml
@@ -3,9 +3,5 @@ humanoid-ppo-gae:
     run: PPO
     stop:
         episode_reward_mean: 6000
-    trial_resources:
-        cpu: 1
-        gpu: 4
-        extra_cpu: 64
     config: {"lambda": 0.95, "clip_param": 0.2, "kl_coeff": 1.0, "num_sgd_iter": 20, "sgd_stepsize": .0001, "sgd_batchsize": 32768, "horizon": 5000, "devices": ["/gpu:0", "/gpu:1", "/gpu:2", "/gpu:3"], "tf_session_args": {"device_count": {"GPU": 4}, "log_device_placement": false, "allow_soft_placement": true}, "timesteps_per_batch": 320000, "num_workers": 64, "model": {"free_log_std": true}, "write_logs": false}
 

--- a/python/ray/rllib/tuned_examples/humanoid-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/humanoid-ppo.yaml
@@ -3,8 +3,4 @@ humanoid-ppo:
     run: PPO
     stop:
        episode_reward_mean: 6000
-    trial_resources:
-       cpu: 1
-       gpu: 4
-       extra_cpu: 64
     config: {"kl_coeff": 1.0, "num_sgd_iter": 20, "sgd_stepsize": .0001, "sgd_batchsize": 32768, "devices": ["/gpu:0", "/gpu:1", "/gpu:2", "/gpu:3"], "tf_session_args": {"device_count": {"GPU": 4}, "log_device_placement": false, "allow_soft_placement": true}, "timesteps_per_batch": 320000, "num_workers": 64, "model": {"free_log_std": true}, "use_gae": false}

--- a/python/ray/rllib/tuned_examples/hyperband-cartpole.yaml
+++ b/python/ray/rllib/tuned_examples/hyperband-cartpole.yaml
@@ -5,9 +5,6 @@ cartpole-ppo:
     stop:
         episode_reward_mean: 200
         time_total_s: 180
-    trial_resources:
-        cpu: 1
-        extra_cpu: 1
     config:
         num_workers: 1
         num_sgd_iter:

--- a/python/ray/rllib/tuned_examples/pendulum-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/pendulum-ppo.yaml
@@ -2,9 +2,6 @@
 pendulum-ppo:
     env: Pendulum-v0
     run: PPO
-    trial_resources:
-        cpu: 1
-        extra_cpu: 4
     config:
         timesteps_per_batch: 2048
         num_workers: 4

--- a/python/ray/rllib/tuned_examples/pong-a3c-pytorch.yaml
+++ b/python/ray/rllib/tuned_examples/pong-a3c-pytorch.yaml
@@ -1,9 +1,6 @@
 pong-a3c-pytorch-cnn:
     env: PongDeterministic-v4
     run: A3C
-    trial_resources:
-        cpu: 1
-        extra_cpu: 16
     config:
         num_workers: 16
         batch_size: 20

--- a/python/ray/rllib/tuned_examples/pong-a3c.yaml
+++ b/python/ray/rllib/tuned_examples/pong-a3c.yaml
@@ -1,9 +1,6 @@
 pong-a3c:
     env: PongDeterministic-v4
     run: A3C
-    trial_resources:
-        cpu: 1
-        extra_cpu: 16
     config:
         num_workers: 16
         batch_size: 20

--- a/python/ray/rllib/tuned_examples/pong-apex.yaml
+++ b/python/ray/rllib/tuned_examples/pong-apex.yaml
@@ -4,11 +4,6 @@
 pong-apex:
     env: PongNoFrameskip-v4
     run: APEX
-    trial_resources:
-        cpu: 1
-        gpu: 1
-        extra_cpu:
-            eval: 4 + spec.config.num_workers
     config:
         target_network_update_freq: 50000
         num_workers: 32

--- a/python/ray/rllib/tuned_examples/pong-dqn.yaml
+++ b/python/ray/rllib/tuned_examples/pong-dqn.yaml
@@ -2,9 +2,6 @@
 pong-deterministic-dqn:
     env: PongDeterministic-v4
     run: DQN
-    trial_resources:
-        cpu: 1
-        gpu: 1
     stop:
         episode_reward_mean: 20
         time_total_s: 7200

--- a/python/ray/rllib/tuned_examples/pong-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/pong-ppo.yaml
@@ -8,10 +8,6 @@
 pong-deterministic-ppo:
     env: PongDeterministic-v4
     run: PPO
-    trial_resources:
-        cpu: 1
-        gpu: 1
-        extra_cpu: 4
     stop:
         episode_reward_mean: 21
     config:

--- a/python/ray/rllib/tuned_examples/regression_tests/cartpole-a3c.yaml
+++ b/python/ray/rllib/tuned_examples/regression_tests/cartpole-a3c.yaml
@@ -4,8 +4,6 @@ cartpole-a3c:
     stop:
         episode_reward_mean: 200
         time_total_s: 600
-    trial_resources:
-        cpu: 2
     config:
         num_workers: 4
         gamma: 0.95

--- a/python/ray/rllib/tuned_examples/regression_tests/cartpole-dqn.yaml
+++ b/python/ray/rllib/tuned_examples/regression_tests/cartpole-dqn.yaml
@@ -4,8 +4,6 @@ cartpole-dqn:
     stop:
         episode_reward_mean: 200
         time_total_s: 600
-    trial_resources:
-        cpu: 1
     config:
         n_step: 3
         gamma: 0.95

--- a/python/ray/rllib/tuned_examples/regression_tests/cartpole-es.yaml
+++ b/python/ray/rllib/tuned_examples/regression_tests/cartpole-es.yaml
@@ -4,8 +4,6 @@ cartpole-es:
     stop:
         episode_reward_mean: 200
         time_total_s: 300
-    trial_resources:
-        cpu: 2
     config:
         num_workers: 2
         noise_size: 25000000

--- a/python/ray/rllib/tuned_examples/regression_tests/cartpole-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/regression_tests/cartpole-ppo.yaml
@@ -4,7 +4,5 @@ cartpole-ppo:
     stop:
         episode_reward_mean: 200
         time_total_s: 300
-    trial_resources:
-        cpu: 1
     config:
         num_workers: 1

--- a/python/ray/rllib/tuned_examples/walker2d-ppo.yaml
+++ b/python/ray/rllib/tuned_examples/walker2d-ppo.yaml
@@ -1,8 +1,4 @@
 walker2d-v1-ppo:
     env: Walker2d-v1
     run: PPO
-    trial_resources:
-        cpu: 1
-        gpu: 4
-        extra_cpu: 64
     config: {"kl_coeff": 1.0, "num_sgd_iter": 20, "sgd_stepsize": .0001, "sgd_batchsize": 32768, "devices": ["/gpu:0", "/gpu:1", "/gpu:2", "/gpu:3"], "tf_session_args": {"device_count": {"GPU": 4}, "log_device_placement": false, "allow_soft_placement": true}, "timesteps_per_batch": 320000, "num_workers": 64}

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -73,7 +73,9 @@ def make_parser(**kwargs):
         help="Algorithm-specific configuration (e.g. env, hyperparams), "
         "specified in JSON.")
     parser.add_argument(
-        "--trial-resources", default=None, type=json_to_resources,
+        "--trial-resources",
+        default=None,
+        type=json_to_resources,
         help="Override the machine resources to allocate per trial, e.g. "
         "'{\"cpu\": 64, \"gpu\": 8}'. Note that GPUs will not be assigned "
         "unless you specify them here. For RLlib, you probably want to "

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -12,6 +12,8 @@ from ray.tune.trial import Resources
 
 
 def json_to_resources(data):
+    if data is None or data == "null":
+        return None
     if type(data) is str:
         data = json.loads(data)
     for k in data:
@@ -30,7 +32,7 @@ def json_to_resources(data):
 
 def resources_to_json(resources):
     if resources is None:
-        resources = Resources(cpu=1, gpu=0)
+        return None
     return {
         "cpu": resources.cpu,
         "gpu": resources.gpu,
@@ -66,15 +68,11 @@ def make_parser(**kwargs):
         help="Algorithm-specific configuration (e.g. env, hyperparams), "
         "specified in JSON.")
     parser.add_argument(
-        "--resources", help="Deprecated, use --trial-resources.",
-        type=lambda v: _tune_error(
-            "The `resources` argument is no longer supported. "
-            "Use `trial_resources` or --trial-resources instead."))
-    parser.add_argument(
-        "--trial-resources", default='{"cpu": 1}', type=json_to_resources,
-        help="Machine resources to allocate per trial, e.g. "
+        "--trial-resources", default=None, type=json_to_resources,
+        help="Override the machine resources to allocate per trial, e.g. "
         "'{\"cpu\": 64, \"gpu\": 8}'. Note that GPUs will not be assigned "
-        "unless you specify them here.")
+        "unless you specify them here. For RLlib, you probably want to "
+        "leave this alone and use RLlib configs to control parallelism.")
     parser.add_argument(
         "--repeat", default=1, type=int,
         help="Number of times to repeat each trial.")
@@ -95,7 +93,7 @@ def make_parser(**kwargs):
         "many times. Only applies if checkpointing is enabled.")
     parser.add_argument(
         "--scheduler", default="FIFO", type=str,
-        help="FIFO (default), MedianStopping, AsyncHyperBand,"
+        help="FIFO (default), MedianStopping, AsyncHyperBand, "
              "HyperBand, or HyperOpt.")
     parser.add_argument(
         "--scheduler-config", default="{}", type=json.loads,

--- a/python/ray/tune/examples/hyperopt_example.py
+++ b/python/ray/tune/examples/hyperopt_example.py
@@ -12,8 +12,8 @@ def easy_objective(config, reporter):
     time.sleep(0.2)
     reporter(
         timesteps_total=1,
-        episode_reward_mean=-((config["height"]-14) ** 2
-                              + abs(config["width"]-3)))
+        episode_reward_mean=-(
+            (config["height"]-14) ** 2 + abs(config["width"]-3)))
     time.sleep(0.2)
 
 

--- a/python/ray/tune/examples/pbt_example.py
+++ b/python/ray/tune/examples/pbt_example.py
@@ -79,7 +79,6 @@ if __name__ == "__main__":
             "run": "my_class",
             "stop": {"training_iteration": 2 if args.smoke_test else 99999},
             "repeat": 10,
-            "trial_resources": {"cpu": 1, "gpu": 0},
             "config": {
                 "factor_1": 4.0,
                 "factor_2": 1.0,

--- a/python/ray/tune/examples/pbt_ppo_example.py
+++ b/python/ray/tune/examples/pbt_ppo_example.py
@@ -50,7 +50,6 @@ if __name__ == "__main__":
             "run": "PPO",
             "env": "Humanoid-v1",
             "repeat": 8,
-            "trial_resources": {"cpu": 4, "gpu": 1},
             "config": {
                 "kl_coeff": 1.0,
                 "num_workers": 8,

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -220,8 +220,8 @@ class HyperBandScheduler(FIFOScheduler):
             for bracket in sorted(
                     hyperband, key=lambda b: b.completion_percentage()):
                 for trial in bracket.current_trials():
-                    if (trial.status == Trial.PENDING
-                            and trial_runner.has_resources(trial.resources)):
+                    if (trial.status == Trial.PENDING and
+                            trial_runner.has_resources(trial.resources)):
                         return trial
         return None
 

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -220,8 +220,8 @@ class HyperBandScheduler(FIFOScheduler):
             for bracket in sorted(
                     hyperband, key=lambda b: b.completion_percentage()):
                 for trial in bracket.current_trials():
-                    if (trial.status == Trial.PENDING and
-                            trial_runner.has_resources(trial.resources)):
+                    if (trial.status == Trial.PENDING
+                            and trial_runner.has_resources(trial.resources)):
                         return trial
         return None
 

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -492,11 +492,11 @@ class TrialRunnerTest(unittest.TestCase):
     def testTrialErrorOnStart(self):
         ray.init()
         _default_registry.register(TRAINABLE_CLASS, "asdf", None)
-        trial = Trial("asdf")
+        trial = Trial("asdf", resources=Resources(1, 0))
         try:
             trial.start()
         except Exception as e:
-            self.assertIn("has no attribute", str(e))
+            self.assertIn("a class", str(e))
 
     def testExtraResources(self):
         ray.init(num_cpus=4, num_gpus=2)

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -58,7 +58,6 @@ class TrainableFunctionApiTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda: register_trainable("foo", A))
 
     def testBuiltInTrainableResources(self):
-
         class B(Trainable):
             @classmethod
             def default_resource_request(cls, config):
@@ -70,13 +69,17 @@ class TrainableFunctionApiTest(unittest.TestCase):
         register_trainable("B", B)
 
         def f(cpus, gpus, queue_trials):
-            return run_experiments({"foo": {
-                "run": "B",
-                "config": {
-                    "cpu": cpus,
-                    "gpu": gpus,
+            return run_experiments(
+                {
+                    "foo": {
+                        "run": "B",
+                        "config": {
+                            "cpu": cpus,
+                            "gpu": gpus,
+                        },
+                    }
                 },
-            }}, queue_trials=queue_trials)[0]
+                queue_trials=queue_trials)[0]
 
         # Should all succeed
         self.assertEqual(f(0, 0, False).status, Trial.TERMINATED)

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -13,7 +13,6 @@ from ray.tune import Trainable, TuneError
 from ray.tune import register_env, register_trainable, run_experiments
 from ray.tune.registry import _default_registry, TRAINABLE_CLASS
 from ray.tune.result import DEFAULT_RESULTS_DIR, TrainingResult
-from ray.tune.result import DEFAULT_RESULTS_DIR
 from ray.tune.util import pin_in_object_store, get_pinned_object
 from ray.tune.experiment import Experiment
 from ray.tune.trial import Trial, Resources

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -25,6 +25,12 @@ def result(t, rew):
 
 
 class EarlyStoppingSuite(unittest.TestCase):
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.worker.cleanup()
+
     def basicSetup(self, rule):
         t1 = Trial("PPO")  # mean is 450, max 900, t_max=10
         t2 = Trial("PPO")  # mean is 450, max 450, t_max=5
@@ -185,6 +191,12 @@ class _MockTrialRunner():
 
 
 class HyperbandSuite(unittest.TestCase):
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.worker.cleanup()
+
     def schedulerSetup(self, num_trials):
         """Setup a scheduler and Runner with max Iter = 9
 
@@ -539,6 +551,12 @@ class _MockTrial(Trial):
 
 
 class PopulationBasedTestingSuite(unittest.TestCase):
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.worker.cleanup()
+
     def basicSetup(self, resample_prob=0.0, explore=None):
         pbt = PopulationBasedTraining(
             time_attr="training_iteration",
@@ -752,6 +770,12 @@ class PopulationBasedTestingSuite(unittest.TestCase):
 
 
 class AsyncHyperBandSuite(unittest.TestCase):
+    def setUp(self):
+        ray.init()
+
+    def tearDown(self):
+        ray.worker.cleanup()
+
     def basicSetup(self, scheduler):
         t1 = Trial("PPO")  # mean is 450, max 900, t_max=10
         t2 = Trial("PPO")  # mean is 450, max 450, t_max=5
@@ -852,5 +876,4 @@ class AsyncHyperBandSuite(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    ray.init()
     unittest.main(verbosity=2)

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -6,6 +6,7 @@ import random
 import unittest
 import numpy as np
 
+import ray
 from ray.tune.hyperband import HyperBandScheduler
 from ray.tune.async_hyperband import AsyncHyperBandScheduler
 from ray.tune.pbt import PopulationBasedTraining, explore
@@ -858,4 +859,5 @@ class AsyncHyperBandSuite(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    ray.init()
     unittest.main(verbosity=2)

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -30,6 +30,7 @@ class EarlyStoppingSuite(unittest.TestCase):
 
     def tearDown(self):
         ray.worker.cleanup()
+        _register_all()  # re-register the evicted objects
 
     def basicSetup(self, rule):
         t1 = Trial("PPO")  # mean is 450, max 900, t_max=10
@@ -196,6 +197,7 @@ class HyperbandSuite(unittest.TestCase):
 
     def tearDown(self):
         ray.worker.cleanup()
+        _register_all()  # re-register the evicted objects
 
     def schedulerSetup(self, num_trials):
         """Setup a scheduler and Runner with max Iter = 9
@@ -556,6 +558,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
 
     def tearDown(self):
         ray.worker.cleanup()
+        _register_all()  # re-register the evicted objects
 
     def basicSetup(self, resample_prob=0.0, explore=None):
         pbt = PopulationBasedTraining(
@@ -775,6 +778,7 @@ class AsyncHyperBandSuite(unittest.TestCase):
 
     def tearDown(self):
         ray.worker.cleanup()
+        _register_all()  # re-register the evicted objects
 
     def basicSetup(self, scheduler):
         t1 = Trial("PPO")  # mean is 450, max 900, t_max=10

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -102,7 +102,7 @@ class Trainable(object):
         return Resources(cpu=1, gpu=0)
 
     @classmethod
-    def resource_help(cls):
+    def resource_help(cls, config):
         """Returns a help string for configuring this trial's resources."""
 
         return ""

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -17,6 +17,7 @@ import ray
 from ray.tune import TuneError
 from ray.tune.logger import UnifiedLogger
 from ray.tune.result import DEFAULT_RESULTS_DIR
+from ray.tune.trial import Resources
 
 
 class Trainable(object):
@@ -89,6 +90,22 @@ class Trainable(object):
         self._setup()
         self._initialize_ok = True
         self._local_ip = ray.services.get_node_ip_address()
+
+    @classmethod
+    def default_resource_request(cls, config):
+        """Returns the resource requirement for the given configuration.
+
+        This can be overriden by sub-classes to set the correct trial resource
+        allocation, so the user does not need to.
+        """
+
+        return Resources(cpu=1, gpu=0)
+
+    @classmethod
+    def resource_help(cls):
+        """Returns a help string for configuring this trial's resources."""
+
+        return ""
 
     def train(self):
         """Runs one logical iteration of training.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -103,7 +103,7 @@ class Trainable(object):
 
     @classmethod
     def resource_help(cls, config):
-        """Returns a help string for configuring this trial's resources."""
+        """Returns a help string for configuring this trainable's resources."""
 
         return ""
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -376,6 +376,11 @@ class Trial(object):
         self.runner = cls.remote(
             config=self.config, registry=ray.tune.registry.get_registry(),
             logger_creator=logger_creator)
+        print("HI")
+        self.runner.train.remote()
+        print("HI2")
+        ray.get(self.runner.train.remote())
+        print("HI3")
 
     def set_verbose(self, verbose):
         self.verbose = verbose

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -376,11 +376,6 @@ class Trial(object):
         self.runner = cls.remote(
             config=self.config, registry=ray.tune.registry.get_registry(),
             logger_creator=logger_creator)
-        print("HI")
-        self.runner.train.remote()
-        print("HI2")
-        ray.get(self.runner.train.remote())
-        print("HI3")
 
     def set_verbose(self, verbose):
         self.verbose = verbose

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -113,8 +113,8 @@ class Trial(object):
         self.local_dir = local_dir
         self.experiment_tag = experiment_tag
         self.resources = (
-            resources or
-            self._get_trainable_cls().default_resource_request(self.config))
+            resources
+            or self._get_trainable_cls().default_resource_request(self.config))
         self.stopping_criterion = stopping_criterion or {}
         self.checkpoint_freq = checkpoint_freq
         self.upload_dir = upload_dir

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -101,9 +101,10 @@ class TrialRunner(object):
                         raise TuneError((
                             "Insufficient cluster resources to launch trial: "
                             "trial requested {} but the cluster only has {} "
-                            "available.").format(
+                            "available. {}").format(
                                 trial.resources.summary_string(),
-                                self._avail_resources.summary_string()))
+                                self._avail_resources.summary_string(),
+                                trial.trainable_cls.resource_help()))
                 elif trial.status == Trial.PAUSED:
                     raise TuneError(
                         "There are paused trials, but no more pending "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -210,7 +210,8 @@ class TrialRunner(object):
 
         can_overcommit = self._queue_trials
 
-        if cpu_avail <= 0 or gpu_avail <= 0:
+        if ((self._avail_resources.cpu and cpu_avail <= 0) or
+                (self._avail_resources.gpu and gpu_avail <= 0)):
             can_overcommit = False  # some resource is already saturated
 
         if can_overcommit:

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -113,7 +113,7 @@ class TrialRunner(object):
                             "up. {}").format(
                                 trial.resources.summary_string(),
                                 self._avail_resources.summary_string(),
-                                trial.trainable_cls.resource_help(
+                                trial._get_trainable_cls().resource_help(
                                     trial.config)))
                 elif trial.status == Trial.PAUSED:
                     raise TuneError(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -104,7 +104,8 @@ class TrialRunner(object):
                             "available. {}").format(
                                 trial.resources.summary_string(),
                                 self._avail_resources.summary_string(),
-                                trial.trainable_cls.resource_help()))
+                                trial.trainable_cls.resource_help(
+                                    trial.config)))
                 elif trial.status == Trial.PAUSED:
                     raise TuneError(
                         "There are paused trials, but no more pending "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -189,7 +189,7 @@ class TrialRunner(object):
         messages.append(self._scheduler_alg.debug_string())
         if self._resources_initialized:
             messages.append(
-                "Resources used: {}/{} CPUs, {}/{} GPUs".format(
+                "Resources requested: {}/{} CPUs, {}/{} GPUs".format(
                     self._committed_resources.cpu,
                     self._avail_resources.cpu,
                     self._committed_resources.gpu,

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -108,8 +108,9 @@ class TrialRunner(object):
                             "Insufficient cluster resources to launch trial: "
                             "trial requested {} but the cluster only has {} "
                             "available. Pass `queue_trials=True` in "
-                            "ray.tune.run_experiments() to queue trials until "
-                            "the cluster scales up. {}").format(
+                            "ray.tune.run_experiments() or on the command "
+                            "line to queue trials until the cluster scales "
+                            "up. {}").format(
                                 trial.resources.summary_string(),
                                 self._avail_resources.summary_string(),
                                 trial.trainable_cls.resource_help(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -38,17 +38,12 @@ class TrialRunner(object):
     misleading benchmark results.
     """
 
-<<<<<<< HEAD
-    def __init__(self, scheduler=None, launch_web_server=False,
-                 server_port=TuneServer.DEFAULT_PORT, verbose=True,
-                 queue_trials=False):
-=======
     def __init__(self,
                  scheduler=None,
                  launch_web_server=False,
                  server_port=TuneServer.DEFAULT_PORT,
-                 verbose=True):
->>>>>>> 74162d149204034ae83e3d7148c857cfcedc0fae
+                 verbose=True,
+                 queue_trials=False):
         """Initializes a new TrialRunner.
 
         Args:
@@ -110,7 +105,6 @@ class TrialRunner(object):
             for trial in self._trials:
                 if trial.status == Trial.PENDING:
                     if not self.has_resources(trial.resources):
-<<<<<<< HEAD
                         raise TuneError((
                             "Insufficient cluster resources to launch trial: "
                             "trial requested {} but the cluster only has {} "
@@ -122,14 +116,6 @@ class TrialRunner(object):
                                 self._avail_resources.summary_string(),
                                 trial._get_trainable_cls().resource_help(
                                     trial.config)))
-=======
-                        raise TuneError(
-                            ("Insufficient cluster resources to launch trial: "
-                             "trial requested {} but the cluster only has {} "
-                             "available.").format(
-                                 trial.resources.summary_string(),
-                                 self._avail_resources.summary_string()))
->>>>>>> 74162d149204034ae83e3d7148c857cfcedc0fae
                 elif trial.status == Trial.PAUSED:
                     raise TuneError(
                         "There are paused trials, but no more pending "
@@ -202,18 +188,12 @@ class TrialRunner(object):
         messages = ["== Status =="]
         messages.append(self._scheduler_alg.debug_string())
         if self._resources_initialized:
-<<<<<<< HEAD
             messages.append(
                 "Resources requested: {}/{} CPUs, {}/{} GPUs".format(
                     self._committed_resources.cpu,
                     self._avail_resources.cpu,
                     self._committed_resources.gpu,
                     self._avail_resources.gpu))
-=======
-            messages.append("Resources used: {}/{} CPUs, {}/{} GPUs".format(
-                self._committed_resources.cpu, self._avail_resources.cpu,
-                self._committed_resources.gpu, self._avail_resources.gpu))
->>>>>>> 74162d149204034ae83e3d7148c857cfcedc0fae
         return messages
 
     def has_resources(self, resources):
@@ -221,15 +201,10 @@ class TrialRunner(object):
 
         cpu_avail = self._avail_resources.cpu - self._committed_resources.cpu
         gpu_avail = self._avail_resources.gpu - self._committed_resources.gpu
-<<<<<<< HEAD
 
         have_space = (
             resources.cpu_total() <= cpu_avail and
             resources.gpu_total() <= gpu_avail)
-=======
-        return (resources.cpu_total() <= cpu_avail
-                and resources.gpu_total() <= gpu_avail)
->>>>>>> 74162d149204034ae83e3d7148c857cfcedc0fae
 
         if have_space:
             return True

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -105,17 +105,17 @@ class TrialRunner(object):
             for trial in self._trials:
                 if trial.status == Trial.PENDING:
                     if not self.has_resources(trial.resources):
-                        raise TuneError((
-                            "Insufficient cluster resources to launch trial: "
-                            "trial requested {} but the cluster only has {} "
-                            "available. Pass `queue_trials=True` in "
-                            "ray.tune.run_experiments() or on the command "
-                            "line to queue trials until the cluster scales "
-                            "up. {}").format(
-                                trial.resources.summary_string(),
-                                self._avail_resources.summary_string(),
-                                trial._get_trainable_cls().resource_help(
-                                    trial.config)))
+                        raise TuneError(
+                            ("Insufficient cluster resources to launch trial: "
+                             "trial requested {} but the cluster only has {} "
+                             "available. Pass `queue_trials=True` in "
+                             "ray.tune.run_experiments() or on the command "
+                             "line to queue trials until the cluster scales "
+                             "up. {}").format(
+                                 trial.resources.summary_string(),
+                                 self._avail_resources.summary_string(),
+                                 trial._get_trainable_cls().resource_help(
+                                     trial.config)))
                 elif trial.status == Trial.PAUSED:
                     raise TuneError(
                         "There are paused trials, but no more pending "
@@ -190,10 +190,8 @@ class TrialRunner(object):
         if self._resources_initialized:
             messages.append(
                 "Resources requested: {}/{} CPUs, {}/{} GPUs".format(
-                    self._committed_resources.cpu,
-                    self._avail_resources.cpu,
-                    self._committed_resources.gpu,
-                    self._avail_resources.gpu))
+                    self._committed_resources.cpu, self._avail_resources.cpu,
+                    self._committed_resources.gpu, self._avail_resources.gpu))
         return messages
 
     def has_resources(self, resources):
@@ -202,27 +200,25 @@ class TrialRunner(object):
         cpu_avail = self._avail_resources.cpu - self._committed_resources.cpu
         gpu_avail = self._avail_resources.gpu - self._committed_resources.gpu
 
-        have_space = (
-            resources.cpu_total() <= cpu_avail and
-            resources.gpu_total() <= gpu_avail)
+        have_space = (resources.cpu_total() <= cpu_avail
+                      and resources.gpu_total() <= gpu_avail)
 
         if have_space:
             return True
 
         can_overcommit = self._queue_trials
 
-        if ((resources.cpu_total() > 0 and cpu_avail <= 0) or
-                (resources.gpu_total() > 0 and gpu_avail <= 0)):
+        if ((resources.cpu_total() > 0 and cpu_avail <= 0)
+                or (resources.gpu_total() > 0 and gpu_avail <= 0)):
             can_overcommit = False  # requested resource is already saturated
 
         if can_overcommit:
-            print(
-                "WARNING:tune:allowing trial to start even though the "
-                "cluster does not have enough free resources. Trial actors "
-                "may appear to hang until enough resources are added to the "
-                "cluster (e.g., via autoscaling). You can disable this "
-                "behavior by specifying `queue_trials=False` in "
-                "ray.tune.run_experiments().")
+            print("WARNING:tune:allowing trial to start even though the "
+                  "cluster does not have enough free resources. Trial actors "
+                  "may appear to hang until enough resources are added to the "
+                  "cluster (e.g., via autoscaling). You can disable this "
+                  "behavior by specifying `queue_trials=False` in "
+                  "ray.tune.run_experiments().")
             return True
 
         return False

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -210,9 +210,9 @@ class TrialRunner(object):
 
         can_overcommit = self._queue_trials
 
-        if ((self._avail_resources.cpu and cpu_avail <= 0) or
-                (self._avail_resources.gpu and gpu_avail <= 0)):
-            can_overcommit = False  # some resource is already saturated
+        if ((resources.cpu_total() > 0 and cpu_avail <= 0) or
+                (resources.gpu_total() > 0 and gpu_avail <= 0)):
+            can_overcommit = False  # requested resource is already saturated
 
         if can_overcommit:
             print(

--- a/python/ray/tune/trial_scheduler.py
+++ b/python/ray/tune/trial_scheduler.py
@@ -99,12 +99,12 @@ class FIFOScheduler(TrialScheduler):
 
     def choose_trial_to_run(self, trial_runner):
         for trial in trial_runner.get_trials():
-            if (trial.status == Trial.PENDING and
-                    trial_runner.has_resources(trial.resources)):
+            if (trial.status == Trial.PENDING
+                    and trial_runner.has_resources(trial.resources)):
                 return trial
         for trial in trial_runner.get_trials():
-            if (trial.status == Trial.PAUSED and
-                    trial_runner.has_resources(trial.resources)):
+            if (trial.status == Trial.PAUSED
+                    and trial_runner.has_resources(trial.resources)):
                 return trial
         return None
 

--- a/python/ray/tune/trial_scheduler.py
+++ b/python/ray/tune/trial_scheduler.py
@@ -99,12 +99,12 @@ class FIFOScheduler(TrialScheduler):
 
     def choose_trial_to_run(self, trial_runner):
         for trial in trial_runner.get_trials():
-            if (trial.status == Trial.PENDING
-                    and trial_runner.has_resources(trial.resources)):
+            if (trial.status == Trial.PENDING and
+                    trial_runner.has_resources(trial.resources)):
                 return trial
         for trial in trial_runner.get_trials():
-            if (trial.status == Trial.PAUSED
-                    and trial_runner.has_resources(trial.resources)):
+            if (trial.status == Trial.PAUSED and
+                    trial_runner.has_resources(trial.resources)):
                 return trial
         return None
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -36,7 +36,8 @@ def _make_scheduler(args):
 
 
 def run_experiments(experiments, scheduler=None, with_server=False,
-                    server_port=TuneServer.DEFAULT_PORT, verbose=True):
+                    server_port=TuneServer.DEFAULT_PORT, verbose=True,
+                    queue_trials=False):
     """Tunes experiments.
 
     Args:
@@ -48,6 +49,10 @@ def run_experiments(experiments, scheduler=None, with_server=False,
             using the Client API.
         server_port (int): Port number for launching TuneServer.
         verbose (bool): How much output should be printed for each trial.
+        queue_trials (bool): Whether to queue trials when the cluster does
+            not currently have enough resources to launch one. This should
+            be set to True when running on an autoscaling cluster to enable
+            automatic scale-up.
     """
 
     if scheduler is None:
@@ -55,7 +60,7 @@ def run_experiments(experiments, scheduler=None, with_server=False,
 
     runner = TrialRunner(
         scheduler, launch_web_server=with_server, server_port=server_port,
-        verbose=verbose)
+        verbose=verbose, queue_trials=queue_trials)
     exp_list = experiments
     if isinstance(experiments, Experiment):
         exp_list = [experiments]

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -74,8 +74,8 @@ def run_experiments(experiments,
             for name, spec in experiments.items()
         ]
 
-    if (type(exp_list) is list
-            and all(isinstance(exp, Experiment) for exp in exp_list)):
+    if (type(exp_list) is list and
+            all(isinstance(exp, Experiment) for exp in exp_list)):
         for experiment in exp_list:
             scheduler.add_experiment(experiment, runner)
     else:

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -74,8 +74,8 @@ def run_experiments(experiments,
             for name, spec in experiments.items()
         ]
 
-    if (type(exp_list) is list and
-            all(isinstance(exp, Experiment) for exp in exp_list)):
+    if (type(exp_list) is list
+            and all(isinstance(exp, Experiment) for exp in exp_list)):
         for experiment in exp_list:
             scheduler.add_experiment(experiment, runner)
     else:

--- a/python/ray/tune/variant_generator.py
+++ b/python/ray/tune/variant_generator.py
@@ -53,12 +53,16 @@ def generate_trials(unresolved_spec, output_path=''):
             else:
                 experiment_tag = str(i)
             i += 1
+            if "trial_resources" in spec:
+                resources = json_to_resources(spec["trial_resources"])
+            else:
+                resources = None
             yield Trial(
                 trainable_name=spec["run"],
                 config=spec.get("config", {}),
                 local_dir=os.path.join(args.local_dir, output_path),
                 experiment_tag=experiment_tag,
-                resources=json_to_resources(spec.get("trial_resources", {})),
+                resources=resources,
                 stopping_criterion=spec.get("stop", {}),
                 checkpoint_freq=args.checkpoint_freq,
                 restore_path=spec.get("restore"),

--- a/python/ray/tune/variant_generator.py
+++ b/python/ray/tune/variant_generator.py
@@ -167,8 +167,8 @@ def _generate_variants(spec):
             for path, value in grid_vars:
                 resolved_vars[path] = _get_value(spec, path)
             for k, v in resolved.items():
-                if (k in resolved_vars and v != resolved_vars[k] and
-                        _is_resolved(resolved_vars[k])):
+                if (k in resolved_vars and v != resolved_vars[k]
+                        and _is_resolved(resolved_vars[k])):
                     raise ValueError(
                         "The variable `{}` could not be unambiguously "
                         "resolved to a single value. Consider simplifying "

--- a/python/ray/tune/variant_generator.py
+++ b/python/ray/tune/variant_generator.py
@@ -167,8 +167,8 @@ def _generate_variants(spec):
             for path, value in grid_vars:
                 resolved_vars[path] = _get_value(spec, path)
             for k, v in resolved.items():
-                if (k in resolved_vars and v != resolved_vars[k]
-                        and _is_resolved(resolved_vars[k])):
+                if (k in resolved_vars and v != resolved_vars[k] and
+                        _is_resolved(resolved_vars[k])):
                     raise ValueError(
                         "The variable `{}` could not be unambiguously "
                         "resolved to a single value. Consider simplifying "

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -876,10 +876,12 @@ void spillback_tasks_handler(LocalSchedulerState *state) {
                       << TaskSpec_actor_creation_id(spec) << " is taking a "
                       << "while to be created. It is possible that the "
                       << "cluster does not have enough resources to place this "
-                      << "actor. Try reducing the number of actors created or "
+                      << "actor (this may be normal while an autoscaling "
+                      << "is scaling up). Consider reducing the number of "
+                      << "actors created, or "
                       << "increasing the number of slots available by using "
                       << "the --num-cpus, --num-gpus, and --resources flags. "
-                      << " The actor creation task is requesting ";
+                      << "The actor creation task is requesting ";
         for (auto const &resource_pair :
              TaskSpec_get_required_resources(spec)) {
           error_message << resource_pair.second << " " << resource_pair.first

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -117,7 +117,7 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     --env CartPole-v0 \
     --run APEX \
     --stop '{"training_iteration": 2}' \
-    --config '{"num_workers": 2, "timesteps_per_iteration": 1000}'
+    --config '{"num_workers": 2, "timesteps_per_iteration": 1000, "gpu": false}'
 
 docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \


### PR DESCRIPTION

## What do these changes do?

RLlib agents now declare their resource requests to Tune, so as a user you don't have to.

Also add a `--queue-trials` option to Tune, which will allow a Trial to be scheduled even if it somewhat exceeds the resource capacity of the cluster. This should allow RLlib to work with autoscaling clusters in many cases. Couple caveats:
- If the cluster has 0 GPUs it won't queue, this is to avoid hangs forever if the cluster would not add more GPUs in the future.
- It's possible some odd shaped resource requests will queue but not trigger auto-scaling, or remain infeasible after autoscaling (e.g. request num cpus greater than the max any single machine can offer). This can be mitigated by just using big machines and setting the autoscaling threshold lower.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
