### PR TITLE
[DataFrame] Fix for __getitem__ string indexing

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -3212,9 +3212,6 @@ class DataFrame(object):
         """
         key = com._apply_if_callable(key, self)
 
-        if key is None:
-            pd.DataFrame()[None]
-
         # shortcut if we are an actual column
         is_mi_columns = isinstance(self.columns, pd.MultiIndex)
         try:

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -3212,6 +3212,9 @@ class DataFrame(object):
         """
         key = com._apply_if_callable(key, self)
 
+        if key is None:
+            pd.DataFrame()[None]
+
         # shortcut if we are an actual column
         is_mi_columns = isinstance(self.columns, pd.MultiIndex)
         try:
@@ -3266,7 +3269,7 @@ class DataFrame(object):
                              columns=columns,
                              index=index)
         else:
-            columns = self.columns[key]
+            columns = self._col_metadata[key].index
 
             indices_for_rows = [self.columns.index(new_col)
                                 for new_col in columns]


### PR DESCRIPTION
This fixes a bug where strings are passed into `__getitem__`