### PR TITLE
[DataFrame] Fix loc with Datetime index

### DIFF
--- a/python/ray/dataframe/indexing.py
+++ b/python/ray/dataframe/indexing.py
@@ -370,7 +370,11 @@ class _Loc_Indexer(_Location_Indexer_Base):
         Returns:
              nan_labels: The labels needs to be added
         """
-        locator_as_index = pandas.Index(locator)
+        # base_index_type can be pd.Index or pd.DatetimeIndex
+        # depending on user input and pandas behavior
+        # See issue #2264
+        base_index_type = type(base_index)
+        locator_as_index = base_index_type(locator)
 
         nan_labels = locator_as_index.difference(base_index)
         common_labels = locator_as_index.intersection(base_index)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR cast locator with the dataframe's index type instead of using `pd.Index` by default. 

<!-- Please give a short brief about these changes. -->

## Related issue number
Fix #2264

<!-- Are there any issues opened that will be resolved by merging this change? -->

@devin-petersohn 