### PR TITLE
Use source code in hash where possible (fix #2089)

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -32,7 +32,7 @@ def compute_function_id(function):
         # in the hash.
         source = inspect.getsource(function).encode("ascii")
         function_id_hash.update(source)
-    except OSError:
+    except (IOError, OSError):
         # Source code may not be available: e.g. Cython or Python interpreter.
         pass
     # Compute the function ID.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -14,15 +14,6 @@ DEFAULT_REMOTE_FUNCTION_NUM_RETURN_VALS = 1
 DEFAULT_REMOTE_FUNCTION_MAX_CALLS = 0
 
 
-def in_ipython():
-    """Return true if we are in an IPython interpreter and false otherwise."""
-    try:
-        __IPYTHON__
-        return True
-    except NameError:
-        return False
-
-
 def compute_function_id(function):
     """Compute an function ID for a function.
 
@@ -36,14 +27,14 @@ def compute_function_id(function):
     # Include the function module and name in the hash.
     function_id_hash.update(function.__module__.encode("ascii"))
     function_id_hash.update(function.__name__.encode("ascii"))
-    # If we are running a script or are in IPython, include the source code in
-    # the hash. If we are in a regular Python interpreter we skip this part
-    # because the source code is not accessible. If the function is a built-in
-    # (e.g., Cython), the source code is not accessible.
-    import __main__ as main
-    if (hasattr(main, "__file__") or in_ipython()) \
-            and inspect.isfunction(function):
-        function_id_hash.update(inspect.getsource(function).encode("ascii"))
+    try:
+        # If we are running a script or are in IPython, include the source code
+        # in the hash.
+        source = inspect.getsource(function).encode("ascii")
+        function_id_hash.update(source)
+    except OSError:
+        # Source code may not be available: e.g. Cython or Python interpreter.
+        pass
     # Compute the function ID.
     function_id = function_id_hash.digest()
     assert len(function_id) == 20

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -32,7 +32,7 @@ def compute_function_id(function):
         # in the hash.
         source = inspect.getsource(function).encode("ascii")
         function_id_hash.update(source)
-    except (IOError, OSError):
+    except (IOError, OSError, TypeError):
         # Source code may not be available: e.g. Cython or Python interpreter.
         pass
     # Compute the function ID.


### PR DESCRIPTION
## What do these changes do?

Rather than attempting to infer when source code for a function is available, we always try and omit it only if we find an inspection.

## Related issue number

Fixes #2089 and maybe #1446 (do not have the setup to confirm)
