### PR TITLE
 Experimental: enable automatic GCS flushing with configurable policy.

### DIFF
--- a/python/ray/experimental/__init__.py
+++ b/python/ray/experimental/__init__.py
@@ -7,6 +7,8 @@ from .features import (
     flush_redis_unsafe, flush_task_and_object_metadata_unsafe,
     flush_finished_tasks_unsafe, flush_evicted_objects_unsafe,
     _flush_finished_tasks_unsafe_shard, _flush_evicted_objects_unsafe_shard)
+from .gcs_flush_policy import (set_flushing_policy, GcsFlushPolicy,
+                               SimpleGcsFlushPolicy)
 from .named_actors import get_actor, register_actor
 from .api import get, wait
 
@@ -15,5 +17,6 @@ __all__ = [
     "flush_task_and_object_metadata_unsafe", "flush_finished_tasks_unsafe",
     "flush_evicted_objects_unsafe", "_flush_finished_tasks_unsafe_shard",
     "_flush_evicted_objects_unsafe_shard", "get_actor", "register_actor",
-    "get", "wait"
+    "get", "wait",
+    "set_flushing_policy", "GcsFlushPolicy", "SimpleGcsFlushPolicy"
 ]

--- a/python/ray/experimental/__init__.py
+++ b/python/ray/experimental/__init__.py
@@ -17,6 +17,6 @@ __all__ = [
     "flush_task_and_object_metadata_unsafe", "flush_finished_tasks_unsafe",
     "flush_evicted_objects_unsafe", "_flush_finished_tasks_unsafe_shard",
     "_flush_evicted_objects_unsafe_shard", "get_actor", "register_actor",
-    "get", "wait",
-    "set_flushing_policy", "GcsFlushPolicy", "SimpleGcsFlushPolicy"
+    "get", "wait", "set_flushing_policy", "GcsFlushPolicy",
+    "SimpleGcsFlushPolicy"
 ]

--- a/python/ray/experimental/features.py
+++ b/python/ray/experimental/features.py
@@ -10,7 +10,7 @@ OBJECT_LOCATION_PREFIX = b"OL:"
 TASK_PREFIX = b"TT:"
 
 
-def flush_redis_unsafe():
+def flush_redis_unsafe(redis_client=None):
     """This removes some non-critical state from the primary Redis shard.
 
     This removes the log files as well as the event log from Redis. This can
@@ -18,10 +18,14 @@ def flush_redis_unsafe():
     of metadata in Redis. However, it will only partially address the issue as
     much of the data is in the task table (and object table), which are not
     flushed.
-    """
-    ray.worker.global_worker.check_connected()
 
-    redis_client = ray.worker.global_worker.redis_client
+    Args:
+      redis_client: optional, if not provided then ray.init() must have been
+        called.
+    """
+    if redis_client is None:
+        ray.worker.global_worker.check_connected()
+        redis_client = ray.worker.global_worker.redis_client
 
     # Delete the log files from the primary Redis shard.
     keys = redis_client.keys("LOGFILE:*")

--- a/python/ray/experimental/gcs_flush_policy.py
+++ b/python/ray/experimental/gcs_flush_policy.py
@@ -79,7 +79,7 @@ class SimpleGcsFlushPolicy(GcsFlushPolicy):
 
 def set_flushing_policy(flushing_policy):
     """Serialize this policy for Monitor to pick up."""
-    if not "RAY_USE_NEW_GCS" in os.environ:
+    if "RAY_USE_NEW_GCS" not in os.environ:
         raise Exception(
             "set_flushing_policy() is only available when environment "
             "variable RAY_USE_NEW_GCS is present at both compile and run time."

--- a/python/ray/experimental/gcs_flush_policy.py
+++ b/python/ray/experimental/gcs_flush_policy.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import time
+
+import ray
+import ray.cloudpickle as pickle
+
+# Set up logging.
+logging.basicConfig()
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+class GcsFlushPolicy(object):
+    """Experimental: a policy to control GCS flushing.
+
+    Used by Monitor to enable automatic control of memory usage.
+    """
+
+    def should_flush(self, redis_client):
+        """Returns a bool, whether a flush request should be issued."""
+        pass
+
+    def num_entries_to_flush(self):
+        """Returns an upper bound for number of entries to flush next."""
+        pass
+
+    def record_flush(self):
+        """Must be called after a flush has been performed."""
+        pass
+
+    def serialize(self):
+        """Serialize."""
+        pass
+
+
+class SimpleGcsFlushPolicy(GcsFlushPolicy):
+    """A simple policy with constant flush rate, after a warmup period.
+
+    Example policy values:
+        flush_when_at_least_bytes 2GB
+        flush_period_secs 10s
+        flush_num_entries_each_time 10k
+
+    This means
+    (1) If the GCS shard uses less than 2GB of memory, no flushing would take
+        place.  This should cover most Ray runs.
+    (2) The GCS shard will only honor a flush request, if it's issued after 10
+        seconds since the last processed flush.  In particular this means it's
+        okay for the Monitor to issue requests more frequently than this param.
+    (3) When processing a flush, the shard will flush at most 10k entries.
+        This is to control the latency of each request.
+
+    Note, flush rate == (flush period) * (num entries each time).  So
+    applications that have a heavier GCS load can tune these params.
+    """
+
+    def __init__(self,
+                 flush_when_at_least_bytes=(1 << 31),
+                 flush_period_secs=10,
+                 flush_num_entries_each_time=10000):
+        self.flush_when_at_least_bytes = flush_when_at_least_bytes
+        self.flush_period_secs = flush_period_secs
+        self.flush_num_entries_each_time = flush_num_entries_each_time
+        self.last_flush_timestamp = time.time()
+
+    def should_flush(self, redis_client):
+        if time.time() - self.last_flush_timestamp < self.flush_period_secs:
+            return False
+
+        reply = redis_client.execute_command("INFO MEMORY")
+        reply = reply.split(b"\n")
+        used_memory = -1
+        for line in reply:
+            if line.startswith(b"used_memory:"):
+                used_memory = int(line.split(b":")[-1])
+                break
+        assert used_memory > 0
+
+        log.debug("used_memory {} threshold {}".format(
+            used_memory, self.flush_when_at_least_bytes))
+        return used_memory >= self.flush_when_at_least_bytes
+
+    def num_entries_to_flush(self):
+        return self.flush_num_entries_each_time
+
+    def record_flush(self):
+        self.last_flush_timestamp = time.time()
+
+    def serialize(self):
+        return pickle.dumps(self)
+
+
+def set_flushing_policy(flushing_policy):
+    """Serialize this policy for Monitor to pick up."""
+    ray.worker.global_worker.check_connected()
+    redis_client = ray.worker.global_worker.redis_client
+
+    serialized = flushing_policy.serialize()
+    redis_client.set("gcs_flushing_policy", serialized)

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -647,7 +647,6 @@ int TableAdd_DoPublish(RedisModuleCtx *ctx,
 int TableAdd_RedisCommand(RedisModuleCtx *ctx,
                           RedisModuleString **argv,
                           int argc) {
-  RAY_CHECK(0) << "TableAdd";
   RedisModule_AutoMemory(ctx);
   TableAdd_DoWrite(ctx, argv, argc, /*mutated_key_str=*/nullptr);
   return TableAdd_DoPublish(ctx, argv, argc);
@@ -657,7 +656,7 @@ int TableAdd_RedisCommand(RedisModuleCtx *ctx,
 int ChainTableAdd_RedisCommand(RedisModuleCtx *ctx,
                                RedisModuleString **argv,
                                int argc) {
-  RAY_CHECK(0) << "ChainTableAdd";
+  RedisModule_AutoMemory(ctx);
   return module.ChainReplicate(ctx, argv, argc, /*node_func=*/TableAdd_DoWrite,
                                /*tail_func=*/TableAdd_DoPublish);
 }

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -647,6 +647,7 @@ int TableAdd_DoPublish(RedisModuleCtx *ctx,
 int TableAdd_RedisCommand(RedisModuleCtx *ctx,
                           RedisModuleString **argv,
                           int argc) {
+  RAY_CHECK(0) << "TableAdd";
   RedisModule_AutoMemory(ctx);
   TableAdd_DoWrite(ctx, argv, argc, /*mutated_key_str=*/nullptr);
   return TableAdd_DoPublish(ctx, argv, argc);
@@ -656,6 +657,7 @@ int TableAdd_RedisCommand(RedisModuleCtx *ctx,
 int ChainTableAdd_RedisCommand(RedisModuleCtx *ctx,
                                RedisModuleString **argv,
                                int argc) {
+  RAY_CHECK(0) << "ChainTableAdd";
   return module.ChainReplicate(ctx, argv, argc, /*node_func=*/TableAdd_DoWrite,
                                /*tail_func=*/TableAdd_DoPublish);
 }

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -18,10 +18,15 @@ AsyncGcsClient::AsyncGcsClient(const ClientID &client_id, CommandType command_ty
   command_type_ = command_type;
 }
 
+#if RAY_USE_NEW_GCS
 // Use of kChain currently only applies to Table::Add which affects only the
 // task table, and when RAY_USE_NEW_GCS is set at compile time.
 AsyncGcsClient::AsyncGcsClient(const ClientID &client_id)
     : AsyncGcsClient(client_id, CommandType::kChain) {}
+#else
+AsyncGcsClient::AsyncGcsClient(const ClientID &client_id)
+    : AsyncGcsClient(client_id, CommandType::kRegular) {}
+#endif  // RAY_USE_NEW_GCS
 
 AsyncGcsClient::AsyncGcsClient(CommandType command_type)
     : AsyncGcsClient(ClientID::from_random(), command_type) {}

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -19,7 +19,7 @@ AsyncGcsClient::AsyncGcsClient(const ClientID &client_id, CommandType command_ty
 }
 
 AsyncGcsClient::AsyncGcsClient(const ClientID &client_id)
-    : AsyncGcsClient(client_id, CommandType::kRegular) {}
+    : AsyncGcsClient(client_id, CommandType::kChain) {}
 
 AsyncGcsClient::AsyncGcsClient(CommandType command_type)
     : AsyncGcsClient(ClientID::from_random(), command_type) {}

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -18,6 +18,8 @@ AsyncGcsClient::AsyncGcsClient(const ClientID &client_id, CommandType command_ty
   command_type_ = command_type;
 }
 
+// Use of kChain currently only applies to Table::Add which affects only the
+// task table, and when RAY_USE_NEW_GCS is set at compile time.
 AsyncGcsClient::AsyncGcsClient(const ClientID &client_id)
     : AsyncGcsClient(client_id, CommandType::kChain) {}
 
@@ -67,7 +69,6 @@ FunctionTable &AsyncGcsClient::function_table() { return *function_table_; }
 ClassTable &AsyncGcsClient::class_table() { return *class_table_; }
 
 HeartbeatTable &AsyncGcsClient::heartbeat_table() { return *heartbeat_table_; }
-
 }  // namespace gcs
 
 }  // namespace ray

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -18,6 +18,14 @@ set -e
 TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)/../
 ROOT_DIR=$TP_DIR/..
 
+# For some reason, on Ubuntu/gcc toolchain linking against static libleveldb.a
+# doesn't work, so we force building the shared library for non-Mac.
+if [ "$(uname)" == "Darwin" ]; then
+    BUILD_LEVELDB_CONFIG=""
+else
+    BUILD_LEVELDB_CONFIG="-DBUILD_SHARED_LIBS=on"
+fi
+
 if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   pushd "$TP_DIR/pkg/"
     rm -rf credis
@@ -45,9 +53,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
     pushd glog; cmake -DWITH_GFLAGS=off . && make -j; popd
     pushd leveldb;
       mkdir -p build && cd build
-      # For some reason, on Ubuntu/gcc toolchain linking against static
-      # libleveldb.a doesn't work, so we force building the shared library here.
-      cmake -DBUILD_SHARED_LIBS=on -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
+      cmake ${BUILD_LEVELDB_CONFIG} -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
     popd
 
     mkdir -p build

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -43,11 +43,14 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
     else
         pushd redis && make -j MALLOC=jemalloc && popd
     fi
-    pushd glog && cmake -DWITH_GFLAGS=off . && make -j && popd
+    pushd glog; cmake -DWITH_GFLAGS=off . && make -j; popd
     # NOTE(zongheng): DO NOT USE -j parallel build for leveldb as it's incorrect!
-    pushd leveldb && CXXFLAGS="$CXXFLAGS -fPIC" make && popd
+    pushd leveldb;
+      mkdir -p build && cd build
+      cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
+    popd
 
-    mkdir build
+    mkdir -p build
     pushd build
       cmake ..
       make -j
@@ -55,6 +58,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
 
     mkdir -p $ROOT_DIR/build/src/credis/redis/src/
     cp redis/src/redis-server $ROOT_DIR/build/src/credis/redis/src/redis-server
+
     mkdir -p $ROOT_DIR/build/src/credis/build/src/
     cp build/src/libmaster.so $ROOT_DIR/build/src/credis/build/src/libmaster.so
     cp build/src/libmember.so $ROOT_DIR/build/src/credis/build/src/libmember.so

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -25,7 +25,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    git checkout 24e8dee320fbd57293a82eaaef591a6097aca4f7
+    git checkout 57aae67e0614143ad8d25e38906f3cb93fcf6ad2
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -25,7 +25,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    git checkout 57aae67e0614143ad8d25e38906f3cb93fcf6ad2
+    git checkout 273d667e5126c246b45f5dcf030b651a653136c3
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.
@@ -43,10 +43,11 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
         pushd redis && make -j MALLOC=jemalloc && popd
     fi
     pushd glog; cmake -DWITH_GFLAGS=off . && make -j; popd
-    # NOTE(zongheng): DO NOT USE -j parallel build for leveldb as it's incorrect!
     pushd leveldb;
       mkdir -p build && cd build
-      cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
+      # For some reason, on Ubuntu/gcc toolchain linking against static
+      # libleveldb.a doesn't work, so we force building the shared library here.
+      cmake -DBUILD_SHARED_LIBS=on -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
     popd
 
     mkdir -p build

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -21,12 +21,13 @@ ROOT_DIR=$TP_DIR/..
 if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   pushd "$TP_DIR/pkg/"
     rm -rf credis
-    git clone --recursive https://github.com/ray-project/credis
+    # git clone --recursive https://github.com/ray-project/credis
+    git clone --recursive https://github.com/concretevitamin/credis-1 credis
   popd
 
   pushd "$TP_DIR/pkg/credis"
     # https://github.com/ray-project/credis/commit/28de4a2be70cc060760ae4731362ff18ecc2077f
-    git checkout 28de4a2be70cc060760ae4731362ff18ecc2077f
+  git checkout 846683c2526228abc6d7
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -25,8 +25,8 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    # 4/10/2018 credis/integrate branch.  With updated redis hacks.
-    git checkout cbe8ade35d2278b1d94684fa5d00010cb015ef82
+    # https://github.com/ray-project/credis/commit/28de4a2be70cc060760ae4731362ff18ecc2077f
+    git checkout 28de4a2be70cc060760ae4731362ff18ecc2077f
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -21,13 +21,11 @@ ROOT_DIR=$TP_DIR/..
 if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   pushd "$TP_DIR/pkg/"
     rm -rf credis
-    # git clone --recursive https://github.com/ray-project/credis
-    git clone --recursive https://github.com/concretevitamin/credis-1 credis
+    git clone --recursive https://github.com/ray-project/credis
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    # https://github.com/ray-project/credis/commit/28de4a2be70cc060760ae4731362ff18ecc2077f
-  git checkout 846683c2526228abc6d7
+    git checkout 24e8dee320fbd57293a82eaaef591a6097aca4f7
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -52,7 +52,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
 
     mkdir -p build
     pushd build
-      cmake ..
+      cmake -DCMAKE_BUILD_TYPE=Release ..
       make -j
     popd
 


### PR DESCRIPTION
Example usage illustrated in this test program (which submits no-op tasks continuously).
```python
import subprocess
import time

import ray
# Pass this flag to avoid annoying output on program exit.
info = ray.init(redirect_worker_output=True)

# Turn on flushing with the next two lines.
pol = ray.experimental.SimpleGcsFlushPolicy(
    flush_when_at_least_bytes=0,
    flush_period_secs=1e-4,
    flush_num_entries_each_time=10000)
ray.experimental.set_flushing_policy(pol)


@ray.remote
def noop():
    return


time.sleep(1)
primary_port = info['redis_address'].split(':')[-1]
pid = subprocess.run(
    ['pgrep', '-f', 'redis-server.*{}'.format(primary_port)],
    stdout=subprocess.PIPE).stdout[:-1].decode()
logfile = 'psrecord-{}.log'.format(primary_port)
args = [
    'psrecord', pid, '--interval', '1', '--duration', '40', '--log', logfile
]
print(' '.join(args))
subprocess.Popen(args)

num_noops = 200000
i = 0
start = time.time()
while i < num_noops:
    noop.remote()
    i += 1
print('Time to execute {} no-ops: {:.2f} seconds'.format(
    num_noops,
    time.time() - start))
```

Result shows that the policy can control memory usage to the minimum possible level, _on the primary redis server_.
![memory_plot](https://i.imgur.com/zFMfrbr.png)
