### PR TITLE
Get Redis keys with scan_iter instead of keys.

### DIFF
--- a/python/ray/experimental/features.py
+++ b/python/ray/experimental/features.py
@@ -118,9 +118,10 @@ def _flush_finished_tasks_unsafe_shard(shard_index):
                                   ray.utils.hex_to_binary(task_id))
 
     num_task_keys_deleted = 0
-    if len(keys_to_delete) > 0:
-        num_task_keys_deleted = redis_client.execute_command(
-            "del", *keys_to_delete)
+    delete_batch_size = 100  # The number of keys to delete at a time.
+    for i in range(0, len(keys_to_delete), delete_batch_size):
+        num_task_keys_deleted += redis_client.execute_command(
+            "del", *keys_to_delete[i:(i + delete_batch_size)])
 
     print("Deleted {} finished tasks from Redis shard."
           .format(num_task_keys_deleted))
@@ -141,9 +142,10 @@ def _flush_evicted_objects_unsafe_shard(shard_index):
                                   ray.utils.hex_to_binary(object_id))
 
     num_object_keys_deleted = 0
-    if len(keys_to_delete) > 0:
-        num_object_keys_deleted = redis_client.execute_command(
-            "del", *keys_to_delete)
+    delete_batch_size = 100  # The number of keys to delete at a time.
+    for i in range(0, len(keys_to_delete), delete_batch_size):
+        num_object_keys_deleted += redis_client.execute_command(
+            "del", *keys_to_delete[i:(i + delete_batch_size)])
 
     print("Deleted {} keys for evicted objects from Redis."
           .format(num_object_keys_deleted))

--- a/python/ray/experimental/features.py
+++ b/python/ray/experimental/features.py
@@ -82,7 +82,7 @@ def flush_task_and_object_metadata_unsafe():
 
 def _task_table_shard(shard_index):
     redis_client = ray.global_state.redis_clients[shard_index]
-    task_table_keys = redis_client.keys(TASK_PREFIX + b"*")
+    task_table_keys = redis_client.scan_iter(match=TASK_PREFIX + b"*")
     results = {}
     for key in task_table_keys:
         task_id_binary = key[len(TASK_PREFIX):]
@@ -94,7 +94,8 @@ def _task_table_shard(shard_index):
 
 def _object_table_shard(shard_index):
     redis_client = ray.global_state.redis_clients[shard_index]
-    object_table_keys = redis_client.keys(OBJECT_LOCATION_PREFIX + b"*")
+    object_table_keys = redis_client.scan_iter(match=OBJECT_LOCATION_PREFIX +
+                                               b"*")
     results = {}
     for key in object_table_keys:
         object_id_binary = key[len(OBJECT_LOCATION_PREFIX):]

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -170,7 +170,7 @@ class GlobalState(object):
         """
         result = []
         for client in self.redis_clients:
-            result.extend(client.keys(pattern))
+            result.extend(client.scan_iter(match=pattern))
         return result
 
     def _object_table(self, object_id):


### PR DESCRIPTION
When using the flushing utilities, sometimes Redis clients are disconnected with a message like

*54436:M 22 May 21:49:23.892 # Client id=9 addr=10.126.16.25:43390 fd=8 name= age=3309 idle=5 flags=N db=0 sub=1 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=8216 omem=134217745 events=rw cmd=subscribe scheduled to be closed ASAP for overcoming of output buffer limits.*

I suspect this is related to the use of **KEYS**.

cc @twanthony