### PR TITLE
[DataFrame] Speed up dtypes

### DIFF
--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -43,7 +43,6 @@ from .utils import (
     _co_op_helper,
     _match_partitioning,
     _concat_index,
-    _correct_column_dtypes,
     fix_blocks_dimensions,
     _compile_remote_dtypes)
 from . import get_npartitions

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -456,17 +456,6 @@ def _concat_index(*index_parts):
     return index_parts[0].append(index_parts[1:])
 
 
-@ray.remote
-def _correct_column_dtypes(*column):
-    """Corrects dtypes of a column by concatenating column partitions and
-    splitting the column back into partitions.
-
-    Args:
-    """
-    concat_column = pd.concat(column, copy=False)
-    return create_blocks_helper(concat_column, len(column), 1)
-
-
 def fix_blocks_dimensions(blocks, axis):
     """Checks that blocks is 2D, and adds a dimension if not.
     """

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -473,3 +473,9 @@ def fix_blocks_dimensions(blocks, axis):
     if blocks.ndim < 2:
         return np.expand_dims(blocks, axis=axis ^ 1)
     return blocks
+
+
+@ray.remote
+def _compile_remote_dtypes(*column_of_blocks):
+    small_dfs = [df.loc[0:0] for df in column_of_blocks]
+    return pd.concat(small_dfs, copy=False).dtypes


### PR DESCRIPTION
## Summary

Speeds up dtypes. In order to save memory, this PR gets smaller dataframes from the partitions which are merged together to find `dtypes`. This saves memory and offers performance benefits because it does not create a new version of `_block_partitions` with similar data.

This PR deprecates #2088.

## Performance tests on 762 MB of data
### Code (copied from iPython)
```python
frame_data = np.random.randint(0,100,size=(10**6, 100))

%%time
df = pd.DataFrame(frame_data)
df.dropna(inplace=True)
repr(df)
```

### On Master
CPU times: user 850 ms, sys: 1.1 s, total: 1.95 s
Wall time: 3.35 s

Number of objects in object table = 336
Total size of objects in object table in MB: 5456.237922668457

### Master modified so dtypes doesn't access Ray/the object store
CPU times: user 851 ms, sys: 1.08 s, total: 1.93 s
Wall time: 3.01 s

Number of objects in object table = 256
Total size of objects in object table in MB: 4631.916297912598

### Current PR
CPU times: user 910 ms, sys: 1.08 s, total: 1.99 s
Wall time: 3.13 s

Number of objects in object table = 393
Total size of objects in object table in MB: 4632.369149208069