### PR TITLE
Make xray object table credis-managed and hence flushable.

### DIFF
--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -111,10 +111,14 @@ class Monitor(object):
         self.issue_gcs_flushes = "RAY_USE_NEW_GCS" in os.environ
         self.gcs_flush_policy = None
         if self.issue_gcs_flushes:
-            # For now, we take the primary redis server to issue flushes,
-            # because task table entries are stored there under this flag.
+            # Data is stored under the first data shard, so we issue flushes to
+            # that redis server.
+            addr_port = self.redis.lrange("RedisShards", 0, -1)[0]
+            addr_port = addr_port.split(b":")
+            self.redis_shard = redis.StrictRedis(
+                host=addr_port[0], port=addr_port[1])
             try:
-                self.redis.execute_command("HEAD.FLUSH 0")
+                self.redis_shard.execute_command("HEAD.FLUSH 0")
             except redis.exceptions.ResponseError as e:
                 log.info("Turning off flushing due to exception: {}".format(
                     str(e)))
@@ -562,11 +566,11 @@ class Monitor(object):
                 return
             self.gcs_flush_policy = pickle.loads(serialized)
 
-        if not self.gcs_flush_policy.should_flush(self.redis):
+        if not self.gcs_flush_policy.should_flush(self.redis_shard):
             return
 
         max_entries_to_flush = self.gcs_flush_policy.num_entries_to_flush()
-        num_flushed = self.redis.execute_command(
+        num_flushed = self.redis_shard.execute_command(
             "HEAD.FLUSH {}".format(max_entries_to_flush))
         log.info('num_flushed {}'.format(num_flushed))
 

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -125,8 +125,9 @@ class Monitor(object):
                 try:
                     self.redis_shard.execute_command("HEAD.FLUSH 0")
                 except redis.exceptions.ResponseError as e:
-                    log.info("Turning off flushing due to exception: {}".format(
-                        str(e)))
+                    log.info(
+                        "Turning off flushing due to exception: {}".format(
+                            str(e)))
                     self.issue_gcs_flushes = False
 
     def subscribe(self, channel):

--- a/src/common/redis_module/chain_module.h
+++ b/src/common/redis_module/chain_module.h
@@ -50,6 +50,8 @@ class RedisChainModule {
 
   // Runs "node_func" on every node in the chain; after the tail node has run it
   // too, finalizes the mutation by running "tail_func".
+  //
+  // The tail function is allowed to be nullptr.
   // TODO(zongheng): currently only supports 1-node chain.
   int ChainReplicate(RedisModuleCtx *ctx,
                      RedisModuleString **argv,

--- a/src/common/redis_module/chain_module.h
+++ b/src/common/redis_module/chain_module.h
@@ -52,8 +52,8 @@ class RedisChainModule {
   // too, finalizes the mutation by running "tail_func".
   //
   // If node_func() returns non-zero, it is treated as an error and the entire
-  // update will terminate. without running subsequent node_func() and the final
-  // tail_func().
+  // update will terminate early, without running subsequent node_func() and the
+  // final tail_func().
   //
   // TODO(zongheng): currently only supports 1-node chain.
   int ChainReplicate(RedisModuleCtx *ctx,

--- a/src/common/redis_module/chain_module.h
+++ b/src/common/redis_module/chain_module.h
@@ -51,7 +51,10 @@ class RedisChainModule {
   // Runs "node_func" on every node in the chain; after the tail node has run it
   // too, finalizes the mutation by running "tail_func".
   //
-  // The tail function is allowed to be nullptr.
+  // If node_func() returns non-zero, it is treated as an error and the entire
+  // update will terminate. without running subsequent node_func() and the final
+  // tail_func().
+  //
   // TODO(zongheng): currently only supports 1-node chain.
   int ChainReplicate(RedisModuleCtx *ctx,
                      RedisModuleString **argv,

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -654,6 +654,75 @@ int ChainTableAdd_RedisCommand(RedisModuleCtx *ctx,
 }
 #endif
 
+int TableAppend_DoWrite(RedisModuleCtx *ctx,
+                        RedisModuleString **argv,
+                        int argc,
+                        RedisModuleString **mutated_key_str) {
+  if (argc < 5 || argc > 6) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  RedisModuleString *prefix_str = argv[1];
+  RedisModuleString *id = argv[3];
+  RedisModuleString *data = argv[4];
+  RedisModuleString *index_str = nullptr;
+  if (argc == 6) {
+    index_str = argv[5];
+  }
+
+  // Set the keys in the table.
+  RedisModuleKey *key =
+      OpenPrefixedKey(ctx, prefix_str, id, REDISMODULE_READ | REDISMODULE_WRITE,
+                      mutated_key_str);
+  // Determine the index at which the data should be appended. If no index is
+  // requested, then is the current length of the log.
+  size_t index = RedisModule_ValueLength(key);
+  if (index_str != nullptr) {
+    // Parse the requested index.
+    long long requested_index;
+    RAY_CHECK(RedisModule_StringToLongLong(index_str, &requested_index) ==
+              REDISMODULE_OK);
+    RAY_CHECK(requested_index >= 0);
+    index = static_cast<size_t>(requested_index);
+  }
+  // Only perform the append if the requested index matches the current length
+  // of the log, or if no index was requested.
+  if (index == RedisModule_ValueLength(key)) {
+    // The requested index matches the current length of the log or no index
+    // was requested. Perform the append.
+    int flags = REDISMODULE_ZADD_NX;
+    RedisModule_ZsetAdd(key, index, data, &flags);
+    // Check that we actually add a new entry during the append. This is only
+    // necessary since we implement the log with a sorted set, so all entries
+    // must be unique, or else we will have gaps in the log.
+    RAY_CHECK(flags == REDISMODULE_ZADD_ADDED) << "Appended a duplicate entry";
+
+  } else {
+    // The requested index did not match the current length of the log. Return
+    // an error message as a string.
+    const char *reply = "ERR entry exists";
+    return RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
+  }
+  return REDISMODULE_OK;
+}
+
+int TableAppend_DoPublish(RedisModuleCtx *ctx,
+                          RedisModuleString **argv,
+                          int /*argc*/) {
+  RedisModuleString *pubsub_channel_str = argv[2];
+  RedisModuleString *id = argv[3];
+  RedisModuleString *data = argv[4];
+  // Publish a message on the requested pubsub channel if necessary.
+  TablePubsub pubsub_channel = ParseTablePubsub(pubsub_channel_str);
+  if (pubsub_channel != TablePubsub::NO_PUBLISH) {
+    // All other pubsub channels write the data back directly onto the
+    // channel.
+    return PublishTableAdd(ctx, pubsub_channel_str, id, data);
+  } else {
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  }
+}
+
 /// Append an entry to the log stored at a key. Publishes a notification about
 /// the update to all subscribers, if a pubsub channel is provided.
 ///
@@ -678,61 +747,24 @@ int TableAppend_RedisCommand(RedisModuleCtx *ctx,
                              RedisModuleString **argv,
                              int argc) {
   RedisModule_AutoMemory(ctx);
-
-  if (argc < 5 || argc > 6) {
-    return RedisModule_WrongArity(ctx);
+  const int status = TableAppend_DoWrite(ctx, argv, argc,
+                                         /*mutated_key_str=*/nullptr);
+  if (status) {
+    return status;
   }
-
-  RedisModuleString *prefix_str = argv[1];
-  RedisModuleString *pubsub_channel_str = argv[2];
-  RedisModuleString *id = argv[3];
-  RedisModuleString *data = argv[4];
-  RedisModuleString *index_str = nullptr;
-  if (argc == 6) {
-    index_str = argv[5];
-  }
-
-  // Set the keys in the table.
-  RedisModuleKey *key = OpenPrefixedKey(ctx, prefix_str, id,
-                                        REDISMODULE_READ | REDISMODULE_WRITE);
-  // Determine the index at which the data should be appended. If no index is
-  // requested, then is the current length of the log.
-  size_t index = RedisModule_ValueLength(key);
-  if (index_str != nullptr) {
-    // Parse the requested index.
-    long long requested_index;
-    RAY_CHECK(RedisModule_StringToLongLong(index_str, &requested_index) ==
-              REDISMODULE_OK);
-    RAY_CHECK(requested_index >= 0);
-    index = static_cast<size_t>(requested_index);
-  }
-  // Only perform the append if the requested index matches the current length
-  // of the log, or if no index was requested.
-  if (index == RedisModule_ValueLength(key)) {
-    // The requested index matches the current length of the log or no index
-    // was requested. Perform the append.
-    int flags = REDISMODULE_ZADD_NX;
-    RedisModule_ZsetAdd(key, index, data, &flags);
-    // Check that we actually add a new entry during the append. This is only
-    // necessary since we implement the log with a sorted set, so all entries
-    // must be unique, or else we will have gaps in the log.
-    RAY_CHECK(flags == REDISMODULE_ZADD_ADDED) << "Appended a duplicate entry";
-    // Publish a message on the requested pubsub channel if necessary.
-    TablePubsub pubsub_channel = ParseTablePubsub(pubsub_channel_str);
-    if (pubsub_channel != TablePubsub::NO_PUBLISH) {
-      // All other pubsub channels write the data back directly onto the
-      // channel.
-      return PublishTableAdd(ctx, pubsub_channel_str, id, data);
-    } else {
-      return RedisModule_ReplyWithSimpleString(ctx, "OK");
-    }
-  } else {
-    // The requested index did not match the current length of the log. Return
-    // an error message as a string.
-    const char *reply = "ERR entry exists";
-    return RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
-  }
+  return TableAppend_DoPublish(ctx, argv, argc);
 }
+
+#if RAY_USE_NEW_GCS
+int ChainTableAppend_RedisCommand(RedisModuleCtx *ctx,
+                                  RedisModuleString **argv,
+                                  int argc) {
+  RedisModule_AutoMemory(ctx);
+  return module.ChainReplicate(ctx, argv, argc,
+                               /*node_func=*/TableAppend_DoWrite,
+                               /*tail_func=*/TableAppend_DoPublish);
+}
+#endif
 
 /// A helper function to create and finish a GcsTableEntry, based on the
 /// current value or values at the given key.
@@ -1909,6 +1941,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx,
   if (RedisModule_CreateCommand(ctx, "ray.chain.table_add",
                                 ChainTableAdd_RedisCommand, "write pubsub", 0,
                                 0, 0) == REDISMODULE_ERR) {
+    return REDISMODULE_ERR;
+  }
+  if (RedisModule_CreateCommand(ctx, "ray.chain.table_append",
+                                ChainTableAppend_RedisCommand, "write pubsub",
+                                0, 0, 0) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
   if (RedisModule_CreateCommand(ctx, "ray.chain.object_table_add",

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -696,7 +696,7 @@ int TableAppend_DoWrite(RedisModuleCtx *ctx,
     // necessary since we implement the log with a sorted set, so all entries
     // must be unique, or else we will have gaps in the log.
     RAY_CHECK(flags == REDISMODULE_ZADD_ADDED) << "Appended a duplicate entry";
-
+    return REDISMODULE_OK;
   } else {
     // The requested index did not match the current length of the log. Return
     // an error message as a string.
@@ -704,7 +704,6 @@ int TableAppend_DoWrite(RedisModuleCtx *ctx,
     RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
     return REDISMODULE_ERR;
   }
-  return REDISMODULE_OK;
 }
 
 int TableAppend_DoPublish(RedisModuleCtx *ctx,

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -1004,10 +1004,27 @@ int TableTestAndUpdate_RedisCommand(RedisModuleCtx *ctx,
   return result;
 }
 
-int ObjectTableAdd_WriteObjectInfo(RedisModuleCtx *ctx,
-                                   RedisModuleString **argv,
-                                   int argc,
-                                   RedisModuleString **mutated_key_str) {
+/**
+ * Add a new entry to the object table or update an existing one.
+ *
+ * This is called from a client with the command:
+ *
+ *     RAY.OBJECT_TABLE_ADD <object id> <data size> <hash string> <manager id>
+ *
+ * @param object_id A string representing the object ID.
+ * @param data_size An integer which is the object size in bytes.
+ * @param hash_string A string which is a hash of the object.
+ * @param manager A string which represents the manager ID of the plasma manager
+ *        that has the object.
+ * @return OK if the operation was successful. If the same object_id is already
+ *         present with a different hash value, the entry is still added, but
+ *         an error with string "hash mismatch" is returned.
+ */
+int ObjectTableAdd_RedisCommand(RedisModuleCtx *ctx,
+                                RedisModuleString **argv,
+                                int argc) {
+  RedisModule_AutoMemory(ctx);
+
   if (argc != 5) {
     return RedisModule_WrongArity(ctx);
   }
@@ -1015,6 +1032,7 @@ int ObjectTableAdd_WriteObjectInfo(RedisModuleCtx *ctx,
   RedisModuleString *object_id = argv[1];
   RedisModuleString *data_size = argv[2];
   RedisModuleString *new_hash = argv[3];
+  RedisModuleString *manager = argv[4];
 
   long long data_size_value;
   if (RedisModule_StringToLongLong(data_size, &data_size_value) !=
@@ -1023,40 +1041,36 @@ int ObjectTableAdd_WriteObjectInfo(RedisModuleCtx *ctx,
   }
 
   /* Set the fields in the object info table. */
-  RedisModuleKey *key =
-      OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id,
-                      REDISMODULE_READ | REDISMODULE_WRITE, mutated_key_str);
+  RedisModuleKey *key;
+  key = OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id,
+                        REDISMODULE_READ | REDISMODULE_WRITE);
+
+  /* Check if this object was already registered and if the hashes agree. */
+  bool hash_mismatch = false;
+  if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
+    RedisModuleString *existing_hash;
+    RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS, "hash", &existing_hash,
+                        NULL);
+    /* The existing hash may be NULL even if the key is present because a call
+     * to RAY.RESULT_TABLE_ADD may have already created the key. */
+    if (existing_hash != NULL) {
+      /* Check whether the new hash value matches the old one. If not, we will
+       * later return the "hash mismatch" error. */
+      hash_mismatch = (RedisModule_StringCompare(existing_hash, new_hash) != 0);
+    }
+  }
 
   RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "hash", new_hash, NULL);
   RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "data_size", data_size,
                       NULL);
-  return REDISMODULE_OK;
-}
-
-int ObjectTableAdd_WriteObjectLocation(RedisModuleCtx *ctx,
-                                       RedisModuleString **argv,
-                                       int /*argc*/,
-                                       RedisModuleString **mutated_key_str) {
-  RedisModuleString *object_id = argv[1];
-  RedisModuleString *manager = argv[4];
 
   /* Add the location in the object location table. */
-  RedisModuleKey *table_key =
-      OpenPrefixedKey(ctx, OBJECT_LOCATION_PREFIX, object_id,
-                      REDISMODULE_READ | REDISMODULE_WRITE, mutated_key_str);
-  /* Sets are not implemented yet, so we use ZSETs instead. */
-  return RedisModule_ZsetAdd(table_key, 0.0, manager, NULL);
-}
+  RedisModuleKey *table_key;
+  table_key = OpenPrefixedKey(ctx, OBJECT_LOCATION_PREFIX, object_id,
+                              REDISMODULE_READ | REDISMODULE_WRITE);
 
-int ObjectTableAdd_DoPublish(RedisModuleCtx *ctx,
-                             RedisModuleString **argv,
-                             int /*argc*/) {
-  RedisModuleString *object_id = argv[1];
-  RedisModuleString *data_size = argv[2];
-  RedisModuleString *new_hash = argv[3];
-  RedisModuleKey *table_key =
-      OpenPrefixedKey(ctx, OBJECT_LOCATION_PREFIX, object_id,
-                      REDISMODULE_READ | REDISMODULE_WRITE);
+  /* Sets are not implemented yet, so we use ZSETs instead. */
+  RedisModule_ZsetAdd(table_key, 0.0, manager, NULL);
 
   RedisModuleString *bcast_client_str =
       RedisModule_CreateString(ctx, OBJECT_BCAST, strlen(OBJECT_BCAST));
@@ -1102,77 +1116,13 @@ int ObjectTableAdd_DoPublish(RedisModuleCtx *ctx,
                 "Unable to delete zset key.");
   }
 
-  /* Check if this object was already registered and if the hashes agree. */
-  RedisModuleKey *key = OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id,
-                                        REDISMODULE_READ | REDISMODULE_WRITE);
-  bool hash_mismatch = false;
-  if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
-    RedisModuleString *existing_hash;
-    RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS, "hash", &existing_hash,
-                        NULL);
-    /* The existing hash may be NULL even if the key is present because a call
-     * to RAY.RESULT_TABLE_ADD may have already created the key. */
-    if (existing_hash != NULL) {
-      /* Check whether the new hash value matches the old one. If not, we will
-       * later return the "hash mismatch" error. */
-      hash_mismatch = (RedisModule_StringCompare(existing_hash, new_hash) != 0);
-    }
-  }
   if (hash_mismatch) {
     return RedisModule_ReplyWithError(ctx, "hash mismatch");
   } else {
-    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
   }
 }
-
-/**
- * Add a new entry to the object table or update an existing one.
- *
- * This is called from a client with the command:
- *
- *     RAY.OBJECT_TABLE_ADD <object id> <data size> <hash string> <manager id>
- *
- * @param object_id A string representing the object ID.
- * @param data_size An integer which is the object size in bytes.
- * @param hash_string A string which is a hash of the object.
- * @param manager A string which represents the manager ID of the plasma manager
- *        that has the object.
- * @return OK if the operation was successful. If the same object_id is already
- *         present with a different hash value, the entry is still added, but
- *         an error with string "hash mismatch" is returned.
- */
-int ObjectTableAdd_RedisCommand(RedisModuleCtx *ctx,
-                                RedisModuleString **argv,
-                                int argc) {
-  RedisModule_AutoMemory(ctx);
-  const int status =
-      ObjectTableAdd_WriteObjectInfo(ctx, argv, argc,
-                                     /*mutated_key_str=*/nullptr);
-  if (status) {
-    return status;  // RM_Reply called.
-  }
-  ObjectTableAdd_WriteObjectLocation(ctx, argv, argc,
-                                     /*mutated_key_str=*/nullptr);
-  return ObjectTableAdd_DoPublish(ctx, argv, argc);
-}
-
-#if RAY_USE_NEW_GCS
-int ChainObjectTableAdd_RedisCommand(RedisModuleCtx *ctx,
-                                     RedisModuleString **argv,
-                                     int argc) {
-  RedisModule_AutoMemory(ctx);
-  const int status =
-      module.ChainReplicate(ctx, argv, argc,
-                            /*node_func=*/ObjectTableAdd_WriteObjectInfo,
-                            /*tail_func=*/nullptr);
-  if (status) {
-    return status;
-  }
-  return module.ChainReplicate(ctx, argv, argc,
-                               /*node_func=*/ObjectTableAdd_WriteObjectLocation,
-                               /*tail_func=*/nullptr);
-}
-#endif
 
 /**
  * Remove a manager from a location entry in the object table.
@@ -1302,10 +1252,25 @@ int ObjectInfoSubscribe_RedisCommand(RedisModuleCtx *ctx,
   return REDISMODULE_OK;
 }
 
-int ResultTableAdd_DoWrite(RedisModuleCtx *ctx,
-                           RedisModuleString **argv,
-                           int argc,
-                           RedisModuleString **mutated_key_str) {
+/**
+ * Add a new entry to the result table or update an existing one.
+ *
+ * This is called from a client with the command:
+ *
+ *     RAY.RESULT_TABLE_ADD <object id> <task id> <is_put>
+ *
+ * @param object_id A string representing the object ID.
+ * @param task_id A string representing the task ID of the task that produced
+ *        the object.
+ * @param is_put An integer that is 1 if the object was created through ray.put
+ *        and 0 if created by return value.
+ * @return OK if the operation was successful.
+ */
+int ResultTableAdd_RedisCommand(RedisModuleCtx *ctx,
+                                RedisModuleString **argv,
+                                int argc) {
+  RedisModule_AutoMemory(ctx);
+
   if (argc != 4) {
     return RedisModule_WrongArity(ctx);
   }
@@ -1325,57 +1290,14 @@ int ResultTableAdd_DoWrite(RedisModuleCtx *ctx,
   }
 
   RedisModuleKey *key;
-  key = OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id, REDISMODULE_WRITE,
-                        mutated_key_str);
+  key = OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id, REDISMODULE_WRITE);
   RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "task", task_id, "is_put",
                       is_put, NULL);
+
+  RedisModule_ReplyWithSimpleString(ctx, "OK");
+
   return REDISMODULE_OK;
 }
-
-int ResultTableAdd_DoFinalize(RedisModuleCtx *ctx,
-                              RedisModuleString **argv,
-                              int argc) {
-  REDISMODULE_NOT_USED(argv);
-  REDISMODULE_NOT_USED(argc);
-  return RedisModule_ReplyWithSimpleString(ctx, "OK");
-}
-
-/**
- * Add a new entry to the result table or update an existing one.
- *
- * This is called from a client with the command:
- *
- *     RAY.RESULT_TABLE_ADD <object id> <task id> <is_put>
- *
- * @param object_id A string representing the object ID.
- * @param task_id A string representing the task ID of the task that produced
- *        the object.
- * @param is_put An integer that is 1 if the object was created through ray.put
- *        and 0 if created by return value.
- * @return OK if the operation was successful.
- */
-int ResultTableAdd_RedisCommand(RedisModuleCtx *ctx,
-                                RedisModuleString **argv,
-                                int argc) {
-  RedisModule_AutoMemory(ctx);
-  const int status =
-      ResultTableAdd_DoWrite(ctx, argv, argc, /*mutated_key_str=*/nullptr);
-  if (status) {
-    return status;  // RM_Reply called.
-  }
-  return ResultTableAdd_DoFinalize(ctx, argv, argc);
-}
-
-#if RAY_USE_NEW_GCS
-int ChainResultTableAdd_RedisCommand(RedisModuleCtx *ctx,
-                                     RedisModuleString **argv,
-                                     int argc) {
-  RedisModule_AutoMemory(ctx);
-  return module.ChainReplicate(ctx, argv, argc,
-                               /*node_func=*/ResultTableAdd_DoWrite,
-                               /*tail_func=*/ResultTableAdd_DoFinalize);
-}
-#endif
 
 /**
  * Reply with information about a task ID. This is used by
@@ -1947,16 +1869,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx,
   if (RedisModule_CreateCommand(ctx, "ray.chain.table_append",
                                 ChainTableAppend_RedisCommand, "write pubsub",
                                 0, 0, 0) == REDISMODULE_ERR) {
-    return REDISMODULE_ERR;
-  }
-  if (RedisModule_CreateCommand(ctx, "ray.chain.object_table_add",
-                                ChainObjectTableAdd_RedisCommand, "write", 0, 0,
-                                0) == REDISMODULE_ERR) {
-    return REDISMODULE_ERR;
-  }
-  if (RedisModule_CreateCommand(ctx, "ray.chain.result_table_add",
-                                ChainResultTableAdd_RedisCommand, "write", 0, 0,
-                                0) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
 #endif

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -700,8 +700,9 @@ int TableAppend_DoWrite(RedisModuleCtx *ctx,
   } else {
     // The requested index did not match the current length of the log. Return
     // an error message as a string.
-    const char *reply = "ERR entry exists";
-    return RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
+    static const char *reply = "ERR entry exists";
+    RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
+    return REDISMODULE_ERR;
   }
   return REDISMODULE_OK;
 }

--- a/src/common/redis_module/ray_redis_module.cc
+++ b/src/common/redis_module/ray_redis_module.cc
@@ -995,8 +995,9 @@ int ObjectTableAdd_WriteObjectInfo(RedisModuleCtx *ctx,
                       REDISMODULE_READ | REDISMODULE_WRITE, mutated_key_str);
 
   RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "hash", new_hash, NULL);
-  return RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "data_size",
-                             data_size, NULL);
+  RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "data_size", data_size,
+                      NULL);
+  return REDISMODULE_OK;
 }
 
 int ObjectTableAdd_WriteObjectLocation(RedisModuleCtx *ctx,
@@ -1114,7 +1115,7 @@ int ObjectTableAdd_RedisCommand(RedisModuleCtx *ctx,
   const int status =
       ObjectTableAdd_WriteObjectInfo(ctx, argv, argc,
                                      /*mutated_key_str=*/nullptr);
-  if (!status) {
+  if (status) {
     return status;  // RM_Reply called.
   }
   ObjectTableAdd_WriteObjectLocation(ctx, argv, argc,
@@ -1131,7 +1132,7 @@ int ChainObjectTableAdd_RedisCommand(RedisModuleCtx *ctx,
       module.ChainReplicate(ctx, argv, argc,
                             /*node_func=*/ObjectTableAdd_WriteObjectInfo,
                             /*tail_func=*/nullptr);
-  if (!status) {
+  if (status) {
     return status;
   }
   return module.ChainReplicate(ctx, argv, argc,
@@ -1293,8 +1294,9 @@ int ResultTableAdd_DoWrite(RedisModuleCtx *ctx,
   RedisModuleKey *key;
   key = OpenPrefixedKey(ctx, OBJECT_INFO_PREFIX, object_id, REDISMODULE_WRITE,
                         mutated_key_str);
-  return RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "task", task_id,
-                             "is_put", is_put, NULL);
+  RedisModule_HashSet(key, REDISMODULE_HASH_CFIELDS, "task", task_id, "is_put",
+                      is_put, NULL);
+  return REDISMODULE_OK;
 }
 
 int ResultTableAdd_DoFinalize(RedisModuleCtx *ctx,
@@ -1325,7 +1327,7 @@ int ResultTableAdd_RedisCommand(RedisModuleCtx *ctx,
   RedisModule_AutoMemory(ctx);
   const int status =
       ResultTableAdd_DoWrite(ctx, argv, argc, /*mutated_key_str=*/nullptr);
-  if (!status) {
+  if (status) {
     return status;  // RM_Reply called.
   }
   return ResultTableAdd_DoFinalize(ctx, argv, argc);

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -10,7 +10,7 @@ AsyncGcsClient::AsyncGcsClient(const ClientID &client_id, CommandType command_ty
   context_ = std::make_shared<RedisContext>();
   primary_context_ = std::make_shared<RedisContext>();
   client_table_.reset(new ClientTable(primary_context_, this, client_id));
-  object_table_.reset(new ObjectTable(context_, this));
+  object_table_.reset(new ObjectTable(context_, this, command_type));
   actor_table_.reset(new ActorTable(context_, this));
   task_table_.reset(new TaskTable(context_, this, command_type));
   raylet_task_table_.reset(new raylet::TaskTable(context_, this, command_type));

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -6,6 +6,16 @@
 namespace {
 static const std::string kTableAppendCommand = "RAY.TABLE_APPEND";
 static const std::string kChainTableAppendCommand = "RAY.CHAIN.TABLE_APPEND";
+
+std::string GetLogAppendCommand(const ray::gcs::CommandType command_type) {
+  if (command_type == ray::gcs::CommandType::kRegular) {
+    return kTableAppendCommand;
+  } else {
+    RAY_CHECK(command_type == ray::gcs::CommandType::kChain);
+    return kChainTableAppendCommand;
+  }
+}
+
 }  // namespace
 
 namespace ray {
@@ -24,15 +34,8 @@ Status Log<ID, Data>::Append(const JobID &job_id, const ID &id,
   flatbuffers::FlatBufferBuilder fbb;
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, dataT.get()));
-
-  std::string command;
-  if (command_type_ == CommandType::kRegular) {
-    command = kTableAppendCommand;
-  } else {
-    RAY_CHECK(command_type_ == CommandType::kChain);
-    command = kChainTableAppendCommand;
-  }
-  return context_->RunAsync(command, id, fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
+  return context_->RunAsync(GetLogAppendCommand(command_type_), id,
+                            fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
                             pubsub_channel_, std::move(callback));
 }
 
@@ -55,15 +58,8 @@ Status Log<ID, Data>::AppendAt(const JobID &job_id, const ID &id,
   flatbuffers::FlatBufferBuilder fbb;
   fbb.ForceDefaults(true);
   fbb.Finish(Data::Pack(fbb, dataT.get()));
-
-  std::string command;
-  if (command_type_ == CommandType::kRegular) {
-    command = kTableAppendCommand;
-  } else {
-    RAY_CHECK(command_type_ == CommandType::kChain);
-    command = kChainTableAppendCommand;
-  }
-  return context_->RunAsync(command, id, fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
+  return context_->RunAsync(GetLogAppendCommand(command_type_), id,
+                            fbb.GetBufferPointer(), fbb.GetSize(), prefix_,
                             pubsub_channel_, std::move(callback), log_length);
 }
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -276,6 +276,13 @@ class ObjectTable : public Log<ObjectID, ObjectTableData> {
     pubsub_channel_ = TablePubsub::OBJECT;
     prefix_ = TablePrefix::OBJECT;
   };
+
+  ObjectTable(const std::shared_ptr<RedisContext> &context, AsyncGcsClient *client,
+              gcs::CommandType command_type)
+      : ObjectTable(context, client) {
+    command_type_ = command_type;
+  };
+
   virtual ~ObjectTable(){};
 };
 

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -33,7 +33,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    git checkout 5a12b8e4973879c52426a54fd6733543d923b83c
+    git checkout 273d667e5126c246b45f5dcf030b651a653136c3
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -33,7 +33,7 @@ if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   popd
 
   pushd "$TP_DIR/pkg/credis"
-    git checkout 273d667e5126c246b45f5dcf030b651a653136c3
+    git checkout 5a12b8e4973879c52426a54fd6733543d923b83c
 
     # If the above commit points to different submodules' commits than
     # origin's head, this updates the submodules.


### PR DESCRIPTION
This is a followup to https://github.com/ray-project/ray/pull/2266 -- that PR laid down the flushing policy framework + made task table flushable.  This PR in addition makes xray's task table flushable.

Testing program: submitting N noops in a loop, monitor memory usage of the _redis data shard_.  Built and ran with both `RAY_USE_NEW_GCS` and `RAY_USE_XRAY`.
```python
import subprocess
import time

import redis

import ray

# Pass this flag to avoid annoying output on program exit.
info = ray.init(redirect_worker_output=True)

# Turn on flushing with the next two lines.
pol = ray.experimental.SimpleGcsFlushPolicy(
    flush_when_at_least_bytes=0,
    flush_period_secs=1e-4,
    flush_num_entries_each_time=10000)
ray.experimental.set_flushing_policy(pol)

primary_port = info['redis_address'].split(':')[-1]
primary = redis.StrictRedis('127.0.0.1', primary_port)
splits = primary.lrange('RedisShards', 0, -1)[0].split(b':')
shard_port = splits[-1].decode()
print('ports: primary {} shard {}'.format(primary_port, shard_port))

measure_shard = True

port = primary_port
if measure_shard:
    port = shard_port

pid = subprocess.run(
    ['pgrep', '-f', 'redis-server.*{}'.format(port)],
    stdout=subprocess.PIPE).stdout[:-1].decode()
logfile = 'psrecord-{}.log'.format(port)


@ray.remote
def noop():
    return


time.sleep(1)
args = [
    'psrecord', pid, '--interval', '1', '--duration', '60', '--log', logfile
    # 'psrecord', pid, '--interval', '1', '--duration', '100000', '--log', logfile
]
print(' '.join(args))
subprocess.Popen(args)

# Assuming each noop generates ~3 writes to the GCS, we need a flush throughput
# of ~2.1k/s to break even.  <- Use this a sanity check.
num_noops = 200000
i = 0
start = time.time()
while i < num_noops:
    noop.remote()
    i += 1
print('Time to execute {} no-ops: {:.2f} seconds'.format(
    num_noops,
    time.time() - start))
```