### PR TITLE
Stop building wheels for Python 3.3 on Linux.

### DIFF
--- a/.travis/test-wheels.sh
+++ b/.travis/test-wheels.sh
@@ -56,7 +56,7 @@ if [[ "$platform" == "linux" ]]; then
 
   # Check that the other wheels are present.
   NUMBER_OF_WHEELS=$(ls -1q $ROOT_DIR/../.whl/*.whl | wc -l)
-  if [[ "$NUMBER_OF_WHEELS" != "5" ]]; then
+  if [[ "$NUMBER_OF_WHEELS" != "4" ]]; then
     echo "Wrong number of wheels found."
     ls -l $ROOT_DIR/../.whl/
     exit 1

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -13,7 +13,7 @@ rm -f /usr/bin/python2
 ln -s /opt/python/cp27-cp27m/bin/python2 /usr/bin/python2
 
 mkdir .whl
-for PYTHON in cp27-cp27mu cp33-cp33m cp34-cp34m cp35-cp35m cp36-cp36m; do
+for PYTHON in cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m; do
   # The -f flag is passed twice to also run git clean in the arrow subdirectory.
   # The -d flag removes directories. The -x flag ignores the .gitignore file,
   # and the -e flag ensures that we don't remove the .whl directory.


### PR DESCRIPTION
Our linux wheels test has been failing. We use the docker image `quay.io/xhochy/arrow_manylinux1_x86_64_base:latest` for building our wheels, and that may no longer contain the binaries for Python 3.3.