### PR TITLE
[tune] Fix registering trainable twice

### DIFF
--- a/python/ray/experimental/internal_kv.py
+++ b/python/ray/experimental/internal_kv.py
@@ -17,7 +17,7 @@ def _internal_kv_get(key):
     return worker.redis_client.hget(key, "value")
 
 
-def _internal_kv_put(key, value):
+def _internal_kv_put(key, value, overwrite=False):
     """Globally associates a value with a given binary key.
 
     This only has an effect if the key does not already have a value.
@@ -27,5 +27,8 @@ def _internal_kv_put(key, value):
     """
 
     worker = ray.worker.get_global_worker()
-    updated = worker.redis_client.hsetnx(key, "value", value)
+    if overwrite:
+        updated = worker.redis_client.hset(key, "value", value)
+    else:
+        updated = worker.redis_client.hsetnx(key, "value", value)
     return updated == 0  # already exists

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -98,7 +98,7 @@ class _Registry(object):
 
     def flush_values(self):
         for (category, key), value in self._to_flush.items():
-            _internal_kv_put(_make_key(category, key), value)
+            _internal_kv_put(_make_key(category, key), value, overwrite=True)
         self._to_flush.clear()
 
 

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -61,8 +61,9 @@ def _make_key(category, key):
     Returns:
         The key to use for storing a the value.
     """
-    return (b"TuneRegistry:" + category.encode("ascii") + b"/" +
-            key.encode("ascii"))
+    driver = ray.worker.global_worker.task_driver_id.hex().encode("ascii")
+    return (b"TuneRegistry:" + driver + b":" + category.encode("ascii") +
+            b"/" + key.encode("ascii"))
 
 
 class _Registry(object):

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -61,8 +61,7 @@ def _make_key(category, key):
     Returns:
         The key to use for storing a the value.
     """
-    driver = ray.worker.global_worker.task_driver_id.hex().encode("ascii")
-    return (b"TuneRegistry:" + driver + b":" + category.encode("ascii") +
+    return (b"TuneRegistry:" + category.encode("ascii") +
             b"/" + key.encode("ascii"))
 
 

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -61,8 +61,8 @@ def _make_key(category, key):
     Returns:
         The key to use for storing a the value.
     """
-    return (b"TuneRegistry:" + category.encode("ascii") +
-            b"/" + key.encode("ascii"))
+    return (b"TuneRegistry:" + category.encode("ascii") + b"/" +
+            key.encode("ascii"))
 
 
 class _Registry(object):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -61,6 +61,26 @@ class TrainableFunctionApiTest(unittest.TestCase):
         register_env("foo", lambda: None)
         self.assertRaises(TypeError, lambda: register_env("foo", 2))
 
+    def testRegisterEnvOverwrite(self):
+        def train(config, reporter):
+            reporter(timesteps_total=100, done=True)
+
+        def train2(config, reporter):
+            reporter(timesteps_total=200, done=True)
+
+        register_trainable("f1", train)
+        register_trainable("f1", train2)
+        [trial] = run_experiments({
+            "foo": {
+                "run": "f1",
+                "config": {
+                    "script_min_iter_time_s": 0,
+                },
+            }
+        })
+        self.assertEqual(trial.status, Trial.TERMINATED)
+        self.assertEqual(trial.last_result.timesteps_total, 200)
+
     def testRegisterTrainable(self):
         def train(config, reporter):
             pass


### PR DESCRIPTION


## What do these changes do?

This allows object registration to be overwritten, which is needed if you re-use the cluster multiple times.

We could alternatively scope registrations by the current driver ID, but I'm not sure how to do that.