### PR TITLE
[xray] Fix bug in updating actor execution dependencies

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -627,10 +627,11 @@ void NodeManager::AssignTask(Task &task) {
       // guarantee deterministic reconstruction ordering for tasks whose
       // updates are reflected in the task table.
       auto execution_dependency = actor_entry->second.GetExecutionDependency();
+      // If the execution dependency is nil, then this is the first task to
+      // run on the actor, which has no dependencies.
       if (!execution_dependency.is_nil()) {
         TaskExecutionSpecification &mutable_spec = task.GetTaskExecutionSpec();
-        mutable_spec.SetExecutionDependencies(
-            {actor_entry->second.GetExecutionDependency()});
+        mutable_spec.SetExecutionDependencies({execution_dependency});
       }
       actor_entry->second.ExtendFrontier(spec.ActorHandleId(), spec.ActorDummyObject());
     }

--- a/src/ray/raylet/task_execution_spec.cc
+++ b/src/ray/raylet/task_execution_spec.cc
@@ -32,6 +32,7 @@ std::vector<ObjectID> TaskExecutionSpecification::ExecutionDependencies() const 
 
 void TaskExecutionSpecification::SetExecutionDependencies(
     const std::vector<ObjectID> &dependencies) {
+  execution_spec_.dependencies.clear();
   for (const auto &dependency : dependencies) {
     execution_spec_.dependencies.push_back(dependency.binary());
   }


### PR DESCRIPTION
## What do these changes do?

Actor execution dependencies are used to schedule actor methods in the correct order. They are updated each time a method is assigned to reflect execution order. This fixes two bugs in the code to update the execution dependencies. The first updated the actor information before updating the execution dependency for a method, causing the method to become dependent on itself. The second did not clear previous execution dependencies when resetting them.