### PR TITLE
[DataFrame] Update _inherit_docstrings

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -49,7 +49,8 @@ from .index_metadata import _IndexMetadata
 from .iterator import PartitionIterator
 
 
-@_inherit_docstrings(pd.DataFrame)
+@_inherit_docstrings(pd.DataFrame,
+                     excluded=[pd.DataFrame, pd.DataFrame.__init__])
 class DataFrame(object):
 
     def __init__(self, data=None, index=None, columns=None, dtype=None,

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -13,7 +13,7 @@ from .utils import _inherit_docstrings
 
 @_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy,
                      excluded=[pandas.core.groupby.DataFrameGroupBy,
-                               pandas.core.groupby.DataFrameGroupBy])
+                               pandas.core.groupby.DataFrameGroupBy.__init__])
 class DataFrameGroupBy(object):
 
     def __init__(self, df, by, axis, level, as_index, sort, group_keys,

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -11,7 +11,9 @@ from .utils import _map_partitions
 from .utils import _inherit_docstrings
 
 
-@_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy)
+@_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy,
+                     excluded=[pandas.core.groupby.DataFrameGroupBy,
+                               pandas.core.groupby.DataFrameGroupBy])
 class DataFrameGroupBy(object):
 
     def __init__(self, df, by, axis, level, as_index, sort, group_keys,

--- a/python/ray/dataframe/series.py
+++ b/python/ray/dataframe/series.py
@@ -14,7 +14,7 @@ def na_op():
     raise NotImplementedError("Not Yet implemented.")
 
 
-@_inherit_docstrings(pd.Series)
+@_inherit_docstrings(pd.Series, excluded=[pd.Series, pd.Series.__init__])
 class Series(object):
 
     def __init__(self, series_oids):

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -321,34 +321,29 @@ def _blocks_to_row(*partition):
     return row_part
 
 
-def _inherit_docstrings(parent):
+def _inherit_docstrings(parent, excluded=[]):
     """Creates a decorator which overwrites a decorated class' __doc__
     attribute with parent's __doc__ attribute. Also overwrites __doc__ of
     methods and properties defined in the class with the __doc__ of matching
-    methods in parent.
+    methods and properties in parent.
 
     Args:
         parent (object): Class from which the decorated class inherits __doc__.
-
-    Note:
-        Currently does not override class' __doc__ or __init__'s __doc__.
-
-    Todo:
-        Override the class' __doc__ and __init__'s __doc__  once DataFrame's
-            __init__ method matches pandas.DataFrame's __init__ method.
+        excluded (list): List of parent objects from which the class does not
+            inherit docstrings.
 
     Returns:
         function: decorator which replaces the decorated class' documentation
             parent's documentation.
     """
     def decorator(cls):
-        # cls.__doc__ = parent.__doc__
+        if parent not in excluded:
+            cls.__doc__ = parent.__doc__
         for attr, obj in cls.__dict__.items():
-            if attr == "__init__":
-                continue
             parent_obj = getattr(parent, attr, None)
-            if not callable(parent_obj) and \
-                    not isinstance(parent_obj, property):
+            if parent_obj in excluded or \
+                    (not callable(parent_obj) and
+                     not isinstance(parent_obj, property)):
                 continue
             if callable(obj):
                 obj.__doc__ = parent_obj.__doc__


### PR DESCRIPTION
Improves the API for `_inherit_docstrings`:
- No longer ignores a class' `__doc__` attribute and `__init__.__doc__` by default.
- Adds an `excluded` argument which does not inherit documentation from all listed objects.
- Updates `_inherit_docstrings` decorator for `DataFrame`, `Series`, and `DataFrameGroupBy`.