### PR TITLE
[autoscaler] Translate to/from AWS 'Name' tag

### DIFF
--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -24,7 +24,7 @@ def from_aws_format(tags):
 
     if "Name" in tags:
         tags[TAG_RAY_NODE_NAME] = tags["Name"]
-        del tags[TAG_RAY_NODE_NAME]
+        del tags["Name"]
     return tags
 
 

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -6,8 +6,26 @@ import boto3
 from botocore.config import Config
 
 from ray.autoscaler.node_provider import NodeProvider
-from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 from ray.ray_constants import BOTO_MAX_RETRIES
+
+
+def to_aws_format(tags):
+    """Convert the Ray node name tag to the AWS-specific 'Name' tag."""
+
+    if TAG_RAY_NODE_NAME in tags:
+        tags["Name"] = tags[TAG_RAY_NODE_NAME]
+        del tags[TAG_RAY_NODE_NAME]
+    return tags
+
+
+def from_aws_format(tags):
+    """Convert the AWS-specific 'Name' tag to the Ray node name tag."""
+
+    if "Name" in tags:
+        tags[TAG_RAY_NODE_NAME] = tags["Name"]
+        del tags[TAG_RAY_NODE_NAME]
+    return tags
 
 
 class AWSNodeProvider(NodeProvider):
@@ -26,6 +44,7 @@ class AWSNodeProvider(NodeProvider):
         self.external_ip_cache = {}
 
     def nodes(self, tag_filters):
+        tag_filters = to_aws_format(tag_filters)
         filters = [
             {
                 "Name": "instance-state-name",
@@ -59,7 +78,7 @@ class AWSNodeProvider(NodeProvider):
         tags = {}
         for tag in node.tags:
             tags[tag["Key"]] = tag["Value"]
-        return tags
+        return from_aws_format(tags)
 
     def external_ip(self, node_id):
         if node_id in self.external_ip_cache:
@@ -80,6 +99,7 @@ class AWSNodeProvider(NodeProvider):
         return ip
 
     def set_node_tags(self, node_id, tags):
+        tags = to_aws_format(tags)
         node = self._node(node_id)
         tag_pairs = []
         for k, v in tags.items():
@@ -90,6 +110,7 @@ class AWSNodeProvider(NodeProvider):
         node.create_tags(Tags=tag_pairs)
 
     def create_node(self, node_config, tags, count):
+        tags = to_aws_format(tags)
         conf = node_config.copy()
         tag_pairs = [{
             "Key": TAG_RAY_CLUSTER_NAME,


### PR DESCRIPTION
## What do these changes do?

GCP support moved tags to have cross-cloud names (https://github.com/ray-project/ray/pull/2061), however we should still use "Name" for the node name. GCP doesn't support upper-case tags, so implement this translation in the AWS node provider.

fyi @hartikainen 

## Related issue number

https://github.com/ray-project/ray/pull/2209