### PR TITLE
Preemptively push arguments to remote nodes for actor tasks

### DIFF
--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -19,6 +19,10 @@ TaskDependencyManager::TaskDependencyManager(
   // TODO(swang): Subscribe to object removed notifications.
 }
 
+bool TaskDependencyManager::CheckObjectLocal(const ObjectID &object_id) const {
+  return local_objects_.count(object_id) == 1;
+}
+
 bool TaskDependencyManager::argumentsReady(const std::vector<ObjectID> arguments) const {
   for (auto &argument : arguments) {
     // Check if any argument is missing.

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -31,6 +31,12 @@ class TaskDependencyManager {
                         // ReconstructionPolicy &reconstruction_policy,
                         std::function<void(const TaskID &)> handler);
 
+  /// Check whether an object is locally available.
+  ///
+  /// \param object_id The object to check for.
+  /// \return Whether the object is local.
+  bool CheckObjectLocal(const ObjectID &object_id) const;
+
   /// Check whether a task's object dependencies are locally available.
   ///
   /// \param task The task whose object dependencies will be checked.


### PR DESCRIPTION
## What do these changes do?

To lower latency, whenever an actor task is forwarded to a remote node for execution, this also preemptively pushes any arguments of the task that are local. We do this for actors only since they have affinity to the receiving node. The arguments that are local are likely to be the result of a `ray.put`.

Unfortunately, there isn't a good way to test this yet since multiple raylets on a single node isn't supported.

A future PR will add support for suppression of duplicate object transfers in the object manager.