### PR TITLE
[JavaWorker] Do not kill local-scheduler-forked workers in RunManager…

### DIFF
--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -376,17 +376,6 @@ public class RunManager {
       runInfo.allProcesses.get(i).clear();
       runInfo.deadProcess.clear();
     }
-
-    if (killAll) {
-      // kill all workers that are forked by local scheduler
-      // ps aux | grep DefaultWorker | awk '{system("kill "$2);}'
-      String[] cmd = {"/bin/sh", "-c", ""};
-      cmd[2] = "ps aux | grep DefaultWorker | grep -v grep | awk \"{print \\$2}\" | xargs kill";
-      try {
-        Runtime.getRuntime().exec(cmd);
-      } catch (IOException e) {
-      }
-    }
   }
 
   private void record_log_files_in_redis(String redis_address, String node_ip_address,


### PR DESCRIPTION
….cleanup

Local-scheduler-forked workers will be killed by local scheduler itself,
don't need to be killed here. See:
https://github.com/ant-tech-alliance/ray/blob/570c3153cd19d533ad370f84581e1cf056f2c7fe/src/local_scheduler/local_scheduler.cc#L184-L192

Also, using `ps | grep | kill` might be dangerous, because it
could also kill irrelevant processes, e.g., `vim DefaultWorker.java`.
