### PR TITLE
[UI] In the UI, display task breakdowns by default.

### DIFF
--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -315,7 +315,7 @@ def task_timeline():
 
     breakdown_opt = widgets.Dropdown(
         options=["Basic", "Task Breakdowns"],
-        value="Basic",
+        value="Task Breakdowns",
         disabled=False,
     )
     obj_dep = widgets.Checkbox(


### PR DESCRIPTION
The task breakdowns are a lot more informative.

E.g.,

<img width="1005" alt="screen shot 2018-04-08 at 8 44 18 pm" src="https://user-images.githubusercontent.com/249517/38478477-c492a296-3b6d-11e8-9cb4-2ea91d309a43.png">

versus

<img width="1002" alt="screen shot 2018-04-08 at 8 45 08 pm" src="https://user-images.githubusercontent.com/249517/38478487-cb64c8d8-3b6d-11e8-8ca1-20dde5a35ddd.png">

The first one shows that all of the overhead is in storing the outputs in the object store, whereas the second plot doesn't convey that.