### PR TITLE
[xray] Improve flush algorithm for the lineage cache

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -285,7 +285,6 @@ bool LineageCache::FlushTask(const TaskID &task_id) {
 
 void LineageCache::Flush() {
   // Iterate through all tasks that are READY.
-  std::vector<TaskID> ready_task_ids;
   for (auto it = uncommitted_ready_tasks_.begin();
        it != uncommitted_ready_tasks_.end();) {
     bool flushed = FlushTask(*it);
@@ -335,6 +334,8 @@ void LineageCache::HandleEntryCommitted(const UniqueID &task_id) {
     subscribed_tasks_.erase(it);
   }
 
+  // Try to flush the children of the committed task. These are the tasks that
+  // have a dependency on the committed task.
   auto children_entry = uncommitted_ready_children_.find(task_id);
   if (children_entry != uncommitted_ready_children_.end()) {
     // Get the children of the committed task that are uncommitted but ready.

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -283,7 +283,7 @@ bool LineageCache::FlushTask(const TaskID &task_id) {
   return all_arguments_committed;
 }
 
-ray::Status LineageCache::Flush() {
+void LineageCache::Flush() {
   // Iterate through all tasks that are READY.
   std::vector<TaskID> ready_task_ids;
   for (auto it = uncommitted_ready_tasks_.begin();
@@ -296,7 +296,6 @@ ray::Status LineageCache::Flush() {
       it++;
     }
   }
-  return ray::Status::OK();
 }
 
 void PopAncestorTasks(const UniqueID &task_id, Lineage &lineage) {

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -196,12 +196,12 @@ class LineageCache {
   /// includes the entry for the requested entry_id.
   Lineage GetUncommittedLineage(const TaskID &entry_id) const;
 
-  /// Asynchronously write any tasks that have been added since the last flush
-  /// to the GCS. When each write is acknowledged, its entry will be marked as
-  /// committed.
-  ///
-  /// \return Status.
-  Status Flush();
+  /// Asynchronously write any tasks that are in the UNCOMMITTED_READY state
+  /// and for which all parents have been committed to the GCS. These tasks
+  /// will be transitioned in this method to state COMMITTING. Once the write
+  /// is acknowledged, the task's state will be transitioned to state
+  /// COMMITTED.
+  void Flush();
 
   /// Handle the commit of a task entry in the GCS. This sets the task to
   /// COMMITTED and cleans up any ancestor tasks that are in the cache.

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -210,6 +210,8 @@ class LineageCache {
   void HandleEntryCommitted(const TaskID &task_id);
 
  private:
+  bool FlushTask(const TaskID &task_id);
+
   /// The client ID, used to request notifications for specific tasks.
   /// TODO(swang): Move the ClientID into the generic Table implementation.
   ClientID client_id_;

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -230,16 +230,17 @@ class LineageCache {
   // UNCOMMITTED_READY, but that have dependencies that have not been committed
   // yet.
   std::unordered_set<TaskID> uncommitted_ready_tasks_;
+  /// A mapping from each task that hasn't been committed yet, to all dependent
+  /// children tasks that are in UNCOMMITTED_READY state. This is used when the
+  /// parent task is committed, for fast lookup of children that may now be
+  /// flushed.
+  std::unordered_map<TaskID, std::unordered_set<TaskID>> uncommitted_ready_children_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.
   Lineage lineage_;
   /// The tasks that we've subscribed to notifications for from the pubsub
   /// storage system. We will receive a notification for these tasks on commit.
   std::unordered_set<TaskID> subscribed_tasks_;
-  /// A mapping from each task that hasn't been committed yet, to all dependent
-  /// children tasks that are in UNCOMMITTED_READY state. Once all parents of
-  /// the child task have been committed, the child task may be flushed.
-  std::unordered_map<TaskID, std::unordered_set<TaskID>> task_children_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -210,6 +210,9 @@ class LineageCache {
   void HandleEntryCommitted(const TaskID &task_id);
 
  private:
+  /// Try to flush a task that is in UNCOMMITTED_READY state. If the task has
+  /// parents that are not committed yet, then the child will be flushed once
+  /// the parents have been committed.
   bool FlushTask(const TaskID &task_id);
 
   /// The client ID, used to request notifications for specific tasks.
@@ -233,6 +236,10 @@ class LineageCache {
   /// The tasks that we've subscribed to notifications for from the pubsub
   /// storage system. We will receive a notification for these tasks on commit.
   std::unordered_set<TaskID> subscribed_tasks_;
+  /// A mapping from each task that hasn't been committed yet, to all dependent
+  /// children tasks that are in UNCOMMITTED_READY state. Once all parents of
+  /// the child task have been committed, the child task may be flushed.
+  std::unordered_map<TaskID, std::unordered_set<TaskID>> task_children_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -184,7 +184,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
 
 void CheckFlush(LineageCache &lineage_cache, MockGcs &mock_gcs,
                 size_t num_tasks_flushed) {
-  RAY_CHECK_OK(lineage_cache.Flush());
+  lineage_cache.Flush();
   ASSERT_EQ(mock_gcs.TaskTable().size(), num_tasks_flushed);
 }
 


### PR DESCRIPTION
## What do these changes do?

This improves the algorithm for flushing tasks from the lineage cache to the GCS. A task only gets flushed if all of its parents have already been flushed to the GCS. Previously, we would only flush tasks in a batched method, where we would iterate over all tasks that were ready every time a new task was marked as ready. However, this could cause some tasks to get "stuck". For example, if a child task's parents are all committed, but no new tasks are marked as ready, then the child task would never be flushed.

This PR tracks the parent -> child dependencies for tasks that are ready to write. Then, when a task is committed, we use this map to check for any children that are now flushable.