### PR TITLE
Update arrow to efficiently serialize more types of numpy arrays.

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -44,10 +44,10 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/1880. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/1874. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout 4009b62086dfa43a4fd8bfa714772716e6531c6f
+    git checkout 0f87c12d45250ee763ac8c43b7e57e8f06a0b9f3
 
     # Revert https://github.com/apache/arrow/pull/1807, which unfortunately
     # introduces the issue in https://issues.apache.org/jira/browse/ARROW-2448.


### PR DESCRIPTION
This updates arrow primarily to pull in https://github.com/apache/arrow/pull/1887, which allows us to efficiently serialize numpy arrays of bools and strings and things like that.

cc @devin-petersohn 