### PR TITLE
[DataFrame] Allow mixed type concat

### DIFF
--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -22,14 +22,12 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
                              verify_integrity, copy)
 
         f1_columns, f2_columns = frame1.columns, frame2.columns
-        
+
         # Case 2: Both are different types
         if isinstance(frame1, pd.DataFrame):
             frame1 = from_pandas(frame1, len(frame1) / 2**16 + 1)
-            frame1.columns = f1_columns
         if isinstance(frame2, pd.DataFrame):
             frame2 = from_pandas(frame2, len(frame2) / 2**16 + 1)
-            frame2.columns = f2_columns
 
         new_columns = f1_columns.join(f2_columns, how=join)
 

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -21,45 +21,38 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
                              ignore_index, keys, levels, names,
                              verify_integrity, copy)
 
-        if not (isinstance(frame1, rdf) and
-           isinstance(frame2, rdf)) and join == 'inner':
-            raise NotImplementedError(
-                  "Obj as dicts not implemented. To contribute to "
-                  "Pandas on Ray, please visit github.com/ray-project/ray."
-                  )
-
+        f1_columns, f2_columns = frame1.columns, frame2.columns
+        
         # Case 2: Both are different types
         if isinstance(frame1, pd.DataFrame):
             frame1 = from_pandas(frame1, len(frame1) / 2**16 + 1)
+            frame1.columns = f1_columns
         if isinstance(frame2, pd.DataFrame):
             frame2 = from_pandas(frame2, len(frame2) / 2**16 + 1)
+            frame2.columns = f2_columns
 
-        # Case 3: Both are Ray DF
-        if isinstance(frame1, rdf) and \
-           isinstance(frame2, rdf):
+        new_columns = f1_columns.join(f2_columns, how=join)
 
-            new_columns = frame1.columns.join(frame2.columns, how=join)
+        def _reindex_helper(pdf, old_columns, join):
+            pdf.columns = old_columns
+            if join == 'outer':
+                pdf = pdf.reindex(columns=new_columns)
+            else:
+                pdf = pdf[new_columns]
 
-            def _reindex_helper(pdf, old_columns, join):
-                pdf.columns = old_columns
-                if join == 'outer':
-                    pdf = pdf.reindex(columns=new_columns)
-                else:
-                    pdf = pdf[new_columns]
-                pdf.columns = pd.RangeIndex(len(new_columns))
+            pdf.columns = pd.RangeIndex(len(new_columns))
 
-                return pdf
+            return pdf
 
-            f1_columns, f2_columns = frame1.columns, frame2.columns
-            new_f1 = [_deploy_func.remote(lambda p: _reindex_helper(p,
-                                          f1_columns, join), part) for
-                      part in frame1._row_partitions]
-            new_f2 = [_deploy_func.remote(lambda p: _reindex_helper(p,
-                                          f2_columns, join), part) for
-                      part in frame2._row_partitions]
+        new_f1 = [_deploy_func.remote(lambda p: _reindex_helper(p,
+                                      f1_columns, join), part) for
+                  part in frame1._row_partitions]
+        new_f2 = [_deploy_func.remote(lambda p: _reindex_helper(p,
+                                      f2_columns, join), part) for
+                  part in frame2._row_partitions]
 
-            return rdf(row_partitions=new_f1 + new_f2, columns=new_columns,
-                       index=frame1.index.append(frame2.index))
+        return rdf(row_partitions=new_f1 + new_f2, columns=new_columns,
+                   index=frame1.index.append(frame2.index))
 
     # (TODO) Group all the pandas dataframes
 

--- a/python/ray/dataframe/test/test_concat.py
+++ b/python/ray/dataframe/test/test_concat.py
@@ -38,6 +38,21 @@ def generate_dfs():
                         'col7': [0, 0, 0, 0]})
     return df, df2
 
+@pytest.fixture
+def generate_none_dfs():
+    df = pd.DataFrame({'col1': [0, 1, 2, 3],
+                       'col2': [4, 5, None, 7],
+                       'col3': [8, 9, 10, 11],
+                       'col4': [12, 13, 14, 15],
+                       'col5': [None, None, None, None]})
+
+    df2 = pd.DataFrame({'col1': [0, 1, 2, 3],
+                        'col2': [4, 5, 6, 7],
+                        'col3': [8, 9, 10, 11],
+                        'col6': [12, 13, 14, 15],
+                        'col7': [0, 0, 0, 0]})
+    return df, df2
+
 
 @pytest.fixture
 def test_df_concat():
@@ -103,5 +118,15 @@ def test_mixed_inner_concat():
 
     mixed_dfs = [from_pandas(df, 2), from_pandas(df2, 2), df3]
 
-    with pytest.raises(NotImplementedError):
-        rdf.concat(mixed_dfs, join="inner")
+    assert(ray_df_equals_pandas(rdf.concat(mixed_dfs, join='inner'),
+                                pd.concat([df, df2, df3], join='inner')))
+
+
+def test_mixed_none_concat():
+    df, df2 = generate_none_dfs()
+    df3 = df.copy()
+
+    mixed_dfs = [from_pandas(df, 2), from_pandas(df2, 2), df3]
+
+    assert(ray_df_equals_pandas(rdf.concat(mixed_dfs),
+                                pd.concat([df, df2, df3])))

--- a/python/ray/dataframe/test/test_concat.py
+++ b/python/ray/dataframe/test/test_concat.py
@@ -38,6 +38,7 @@ def generate_dfs():
                         'col7': [0, 0, 0, 0]})
     return df, df2
 
+
 @pytest.fixture
 def generate_none_dfs():
     df = pd.DataFrame({'col1': [0, 1, 2, 3],

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -91,13 +91,14 @@ def from_pandas(df, num_partitions=None, chunksize=None):
         A new Ray DataFrame object.
     """
     from .dataframe import DataFrame
+    df_op = df.copy(deep=True)
 
     row_partitions = \
-        _partition_pandas_dataframe(df, num_partitions, chunksize)
+        _partition_pandas_dataframe(df_op, num_partitions, chunksize)
 
     return DataFrame(row_partitions=row_partitions,
-                     columns=df.columns,
-                     index=df.index)
+                     columns=df_op.columns,
+                     index=df_op.index)
 
 
 def to_pandas(df):

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -91,14 +91,12 @@ def from_pandas(df, num_partitions=None, chunksize=None):
         A new Ray DataFrame object.
     """
     from .dataframe import DataFrame
-    df_op = df.copy(deep=True)
 
-    row_partitions = \
-        _partition_pandas_dataframe(df_op, num_partitions, chunksize)
+    row_partitions = _partition_pandas_dataframe(df, num_partitions, chunksize)
 
     return DataFrame(row_partitions=row_partitions,
-                     columns=df_op.columns,
-                     index=df_op.index)
+                     columns=df.columns,
+                     index=df.index)
 
 
 def to_pandas(df):


### PR DESCRIPTION
Allowing for correct mixed type concats,

Corrected mutation of Pandas dataframe when from_pandas called

Added tests for inner join and None values in joining tables

## Related issue number

#1865 
