### PR TITLE
 supplement missed optimizer argument clip_rewards in default DQN con…

### DIFF
--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -18,7 +18,7 @@ from ray.tune.result import TrainingResult
 OPTIMIZER_SHARED_CONFIGS = [
     "buffer_size", "prioritized_replay", "prioritized_replay_alpha",
     "prioritized_replay_beta", "prioritized_replay_eps", "sample_batch_size",
-    "train_batch_size", "learning_starts"]
+    "train_batch_size", "learning_starts", "clip_rewards"]
 
 DEFAULT_CONFIG = dict(
     # === Model ===


### PR DESCRIPTION
…figuration

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
supplement missed optimizer argument "clip_rewards" to the dict "OPTIMIZER_SHARED_CONFIGS", so that "clip_rewards" will be included in the optimizer configuration which will be passed to optimizers as their arguments.
<!-- Please give a short brief about these changes. -->

## Related issue number
#1852
<!-- Are there any issues opened that will be resolved by merging this change? -->
