### PR TITLE
Fix redefinition of flatbuffer types

### DIFF
--- a/src/local_scheduler/format/local_scheduler.fbs
+++ b/src/local_scheduler/format/local_scheduler.fbs
@@ -1,4 +1,5 @@
 // Local scheduler protocol specification
+namespace ray.local_scheduler.protocol;
 
 enum MessageType:int {
   // Task is submitted to the local scheduler. This is sent from a worker to a

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -28,6 +28,9 @@
 #include "state/object_table.h"
 #include "state/error_table.h"
 
+// Using flatbuffer types defined in "format/local_scheduler_generated.h"
+using namespace ray::local_scheduler::protocol;
+
 /**
  * A helper function for printing available and requested resource information.
  *

--- a/src/local_scheduler/local_scheduler.cc
+++ b/src/local_scheduler/local_scheduler.cc
@@ -528,8 +528,8 @@ void assign_task_to_worker(LocalSchedulerState *state,
 
   /* Construct a flatbuffer object to send to the worker. */
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = ray::local_scheduler::protocol::CreateGetTaskReply(fbb,
-      fbb.CreateString((char *) spec, task_spec_size),
+  auto message = ray::local_scheduler::protocol::CreateGetTaskReply(
+      fbb, fbb.CreateString((char *) spec, task_spec_size),
       fbb.CreateVector(worker->gpus_in_use));
   fbb.Finish(message);
 
@@ -925,7 +925,8 @@ void reconstruct_object(LocalSchedulerState *state,
 }
 
 void handle_client_register(
-    LocalSchedulerState *state, LocalSchedulerClient *worker,
+    LocalSchedulerState *state,
+    LocalSchedulerClient *worker,
     const ray::local_scheduler::protocol::RegisterClientRequest *message) {
   /* Make sure this worker hasn't already registered. */
   RAY_CHECK(!worker->registered);
@@ -1051,7 +1052,8 @@ void handle_get_actor_frontier(LocalSchedulerState *state,
 }
 
 void handle_set_actor_frontier(
-    LocalSchedulerState *state, LocalSchedulerClient *worker,
+    LocalSchedulerState *state,
+    LocalSchedulerClient *worker,
     ray::local_scheduler::protocol::ActorFrontier const &frontier) {
   /* Parse the ActorFrontier flatbuffer. */
   ActorID actor_id = from_flatbuf(*frontier.actor_id());

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -56,8 +56,8 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
   flatbuffers::FlatBufferBuilder fbb;
   auto key_string = fbb.CreateString((char *) key, key_length);
   auto value_string = fbb.CreateString((char *) value, value_length);
-  auto message = ray::local_scheduler::protocol::CreateEventLogMessage(fbb,
-      key_string, value_string, timestamp);
+  auto message = ray::local_scheduler::protocol::CreateEventLogMessage(
+      fbb, key_string, value_string, timestamp);
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_EventLogMessage,
@@ -72,8 +72,8 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
   auto task_spec =
       fbb.CreateString(reinterpret_cast<char *>(execution_spec.Spec()),
                        execution_spec.SpecSize());
-  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(fbb,
-      execution_dependencies, task_spec);
+  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(
+      fbb, execution_dependencies, task_spec);
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_SubmitTask,
@@ -144,8 +144,8 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn) {
 void local_scheduler_reconstruct_object(LocalSchedulerConnection *conn,
                                         ObjectID object_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = ray::local_scheduler::protocol::CreateReconstructObject(fbb,
-      to_flatbuf(fbb, object_id));
+  auto message = ray::local_scheduler::protocol::CreateReconstructObject(
+      fbb, to_flatbuf(fbb, object_id));
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_ReconstructObject,
@@ -169,8 +169,8 @@ void local_scheduler_put_object(LocalSchedulerConnection *conn,
                                 TaskID task_id,
                                 ObjectID object_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = ray::local_scheduler::protocol::CreatePutObject(fbb,
-      to_flatbuf(fbb, task_id), to_flatbuf(fbb, object_id));
+  auto message = ray::local_scheduler::protocol::CreatePutObject(
+      fbb, to_flatbuf(fbb, task_id), to_flatbuf(fbb, object_id));
   fbb.Finish(message);
 
   write_message(conn->conn,

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -9,6 +9,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+// Using flatbuffer types definded in "format/local_scheduler_generated.h"
+using namespace ray::local_scheduler::protocol;
+
 LocalSchedulerConnection *LocalSchedulerConnection_init(
     const char *local_scheduler_socket,
     UniqueID client_id,

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -20,7 +20,7 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
    * NOTE(swang): If the local scheduler exits and we are registered as a
    * worker, we will get killed. */
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateRegisterClientRequest(
+  auto message = ray::local_scheduler::protocol::CreateRegisterClientRequest(
       fbb, is_worker, to_flatbuf(fbb, client_id), getpid());
   fbb.Finish(message);
   /* Register the process ID with the local scheduler. */
@@ -40,7 +40,7 @@ void LocalSchedulerConnection_free(LocalSchedulerConnection *conn) {
 
 void local_scheduler_disconnect_client(LocalSchedulerConnection *conn) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateDisconnectClient(fbb);
+  auto message = ray::local_scheduler::protocol::CreateDisconnectClient(fbb);
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_DisconnectClient,
@@ -56,8 +56,8 @@ void local_scheduler_log_event(LocalSchedulerConnection *conn,
   flatbuffers::FlatBufferBuilder fbb;
   auto key_string = fbb.CreateString((char *) key, key_length);
   auto value_string = fbb.CreateString((char *) value, value_length);
-  auto message =
-      CreateEventLogMessage(fbb, key_string, value_string, timestamp);
+  auto message = ray::local_scheduler::protocol::CreateEventLogMessage(fbb,
+      key_string, value_string, timestamp);
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_EventLogMessage,
@@ -72,8 +72,8 @@ void local_scheduler_submit(LocalSchedulerConnection *conn,
   auto task_spec =
       fbb.CreateString(reinterpret_cast<char *>(execution_spec.Spec()),
                        execution_spec.SpecSize());
-  auto message =
-      CreateSubmitTaskRequest(fbb, execution_dependencies, task_spec);
+  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(fbb,
+      execution_dependencies, task_spec);
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_SubmitTask,
@@ -86,7 +86,8 @@ void local_scheduler_submit_raylet(
     ray::raylet::TaskSpecification task_spec) {
   flatbuffers::FlatBufferBuilder fbb;
   auto execution_dependencies_message = to_flatbuf(fbb, execution_dependencies);
-  auto message = CreateSubmitTaskRequest(fbb, execution_dependencies_message,
+  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(fbb,
+      execution_dependencies_message,
                                          task_spec.ToFlatbuffer(fbb));
   fbb.Finish(message);
   write_message(conn->conn,
@@ -143,7 +144,8 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn) {
 void local_scheduler_reconstruct_object(LocalSchedulerConnection *conn,
                                         ObjectID object_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateReconstructObject(fbb, to_flatbuf(fbb, object_id));
+  auto message = ray::local_scheduler::protocol::CreateReconstructObject(fbb,
+      to_flatbuf(fbb, object_id));
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_ReconstructObject,
@@ -167,8 +169,8 @@ void local_scheduler_put_object(LocalSchedulerConnection *conn,
                                 TaskID task_id,
                                 ObjectID object_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreatePutObject(fbb, to_flatbuf(fbb, task_id),
-                                 to_flatbuf(fbb, object_id));
+  auto message = ray::local_scheduler::protocol::CreatePutObject(fbb,
+      to_flatbuf(fbb, task_id), to_flatbuf(fbb, object_id));
   fbb.Finish(message);
 
   write_message(conn->conn,
@@ -180,7 +182,8 @@ const std::vector<uint8_t> local_scheduler_get_actor_frontier(
     LocalSchedulerConnection *conn,
     ActorID actor_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreateGetActorFrontierRequest(fbb, to_flatbuf(fbb, actor_id));
+  auto message = ray::local_scheduler::protocol::CreateGetActorFrontierRequest(
+      fbb, to_flatbuf(fbb, actor_id));
   fbb.Finish(message);
   write_message(
       conn->conn,

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -86,9 +86,8 @@ void local_scheduler_submit_raylet(
     ray::raylet::TaskSpecification task_spec) {
   flatbuffers::FlatBufferBuilder fbb;
   auto execution_dependencies_message = to_flatbuf(fbb, execution_dependencies);
-  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(fbb,
-      execution_dependencies_message,
-                                         task_spec.ToFlatbuffer(fbb));
+  auto message = ray::local_scheduler::protocol::CreateSubmitTaskRequest(
+      fbb, execution_dependencies_message, task_spec.ToFlatbuffer(fbb));
   fbb.Finish(message);
   write_message(conn->conn,
                 ray::local_scheduler::protocol::MessageType_SubmitTask,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -9,25 +9,37 @@ namespace {
 #define RAY_CHECK_ENUM(x, y) \
   static_assert(static_cast<int>(x) == static_cast<int>(y), "protocol mismatch")
 
+namespace local_scheduler_protocol = ray::local_scheduler::protocol;
+
 // Check consistency between client and server protocol.
-RAY_CHECK_ENUM(protocol::MessageType_SubmitTask, MessageType_SubmitTask);
-RAY_CHECK_ENUM(protocol::MessageType_TaskDone, MessageType_TaskDone);
-RAY_CHECK_ENUM(protocol::MessageType_EventLogMessage, MessageType_EventLogMessage);
+RAY_CHECK_ENUM(protocol::MessageType_SubmitTask,
+               local_scheduler_protocol::MessageType_SubmitTask);
+RAY_CHECK_ENUM(protocol::MessageType_TaskDone,
+               local_scheduler_protocol::MessageType_TaskDone);
+RAY_CHECK_ENUM(protocol::MessageType_EventLogMessage,
+               local_scheduler_protocol::MessageType_EventLogMessage);
 RAY_CHECK_ENUM(protocol::MessageType_RegisterClientRequest,
-               MessageType_RegisterClientRequest);
+               local_scheduler_protocol::MessageType_RegisterClientRequest);
 RAY_CHECK_ENUM(protocol::MessageType_RegisterClientReply,
-               MessageType_RegisterClientReply);
-RAY_CHECK_ENUM(protocol::MessageType_DisconnectClient, MessageType_DisconnectClient);
-RAY_CHECK_ENUM(protocol::MessageType_GetTask, MessageType_GetTask);
-RAY_CHECK_ENUM(protocol::MessageType_ExecuteTask, MessageType_ExecuteTask);
-RAY_CHECK_ENUM(protocol::MessageType_ReconstructObject, MessageType_ReconstructObject);
-RAY_CHECK_ENUM(protocol::MessageType_NotifyUnblocked, MessageType_NotifyUnblocked);
-RAY_CHECK_ENUM(protocol::MessageType_PutObject, MessageType_PutObject);
+               local_scheduler_protocol::MessageType_RegisterClientReply);
+RAY_CHECK_ENUM(protocol::MessageType_DisconnectClient,
+               local_scheduler_protocol::MessageType_DisconnectClient);
+RAY_CHECK_ENUM(protocol::MessageType_GetTask,
+               local_scheduler_protocol::MessageType_GetTask);
+RAY_CHECK_ENUM(protocol::MessageType_ExecuteTask,
+               local_scheduler_protocol::MessageType_ExecuteTask);
+RAY_CHECK_ENUM(protocol::MessageType_ReconstructObject,
+               local_scheduler_protocol::MessageType_ReconstructObject);
+RAY_CHECK_ENUM(protocol::MessageType_NotifyUnblocked,
+               local_scheduler_protocol::MessageType_NotifyUnblocked);
+RAY_CHECK_ENUM(protocol::MessageType_PutObject,
+               local_scheduler_protocol::MessageType_PutObject);
 RAY_CHECK_ENUM(protocol::MessageType_GetActorFrontierRequest,
-               MessageType_GetActorFrontierRequest);
+               local_scheduler_protocol::MessageType_GetActorFrontierRequest);
 RAY_CHECK_ENUM(protocol::MessageType_GetActorFrontierReply,
-               MessageType_GetActorFrontierReply);
-RAY_CHECK_ENUM(protocol::MessageType_SetActorFrontier, MessageType_SetActorFrontier);
+               local_scheduler_protocol::MessageType_GetActorFrontierReply);
+RAY_CHECK_ENUM(protocol::MessageType_SetActorFrontier,
+               local_scheduler_protocol::MessageType_SetActorFrontier);
 
 /// A helper function to determine whether a given actor task has already been executed
 /// according to the given actor registry. Returns true if the task is a duplicate.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -5,7 +5,8 @@
 #include "ray/raylet/format/node_manager_generated.h"
 
 namespace {
-namespace local_scheduler_protocol = ray::local_scheduler::protocol;
+
+using local_scheduler_protocol = ray::local_scheduler::protocol;
 
 #define RAY_CHECK_ENUM(x, y) \
   static_assert(static_cast<int>(x) == static_cast<int>(y), "protocol mismatch")

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -6,7 +6,7 @@
 
 namespace {
 
-using local_scheduler_protocol = ray::local_scheduler::protocol;
+namespace local_scheduler_protocol = ray::local_scheduler::protocol;
 
 #define RAY_CHECK_ENUM(x, y) \
   static_assert(static_cast<int>(x) == static_cast<int>(y), "protocol mismatch")

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -5,11 +5,10 @@
 #include "ray/raylet/format/node_manager_generated.h"
 
 namespace {
+namespace local_scheduler_protocol = ray::local_scheduler::protocol;
 
 #define RAY_CHECK_ENUM(x, y) \
   static_assert(static_cast<int>(x) == static_cast<int>(y), "protocol mismatch")
-
-namespace local_scheduler_protocol = ray::local_scheduler::protocol;
 
 // Check consistency between client and server protocol.
 RAY_CHECK_ENUM(protocol::MessageType_SubmitTask,


### PR DESCRIPTION


## What do these changes do?

Now, flatbuffer types are defined in `*.fbs` files, such as `src/local_scheduler/format/local_scheduler.fbs`, `src/ray/object_manager/format/object_manager.fbs` and `src/ray/raylet/format/node_manager.fbs`, which will then be turned to `*_generated.h` files. However, the last two files define flatbuffer types in namespace, while the first file doesn't. That caused a problem about variables' name conflicting.

For example, in file `src/ray/raylet/node_manager.cc`, it includes two `*_generated.h` files, and when we need to include another `*_generated.h` file (in fact, we will do it soon) which also doesn't defines flatbuffer types in namespace, the conflicting problem will appear.

To solve the problem, make sure every `*.fbs` file defines variables in namespace and that's the PR does.