### PR TITLE
[DataFrame] Fixing bugs in groupby

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -634,6 +634,9 @@ class DataFrame(object):
         elif isinstance(by, compat.string_types):
             by = self.__getitem__(by).values.tolist()
         elif is_list_like(by):
+            if isinstance(by, pd.Series):
+                by = by.values.tolist()
+
             mismatch = len(by) != len(self) if axis == 0 \
                 else len(by) != len(self.columns)
 

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import pandas.core.groupby
-import numpy as np
 import pandas as pd
 from pandas.core.dtypes.common import is_list_like
 import ray

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -34,7 +34,7 @@ class DataFrameGroupBy(object):
             self._index_grouped = pd.Series(self._columns, index=self._index)\
                 .groupby(by=by, sort=sort)
 
-        self._keys_and_values = [(k, np.array(v))
+        self._keys_and_values = [(k, v)
                                  for k, v in self._index_grouped]
 
         self._grouped_partitions = \
@@ -44,7 +44,7 @@ class DataFrameGroupBy(object):
                                              as_index,
                                              sort,
                                              group_keys,
-                                             squeeze) + part,
+                                             squeeze) + tuple(part.tolist()),
                                        num_return_vals=len(self))
                        for part in partitions)))
 


### PR DESCRIPTION
Fixing a few bugs in `groupby`:

Passing a `df.column_name` to `groupby` as the `by` parameter gave a `ValueError: buffer source array is read-only`. We fix this by extracting the values (those are all we need anyway).

Also fixing a bug where we try to append the `tuple` partition to the list of args.

Finally, I found a bug where we were trying to access the value in `keys_and_values` as a Series still, so it no longer needs to be a `np.array`.