### PR TITLE
[xray] raylet task queue transition discipline

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -199,7 +199,7 @@ void LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
 void LineageCache::AddReadyTask(const Task &task) {
   const TaskID task_id = task.GetTaskSpecification().TaskId();
 
-  // Tasks can only become READY if they were in WAITING.
+  // Tasks can only become PLACEABLE if they were in WAITING.
   auto entry = lineage_.GetEntry(task_id);
   RAY_CHECK(entry);
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_WAITING);
@@ -326,7 +326,7 @@ bool LineageCache::FlushTask(const TaskID &task_id) {
 }
 
 void LineageCache::Flush() {
-  // Iterate through all tasks that are READY.
+  // Iterate through all tasks that are PLACEABLE.
   for (auto it = uncommitted_ready_tasks_.begin();
        it != uncommitted_ready_tasks_.end();) {
     bool flushed = FlushTask(*it);

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -199,7 +199,7 @@ void LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
 void LineageCache::AddReadyTask(const Task &task) {
   const TaskID task_id = task.GetTaskSpecification().TaskId();
 
-  // Tasks can only become PLACEABLE if they were in WAITING.
+  // Tasks can only become READY if they were in WAITING.
   auto entry = lineage_.GetEntry(task_id);
   RAY_CHECK(entry);
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_WAITING);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -620,15 +620,12 @@ void NodeManager::ScheduleTasks() {
     }
   }
 
-  // Transition locally scheduled tasks to READY and dispatch scheduled tasks.
   // Transition locally placed tasks to waiting or ready for dispatch.
   if (local_task_ids.size() > 0) {
     std::vector<Task> tasks = local_queues_.RemoveTasks(local_task_ids);
     for (const auto &t : tasks) {
       TransitionPlaceableTask(t);
     }
-    //local_queues_.QueueReadyTasks(tasks);
-    //DispatchTasks();
   }
 }
 
@@ -650,8 +647,8 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
       auto node_manager_id = actor_entry->second.GetNodeManagerId();
       if (node_manager_id == gcs_client_->client_table().GetLocalClientId()) {
         // The actor is local. Queue the task for local execution, bypassing placement.
-        // TransitionPlaceableTask(task);
-        local_queues_.QueueWaitingTasks({task});
+        TransitionPlaceableTask(task);
+        //local_queues_.QueueWaitingTasks({task});
       } else {
         // The actor is remote. Forward the task to the node manager that owns
         // the actor.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -648,7 +648,6 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
       if (node_manager_id == gcs_client_->client_table().GetLocalClientId()) {
         // The actor is local. Queue the task for local execution, bypassing placement.
         TransitionPlaceableTask(task);
-        //local_queues_.QueueWaitingTasks({task});
       } else {
         // The actor is remote. Forward the task to the node manager that owns
         // the actor.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -577,7 +577,7 @@ void NodeManager::ProcessNodeManagerMessage(TcpClientConnection &node_manager_cl
     const Task &task = uncommitted_lineage.GetEntry(task_id)->TaskData();
     RAY_LOG(DEBUG) << "got task " << task.GetTaskSpecification().TaskId()
                    << " spillback=" << task.GetTaskExecutionSpecReadonly().NumForwards();
-    SubmitTask(task, uncommitted_lineage, /* forwarded = */true);
+    SubmitTask(task, uncommitted_lineage, /* forwarded = */ true);
   } break;
   case protocol::MessageType::DisconnectClient: {
     // TODO(rkn): We need to do some cleanup here.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -577,7 +577,7 @@ void NodeManager::ProcessNodeManagerMessage(TcpClientConnection &node_manager_cl
     const Task &task = uncommitted_lineage.GetEntry(task_id)->TaskData();
     RAY_LOG(DEBUG) << "got task " << task.GetTaskSpecification().TaskId()
                    << " spillback=" << task.GetTaskExecutionSpecReadonly().NumForwards();
-    SubmitTask(task, uncommitted_lineage);
+    SubmitTask(task, uncommitted_lineage, /* forwarded = */true);
   } break;
   case protocol::MessageType::DisconnectClient: {
     // TODO(rkn): We need to do some cleanup here.
@@ -611,6 +611,7 @@ void NodeManager::ScheduleTasks() {
     if (client_id == gcs_client_->client_table().GetLocalClientId()) {
       local_task_ids.insert(task_id);
     } else {
+      // TODO(atumanov): need a better interface for task exit on forward.
       auto tasks = local_queues_.RemoveTasks({task_id});
       RAY_CHECK(1 == tasks.size());
       Task &task = tasks.front();
@@ -621,18 +622,24 @@ void NodeManager::ScheduleTasks() {
     // object dependencies.
     // NOTE(swang): For local tasks, the scheduled task's dependencies may get
     // evicted before it can be assigned to a worker.
-    task_dependency_manager_.UnsubscribeDependencies(task_id);
+    // TODO(atumanov): why are we unsubscribing from dependencies here?
+    // task_dependency_manager_.UnsubscribeDependencies(task_id);
   }
 
   // Transition locally scheduled tasks to SCHEDULED and dispatch scheduled tasks.
+  // Transition locally placed tasks to waiting or ready for dispatch.
   if (local_task_ids.size() > 0) {
     std::vector<Task> tasks = local_queues_.RemoveTasks(local_task_ids);
-    local_queues_.QueueScheduledTasks(tasks);
-    DispatchTasks();
+    for (const auto &t : tasks) {
+      QueueTask(t);
+    }
+    //local_queues_.QueueScheduledTasks(tasks);
+    //DispatchTasks();
   }
 }
 
-void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineage) {
+void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
+                             bool forwarded) {
   // Add the task and its uncommitted lineage to the lineage cache.
   lineage_cache_.AddWaitingTask(task, uncommitted_lineage);
   // Mark the task as pending. Once the task has finished execution, or once it
@@ -648,8 +655,9 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
       // We have a known location for the actor.
       auto node_manager_id = actor_entry->second.GetNodeManagerId();
       if (node_manager_id == gcs_client_->client_table().GetLocalClientId()) {
-        // The actor is local. Queue the task for local execution.
-        QueueTask(task);
+        // The actor is local. Queue the task for local execution, bypassing placement.
+        // QueueTask(task);
+        local_queues_.QueueWaitingTasks({task});
       } else {
         // The actor is remote. Forward the task to the node manager that owns
         // the actor.
@@ -680,8 +688,15 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
       local_queues_.QueueUncreatedActorMethods({task});
     }
   } else {
-    // This is a non-actor task. Queue the task for local execution.
-    QueueTask(task);
+    // This is a non-actor task. Queue the task for a placement decision or for dispatch
+    // if the task was forwarded.
+    if (forwarded) {
+      // Check for local dependencies and enqueue as waiting or ready for dispatch.
+      QueueTask(task);
+    } else {
+      local_queues_.QueueReadyTasks({task});
+      ScheduleTasks();
+    }
   }
 }
 
@@ -698,6 +713,8 @@ void NodeManager::HandleRemoteDependencyCanceled(const ObjectID &dependency_id) 
   // TODO(swang): Cancel reconstruction of the object.
 }
 
+// Check the task's dependencies and enqueue to either be ready for dispatch or waiting.
+// Called with tasks for which a placement decision has been made.
 void NodeManager::QueueTask(const Task &task) {
   // Subscribe to the task's dependencies.
   bool ready = task_dependency_manager_.SubscribeDependencies(
@@ -705,9 +722,11 @@ void NodeManager::QueueTask(const Task &task) {
   // Queue the task. If all dependencies are available, then the task is queued
   // in the READY state, else the WAITING.
   if (ready) {
-    local_queues_.QueueReadyTasks({task});
-    // Try to schedule the newly ready task.
-    ScheduleTasks();
+    //local_queues_.QueueReadyTasks({task});
+    local_queues_.QueueScheduledTasks({task});
+    // Try to dispatch the newly ready task.
+    //ScheduleTasks();
+    DispatchTasks();
   } else {
     local_queues_.QueueWaitingTasks({task});
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -873,10 +873,13 @@ void NodeManager::HandleObjectLocal(const ObjectID &object_id) {
   if (ready_task_ids.size() > 0) {
     std::unordered_set<TaskID> ready_task_id_set(ready_task_ids.begin(),
                                                  ready_task_ids.end());
-    auto ready_tasks = local_queues_.RemoveTasks(ready_task_id_set);
-    local_queues_.QueueReadyTasks(std::vector<Task>(ready_tasks));
-    // Schedule the newly ready tasks.
-    ScheduleTasks();
+//    auto ready_tasks = local_queues_.RemoveTasks(ready_task_id_set);
+//    local_queues_.QueueReadyTasks(std::vector<Task>(ready_tasks));
+//    ScheduleTasks();
+    // Transition tasks from waiting to scheduled.
+    local_queues_.MoveTasks(ready_task_id_set, WAITING, SCHEDULED);
+    // New scheduled tasks appeared in the queue, try to dispatch them.
+    DispatchTasks();
   }
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -72,7 +72,8 @@ class NodeManager {
   /// Enqueue a placeable task to wait on object dependencies or be ready for dispatch.
   void EnqueuePlaceableTask(const Task &task);
   /// Handle specified task's submission to the local node manager.
-  void SubmitTask(const Task &task, const Lineage &uncommitted_lineage, bool forwarded = false);
+  void SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
+                  bool forwarded = false);
   /// Assign a task. The task is assumed to not be queued in local_queues_.
   void AssignTask(Task &task);
   /// Handle a worker finishing its assigned task.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -70,7 +70,7 @@ class NodeManager {
 
   /// Methods for task scheduling.
   /// Transition a placeable task to wait on object dependencies or ready for dispatch.
-  void MovePlaceableTask(const Task &task);
+  void TransitionPlaceableTask(const Task &task);
   /// Handle specified task's submission to the local node manager.
   void SubmitTask(const Task &task, const Lineage &uncommitted_lineage, bool forwarded = false);
   /// Assign a task. The task is assumed to not be queued in local_queues_.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -69,8 +69,8 @@ class NodeManager {
                       const HeartbeatTableDataT &data);
 
   /// Methods for task scheduling.
-  // Queue a task for local execution.
-  void QueueTask(const Task &task);
+  /// Transition a placeable task to wait on object dependencies or ready for dispatch.
+  void MovePlaceableTask(const Task &task);
   /// Handle specified task's submission to the local node manager.
   void SubmitTask(const Task &task, const Lineage &uncommitted_lineage, bool forwarded = false);
   /// Assign a task. The task is assumed to not be queued in local_queues_.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -69,15 +69,15 @@ class NodeManager {
                       const HeartbeatTableDataT &data);
 
   /// Methods for task scheduling.
-  /// Transition a placeable task to wait on object dependencies or ready for dispatch.
-  void TransitionPlaceableTask(const Task &task);
+  /// Enqueue a placeable task to wait on object dependencies or be ready for dispatch.
+  void EnqueuePlaceableTask(const Task &task);
   /// Handle specified task's submission to the local node manager.
   void SubmitTask(const Task &task, const Lineage &uncommitted_lineage, bool forwarded = false);
   /// Assign a task. The task is assumed to not be queued in local_queues_.
   void AssignTask(Task &task);
   /// Handle a worker finishing its assigned task.
   void FinishAssignedTask(Worker &worker);
-  /// Schedule tasks.
+  /// Perform a placement decision on placeable tasks.
   void ScheduleTasks();
   /// Resubmit a task whose return value needs to be reconstructed.
   void ResubmitTask(const TaskID &task_id);
@@ -118,7 +118,6 @@ class NodeManager {
   const SchedulingResources local_resources_;
   /// The resources (and specific resource IDs) that are currently available.
   ResourceIdSet local_available_resources_;
-  // TODO(atumanov): Add resource information from other nodes.
   std::unordered_map<ClientID, SchedulingResources> cluster_resource_map_;
   /// A pool of workers.
   WorkerPool worker_pool_;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -71,8 +71,8 @@ class NodeManager {
   /// Methods for task scheduling.
   // Queue a task for local execution.
   void QueueTask(const Task &task);
-  /// Submit a task to this node.
-  void SubmitTask(const Task &task, const Lineage &uncommitted_lineage);
+  /// Handle specified task's submission to the local node manager.
+  void SubmitTask(const Task &task, const Lineage &uncommitted_lineage, bool forwarded = false);
   /// Assign a task. The task is assumed to not be queued in local_queues_.
   void AssignTask(Task &task);
   /// Handle a worker finishing its assigned task.

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -25,7 +25,7 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
   }
 
   // Iterate over running tasks, get their resource demand and try to schedule.
-  for (const auto &t : scheduling_queue_.GetReadyTasks()) {
+  for (const auto &t : scheduling_queue_.GetPlaceableTasks()) {
     // Get task's resource demand
     const auto &resource_demand = t.GetTaskSpecification().GetRequiredResources();
     const TaskID &task_id = t.GetTaskSpecification().TaskId();

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -73,34 +73,38 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
   // TODO(atumanov): check the states first to ensure the move is transactional.
   std::vector<Task> removed_tasks;
   // Remove the tasks from the specified source queue.
-  switch(src_state) {
-    case PLACEABLE:
-      removeTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
-      break;
-    case WAITING:
-      removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
-      break;
-    case READY:
-      removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
-      break;
-    case RUNNING:
-      removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
-      break;
-    default:
-      RAY_LOG(ERROR) << "Attempting to move tasks from unrecognized state " << src_state;
+  switch (src_state) {
+  case PLACEABLE:
+    removeTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
+    break;
+  case WAITING:
+    removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
+    break;
+  case READY:
+    removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
+    break;
+  case RUNNING:
+    removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
+    break;
+  default:
+    RAY_LOG(ERROR) << "Attempting to move tasks from unrecognized state " << src_state;
   }
   // Add the tasks to the specified destination queue.
-  switch(dst_state) {
-    case PLACEABLE:
-      queueTasks(placeable_tasks_, removed_tasks); break;
-    case WAITING:
-      queueTasks(waiting_tasks_, removed_tasks); break;
-    case READY:
-      queueTasks(ready_tasks_, removed_tasks); break;
-    case RUNNING:
-      queueTasks(running_tasks_, removed_tasks); break;
-    default:
-      RAY_LOG(ERROR) << "Attempting to move tasks to unrecognized state " << dst_state;
+  switch (dst_state) {
+  case PLACEABLE:
+    queueTasks(placeable_tasks_, removed_tasks);
+    break;
+  case WAITING:
+    queueTasks(waiting_tasks_, removed_tasks);
+    break;
+  case READY:
+    queueTasks(ready_tasks_, removed_tasks);
+    break;
+  case RUNNING:
+    queueTasks(running_tasks_, removed_tasks);
+    break;
+  default:
+    RAY_LOG(ERROR) << "Attempting to move tasks to unrecognized state " << dst_state;
   }
 }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -14,8 +14,8 @@ const std::list<Task> &SchedulingQueue::GetWaitingTasks() const {
   return this->waiting_tasks_;
 }
 
-const std::list<Task> &SchedulingQueue::GetReadyTasks() const {
-  return this->ready_tasks_;
+const std::list<Task> &SchedulingQueue::GetPlaceableTasks() const {
+  return this->placeable_tasks_;
 }
 
 const std::list<Task> &SchedulingQueue::GetScheduledTasks() const {
@@ -30,7 +30,7 @@ const std::list<Task> &SchedulingQueue::GetBlockedTasks() const {
   return this->blocked_tasks_;
 }
 
-const std::list<Task> &SchedulingQueue::GetReadyMethods() const {
+const std::list<Task> &SchedulingQueue::GetPlaceableMethods() const {
   throw std::runtime_error("Method not implemented");
 }
 
@@ -62,7 +62,7 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> task_i
   // Try to find the tasks to remove from the waiting tasks.
   removeTasksFromQueue(uncreated_actor_methods_, task_ids, removed_tasks);
   removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
-  removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
+  removeTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(scheduled_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(blocked_tasks_, task_ids, removed_tasks);
@@ -78,8 +78,8 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
   std::vector<Task> removed_tasks;
   // Remove the tasks from the specified source queue.
   switch(src_state) {
-    case READY:
-      removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
+    case PLACEABLE:
+      removeTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
       break;
     case WAITING:
       removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
@@ -95,8 +95,8 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
   }
   // Add the tasks to the specified destination queue.
   switch(dst_state) {
-    case READY:
-      queueTasks(ready_tasks_, removed_tasks); break;
+    case PLACEABLE:
+      queueTasks(placeable_tasks_, removed_tasks); break;
     case WAITING:
       queueTasks(waiting_tasks_, removed_tasks); break;
     case SCHEDULED:
@@ -116,8 +116,8 @@ void SchedulingQueue::QueueWaitingTasks(const std::vector<Task> &tasks) {
   queueTasks(waiting_tasks_, tasks);
 }
 
-void SchedulingQueue::QueueReadyTasks(const std::vector<Task> &tasks) {
-  queueTasks(ready_tasks_, tasks);
+void SchedulingQueue::QueuePlaceableTasks(const std::vector<Task> &tasks) {
+  queueTasks(placeable_tasks_, tasks);
 }
 
 void SchedulingQueue::QueueScheduledTasks(const std::vector<Task> &tasks) {

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -18,8 +18,8 @@ const std::list<Task> &SchedulingQueue::GetPlaceableTasks() const {
   return this->placeable_tasks_;
 }
 
-const std::list<Task> &SchedulingQueue::GetScheduledTasks() const {
-  return this->scheduled_tasks_;
+const std::list<Task> &SchedulingQueue::GetReadyTasks() const {
+  return this->ready_tasks_;
 }
 
 const std::list<Task> &SchedulingQueue::GetRunningTasks() const {
@@ -63,7 +63,7 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> task_i
   removeTasksFromQueue(uncreated_actor_methods_, task_ids, removed_tasks);
   removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
-  removeTasksFromQueue(scheduled_tasks_, task_ids, removed_tasks);
+  removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
   removeTasksFromQueue(blocked_tasks_, task_ids, removed_tasks);
   // TODO(swang): Remove from running methods.
@@ -84,8 +84,8 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
     case WAITING:
       removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
       break;
-    case SCHEDULED:
-      removeTasksFromQueue(scheduled_tasks_, task_ids, removed_tasks);
+    case READY:
+      removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
       break;
     case RUNNING:
       removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
@@ -99,8 +99,8 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
       queueTasks(placeable_tasks_, removed_tasks); break;
     case WAITING:
       queueTasks(waiting_tasks_, removed_tasks); break;
-    case SCHEDULED:
-      queueTasks(scheduled_tasks_, removed_tasks); break;
+    case READY:
+      queueTasks(ready_tasks_, removed_tasks); break;
     case RUNNING:
       queueTasks(running_tasks_, removed_tasks); break;
     default:
@@ -120,8 +120,8 @@ void SchedulingQueue::QueuePlaceableTasks(const std::vector<Task> &tasks) {
   queueTasks(placeable_tasks_, tasks);
 }
 
-void SchedulingQueue::QueueScheduledTasks(const std::vector<Task> &tasks) {
-  queueTasks(scheduled_tasks_, tasks);
+void SchedulingQueue::QueueReadyTasks(const std::vector<Task> &tasks) {
+  queueTasks(ready_tasks_, tasks);
 }
 
 void SchedulingQueue::QueueRunningTasks(const std::vector<Task> &tasks) {

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -72,6 +72,42 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> task_i
   return removed_tasks;
 }
 
+void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState src_state,
+                                TaskState dst_state) {
+  // TODO(atumanov): check the states first to ensure the move is transactional.
+  std::vector<Task> removed_tasks;
+  // Remove the tasks from the specified source queue.
+  switch(src_state) {
+    case READY:
+      removeTasksFromQueue(ready_tasks_, task_ids, removed_tasks);
+      break;
+    case WAITING:
+      removeTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
+      break;
+    case SCHEDULED:
+      removeTasksFromQueue(scheduled_tasks_, task_ids, removed_tasks);
+      break;
+    case RUNNING:
+      removeTasksFromQueue(running_tasks_, task_ids, removed_tasks);
+      break;
+    default:
+      RAY_LOG(ERROR) << "Attempting to move tasks from unrecognized state " << src_state;
+  }
+  // Add the tasks to the specified destination queue.
+  switch(dst_state) {
+    case READY:
+      queueTasks(ready_tasks_, removed_tasks); break;
+    case WAITING:
+      queueTasks(waiting_tasks_, removed_tasks); break;
+    case SCHEDULED:
+      queueTasks(scheduled_tasks_, removed_tasks); break;
+    case RUNNING:
+      queueTasks(running_tasks_, removed_tasks); break;
+    default:
+      RAY_LOG(ERROR) << "Attempting to move tasks to the recognized state " << dst_state;
+  }
+}
+
 void SchedulingQueue::QueueUncreatedActorMethods(const std::vector<Task> &tasks) {
   queueTasks(uncreated_actor_methods_, tasks);
 }

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -30,10 +30,6 @@ const std::list<Task> &SchedulingQueue::GetBlockedTasks() const {
   return this->blocked_tasks_;
 }
 
-const std::list<Task> &SchedulingQueue::GetPlaceableMethods() const {
-  throw std::runtime_error("Method not implemented");
-}
-
 // Helper function to remove tasks in the given set of task_ids from a
 // queue, and append them to the given vector removed_tasks.
 void removeTasksFromQueue(std::list<Task> &queue, std::unordered_set<TaskID> &task_ids,
@@ -104,7 +100,7 @@ void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> task_ids, TaskState s
     case RUNNING:
       queueTasks(running_tasks_, removed_tasks); break;
     default:
-      RAY_LOG(ERROR) << "Attempting to move tasks to the recognized state " << dst_state;
+      RAY_LOG(ERROR) << "Attempting to move tasks to unrecognized state " << dst_state;
   }
 }
 

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -12,15 +12,15 @@ namespace ray {
 
 namespace raylet {
 
-enum TaskState { INIT, READY, WAITING, SCHEDULED, RUNNING};
+enum TaskState { INIT, PLACEABLE, WAITING, SCHEDULED, RUNNING};
 /// \class SchedulingQueue
 ///
 /// Encapsulates task queues. Each queue represents a scheduling state for a
-/// task. The scheduling state is one of (1) waiting: for object dependencies
-/// to become available, (2) ready: object dependencies are available and the
-/// task is ready to be scheduled, (3) scheduled: the task has been scheduled
-/// but is waiting for a worker, or (4) running: the task has been scheduled
-/// and is running on a worker.
+/// task. The scheduling state is one of
+/// (1) placeable: the task is ready for a placement decision,
+/// (2) waiting: waiting for object dependencies to become locally available,
+/// (3) scheduled: the task is ready for local dispatch, with all arguments locally ready,
+/// (4) running: the task has been dispatched and is running on a worker.
 class SchedulingQueue {
  public:
   /// Create a scheduling queue.
@@ -42,17 +42,17 @@ class SchedulingQueue {
   /// object dependencies to become available.
   const std::list<Task> &GetWaitingTasks() const;
 
-  /// Get the queue of tasks in the ready state.
+  /// Get the queue of tasks in the placeable state.
   ///
   /// \return A const reference to the queue of tasks that have all
   /// dependencies local and that are waiting to be scheduled.
-  const std::list<Task> &GetReadyTasks() const;
+  const std::list<Task> &GetPlaceableTasks() const;
 
-  /// Get the queue of actor methods in the ready state.
+  /// Get the queue of actor methods in the placeable state.
   ///
   /// \return A const reference to the queue of actor methods that have all
   /// dependencies local and that are waiting to be scheduled.
-  const std::list<Task> &GetReadyMethods() const;
+  const std::list<Task> &GetPlaceableMethods() const;
 
   /// Get the queue of tasks in the scheduled state.
   ///
@@ -91,10 +91,10 @@ class SchedulingQueue {
   /// \param tasks The tasks to queue.
   void QueueWaitingTasks(const std::vector<Task> &tasks);
 
-  /// Queue tasks in the ready state.
+  /// Queue tasks in the placeable state.
   ///
   /// \param tasks The tasks to queue.
-  void QueueReadyTasks(const std::vector<Task> &tasks);
+  void QueuePlaceableTasks(const std::vector<Task> &tasks);
 
   /// Queue tasks in the scheduled state.
   ///
@@ -128,7 +128,7 @@ class SchedulingQueue {
   std::list<Task> waiting_tasks_;
   /// Tasks whose object dependencies are locally available, but that are
   /// waiting to be scheduled.
-  std::list<Task> ready_tasks_;
+  std::list<Task> placeable_tasks_;
   /// Tasks that have been scheduled to run, but that are waiting for a worker.
   std::list<Task> scheduled_tasks_;
   /// Tasks that are running on a worker.

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -12,14 +12,14 @@ namespace ray {
 
 namespace raylet {
 
-enum TaskState { INIT, PLACEABLE, WAITING, SCHEDULED, RUNNING};
+enum TaskState { INIT, PLACEABLE, WAITING, READY, RUNNING};
 /// \class SchedulingQueue
 ///
 /// Encapsulates task queues. Each queue represents a scheduling state for a
 /// task. The scheduling state is one of
 /// (1) placeable: the task is ready for a placement decision,
 /// (2) waiting: waiting for object dependencies to become locally available,
-/// (3) scheduled: the task is ready for local dispatch, with all arguments locally ready,
+/// (3) ready: the task is ready for local dispatch, with all arguments locally ready,
 /// (4) running: the task has been dispatched and is running on a worker.
 class SchedulingQueue {
  public:
@@ -54,11 +54,11 @@ class SchedulingQueue {
   /// dependencies local and that are waiting to be scheduled.
   const std::list<Task> &GetPlaceableMethods() const;
 
-  /// Get the queue of tasks in the scheduled state.
+  /// Get the queue of tasks in the ready state.
   ///
-  /// \return A const reference to the queue of tasks that have been scheduled
+  /// \return A const reference to the queue of tasks ready
   /// to execute but that are waiting for a worker.
-  const std::list<Task> &GetScheduledTasks() const;
+  const std::list<Task> &GetReadyTasks() const;
 
   /// Get the queue of tasks in the running state.
   ///
@@ -86,7 +86,7 @@ class SchedulingQueue {
   void QueueUncreatedActorMethods(const std::vector<Task> &tasks);
 
   /// Queue tasks in the waiting state. These are tasks that cannot yet be
-  /// scheduled since they are blocked on a missing data dependency.
+  /// dispatched since they are blocked on a missing data dependency.
   ///
   /// \param tasks The tasks to queue.
   void QueueWaitingTasks(const std::vector<Task> &tasks);
@@ -96,10 +96,10 @@ class SchedulingQueue {
   /// \param tasks The tasks to queue.
   void QueuePlaceableTasks(const std::vector<Task> &tasks);
 
-  /// Queue tasks in the scheduled state.
+  /// Queue tasks in the ready state.
   ///
   /// \param tasks The tasks to queue.
-  void QueueScheduledTasks(const std::vector<Task> &tasks);
+  void QueueReadyTasks(const std::vector<Task> &tasks);
 
   /// Queue tasks in the running state.
   ///
@@ -129,8 +129,8 @@ class SchedulingQueue {
   /// Tasks whose object dependencies are locally available, but that are
   /// waiting to be scheduled.
   std::list<Task> placeable_tasks_;
-  /// Tasks that have been scheduled to run, but that are waiting for a worker.
-  std::list<Task> scheduled_tasks_;
+  /// Tasks ready for dispatch, but that are waiting for a worker.
+  std::list<Task> ready_tasks_;
   /// Tasks that are running on a worker.
   std::list<Task> running_tasks_;
   /// Tasks that were dispatched to a worker but are blocked on a data

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -48,12 +48,6 @@ class SchedulingQueue {
   /// dependencies local and that are waiting to be scheduled.
   const std::list<Task> &GetPlaceableTasks() const;
 
-  /// Get the queue of actor methods in the placeable state.
-  ///
-  /// \return A const reference to the queue of actor methods that have all
-  /// dependencies local and that are waiting to be scheduled.
-  const std::list<Task> &GetPlaceableMethods() const;
-
   /// Get the queue of tasks in the ready state.
   ///
   /// \return A const reference to the queue of tasks ready

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -12,6 +12,7 @@ namespace ray {
 
 namespace raylet {
 
+enum TaskState { INIT, READY, WAITING, SCHEDULED, RUNNING};
 /// \class SchedulingQueue
 ///
 /// Encapsulates task queues. Each queue represents a scheduling state for a
@@ -111,6 +112,14 @@ class SchedulingQueue {
   ///
   /// \param tasks The tasks to queue.
   void QueueBlockedTasks(const std::vector<Task> &tasks);
+
+  /// \brief Move the specified tasks from the source state to the destination state.
+  ///
+  /// \param tasks The set of task IDs to move.
+  /// \param src_state Source state, which corresponds to one of the internal task queues.
+  /// \param dst_state Destination state, corresponding to one of the internal task queues.
+  void MoveTasks(std::unordered_set<TaskID> tasks, TaskState src_state, TaskState dst_state);
+
 
  private:
   /// Tasks that are destined for actors that have not yet been created.

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -12,7 +12,7 @@ namespace ray {
 
 namespace raylet {
 
-enum TaskState { INIT, PLACEABLE, WAITING, READY, RUNNING};
+enum TaskState { INIT, PLACEABLE, WAITING, READY, RUNNING };
 /// \class SchedulingQueue
 ///
 /// Encapsulates task queues. Each queue represents a scheduling state for a
@@ -111,9 +111,10 @@ class SchedulingQueue {
   ///
   /// \param tasks The set of task IDs to move.
   /// \param src_state Source state, which corresponds to one of the internal task queues.
-  /// \param dst_state Destination state, corresponding to one of the internal task queues.
-  void MoveTasks(std::unordered_set<TaskID> tasks, TaskState src_state, TaskState dst_state);
-
+  /// \param dst_state Destination state, corresponding to one of the internal task
+  /// queues.
+  void MoveTasks(std::unordered_set<TaskID> tasks, TaskState src_state,
+                 TaskState dst_state);
 
  private:
   /// Tasks that are destined for actors that have not yet been created.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR implements the following task state transition diagram in the raylet:
init --> placeable --> waiting --> ready --> running --> done

Each queue represents a scheduling state for a task. The scheduling state is one of
1. placeable: the task is ready for a placement decision,
2. waiting: waiting for object dependencies to become locally available,
3. ready: the task is ready for local dispatch, with all arguments locally ready,
4. running: the task has been dispatched and is running on a worker.

## Related issue number

n/a
