### PR TITLE
Fixes object seal bug.

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -489,11 +489,15 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     buffer.push_back(asio::buffer(mutable_data, object_size));
     conn->ReadBuffer(buffer, ec);
     if (!ec.value()) {
+      seal_lock_.lock();
       ARROW_CHECK_OK(store_client->Seal(plasma_id));
       ARROW_CHECK_OK(store_client->Release(plasma_id));
+      seal_lock_.unlock();
     } else {
+      seal_lock_.lock();
       ARROW_CHECK_OK(store_client->Release(plasma_id));
       ARROW_CHECK_OK(store_client->Abort(plasma_id));
+      seal_lock_.unlock();
       RAY_LOG(ERROR) << "Receive Failed";
     }
   } else {

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -193,6 +193,8 @@ class ObjectManager {
   /// Cache of locally available objects.
   std::unordered_map<ObjectID, ObjectInfoT, UniqueIDHasher> local_objects_;
 
+  std::mutex seal_lock_;
+
   /// Handle starting, running, and stopping asio io_service.
   void StartIOService();
   void IOServiceLoop();


### PR DESCRIPTION
The plasma client is maintaining a static vector of threads, which is written to whenever a thread is created for hashing: https://github.com/apache/arrow/blob/master/cpp/src/plasma/client.cc#L73

A hash is computed whenever seal is invoked. This PR implements a temporary workaround, which adds a lock before invoking seal on the plasma store.