### PR TITLE
Use more CPUs for testMultipleWaitsAndGets.

### DIFF
--- a/test/runtest.py
+++ b/test/runtest.py
@@ -788,7 +788,7 @@ class APITest(unittest.TestCase):
     def testMultipleWaitsAndGets(self):
         # It is important to use three workers here, so that the three tasks
         # launched in this experiment can run at the same time.
-        self.init_ray()
+        self.init_ray(num_cpus=3)
 
         @ray.remote
         def f(delay):


### PR DESCRIPTION
This might address #776.