### PR TITLE
Replenish workers for disconnected actors

### DIFF
--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -1528,6 +1528,10 @@ void handle_actor_worker_disconnect(LocalSchedulerState *state,
 
   /* Attempt to dispatch some tasks because some resources may have freed up. */
   dispatch_all_tasks(state, algorithm_state);
+
+  /* Start a worker to replace the removed actor's worker and replenish the
+   * worker pool. */
+  start_worker(state);
 }
 
 /* NOTE(swang): For tasks that saved a checkpoint, we should consider


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR improves performance in applications that create and destroy actors.

Currently, creating an actor consumes a worker, but destroying an actor does not replenish the worker in the pool of available workers. This creates slows down creating new actors or launching tasks after destroying actors because the local scheduler must first launch a new worker.

Eagerly starting a new worker when an actor disconnects prevents slowdown due to depleted available workers.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #2295