### PR TITLE
Add a timeline hook to ray.worker

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -76,6 +76,9 @@ DEFAULT_ACTOR_METHOD_CPUS_SPECIFIED_CASE = 0
 DEFAULT_ACTOR_CREATION_CPUS_SPECIFIED_CASE = 1
 DEFAULT_ACTOR_CREATION_GPUS_SPECIFIED_CASE = 0
 
+# Timeline hook that the user can set for custom profiling
+global_timeline = None
+
 
 class FunctionID(object):
     def __init__(self, function_id):
@@ -2333,6 +2336,10 @@ class RayLogSpan(object):
 
     def __enter__(self):
         """Log the beginning of a span event."""
+
+        if global_timeline:
+            global_timeline.start(self.event_type)
+
         log(event_type=self.event_type,
             contents=self.contents,
             kind=LOG_SPAN_START,
@@ -2340,6 +2347,10 @@ class RayLogSpan(object):
 
     def __exit__(self, type, value, tb):
         """Log the end of a span event. Log any exception that occurred."""
+
+        if global_timeline:
+            global_timeline.end(self.event_type)
+
         if type is None:
             log(event_type=self.event_type,
                 kind=LOG_SPAN_END,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This exposes a global hook `ray.worker.global_timeline`, that can be hooked into by user code for custom profiling. This is intended for internal profiling for now; we might expose more utils around it in the future.

<!-- Are there any issues opened that will be resolved by merging this change? -->
