### PR TITLE
[rllib] Make more Python 3.7 friendly

### DIFF
--- a/python/ray/rllib/a3c/a3c_evaluator.py
+++ b/python/ray/rllib/a3c/a3c_evaluator.py
@@ -45,7 +45,7 @@ class A3CEvaluator(PolicyEvaluator):
                         "rew_filter": self.rew_filter}
         self.sampler = AsyncSampler(env, self.policy, self.obs_filter,
                                     config["batch_size"])
-        if start_sampler and self.sampler.async:
+        if start_sampler and self.sampler._async:
             self.sampler.start()
         self.logdir = logdir
 

--- a/python/ray/rllib/utils/sampler.py
+++ b/python/ray/rllib/utils/sampler.py
@@ -90,7 +90,7 @@ class SyncSampler(object):
 
     This class provides data on invocation, rather than on a separate
     thread."""
-    async = False
+    _async = False
 
     def __init__(self, env, policy, obs_filter, num_local_steps, horizon=None):
         self.num_local_steps = num_local_steps
@@ -126,7 +126,7 @@ class AsyncSampler(threading.Thread):
 
     Note that batch_size is only a unit of measure here. Batches can
     accumulate and the gradient can be calculated on up to 5 batches."""
-    async = True
+    _async = True
 
     def __init__(self, env, policy, obs_filter, num_local_steps, horizon=None):
         assert getattr(


### PR DESCRIPTION
## What do these changes do?

`async` and `await` are reserved words in Python 3.7, and will give a syntax error,
so we use `_async` instead.

## Related issue number

#1115

<!-- Are there any issues opened that will be resolved by merging this change? -->