### PR TITLE
Change surefire version to 2.21.0 to fix test failure on Java10.

### DIFF
--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.21.0</version>
         <configuration>
           <!-- <properties>
             <property>


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Change surefire version to 2.21.0. In Ant Financial, we use Java 8 which is OK with Surefile 2.20.1. However, for outside users, they may use Java 10. I found there was a strange failure. 
![image](https://user-images.githubusercontent.com/19584326/41028429-ffc0bc92-69ab-11e8-80e2-4f3f2964883a.png)
Here is the [discussion](https://github.com/junit-team/junit4/issues/1513) from Junit-Team.
I have tested this change in both Java 8 and Java 10. 
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
