### PR TITLE
Fix support for actor classmethods

### DIFF
--- a/python/ray/signature.py
+++ b/python/ray/signature.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from collections import namedtuple
 import funcsigs
 from funcsigs import Parameter
-import inspect
 
 from ray.utils import is_cython
 

--- a/python/ray/signature.py
+++ b/python/ray/signature.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from collections import namedtuple
 import funcsigs
 from funcsigs import Parameter
+import inspect
 
 from ray.utils import is_cython
 

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -420,6 +420,32 @@ class ActorMethods(unittest.TestCase):
         c2.increase.remote()
         self.assertEqual(ray.get(c2.value.remote()), 2)
 
+    def testActorClassMethods(self):
+        ray.init()
+
+        class Foo(object):
+            x = 2
+
+            @classmethod
+            def as_remote(cls):
+                return ray.remote(cls)
+
+            @classmethod
+            def f(cls):
+                return cls.x
+
+            @classmethod
+            def g(cls, y):
+                return cls.x + y
+
+            def echo(self, value):
+                return value
+
+        a = Foo.as_remote().remote()
+        self.assertEqual(ray.get(a.echo.remote(2)), 2)
+        self.assertEqual(ray.get(a.f.remote()), 2)
+        self.assertEqual(ray.get(a.g.remote(2)), 4)
+
     def testMultipleActors(self):
         # Create a bunch of actors and call a bunch of methods on all of them.
         ray.init(num_workers=0)


### PR DESCRIPTION

## What do these changes do?

Currently, you cannot convert a class into a remote class if it has class methods defined (it will crash incorrectly with `Methods must take a self argument`). This fixes the crash by supporting methods properly.