### PR TITLE
Check if Arrow build directory exists before creating it

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -50,7 +50,9 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
     git checkout 46aa99e9843ac0148357bb36a9235cfd48903e73
 
     cd cpp
-    mkdir build
+    if [ ! -d "build" ]; then
+      mkdir build
+    fi
     cd build
 
     ARROW_HOME=$TP_DIR/pkg/arrow/cpp/build/cpp-install


### PR DESCRIPTION
## What do these changes do?

Check if the Arrow build directory exists before trying to create it. Otherwise consecutive builds fail.

## Related issue number

Not that I know off...
