### PR TITLE
import queue from six.moves for better py2 compatibility

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -7,7 +7,7 @@ import json
 import hashlib
 import math
 import os
-import queue
+from six.moves import queue
 import subprocess
 import threading
 import time

--- a/python/ray/rllib/bc/bc_evaluator.py
+++ b/python/ray/rllib/bc/bc_evaluator.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import pickle
-import queue
+from six.moves import queue
 
 import ray
 from ray.rllib.bc.experience_dataset import ExperienceDataset

--- a/python/ray/tune/util.py
+++ b/python/ray/tune/util.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import base64
-import queue
+from six.moves import queue
 import threading
 
 import ray


### PR DESCRIPTION


## What do these changes do?

Odd that this passes in travis, perhaps only some versions of py2 don't have queue.