### PR TITLE
Pin Cython in autoscaler development example.

### DIFF
--- a/python/ray/autoscaler/aws/development-example.yaml
+++ b/python/ray/autoscaler/aws/development-example.yaml
@@ -94,7 +94,7 @@ setup_commands:
     - echo 'export PATH="$HOME/anaconda3/bin:$PATH"' >> ~/.bashrc
     # Build Ray.
     - git clone https://github.com/ray-project/ray || true
-    - pip install boto3==1.4.8
+    - pip install boto3==1.4.8 cython==0.27.3
     - cd ray/python; pip install -e . --verbose
 
 # Custom commands that will be run on the head node after common setup.


### PR DESCRIPTION
Currently the autoscaler development example doesn't work. This should fix it.