### PR TITLE
[rllib] Propagate dim option to deepmind wrappers

### DIFF
--- a/python/ray/rllib/dqn/common/wrappers.py
+++ b/python/ray/rllib/dqn/common/wrappers.py
@@ -14,6 +14,7 @@ def wrap_dqn(registry, env, options, random_starts):
     # Override atari default to use the deepmind wrappers.
     # TODO(ekl) this logic should be pushed to the catalog.
     if is_atari and "custom_preprocessor" not in options:
-        return wrap_deepmind(env, random_starts=random_starts)
+        return wrap_deepmind(
+            env, random_starts=random_starts, dim=options.get("dim", 80))
 
     return ModelCatalog.get_preprocessor_as_wrapper(registry, env, options)

--- a/python/ray/rllib/tuned_examples/pong-dqn.yaml
+++ b/python/ray/rllib/tuned_examples/pong-dqn.yaml
@@ -21,9 +21,9 @@ pong-deterministic-dqn:
         model:
           grayscale: True
           zero_mean: False
-          dim: 42
-          conv_filters: [
-              [16, [4, 4], 2],
-              [32, [4, 4], 2],
-              [512, [11, 11], 1],
-          ]
+#          dim: 42
+#          conv_filters: [
+#              [16, [4, 4], 2],
+#              [32, [4, 4], 2],
+#              [512, [11, 11], 1],
+#          ]

--- a/python/ray/rllib/tuned_examples/pong-dqn.yaml
+++ b/python/ray/rllib/tuned_examples/pong-dqn.yaml
@@ -2,9 +2,6 @@
 pong-deterministic-dqn:
     env: PongDeterministic-v4
     run: DQN
-    trial_resources:
-        cpu: 1
-        gpu: 1
     stop:
         episode_reward_mean: 20
         time_total_s: 7200
@@ -21,9 +18,9 @@ pong-deterministic-dqn:
         model:
           grayscale: True
           zero_mean: False
-#          dim: 42
-#          conv_filters: [
-#              [16, [4, 4], 2],
-#              [32, [4, 4], 2],
-#              [512, [11, 11], 1],
-#          ]
+          dim: 42
+          conv_filters: [
+              [16, [4, 4], 2],
+              [32, [4, 4], 2],
+              [512, [11, 11], 1],
+          ]


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This fixes the `pong-dqn.yaml` example. The example was broken since the conv filters there were for 42x42 and not 80x80.

Note: in a future pr we should apply the deepmind wrappers to atari envs in the agent class and not just in DQN.