### PR TITLE
Fix compilation error for RAY_USE_NEW_GCS with latest clang.

### DIFF
--- a/src/plasma/plasma_manager.cc
+++ b/src/plasma/plasma_manager.cc
@@ -1333,7 +1333,7 @@ void log_object_hash_mismatch_error_result_callback(ObjectID object_id,
         log_object_hash_mismatch_error_task_callback(task, user_context);
         Task_free(task);
       },
-      [user_context](gcs::AsyncGcsClient *, const TaskID &) {
+      [](gcs::AsyncGcsClient *, const TaskID &) {
         // TODO(pcmoritz): Handle failure.
       }));
 #endif


### PR DESCRIPTION
Fixes

```
    [ 87%] Building CXX object src/local_scheduler/CMakeFiles/local_scheduler_library.dir/local_scheduler_extension.cc.o
    /Users/rkn/Workspace/ray/src/plasma/plasma_manager.cc:1336:8: error: lambda capture 'user_context' is not used [-Werror,-Wunused-lambda-capture]
          [user_context](gcs::AsyncGcsClient *, const TaskID &) {
           ^
```