### PR TITLE
bugfix: use array redis_primary_addr out of its scope

### DIFF
--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -1566,8 +1566,6 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  char *redis_addr = NULL;
-  int redis_port = -1;
   if (!redis_primary_addr_port) {
     /* Start the local scheduler without connecting to Redis. In this case, all
      * submitted tasks will be queued and scheduled locally. */
@@ -1589,13 +1587,12 @@ int main(int argc, char *argv[]) {
       RAY_LOG(FATAL) << "please specify socket for connecting to Plasma "
                      << "manager with -m switch";
     }
-    redis_addr = redis_primary_addr;
-    redis_port = redis_primary_port;
+    start_server(node_ip_address, scheduler_socket_name,
+                 redis_primary_addr, redis_primary_port,
+                 plasma_store_socket_name, plasma_manager_socket_name,
+                 plasma_manager_address, global_scheduler_exists,
+                 static_resource_conf, start_worker_command, num_workers);
   }
 
-  start_server(node_ip_address, scheduler_socket_name, redis_addr, redis_port,
-               plasma_store_socket_name, plasma_manager_socket_name,
-               plasma_manager_address, global_scheduler_exists,
-               static_resource_conf, start_worker_command, num_workers);
 }
 #endif


### PR DESCRIPTION
Problem:
*array ```redis_primary_addr``` is in the 'else' block, but are referenced by ```redis_addr``` out of this scope.

Solution:
*since the "if" block won't use redis_addr, inline it.