### PR TITLE
Add Explicit pthread linking in Global Scheduler

### DIFF
--- a/src/global_scheduler/CMakeLists.txt
+++ b/src/global_scheduler/CMakeLists.txt
@@ -7,4 +7,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/../common/cmake/Common.cmake)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 
 add_executable(global_scheduler global_scheduler.cc global_scheduler_algorithm.cc)
-target_link_libraries(global_scheduler common ${HIREDIS_LIB} ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
+target_link_libraries(global_scheduler common ${HIREDIS_LIB} ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY} pthread)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add an explicit pthread linking flag to the global scheduler build.
Ray could not build on my system because the linker could not find pthread symbols while building the global scheduler. I'm building using gcc 7.3.1 on fedora 28 stage-4 images for risc-v

## Related issue number

No
