### PR TITLE
Use hashing function that takes into account all UniqueID bytes

### DIFF
--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -131,9 +131,7 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
   return h;
 }
 
-size_t UniqueID::hash() const {
-  return MurmurHash64A(&id_[0], kUniqueIDSize, 0);
-}
+size_t UniqueID::hash() const { return MurmurHash64A(&id_[0], kUniqueIDSize, 0); }
 
 std::ostream &operator<<(std::ostream &os, const UniqueID &id) {
   os << id.hex();

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -82,11 +82,50 @@ bool UniqueID::operator==(const UniqueID &rhs) const {
   return std::memcmp(data(), rhs.data(), kUniqueIDSize) == 0;
 }
 
+// This code is from https://sites.google.com/site/murmurhash/
+// and is public domain.
+uint64_t MurmurHash64A (const void *key, int len, unsigned int seed) {
+	const uint64_t m = 0xc6a4a7935bd1e995;
+	const int r = 47;
+
+	uint64_t h = seed ^ (len * m);
+
+	const uint64_t * data = reinterpret_cast<const uint64_t *>(key);
+	const uint64_t * end = data + (len/8);
+
+	while (data != end) {
+		uint64_t k = *data++;
+
+		k *= m;
+		k ^= k >> r;
+		k *= m;
+
+		h ^= k;
+		h *= m;
+	}
+
+	const unsigned char * data2 = reinterpret_cast<const unsigned char *>(data);
+
+	switch(len & 7) {
+	case 7: h ^= uint64_t(data2[6]) << 48;
+	case 6: h ^= uint64_t(data2[5]) << 40;
+	case 5: h ^= uint64_t(data2[4]) << 32;
+	case 4: h ^= uint64_t(data2[3]) << 24;
+	case 3: h ^= uint64_t(data2[2]) << 16;
+	case 2: h ^= uint64_t(data2[1]) << 8;
+	case 1: h ^= uint64_t(data2[0]);
+	        h *= m;
+	};
+
+	h ^= h >> r;
+	h *= m;
+	h ^= h >> r;
+
+	return h;
+}
+
 size_t UniqueID::hash() const {
-  size_t result;
-  // Skip the bytes for the object prefix.
-  std::memcpy(&result, id_ + (kObjectIdIndexSize / CHAR_BIT), sizeof(size_t));
-  return result;
+  return MurmurHash64A(&id_[0], kUniqueIDSize, 0);
 }
 
 std::ostream &operator<<(std::ostream &os, const UniqueID &id) {

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -84,44 +84,51 @@ bool UniqueID::operator==(const UniqueID &rhs) const {
 
 // This code is from https://sites.google.com/site/murmurhash/
 // and is public domain.
-uint64_t MurmurHash64A (const void *key, int len, unsigned int seed) {
-	const uint64_t m = 0xc6a4a7935bd1e995;
-	const int r = 47;
+uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
+  const uint64_t m = 0xc6a4a7935bd1e995;
+  const int r = 47;
 
-	uint64_t h = seed ^ (len * m);
+  uint64_t h = seed ^ (len * m);
 
-	const uint64_t * data = reinterpret_cast<const uint64_t *>(key);
-	const uint64_t * end = data + (len/8);
+  const uint64_t *data = reinterpret_cast<const uint64_t *>(key);
+  const uint64_t *end = data + (len / 8);
 
-	while (data != end) {
-		uint64_t k = *data++;
+  while (data != end) {
+    uint64_t k = *data++;
 
-		k *= m;
-		k ^= k >> r;
-		k *= m;
+    k *= m;
+    k ^= k >> r;
+    k *= m;
 
-		h ^= k;
-		h *= m;
-	}
+    h ^= k;
+    h *= m;
+  }
 
-	const unsigned char * data2 = reinterpret_cast<const unsigned char *>(data);
+  const unsigned char *data2 = reinterpret_cast<const unsigned char *>(data);
 
-	switch(len & 7) {
-	case 7: h ^= uint64_t(data2[6]) << 48;
-	case 6: h ^= uint64_t(data2[5]) << 40;
-	case 5: h ^= uint64_t(data2[4]) << 32;
-	case 4: h ^= uint64_t(data2[3]) << 24;
-	case 3: h ^= uint64_t(data2[2]) << 16;
-	case 2: h ^= uint64_t(data2[1]) << 8;
-	case 1: h ^= uint64_t(data2[0]);
-	        h *= m;
-	};
+  switch (len & 7) {
+  case 7:
+    h ^= uint64_t(data2[6]) << 48;
+  case 6:
+    h ^= uint64_t(data2[5]) << 40;
+  case 5:
+    h ^= uint64_t(data2[4]) << 32;
+  case 4:
+    h ^= uint64_t(data2[3]) << 24;
+  case 3:
+    h ^= uint64_t(data2[2]) << 16;
+  case 2:
+    h ^= uint64_t(data2[1]) << 8;
+  case 1:
+    h ^= uint64_t(data2[0]);
+    h *= m;
+  };
 
-	h ^= h >> r;
-	h *= m;
-	h ^= h >> r;
+  h ^= h >> r;
+  h *= m;
+  h ^= h >> r;
 
-	return h;
+  return h;
 }
 
 size_t UniqueID::hash() const {


### PR DESCRIPTION
In the past we had problems with collisions in our UniqueID hash tables that recently resurfaced in Ray. This PR introduces a slower but hopefully more reliable hash function that will be less susceptible to changes in the ObjectID byte layout.