### PR TITLE
Use JobID::nil() for GCS client.

### DIFF
--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -58,7 +58,7 @@ ray::Status ObjectDirectory::GetLocations(const ObjectID &object_id,
 };
 
 ray::Status ObjectDirectory::ExecuteGetLocations(const ObjectID &object_id) {
-  JobID job_id = JobID::from_random();
+  JobID job_id = JobID::nil();
   // Note: Lookup must be synchronous for thread-safe access.
   // For now, this is only accessed by the main thread.
   ray::Status status = gcs_client_->object_table().Lookup(


### PR DESCRIPTION
This PR uses `JobID::nil()` with the GCS client. This is okay since the job id is not needed, and reduces object transfer overhead observed during profiling.