### PR TITLE
Pin cython version in docker base dependencies file.

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
         libgcc \
     && /opt/conda/bin/conda clean -y --all \
     && /opt/conda/bin/pip install \
-        flatbuffers
+        flatbuffers \
+        cython==0.27.3
 
 ENV PATH "/opt/conda/bin:$PATH"


### PR DESCRIPTION
Attempting to fix some jenkins issues we've been seeing, e.g., https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/4875/console.