### PR TITLE
[xray] Turn on flushing to the GCS for the lineage cache

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -192,7 +192,7 @@ void LineageCache::AddReadyTask(const Task &task) {
 
   // Try to flush the task to the GCS.
   // TODO(swang): Allow a pluggable policy for when to flush.
-  Flush();
+  RAY_CHECK_OK(Flush());
 }
 
 void LineageCache::RemoveWaitingTask(const TaskID &task_id) {

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -206,6 +206,10 @@ class LineageCache {
   gcs::TableInterface<TaskID, protocol::Task> &task_storage_;
   /// The set of tasks that are in UNCOMMITTED_READY state. This is a cache of
   /// the tasks that may be flushable.
+  // TODO(swang): As an optimization, we may also want to further distinguish
+  // which tasks are flushable, to avoid iterating over tasks that are in
+  // UNCOMMITTED_READY, but that have dependencies that have not been committed
+  // yet.
   std::unordered_set<TaskID, UniqueIDHasher> uncommitted_ready_tasks_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -204,6 +204,9 @@ class LineageCache {
 
   /// The durable storage system for task information.
   gcs::TableInterface<TaskID, protocol::Task> &task_storage_;
+  /// The set of tasks that are in UNCOMMITTED_READY state. This is a cache of
+  /// the tasks that may be flushable.
+  std::unordered_set<TaskID, UniqueIDHasher> uncommitted_ready_tasks_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.
   Lineage lineage_;


### PR DESCRIPTION
## What do these changes do?

This flushes the lineage cache every time a task that is ready is added. Ready tasks are ones that have been scheduled for execution on the local node. This also adds an internal cache to the lineage cache that stores tasks that are in this state.