### PR TITLE
[autoscaler] Should use internal IP for ssh

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -488,7 +488,8 @@ class StandardAutoscaler(object):
             with_head_node_ip(self.config["worker_start_ray_commands"]),
             self.runtime_hash,
             redirect_output=not self.verbose_updates,
-            process_runner=self.process_runner)
+            process_runner=self.process_runner,
+            use_external_ip=False)
         updater.start()
         self.updaters[node_id] = updater
 
@@ -514,7 +515,8 @@ class StandardAutoscaler(object):
             with_head_node_ip(init_commands),
             self.runtime_hash,
             redirect_output=not self.verbose_updates,
-            process_runner=self.process_runner)
+            process_runner=self.process_runner,
+            use_external_ip=False)
         updater.start()
         self.updaters[node_id] = updater
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -489,7 +489,7 @@ class StandardAutoscaler(object):
             self.runtime_hash,
             redirect_output=not self.verbose_updates,
             process_runner=self.process_runner,
-            use_external_ip=False)
+            use_internal_ip=True)
         updater.start()
         self.updaters[node_id] = updater
 
@@ -516,7 +516,7 @@ class StandardAutoscaler(object):
             self.runtime_hash,
             redirect_output=not self.verbose_updates,
             process_runner=self.process_runner,
-            use_external_ip=False)
+            use_internal_ip=True)
         updater.start()
         self.updaters[node_id] = updater
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -45,7 +45,7 @@ class NodeUpdater(object):
         self.provider = get_node_provider(provider_config, cluster_name)
         self.ssh_private_key = auth_config["ssh_private_key"]
         self.ssh_user = auth_config["ssh_user"]
-        self.ssh_ip = self.provider.external_ip(node_id)
+        self.ssh_ip = self.provider.internal_ip(node_id)
         self.node_id = node_id
         self.file_mounts = {
             remote: os.path.expanduser(local)
@@ -107,7 +107,7 @@ class NodeUpdater(object):
             print(
                 "NodeUpdater: Waiting for IP of {}...".format(self.node_id),
                 file=self.stdout)
-            self.ssh_ip = self.provider.external_ip(self.node_id)
+            self.ssh_ip = self.provider.internal_ip(self.node_id)
             if self.ssh_ip is not None:
                 break
             time.sleep(10)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -39,14 +39,16 @@ class NodeUpdater(object):
                  setup_cmds,
                  runtime_hash,
                  redirect_output=True,
-                 process_runner=subprocess):
+                 process_runner=subprocess,
+                 use_external_ip=True):
         self.daemon = True
         self.process_runner = process_runner
+        self.node_id = node_id
+        self.use_external_ip = use_external_ip
         self.provider = get_node_provider(provider_config, cluster_name)
         self.ssh_private_key = auth_config["ssh_private_key"]
         self.ssh_user = auth_config["ssh_user"]
-        self.ssh_ip = self.provider.internal_ip(node_id)
-        self.node_id = node_id
+        self.ssh_ip = self.get_node_ip()
         self.file_mounts = {
             remote: os.path.expanduser(local)
             for remote, local in file_mounts.items()
@@ -64,6 +66,12 @@ class NodeUpdater(object):
             self.output_name = "(console)"
             self.stdout = sys.stdout
             self.stderr = sys.stderr
+
+    def get_node_ip(self):
+        if use_external_ip:
+            return self.provider.external_ip(self.node_id)
+        else:
+            return self.provider.internal_ip(self.node_id)
 
     def run(self):
         print("NodeUpdater: Updating {} to {}, logging to {}".format(
@@ -107,7 +115,7 @@ class NodeUpdater(object):
             print(
                 "NodeUpdater: Waiting for IP of {}...".format(self.node_id),
                 file=self.stdout)
-            self.ssh_ip = self.provider.internal_ip(self.node_id)
+            self.ssh_ip = self.get_node_ip()
             if self.ssh_ip is not None:
                 break
             time.sleep(10)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -40,11 +40,11 @@ class NodeUpdater(object):
                  runtime_hash,
                  redirect_output=True,
                  process_runner=subprocess,
-                 use_external_ip=True):
+                 use_internal_ip=False):
         self.daemon = True
         self.process_runner = process_runner
         self.node_id = node_id
-        self.use_external_ip = use_external_ip
+        self.use_internal_ip = use_internal_ip
         self.provider = get_node_provider(provider_config, cluster_name)
         self.ssh_private_key = auth_config["ssh_private_key"]
         self.ssh_user = auth_config["ssh_user"]
@@ -68,10 +68,10 @@ class NodeUpdater(object):
             self.stderr = sys.stderr
 
     def get_node_ip(self):
-        if use_external_ip:
-            return self.provider.external_ip(self.node_id)
-        else:
+        if self.use_internal_ip:
             return self.provider.internal_ip(self.node_id)
+        else:
+            return self.provider.external_ip(self.node_id)
 
     def run(self):
         print("NodeUpdater: Updating {} to {}, logging to {}".format(


### PR DESCRIPTION

## What do these changes do?

As reported on the dev list, the external ip is not always accessible from the head node.

@richardliaw 