### PR TITLE
enable starting remote ray nodes with raylet

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1551,7 +1551,8 @@ def start_ray_node(node_ip_address,
         redirect_output=redirect_output,
         resources=resources,
         plasma_directory=plasma_directory,
-        huge_pages=huge_pages)
+        huge_pages=huge_pages,
+        use_raylet=use_raylet)
 
 
 def start_ray_head(address_info=None,


### PR DESCRIPTION


## What do these changes do?
We're passing use_raylet for non-head ray nodes, to enable non-head nodes to be started with raylet instead of the local_scheduler. Currently, remote nodes start with local_scheduler even when `--use-raylet` is specified on the command line. This may resolve #1870.

<!-- Please give a short brief about these changes. -->

## Related issue number
#1870 

<!-- Are there any issues opened that will be resolved by merging this change? -->
