### PR TITLE
Fix redis module build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     add_dependencies(copy_ray ${LOCAL_SCHEDULER_LIBRARY_LANG})
   endif()
 
+  add_dependencies(copy_ray ray_redis_module)
+
   foreach(file ${ray_file_list})
   add_custom_command(TARGET copy_ray POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E


### PR DESCRIPTION
Same issue as https://github.com/ray-project/ray/pull/2221, but for the redis module

Also related to https://github.com/ray-project/ray/pull/2171 @songqing Is there a better way to do this and make sure copy_ray gets called at the end of the build?