### PR TITLE
Build python extensions before copying files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,16 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
   add_custom_target(copy_ray ALL
       DEPENDS ${build_ray_file_list})
 
+  # Make sure that the Python extensions are built before copying the files.
+  if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
+    get_local_scheduler_library("python" LOCAL_SCHEDULER_LIBRARY_LANG)
+    add_dependencies(copy_ray ${LOCAL_SCHEDULER_LIBRARY_LANG})
+  endif()
+  if ("${CMAKE_RAY_LANG_JAVA}" STREQUAL "YES")
+    get_local_scheduler_library("java" LOCAL_SCHEDULER_LIBRARY_LANG)
+    add_dependencies(copy_ray ${LOCAL_SCHEDULER_LIBRARY_LANG})
+  endif()
+
   foreach(file ${ray_file_list})
   add_custom_command(TARGET copy_ray POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -70,24 +70,29 @@ add_executable(local_scheduler_tests test/local_scheduler_tests.cc local_schedul
 target_link_libraries(local_scheduler_tests local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})
 target_compile_options(local_scheduler_tests PUBLIC "-DLOCAL_SCHEDULER_TEST")
 
+macro(get_local_scheduler_library LANG VAR)
+  set(${VAR} "local_scheduler_library_${LANG}")
+endmacro()
+
 macro(set_local_scheduler_library LANG)
+  get_local_scheduler_library(${LANG} LOCAL_SCHEDULER_LIBRARY_LANG)
   include_directories("${CMAKE_CURRENT_LIST_DIR}/../common/lib/${LANG}/")
 
   file(GLOB LOCAL_SCHEDULER_LIBRARY_${LANG}_SRC
     lib/${LANG}/*.cc
     ${CMAKE_CURRENT_LIST_DIR}/../common/lib/${LANG}/*.cc)
-  add_library(local_scheduler_library_${LANG} SHARED
+  add_library(${LOCAL_SCHEDULER_LIBRARY_LANG} SHARED
     ${LOCAL_SCHEDULER_LIBRARY_${LANG}_SRC})
 
     if(APPLE)
-      target_link_libraries(local_scheduler_library_${LANG} "-undefined dynamic_lookup" local_scheduler_client common ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
+      target_link_libraries(${LOCAL_SCHEDULER_LIBRARY_LANG} "-undefined dynamic_lookup" local_scheduler_client common ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
     else(APPLE)
-      target_link_libraries(local_scheduler_library_${LANG} local_scheduler_client common ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
+      target_link_libraries(${LOCAL_SCHEDULER_LIBRARY_LANG} local_scheduler_client common ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
     endif(APPLE)
 
-  add_dependencies(local_scheduler_library_${LANG} gen_local_scheduler_fbs)
+  add_dependencies(${LOCAL_SCHEDULER_LIBRARY_LANG} gen_local_scheduler_fbs)
 
-  install(TARGETS local_scheduler_library_${LANG} DESTINATION ${CMAKE_SOURCE_DIR}/local_scheduler)
+  install(TARGETS ${LOCAL_SCHEDULER_LIBRARY_LANG} DESTINATION ${CMAKE_SOURCE_DIR}/local_scheduler)
 endmacro()
 
 if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")


### PR DESCRIPTION
## What do these changes do?

This fixes a bug where the built targets were getting copied from the build directory before the Python extensions were built. I believe this happened because the target for Python extensions (`local_scheduler_library_python` or `local_scheduler_library_java`) has a different name from the outputted file (`liblocal_scheduler_library_python.so`).

## Related issue number

I think this may fix #2216.
