### PR TITLE
[DataFrame] Fix bug with consistency between IndexMetadata and partitions

### DIFF
--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -460,4 +460,11 @@ def _correct_column_dtypes(*column):
     Args:
     """
     concat_column = pd.concat(column, copy=False)
-    return create_blocks_helper(concat_column, len(column), 1)
+    partitions = []
+    i = 0
+    for old_part in column:
+        new_part = concat_column.iloc[i:i + len(old_part)]
+        new_part.index = pd.RangeIndex(0, len(new_part))
+        partitions.append(new_part)
+        i += len(new_part)
+    return partitions


### PR DESCRIPTION
Calling `_correct_column_dtypes` rebuilds partitions using `create_blocks_helper`. However, `create_blocks_helper` creates partitions of equal size which results in an inconsistency between `IndexMetadata` and column partitions. This PR aims to fix the issue by ensuring that `_correct_column_dtypes` constructs partitions of the same size as before.

Code which demonstrates the bug:
```python
import ray
import ray.dataframe as rdf
df = rdf.DataFrame({"col": list(range(1000000))})
df.to_csv("test_df.csv")
read_df = rdf.read_csv("test_df.csv")
print(read_df._row_metadata._lengths) 
print(ray.get(rdf.utils._map_partitions(lambda df: len(df), read_df._row_partitions)))
```