### PR TITLE
Launch nodes in separate threads

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import copy
 import json
 import hashlib
+import math
 import os
 import queue
 import subprocess
@@ -312,13 +313,11 @@ class StandardAutoscaler(object):
         # Node launchers
         self.launch_queue = queue.Queue()
         self.num_launches_pending = ConcurrentCounter()
-        # max_batches = integer ceiling of max_concurrent_launches / max_launch_batch
-        max_batches = max_concurrent_launches // max_launch_batch
-        max_batches += (max_concurrent_launches % max_launch_batch > 0)
-        for i in range(max_batches):
+        max_batches = math.ceil(
+            max_concurrent_launches / float(max_launch_batch))
+        for i in range(int(max_batches)):
             node_launcher = NodeLauncher(
-                queue=self.launch_queue,
-                pending=self.num_launches_pending)
+                queue=self.launch_queue, pending=self.num_launches_pending)
             node_launcher.daemon = True
             node_launcher.start()
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -208,7 +208,7 @@ class NodeLauncher(threading.Thread):
         self.queue = queue
         self.pending = pending
         self.provider = None
-        super().__init__(*args, **kwargs)
+        super(NodeLauncher, self).__init__(*args, **kwargs)
 
     def _launch_node(self, config, count):
         if self.provider is None:

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -537,7 +537,8 @@ def check_extraneous(config, schema):
             if not isinstance(config[k], v):
                 raise ValueError(
                     "Config key `{}` has wrong type {}, expected {}".format(
-                        k, type(config[k]).__name__, v.__name__))
+                        k,
+                        type(config[k]).__name__, v.__name__))
         else:
             check_extraneous(config[k], v)
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -353,6 +353,7 @@ class StandardAutoscaler(object):
             return
 
         self.last_update_time = time.time()
+        num_pending = self.num_launches_pending.value
         nodes = self.workers()
         print(self.debug_string(nodes))
         self.load_metrics.prune_active_ips(
@@ -393,7 +394,6 @@ class StandardAutoscaler(object):
 
         # Launch new nodes if needed
         target_num = self.target_num_workers()
-        num_pending = self.num_launches_pending.value
         num_nodes = len(nodes) + num_pending
         if num_nodes < target_num:
             max_allowed = min(self.max_launch_batch,

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import json
 import hashlib
+import json
 import os
 import subprocess
-import time
 import threading
+import time
 import traceback
 
 from collections import defaultdict

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -16,6 +16,11 @@ def env_integer(key, default):
 # is a safety feature to prevent e.g. runaway node launches.
 AUTOSCALER_MAX_NUM_FAILURES = env_integer("AUTOSCALER_MAX_NUM_FAILURES", 5)
 
+# The maximum number of nodes to launch in a single request.
+# Multiple requests may be made for this batch size, up to
+# the limit of AUTOSCALER_MAX_CONCURRENT_LAUNCHES.
+AUTOSCALER_MAX_LAUNCH_BATCH = env_integer("AUTOSCALER_MAX_LAUNCH_BATCH", 5)
+
 # Max number of nodes to launch at a time.
 AUTOSCALER_MAX_CONCURRENT_LAUNCHES = env_integer(
     "AUTOSCALER_MAX_CONCURRENT_LAUNCHES", 10)

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -403,13 +403,15 @@ class AutoscalingTest(unittest.TestCase):
             max_failures=0,
             update_interval_s=10)
         autoscaler.update()
+        self.waitForNodes(2)
         self.assertEqual(autoscaler.num_launches_pending.value, 0)
-        self.assertEqual(len(self.provider.nodes({})), 2)
         new_config = SMALL_CLUSTER.copy()
         new_config["max_workers"] = 1
         self.write_config(new_config)
         autoscaler.update()
         # not updated yet
+        # note that node termination happens in the main thread, so
+        # we do not need to add any delay here before checking
         self.assertEqual(len(self.provider.nodes({})), 2)
         self.assertEqual(autoscaler.num_launches_pending.value, 0)
 

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import shutil
 import tempfile
+import threading
 import time
 import unittest
 import yaml
@@ -50,6 +51,8 @@ class MockProvider(NodeProvider):
         self.next_id = 0
         self.throw = False
         self.fail_creates = False
+        self.ready_to_create = threading.Event()
+        self.ready_to_create.set()
 
     def nodes(self, tag_filters):
         if self.throw:
@@ -75,6 +78,7 @@ class MockProvider(NodeProvider):
         return self.mock_nodes[node_id].external_ip
 
     def create_node(self, node_config, tags, count):
+        self.ready_to_create.wait()
         if self.fail_creates:
             return
         for _ in range(count):
@@ -179,8 +183,20 @@ class AutoscalingTest(unittest.TestCase):
         for _ in range(50):
             if condition():
                 return
+
+    def waitForNodes(self, expected, comparison=None, tag_filters={}):
+        MAX_ITER = 50
+        for i in range(MAX_ITER):
+            n = len(self.provider.nodes(tag_filters))
+            if comparison is None:
+                comparison = self.assertEqual
+            try:
+                comparison(n, expected)
+                return
+            except Exception:
+                if i == MAX_ITER - 1:
+                    raise
             time.sleep(.1)
-        raise Exception("Timed out waiting for {}".format(condition))
 
     def create_provider(self, config, cluster_name):
         assert self.provider
@@ -241,9 +257,9 @@ class AutoscalingTest(unittest.TestCase):
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
         self.assertEqual(len(self.provider.nodes({})), 0)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
 
     def testTerminateOutdatedNodesGracefully(self):
         config = SMALL_CLUSTER.copy()
@@ -254,16 +270,16 @@ class AutoscalingTest(unittest.TestCase):
         self.provider.create_node({}, {TAG_RAY_NODE_TYPE: "worker"}, 10)
         autoscaler = StandardAutoscaler(
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
-        self.assertEqual(len(self.provider.nodes({})), 10)
+        self.waitForNodes(10)
 
         # Gradually scales down to meet target size, never going too low
         for _ in range(10):
             autoscaler.update()
-            self.assertLessEqual(len(self.provider.nodes({})), 5)
-            self.assertGreaterEqual(len(self.provider.nodes({})), 4)
+            self.waitForNodes(5, comparison=self.assertLessEqual)
+            self.waitForNodes(4, comparison=self.assertGreaterEqual)
 
         # Eventually reaches steady state
-        self.assertEqual(len(self.provider.nodes({})), 5)
+        self.waitForNodes(5)
 
     def testDynamicScaling(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -274,9 +290,47 @@ class AutoscalingTest(unittest.TestCase):
             max_concurrent_launches=5,
             max_failures=0,
             update_interval_s=0)
-        self.assertEqual(len(self.provider.nodes({})), 0)
+        self.waitForNodes(0)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
+
+        # Update the config to reduce the cluster size
+        new_config = SMALL_CLUSTER.copy()
+        new_config["max_workers"] = 1
+        self.write_config(new_config)
+        autoscaler.update()
+        self.waitForNodes(1)
+
+        # Update the config to reduce the cluster size
+        new_config["min_workers"] = 10
+        new_config["max_workers"] = 10
+        self.write_config(new_config)
+        autoscaler.update()
+        self.waitForNodes(6)
+        autoscaler.update()
+        self.waitForNodes(10)
+
+    def testDelayedLaunch(self):
+        config_path = self.write_config(SMALL_CLUSTER)
+        self.provider = MockProvider()
+        autoscaler = StandardAutoscaler(
+            config_path,
+            LoadMetrics(),
+            max_concurrent_launches=5,
+            max_failures=0,
+            update_interval_s=0)
+        self.assertEqual(len(self.provider.nodes({})), 0)
+
+        # Update will try to create, but will block until we set the flag
+        self.provider.ready_to_create.clear()
+        autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 2)
+        self.assertEqual(len(self.provider.nodes({})), 0)
+
+        # Set the flag, check it updates
+        self.provider.ready_to_create.set()
+        self.waitForNodes(2)
+        self.assertEqual(autoscaler.num_launches_pending, 0)
 
         # Update the config to reduce the cluster size
         new_config = SMALL_CLUSTER.copy()
@@ -285,14 +339,47 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.assertEqual(len(self.provider.nodes({})), 1)
 
-        # Update the config to reduce the cluster size
-        new_config["min_workers"] = 10
-        new_config["max_workers"] = 10
-        self.write_config(new_config)
+    def testDelayedLaunchWithFailure(self):
+        config = SMALL_CLUSTER.copy()
+        config["min_workers"] = 9
+        config["max_workers"] = 9
+        config_path = self.write_config(config)
+        self.provider = MockProvider()
+        autoscaler = StandardAutoscaler(
+            config_path,
+            LoadMetrics(),
+            max_concurrent_launches=5,
+            max_failures=0,
+            update_interval_s=0)
+        self.assertEqual(len(self.provider.nodes({})), 0)
+
+        # update() should launch a wave of 5 nodes (max_concurrent_launches).
+        # Force this first wave to block.
+        rtc1 = self.provider.ready_to_create
+        rtc1.clear()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 6)
+        self.assertEqual(autoscaler.num_launches_pending, 5)
+        self.assertEqual(len(self.provider.nodes({})), 0)
+
+        # Call update() to launch a second wave of 4 nodes.
+        # Make this wave will complete immediately.
+        rtc2 = threading.Event()
+        self.provider.ready_to_create = rtc2
+        rtc2.set()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 10)
+        self.waitForNodes(4)
+
+        # The first wave of 5 will now tragically fail
+        self.provider.fail_creates = True
+        rtc1.set()
+        self.waitFor(lambda: autoscaler.num_launches_pending == 0)
+        self.assertEqual(len(self.provider.nodes({})), 4)
+
+        # Retry the first wave, allowing it to succeed this time
+        self.provider.fail_creates = False
+        autoscaler.update()
+        self.waitForNodes(9)
+        self.assertEqual(autoscaler.num_launches_pending, 0)
 
     def testUpdateThrottling(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -304,12 +391,15 @@ class AutoscalingTest(unittest.TestCase):
             max_failures=0,
             update_interval_s=10)
         autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
         new_config = SMALL_CLUSTER.copy()
         new_config["max_workers"] = 1
         self.write_config(new_config)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)  # not updated yet
+        # not updated yet
+        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.assertEqual(autoscaler.num_launches_pending, 0)
 
     def testLaunchConfigChange(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -326,6 +416,7 @@ class AutoscalingTest(unittest.TestCase):
         existing_nodes = set(self.provider.nodes({}))
         for _ in range(5):
             autoscaler.update()
+        self.waitForNodes(2)
         new_nodes = set(self.provider.nodes({}))
         self.assertEqual(len(new_nodes), 2)
         self.assertEqual(len(new_nodes.intersection(existing_nodes)), 0)
@@ -340,11 +431,14 @@ class AutoscalingTest(unittest.TestCase):
             max_failures=0,
             update_interval_s=0)
         autoscaler.update()
+        self.waitForNodes(2)
 
         # Write a corrupted config
         self.write_config("asdf")
         for _ in range(10):
             autoscaler.update()
+        time.sleep(0.1)
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
         # New a good config again
@@ -353,7 +447,7 @@ class AutoscalingTest(unittest.TestCase):
         new_config["max_workers"] = 10
         self.write_config(new_config)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 10)
+        self.waitForNodes(10)
 
     def testMaxFailures(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -372,12 +466,12 @@ class AutoscalingTest(unittest.TestCase):
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
         autoscaler.update()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         for node in self.provider.mock_nodes.values():
             node.state = "terminated"
         self.assertEqual(len(self.provider.nodes({})), 0)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
 
     def testConfiguresNewNodes(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -393,7 +487,7 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0)
         autoscaler.update()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         for node in self.provider.mock_nodes.values():
             node.state = "running"
         assert len(
@@ -401,9 +495,7 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_NODE_STATUS: "uninitialized"
             })) == 2
         autoscaler.update()
-        self.waitFor(
-            lambda: len(self.provider.nodes(
-                {TAG_RAY_NODE_STATUS: "up-to-date"})) == 2)
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: "up-to-date"})
 
     def testReportsConfigFailures(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -419,7 +511,7 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0)
         autoscaler.update()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         for node in self.provider.mock_nodes.values():
             node.state = "running"
         assert len(
@@ -427,9 +519,8 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_NODE_STATUS: "uninitialized"
             })) == 2
         autoscaler.update()
-        self.waitFor(
-            lambda: len(self.provider.nodes(
-                {TAG_RAY_NODE_STATUS: "update-failed"})) == 2)
+        self.waitForNodes(
+            2, tag_filters={TAG_RAY_NODE_STATUS: "update-failed"})
 
     def testConfiguresOutdatedNodes(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -445,13 +536,11 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0)
         autoscaler.update()
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         for node in self.provider.mock_nodes.values():
             node.state = "running"
         autoscaler.update()
-        self.waitFor(
-            lambda: len(self.provider.nodes(
-                {TAG_RAY_NODE_STATUS: "up-to-date"})) == 2)
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: "up-to-date"})
         runner.calls = []
         new_config = SMALL_CLUSTER.copy()
         new_config["worker_setup_commands"] = ["cmdX", "cmdY"]
@@ -472,33 +561,37 @@ class AutoscalingTest(unittest.TestCase):
             config_path, lm, max_failures=0, update_interval_s=0)
         self.assertEqual(len(self.provider.nodes({})), 0)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
         autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
         # Scales up as nodes are reported as used
         lm.update("172.0.0.0", {"CPU": 2}, {"CPU": 0})
         lm.update("172.0.0.1", {"CPU": 2}, {"CPU": 0})
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 4)
+        self.waitForNodes(4)
         lm.update("172.0.0.2", {"CPU": 2}, {"CPU": 0})
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 6)
+        self.waitForNodes(6)
 
         # Holds steady when load is removed
         lm.update("172.0.0.0", {"CPU": 2}, {"CPU": 2})
         lm.update("172.0.0.1", {"CPU": 2}, {"CPU": 2})
         autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 6)
 
         # Scales down as nodes become unused
         lm.last_used_time_by_ip["172.0.0.0"] = 0
         lm.last_used_time_by_ip["172.0.0.1"] = 0
         autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 4)
         lm.last_used_time_by_ip["172.0.0.2"] = 0
         lm.last_used_time_by_ip["172.0.0.3"] = 0
         autoscaler.update()
+        self.assertEqual(autoscaler.num_launches_pending, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
     def testRecoverUnhealthyWorkers(self):
@@ -518,9 +611,7 @@ class AutoscalingTest(unittest.TestCase):
         for node in self.provider.mock_nodes.values():
             node.state = "running"
         autoscaler.update()
-        self.waitFor(
-            lambda: len(self.provider.nodes(
-                {TAG_RAY_NODE_STATUS: "up-to-date"})) == 2)
+        self.waitForNodes(2, tag_filters={TAG_RAY_NODE_STATUS: "up-to-date"})
 
         # Mark a node as unhealthy
         lm.last_heartbeat_time_by_ip["172.0.0.0"] = 0

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -363,6 +363,8 @@ class AutoscalingTest(unittest.TestCase):
         rtc1 = self.provider.ready_to_create
         rtc1.clear()
         autoscaler.update()
+        # Synchronization: wait for launch thread to be blocked on rtc1
+        self.waitFor(lambda: len(rtc1._cond._waiters) == 1)
         self.assertEqual(autoscaler.num_launches_pending.value, 5)
         self.assertEqual(len(self.provider.nodes({})), 0)
 
@@ -374,6 +376,7 @@ class AutoscalingTest(unittest.TestCase):
         rtc2.set()
         autoscaler.update()
         self.waitForNodes(3)
+        self.assertEqual(autoscaler.num_launches_pending.value, 5)
 
         # The first wave of 5 will now tragically fail
         self.provider.fail_creates = True

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -183,6 +183,8 @@ class AutoscalingTest(unittest.TestCase):
         for _ in range(50):
             if condition():
                 return
+            time.sleep(.1)
+        raise Exception("Timed out waiting for {}".format(condition))
 
     def waitForNodes(self, expected, comparison=None, tag_filters={}):
         MAX_ITER = 50
@@ -287,6 +289,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
+            max_launch_batch=5,
             max_concurrent_launches=5,
             max_failures=0,
             update_interval_s=0)
@@ -316,6 +319,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
+            max_launch_batch=5,
             max_concurrent_launches=5,
             max_failures=0,
             update_interval_s=0)
@@ -324,13 +328,13 @@ class AutoscalingTest(unittest.TestCase):
         # Update will try to create, but will block until we set the flag
         self.provider.ready_to_create.clear()
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 2)
+        self.assertEqual(autoscaler.num_launches_pending.value, 2)
         self.assertEqual(len(self.provider.nodes({})), 0)
 
         # Set the flag, check it updates
         self.provider.ready_to_create.set()
         self.waitForNodes(2)
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
 
         # Update the config to reduce the cluster size
         new_config = SMALL_CLUSTER.copy()
@@ -341,45 +345,52 @@ class AutoscalingTest(unittest.TestCase):
 
     def testDelayedLaunchWithFailure(self):
         config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 9
-        config["max_workers"] = 9
+        config["min_workers"] = 10
+        config["max_workers"] = 10
         config_path = self.write_config(config)
         self.provider = MockProvider()
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
-            max_concurrent_launches=5,
+            max_launch_batch=5,
+            max_concurrent_launches=8,
             max_failures=0,
             update_interval_s=0)
         self.assertEqual(len(self.provider.nodes({})), 0)
 
-        # update() should launch a wave of 5 nodes (max_concurrent_launches).
+        # update() should launch a wave of 5 nodes (max_launch_batch)
         # Force this first wave to block.
         rtc1 = self.provider.ready_to_create
         rtc1.clear()
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 5)
+        self.assertEqual(autoscaler.num_launches_pending.value, 5)
         self.assertEqual(len(self.provider.nodes({})), 0)
 
-        # Call update() to launch a second wave of 4 nodes.
-        # Make this wave will complete immediately.
+        # Call update() to launch a second wave of 3 nodes,
+        # as 5 + 3 = 8 = max_concurrent_launches.
+        # Make this wave complete immediately.
         rtc2 = threading.Event()
         self.provider.ready_to_create = rtc2
         rtc2.set()
         autoscaler.update()
-        self.waitForNodes(4)
+        self.waitForNodes(3)
 
         # The first wave of 5 will now tragically fail
         self.provider.fail_creates = True
         rtc1.set()
-        self.waitFor(lambda: autoscaler.num_launches_pending == 0)
-        self.assertEqual(len(self.provider.nodes({})), 4)
+        self.waitFor(lambda: autoscaler.num_launches_pending.value == 0)
+        self.assertEqual(len(self.provider.nodes({})), 3)
 
         # Retry the first wave, allowing it to succeed this time
         self.provider.fail_creates = False
         autoscaler.update()
-        self.waitForNodes(9)
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.waitForNodes(8)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
+
+        # Final wave of 2 nodes
+        autoscaler.update()
+        self.waitForNodes(10)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
 
     def testUpdateThrottling(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -387,11 +398,12 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
+            max_launch_batch=5,
             max_concurrent_launches=5,
             max_failures=0,
             update_interval_s=10)
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
         new_config = SMALL_CLUSTER.copy()
         new_config["max_workers"] = 1
@@ -399,7 +411,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         # not updated yet
         self.assertEqual(len(self.provider.nodes({})), 2)
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
 
     def testLaunchConfigChange(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -407,19 +419,18 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler = StandardAutoscaler(
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
         autoscaler.update()
-        self.assertEqual(len(self.provider.nodes({})), 2)
+        self.waitForNodes(2)
 
         # Update the config to change the node type
         new_config = SMALL_CLUSTER.copy()
         new_config["worker_nodes"]["InstanceType"] = "updated"
         self.write_config(new_config)
-        existing_nodes = set(self.provider.nodes({}))
+        self.provider.ready_to_create.clear()
         for _ in range(5):
             autoscaler.update()
+        self.waitForNodes(0)
+        self.provider.ready_to_create.set()
         self.waitForNodes(2)
-        new_nodes = set(self.provider.nodes({}))
-        self.assertEqual(len(new_nodes), 2)
-        self.assertEqual(len(new_nodes.intersection(existing_nodes)), 0)
 
     def testIgnoresCorruptedConfig(self):
         config_path = self.write_config(SMALL_CLUSTER)
@@ -427,6 +438,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler = StandardAutoscaler(
             config_path,
             LoadMetrics(),
+            max_launch_batch=10,
             max_concurrent_launches=10,
             max_failures=0,
             update_interval_s=0)
@@ -438,7 +450,7 @@ class AutoscalingTest(unittest.TestCase):
         for _ in range(10):
             autoscaler.update()
         time.sleep(0.1)
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
         # New a good config again
@@ -563,7 +575,7 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(2)
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
         # Scales up as nodes are reported as used
@@ -579,19 +591,19 @@ class AutoscalingTest(unittest.TestCase):
         lm.update("172.0.0.0", {"CPU": 2}, {"CPU": 2})
         lm.update("172.0.0.1", {"CPU": 2}, {"CPU": 2})
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 6)
 
         # Scales down as nodes become unused
         lm.last_used_time_by_ip["172.0.0.0"] = 0
         lm.last_used_time_by_ip["172.0.0.1"] = 0
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 4)
         lm.last_used_time_by_ip["172.0.0.2"] = 0
         lm.last_used_time_by_ip["172.0.0.3"] = 0
         autoscaler.update()
-        self.assertEqual(autoscaler.num_launches_pending, 0)
+        self.assertEqual(autoscaler.num_launches_pending.value, 0)
         self.assertEqual(len(self.provider.nodes({})), 2)
 
     def testRecoverUnhealthyWorkers(self):
@@ -608,6 +620,7 @@ class AutoscalingTest(unittest.TestCase):
             node_updater_cls=NodeUpdaterThread,
             update_interval_s=0)
         autoscaler.update()
+        self.waitForNodes(2)
         for node in self.provider.mock_nodes.values():
             node.state = "running"
         autoscaler.update()

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -363,8 +363,12 @@ class AutoscalingTest(unittest.TestCase):
         rtc1 = self.provider.ready_to_create
         rtc1.clear()
         autoscaler.update()
-        # Synchronization: wait for launch thread to be blocked on rtc1
-        self.waitFor(lambda: len(rtc1._cond._waiters) == 1)
+        # Synchronization: wait for launchy thread to be blocked on rtc1
+        if hasattr(rtc1, '_cond'):  # Python 3.5
+            waiters = rtc1._cond._waiters
+        else:  # Python 2.7
+            waiters = rtc1._Event__cond._Condition__waiters
+        self.waitFor(lambda: len(waiters) == 1)
         self.assertEqual(autoscaler.num_launches_pending.value, 5)
         self.assertEqual(len(self.provider.nodes({})), 0)
 


### PR DESCRIPTION
## What do these changes do?

Modifies the autoscaler to run launch_new_nodes in a separate thread, keeping track of the number of pending requests. 

Added unit tests to cover this.

Also had to modify existing unit tests: a lot of things are asynchronous now, so need to poll in the unit test rather than immediately call assert. I'm not particularly happy about this but with the helper function ```waitForNode``` it is not too bad.

Requesting review from @ericl who proposed changes along these lines (any mistakes my own).

## Related issue number

#2138