### PR TITLE
Allow Ray API to be used from multiple threads.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -471,7 +471,6 @@ def export_actor(actor_id, class_id, class_name, actor_method_names,
             quantity of that resource required by the actor.
         actor_method_cpus: The number of CPUs required by actor methods.
     """
-    ray.worker.check_main_thread()
     if worker.mode is None:
         raise Exception("Actors cannot be created before Ray has been "
                         "started. You can start Ray with 'ray.init()'.")
@@ -787,7 +786,6 @@ class ActorHandle(object):
                 method.
         """
         ray.worker.check_connected()
-        ray.worker.check_main_thread()
         function_signature = self._ray_method_signatures[method_name]
         if args is None:
             args = []
@@ -947,7 +945,6 @@ class ActorHandle(object):
                 the actor handle and false if it is being called by pickling.
         """
         ray.worker.check_connected()
-        ray.worker.check_main_thread()
 
         if state["ray_forking"]:
             actor_handle_id = compute_actor_handle_id(

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -4,6 +4,7 @@ import os
 import re
 import string
 import sys
+import threading
 import time
 import unittest
 from collections import defaultdict, namedtuple, OrderedDict
@@ -1017,6 +1018,25 @@ class APITest(unittest.TestCase):
         # Verify that we cannot call get on a regular value.
         with self.assertRaises(Exception):
             ray.get(3)
+
+    def testMultithreading(self):
+        self.init_ray(driver_mode=ray.SILENT_MODE)
+
+        @ray.remote
+        def f():
+            pass
+
+        def g(n):
+            for _ in range(1000 // n):
+                ray.get([f.remote() for _ in range(n)])
+
+        threads = [
+            threading.Thread(target=g, args=(n, ))
+            for n in [1, 5, 10, 100, 1000]
+        ]
+
+        [thread.start() for thread in threads]
+        [thread.join() for thread in threads]
 
 
 class APITestSharded(APITest):


### PR DESCRIPTION
The goal of this PR is to allow the Ray API to be used from multiple threads.

This simply locks the thread unsafe things (just reads/writes on sockets to the other processes like the object store).

Before merging:

- [ ] Check the performance implications of doing this (basically how expensive is it to acquire and release a lock from a single thread when there is no contention).

cc @twanthony @ericl 