### PR TITLE
[DataFrame] Fix equals and make it more efficient

### DIFF
--- a/python/ray/dataframe/index_metadata.py
+++ b/python/ray/dataframe/index_metadata.py
@@ -8,6 +8,7 @@ from .utils import (
     _build_coord_df)
 
 from pandas.core.indexing import convert_to_index_sliceable
+from pandas.core.dtypes.common import is_list_like
 
 
 class _IndexMetadata(object):
@@ -49,7 +50,7 @@ class _IndexMetadata(object):
                 lengths_oid = _build_col_widths.remote(dfs)
             coord_df_oid = _build_coord_df.remote(lengths_oid, index)
 
-        self._lengths = lengths_oid
+        self._lengths_cache = lengths_oid
         self._coord_df = coord_df_oid
         self._index_cache = index
         self._cached_index = False
@@ -59,6 +60,13 @@ class _IndexMetadata(object):
             (isinstance(self._lengths_cache, list) and
              isinstance(self._lengths_cache[0], ray.ObjectID)):
             self._lengths_cache = ray.get(self._lengths_cache)
+
+        # NOTE: Something
+        self._lengths_cache = [l for l in self._lengths_cache if l != 0]
+
+        if len(self._lengths_cache) == 0:
+            self._lengths_cache = [0]
+
         return self._lengths_cache
 
     def _set__lengths(self, lengths):
@@ -353,6 +361,9 @@ class _IndexMetadata(object):
         Returns:
             DataFrame with coordinates of dropped labels
         """
+        if not is_list_like(labels):
+            labels = [labels]
+
         dropped = self.coords_of(labels)
 
         # Update first lengths to prevent possible length inconsistencies
@@ -372,9 +383,19 @@ class _IndexMetadata(object):
             drop_per_part[dropped["partition"]] = 1
         else:
             raise AssertionError("Unrecognized result from `coords_of`")
-        self._lengths = self._lengths - drop_per_part
 
+        self._lengths_cache = self._lengths - drop_per_part
         self._coord_df = self._coord_df.drop(labels, errors=errors)
+
+        # Since we are dropping the empty partition(s) when we convert to
+        # blocks, update the partition number here
+
+        x = self._coord_df['partition'].unique()
+        z = dict(zip(x, range(len(x))))
+
+        self._coord_df['partition'] = \
+            [z[i] for i in self._coord_df['partition']]
+
         return dropped
 
     def rename_index(self, mapper):
@@ -402,3 +423,8 @@ class _IndexMetadata(object):
         return (self._coord_df
                     .sort_values(['partition', 'index_within_partition'])
                     .index)
+
+
+@ray.remote
+def _get_lengths_from_coords_df(coords_df):
+    return coords_df.groupby(by='partition').apply(lambda x: len(x))

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -17,8 +17,8 @@ def ray_df_equals_pandas(ray_df, pandas_df):
 
 
 @pytest.fixture
-def ray_series_equals_pandas(ray_df, pandas_df):
-    return ray_df.equals(pandas_df)
+def ray_series_equals_pandas(ray_series, pandas_series):
+    return ray_series.equals(pandas_series)
 
 
 @pytest.fixture

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -23,7 +23,7 @@ def ray_series_equals_pandas(ray_df, pandas_df):
 
 @pytest.fixture
 def ray_df_equals(ray_df1, ray_df2):
-    return to_pandas(ray_df1).equals(to_pandas(ray_df2))
+    return ray_df1.equals(ray_df2)
 
 
 @pytest.fixture

--- a/python/ray/dataframe/utils.py
+++ b/python/ray/dataframe/utils.py
@@ -133,8 +133,15 @@ def to_pandas(df):
         A new pandas DataFrame.
     """
     pd_df = pd.concat(ray.get(df._row_partitions), copy=False)
-    pd_df.index = df.index
-    pd_df.columns = df.columns
+
+    try:
+        pd_df.index = df.index
+        pd_df.columns = df.columns
+    except Exception as e:
+        print(pd_df)
+        print(df.columns)
+        print(df.index)
+        raise e
     return pd_df
 
 


### PR DESCRIPTION
Previous equals had a bug and created a remote task for each line. New implementation uses `_copartition` to efficiently align both dataframes.

Also added some documentation for `_match_partitioning` because when I tried to use it, it caused problems for `DataFrames` that had `drop` on one axis and an operation on the opposite axis (i.e. a `df.drop(columns=['A', 'B']).drop(index=[1, 4])`. 