### PR TITLE
[DataFrame] Improve performance of iteration methods

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2336,10 +2336,13 @@ class DataFrame(object):
         Returns:
             A generator that iterates over the rows of the frame.
         """
-        def iterrow_helper(part, i):
+        index_iter = iter([self._row_metadata.partition_series(i).index
+                           for i in range(len(self._row_partitions))])
+
+        def iterrow_helper(part):
             df = ray.get(part)
             df.columns = self.columns
-            df.index = self._row_metadata.partition_series(i).index
+            df.index = next(index_iter)
             return df.iterrows()
 
         partition_iterator = PartitionIterator(self._row_partitions,
@@ -2359,9 +2362,12 @@ class DataFrame(object):
         Returns:
             A generator that iterates over the columns of the frame.
         """
-        def items_helper(part, i):
+        col_iter = iter([self._col_metadata.partition_series(i).index
+                         for i in range(len(self._col_partitions))])
+
+        def items_helper(part):
             df = ray.get(part)
-            df.columns = self._col_metadata.partition_series(i).index
+            df.columns = next(col_iter)
             df.index = self.index
             return df.items()
 
@@ -2398,10 +2404,13 @@ class DataFrame(object):
         Returns:
             A tuple representing row data. See args for varying tuples.
         """
-        def itertuples_helper(part, i):
+        index_iter = iter([self._row_metadata.partition_series(i).index
+                           for i in range(len(self._row_partitions))])
+
+        def itertuples_helper(part):
             df = ray.get(part)
             df.columns = self.columns
-            df.index = self._row_metadata.partition_series(i).index
+            df.index = next(index_iter)
             return df.itertuples(index=index, name=name)
 
         partition_iterator = PartitionIterator(self._row_partitions,

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -2336,8 +2336,8 @@ class DataFrame(object):
         Returns:
             A generator that iterates over the rows of the frame.
         """
-        index_iter = iter([self._row_metadata.partition_series(i).index
-                           for i in range(len(self._row_partitions))])
+        index_iter = (self._row_metadata.partition_series(i).index
+                      for i in range(len(self._row_partitions)))
 
         def iterrow_helper(part):
             df = ray.get(part)
@@ -2362,8 +2362,8 @@ class DataFrame(object):
         Returns:
             A generator that iterates over the columns of the frame.
         """
-        col_iter = iter([self._col_metadata.partition_series(i).index
-                         for i in range(len(self._col_partitions))])
+        col_iter = (self._col_metadata.partition_series(i).index
+                    for i in range(len(self._col_partitions)))
 
         def items_helper(part):
             df = ray.get(part)
@@ -2404,8 +2404,8 @@ class DataFrame(object):
         Returns:
             A tuple representing row data. See args for varying tuples.
         """
-        index_iter = iter([self._row_metadata.partition_series(i).index
-                           for i in range(len(self._row_partitions))])
+        index_iter = (self._row_metadata.partition_series(i).index
+                      for i in range(len(self._row_partitions)))
 
         def itertuples_helper(part):
             df = ray.get(part)

--- a/python/ray/dataframe/iterator.py
+++ b/python/ray/dataframe/iterator.py
@@ -1,0 +1,33 @@
+class PartitionIterator(object):
+    def __init__(self, partitions, func):
+        """PartitionIterator class to define a generator on partitioned data
+
+        Args:
+            partitions ([ObjectID]): Partitions to iterate over
+            func (callable): The function to get inner iterables from
+                each partition
+        """
+        self.partitions = partitions
+        self.curr_partition = -1
+        self.func = func
+        self.iter_cache = iter([])
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        try:
+            n = next(self.iter_cache)
+            return n
+        except StopIteration:
+            self.curr_partition += 1
+            if self.curr_partition < len(self.partitions):
+                next_partition = self.partitions[self.curr_partition]
+            else:
+                raise StopIteration()
+
+            self.iter_cache = self.func(next_partition, self.curr_partition)
+            return self.next()

--- a/python/ray/dataframe/iterator.py
+++ b/python/ray/dataframe/iterator.py
@@ -1,4 +1,7 @@
-class PartitionIterator(object):
+import collections
+
+
+class PartitionIterator(collections.Iterator):
     def __init__(self, partitions, func):
         """PartitionIterator class to define a generator on partitioned data
 

--- a/python/ray/dataframe/iterator.py
+++ b/python/ray/dataframe/iterator.py
@@ -1,7 +1,7 @@
-import collections
+from collections import Iterator
 
 
-class PartitionIterator(collections.Iterator):
+class PartitionIterator(Iterator):
     def __init__(self, partitions, func):
         """PartitionIterator class to define a generator on partitioned data
 
@@ -10,8 +10,7 @@ class PartitionIterator(collections.Iterator):
             func (callable): The function to get inner iterables from
                 each partition
         """
-        self.partitions = partitions
-        self.curr_partition = -1
+        self.partitions = iter(partitions)
         self.func = func
         self.iter_cache = iter([])
 
@@ -23,14 +22,8 @@ class PartitionIterator(collections.Iterator):
 
     def next(self):
         try:
-            n = next(self.iter_cache)
-            return n
+            return next(self.iter_cache)
         except StopIteration:
-            self.curr_partition += 1
-            if self.curr_partition < len(self.partitions):
-                next_partition = self.partitions[self.curr_partition]
-            else:
-                raise StopIteration()
-
-            self.iter_cache = self.func(next_partition, self.curr_partition)
+            next_partition = next(self.partitions)
+            self.iter_cache = self.func(next_partition)
             return self.next()


### PR DESCRIPTION
## What do these changes do?

Make DataFrame iteration methods much more performant. Uses generators to iterate through row/column partitions and only fetches data as needed.

Performance Analysis:

New Performance:
```python
In [6]: df = pd.DataFrame(np.random.randint(0,100,size=(100000, 200)))

In [7]: %time x = list(df.iterrows())
CPU times: user 6.68 s, sys: 106 ms, total: 6.79 s
Wall time: 7.35 s

In [8]: %time x = list(df.items())
CPU times: user 162 ms, sys: 40 ms, total: 202 ms
Wall time: 511 ms

In [9]: %time x = list(df.itertuples())
CPU times: user 1.69 s, sys: 167 ms, total: 1.86 s
Wall time: 2.18 s
```

Old Performance:
```python
In [5]: df = pd.DataFrame(np.random.randint(0,100,size=(100000, 200)))

In [6]: %time x = list(df.iterrows())
CPU times: user 7min 16s, sys: 5.28 s, total: 7min 22s
Wall time: 7min 57s

In [7]: %time x = list(df.items())
CPU times: user 1.18 s, sys: 412 ms, total: 1.59 s
Wall time: 3.13 s

In [8]: %time x = list(df.itertuples())
CPU times: user 5.45 s, sys: 515 ms, total: 5.97 s
Wall time: 9.81 s
```

Standard Pandas Performance:
```python
In [4]: df = pd.DataFrame(np.random.randint(0,100,size=(100000, 200)))

In [5]: %time x = list(df.iterrows())
CPU times: user 6.44 s, sys: 107 ms, total: 6.54 s
Wall time: 6.58 s

In [6]: %time x = list(df.items())
CPU times: user 128 ms, sys: 29.9 ms, total: 158 ms
Wall time: 163 ms

In [7]: %time x = list(df.itertuples())
CPU times: user 2.63 s, sys: 176 ms, total: 2.81 s
Wall time: 2.9 s
```

## Related issue number

#2025 
