### PR TITLE
Make autoscaler logs verbose

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -224,7 +224,7 @@ class StandardAutoscaler(object):
                  max_concurrent_launches=AUTOSCALER_MAX_CONCURRENT_LAUNCHES,
                  max_failures=AUTOSCALER_MAX_NUM_FAILURES,
                  process_runner=subprocess,
-                 verbose_updates=False,
+                 verbose_updates=True,
                  node_updater_cls=NodeUpdaterProcess,
                  update_interval_s=AUTOSCALER_UPDATE_INTERVAL_S):
         self.config_path = config_path


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The per-worker setup logs aren't printed to the main monitor log by default. This has caused a lot of confusion around how to access those logs, so put them in the main stream.