### PR TITLE
arr[end] was excluded when end is not None

### DIFF
--- a/python/ray/rllib/optimizers/segment_tree.py
+++ b/python/ray/rllib/optimizers/segment_tree.py
@@ -78,10 +78,9 @@ class SegmentTree(object):
           elements.
         """
         if end is None:
-            end = self._capacity
+            end = self._capacity - 1
         if end < 0:
             end += self._capacity
-        end -= 1
         return self._reduce_helper(start, end, 1, 0, self._capacity - 1)
 
     def __setitem__(self, idx, val):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`SegmentTree.reduce` had an off-by-one where the end element wasn't included.
This was also reported to `openai/baselines`, whose code this is copied from: https://github.com/openai/baselines/pull/375.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
