### PR TITLE
Require Cython 0.27 for setup.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -143,7 +143,7 @@ setup(
         "six >= 1.0.0",
         "flatbuffers"
     ],
-    setup_requires=["cython == 0.27.3"],
+    setup_requires=["cython >= 0.27, < 0.28"],
     extras_require=extras,
     entry_points={"console_scripts": ["ray=ray.scripts.scripts:main"]},
     include_package_data=True,

--- a/python/setup.py
+++ b/python/setup.py
@@ -143,7 +143,7 @@ setup(
         "six >= 1.0.0",
         "flatbuffers"
     ],
-    setup_requires=["cython >= 0.23"],
+    setup_requires=["cython == 0.27"],
     extras_require=extras,
     entry_points={"console_scripts": ["ray=ray.scripts.scripts:main"]},
     include_package_data=True,

--- a/python/setup.py
+++ b/python/setup.py
@@ -143,7 +143,7 @@ setup(
         "six >= 1.0.0",
         "flatbuffers"
     ],
-    setup_requires=["cython == 0.27"],
+    setup_requires=["cython == 0.27.3"],
     extras_require=extras,
     entry_points={"console_scripts": ["ray=ray.scripts.scripts:main"]},
     include_package_data=True,


### PR DESCRIPTION
Arrow requires `>= 0.27` https://github.com/apache/arrow/blob/5e6c773ab8e68e8769a59d37f58f122ebf17a21c/python/setup.py#L530. However, I don't think Arrow works with 0.28.

Addresses #2310.