### PR TITLE
Write magic methods for SampleBatch/PartialRollout

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -75,9 +75,9 @@ class NodeUpdater(object):
             self.provider.set_node_tags(self.node_id,
                                         {TAG_RAY_NODE_STATUS: "UpdateFailed"})
             if self.logfile is not None:
-                print("----- BEGIN REMOTE LOGS -----\n" + open(
-                    self.logfile.name).read() + "\n----- END REMOTE LOGS -----"
-                      )
+                print("----- BEGIN REMOTE LOGS -----\n" +
+                      open(self.logfile.name).read() +
+                      "\n----- END REMOTE LOGS -----")
             raise e
         self.provider.set_node_tags(
             self.node_id, {

--- a/python/ray/experimental/array/distributed/linalg.py
+++ b/python/ray/experimental/array/distributed/linalg.py
@@ -76,10 +76,9 @@ def tsqr(a):
                 lower = [a.shape[1], 0]
                 upper = [2 * a.shape[1], core.BLOCK_SIZE]
             ith_index //= 2
-            q_block_current = ra.dot.remote(q_block_current,
-                                            ra.subarray.remote(
-                                                q_tree[ith_index, j], lower,
-                                                upper))
+            q_block_current = ra.dot.remote(
+                q_block_current,
+                ra.subarray.remote(q_tree[ith_index, j], lower, upper))
         q_result.objectids[i] = q_block_current
     r = current_rs[0]
     return q_result, ray.get(r)
@@ -222,10 +221,10 @@ def qr(a):
         y_col_block = core.subblocks.remote(y_res, [], [i])
         q = core.subtract.remote(
             q,
-            core.dot.remote(y_col_block,
-                            core.dot.remote(
-                                Ts[i],
-                                core.dot.remote(
-                                    core.transpose.remote(y_col_block), q))))
+            core.dot.remote(
+                y_col_block,
+                core.dot.remote(
+                    Ts[i],
+                    core.dot.remote(core.transpose.remote(y_col_block), q))))
 
     return ray.get(q), r_res

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -750,8 +750,8 @@ class GlobalState(object):
                         "name":
                         "SubmitTask",
                         "args": {},
-                        "id": (parent_info["worker_id"] +
-                               str(micros(min(parent_times))))
+                        "id": (parent_info["worker_id"] + str(
+                            micros(min(parent_times))))
                     }
                     full_trace.append(parent)
 
@@ -825,8 +825,8 @@ class GlobalState(object):
                         "name":
                         "SubmitTask",
                         "args": {},
-                        "id": (parent_info["worker_id"] +
-                               str(micros(min(parent_times))))
+                        "id": (parent_info["worker_id"] + str(
+                            micros(min(parent_times))))
                     }
                     full_trace.append(parent)
 

--- a/python/ray/experimental/ui.py
+++ b/python/ray/experimental/ui.py
@@ -451,8 +451,8 @@ def task_completion_time_distribution():
         # Create the distribution to plot
         distr = []
         for task_id, data in tasks.items():
-            distr.append(
-                data["store_outputs_end"] - data["get_arguments_start"])
+            distr.append(data["store_outputs_end"] -
+                         data["get_arguments_start"])
 
         # Create a histogram from the distribution
         top, bin_edges = np.histogram(distr, bins="auto")
@@ -520,10 +520,10 @@ def compute_utilizations(abs_earliest,
         # Walk over each time bucket that this task intersects, adding the
         # amount of time that the task intersects within each bucket
         for bucket_idx in range(start_bucket, end_bucket + 1):
-            bucket_start_time = ((
-                earliest_time + bucket_idx) * bucket_time_length)
-            bucket_end_time = ((earliest_time +
-                                (bucket_idx + 1)) * bucket_time_length)
+            bucket_start_time = (
+                (earliest_time + bucket_idx) * bucket_time_length)
+            bucket_end_time = (
+                (earliest_time + (bucket_idx + 1)) * bucket_time_length)
 
             task_start_time_within_bucket = max(task_start_time,
                                                 bucket_start_time)

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -39,8 +39,9 @@ class LogMonitor(object):
     def update_log_filenames(self):
         """Get the most up-to-date list of log files to monitor from Redis."""
         num_current_log_files = len(self.log_files)
-        new_log_filenames = self.redis_client.lrange("LOG_FILENAMES:{}".format(
-            self.node_ip_address), num_current_log_files, -1)
+        new_log_filenames = self.redis_client.lrange(
+            "LOG_FILENAMES:{}".format(self.node_ip_address),
+            num_current_log_files, -1)
         for log_filename in new_log_filenames:
             print("Beginning to track file {}".format(log_filename))
             assert log_filename not in self.log_files

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -189,10 +189,9 @@ class Monitor(object):
                 if manager in self.dead_plasma_managers:
                     # If the object was on a dead plasma manager, remove that
                     # location entry.
-                    ok = self.state._execute_command(object_id,
-                                                     "RAY.OBJECT_TABLE_REMOVE",
-                                                     object_id.id(),
-                                                     hex_to_binary(manager))
+                    ok = self.state._execute_command(
+                        object_id, "RAY.OBJECT_TABLE_REMOVE", object_id.id(),
+                        hex_to_binary(manager))
                     if ok != b"OK":
                         log.warn("Failed to remove object location for dead "
                                  "plasma manager.")
@@ -507,8 +506,8 @@ class Monitor(object):
         log.debug("{} dead local schedulers, {} plasma managers total, {} "
                   "dead plasma managers".format(
                       len(self.dead_local_schedulers),
-                      (len(self.live_plasma_managers) +
-                       len(self.dead_plasma_managers)),
+                      (len(self.live_plasma_managers) + len(
+                          self.dead_plasma_managers)),
                       len(self.dead_plasma_managers)))
 
         # Handle messages from the subscription channels.

--- a/python/ray/rllib/optimizers/sample_batch.py
+++ b/python/ray/rllib/optimizers/sample_batch.py
@@ -36,8 +36,8 @@ class SampleBatch(object):
     @staticmethod
     def concat_samples(samples):
         out = {}
-        for k in samples[0].data.keys():
-            out[k] = np.concatenate([s.data[k] for s in samples])
+        for k in samples[0].keys():
+            out[k] = np.concatenate([s[k] for s in samples])
         return SampleBatch(out)
 
     def concat(self, other):
@@ -50,10 +50,10 @@ class SampleBatch(object):
             {"a": [1, 2, 3, 4, 5]}
         """
 
-        assert self.data.keys() == other.data.keys(), "must have same columns"
+        assert self.keys() == other.keys(), "must have same columns"
         out = {}
-        for k in self.data.keys():
-            out[k] = np.concatenate([self.data[k], other.data[k]])
+        for k in self.keys():
+            out[k] = np.concatenate([self[k], other[k]])
         return SampleBatch(out)
 
     def rows(self):
@@ -70,7 +70,7 @@ class SampleBatch(object):
 
         for i in range(self.count):
             row = {}
-            for k in self.data.keys():
+            for k in self.keys():
                 row[k] = self[k][i]
             yield row
 
@@ -85,19 +85,37 @@ class SampleBatch(object):
 
         out = []
         for k in keys:
-            out.append(self.data[k])
+            out.append(self[k])
         return out
 
     def shuffle(self):
         permutation = np.random.permutation(self.count)
-        for key, val in self.data.items():
-            self.data[key] = val[permutation]
+        for key, val in self.items():
+            self[key] = val[permutation]
 
     def __getitem__(self, key):
         return self.data[key]
+
+    def __setitem__(self, key, item):
+        self.data[key] = item
 
     def __str__(self):
         return "SampleBatch({})".format(str(self.data))
 
     def __repr__(self):
         return "SampleBatch({})".format(str(self.data))
+
+    def keys(self):
+        return self.data.keys()
+
+    def items(self):
+        return self.data.items()
+
+    def __iter__(self):
+        return self.data.__iter__()
+
+    def __next__(self):
+        return self.data.__next__()
+
+    def __contains__(self, x):
+        return x in self.data

--- a/python/ray/rllib/test/test_optimizers.py
+++ b/python/ray/rllib/test/test_optimizers.py
@@ -33,11 +33,11 @@ class SampleBatchTest(unittest.TestCase):
         b2 = SampleBatch({"a": np.array([1]), "b": np.array([4])})
         b3 = SampleBatch({"a": np.array([1]), "b": np.array([5])})
         b12 = b1.concat(b2)
-        self.assertEqual(b12.data["a"].tolist(), [1, 2, 3, 1])
-        self.assertEqual(b12.data["b"].tolist(), [4, 5, 6, 4])
+        self.assertEqual(b12["a"].tolist(), [1, 2, 3, 1])
+        self.assertEqual(b12["b"].tolist(), [4, 5, 6, 4])
         b = SampleBatch.concat_samples([b1, b2, b3])
-        self.assertEqual(b.data["a"].tolist(), [1, 2, 3, 1, 1])
-        self.assertEqual(b.data["b"].tolist(), [4, 5, 6, 4, 5])
+        self.assertEqual(b["a"].tolist(), [1, 2, 3, 1, 1])
+        self.assertEqual(b["b"].tolist(), [4, 5, 6, 4, 5])
 
 
 if __name__ == '__main__':

--- a/python/ray/rllib/utils/process_rollout.py
+++ b/python/ray/rllib/utils/process_rollout.py
@@ -26,14 +26,14 @@ def process_rollout(rollout, reward_filter, gamma, lambda_=1.0, use_gae=True):
             processed rewards."""
 
     traj = {}
-    trajsize = len(rollout.data["actions"])
-    for key in rollout.data:
-        traj[key] = np.stack(rollout.data[key])
+    trajsize = len(rollout["actions"])
+    for key in rollout:
+        traj[key] = np.stack(rollout[key])
 
     if use_gae:
-        assert "vf_preds" in rollout.data, "Values not found!"
+        assert "vf_preds" in rollout, "Values not found!"
         vpred_t = np.stack(
-            rollout.data["vf_preds"] + [np.array(rollout.last_r)]).squeeze()
+            rollout["vf_preds"] + [np.array(rollout.last_r)]).squeeze()
         delta_t = traj["rewards"] + gamma * vpred_t[1:] - vpred_t[:-1]
         # This formula for the advantage comes
         # "Generalized Advantage Estimation": https://arxiv.org/abs/1506.02438
@@ -41,7 +41,7 @@ def process_rollout(rollout, reward_filter, gamma, lambda_=1.0, use_gae=True):
         traj["value_targets"] = traj["advantages"] + traj["vf_preds"]
     else:
         rewards_plus_v = np.stack(
-            rollout.data["rewards"] + [np.array(rollout.last_r)]).squeeze()
+            rollout["rewards"] + [np.array(rollout.last_r)]).squeeze()
         traj["advantages"] = discount(rewards_plus_v, gamma)[:-1]
 
     for i in range(traj["advantages"].shape[0]):

--- a/python/ray/rllib/utils/sampler.py
+++ b/python/ray/rllib/utils/sampler.py
@@ -59,8 +59,6 @@ class PartialRollout(object):
     def __getitem__(self, key):
         return self.data[key]
 
-CompletedRollout = namedtuple(
-    "CompletedRollout", ["episode_length", "episode_reward"])
     def __setitem__(self, key, item):
         self.data[key] = item
 
@@ -79,6 +77,9 @@ CompletedRollout = namedtuple(
     def __contains__(self, x):
         return x in self.data
 
+
+CompletedRollout = namedtuple(
+    "CompletedRollout", ["episode_length", "episode_reward"])
 
 class SyncSampler(object):
     """This class interacts with the environment and tells it what to do.

--- a/python/ray/rllib/utils/sampler.py
+++ b/python/ray/rllib/utils/sampler.py
@@ -81,6 +81,7 @@ class PartialRollout(object):
 CompletedRollout = namedtuple(
     "CompletedRollout", ["episode_length", "episode_reward"])
 
+
 class SyncSampler(object):
     """This class interacts with the environment and tells it what to do.
 

--- a/python/ray/rllib/utils/sampler.py
+++ b/python/ray/rllib/utils/sampler.py
@@ -56,9 +56,28 @@ class PartialRollout(object):
             terminal (bool): if rollout has terminated."""
         return self.data["dones"][-1]
 
+    def __getitem__(self, key):
+        return self.data[key]
 
 CompletedRollout = namedtuple(
     "CompletedRollout", ["episode_length", "episode_reward"])
+    def __setitem__(self, key, item):
+        self.data[key] = item
+
+    def keys(self):
+        return self.data.keys()
+
+    def items(self):
+        return self.data.items()
+
+    def __iter__(self):
+        return self.data.__iter__()
+
+    def __next__(self):
+        return self.data.__next__()
+
+    def __contains__(self, x):
+        return x in self.data
 
 
 class SyncSampler(object):

--- a/python/ray/tune/hyperband.py
+++ b/python/ray/tune/hyperband.py
@@ -391,9 +391,9 @@ class Bracket():
 
     def __repr__(self):
         status = ", ".join([
-            "Max Size (n)={}".format(self._n), "Milestone (r)={}".format(
-                self._cumul_r), "completed={:.1%}".format(
-                    self.completion_percentage())
+            "Max Size (n)={}".format(self._n),
+            "Milestone (r)={}".format(self._cumul_r),
+            "completed={:.1%}".format(self.completion_percentage())
         ])
         counts = collections.Counter([t.status for t in self._all_trials])
         trial_statuses = ", ".join(

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -370,12 +370,14 @@ class HyperbandSuite(unittest.TestCase):
             mock_runner._launch_trial(t)
 
         sched.on_trial_error(mock_runner, t3)
-        self.assertEqual(TrialScheduler.PAUSE,
-                         sched.on_trial_result(mock_runner, t1,
-                                               result(stats[str(1)]["r"], 10)))
-        self.assertEqual(TrialScheduler.CONTINUE,
-                         sched.on_trial_result(mock_runner, t2,
-                                               result(stats[str(1)]["r"], 10)))
+        self.assertEqual(
+            TrialScheduler.PAUSE,
+            sched.on_trial_result(mock_runner, t1,
+                                  result(stats[str(1)]["r"], 10)))
+        self.assertEqual(
+            TrialScheduler.CONTINUE,
+            sched.on_trial_result(mock_runner, t2,
+                                  result(stats[str(1)]["r"], 10)))
 
     def testTrialErrored2(self):
         """Check successive halving happened even when last trial failed"""
@@ -405,12 +407,14 @@ class HyperbandSuite(unittest.TestCase):
             mock_runner._launch_trial(t)
 
         sched.on_trial_complete(mock_runner, t3, result(1, 12))
-        self.assertEqual(TrialScheduler.PAUSE,
-                         sched.on_trial_result(mock_runner, t1,
-                                               result(stats[str(1)]["r"], 10)))
-        self.assertEqual(TrialScheduler.CONTINUE,
-                         sched.on_trial_result(mock_runner, t2,
-                                               result(stats[str(1)]["r"], 10)))
+        self.assertEqual(
+            TrialScheduler.PAUSE,
+            sched.on_trial_result(mock_runner, t1,
+                                  result(stats[str(1)]["r"], 10)))
+        self.assertEqual(
+            TrialScheduler.CONTINUE,
+            sched.on_trial_result(mock_runner, t2,
+                                  result(stats[str(1)]["r"], 10)))
 
     def testTrialEndedEarly2(self):
         """Check successive halving happened even when last trial failed"""
@@ -449,13 +453,13 @@ class HyperbandSuite(unittest.TestCase):
         self.assertEqual(len(sched._state["bracket"].current_trials()), 2)
 
         # Make sure that newly added trial gets fair computation (not just 1)
-        self.assertEqual(TrialScheduler.CONTINUE,
-                         sched.on_trial_result(mock_runner, t,
-                                               result(init_units, 12)))
+        self.assertEqual(
+            TrialScheduler.CONTINUE,
+            sched.on_trial_result(mock_runner, t, result(init_units, 12)))
         new_units = init_units + int(init_units * sched._eta)
-        self.assertEqual(TrialScheduler.PAUSE,
-                         sched.on_trial_result(mock_runner, t,
-                                               result(new_units, 12)))
+        self.assertEqual(
+            TrialScheduler.PAUSE,
+            sched.on_trial_result(mock_runner, t, result(new_units, 12)))
 
     def testAlternateMetrics(self):
         """Checking that alternate metrics will pass."""

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -174,8 +174,8 @@ class Trial(object):
         try:
             if error_msg and self.logdir:
                 self.num_failures += 1
-                error_file = os.path.join(self.logdir, "error_{}.txt".format(
-                    date_str()))
+                error_file = os.path.join(self.logdir,
+                                          "error_{}.txt".format(date_str()))
                 with open(error_file, "w") as f:
                     f.write(error_msg)
                 self.error_file = error_file
@@ -261,9 +261,10 @@ class Trial(object):
                 return '{} pid={}'.format(hostname, pid)
 
         pieces = [
-            '{} [{}]'.format(self._status_string(),
-                             location_string(self.last_result.hostname,
-                                             self.last_result.pid)),
+            '{} [{}]'.format(
+                self._status_string(),
+                location_string(self.last_result.hostname,
+                                self.last_result.pid)),
             '{} s'.format(int(self.last_result.time_total_s)), '{} ts'.format(
                 int(self.last_result.timesteps_total))
         ]
@@ -283,8 +284,10 @@ class Trial(object):
         return ', '.join(pieces)
 
     def _status_string(self):
-        return "{}{}".format(self.status, ", {} failures: {}".format(
-            self.num_failures, self.error_file) if self.error_file else "")
+        return "{}{}".format(
+            self.status, ", {} failures: {}".format(self.num_failures,
+                                                    self.error_file)
+            if self.error_file else "")
 
     def has_checkpoint(self):
         return self._checkpoint_path is not None or \

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -817,10 +817,9 @@ class Worker(object):
                                               e, None)
             return
         except Exception as e:
-            self._handle_process_task_failure(function_id, return_object_ids,
-                                              e,
-                                              ray.utils.format_error_message(
-                                                  traceback.format_exc()))
+            self._handle_process_task_failure(
+                function_id, return_object_ids, e,
+                ray.utils.format_error_message(traceback.format_exc()))
             return
 
         # Execute the task.
@@ -853,10 +852,9 @@ class Worker(object):
                     outputs = (outputs, )
                 self._store_outputs_in_objstore(return_object_ids, outputs)
         except Exception as e:
-            self._handle_process_task_failure(function_id, return_object_ids,
-                                              e,
-                                              ray.utils.format_error_message(
-                                                  traceback.format_exc()))
+            self._handle_process_task_failure(
+                function_id, return_object_ids, e,
+                ray.utils.format_error_message(traceback.format_exc()))
 
     def _handle_process_task_failure(self, function_id, return_object_ids,
                                      error, backtrace):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1017,14 +1017,14 @@ class ActorsWithGPUs(unittest.TestCase):
         def locations_to_intervals_for_many_tasks():
             # Launch a bunch of GPU tasks.
             locations_ids_and_intervals = ray.get([
-                f1.remote() for _ in range(
-                    5 * num_local_schedulers * num_gpus_per_scheduler)
+                f1.remote() for _ in range(5 * num_local_schedulers *
+                                           num_gpus_per_scheduler)
             ] + [
-                f2.remote() for _ in range(
-                    5 * num_local_schedulers * num_gpus_per_scheduler)
+                f2.remote() for _ in range(5 * num_local_schedulers *
+                                           num_gpus_per_scheduler)
             ] + [
-                f1.remote() for _ in range(
-                    5 * num_local_schedulers * num_gpus_per_scheduler)
+                f1.remote() for _ in range(5 * num_local_schedulers *
+                                           num_gpus_per_scheduler)
             ])
 
             locations_to_intervals = collections.defaultdict(lambda: [])
@@ -1087,8 +1087,9 @@ class ActorsWithGPUs(unittest.TestCase):
 
         # Create more actors to fill up all the GPUs.
         more_actors = [
-            Actor1.remote() for _ in range(
-                num_local_schedulers * num_gpus_per_scheduler - 1 - 3)
+            Actor1.remote()
+            for _ in range(num_local_schedulers * num_gpus_per_scheduler - 1 -
+                           3)
         ]
         # Wait for the actors to finish being created.
         ray.get([actor.get_location_and_ids.remote() for actor in more_actors])

--- a/test/array_test.py
+++ b/test/array_test.py
@@ -67,11 +67,12 @@ class DistributedArrayTest(unittest.TestCase):
         b = ra.zeros.remote([da.BLOCK_SIZE, da.BLOCK_SIZE])
         x = da.DistArray([2 * da.BLOCK_SIZE, da.BLOCK_SIZE],
                          np.array([[a], [b]]))
-        assert_equal(x.assemble(),
-                     np.vstack([
-                         np.ones([da.BLOCK_SIZE, da.BLOCK_SIZE]),
-                         np.zeros([da.BLOCK_SIZE, da.BLOCK_SIZE])
-                     ]))
+        assert_equal(
+            x.assemble(),
+            np.vstack([
+                np.ones([da.BLOCK_SIZE, da.BLOCK_SIZE]),
+                np.zeros([da.BLOCK_SIZE, da.BLOCK_SIZE])
+            ]))
 
     def testMethods(self):
         for module in [

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -372,9 +372,8 @@ class PutErrorTest(unittest.TestCase):
             # on the one before it. The result of the first task should get
             # evicted.
             args = []
-            arg = single_dependency.remote(0,
-                                           np.zeros(
-                                               object_size, dtype=np.uint8))
+            arg = single_dependency.remote(
+                0, np.zeros(object_size, dtype=np.uint8))
             for i in range(num_objects):
                 arg = single_dependency.remote(i, arg)
                 args.append(arg)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -180,12 +180,10 @@ LIST_OBJECTS = [[obj] for obj in BASE_OBJECTS]
 TUPLE_OBJECTS = [(obj, ) for obj in BASE_OBJECTS]
 # The check that type(obj).__module__ != "numpy" should be unnecessary, but
 # otherwise this seems to fail on Mac OS X on Travis.
-DICT_OBJECTS = (
-    [{
-        obj: obj
-    } for obj in PRIMITIVE_OBJECTS
-     if (obj.__hash__ is not None and type(obj).__module__ != "numpy")] +
-    [{
+DICT_OBJECTS = ([{
+    obj: obj
+} for obj in PRIMITIVE_OBJECTS if (
+    obj.__hash__ is not None and type(obj).__module__ != "numpy")] + [{
         0: obj
     } for obj in BASE_OBJECTS] + [{
         Foo(123): Foo(456)


### PR DESCRIPTION
## What do these changes do?

Everybody loves that sweet sweet (syntactic) sugar.

Since we typically care about the `.data` attribute, but may not want to just
subclass dict (I assume), we can use `dict`'s already implemented magic methods
to clean up syntax. These let us just treat rollouts more or less as dicts.

## Related issue number

None.

<!-- Are there any issues opened that will be resolved by merging this change? -->