### PR TITLE
[xray] Fix UniqueID hashing for object and task IDs.

### DIFF
--- a/src/ray/constants.h
+++ b/src/ray/constants.h
@@ -1,12 +1,16 @@
 #ifndef RAY_CONSTANTS_H_
 #define RAY_CONSTANTS_H_
 
+#include <limits.h>
+
 /// Length of Ray IDs in bytes.
 constexpr int64_t kUniqueIDSize = 20;
 
 /// An ObjectID's bytes are split into the task ID itself and the index of the
 /// object's creation. This is the maximum width of the object index in bits.
 constexpr int kObjectIdIndexSize = 32;
+static_assert(kObjectIdIndexSize % CHAR_BIT == 0, "ObjectID prefix not a multiple of bytes");
+
 /// The maximum number of objects that can be returned by a task when finishing
 /// execution. An ObjectID's bytes are split into the task ID itself and the
 /// index of the object's creation. A positive index indicates an object

--- a/src/ray/constants.h
+++ b/src/ray/constants.h
@@ -9,7 +9,8 @@ constexpr int64_t kUniqueIDSize = 20;
 /// An ObjectID's bytes are split into the task ID itself and the index of the
 /// object's creation. This is the maximum width of the object index in bits.
 constexpr int kObjectIdIndexSize = 32;
-static_assert(kObjectIdIndexSize % CHAR_BIT == 0, "ObjectID prefix not a multiple of bytes");
+static_assert(kObjectIdIndexSize % CHAR_BIT == 0,
+              "ObjectID prefix not a multiple of bytes");
 
 /// The maximum number of objects that can be returned by a task when finishing
 /// execution. An ObjectID's bytes are split into the task ID itself and the

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -1,5 +1,6 @@
 #include "ray/id.h"
 
+#include <limits.h>
 #include <random>
 
 #include "ray/constants.h"
@@ -83,7 +84,8 @@ bool UniqueID::operator==(const UniqueID &rhs) const {
 
 size_t UniqueID::hash() const {
   size_t result;
-  std::memcpy(&result, id_, sizeof(size_t));
+  // Skip the bytes for the object prefix.
+  std::memcpy(&result, id_ + (kObjectIdIndexSize / CHAR_BIT), sizeof(size_t));
   return result;
 }
 


### PR DESCRIPTION
## What do these changes do?

`ObjectID`s in xray share the same suffix as the ID of the task that created the objects. The prefix is the index of the object creation (0 for the task, <0 for objects created by `ray.put`, >0 for returned objects). Therefore, hashing on the prefix bytes will cause more collisions than expected. This PR skips the prefix for the `UniqueID` hash function.