### PR TITLE
Do not fetch from dead Plasma Manager

### DIFF
--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -45,7 +45,9 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
   for (auto const &manager_id : manager_ids) {
     DBClient client = redis_cache_get_db_client(db_handle, manager_id);
     RAY_CHECK(!client.manager_address.empty());
-    manager_vector.push_back(client.manager_address);
+    if (client.is_alive) {
+      manager_vector.push_back(client.manager_address);
+    }
   }
 
   int64_t end_time = current_time_ms();


### PR DESCRIPTION
- Problem
    During the execution of cleanup_object_table() in monitor.py, objects in the dead Plasma manager may be fetched by others. This manager has been marked as "deleted" but the object location tables may have not been cleaned up yet.
    This logic would cause:
    1. unnecessary fetching attempts;
    2. occasionally, if the recovered Plasma manager is in the same machine and takes the same listening port as the dead one, it may connect to itself during fetching and causes unpredictable results.
- Solution
    After looking up DB client table, filter the result to drop dead Plasma managers.