### PR TITLE
Update arrow and parquet-cpp.

### DIFF
--- a/src/plasma/test/client_tests.cc
+++ b/src/plasma/test/client_tests.cc
@@ -240,7 +240,7 @@ TEST plasma_get_tests(void) {
                                  PLASMA_DEFAULT_RELEASE_DELAY));
   ObjectID oid1 = ObjectID::from_random();
   ObjectID oid2 = ObjectID::from_random();
-  ObjectBuffer obj_buffer;
+  ObjectBuffer obj_buffer1;
 
   ObjectID oid_array1[1] = {oid1};
   ObjectID oid_array2[1] = {oid2};
@@ -254,17 +254,18 @@ TEST plasma_get_tests(void) {
   init_data_123(data->mutable_data(), data_size, 1);
   ARROW_CHECK_OK(client1.Seal(oid1));
 
-  ARROW_CHECK_OK(client1.Get(oid_array1, 1, -1, &obj_buffer));
-  ASSERT(data->data()[0] == obj_buffer.data->data()[0]);
+  ARROW_CHECK_OK(client1.Get(oid_array1, 1, -1, &obj_buffer1));
+  ASSERT(data->data()[0] == obj_buffer1.data->data()[0]);
 
+  ObjectBuffer obj_buffer2;
   ARROW_CHECK_OK(
       client2.Create(oid2, data_size, metadata, metadata_size, &data));
   init_data_123(data->mutable_data(), data_size, 2);
   ARROW_CHECK_OK(client2.Seal(oid2));
 
   ARROW_CHECK_OK(client1.Fetch(1, oid_array2));
-  ARROW_CHECK_OK(client1.Get(oid_array2, 1, -1, &obj_buffer));
-  ASSERT(data->data()[0] == obj_buffer.data->data()[0]);
+  ARROW_CHECK_OK(client1.Get(oid_array2, 1, -1, &obj_buffer2));
+  ASSERT(data->data()[0] == obj_buffer2.data->data()[0]);
 
   sleep(1);
   ARROW_CHECK_OK(client1.Disconnect());

--- a/src/plasma/test/client_tests.cc
+++ b/src/plasma/test/client_tests.cc
@@ -137,7 +137,7 @@ TEST plasma_nonblocking_get_tests(void) {
 
   /* Test for object non-existence. */
   ARROW_CHECK_OK(client.Get(oid_array, 1, 0, &obj_buffer));
-  ASSERT(obj_buffer.data_size == -1);
+  ASSERT(obj_buffer.data == nullptr);
 
   /* Test for the object being in local Plasma store. */
   /* First create object. */

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -286,8 +286,8 @@ class StressTestObjectManager : public TestObjectManagerBase {
     plasma::ObjectBuffer object_buffer_2 = GetObject(client1, object_id_1);
     uint8_t *data_1 = const_cast<uint8_t *>(object_buffer_1.data->data());
     uint8_t *data_2 = const_cast<uint8_t *>(object_buffer_2.data->data());
-    ASSERT_EQ(object_buffer_1.data_size, object_buffer_2.data_size);
-    for (int i = -1; ++i < object_buffer_1.data_size;) {
+    ASSERT_EQ(object_buffer_1.data->size(), object_buffer_2.data->size());
+    for (int i = -1; ++i < object_buffer_1.data->size();) {
       ASSERT_TRUE(data_1[i] == data_2[i]);
     }
   }

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -44,10 +44,10 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/1581. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/1859. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout 46aa99e9843ac0148357bb36a9235cfd48903e73
+    git checkout e941af8964bed67faffdab50e33f7e336ae33612
 
     cd cpp
     if [ ! -d "build" ]; then

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -44,10 +44,14 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/1859. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/1880. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout e941af8964bed67faffdab50e33f7e336ae33612
+    git checkout 4009b62086dfa43a4fd8bfa714772716e6531c6f
+
+    # Revert https://github.com/apache/arrow/pull/1807, which unfortunately
+    # introduces the issue in https://issues.apache.org/jira/browse/ARROW-2448.
+    git revert --no-commit cf396867df6f1f93948c69ce10ceb0f95e399242
 
     cd cpp
     if [ ! -d "build" ]; then

--- a/thirdparty/scripts/build_parquet.sh
+++ b/thirdparty/scripts/build_parquet.sh
@@ -15,7 +15,7 @@ if [ ! -d $TP_DIR/build/parquet-cpp ]; then
   git clone https://github.com/apache/parquet-cpp.git "$TP_DIR/build/parquet-cpp"
   pushd $TP_DIR/build/parquet-cpp
   git fetch origin master
-  git checkout 76388ea4eb8b23656283116bc656b0c8f5db093b
+  git checkout 4e7ef12dccb250074370376dc31a4963e1010447
 
   if [ "$unamestr" == "Darwin" ]; then
     OPENSSL_ROOT_DIR=$OPENSSL_DIR \

--- a/thirdparty/scripts/build_parquet.sh
+++ b/thirdparty/scripts/build_parquet.sh
@@ -15,13 +15,7 @@ if [ ! -d $TP_DIR/build/parquet-cpp ]; then
   git clone https://github.com/apache/parquet-cpp.git "$TP_DIR/build/parquet-cpp"
   pushd $TP_DIR/build/parquet-cpp
   git fetch origin master
-  git checkout 4e7ef12dccb250074370376dc31a4963e1010447
-
-  # The below cherry-pick is to fix a segfault when linking boost statically in
-  # parquet. See https://issues.apache.org/jira/browse/ARROW-2247.
-  git remote add majetideepak https://github.com/majetideepak/parquet-cpp
-  git fetch majetideepak
-  git cherry-pick --no-commit b23d3b33de25ece8544f206e2d2c9c1d41aaddc2
+  git checkout 0875e43010af485e1c0b506d77d7e0edc80c66cc
 
   if [ "$unamestr" == "Darwin" ]; then
     OPENSSL_ROOT_DIR=$OPENSSL_DIR \

--- a/thirdparty/scripts/build_parquet.sh
+++ b/thirdparty/scripts/build_parquet.sh
@@ -17,6 +17,12 @@ if [ ! -d $TP_DIR/build/parquet-cpp ]; then
   git fetch origin master
   git checkout 4e7ef12dccb250074370376dc31a4963e1010447
 
+  # The below cherry-pick is to fix a segfault when linking boost statically in
+  # parquet. See https://issues.apache.org/jira/browse/ARROW-2247.
+  git remote add majetideepak https://github.com/majetideepak/parquet-cpp
+  git fetch majetideepak
+  git cherry-pick --no-commit b23d3b33de25ece8544f206e2d2c9c1d41aaddc2
+
   if [ "$unamestr" == "Darwin" ]; then
     OPENSSL_ROOT_DIR=$OPENSSL_DIR \
     PATH="$BISON_DIR:$PATH" \


### PR DESCRIPTION
This uses a more recent version of Arrow. The primary reason for doing this is to include
- https://github.com/apache/arrow/pull/1660 (huge pages fix)
- https://github.com/apache/arrow/pull/1802 (numpy 64-byte alignment)

However, there are also some important Plasma client API changes from https://github.com/apache/arrow/pull/1807.

Note that right now parquet doesn't work if you statically link boost (which we are doing). See the discussion in
- https://issues.apache.org/jira/browse/ARROW-2247
- https://issues.apache.org/jira/browse/PARQUET-1265

Now that https://github.com/apache/parquet-cpp/pull/452 is merged, a segfault I was seeing related to statically linking boost should be fixed.

Note that statically linking boost may not be supported in the future, so in the future we may need to dynamically link boost and bundle it with our wheels or something like that.