### PR TITLE
[DataFrame] Implement Inter-DataFrame operations

### DIFF
--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -113,7 +113,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     if axis == 0:
         new_blocks = np.array([_reindex_helper._submit(
             args=tuple([all_columns[i], final_columns, axis,
-                  len(objs[0]._block_partitions)] + part.tolist()),
+                       len(objs[0]._block_partitions)] + part.tolist()),
             num_return_vals=len(objs[0]._block_partitions))
             for i in range(len(objs))
             for part in objs[i]._block_partitions])
@@ -123,7 +123,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         # operation is cheap in numpy.
         new_blocks = np.array([_reindex_helper._submit(
             args=tuple([all_index[i], final_index, axis,
-                  len(objs[0]._block_partitions.T)] + part),
+                       len(objs[0]._block_partitions.T)] + part.tolist()),
             num_return_vals=len(objs[0]._block_partitions.T))
             for i in range(len(objs))
             for part in objs[i]._block_partitions.T]).T

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -113,7 +113,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     if axis == 0:
         new_blocks = np.array([_reindex_helper._submit(
             args=tuple([all_columns[i], final_columns, axis,
-                  len(objs[0]._block_partitions)] + part.tolist),
+                  len(objs[0]._block_partitions)] + part.tolist()),
             num_return_vals=len(objs[0]._block_partitions))
             for i in range(len(objs))
             for part in objs[i]._block_partitions])

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -111,7 +111,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     # from remote memory built in the previous line. In the future, we won't be
     # building new DataFrames, rather just partitioning the DataFrames.
     if axis == 0:
-        new_blocks = np.array([_reindex_helper._submit(args=(all_columns[i],
+        new_blocks = \
+            np.array([_reindex_helper._submit(args=(all_columns[i],
                                                     final_columns,
                                                     axis,
                                                     len(objs[i]),

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -111,26 +111,20 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     # from remote memory built in the previous line. In the future, we won't be
     # building new DataFrames, rather just partitioning the DataFrames.
     if axis == 0:
-        new_blocks = \
-            np.array([_reindex_helper._submit(args=(all_columns[i],
-                                                    final_columns,
-                                                    axis,
-                                                    len(objs[i]),
-                                                    *part),
-                                              num_return_vals=len(objs[i]))
-                      for i in range(len(objs))
-                      for part in objs[i]._block_partitions])
+        new_blocks = np.array([_reindex_helper._submit(
+            args=(all_columns[i], final_columns, axis,
+                  len(objs[0]._block_partitions), *part),
+            num_return_vals=len(objs[0]._block_partitions))
+            for i in range(len(objs))
+            for part in objs[i]._block_partitions])
     else:
         # Transposing the columns is necessary because the remote task treats
         # everything like rows and returns in row-major format. Luckily, this
         # operation is cheap in numpy.
-        new_blocks = np.array([
-            _reindex_helper._submit(args=(all_index[i],
-                                          final_index,
-                                          axis,
-                                          len(objs[i].columns),
-                                          *part),
-                                    num_return_vals=len(objs[i].columns))
+        new_blocks = np.array([_reindex_helper._submit(
+            args=(all_index[i], final_index, axis,
+                  len(objs[0]._block_partitions.T), *part),
+            num_return_vals=len(objs[0]._block_partitions.T))
             for i in range(len(objs))
             for part in objs[i]._block_partitions.T]).T
 

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -112,8 +112,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     # building new DataFrames, rather just partitioning the DataFrames.
     if axis == 0:
         new_blocks = np.array([_reindex_helper._submit(
-            args=(all_columns[i], final_columns, axis,
-                  len(objs[0]._block_partitions), *part),
+            args=tuple([all_columns[i], final_columns, axis,
+                  len(objs[0]._block_partitions)] + part.tolist),
             num_return_vals=len(objs[0]._block_partitions))
             for i in range(len(objs))
             for part in objs[i]._block_partitions])
@@ -122,8 +122,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         # everything like rows and returns in row-major format. Luckily, this
         # operation is cheap in numpy.
         new_blocks = np.array([_reindex_helper._submit(
-            args=(all_index[i], final_index, axis,
-                  len(objs[0]._block_partitions.T), *part),
+            args=tuple([all_index[i], final_index, axis,
+                  len(objs[0]._block_partitions.T)] + part),
             num_return_vals=len(objs[0]._block_partitions.T))
             for i in range(len(objs))
             for part in objs[i]._block_partitions.T]).T

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -143,6 +143,7 @@ class DataFrame(object):
     def _get_row_partitions(self):
         return [_blocks_to_row.remote(*part)
                 for part in self._block_partitions]
+                for part in self._block_partitions]
 
     def _set_row_partitions(self, new_row_partitions):
         self._block_partitions = \
@@ -4084,8 +4085,9 @@ class DataFrame(object):
 
             new_blocks = \
                 np.array([co_op_helper._submit(
-                    args=(func, self.columns, other.columns, len(part[0]),
-                          *np.concatenate(part)),
+                    args=tuple([func, self.columns, other.columns,
+                                len(part[0])] +
+                          np.concatenate(part).tolist()),
                     num_return_vals=len(part[0]))
                     for part in copartitions])
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -143,7 +143,6 @@ class DataFrame(object):
     def _get_row_partitions(self):
         return [_blocks_to_row.remote(*part)
                 for part in self._block_partitions]
-                for part in self._block_partitions]
 
     def _set_row_partitions(self, new_row_partitions):
         self._block_partitions = \

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -4084,10 +4084,13 @@ class DataFrame(object):
             new_column_index = self.columns.join(other.columns, how="outer")
             new_index = self.index.join(other.index, how="outer")
             copartitions = self._copartition(other, new_index)
-
+            for part in copartitions:
+                print(ray.get(part[0]))
+                print(ray.get(part[1]))
             new_columns = [co_op_helper.remote(func, *part)
                            for part in copartitions]
-
+            # print(ray.get(new_columns))
+            print(new_column_index)
             return DataFrame(col_partitions=new_columns,
                              columns=new_column_index,
                              index=new_index)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -3988,6 +3988,10 @@ class DataFrame(object):
     def _copartition(self, other, new_index):
         """Colocates the values of other with this for certain operations.
 
+        NOTE: This method uses the indexes of each DataFrame to order them the
+            same. This operation does an implicit shuffling of data and zips
+            the two DataFrames together to be operated on.
+
         Args:
             other: The other DataFrame to copartition with.
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1470,9 +1470,24 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def eq(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is equal to other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the eq over.
+            level: The Multilevel index level to apply eq over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.eq(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.eq(other, axis, level),
+                other, axis, level)
 
     def equals(self, other):
         """
@@ -1787,9 +1802,24 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def ge(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is greater than or equal to other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the gt over.
+            level: The Multilevel index level to apply gt over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.ge(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.ge(other, axis, level),
+                other, axis, level)
 
     def get(self, key, default=None):
         """Get item from object for given key (DataFrame column, Panel
@@ -1837,9 +1867,24 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def gt(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is greater than other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the gt over.
+            level: The Multilevel index level to apply gt over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.gt(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.gt(other, axis, level),
+                other, axis, level)
 
     def head(self, n=5):
         """Get the first n rows of the dataframe.
@@ -2248,9 +2293,24 @@ class DataFrame(object):
         return self._row_metadata.last_valid_index()
 
     def le(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is less than or equal to other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the le over.
+            level: The Multilevel index level to apply le over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.le(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.le(other, axis, level),
+                other, axis, level)
 
     def lookup(self, row_labels, col_labels):
         raise NotImplementedError(
@@ -2258,9 +2318,24 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def lt(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is less than other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the lt over.
+            level: The Multilevel index level to apply lt over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.lt(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.lt(other, axis, level),
+                other, axis, level)
 
     def mad(self, axis=None, skipna=None, level=None):
         raise NotImplementedError(
@@ -2431,9 +2506,24 @@ class DataFrame(object):
         return self.mul(other, axis, level, fill_value)
 
     def ne(self, other, axis='columns', level=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Checks element-wise that this is not equal to other.
+
+        Args:
+            other: A DataFrame or Series or scalar to compare to.
+            axis: The axis to perform the ne over.
+            level: The Multilevel index level to apply ne over.
+
+        Returns:
+            A new DataFrame filled with Booleans.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.ne(y, axis, level),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.ne(other, axis, level),
+                other, axis, level)
 
     def nlargest(self, n, columns, keep='first'):
         raise NotImplementedError(
@@ -3785,40 +3875,22 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def __lt__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.lt(other)
 
     def __le__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.le(other)
 
     def __gt__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.gt(other)
 
     def __ge__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.ge(other)
 
     def __eq__(self, other):
-        """Computes the equality of this DataFrame with another
-
-        Returns:
-            True, if the DataFrames are equal. False otherwise.
-        """
-        return self.equals(other)
+        return self.eq(other)
 
     def __ne__(self, other):
-        """Checks that this DataFrame is not equal to another
-
-        Returns:
-            True, if the DataFrames are not equal. False otherwise.
-        """
-        return not self.equals(other)
+        return self.ne(other)
 
     def __add__(self, other):
         return self.add(other)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -280,8 +280,8 @@ class DataFrame(object):
             return self._repr_helper_()._repr_html_()
         # We split so that we insert our correct dataframe dimensions.
         result = self._repr_helper_()._repr_html_()
-        return result.split('<p>')[0] + \
-            '<p>{0} rows × {1} columns</p>\n</div>'.format(len(self.index),
+        return result.split("<p>")[0] + \
+            "<p>{0} rows × {1} columns</p>\n</div>".format(len(self.index),
                                                            len(self.columns))
 
     def _get_index(self):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -281,7 +281,7 @@ class DataFrame(object):
         # We split so that we insert our correct dataframe dimensions.
         result = self._repr_helper_()._repr_html_()
         return result.split("<p>")[0] + \
-            "<p>{0} rows × {1} columns</p>\n</div>".format(len(self.index),
+            "<p>{0} rows x {1} columns</p>\n</div>".format(len(self.index),
                                                            len(self.columns))
 
     def _get_index(self):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -714,9 +714,25 @@ class DataFrame(object):
         raise NotImplementedError("Not yet")
 
     def add(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Add this DataFrame to another or a scalar/list.
+
+        Args:
+            other: What to add this this DataFrame.
+            axis: The axis to apply addition over. Only applicaable to Series or list 'other'.
+            level: A level in the multilevel axis to add over.
+            fill_value: The value to fill NaN.
+
+        Returns:
+            A new DataFrame with the applied addition.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.add(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.add(other, axis, level, fill_value),
+                other, axis, level)
 
     def agg(self, func, axis=0, *args, **kwargs):
         return self.aggregate(func, axis, *args, **kwargs)
@@ -1261,14 +1277,39 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def div(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Divides this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the divide against this.
+            axis: The axis to divide over.
+            level: The Multilevel index level to apply divide over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Divide applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.div(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.div(other, axis, level, fill_value),
+                other, axis, level)
 
     def divide(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Synonym for div.
+
+        Args:
+            other: The object to use to apply the divide against this.
+            axis: The axis to divide over.
+            level: The Multilevel index level to apply divide over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Divide applied.
+        """
+        return self.div(other, axis, level, fill_value)
 
     def dot(self, other):
         raise NotImplementedError(
@@ -1688,9 +1729,25 @@ class DataFrame(object):
         return self._row_metadata.first_valid_index()
 
     def floordiv(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Divides this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the divide against this.
+            axis: The axis to divide over.
+            level: The Multilevel index level to apply divide over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Divide applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.floordiv(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.floordiv(other, axis, level, fill_value),
+                other, axis, level)
 
     @classmethod
     def from_csv(self, path, header=0, sep=', ', index_col=0,
@@ -2303,9 +2360,25 @@ class DataFrame(object):
         return self._arithmetic_helper(remote_func, axis, level)
 
     def mod(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Mods this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the mod against this.
+            axis: The axis to mod over.
+            level: The Multilevel index level to apply mod over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Mod applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.mod(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.mod(other, axis, level, fill_value),
+                other, axis, level)
 
     def mode(self, axis=0, numeric_only=False):
         raise NotImplementedError(
@@ -2313,14 +2386,39 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def mul(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Multiplies this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the multiply against this.
+            axis: The axis to multiply over.
+            level: The Multilevel index level to apply multiply over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Multiply applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.mul(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.mul(other, axis, level, fill_value),
+                other, axis, level)
 
     def multiply(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Synonym for mul.
+
+        Args:
+            other: The object to use to apply the multiply against this.
+            axis: The axis to multiply over.
+            level: The Multilevel index level to apply multiply over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Multiply applied.
+        """
+        return self.mul(other, axis, level, fill_value)
 
     def ne(self, other, axis='columns', level=None):
         raise NotImplementedError(
@@ -2426,9 +2524,25 @@ class DataFrame(object):
         return result
 
     def pow(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Pow this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the pow against this.
+            axis: The axis to pow over.
+            level: The Multilevel index level to apply pow over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Pow applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.pow(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.pow(other, axis, level, fill_value),
+                other, axis, level)
 
     def prod(self, axis=None, skipna=None, level=None, numeric_only=None,
              min_count=0, **kwargs):
@@ -3002,14 +3116,39 @@ class DataFrame(object):
         return self._arithmetic_helper(remote_func, axis, level)
 
     def sub(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Subtract a DataFrame/Series/scalar from this DataFrame.
+
+        Args:
+            other: The object to use to apply the subtraction to this.
+            axis: THe axis to apply the subtraction over.
+            level: Mutlilevel index level to subtract over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+             A new DataFrame with the subtraciont applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.sub(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.sub(other, axis, level, fill_value),
+                other, axis, level)
 
     def subtract(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Alias for sub.
+
+        Args:
+            other: The object to use to apply the subtraction to this.
+            axis: THe axis to apply the subtraction over.
+            level: Mutlilevel index level to subtract over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+             A new DataFrame with the subtraciont applied.
+        """
+        return self.sub(other, axis, level, fill_value)
 
     def swapaxes(self, axis1, axis2, copy=True):
         raise NotImplementedError(
@@ -3259,9 +3398,25 @@ class DataFrame(object):
         return result
 
     def truediv(self, other, axis='columns', level=None, fill_value=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        """Divides this DataFrame against another DataFrame/Series/scalar.
+
+        Args:
+            other: The object to use to apply the divide against this.
+            axis: The axis to divide over.
+            level: The Multilevel index level to apply divide over.
+            fill_value: The value to fill NaNs with.
+
+        Returns:
+            A new DataFrame with the Divide applied.
+        """
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: x.truediv(y, axis, level, fill_value),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: df.truediv(other, axis, level, fill_value),
+                other, axis, level)
 
     def truncate(self, before=None, after=None, axis=None, copy=True):
         raise NotImplementedError(
@@ -3660,9 +3815,7 @@ class DataFrame(object):
         return not self.equals(other)
 
     def __add__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.add(other)
 
     def __iadd__(self, other):
         raise NotImplementedError(
@@ -3670,9 +3823,7 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def __mul__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.mul(other)
 
     def __imul__(self, other):
         raise NotImplementedError(
@@ -3680,9 +3831,7 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def __pow__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.pow(other)
 
     def __ipow__(self, other):
         raise NotImplementedError(
@@ -3690,9 +3839,7 @@ class DataFrame(object):
             "github.com/ray-project/ray.")
 
     def __sub__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.sub(other)
 
     def __isub__(self, other):
         raise NotImplementedError(
@@ -3721,19 +3868,13 @@ class DataFrame(object):
                          index=self.index)
 
     def __floordiv__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.floordiv(other)
 
     def __truediv__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.truediv(other)
 
     def __mod__(self, other):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        return self.mod(other)
 
     def __sizeof__(self):
         raise NotImplementedError(
@@ -3758,12 +3899,12 @@ class DataFrame(object):
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
 
-    def iat(axis=None):
+    def iat(self, axis=None):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
 
-    def __rsub__(other, axis=None, level=None, fill_value=None):
+    def __rsub__(self, other, axis=None, level=None, fill_value=None):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
@@ -3785,22 +3926,20 @@ class DataFrame(object):
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
 
-    def __itruediv__(other):
+    def __itruediv__(self, other):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
 
-    def __div__(other, axis=None, level=None, fill_value=None):
+    def __div__(self, other, axis=None, level=None, fill_value=None):
+        return self.div(other, axis, level, fill_value)
+
+    def at(self, axis=None):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
 
-    def at(axis=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
-
-    def ix(axis=None):
+    def ix(self, axis=None):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
@@ -3815,3 +3954,92 @@ class DataFrame(object):
         raise NotImplementedError(
             "To contribute to Pandas on Ray, please visit "
             "github.com/ray-project/ray.")
+
+    def _copartition(self, other, new_index):
+        """Colocates the values of other with this for certain operations.
+
+        Args:
+            other: The other DataFrame to copartition with.
+
+        Returns:
+            Two new sets of partitions, copartitioned and zipped.
+        """
+        # Put in the object store so they aren't serialized each iteration.
+        old_self_index = ray.put(self.index)
+        new_index = ray.put(new_index)
+        old_other_index = ray.put(other.index)
+
+        new_partitions_self = [_reindex_helper.remote(df, old_self_index,
+                                                      new_index, 1)
+                               for df in self._col_partitions]
+
+        new_partitions_other = [_reindex_helper.remote(df, old_other_index,
+                                                       new_index, 1)
+                                for df in other._col_partitions]
+
+        return zip(new_partitions_self, new_partitions_other)
+
+    def _inter_df_op_helper(self, func, other, axis, level):
+        if level is not None:
+            raise NotImplementedError("Mutlilevel index not yet supported "
+                                      "in Pandas on Ray")
+        axis = pd.DataFrame()._get_axis_number(axis)
+
+        # Adding two DataFrames causes an outer join.
+        if isinstance(other, DataFrame):
+            new_column_index = self.columns.join(other.columns, how="outer")
+            new_index = self.index.join(other.index, how="outer")
+            copartitions = self._copartition(other, new_index)
+
+            new_columns = [co_op_helper.remote(func, *part)
+                           for part in copartitions]
+
+            return DataFrame(col_partitions=new_columns,
+                             columns=new_column_index,
+                             index=new_index)
+
+    def _single_df_op_helper(self, func, other, axis, level):
+        if level is not None:
+            raise NotImplementedError("Mutlilevel index not yet supported "
+                                      "in Pandas on Ray")
+        axis = pd.DataFrame()._get_axis_number(axis)
+
+        if is_list_like(other):
+            new_index = self.index
+            new_column_index = self.columns
+            new_col_metadata = self._col_metadata
+            new_row_metadata = self._row_metadata
+
+            if axis == 0:
+                if len(other) != len(self.index):
+                    raise ValueError(
+                        "Unable to coerce to Series, length must be {0}: "
+                        "given {1}".format(len(self.index), len(other)))
+                new_columns = _map_partitions(func, self._col_partitions)
+                new_rows = None
+            else:
+                if len(other) != len(self.columns):
+                    raise ValueError(
+                        "Unable to coerce to Series, length must be {0}: "
+                        "given {1}".format(len(self.columns), len(other)))
+                new_rows = _map_partitions(func, self._row_partitions)
+                new_columns = None
+
+        else:
+            new_columns = _map_partitions(func, self._col_partitions)
+            new_rows = None
+            new_index = self.index
+            new_column_index = self.columns
+            new_col_metadata = self._col_metadata
+            new_row_metadata = self._row_metadata
+
+        return DataFrame(col_partitions=new_columns,
+                         row_partitions=new_rows,
+                         index=new_index,
+                         columns=new_column_index,
+                         col_metadata=new_col_metadata,
+                         row_metadata=new_row_metadata)
+
+@ray.remote
+def co_op_helper(func, *zipped):
+    return func(zipped[0], zipped[1])

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -104,8 +104,7 @@ class DataFrame(object):
             if block_partitions is not None:
                 # put in numpy array here to make accesses easier since it's 2D
                 self._block_partitions = np.array(block_partitions)
-                assert self._block_partitions.ndim == 2, \
-                    "Block Partitions must be 2D."
+                axis = 0
             else:
                 if row_partitions is not None:
                     axis = 0
@@ -126,9 +125,11 @@ class DataFrame(object):
         # Sometimes we only get a single column or row, which is
         # problematic for building blocks from the partitions, so we
         # add whatever dimension we're missing from the input.
-        if self._block_partitions.ndim != 2:
+        if self._block_partitions.ndim < 2:
             self._block_partitions = np.expand_dims(self._block_partitions,
                                                     axis=axis ^ 1)
+
+        assert self._block_partitions.ndim == 2, "Block Partitions must be 2D."
 
         # Create the row and column index objects for using our partitioning.
         # If the objects haven't been inherited, then generate them
@@ -981,6 +982,7 @@ class DataFrame(object):
             to_concat = [self] + other
         else:
             to_concat = [self, other]
+
         return concat(to_concat, ignore_index=ignore_index,
                       verify_integrity=verify_integrity)
 
@@ -3979,7 +3981,7 @@ class DataFrame(object):
     def __rmod__(self, other, axis="columns", level=None, fill_value=None):
         return self.rmod(other, axis, level, fill_value)
 
-    def __div__(self, other, axis=None, level=None, fill_value=None):
+    def __div__(self, other, axis="columns", level=None, fill_value=None):
         return self.div(other, axis, level, fill_value)
 
     def __rdiv__(self, other, axis="columns", level=None, fill_value=None):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2190,14 +2190,14 @@ class DataFrame(object):
             # to the index variable which may be 'on'.
             new_self = np.array([
                 _reindex_helper._submit(args=tuple([index, new_index, 1,
-                                              new_partition_num] +
-                                              block.tolist()),
+                                                    new_partition_num] +
+                                                   block.tolist()),
                                         num_return_vals=new_partition_num)
                 for block in self._block_partitions.T])
             new_other = np.array([
                 _reindex_helper._submit(args=tuple([other.index, new_index, 1,
-                                              new_partition_num] +
-                                              block.tolist()),
+                                                    new_partition_num] +
+                                                   block.tolist()),
                                         num_return_vals=new_partition_num)
                 for block in other._block_partitions.T])
 
@@ -2235,14 +2235,14 @@ class DataFrame(object):
 
             new_self = np.array([
                 _reindex_helper._submit(args=tuple([self.index, new_index, 1,
-                                              new_partition_num] +
-                                              block.tolist()),
+                                                    new_partition_num] +
+                                                   block.tolist()),
                                         num_return_vals=new_partition_num)
                 for block in self._block_partitions.T])
 
             new_others = np.array([_reindex_helper._submit(
                 args=tuple([obj.index, new_index, 1, new_partition_num] +
-                            block.tolist()),
+                           block.tolist()),
                 num_return_vals=new_partition_num
             ) for obj in other for block in obj._block_partitions.T])
 
@@ -4009,14 +4009,14 @@ class DataFrame(object):
         new_partitions_self = \
             np.array([_reindex_helper._submit(
                 args=tuple([old_self_index, new_index, 1,
-                             new_num_partitions] + block.tolist()),
+                            new_num_partitions] + block.tolist()),
                 num_return_vals=new_num_partitions)
                 for block in self._block_partitions.T]).T
 
         new_partitions_other = \
             np.array([_reindex_helper._submit(
                 args=tuple([old_other_index, new_index, 1,
-                             new_num_partitions] + block.tolist()),
+                            new_num_partitions] + block.tolist()),
                 num_return_vals=new_num_partitions)
                 for block in other._block_partitions.T]).T
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -738,14 +738,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the applied addition.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.add(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.add(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("add", other, axis, level,
+                                                fill_value)
 
     def agg(self, func, axis=0, *args, **kwargs):
         return self.aggregate(func, axis, *args, **kwargs)
@@ -1302,14 +1296,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Divide applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.div(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.div(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("div", other, axis, level,
+                                                fill_value)
 
     def divide(self, other, axis='columns', level=None, fill_value=None):
         """Synonym for div.
@@ -1769,14 +1757,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Divide applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.floordiv(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.floordiv(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("floordiv", other, axis, level,
+                                                fill_value)
 
     @classmethod
     def from_csv(self, path, header=0, sep=', ', index_col=0,
@@ -2481,14 +2463,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Mod applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.mod(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.mod(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("mod", other, axis, level,
+                                                fill_value)
 
     def mode(self, axis=0, numeric_only=False):
         raise NotImplementedError(
@@ -2507,14 +2483,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Multiply applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.mul(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.mul(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("mul", other, axis, level,
+                                                fill_value)
 
     def multiply(self, other, axis='columns', level=None, fill_value=None):
         """Synonym for mul.
@@ -2660,14 +2630,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Pow applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.pow(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.pow(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("pow", other, axis, level,
+                                                fill_value)
 
     def prod(self, axis=None, skipna=None, level=None, numeric_only=None,
              min_count=0, **kwargs):
@@ -3248,14 +3212,8 @@ class DataFrame(object):
         Returns:
              A new DataFrame with the subtraciont applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.sub(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.sub(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("sub", other, axis, level,
+                                                fill_value)
 
     def subtract(self, other, axis='columns', level=None, fill_value=None):
         """Alias for sub.
@@ -3530,14 +3488,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the Divide applied.
         """
-        if isinstance(other, DataFrame):
-            return self._inter_df_op_helper(
-                lambda x, y: x.truediv(y, axis, level, fill_value),
-                other, axis, level)
-        else:
-            return self._single_df_op_helper(
-                lambda df: df.truediv(other, axis, level, fill_value),
-                other, axis, level)
+        return self._inter_and_single_op_helper("truediv", other, axis, level,
+                                                fill_value)
 
     def truncate(self, before=None, after=None, axis=None, copy=True):
         raise NotImplementedError(
@@ -4106,6 +4058,16 @@ class DataFrame(object):
                 for block in other._block_partitions.T]).T
 
         return zip(new_partitions_self, new_partitions_other)
+
+    def _inter_and_single_op_helper(self, op, other, axis, level, *args):
+        if isinstance(other, DataFrame):
+            return self._inter_df_op_helper(
+                lambda x, y: getattr(x, op)(y, axis, level, *args),
+                other, axis, level)
+        else:
+            return self._single_df_op_helper(
+                lambda df: getattr(df, op)(other, axis, level, *args),
+                other, axis, level)
 
     def _inter_df_op_helper(self, func, other, axis, level):
         if level is not None:

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2210,15 +2210,15 @@ class DataFrame(object):
             # Another important thing to note: We set the current self index
             # to the index variable which may be 'on'.
             new_self = np.array([
-                _reindex_helper._submit(args=(index, new_index, 1,
-                                              new_partition_num,
-                                              *block),
+                _reindex_helper._submit(args=(tuple([index, new_index, 1,
+                                              new_partition_num] +
+                                              block.tolist())),
                                         num_return_vals=new_partition_num)
                 for block in self._block_partitions.T])
             new_other = np.array([
-                _reindex_helper._submit(args=(other.index, new_index, 1,
-                                              new_partition_num,
-                                              *block),
+                _reindex_helper._submit(args=(tuple([other.index, new_index, 1,
+                                              new_partition_num] +
+                                              block.tolist())),
                                         num_return_vals=new_partition_num)
                 for block in other._block_partitions.T])
 
@@ -2255,14 +2255,15 @@ class DataFrame(object):
                                      for obj in other])
 
             new_self = np.array([
-                _reindex_helper._submit(args=(self.index, new_index, 1,
-                                              new_partition_num,
-                                              *block),
+                _reindex_helper._submit(args=(tuple([self.index, new_index, 1,
+                                              new_partition_num] +
+                                              block.tolist())),
                                         num_return_vals=new_partition_num)
                 for block in self._block_partitions.T])
 
             new_others = np.array([_reindex_helper._submit(
-                args=(obj.index, new_index, 1, new_partition_num, *block),
+                args=(tuple([obj.index, new_index, 1, new_partition_num] +
+                            block.tolist())),
                 num_return_vals=new_partition_num
             ) for obj in other for block in obj._block_partitions.T])
 
@@ -4045,15 +4046,15 @@ class DataFrame(object):
 
         new_partitions_self = \
             np.array([_reindex_helper._submit(
-                args=(old_self_index, new_index, 1, new_num_partitions,
-                      *block),
+                args=(tuple([old_self_index, new_index, 1,
+                             new_num_partitions] + block.tolist())),
                 num_return_vals=new_num_partitions)
                 for block in self._block_partitions.T]).T
 
         new_partitions_other = \
             np.array([_reindex_helper._submit(
-                args=(old_other_index, new_index, 1, new_num_partitions,
-                      *block),
+                args=(tuple([old_other_index, new_index, 1,
+                             new_num_partitions] + block.tolist())),
                 num_return_vals=new_num_partitions)
                 for block in other._block_partitions.T]).T
 

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -807,10 +807,28 @@ def test_nan_dataframe():
 
 
 def test_add():
-    ray_df = create_test_dataframe()
+    ray_df = rdf.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                            "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
 
-    with pytest.raises(NotImplementedError):
-        ray_df.add(None)
+    pandas_df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                              "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
+
+    ray_df_equals_pandas(ray_df.add(ray_df), pandas_df.add(pandas_df))
+    ray_df_equals_pandas(ray_df.add(4), pandas_df.add(4))
+    ray_df_equals_pandas(ray_df.add(4.0), pandas_df.add(4.0))
+
+    ray_df2 = rdf.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
+    pandas_df2 = pd.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
+
+    ray_df_equals_pandas(ray_df.add(ray_df2), pandas_df.add(pandas_df2))
+
+    list_test = [0, 1, 2, 4]
+
+    ray_df_equals_pandas(ray_df.add(list_test, axis=1),
+                         pandas_df.add(list_test, axis=1))
+
+    ray_df_equals_pandas(ray_df.add(list_test, axis=0),
+                         pandas_df.add(list_test, axis=0))
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -806,29 +806,75 @@ def test_nan_dataframe():
         test_transform(ray_df, pandas_df)
 
 
-def test_add():
+@pytest.fixture
+def test_inter_df_math(op, simple=False):
     ray_df = rdf.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
                             "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
 
     pandas_df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
                               "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
 
-    ray_df_equals_pandas(ray_df.add(ray_df), pandas_df.add(pandas_df))
-    ray_df_equals_pandas(ray_df.add(4), pandas_df.add(4))
-    ray_df_equals_pandas(ray_df.add(4.0), pandas_df.add(4.0))
+    ray_df_equals_pandas(getattr(ray_df, op)(ray_df),
+                         getattr(pandas_df, op)(pandas_df))
+    ray_df_equals_pandas(getattr(ray_df, op)(4),
+                         getattr(pandas_df, op)(4))
+    ray_df_equals_pandas(getattr(ray_df, op)(4.0),
+                         getattr(pandas_df, op)(4.0))
 
     ray_df2 = rdf.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
     pandas_df2 = pd.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
 
-    ray_df_equals_pandas(ray_df.add(ray_df2), pandas_df.add(pandas_df2))
+    ray_df_equals_pandas(getattr(ray_df, op)(ray_df2),
+                         getattr(pandas_df, op)(pandas_df2))
 
     list_test = [0, 1, 2, 4]
 
-    ray_df_equals_pandas(ray_df.add(list_test, axis=1),
-                         pandas_df.add(list_test, axis=1))
+    if not simple:
+        ray_df_equals_pandas(getattr(ray_df, op)(list_test, axis=1),
+                             getattr(pandas_df, op)(list_test, axis=1))
 
-    ray_df_equals_pandas(ray_df.add(list_test, axis=0),
-                         pandas_df.add(list_test, axis=0))
+        ray_df_equals_pandas(getattr(ray_df, op)(list_test, axis=0),
+                             getattr(pandas_df, op)(list_test, axis=0))
+
+
+@pytest.fixture
+def test_comparison_inter_ops(op):
+    ray_df = rdf.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                            "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
+
+    pandas_df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                              "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
+
+    ray_df_equals_pandas(getattr(ray_df, op)(ray_df),
+                         getattr(pandas_df, op)(pandas_df))
+    ray_df_equals_pandas(getattr(ray_df, op)(4),
+                         getattr(pandas_df, op)(4))
+    ray_df_equals_pandas(getattr(ray_df, op)(4.0),
+                         getattr(pandas_df, op)(4.0))
+
+    ray_df2 = rdf.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
+    pandas_df2 = pd.DataFrame({"A": [0, 2], "col1": [0, 19], "col2": [1, 1]})
+
+    ray_df_equals_pandas(getattr(ray_df, op)(ray_df2),
+                         getattr(pandas_df, op)(pandas_df2))
+
+
+@pytest.fixture
+def test_inter_df_math_right_ops(op):
+    ray_df = rdf.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                            "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
+
+    pandas_df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [4, 5, 6, 7],
+                              "col3": [8, 9, 0, 1], "col4": [2, 4, 5, 6]})
+
+    ray_df_equals_pandas(getattr(ray_df, op)(4),
+                         getattr(pandas_df, op)(4))
+    ray_df_equals_pandas(getattr(ray_df, op)(4.0),
+                         getattr(pandas_df, op)(4.0))
+
+
+def test_add():
+    test_inter_df_math("add", simple=False)
 
 
 @pytest.fixture
@@ -880,6 +926,8 @@ def test_append():
     ray_df2 = rdf.DataFrame({"col5": [0], "col6": [1]})
 
     pandas_df2 = pd.DataFrame({"col5": [0], "col6": [1]})
+
+    print(ray_df.append(ray_df2))
 
     assert ray_df_equals_pandas(ray_df.append(ray_df2),
                                 pandas_df.append(pandas_df2))
@@ -1101,17 +1149,11 @@ def test_diff():
 
 
 def test_div():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.div(None)
+    test_inter_df_math("div", simple=False)
 
 
 def test_divide():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.divide(None)
+    test_inter_df_math("divide", simple=False)
 
 
 def test_dot():
@@ -1226,10 +1268,8 @@ def test_duplicated():
 
 
 def test_eq():
-    ray_df = create_test_dataframe()
+    test_comparison_inter_ops("eq")
 
-    with pytest.raises(NotImplementedError):
-        ray_df.eq(None)
 
 
 def test_equals():
@@ -1736,10 +1776,7 @@ def test_first_valid_index(ray_df, pandas_df):
 
 
 def test_floordiv():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.floordiv(None)
+    test_inter_df_math("floordiv", simple=False)
 
 
 def test_from_csv():
@@ -1763,10 +1800,7 @@ def test_from_records():
 
 
 def test_ge():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.ge(None)
+    test_comparison_inter_ops("ge")
 
 
 def test_get_value():
@@ -1784,10 +1818,7 @@ def test_get_values():
 
 
 def test_gt():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.gt(None)
+    test_comparison_inter_ops("gt")
 
 
 @pytest.fixture
@@ -1953,10 +1984,7 @@ def test_last_valid_index(ray_df, pandas_df):
 
 
 def test_le():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.le(None)
+    test_comparison_inter_ops("le")
 
 
 def test_lookup():
@@ -1967,10 +1995,7 @@ def test_lookup():
 
 
 def test_lt():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.lt(None)
+    test_comparison_inter_ops("lt")
 
 
 def test_mad():
@@ -2032,10 +2057,7 @@ def test_min(ray_df, pandas_df):
 
 
 def test_mod():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.mod(None)
+    test_inter_df_math("mod", simple=False)
 
 
 def test_mode():
@@ -2046,24 +2068,15 @@ def test_mode():
 
 
 def test_mul():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.mul(None)
+    test_inter_df_math("mul", simple=False)
 
 
 def test_multiply():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.multiply(None)
+    test_inter_df_math("multiply", simple=False)
 
 
 def test_ne():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.ne(None)
+    test_comparison_inter_ops("ne")
 
 
 def test_nlargest():
@@ -2143,10 +2156,7 @@ def test_pop(ray_df, pandas_df):
 
 
 def test_pow():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.pow(None)
+    test_inter_df_math("pow", simple=False)
 
 
 def test_prod():
@@ -2176,10 +2186,7 @@ def test_query(ray_df, pandas_df, funcs):
 
 
 def test_radd():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.radd(None)
+    test_inter_df_math_right_ops("radd")
 
 
 def test_rank():
@@ -2190,10 +2197,7 @@ def test_rank():
 
 
 def test_rdiv():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rdiv(None)
+    test_inter_df_math_right_ops("rdiv")
 
 
 def test_reindex():
@@ -2505,24 +2509,15 @@ def test_reset_index(ray_df, pandas_df, inplace=False):
 
 
 def test_rfloordiv():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rfloordiv(None)
+    test_inter_df_math_right_ops("rfloordiv")
 
 
 def test_rmod():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rmod(None)
+    test_inter_df_math_right_ops("rmod")
 
 
 def test_rmul():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rmul(None)
+    test_inter_df_math_right_ops("rmul")
 
 
 def test_rolling():
@@ -2539,24 +2534,15 @@ def test_round(ray_df, pd_df):
 
 
 def test_rpow():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rpow(None)
+    test_inter_df_math_right_ops("rpow")
 
 
 def test_rsub():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rsub(None)
+    test_inter_df_math_right_ops("rsub")
 
 
 def test_rtruediv():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.rtruediv(None)
+    test_inter_df_math_right_ops("rtruediv")
 
 
 def test_sample():
@@ -2675,17 +2661,11 @@ def test_std(ray_df, pandas_df):
 
 
 def test_sub():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.sub(None)
+    test_inter_df_math("sub", simple=False)
 
 
 def test_subtract():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.subtract(None)
+    test_inter_df_math("subtract", simple=False)
 
 
 def test_swapaxes():
@@ -2758,10 +2738,7 @@ def test_transform(ray_df, pandas_df):
 
 
 def test_truediv():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.truediv(None)
+    test_inter_df_math("truediv", simple=False)
 
 
 def test_truncate():
@@ -3010,10 +2987,7 @@ def test_iat():
 
 
 def test___rsub__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__rsub__(None, None, None)
+    test_inter_df_math_right_ops("__rsub__")
 
 
 @pytest.fixture
@@ -3040,17 +3014,11 @@ def test_is_copy():
 
 
 def test___itruediv__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__itruediv__()
+    test_inter_df_math("__itruediv__", simple=True)
 
 
 def test___div__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__div__(None)
+    test_inter_df_math("__div__", simple=True)
 
 
 def test_at():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -1271,7 +1271,6 @@ def test_eq():
     test_comparison_inter_ops("eq")
 
 
-
 def test_equals():
     pandas_df1 = pd.DataFrame({'col1': [2.9, 3, 3, 3],
                                'col2': [2, 3, 4, 1]})

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -314,8 +314,23 @@ def _reindex_helper(old_index, new_index, axis, npartitions, *df):
 
 
 @ray.remote
-def co_op_helper(func, left_columns, right_columns, left_df_len, *zipped):
+def _co_op_helper(func, left_columns, right_columns, left_df_len, *zipped):
+    """Copartition operation where two DataFrames must have aligned indexes.
 
+    NOTE: This function assumes things are already copartitioned. Requires that
+        row partitions are passed in as blocks.
+
+    Args:
+        func: The operation to conduct between two DataFrames.
+        left_columns: The column names for the left DataFrame.
+        right_columns: The column names for the right DataFrame.
+        left_df_len: The length of the left. This is used so we can split up
+            the zipped partitions.
+        zipped: The DataFrame partitions (in blocks).
+
+    Returns:
+         A new set of blocks for the partitioned DataFrame.
+    """
     left = pd.concat(zipped[:left_df_len], axis=1, copy=False)
     left.columns = left_columns
 

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -200,12 +200,16 @@ def _create_block_partitions(partitions, axis=0, length=None):
          for partition in partitions]
 
     # In the case that axis is 1 we have to transpose because we build the
-    # columns into rows. Fortunately numpy is efficent at this.
+    # columns into rows. Fortunately numpy is efficient at this.
     return np.array(x) if axis == 0 else np.array(x).T
 
 
 @ray.remote
 def create_blocks(df, npartitions, axis):
+    return create_blocks_helper(df, npartitions, axis)
+
+
+def create_blocks_helper(df, npartitions, axis):
     # Single partition dataframes don't need to be repartitioned
     if npartitions == 1:
         return df
@@ -285,7 +289,7 @@ def _inherit_docstrings(parent):
 
 
 @ray.remote
-def _reindex_helper(df, old_index, new_index, axis):
+def _reindex_helper(old_index, new_index, axis, npartitions, *df):
     """Reindexes a dataframe to prepare for join/concat.
 
     Args:
@@ -295,8 +299,9 @@ def _reindex_helper(df, old_index, new_index, axis):
         axis: Which axis to reindex over.
 
     Returns:
-        A new reindexed DataFrame.
+        A new set of blocks made up of DataFrames.
     """
+    df = pd.concat(df, axis=axis ^ 1)
     if axis == 1:
         df.index = old_index
         df = df.reindex(new_index, copy=False)
@@ -305,4 +310,4 @@ def _reindex_helper(df, old_index, new_index, axis):
         df.columns = old_index
         df = df.reindex(columns=new_index, copy=False)
         df.columns = pd.RangeIndex(len(df.columns))
-    return df
+    return create_blocks_helper(df, npartitions, axis)


### PR DESCRIPTION
Implements the inter-DataFrame and scalar operations:

- `add`, `__add__`
- `radd`, `__radd__`
- `__iadd__`
- `sub`, `__sub__`, `subtract`
- `rsub`, `__rsub__`
- `__isub__`
- `mul`, `__mul__`, `multiply`
- `rmul`, `__rmul__`
- `div`, `__div__`, `divide`
- `floordiv`, `__floordiv__`
- `rfloordiv`, `__rfloordiv`
- `__ifloordiv__`
- `truediv`, `__truediv__`
- `rtruediv`, `__rtruediv__`
- `__itruediv__`
- `mod`, `__mod__`
- `rmod`, `__rmod__`
- `__imod__`
- `pow`, `__pow__`
- `rpow`, `__rpow`
- `__ipow__`

Depends on #1932, don't merge until after that is merged.

Edit: Also add comparison methods:

- `ge`, `__ge__`
- `gt`, `__gt__`
- `le`, `__le__`
- `lt`, `__lt__`
- `eq`, `__eq__`
- `ne`, `__ne__`
