### PR TITLE
Handle interrupts correctly for ASIO synchronous reads and writes.

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -30,7 +30,9 @@ void ServerConnection<T>::WriteBuffer(
     const std::vector<boost::asio::const_buffer> &buffer, boost::system::error_code &ec) {
   // Loop until all bytes are written, and handle system errors.
   do {
-    boost::asio::write(socket_, buffer, boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)), ec);
+    boost::asio::write(socket_, buffer,
+                       boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)),
+                       ec);
   } while (ec.value() == EINTR);
 }
 
@@ -40,10 +42,10 @@ void ServerConnection<T>::ReadBuffer(
     boost::system::error_code &ec) {
   // Loop until all bytes are read, and handle system errors.
   do {
-
-    boost::asio::read(socket_, buffer, boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)), ec);
+    boost::asio::read(socket_, buffer,
+                      boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)),
+                      ec);
   } while (ec.value() == EINTR);
-
 }
 
 template <class T>

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -28,24 +28,46 @@ ServerConnection<T>::ServerConnection(boost::asio::basic_stream_socket<T> &&sock
 template <class T>
 void ServerConnection<T>::WriteBuffer(
     const std::vector<boost::asio::const_buffer> &buffer, boost::system::error_code &ec) {
-  // Loop until all bytes are written, and handle system errors.
-  do {
-    boost::asio::write(socket_, buffer,
-                       boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)),
-                       ec);
-  } while (ec.value() == EINTR);
+  // Loop until all bytes are written while handling interrupts.
+  // When profiling with pprof, unhandled interrupts were being sent by the profiler to
+  // the raylet process, which was causing synchronous reads and writes to fail.
+  for (const auto &b : buffer) {
+    uint64_t bytes_remaining = boost::asio::buffer_size(b);
+    uint64_t position = 0;
+    while (bytes_remaining != 0) {
+      size_t bytes_written =
+          socket_.write_some(boost::asio::buffer(b + position, bytes_remaining), ec);
+      position += bytes_written;
+      bytes_remaining -= bytes_written;
+      if (ec.value() == EINTR) {
+        continue;
+      } else if (ec.value() != boost::system::errc::errc_t::success) {
+        return;
+      }
+    }
+  }
 }
 
 template <class T>
 void ServerConnection<T>::ReadBuffer(
     const std::vector<boost::asio::mutable_buffer> &buffer,
     boost::system::error_code &ec) {
-  // Loop until all bytes are read, and handle system errors.
-  do {
-    boost::asio::read(socket_, buffer,
-                      boost::asio::transfer_exactly(boost::asio::buffer_size(buffer)),
-                      ec);
-  } while (ec.value() == EINTR);
+  // Loop until all bytes are read while handling interrupts.
+  for (const auto &b : buffer) {
+    uint64_t bytes_remaining = boost::asio::buffer_size(b);
+    uint64_t position = 0;
+    while (bytes_remaining != 0) {
+      size_t bytes_read =
+          socket_.read_some(boost::asio::buffer(b + position, bytes_remaining), ec);
+      position += bytes_read;
+      bytes_remaining -= bytes_read;
+      if (ec.value() == EINTR) {
+        continue;
+      } else if (ec.value() != boost::system::errc::errc_t::success) {
+        return;
+      }
+    }
+  }
 }
 
 template <class T>


### PR DESCRIPTION
This PR fixes any issues due to interrupts during ASIO synchronous reads and writes.

When a system interrupt signal is sent to the raylet process during a synchronous read or write, no bytes are transferred, which causes the ObjectManager protocol to enter an unsupported state. This issue occurred frequently when attempting to profile the raylet process.