### PR TITLE
Remove num_threads as a parameter.

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -339,18 +339,7 @@ ray::Status ObjectManager::SendObjectHeaders(const ObjectID &object_id_const,
   ray::Status status =
       conn->WriteMessage(object_manager_protocol::MessageType_PushRequest, fbb.GetSize(),
                          fbb.GetBufferPointer());
-  if (!status.ok()) {
-    // push failed.
-    // TODO(hme): Trash sender.
-    ARROW_CHECK_OK(store_client->Release(object_id.to_plasma_id()));
-    store_pool_.ReleaseObjectStore(store_client);
-    RAY_CHECK_OK(
-        connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::TRANSFER, conn));
-    RAY_CHECK_OK(transfer_queue_.RemoveContext(context_id));
-    RAY_CHECK_OK(TransferCompleted(TransferQueue::TransferType::SEND));
-    return status;
-  }
-
+  RAY_CHECK_OK(status);
   // TODO(hme): Make this async.
   return SendObjectData(conn, context_id, store_client);
 }

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -21,9 +21,9 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
       transfer_queue_(),
       num_transfers_send_(0),
       num_transfers_receive_(0),
-      max_sends_(config_.max_sends),
-      max_receives_(config_.max_receives),
       num_threads_(config_.max_sends + config_.max_receives) {
+  RAY_CHECK(config_.max_sends > 0);
+  RAY_CHECK(config_.max_receives > 0);
   main_service_ = &main_service;
   config_ = config;
   store_notification_.SubscribeObjAdded(
@@ -46,9 +46,9 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
       transfer_queue_(),
       num_transfers_send_(0),
       num_transfers_receive_(0),
-      max_sends_(config_.max_sends),
-      max_receives_(config_.max_receives),
       num_threads_(config_.max_sends + config_.max_receives) {
+  RAY_CHECK(config_.max_sends > 0);
+  RAY_CHECK(config_.max_receives > 0);
   // TODO(hme) Client ID is never set with this constructor.
   main_service_ = &main_service;
   config_ = config;
@@ -216,40 +216,16 @@ ray::Status ObjectManager::Push(const ObjectID &object_id, const ClientID &clien
 
 ray::Status ObjectManager::DequeueTransfers() {
   ray::Status status = ray::Status::OK();
-  // Dequeue receives.
-  while (true) {
-    if (std::atomic_fetch_add(&num_transfers_receive_, 1) < max_receives_) {
-      RAY_CHECK(num_transfers_receive_ <= max_receives_);
-      RAY_CHECK(num_transfers_send_ + num_transfers_receive_ <= num_threads_);
-      TransferQueue::ReceiveRequest req;
-      bool exists = transfer_queue_.DequeueReceiveIfPresent(&req);
-      if (exists) {
-        object_manager_service_->dispatch([this, req]() {
-          RAY_LOG(DEBUG) << "DequeueReceive " << client_id_ << " " << req.object_id << " "
-                         << num_transfers_receive_ << "/" << max_receives_;
-          RAY_CHECK_OK(ExecuteReceiveObject(req.client_id, req.object_id, req.object_size,
-                                            req.conn));
-        });
-      } else {
-        std::atomic_fetch_sub(&num_transfers_receive_, 1);
-        break;
-      }
-    } else {
-      std::atomic_fetch_sub(&num_transfers_receive_, 1);
-      break;
-    }
-  }
   // Dequeue sends.
   while (true) {
-    if (std::atomic_fetch_add(&num_transfers_send_, 1) < max_sends_) {
-      RAY_CHECK(num_transfers_send_ <= max_sends_);
-      RAY_CHECK(num_transfers_send_ + num_transfers_receive_ <= num_threads_);
+    int num_transfers_send = std::atomic_fetch_add(&num_transfers_send_, 1);
+    if (num_transfers_send < config_.max_sends) {
       TransferQueue::SendRequest req;
       bool exists = transfer_queue_.DequeueSendIfPresent(&req);
       if (exists) {
         object_manager_service_->dispatch([this, req]() {
           RAY_LOG(DEBUG) << "DequeueSend " << client_id_ << " " << req.object_id << " "
-                         << num_transfers_send_ << "/" << max_sends_;
+                         << num_transfers_send_ << "/" << config_.max_sends;
           RAY_CHECK_OK(
               ExecuteSendObject(req.object_id, req.client_id, req.connection_info));
         });
@@ -259,6 +235,28 @@ ray::Status ObjectManager::DequeueTransfers() {
       }
     } else {
       std::atomic_fetch_sub(&num_transfers_send_, 1);
+      break;
+    }
+  }
+  // Dequeue receives.
+  while (true) {
+    int num_transfers_receive = std::atomic_fetch_add(&num_transfers_receive_, 1);
+    if (num_transfers_receive < config_.max_receives) {
+      TransferQueue::ReceiveRequest req;
+      bool exists = transfer_queue_.DequeueReceiveIfPresent(&req);
+      if (exists) {
+        object_manager_service_->dispatch([this, req]() {
+          RAY_LOG(DEBUG) << "DequeueReceive " << client_id_ << " " << req.object_id << " "
+                         << num_transfers_receive_ << "/" << config_.max_receives;
+          RAY_CHECK_OK(ExecuteReceiveObject(req.client_id, req.object_id, req.object_size,
+                                            req.conn));
+        });
+      } else {
+        std::atomic_fetch_sub(&num_transfers_receive_, 1);
+        break;
+      }
+    } else {
+      std::atomic_fetch_sub(&num_transfers_receive_, 1);
       break;
     }
   }
@@ -380,7 +378,7 @@ ray::Status ObjectManager::SendObjectData(
       connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::TRANSFER, conn));
   RAY_CHECK_OK(transfer_queue_.RemoveContext(context_id));
   RAY_LOG(DEBUG) << "SendCompleted " << client_id_ << " " << context.object_id << " "
-                 << num_transfers_send_ << "/" << max_sends_;
+                 << num_transfers_send_ << "/" << config_.max_sends;
   RAY_CHECK_OK(TransferCompleted(TransferQueue::TransferType::SEND));
   return status;
 }
@@ -523,7 +521,7 @@ ray::Status ObjectManager::ExecuteReceiveObject(
   store_pool_.ReleaseObjectStore(store_client);
   conn->ProcessMessages();
   RAY_LOG(DEBUG) << "ReceiveCompleted " << client_id_ << " " << object_id << " "
-                 << num_transfers_receive_ << "/" << max_receives_;
+                 << num_transfers_receive_ << "/" << config_.max_receives;
   RAY_CHECK_OK(TransferCompleted(TransferQueue::TransferType::RECEIVE));
   return Status::OK();
 }

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -316,7 +316,7 @@ ray::Status ObjectManager::SendObjectHeaders(const ObjectID &object_id_const,
     RAY_CHECK_OK(
         connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::TRANSFER, conn));
     store_pool_.ReleaseObjectStore(store_client);
-    TransferCompleted(TransferQueue::TransferType::SEND);
+    RAY_CHECK_OK(TransferCompleted(TransferQueue::TransferType::SEND));
     return ray::Status::IOError(
         "Unable to transfer object to requesting plasma manager, object not local.");
   }

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -219,6 +219,7 @@ ray::Status ObjectManager::DequeueTransfers() {
   // Dequeue receives.
   while (true) {
     if (std::atomic_fetch_add(&num_transfers_receive_, 1) < max_receives_) {
+      RAY_CHECK(num_transfers_receive_ <= max_receives_);
       RAY_CHECK(num_transfers_send_ + num_transfers_receive_ <= num_threads_);
       TransferQueue::ReceiveRequest req;
       bool exists = transfer_queue_.DequeueReceiveIfPresent(&req);
@@ -241,6 +242,7 @@ ray::Status ObjectManager::DequeueTransfers() {
   // Dequeue sends.
   while (true) {
     if (std::atomic_fetch_add(&num_transfers_send_, 1) < max_sends_) {
+      RAY_CHECK(num_transfers_send_ <= max_sends_);
       RAY_CHECK(num_transfers_send_ + num_transfers_receive_ <= num_threads_);
       TransferQueue::SendRequest req;
       bool exists = transfer_queue_.DequeueSendIfPresent(&req);

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -35,9 +35,9 @@ struct ObjectManagerConfig {
   /// that failed due to client id lookup.
   uint pull_timeout_ms = 100;
   /// Maximum number of sends allowed.
-  uint max_sends = 2;
+  int max_sends = 2;
   /// Maximum number of receives allowed.
-  uint max_receives = 2;
+  int max_receives = 2;
   // TODO(hme): Implement num retries (to avoid infinite retries).
   std::string store_socket_name;
 };
@@ -187,11 +187,6 @@ class ObjectManager {
   /// Variables to track number of concurrent sends and receives.
   std::atomic<int> num_transfers_send_;
   std::atomic<int> num_transfers_receive_;
-
-  /// Maximum number of sends allowed.
-  const int max_sends_;
-  /// Maximum number of receives allowed.
-  const int max_receives_;
 
   /// Size of thread pool. This is the sum of
   /// config_.max_sends and config_.max_receives

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -33,13 +33,11 @@ namespace ray {
 struct ObjectManagerConfig {
   /// The time in milliseconds to wait before retrying a pull
   /// that failed due to client id lookup.
-  int pull_timeout_ms = 100;
-  /// Size of thread pool.
-  int num_threads = 2;
+  uint pull_timeout_ms = 100;
   /// Maximum number of sends allowed.
-  int max_sends = 20;
+  uint max_sends = 2;
   /// Maximum number of receives allowed.
-  int max_receives = 20;
+  uint max_receives = 2;
   // TODO(hme): Implement num retries (to avoid infinite retries).
   std::string store_socket_name;
 };
@@ -189,6 +187,15 @@ class ObjectManager {
   /// Variables to track number of concurrent sends and receives.
   std::atomic<int> num_transfers_send_;
   std::atomic<int> num_transfers_receive_;
+
+  /// Maximum number of sends allowed.
+  const int max_sends_;
+  /// Maximum number of receives allowed.
+  const int max_receives_;
+
+  /// Size of thread pool. This is the sum of
+  /// config_.max_sends and config_.max_receives
+  const int num_threads_;
 
   /// Cache of locally available objects.
   std::unordered_map<ObjectID, ObjectInfoT, UniqueIDHasher> local_objects_;

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -257,7 +257,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
     async_loop_index += 1;
     if ((uint)async_loop_index < async_loop_patterns.size()) {
       TransferPattern pattern = async_loop_patterns[async_loop_index];
-      TransferTestExecute(1000, 100, pattern);
+      TransferTestExecute(10000, 100, pattern);
     } else {
       main_service.stop();
     }

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -120,9 +120,8 @@ class TestObjectManagerBase : public ::testing::Test {
     gcs_client_1 = std::shared_ptr<gcs::AsyncGcsClient>(new gcs::AsyncGcsClient());
     ObjectManagerConfig om_config_1;
     om_config_1.store_socket_name = store_sock_1;
-    om_config_1.num_threads = 4;
-    om_config_1.max_sends = 20;
-    om_config_1.max_receives = 20;
+    om_config_1.max_sends = 2;
+    om_config_1.max_receives = 2;
     server1.reset(new MockServer(main_service, std::move(object_manager_service_1),
                                  om_config_1, gcs_client_1));
 
@@ -130,9 +129,8 @@ class TestObjectManagerBase : public ::testing::Test {
     gcs_client_2 = std::shared_ptr<gcs::AsyncGcsClient>(new gcs::AsyncGcsClient());
     ObjectManagerConfig om_config_2;
     om_config_2.store_socket_name = store_sock_2;
-    om_config_2.num_threads = 4;
-    om_config_2.max_sends = 20;
-    om_config_2.max_receives = 20;
+    om_config_2.max_sends = 2;
+    om_config_2.max_receives = 2;
     server2.reset(new MockServer(main_service, std::move(object_manager_service_2),
                                  om_config_2, gcs_client_2));
 

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -41,9 +41,7 @@ class MockServer {
     DoAcceptObjectManager();
   }
 
-  ~MockServer() {
-    RAY_CHECK_OK(gcs_client_->client_table().Disconnect());
-  }
+  ~MockServer() { RAY_CHECK_OK(gcs_client_->client_table().Disconnect()); }
 
  private:
   ray::Status RegisterGcs(boost::asio::io_service &io_service) {

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -32,9 +32,7 @@ class MockServer {
     DoAcceptObjectManager();
   }
 
-  ~MockServer() {
-    RAY_CHECK_OK(gcs_client_->client_table().Disconnect());
-  }
+  ~MockServer() { RAY_CHECK_OK(gcs_client_->client_table().Disconnect()); }
 
  private:
   ray::Status RegisterGcs(boost::asio::io_service &io_service) {


### PR DESCRIPTION
Removes `num_threads` as a parameter. This corrects the "mac" issue on #1827. It allows the system to make progress by always maintaining non-zero number of threads for receiving data.