### PR TITLE
place forwarded actor tasks locally

### DIFF
--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -39,6 +39,11 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       decision[task_id] = local_client_id;
       continue;
     }
+    // Place actor tasks locally.
+    if (t.GetTaskSpecification().IsActorTask()) {
+      decision[task_id] = local_client_id;
+      continue;
+    }
     // Construct a set of viable node candidates and randomly pick between them.
     // Get all the client id keys and randomly pick.
     std::vector<ClientID> client_keys;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR makes sure that any actor tasks that may be found in the placeable queue (unlikely) are guaranteed to be placed locally.

## Related issue number

n/a
