### PR TITLE
raylet command line resource configuration plumbing

### DIFF
--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -5,7 +5,7 @@
 
 #ifndef RAYLET_TEST
 int main(int argc, char *argv[]) {
-  RAY_CHECK(argc == 7);
+  RAY_CHECK(argc == 8);
 
   const std::string raylet_socket_name = std::string(argv[1]);
   const std::string store_socket_name = std::string(argv[2]);
@@ -13,13 +13,25 @@ int main(int argc, char *argv[]) {
   const std::string redis_address = std::string(argv[4]);
   int redis_port = std::stoi(argv[5]);
   const std::string worker_command = std::string(argv[6]);
+  const std::string static_resource_list = std::string(argv[7]);
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
   std::unordered_map<std::string, double> static_resource_conf;
-  static_resource_conf = {{"CPU", 1}, {"GPU", 1}};
+  // Parse the resource list.
+  std::istringstream resource_string(static_resource_list);
+  std::string resource_name;
+  std::string resource_quantity;
+
+  while (std::getline(resource_string, resource_name, ',')) {
+    RAY_CHECK(std::getline(resource_string, resource_quantity, ','));
+    // TODO(rkn): The line below could throw an exception. What should we do about this?
+    static_resource_conf[resource_name] = std::stod(resource_quantity);
+  }
   node_manager_config.resource_config =
       ray::raylet::ResourceSet(std::move(static_resource_conf));
+  RAY_LOG(INFO) << "Starting raylet with static resource configuration: "
+                << node_manager_config.resource_config.ToString();
   node_manager_config.num_initial_workers = 0;
   // Use a default worker that can execute empty tasks with dependencies.
 


### PR DESCRIPTION
## What do these changes do?
* Pipeline resource configuration from the frontend to the raylet command line.
* Parse command-line provided resource config and use internally.
* enables specifying custom labels when starting ray with `ray start --use-raylet` and when defining tasks and actors, as in #1869.

<!-- Please give a short brief about these changes. -->

## Related issue number
#1869 