### PR TITLE
Fix Plasma starting failure when specify the memory in float value.

### DIFF
--- a/python/ray/plasma/plasma.py
+++ b/python/ray/plasma/plasma.py
@@ -61,7 +61,7 @@ def start_plasma_store(plasma_store_memory=DEFAULT_PLASMA_STORE_MEMORY,
                         "plasma_directory argument must be provided.")
 
     if not isinstance(plasma_store_memory, int):
-        raise Exception("plasma_store_memory should be an interger.")
+        raise Exception("plasma_store_memory should be an integer.")
 
     plasma_store_executable = os.path.join(
         os.path.abspath(os.path.dirname(__file__)),

--- a/python/ray/plasma/plasma.py
+++ b/python/ray/plasma/plasma.py
@@ -60,6 +60,9 @@ def start_plasma_store(plasma_store_memory=DEFAULT_PLASMA_STORE_MEMORY,
         raise Exception("If huge_pages is True, then the "
                         "plasma_directory argument must be provided.")
 
+    if isinstance(plasma_store_memory, float):
+        raise Exception("plasma_store_memory should be an interger.")
+
     plasma_store_executable = os.path.join(
         os.path.abspath(os.path.dirname(__file__)),
         "../core/src/plasma/plasma_store")

--- a/python/ray/plasma/plasma.py
+++ b/python/ray/plasma/plasma.py
@@ -60,7 +60,7 @@ def start_plasma_store(plasma_store_memory=DEFAULT_PLASMA_STORE_MEMORY,
         raise Exception("If huge_pages is True, then the "
                         "plasma_directory argument must be provided.")
 
-    if isinstance(plasma_store_memory, float):
+    if not isinstance(plasma_store_memory, int):
         raise Exception("plasma_store_memory should be an interger.")
 
     plasma_store_executable = os.path.join(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1728,6 +1728,10 @@ def init(redis_address=None,
     if redis_address is not None:
         redis_address = services.address_to_ip(redis_address)
 
+    # If object_store_memory is a float value, Plasma's starting process will fail.
+    if object_store_memory is not None:
+       object_store_memory = int(object_store_memory)
+
     info = {"node_ip_address": node_ip_address, "redis_address": redis_address}
     ret = _init(
         address_info=info,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1728,7 +1728,7 @@ def init(redis_address=None,
     if redis_address is not None:
         redis_address = services.address_to_ip(redis_address)
 
-    # If object_store_memory is a float value, Plasma's starting process will fail.
+    # If object_store_memory is a float, Plasma's starting process will fail.
     if object_store_memory is not None:
         object_store_memory = int(object_store_memory)
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1730,7 +1730,7 @@ def init(redis_address=None,
 
     # If object_store_memory is a float value, Plasma's starting process will fail.
     if object_store_memory is not None:
-       object_store_memory = int(object_store_memory)
+        object_store_memory = int(object_store_memory)
 
     info = {"node_ip_address": node_ip_address, "redis_address": redis_address}
     ret = _init(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1728,10 +1728,6 @@ def init(redis_address=None,
     if redis_address is not None:
         redis_address = services.address_to_ip(redis_address)
 
-    # If object_store_memory is a float, Plasma's starting process will fail.
-    if object_store_memory is not None:
-        object_store_memory = int(object_store_memory)
-
     info = {"node_ip_address": node_ip_address, "redis_address": redis_address}
     ret = _init(
         address_info=info,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
When we set a float value to object_store_memory to do ray.init(object_store_memory=XXX), Plasma store won't start. We need to guarantee that object_store_memory is an integer. 
<!-- Please give a short brief about these changes. -->

## Related issue number
[2333](https://github.com/ray-project/ray/issues/2333)
<!-- Are there any issues opened that will be resolved by merging this change? -->
