### PR TITLE
Allow Ray API to be used from multiple threads

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -581,7 +581,6 @@ class ActorClass(object):
             A handle to the newly created actor.
         """
         worker = ray.worker.get_global_worker()
-        ray.worker.check_main_thread()
         if worker.mode is None:
             raise Exception("Actors cannot be created before ray.init() "
                             "has been called.")
@@ -760,7 +759,6 @@ class ActorHandle(object):
         worker = ray.worker.get_global_worker()
 
         worker.check_connected()
-        ray.worker.check_main_thread()
 
         function_signature = self._ray_method_signatures[method_name]
         if args is None:
@@ -915,7 +913,6 @@ class ActorHandle(object):
         """
         worker = ray.worker.get_global_worker()
         worker.check_connected()
-        ray.worker.check_main_thread()
 
         if state["ray_forking"]:
             actor_handle_id = compute_actor_handle_id(

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -114,7 +114,6 @@ class RemoteFunction(object):
         """An experimental alternate way to submit remote functions."""
         worker = ray.worker.get_global_worker()
         worker.check_connected()
-        ray.worker.check_main_thread()
         kwargs = {} if kwargs is None else kwargs
         args = ray.signature.extend_args(self._function_signature, args,
                                          kwargs)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -282,7 +282,6 @@ class _ThreadSafeProxy(object):
         _wrapper_cache (dict): a cache from original object's methods to the proxy methods.
     """
 
-
     def __init__(self, orig_obj, lock):
         self.orig_obj = orig_obj
         self.lock = lock
@@ -298,11 +297,14 @@ class _ThreadSafeProxy(object):
             # return a wrapper that guards the original method with a lock.
             wrapper = self._wrapper_cache.get(attr)
             if wrapper is None:
+
                 @functools.wraps(orig_attr)
                 def _wrapper(*args, **kwargs):
                     with self.lock:
                         return orig_attr(*args, **kwargs)
-                self._wrapper_cache[attr] = wrapper = _wrapper
+
+                self._wrapper_cache[attr] = _wrapper
+                wrapper = _wrapper
             return wrapper
 
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -279,7 +279,8 @@ class _ThreadSafeProxy(object):
     Attributes:
         orig_obj (object): the original object.
         lock (threading.Lock): the lock object.
-        _wrapper_cache (dict): a cache from original object's methods to the proxy methods.
+        _wrapper_cache (dict): a cache from original object's methods to
+            the proxy methods.
     """
 
     def __init__(self, orig_obj, lock):
@@ -309,7 +310,8 @@ class _ThreadSafeProxy(object):
 
 
 def thread_safe_client(client, lock=None):
-    """Create a thread-safe proxy which locks every method call for the given client.
+    """Create a thread-safe proxy which locks every method call
+    for the given client.
 
     Args:
         client: the client object to be guarded.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -201,7 +201,11 @@ class Worker(object):
             that connect has been called already.
         cached_functions_to_run (List): A list of functions to run on all of
             the workers that should be exported as soon as connect is called.
-        reconstruction_lock (Lock): A lock object used to guard object reconstruction.
+        reconstruction_lock (Lock):
+            A lock object used to guard object reconstruction.
+            Because the node manager will recycle/return the worker's resources
+            before/after object reconstruction, it's unsafe for multiple threads
+            to call object reconstruction simultaneously.
     """
 
     def __init__(self):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1117,6 +1117,8 @@ class APITest(unittest.TestCase):
         def g(n):
             for _ in range(1000 // n):
                 ray.get([f.remote() for _ in range(n)])
+            res = [ray.put(i) for i in range(1000 // n)]
+            ray.wait(res, len(res))
 
         threads = [
             threading.Thread(target=g, args=(n, ))

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1120,13 +1120,17 @@ class APITest(unittest.TestCase):
             res = [ray.put(i) for i in range(1000 // n)]
             ray.wait(res, len(res))
 
-        threads = [
-            threading.Thread(target=g, args=(n, ))
-            for n in [1, 5, 10, 100, 1000]
-        ]
+        @ray.remote
+        def multi_thread_worker():
+            threads = [
+                threading.Thread(target=g, args=(n, ))
+                for n in [1, 5, 10, 100, 1000]
+            ]
 
-        [thread.start() for thread in threads]
-        [thread.join() for thread in threads]
+            [thread.start() for thread in threads]
+            [thread.join() for thread in threads]
+
+        multi_thread_worker.remote()
 
 
 @unittest.skipIf(

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1120,8 +1120,7 @@ class APITest(unittest.TestCase):
             res = [ray.put(i) for i in range(1000 // n)]
             ray.wait(res, len(res))
 
-        @ray.remote
-        def multi_thread_worker():
+        def test_multi_threading():
             threads = [
                 threading.Thread(target=g, args=(n, ))
                 for n in [1, 5, 10, 100, 1000]
@@ -1130,7 +1129,14 @@ class APITest(unittest.TestCase):
             [thread.start() for thread in threads]
             [thread.join() for thread in threads]
 
-        multi_thread_worker.remote()
+        @ray.remote
+        def test_multi_threading_in_worker():
+            test_multi_threading()
+
+        # test multi-threading in the driver
+        test_multi_threading()
+        # test multi-threading in the worker
+        ray.get(test_multi_threading_in_worker.remote())
 
 
 @unittest.skipIf(


### PR DESCRIPTION
# What does this PR do?
Previously, Ray API isn't multi-thread safe and can only be called from the main thread.
This PR fixes the issue by simply locking all IO operations (redis_client/plasma_client/local_scheduler_client).
NOTE: the purpose of this RP is only to enable using Ray API in multiple threads, we'll need to make the locks smaller grained to achieve maximum performance.

# Perf
Benchmarking perf impact for single-thread use: https://gist.github.com/raulchen/2c315cbd4d2387bf356adbe2a8641986#file-gistfile1-txt 
Results:
```
Without this PR:
test_put_and_get: Avg: 227.28, Min: 210.65, Max: 372.84, P50: 221.11, P90: 239.36
test_remote: Avg: 124.40, Min: 60.63, Max: 268.67, P50: 118.21, P90: 171.80

With this PR:
test_put_and_get: Avg: 238.71, Min: 218.51, Max: 400.44, P50: 231.47, P90: 250.59
test_remote: Avg: 122.35, Min: 66.46, Max: 244.03, P50: 119.02, P90: 169.37
```
No significant perf impact.

# Related issues
#1409 
#2215