### PR TITLE
[DataFrame] Refactor GroupBy Methods and Implement Reindex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,6 @@ matrix:
         - python -m pytest python/ray/dataframe/test/test_io.py
         # - python -m pytest python/ray/dataframe/test/test_groupby.py
 
-
         # ray tune tests
         # - python python/ray/tune/test/dependency_test.py
         # - python -m pytest python/ray/tune/test/trial_runner_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,8 @@ matrix:
         # - python -m pytest python/ray/dataframe/test/test_dataframe.py
         - python -m pytest python/ray/dataframe/test/test_concat.py
         - python -m pytest python/ray/dataframe/test/test_io.py
+        # - python -m pytest python/ray/dataframe/test/test_groupby.py
+
 
         # ray tune tests
         # - python python/ray/tune/test/dependency_test.py
@@ -199,6 +201,7 @@ script:
   - python -m pytest python/ray/dataframe/test/test_dataframe.py
   - python -m pytest python/ray/dataframe/test/test_concat.py
   - python -m pytest python/ray/dataframe/test/test_io.py
+  - python -m pytest python/ray/dataframe/test/test_groupby.py
 
   # ray tune tests
   - python python/ray/tune/test/dependency_test.py

--- a/python/ray/dataframe/concat.py
+++ b/python/ray/dataframe/concat.py
@@ -41,9 +41,9 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     all_series = all(isinstance(obj, pandas.Series)
                      for obj in objs)
     if all_series:
-        return pandas.concat(objs, axis, join, join_axes,
-                             ignore_index, keys, levels, names,
-                             verify_integrity, copy)
+        return DataFrame(pandas.concat(objs, axis, join, join_axes,
+                                       ignore_index, keys, levels, names,
+                                       verify_integrity, copy))
 
     if isinstance(objs, dict):
         raise NotImplementedError(

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1028,12 +1028,12 @@ class DataFrame(object):
                                           cols,
                                           *args,
                                           **kwargs),
-                                          part), num_return_vals=4)
+                                      part), num_return_vals=4)
                  for cols, part in zip(columns, self._col_partitions)]
 
         if axis == 1:
             indexes = [self._row_metadata.partition_series(i).index
-                     for i in range(len(self._row_partitions))]
+                       for i in range(len(self._row_partitions))]
             columns = self.columns
 
             remote_result = \
@@ -1044,7 +1044,7 @@ class DataFrame(object):
                                           columns,
                                           *args,
                                           **kwargs),
-                                          part), num_return_vals=4)
+                                      part), num_return_vals=4)
                  for index, part in zip(indexes, self._row_partitions)]
 
         # This magic transposes the list comprehension returned from remote

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1069,7 +1069,8 @@ class DataFrame(object):
         elif axis == 0:
             new_index = ray.get(index[0])
             # This does not handle the Multi Index case
-            new_columns = pd.Index([i for j in ray.get(columns) for i in j])
+            new_columns = ray.get(columns)
+            new_columns = new_columns[0].append(new_columns[1:])
 
             return DataFrame(col_partitions=new_parts,
                              columns=new_columns,
@@ -1077,7 +1078,8 @@ class DataFrame(object):
         else:
             new_columns = ray.get(columns[0])
             # This does not handle the Multi Index case
-            new_index = pd.Index([i for j in ray.get(index) for i in j])
+            new_index = ray.get(index)
+            new_index = new_index[0].append(new_index[1:])
 
             return DataFrame(row_partitions=new_parts,
                              columns=new_columns,

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -29,7 +29,6 @@ import io
 import sys
 import re
 
-from .groupby import DataFrameGroupBy
 from .utils import (
     _deploy_func,
     _map_partitions,
@@ -143,15 +142,6 @@ class DataFrame(object):
                 self._block_partitions = \
                     _create_block_partitions(partitions, axis=axis,
                                              length=axis_length)
-
-        # Sometimes we only get a single column or row, which is
-        # problematic for building blocks from the partitions, so we
-        # add whatever dimension we're missing from the input.
-        if self._block_partitions.ndim < 2:
-            self._block_partitions = np.expand_dims(self._block_partitions,
-                                                    axis=axis ^ 1)
-
-        assert self._block_partitions.ndim == 2, "Block Partitions must be 2D."
 
         # Create the row and column index objects for using our partitioning.
         # If the objects haven't been inherited, then generate them
@@ -656,6 +646,8 @@ class DataFrame(object):
         Returns:
             A new DataFrame resulting from the groupby.
         """
+        from .groupby import DataFrameGroupBy
+
         axis = pd.DataFrame()._get_axis_number(axis)
         if callable(by):
             by = by(self.index)

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -649,6 +649,7 @@ class DataFrame(object):
         from .groupby import DataFrameGroupBy
 
         axis = pd.DataFrame()._get_axis_number(axis)
+
         if callable(by):
             by = by(self.index)
         elif isinstance(by, compat.string_types):

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -988,8 +988,7 @@ class DataFrame(object):
         raise ValueError("{} is an unknown string function".format(func))
 
     def _callable_function(self, func, axis, *args, **kwargs):
-        if axis == 1:
-            kwargs['axis'] = axis
+        kwargs['axis'] = axis
 
         def agg_helper(df, arg, index, columns, *args, **kwargs):
             df.index = index

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -1068,16 +1068,16 @@ class DataFrame(object):
         # remote objects. We build a Ray DataFrame from the Pandas partitions.
         elif axis == 0:
             new_index = ray.get(index[0])
-            new_columns = ray.get(columns)
-            new_columns = [i for j in new_columns for i in j]
+            # This does not handle the Multi Index case
+            new_columns = pd.Index([i for j in ray.get(columns) for i in j])
 
             return DataFrame(col_partitions=new_parts,
                              columns=new_columns,
                              index=new_index)
         else:
             new_columns = ray.get(columns[0])
-            new_index = ray.get(index)
-            new_index = [i for j in new_index for i in j]
+            # This does not handle the Multi Index case
+            new_index = pd.Index([i for j in ray.get(index) for i in j])
 
             return DataFrame(row_partitions=new_parts,
                              columns=new_columns,
@@ -3367,7 +3367,7 @@ class DataFrame(object):
 
             new_df = DataFrame(col_partitions=new_cols,
                                columns=new_df.columns,
-                               index=index,
+                               index=pd.Index(index),
                                col_metadata=new_df._col_metadata)
 
         if columns is not None:
@@ -3385,7 +3385,7 @@ class DataFrame(object):
                                        new_df._row_partitions)
 
             new_df = DataFrame(row_partitions=new_rows,
-                               columns=columns,
+                               columns=pd.Index(columns),
                                index=new_df.index,
                                row_metadata=new_df._row_metadata)
 

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -3344,10 +3344,10 @@ class DataFrame(object):
                 "github.com/ray-project/ray.")
 
         axis = pd.DataFrame()._get_axis_number(axis) if axis is not None \
-            else None
-        if axis == 0:
+            else 0
+        if axis == 0 and labels is not None:
             index = labels
-        elif axis == 1:
+        elif labels is not None:
             columns = labels
 
         new_df = self

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -50,7 +50,8 @@ class DataFrameGroupBy(object):
                                                  as_index,
                                                  sort,
                                                  group_keys,
-                                                 squeeze) + tuple(part.tolist()),
+                                                 squeeze)
+                                           + tuple(part.tolist()),
                                            num_return_vals=len(self))
                            for part in partitions)))
         else:

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -384,7 +384,7 @@ class DataFrameGroupBy(object):
 
         if self._axis == 0:
             index_head = [v[:n] for k, v in self._keys_and_values]
-            flattened_index = set([i for j in index_head for i in j])
+            flattened_index = set(i for j in index_head for i in j)
             sorted_index = [i for i in self._index if i in flattened_index]
             new_df._block_partitions = np.array([_reindex_helper._submit(
                 args=tuple([new_df.index, sorted_index, 1,
@@ -439,7 +439,7 @@ class DataFrameGroupBy(object):
 
         if self._axis == 0:
             index_tail = [v[-n:] for k, v in self._keys_and_values]
-            flattened_index = set([i for j in index_tail for i in j])
+            flattened_index = set(i for j in index_tail for i in j)
             sorted_index = [i for i in self._index if i in flattened_index]
             new_df._block_partitions = np.array([_reindex_helper._submit(
                 args=tuple([new_df.index, sorted_index, 1,

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -10,7 +10,6 @@ import pandas.core.common as com
 import ray
 
 from .utils import _inherit_docstrings
-from .dataframe import DataFrame
 from .concat import concat
 
 
@@ -139,15 +138,15 @@ class DataFrameGroupBy(object):
             result = result.apply(lambda v: index[v])
             return result
 
-        results = [DataFrame(idxmax_helper(g[1], i[1])).T
+        results = [idxmax_helper(g[1], i[1])
                    for g, i in zip(self._iter, self._index_grouped)]
 
-        new_df = concat(results)
+        new_df = concat(results, axis=1)
         if self._axis == 0:
+            new_df = new_df.T
             new_df.columns = self._columns
             new_df.index = [k for k, v in self._iter]
         else:
-            new_df = new_df.T
             new_df.columns = [k for k, v in self._iter]
             new_df.index = self._index
         return new_df
@@ -196,8 +195,7 @@ class DataFrameGroupBy(object):
         if self._axis == 0:
             if isinstance(result[0], pd.Series):
                 # Applied an aggregation function
-                result = [DataFrame(x).T for x in result]
-                new_df = concat(result)
+                new_df = concat(result, axis=1).T
                 new_df.columns = self._columns
                 new_df.index = [k for k, v in self._iter]
             else:
@@ -206,9 +204,7 @@ class DataFrameGroupBy(object):
         else:
             if isinstance(result[0], pd.Series):
                 # Applied an aggregation function
-                result = [DataFrame(x).T for x in result]
-                new_df = concat(result)
-                new_df = new_df.T
+                new_df = concat(result, axis=1)
                 new_df.columns = [k for k, v in self._iter]
                 new_df.index = self._index
             else:
@@ -250,15 +246,15 @@ class DataFrameGroupBy(object):
             result = result.apply(lambda v: index[v])
             return result
 
-        results = [DataFrame(idxmin_helper(g[1], i[1])).T
+        results = [idxmin_helper(g[1], i[1])
                    for g, i in zip(self._iter, self._index_grouped)]
 
-        new_df = concat(results)
+        new_df = concat(results, axis=1)
         if self._axis == 0:
+            new_df = new_df.T
             new_df.columns = self._columns
             new_df.index = [k for k, v in self._iter]
         else:
-            new_df = new_df.T
             new_df.columns = [k for k, v in self._iter]
             new_df.index = self._index
         return new_df
@@ -467,15 +463,14 @@ class DataFrameGroupBy(object):
     def _apply_agg_function(self, f):
         assert callable(f), "\'{0}\' object is not callable".format(type(f))
 
+        result = [f(v) for k, v in self._iter]
+        new_df = concat(result, axis=1)
+
         if self._axis == 0:
-            result = [DataFrame(f(v)).T for k, v in self._iter]
-            new_df = concat(result)
+            new_df = new_df.T
             new_df.columns = self._columns
             new_df.index = [k for k, v in self._iter]
         else:
-            result = [DataFrame(f(v)).T for k, v in self._iter]
-            new_df = concat(result)
-            new_df = new_df.T
             new_df.columns = [k for k, v in self._iter]
             new_df.index = self._index
         return new_df

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pandas.core.groupby
 import pandas as pd
+import pandas.core.groupby
 from pandas.core.dtypes.common import is_list_like
+import pandas.core.common as com
+
 import ray
 
-from .utils import _map_partitions
 from .utils import _inherit_docstrings
 from .dataframe import DataFrame
 from .concat import concat
@@ -97,17 +98,25 @@ class DataFrameGroupBy(object):
 
     @property
     def plot(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def ohlc(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def __bytes__(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     @property
     def tshift(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     @property
     def groups(self):
@@ -141,10 +150,14 @@ class DataFrameGroupBy(object):
         return 2  # ndim is always 2 for DataFrames
 
     def shift(self, periods=1, freq=None, axis=0):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def nth(self, n, dropna=None):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def cumsum(self, axis=0, *args, **kwargs):
         return self._apply_df_function(lambda df: df.cumsum(axis,
@@ -160,7 +173,9 @@ class DataFrameGroupBy(object):
             lambda df: df.pct_change(axis=self._axis))
 
     def filter(self, func, dropna=True, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def cummax(self, axis=0, **kwargs):
         return self._apply_df_function(lambda df: df.cummax(axis,
@@ -187,12 +202,10 @@ class DataFrameGroupBy(object):
                 result = [DataFrame(x).T for x in result]
                 new_df = concat(result)
                 new_df = new_df.T
-                print(new_df)
                 new_df.columns = [k for k, v in self._iter]
                 new_df.index = self._index
             else:
                 new_df = concat(result, axis=1)
-                print(new_df)
                 new_df.reindex(self._columns, axis=1, copy=False)
 
         return new_df
@@ -212,7 +225,9 @@ class DataFrameGroupBy(object):
 
     def __getitem__(self, key):
         # This operation requires a SeriesGroupBy Object
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def cummin(self, axis=0, **kwargs):
         return self._apply_df_function(lambda df: df.cummin(axis=axis,
@@ -268,31 +283,40 @@ class DataFrameGroupBy(object):
                                                           **kwargs))
 
     def last(self, **kwargs):
-        return self._apply_df_function(lambda df: df.last(**kwargs))
+        return self._apply_df_function(lambda df: df.last(offset=0,
+                                                          **kwargs))
 
     def mad(self):
         return self._apply_agg_function(lambda df: df.mad())
 
     def rank(self):
-        return self._apply_df_function(lambda df: df.rank())
+        return self._apply_df_function(lambda df: df.rank(axis=self._axis))
 
     @property
     def corrwith(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def pad(self, limit=None):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def max(self, **kwargs):
-        return self._apply_agg_function(lambda df: df.max(**kwargs))
+        return self._apply_agg_function(lambda df: df.max(axis=self._axis,
+                                                          **kwargs))
 
     def var(self, ddof=1, *args, **kwargs):
-        return self._apply_agg_function(lambda df: df.var(ddof,
+        return self._apply_agg_function(lambda df: df.var(ddof=ddof,
+                                                          axis=self._axis,
                                                           *args,
                                                           **kwargs))
 
     def get_group(self, name, obj=None):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def __len__(self):
         return len(self._keys_and_values)
@@ -308,29 +332,46 @@ class DataFrameGroupBy(object):
                                         df.sum(axis=self._axis, **kwargs))
 
     def __unicode__(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def describe(self, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def boxplot(self, grouped, subplots=True, column=None, fontsize=None,
                 rot=0, grid=True, ax=None, figsize=None, layout=None, **kwds):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def ngroup(self, ascending=True):
         return self._index_grouped.ngroup(ascending)
 
     def nunique(self, dropna=True):
-        return self._apply_agg_function(lambda df: df.nunique(dropna))
+        return self._apply_agg_function(lambda df: df.nunique(dropna=dropna,
+                                                              axis=self._axis))
 
     def resample(self, rule, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def median(self, **kwargs):
-        return self._apply_agg_function(lambda df: df.median(**kwargs))
+        return self._apply_agg_function(lambda df: df.median(axis=self._axis,
+                                                             **kwargs))
 
     def head(self, n=5):
-        return self._apply_df_function(lambda df: df.head(n))
+        result = [v.head(n) for k, v in self._iter]
+        new_df = concat(result, axis=self._axis)
+
+        if self._axis == 0:
+            new_index = [v[:n] for k, v in self._keys_and_values]
+            new_df.index = [i for j in new_index for i in j]
+
+        return new_df
 
     def cumprod(self, axis=0, *args, **kwargs):
         return self._apply_df_function(lambda df: df.cumprod(axis,
@@ -347,50 +388,71 @@ class DataFrameGroupBy(object):
         return self._apply_agg_function(lambda df: df.cov())
 
     def transform(self, func, *args, **kwargs):
-        from .concat import concat
-
-        new_parts = concat([v.transform(func, *args, **kwargs)
-                            for k, v in self._iter])
-        return new_parts
+        return self._apply_df_function(lambda df: df.transform(func,
+                                                               *args,
+                                                               **kwargs))
 
     def corr(self, **kwargs):
         return self._apply_agg_function(lambda df: df.corr(**kwargs))
 
     def fillna(self, **kwargs):
-        return self._apply_df_function(lambda df: df.fillna(**kwargs))
+        return self._apply_df_function(lambda df: df.fillna(axis=self._axis,
+                                                            **kwargs))
 
     def count(self, **kwargs):
-        return self._apply_agg_function(lambda df: df.count(**kwargs))
+        return self._apply_agg_function(lambda df: df.count(self._axis,
+                                                            **kwargs))
 
     def pipe(self, func, *args, **kwargs):
-        return self._apply_df_function(lambda df: df.pipe(func,
-                                                          *args,
-                                                          **kwargs))
+        return com._pipe(self, func, *args, **kwargs)
 
     def cumcount(self, ascending=True):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def tail(self, n=5):
-        return self._apply_df_function(lambda df: df.tail(n))
+        result = [v.tail(n) for k, v in self._iter]
+        new_df = concat(result, axis=self._axis)
+
+        if self._axis == 0:
+            new_index = [v[-n:] for k, v in self._keys_and_values]
+            new_df.index = [i for j in new_index for i in j]
+
+        return new_df
 
     # expanding and rolling are unique cases and need to likely be handled
     # separately. They do not appear to be commonly used.
     def expanding(self, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def rolling(self, *args, **kwargs):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def hist(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def quantile(self, q=0.5, **kwargs):
-        return self._apply_df_function(lambda df: df.quantile(q, **kwargs)) \
-            if is_list_like(q) \
-            else self._apply_agg_function(lambda df: df.quantile(q, **kwargs))
+        if is_list_like(q):
+            raise NotImplementedError(
+                "This requires Multi-level index to be implemented. "
+                "To contribute to Pandas on Ray, please visit "
+                "github.com/ray-project/ray.")
+
+        return self._apply_agg_function(lambda df: df.quantile(q=q,
+                                                               axis=self._axis,
+                                                               **kwargs))
 
     def diff(self):
-        raise NotImplementedError("Not Yet implemented.")
+        raise NotImplementedError(
+            "To contribute to Pandas on Ray, please visit "
+            "github.com/ray-project/ray.")
 
     def take(self, **kwargs):
         return self._apply_df_function(lambda df: df.take(**kwargs))

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -346,18 +346,13 @@ class DataFrameGroupBy(object):
 
         result = [DataFrame(f(v)).T for k, v in self._iter]
         concat_axis = self._axis if concat_axis is None else concat_axis
-        print(result)
 
         new_df = concat(result, axis=concat_axis)
         if self._axis == 0:
-            print(new_df)
-            print("COLUMNS: ", self._columns)
             new_df.columns = self._columns
             new_df.index = [k for k, v in self._iter]
         else:
             new_df = new_df.T
-            print(new_df)
-            print([k for k, v in self._iter])
             new_df.columns = [k for k, v in self._iter]
             new_df.index = self._index
         return new_df
@@ -371,9 +366,9 @@ class DataFrameGroupBy(object):
         new_df = concat(result, axis=concat_axis)
 
         if self._axis == 0:
-            new_df.reindex(self._index, axis=0)
+            new_df.reindex(self._index, axis=0, copy=False)
         else:
-            new_df.reindex(self._columns, axis=1)
+            new_df.reindex(self._columns, axis=1, copy=False)
 
         return new_df
 

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -384,7 +384,7 @@ class DataFrameGroupBy(object):
 
         if self._axis == 0:
             index_head = [v[:n] for k, v in self._keys_and_values]
-            flattened_index = set(i for j in index_head for i in j)
+            flattened_index = {i for j in index_head for i in j}
             sorted_index = [i for i in self._index if i in flattened_index]
             new_df._block_partitions = np.array([_reindex_helper._submit(
                 args=tuple([new_df.index, sorted_index, 1,
@@ -439,7 +439,7 @@ class DataFrameGroupBy(object):
 
         if self._axis == 0:
             index_tail = [v[-n:] for k, v in self._keys_and_values]
-            flattened_index = set(i for j in index_tail for i in j)
+            flattened_index = {i for j in index_tail for i in j}
             sorted_index = [i for i in self._index if i in flattened_index]
             new_df._block_partitions = np.array([_reindex_helper._submit(
                 args=tuple([new_df.index, sorted_index, 1,

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -34,7 +34,8 @@ class DataFrameGroupBy(object):
                 .groupby(by=by, sort=sort)
         else:
             partitions = [row for row in df._block_partitions]
-            self._index_grouped = pd.Series(self._columns, index=self._index)\
+            self._index_grouped = \
+                pd.Series(self._columns, index=self._columns) \
                 .groupby(by=by, sort=sort)
 
         self._keys_and_values = [(k, v)

--- a/python/ray/dataframe/groupby.py
+++ b/python/ray/dataframe/groupby.py
@@ -9,6 +9,8 @@ import ray
 
 from .utils import _map_partitions
 from .utils import _inherit_docstrings
+from .dataframe import DataFrame
+from .concat import concat
 
 
 @_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy,
@@ -80,7 +82,7 @@ class DataFrameGroupBy(object):
         return self._apply_agg_function(lambda df: df.skew(**kwargs))
 
     def ffill(self, limit=None):
-        return self._apply_agg_function(lambda df: df.ffill(limit=limit))
+        return self._apply_df_function(lambda df: df.ffill(limit=limit))
 
     def sem(self, ddof=1):
         return self._apply_agg_function(lambda df: df.sem(ddof=ddof))
@@ -338,9 +340,9 @@ class DataFrameGroupBy(object):
     def _apply_agg_function(self, f):
         assert callable(f), "\'{0}\' object is not callable".format(type(f))
 
-        result = [pd.DataFrame(f(v)).T for k, v in self._iter]
+        result = [DataFrame(f(v)).T for k, v in self._iter]
 
-        new_df = pd.concat(result)
+        new_df = concat(result)
         if self._axis == 0:
             new_df.columns = self._columns
             new_df.index = [k for k, v in self._iter]
@@ -354,8 +356,6 @@ class DataFrameGroupBy(object):
         assert callable(f), "\'{0}\' object is not callable".format(type(f))
 
         result = [f(v) for k, v in self._iter]
-
-        from .concat import concat
 
         new_df = concat(result)
         return new_df

--- a/python/ray/dataframe/index_metadata.py
+++ b/python/ray/dataframe/index_metadata.py
@@ -51,7 +51,7 @@ class _IndexMetadata(object):
 
         self._lengths = lengths_oid
         self._coord_df = coord_df_oid
-        self._index_cache = np.array(index)
+        self._index_cache = index
         self._cached_index = False
 
     def _get__lengths(self):

--- a/python/ray/dataframe/index_metadata.py
+++ b/python/ray/dataframe/index_metadata.py
@@ -51,7 +51,7 @@ class _IndexMetadata(object):
 
         self._lengths = lengths_oid
         self._coord_df = coord_df_oid
-        self._index_cache = index
+        self._index_cache = np.array(index)
         self._cached_index = False
 
     def _get__lengths(self):

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -2459,8 +2459,32 @@ def test_rdiv():
 
 
 def test_reindex():
-    # TODO(kunalgosar): Implement this
-    pass
+    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
+                              'col2': [4, 5, 6, 7],
+                              'col3': [8, 9, 10, 11],
+                              'col4': [12, 13, 14, 15],
+                              'col5': [0, 0, 0, 0]})
+    ray_df = from_pandas(pandas_df, 2)
+
+    assert ray_df_equals_pandas(
+        ray_df.reindex([0, 3, 2, 1]), pandas_df.reindex([0, 3, 2, 1]))
+
+    assert ray_df_equals_pandas(
+        ray_df.reindex([0, 6, 2]), pandas_df.reindex([0, 6, 2]))
+
+    assert ray_df_equals_pandas(
+        ray_df.reindex(['col1', 'col3', 'col4', 'col2'], axis=1),
+        pandas_df.reindex(['col1', 'col3', 'col4', 'col2'], axis=1))
+
+    assert ray_df_equals_pandas(
+        ray_df.reindex(['col1', 'col7', 'col4', 'col8'], axis=1),
+        pandas_df.reindex(['col1', 'col7', 'col4', 'col8'], axis=1))
+
+    assert ray_df_equals_pandas(
+        ray_df.reindex(index=[0, 1, 5],
+                       columns=['col1', 'col7', 'col4', 'col8']),
+        pandas_df.reindex(index=[0, 1, 5],
+                          columns=['col1', 'col7', 'col4', 'col8']))
 
 
 def test_reindex_axis():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -330,7 +330,9 @@ def test_int_dataframe():
         with pytest.raises(TypeError):
             test_agg(ray_df, pandas_df, func, 1)
 
-        test_transform(ray_df, pandas_df)
+    test_apply(ray_df, pandas_df, lambda df: df.drop('col1'), 1)
+    test_apply(ray_df, pandas_df, lambda df: -df, 0)
+    test_transform(ray_df, pandas_df)
 
 
 def test_float_dataframe():
@@ -499,7 +501,9 @@ def test_float_dataframe():
         with pytest.raises(TypeError):
             test_agg(ray_df, pandas_df, func, 1)
 
-        test_transform(ray_df, pandas_df)
+    test_apply(ray_df, pandas_df, lambda df: df.drop('col1'), 1)
+    test_apply(ray_df, pandas_df, lambda df: -df, 0)
+    test_transform(ray_df, pandas_df)
 
 
 def test_mixed_dtype_dataframe():
@@ -665,7 +669,9 @@ def test_mixed_dtype_dataframe():
         with pytest.raises(TypeError):
             test_agg(ray_df, pandas_df, func, 1)
 
-        test_transform(ray_df, pandas_df)
+    test_transform(ray_df, pandas_df)
+    test_apply(ray_df, pandas_df, lambda df: df.drop('col1'), 1)
+    test_apply(ray_df, pandas_df, lambda df: -df, 0)
 
 
 def test_nan_dataframe():
@@ -828,7 +834,9 @@ def test_nan_dataframe():
         with pytest.raises(TypeError):
             test_agg(ray_df, pandas_df, func, 1)
 
-        test_transform(ray_df, pandas_df)
+    test_apply(ray_df, pandas_df, lambda df: df.drop('col1'), 1)
+    test_apply(ray_df, pandas_df, lambda df: -df, 0)
+    test_transform(ray_df, pandas_df)
 
 
 def test_dense_nan_df():
@@ -2452,10 +2460,8 @@ def test_rdiv():
 
 
 def test_reindex():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.reindex()
+    # TODO(kunalgosar): Implement this
+    pass
 
 
 def test_reindex_axis():

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -671,7 +671,6 @@ def test_mixed_dtype_dataframe():
 
     test_transform(ray_df, pandas_df)
     test_apply(ray_df, pandas_df, lambda df: df.drop('col1'), 1)
-    test_apply(ray_df, pandas_df, lambda df: -df, 0)
 
 
 def test_nan_dataframe():

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+import ray.dataframe as rdf
+from ray.dataframe.utils import (
+    from_pandas,
+    to_pandas)
+
+from pandas.tests.frame.common import TestData
+
+
+@pytest.fixture
+def ray_df_equals_pandas(ray_df, pandas_df):
+    return to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
+
+
+@pytest.fixture
+def ray_series_equals_pandas(ray_df, pandas_df):
+    return ray_df.sort_index().equals(pandas_df.sort_index())
+
+
+@pytest.fixture
+def ray_df_equals(ray_df1, ray_df2):
+    return to_pandas(ray_df1).sort_index().equals(
+        to_pandas(ray_df2).sort_index()
+    )

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -3,15 +3,10 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
-import ray.dataframe as rdf
 from ray.dataframe.utils import (
     from_pandas,
     to_pandas)
-
-from pandas.tests.frame.common import TestData
 
 
 @pytest.fixture
@@ -29,3 +24,35 @@ def ray_df_equals(ray_df1, ray_df2):
     return to_pandas(ray_df1).sort_index().equals(
         to_pandas(ray_df2).sort_index()
     )
+
+
+@pytest.fixture
+def ray_groupby_equals_pandas(ray_groupby, pandas_groupby):
+    for g1, g2 in zip(ray_groupby, pandas_groupby):
+        assert g1[0] == g2[0]
+        assert ray_df_equals_pandas(g1[1], g2[1])
+
+
+def test_simple_row_groupby():
+    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
+                              'col2': [4, 5, 6, 7],
+                              'col3': [8, 9, 10, 11],
+                              'col4': [12, 13, 14, 15],
+                              'col5': [0, 0, 0, 0]})
+
+    ray_df = from_pandas(pandas_df, 2)
+
+    by = [1, 2, 1, 2]
+
+    ray_groupby = ray_df.groupby(by=by)
+    pandas_groupby = pandas_df.groupby(by=by)
+
+    assert ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
+
+
+
+
+
+    by_col_axis = [[1, 2, 3, 2, 1],
+                   [0, 0, 0, 0, 0],
+                   [1, 2, 3, 4, 5]]

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -63,9 +63,8 @@ def test_simple_row_groupby():
     test_pct_change(ray_groupby, pandas_groupby)
     test_cummax(ray_groupby, pandas_groupby)
 
-    apply_agg_functions = [lambda df: df.sum(),
-                           lambda df: -df]
-    for func in apply_agg_functions:
+    apply_functions = [lambda df: df.sum(), lambda df: -df]
+    for func in apply_functions:
         test_apply(ray_groupby, pandas_groupby, func)
 
 
@@ -99,9 +98,8 @@ def test_simple_col_groupby():
     # test_cummax(ray_groupby, pandas_groupby)
 
     test_pct_change(ray_groupby, pandas_groupby)
-    apply_agg_functions = [lambda df: df.sum(),
-                           lambda df: -df]
-    for func in apply_agg_functions:
+    apply_functions = [lambda df: -df, lambda df: df.sum(axis=1)]
+    for func in apply_functions:
         test_apply(ray_groupby, pandas_groupby, func)
 
 

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -3,7 +3,8 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-import pandas as pd
+import pandas
+import ray.dataframe as pd
 from ray.dataframe.utils import (
     from_pandas,
     to_pandas)
@@ -11,17 +12,18 @@ from ray.dataframe.utils import (
 
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
-    return to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
+    assert isinstance(ray_df, pd.DataFrame)
+    assert to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
 
 
 @pytest.fixture
 def ray_series_equals_pandas(ray_df, pandas_df):
-    return ray_df.sort_index().equals(pandas_df.sort_index())
+    assert ray_df.sort_index().equals(pandas_df.sort_index())
 
 
 @pytest.fixture
 def ray_df_equals(ray_df1, ray_df2):
-    return to_pandas(ray_df1).sort_index().equals(
+    assert to_pandas(ray_df1).sort_index().equals(
         to_pandas(ray_df2).sort_index()
     )
 
@@ -30,15 +32,15 @@ def ray_df_equals(ray_df1, ray_df2):
 def ray_groupby_equals_pandas(ray_groupby, pandas_groupby):
     for g1, g2 in zip(ray_groupby, pandas_groupby):
         assert g1[0] == g2[0]
-        assert ray_df_equals_pandas(g1[1], g2[1])
+        ray_df_equals_pandas(g1[1], g2[1])
 
 
 def test_simple_row_groupby():
-    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
-                              'col2': [4, 5, 6, 7],
-                              'col3': [8, 9, 10, 11],
-                              'col4': [12, 13, 14, 15],
-                              'col5': [0, 0, 0, 0]})
+    pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
+                                  'col2': [4, 5, 6, 7],
+                                  'col3': [8, 9, 10, 11],
+                                  'col4': [12, 13, 14, 15],
+                                  'col5': [0, 0, 0, 0]})
 
     ray_df = from_pandas(pandas_df, 2)
 
@@ -48,14 +50,17 @@ def test_simple_row_groupby():
     pandas_groupby = pandas_df.groupby(by=by)
 
     ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
+    test_ngroups(ray_groupby, pandas_groupby)
+    test_skew(ray_groupby, pandas_groupby)
+    test_ffill(ray_groupby, pandas_groupby)
 
 
 def test_simple_col_groupby():
-    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
-                              'col2': [4, 5, 6, 7],
-                              'col3': [8, 9, 10, 11],
-                              'col4': [12, 13, 14, 15],
-                              'col5': [0, 0, 0, 0]})
+    pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
+                                  'col2': [4, 5, 6, 7],
+                                  'col3': [8, 9, 10, 11],
+                                  'col4': [12, 13, 14, 15],
+                                  'col5': [0, 0, 0, 0]})
 
     ray_df = from_pandas(pandas_df, 2)
 
@@ -65,3 +70,21 @@ def test_simple_col_groupby():
     pandas_groupby = pandas_df.groupby(axis=1, by=by)
 
     ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
+    test_ngroups(ray_groupby, pandas_groupby)
+    test_skew(ray_groupby, pandas_groupby)
+    test_ffill(ray_groupby, pandas_groupby)
+
+
+@pytest.fixture
+def test_ngroups(ray_groupby, pandas_groupby):
+    assert ray_groupby.ngroups == pandas_groupby.ngroups
+
+
+@pytest.fixture
+def test_skew(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.skew(), pandas_groupby.skew())
+
+
+@pytest.fixture
+def test_ffill(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.ffill(), pandas_groupby.ffill())

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -19,28 +19,25 @@ if sys.version_info.major < 3:
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
     assert isinstance(ray_df, pd.DataFrame)
-    assert to_pandas(ray_df).sort_index().equals(pandas_df.sort_index())
+    assert to_pandas(ray_df).equals(pandas_df)
 
 
 @pytest.fixture
 def ray_df_almost_equals_pandas(ray_df, pandas_df):
     assert isinstance(ray_df, pd.DataFrame)
-    difference = to_pandas(ray_df).sort_index() - pandas_df.sort_index()
+    difference = to_pandas(ray_df) - pandas_df
     diff_max = difference.max().max()
-    assert to_pandas(ray_df).sort_index().equals(pandas_df.sort_index()) or \
-        diff_max < 0.01
+    assert to_pandas(ray_df).equals(pandas_df) or diff_max < 0.0001
 
 
 @pytest.fixture
 def ray_series_equals_pandas(ray_df, pandas_df):
-    assert ray_df.sort_index().equals(pandas_df.sort_index())
+    assert ray_df.equals(pandas_df)
 
 
 @pytest.fixture
 def ray_df_equals(ray_df1, ray_df2):
-    assert to_pandas(ray_df1).sort_index().equals(
-        to_pandas(ray_df2).sort_index()
-    )
+    assert to_pandas(ray_df1).equals(to_pandas(ray_df2))
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -306,6 +306,8 @@ def test_simple_col_groupby():
         # idxmax and idxmin fail on column groupby in pandas with python2
         test_idxmax(ray_groupby, pandas_groupby)
         test_idxmin(ray_groupby, pandas_groupby)
+        test_rank(ray_groupby, pandas_groupby)
+        test_quantile(ray_groupby, pandas_groupby)
 
     # https://github.com/pandas-dev/pandas/issues/21127
     # test_cumsum(ray_groupby, pandas_groupby)
@@ -325,7 +327,6 @@ def test_simple_col_groupby():
     test_std(ray_groupby, pandas_groupby)
     test_last(ray_groupby, pandas_groupby)
     test_mad(ray_groupby, pandas_groupby)
-    test_rank(ray_groupby, pandas_groupby)
     test_max(ray_groupby, pandas_groupby)
     test_var(ray_groupby, pandas_groupby)
     test_len(ray_groupby, pandas_groupby)
@@ -348,7 +349,6 @@ def test_simple_col_groupby():
     test_corr(ray_groupby, pandas_groupby)
     test_fillna(ray_groupby, pandas_groupby)
     test_count(ray_groupby, pandas_groupby)
-    test_quantile(ray_groupby, pandas_groupby)
     test_take(ray_groupby, pandas_groupby)
 
 

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -45,6 +45,7 @@ def test_simple_row_groupby():
     ray_df = from_pandas(pandas_df, 2)
 
     by = [1, 2, 1, 2]
+    n = 1
 
     ray_groupby = ray_df.groupby(by=by)
     pandas_groupby = pandas_df.groupby(by=by)
@@ -81,6 +82,35 @@ def test_simple_row_groupby():
         test_agg(ray_groupby, pandas_groupby, func)
         test_aggregate(ray_groupby, pandas_groupby, func)
 
+    test_last(ray_groupby, pandas_groupby)
+    test_mad(ray_groupby, pandas_groupby)
+    test_rank(ray_groupby, pandas_groupby)
+    test_max(ray_groupby, pandas_groupby)
+    test_var(ray_groupby, pandas_groupby)
+    test_len(ray_groupby, pandas_groupby)
+    test_sum(ray_groupby, pandas_groupby)
+    test_ngroup(ray_groupby, pandas_groupby)
+    test_nunique(ray_groupby, pandas_groupby)
+    test_median(ray_groupby, pandas_groupby)
+    test_head(ray_groupby, pandas_groupby, n)
+    test_cumprod(ray_groupby, pandas_groupby)
+    test_cov(ray_groupby, pandas_groupby)
+
+    transform_functions = [lambda df: df + 4, lambda df: -df - 10]
+    for func in transform_functions:
+        test_transform(ray_groupby, pandas_groupby, func)
+
+    pipe_functions = [lambda dfgb: dfgb.sum()]
+    for func in pipe_functions:
+        test_pipe(ray_groupby, pandas_groupby, func)
+
+    test_corr(ray_groupby, pandas_groupby)
+    test_fillna(ray_groupby, pandas_groupby)
+    test_count(ray_groupby, pandas_groupby)
+    test_tail(ray_groupby, pandas_groupby, n)
+    test_quantile(ray_groupby, pandas_groupby)
+    test_take(ray_groupby, pandas_groupby)
+
 
 def test_simple_col_groupby():
     pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
@@ -111,6 +141,7 @@ def test_simple_col_groupby():
     # test_cumsum(ray_groupby, pandas_groupby)
     # test_cummax(ray_groupby, pandas_groupby)
     # test_cummin(ray_groupby, pandas_groupby)
+    # test_cumprod(ray_groupby, pandas_groupby)
 
     test_pct_change(ray_groupby, pandas_groupby)
     apply_functions = [lambda df: -df, lambda df: df.sum(axis=1)]
@@ -123,6 +154,33 @@ def test_simple_col_groupby():
     test_idxmin(ray_groupby, pandas_groupby)
     test_prod(ray_groupby, pandas_groupby)
     test_std(ray_groupby, pandas_groupby)
+    test_last(ray_groupby, pandas_groupby)
+    test_mad(ray_groupby, pandas_groupby)
+    test_rank(ray_groupby, pandas_groupby)
+    test_max(ray_groupby, pandas_groupby)
+    test_var(ray_groupby, pandas_groupby)
+    test_len(ray_groupby, pandas_groupby)
+    test_sum(ray_groupby, pandas_groupby)
+
+    # Pandas fails on this case with ValueError
+    # test_ngroup(ray_groupby, pandas_groupby)
+    # test_nunique(ray_groupby, pandas_groupby)
+    test_median(ray_groupby, pandas_groupby)
+    test_cov(ray_groupby, pandas_groupby)
+
+    transform_functions = [lambda df: df + 4, lambda df: -df - 10]
+    for func in transform_functions:
+        test_transform(ray_groupby, pandas_groupby, func)
+
+    pipe_functions = [lambda dfgb: dfgb.sum()]
+    for func in pipe_functions:
+        test_pipe(ray_groupby, pandas_groupby, func)
+
+    test_corr(ray_groupby, pandas_groupby)
+    test_fillna(ray_groupby, pandas_groupby)
+    test_count(ray_groupby, pandas_groupby)
+    test_quantile(ray_groupby, pandas_groupby)
+    test_take(ray_groupby, pandas_groupby)
 
 
 @pytest.fixture
@@ -244,3 +302,116 @@ def test_aggregate(ray_groupby, pandas_groupby, func):
 @pytest.fixture
 def test_agg(ray_groupby, pandas_groupby, func):
     ray_df_equals_pandas(ray_groupby.agg(func), pandas_groupby.agg(func))
+
+
+@pytest.fixture
+def test_last(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.last()
+
+
+@pytest.fixture
+def test_mad(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.mad()
+
+
+@pytest.fixture
+def test_rank(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.rank(), pandas_groupby.rank())
+
+
+@pytest.fixture
+def test_max(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.max(), pandas_groupby.max())
+
+
+@pytest.fixture
+def test_var(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.var(), pandas_groupby.var())
+
+
+@pytest.fixture
+def test_len(ray_groupby, pandas_groupby):
+    assert len(ray_groupby) == len(pandas_groupby)
+
+
+@pytest.fixture
+def test_sum(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.sum(), pandas_groupby.sum())
+
+
+@pytest.fixture
+def test_ngroup(ray_groupby, pandas_groupby):
+    ray_series_equals_pandas(ray_groupby.ngroup(), pandas_groupby.ngroup())
+
+
+@pytest.fixture
+def test_nunique(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.nunique(), pandas_groupby.nunique())
+
+
+@pytest.fixture
+def test_median(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.median(), pandas_groupby.median())
+
+
+@pytest.fixture
+def test_head(ray_groupby, pandas_groupby, n):
+    ray_df_equals_pandas(ray_groupby.head(n=n), pandas_groupby.head(n=n))
+
+
+@pytest.fixture
+def test_cumprod(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.cumprod(), pandas_groupby.cumprod())
+
+
+@pytest.fixture
+def test_cov(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.cov()
+
+
+@pytest.fixture
+def test_transform(ray_groupby, pandas_groupby, func):
+    ray_df_equals_pandas(ray_groupby.transform(func),
+                         pandas_groupby.transform(func))
+
+
+@pytest.fixture
+def test_corr(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.corr()
+
+
+@pytest.fixture
+def test_fillna(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.fillna(method="ffill"),
+                         pandas_groupby.fillna(method="ffill"))
+
+
+@pytest.fixture
+def test_count(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.count(), pandas_groupby.count())
+
+
+@pytest.fixture
+def test_pipe(ray_groupby, pandas_groupby, func):
+    ray_df_equals_pandas(ray_groupby.pipe(func), pandas_groupby.pipe(func))
+
+
+@pytest.fixture
+def test_tail(ray_groupby, pandas_groupby, n):
+    ray_df_equals_pandas(ray_groupby.tail(n=n), pandas_groupby.tail(n=n))
+
+
+@pytest.fixture
+def test_quantile(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.quantile(q=0.4),
+                         pandas_groupby.quantile(q=0.4))
+
+
+@pytest.fixture
+def test_take(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.take(indices=[1])

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -67,6 +67,20 @@ def test_simple_row_groupby():
     for func in apply_functions:
         test_apply(ray_groupby, pandas_groupby, func)
 
+    test_dtypes(ray_groupby, pandas_groupby)
+    test_first(ray_groupby, pandas_groupby)
+    test_backfill(ray_groupby, pandas_groupby)
+    test_cummin(ray_groupby, pandas_groupby)
+    test_bfill(ray_groupby, pandas_groupby)
+    test_idxmin(ray_groupby, pandas_groupby)
+    test_prod(ray_groupby, pandas_groupby)
+    test_std(ray_groupby, pandas_groupby)
+
+    agg_functions = ['min', 'max']
+    for func in agg_functions:
+        test_agg(ray_groupby, pandas_groupby, func)
+        test_aggregate(ray_groupby, pandas_groupby, func)
+
 
 def test_simple_col_groupby():
     pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
@@ -96,11 +110,19 @@ def test_simple_col_groupby():
     # https://github.com/pandas-dev/pandas/issues/21127
     # test_cumsum(ray_groupby, pandas_groupby)
     # test_cummax(ray_groupby, pandas_groupby)
+    # test_cummin(ray_groupby, pandas_groupby)
 
     test_pct_change(ray_groupby, pandas_groupby)
     apply_functions = [lambda df: -df, lambda df: df.sum(axis=1)]
     for func in apply_functions:
         test_apply(ray_groupby, pandas_groupby, func)
+
+    test_first(ray_groupby, pandas_groupby)
+    test_backfill(ray_groupby, pandas_groupby)
+    test_bfill(ray_groupby, pandas_groupby)
+    test_idxmin(ray_groupby, pandas_groupby)
+    test_prod(ray_groupby, pandas_groupby)
+    test_std(ray_groupby, pandas_groupby)
 
 
 @pytest.fixture
@@ -169,7 +191,56 @@ def test_cummax(ray_groupby, pandas_groupby):
 
 @pytest.fixture
 def test_apply(ray_groupby, pandas_groupby, func):
-    print(ray_groupby.apply(func))
-    print(type(ray_groupby.apply(func)))
-    print(pandas_groupby.apply(func))
     ray_df_equals_pandas(ray_groupby.apply(func), pandas_groupby.apply(func))
+
+
+@pytest.fixture
+def test_dtypes(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.dtypes, pandas_groupby.dtypes)
+
+
+@pytest.fixture
+def test_first(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.first()
+
+
+@pytest.fixture
+def test_backfill(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.backfill(), pandas_groupby.backfill())
+
+
+@pytest.fixture
+def test_cummin(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.cummin(), pandas_groupby.cummin())
+
+
+@pytest.fixture
+def test_bfill(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.bfill(), pandas_groupby.bfill())
+
+
+@pytest.fixture
+def test_idxmin(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.idxmin(), pandas_groupby.idxmin())
+
+
+@pytest.fixture
+def test_prod(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.prod(), pandas_groupby.prod())
+
+
+@pytest.fixture
+def test_std(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.std(), pandas_groupby.std())
+
+
+@pytest.fixture
+def test_aggregate(ray_groupby, pandas_groupby, func):
+    ray_df_equals_pandas(ray_groupby.aggregate(func),
+                         pandas_groupby.aggregate(func))
+
+
+@pytest.fixture
+def test_agg(ray_groupby, pandas_groupby, func):
+    ray_df_equals_pandas(ray_groupby.agg(func), pandas_groupby.agg(func))

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -38,9 +38,9 @@ def ray_groupby_equals_pandas(ray_groupby, pandas_groupby):
 def test_simple_row_groupby():
     pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
                                   'col2': [4, 5, 6, 7],
-                                  'col3': [8, 9, 10, 11],
-                                  'col4': [12, 13, 14, 15],
-                                  'col5': [0, 0, 0, 0]})
+                                  'col3': [3, 8, 12, 10],
+                                  'col4': [17, 13, 16, 15],
+                                  'col5': [-4, -5, -6, -7]})
 
     ray_df = from_pandas(pandas_df, 2)
 
@@ -53,14 +53,28 @@ def test_simple_row_groupby():
     test_ngroups(ray_groupby, pandas_groupby)
     test_skew(ray_groupby, pandas_groupby)
     test_ffill(ray_groupby, pandas_groupby)
+    test_sem(ray_groupby, pandas_groupby)
+    test_mean(ray_groupby, pandas_groupby)
+    test_any(ray_groupby, pandas_groupby)
+    test_min(ray_groupby, pandas_groupby)
+    test_idxmax(ray_groupby, pandas_groupby)
+    test_ndim(ray_groupby, pandas_groupby)
+    test_cumsum(ray_groupby, pandas_groupby)
+    test_pct_change(ray_groupby, pandas_groupby)
+    test_cummax(ray_groupby, pandas_groupby)
+
+    apply_agg_functions = [lambda df: df.sum(),
+                           lambda df: -df]
+    for func in apply_agg_functions:
+        test_apply(ray_groupby, pandas_groupby, func)
 
 
 def test_simple_col_groupby():
     pandas_df = pandas.DataFrame({'col1': [0, 1, 2, 3],
                                   'col2': [4, 5, 6, 7],
-                                  'col3': [8, 9, 10, 11],
-                                  'col4': [12, 13, 14, 15],
-                                  'col5': [0, 0, 0, 0]})
+                                  'col3': [3, 8, 12, 10],
+                                  'col4': [17, 13, 16, 15],
+                                  'col5': [-4, -5, -6, -7]})
 
     ray_df = from_pandas(pandas_df, 2)
 
@@ -73,6 +87,22 @@ def test_simple_col_groupby():
     test_ngroups(ray_groupby, pandas_groupby)
     test_skew(ray_groupby, pandas_groupby)
     test_ffill(ray_groupby, pandas_groupby)
+    test_sem(ray_groupby, pandas_groupby)
+    test_mean(ray_groupby, pandas_groupby)
+    test_any(ray_groupby, pandas_groupby)
+    test_min(ray_groupby, pandas_groupby)
+    test_idxmax(ray_groupby, pandas_groupby)
+    test_ndim(ray_groupby, pandas_groupby)
+
+    # https://github.com/pandas-dev/pandas/issues/21127
+    # test_cumsum(ray_groupby, pandas_groupby)
+    # test_cummax(ray_groupby, pandas_groupby)
+
+    test_pct_change(ray_groupby, pandas_groupby)
+    apply_agg_functions = [lambda df: df.sum(),
+                           lambda df: -df]
+    for func in apply_agg_functions:
+        test_apply(ray_groupby, pandas_groupby, func)
 
 
 @pytest.fixture
@@ -88,3 +118,60 @@ def test_skew(ray_groupby, pandas_groupby):
 @pytest.fixture
 def test_ffill(ray_groupby, pandas_groupby):
     ray_df_equals_pandas(ray_groupby.ffill(), pandas_groupby.ffill())
+
+
+@pytest.fixture
+def test_sem(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.sem()
+
+
+@pytest.fixture
+def test_mean(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.mean(), pandas_groupby.mean())
+
+
+@pytest.fixture
+def test_any(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.any(), pandas_groupby.any())
+
+
+@pytest.fixture
+def test_min(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.min(), pandas_groupby.min())
+
+
+@pytest.fixture
+def test_idxmax(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.idxmax(), pandas_groupby.idxmax())
+
+
+@pytest.fixture
+def test_ndim(ray_groupby, pandas_groupby):
+    assert ray_groupby.ndim == pandas_groupby.ndim
+
+
+@pytest.fixture
+def test_cumsum(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.cumsum(), pandas_groupby.cumsum())
+    ray_df_equals_pandas(ray_groupby.cumsum(axis=1),
+                         pandas_groupby.cumsum(axis=1))
+
+
+@pytest.fixture
+def test_pct_change(ray_groupby, pandas_groupby):
+    with pytest.raises(NotImplementedError):
+        ray_groupby.pct_change()
+
+
+@pytest.fixture
+def test_cummax(ray_groupby, pandas_groupby):
+    ray_df_equals_pandas(ray_groupby.cummax(), pandas_groupby.cummax())
+
+
+@pytest.fixture
+def test_apply(ray_groupby, pandas_groupby, func):
+    print(ray_groupby.apply(func))
+    print(type(ray_groupby.apply(func)))
+    print(pandas_groupby.apply(func))
+    ray_df_equals_pandas(ray_groupby.apply(func), pandas_groupby.apply(func))

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -3,12 +3,17 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
+import sys
 import pandas
 import numpy as np
 import ray.dataframe as pd
 from ray.dataframe.utils import (
     from_pandas,
     to_pandas)
+
+PY2 = False
+if sys.version_info.major < 3:
+    PY2 = True
 
 
 @pytest.fixture
@@ -295,8 +300,12 @@ def test_simple_col_groupby():
     test_mean(ray_groupby, pandas_groupby)
     test_any(ray_groupby, pandas_groupby)
     test_min(ray_groupby, pandas_groupby)
-    test_idxmax(ray_groupby, pandas_groupby)
     test_ndim(ray_groupby, pandas_groupby)
+
+    if not PY2:
+        # idxmax and idxmin fail on column groupby in pandas with python2
+        test_idxmax(ray_groupby, pandas_groupby)
+        test_idxmin(ray_groupby, pandas_groupby)
 
     # https://github.com/pandas-dev/pandas/issues/21127
     # test_cumsum(ray_groupby, pandas_groupby)
@@ -312,7 +321,6 @@ def test_simple_col_groupby():
     test_first(ray_groupby, pandas_groupby)
     test_backfill(ray_groupby, pandas_groupby)
     test_bfill(ray_groupby, pandas_groupby)
-    test_idxmin(ray_groupby, pandas_groupby)
     test_prod(ray_groupby, pandas_groupby)
     test_std(ray_groupby, pandas_groupby)
     test_last(ray_groupby, pandas_groupby)
@@ -406,6 +414,8 @@ def test_pct_change(ray_groupby, pandas_groupby):
 @pytest.fixture
 def test_cummax(ray_groupby, pandas_groupby):
     ray_df_equals_pandas(ray_groupby.cummax(), pandas_groupby.cummax())
+    ray_df_equals_pandas(ray_groupby.cummax(axis=1),
+                         pandas_groupby.cummax(axis=1))
 
 
 @pytest.fixture
@@ -432,6 +442,8 @@ def test_backfill(ray_groupby, pandas_groupby):
 @pytest.fixture
 def test_cummin(ray_groupby, pandas_groupby):
     ray_df_equals_pandas(ray_groupby.cummin(), pandas_groupby.cummin())
+    ray_df_equals_pandas(ray_groupby.cummin(axis=1),
+                         pandas_groupby.cummin(axis=1))
 
 
 @pytest.fixture
@@ -525,6 +537,8 @@ def test_head(ray_groupby, pandas_groupby, n):
 @pytest.fixture
 def test_cumprod(ray_groupby, pandas_groupby):
     ray_df_equals_pandas(ray_groupby.cumprod(), pandas_groupby.cumprod())
+    ray_df_equals_pandas(ray_groupby.cumprod(axis=1),
+                         pandas_groupby.cumprod(axis=1))
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_groupby.py
+++ b/python/ray/dataframe/test/test_groupby.py
@@ -47,12 +47,21 @@ def test_simple_row_groupby():
     ray_groupby = ray_df.groupby(by=by)
     pandas_groupby = pandas_df.groupby(by=by)
 
-    assert ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
+    ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
 
 
+def test_simple_col_groupby():
+    pandas_df = pd.DataFrame({'col1': [0, 1, 2, 3],
+                              'col2': [4, 5, 6, 7],
+                              'col3': [8, 9, 10, 11],
+                              'col4': [12, 13, 14, 15],
+                              'col5': [0, 0, 0, 0]})
 
+    ray_df = from_pandas(pandas_df, 2)
 
+    by = [1, 2, 3, 2, 1]
 
-    by_col_axis = [[1, 2, 3, 2, 1],
-                   [0, 0, 0, 0, 0],
-                   [1, 2, 3, 4, 5]]
+    ray_groupby = ray_df.groupby(axis=1, by=by)
+    pandas_groupby = pandas_df.groupby(axis=1, by=by)
+
+    ray_groupby_equals_pandas(ray_groupby, pandas_groupby)

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -271,7 +271,16 @@ def _create_block_partitions(partitions, axis=0, length=None):
 
     # In the case that axis is 1 we have to transpose because we build the
     # columns into rows. Fortunately numpy is efficient at this.
-    return np.array(x) if axis == 0 else np.array(x).T
+    blocks = np.array(x) if axis == 0 else np.array(x).T
+
+    # Sometimes we only get a single column or row, which is
+    # problematic for building blocks from the partitions, so we
+    # add whatever dimension we're missing from the input.
+    if blocks.ndim < 2:
+        blocks = np.expand_dims(blocks, axis=axis ^ 1)
+    assert blocks.ndim == 2, "Block Partitions must be 2D."
+
+    return blocks
 
 
 @ray.remote

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -208,8 +208,7 @@ def _deploy_func(func, dataframe, *args):
 @ray.remote
 def _deploy_generic_func(func, *args):
     """Deploys a function for the _map_partitions call.
-    Args:
-        dataframe (pandas.DataFrame): The pandas DataFrame for this partition.
+
     Returns:
         A futures object representing the return value of the function
         provided.

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -205,20 +205,6 @@ def _deploy_func(func, dataframe, *args):
         return func(dataframe, *args)
 
 
-@ray.remote
-def _deploy_generic_func(func, *args):
-    """Deploys a function for the _map_partitions call.
-
-    Returns:
-        A futures object representing the return value of the function
-        provided.
-    """
-    if len(args) == 0:
-        return func()
-    else:
-        return func(*args)
-
-
 def _map_partitions(func, partitions, *argslists):
     """Apply a function across the specified axis
 

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -205,6 +205,21 @@ def _deploy_func(func, dataframe, *args):
         return func(dataframe, *args)
 
 
+@ray.remote
+def _deploy_generic_func(func, *args):
+    """Deploys a function for the _map_partitions call.
+    Args:
+        dataframe (pandas.DataFrame): The pandas DataFrame for this partition.
+    Returns:
+        A futures object representing the return value of the function
+        provided.
+    """
+    if len(args) == 0:
+        return func()
+    else:
+        return func(*args)
+
+
 def _map_partitions(func, partitions, *argslists):
     """Apply a function across the specified axis
 
@@ -276,11 +291,7 @@ def _create_block_partitions(partitions, axis=0, length=None):
     # Sometimes we only get a single column or row, which is
     # problematic for building blocks from the partitions, so we
     # add whatever dimension we're missing from the input.
-    if blocks.ndim < 2:
-        blocks = np.expand_dims(blocks, axis=axis ^ 1)
-    assert blocks.ndim == 2, "Block Partitions must be 2D."
-
-    return blocks
+    return fix_blocks_dimensions(blocks, axis)
 
 
 @ray.remote
@@ -308,6 +319,7 @@ def create_blocks_helper(df, npartitions, axis):
 
     for block in blocks:
         block.columns = pd.RangeIndex(0, len(block.columns))
+        block.reset_index(inplace=True, drop=True)
     return blocks
 
 
@@ -381,12 +393,10 @@ def _reindex_helper(old_index, new_index, axis, npartitions, *df):
     df = pd.concat(df, axis=axis ^ 1)
     if axis == 1:
         df.index = old_index
-        df = df.reindex(new_index, copy=False)
-        df.reset_index(inplace=True, drop=True)
     elif axis == 0:
         df.columns = old_index
-        df = df.reindex(columns=new_index, copy=False)
-        df.columns = pd.RangeIndex(len(df.columns))
+
+    df = df.reindex(new_index, copy=False, axis=axis ^ 1)
     return create_blocks_helper(df, npartitions, axis)
 
 
@@ -470,3 +480,11 @@ def _correct_column_dtypes(*column):
     """
     concat_column = pd.concat(column, copy=False)
     return create_blocks_helper(concat_column, len(column), 1)
+
+
+def fix_blocks_dimensions(blocks, axis):
+    """Checks that blocks is 2D, and adds a dimension if not.
+    """
+    if blocks.ndim < 2:
+        return np.expand_dims(blocks, axis=axis ^ 1)
+    return blocks


### PR DESCRIPTION
Some of the changes in this PR are:
- Creates a test suite for groupby methods
- Fixes many of the groupby methods
- Fixes the case where there is only one group after groupby
- Fixes bugs where `_block_partitions` was 1D
- Implements df.reindex
- Fixes `df.apply` and `df.agg`