### PR TITLE
Fix build error when building Ray for Java later than Python

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -41,8 +41,15 @@ else
 fi
 
 # Download and compile arrow if it isn't already present.
-if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
+if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
+  "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
     echo "building arrow"
+
+    if [[ "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
+      rm -rf $TP_DIR/build/arrow
+      rm -rf $TP_DIR/build/parquet-cpp
+      rm -rf $TP_DIR/pkg/arrow
+    fi
 
     if [[ ! -d $TP_DIR/build/arrow ]]; then
       git clone https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
@@ -53,7 +60,7 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
     # The PR for this commit is https://github.com/apache/arrow/pull/2065. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout ce23c06469de9cf0c3e38e35cdb8d135f341b964
+    git checkout 34890cc133d6761bdedc53e0b88374ccd7641c55
 
     cd cpp
     if [ ! -d "build" ]; then

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -45,7 +45,8 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
   "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
     echo "building arrow"
 
-    if [[ "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
+    # Make sure arrow will be built again when building ray for java later than python
+    if [[ "$LANGUAGE" == "java" ]]; then
       rm -rf $TP_DIR/build/arrow
       rm -rf $TP_DIR/build/parquet-cpp
       rm -rf $TP_DIR/pkg/arrow
@@ -57,10 +58,10 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/2065. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/2128. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout 34890cc133d6761bdedc53e0b88374ccd7641c55
+    git checkout 6b80fa824ed6b621122eb17f46106936fa72dd4b
 
     cd cpp
     if [ ! -d "build" ]; then

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -58,10 +58,10 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/2128. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/2106. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout 6b80fa824ed6b621122eb17f46106936fa72dd4b
+    git checkout b165e46183300ca9bc531f8177b9819b67fa9ce9
 
     cd cpp
     if [ ! -d "build" ]; then

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -58,10 +58,10 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
 
     pushd $TP_DIR/build/arrow
     git fetch origin master
-    # The PR for this commit is https://github.com/apache/arrow/pull/2106. We
+    # The PR for this commit is https://github.com/apache/arrow/pull/2065. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout b165e46183300ca9bc531f8177b9819b67fa9ce9
+    git checkout ce23c06469de9cf0c3e38e35cdb8d135f341b964
 
     cd cpp
     if [ ! -d "build" ]; then


### PR DESCRIPTION

## What do these changes do?

Now, Ray supports both Python and Java client, we can build Ray for both. However, if we build ray for Python first and then build ray for Java, we'll fail. That's because Ray's build depends on Arrow which only be built once. Arrow will not generate libs for Java when building Ray for Python (BTW, if we build Ray for Java first, we will also generate arrow's Python client).

So, to solve the problem, we should make sure Arrow will be built again when building Ray for Java later than Python.
