### PR TITLE
move import_thread to a separate file

### DIFF
--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pickle
 import ray
 import redis
 import threading
-import pickle
 import traceback
 
 from ray import ray_constants

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -14,8 +14,7 @@ from ray import utils
 
 
 class ImportThread(object):
-    """
-    A thread used to import exports from the driver or from other workers.
+    """A thread used to import exports from the driver or other workers.
 
     Note:
     The driver also has an import thread, which is used only to

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -1,0 +1,212 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import ray
+import redis
+import threading
+import pickle
+import traceback
+
+from ray import ray_constants
+from ray.utils import (
+    decode,
+    format_error_message,
+    push_error_to_driver,
+)
+
+
+class ImportThread(object):
+    """
+    A thread used to import exports from the driver or from other workers.
+
+    Note:
+    The driver also has an import thread, which is used only to
+    import custom class definitions from calls to register_custom_serializer
+    that happen under the hood on workers.
+
+    Attributes:
+        worker: the worker object in this process.
+        mode: worker mode
+        redis_client: the redis client used to query exports.
+    """
+
+    def __init__(self, worker, mode):
+        self.worker = worker
+        self.mode = mode
+        self.redis_client = worker.redis_client
+
+    def start(self):
+        """Start the import thread."""
+        t = threading.Thread(target=self._run)
+        # Making the thread a daemon causes it to exit
+        # when the main thread exits.
+        t.daemon = True
+        t.start()
+
+    def _run(self):
+        from ray.worker import profile, WORKER_MODE
+        import_pubsub_client = self.redis_client.pubsub()
+        # Exports that are published after the call to
+        # import_pubsub_client.subscribe and before the call to
+        # import_pubsub_client.listen will still be processed in the loop.
+        import_pubsub_client.subscribe("__keyspace@0__:Exports")
+        # Keep track of the number of imports that we've imported.
+        num_imported = 0
+
+        # Get the exports that occurred before the call to subscribe.
+        with self.worker.lock:
+            export_keys = self.redis_client.lrange("Exports", 0, -1)
+            for key in export_keys:
+                num_imported += 1
+
+                # Handle the driver case first.
+                if self.mode != WORKER_MODE:
+                    if key.startswith(b"FunctionsToRun"):
+                        self.fetch_and_execute_function_to_run(key)
+                    # Continue because FunctionsToRun are the only things that
+                    # the driver should import.
+                    continue
+
+                if key.startswith(b"RemoteFunction"):
+                    self.fetch_and_register_remote_function(key)
+                elif key.startswith(b"FunctionsToRun"):
+                    self.fetch_and_execute_function_to_run(key)
+                elif key.startswith(b"ActorClass"):
+                    # Keep track of the fact that this actor class has been
+                    # exported so that we know it is safe to turn this worker
+                    # into an actor of that class.
+                    self.worker.imported_actor_classes.add(key)
+                else:
+                    raise Exception("This code should be unreachable.")
+
+        try:
+            for msg in import_pubsub_client.listen():
+                with self.worker.lock:
+                    if msg["type"] == "subscribe":
+                        continue
+                    assert msg["data"] == b"rpush"
+                    num_imports = self.redis_client.llen("Exports")
+                    assert num_imports >= num_imported
+                    for i in range(num_imported, num_imports):
+                        num_imported += 1
+                        key = self.redis_client.lindex("Exports", i)
+
+                        # Handle the driver case first.
+                        if self.mode != WORKER_MODE:
+                            if key.startswith(b"FunctionsToRun"):
+                                with profile(
+                                        "ray:import_function_to_run",
+                                        worker=self.worker):
+                                    self.fetch_and_execute_function_to_run(key)
+                            # Continue because FunctionsToRun are the only
+                            # things that the driver should import.
+                            continue
+
+                        if key.startswith(b"RemoteFunction"):
+                            with profile(
+                                    "ray:import_remote_function",
+                                    worker=self.worker):
+                                self.fetch_and_register_remote_function(key)
+                        elif key.startswith(b"FunctionsToRun"):
+                            with profile(
+                                    "ray:import_function_to_run",
+                                    worker=self.worker):
+                                self.fetch_and_execute_function_to_run(key)
+                        elif key.startswith(b"ActorClass"):
+                            # Keep track of the fact that this actor class has
+                            # been exported so that we know it is safe to turn
+                            # this worker into an actor of that class.
+                            self.worker.imported_actor_classes.add(key)
+
+                        # TODO(rkn): We may need to bring back the case of
+                        # fetching actor classes here.
+                        else:
+                            raise Exception("This code should be unreachable.")
+        except redis.ConnectionError:
+            # When Redis terminates the listen call will throw a
+            # ConnectionError, which we catch here.
+            pass
+
+    def fetch_and_register_remote_function(self, key):
+        """Import a remote function."""
+        from ray.worker import FunctionExecutionInfo
+        (driver_id, function_id_str, function_name, serialized_function,
+         num_return_vals, module, resources,
+         max_calls) = self.redis_client.hmget(key, [
+             "driver_id", "function_id", "name", "function", "num_return_vals",
+             "module", "resources", "max_calls"
+         ])
+        function_id = ray.ObjectID(function_id_str)
+        function_name = decode(function_name)
+        max_calls = int(max_calls)
+        module = decode(module)
+
+        # This is a placeholder in case the function can't be unpickled. This
+        # will be overwritten if the function is successfully registered.
+        def f():
+            raise Exception("This function was not imported properly.")
+
+        self.worker.function_execution_info[driver_id][function_id.id()] = (
+            FunctionExecutionInfo(
+                function=f, function_name=function_name, max_calls=max_calls))
+        self.worker.num_task_executions[driver_id][function_id.id()] = 0
+
+        try:
+            function = pickle.loads(serialized_function)
+        except Exception:
+            # If an exception was thrown when the remote function was imported,
+            # we record the traceback and notify the scheduler of the failure.
+            traceback_str = format_error_message(traceback.format_exc())
+            # Log the error message.
+            push_error_to_driver(
+                self.worker,
+                ray_constants.REGISTER_REMOTE_FUNCTION_PUSH_ERROR,
+                traceback_str,
+                driver_id=driver_id,
+                data={
+                    "function_id": function_id.id(),
+                    "function_name": function_name
+                })
+        else:
+            # TODO(rkn): Why is the below line necessary?
+            function.__module__ = module
+            self.worker.function_execution_info[driver_id][
+                function_id.id()] = (FunctionExecutionInfo(
+                    function=function,
+                    function_name=function_name,
+                    max_calls=max_calls))
+            # Add the function to the function table.
+            self.redis_client.rpush(b"FunctionTable:" + function_id.id(),
+                                    self.worker.worker_id)
+
+    def fetch_and_execute_function_to_run(self, key):
+        """Run on arbitrary function on the worker."""
+        from ray.worker import SCRIPT_MODE, SILENT_MODE
+        driver_id, serialized_function = self.redis_client.hmget(
+            key, ["driver_id", "function"])
+
+        if (self.worker.mode in [SCRIPT_MODE, SILENT_MODE]
+                and driver_id != self.worker.task_driver_id.id()):
+            # This export was from a different driver and there's no need for
+            # this driver to import it.
+            return
+
+        try:
+            # Deserialize the function.
+            function = pickle.loads(serialized_function)
+            # Run the function.
+            function({"worker": self.worker})
+        except Exception:
+            # If an exception was thrown when the function was run, we record
+            # the traceback and notify the scheduler of the failure.
+            traceback_str = traceback.format_exc()
+            # Log the error message.
+            name = function.__name__ if ("function" in locals() and hasattr(
+                function, "__name__")) else ""
+            push_error_to_driver(
+                self.worker,
+                ray_constants.FUNCTION_TO_RUN_PUSH_ERROR,
+                traceback_str,
+                driver_id=driver_id,
+                data={"name": name})

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pickle
-import ray
 import redis
 import threading
 import traceback
 
+import ray
 from ray import ray_constants
+import ray.cloudpickle as pickle
 from ray.utils import (
     decode,
     format_error_message,

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -60,15 +60,20 @@ class ImportThread(object):
                 # Handle the driver case first.
                 if self.mode != WORKER_MODE:
                     if key.startswith(b"FunctionsToRun"):
-                        self.fetch_and_execute_function_to_run(key)
+                        with profile(
+                                "fetch_and_run_function", worker=self.worker):
+                            self.fetch_and_execute_function_to_run(key)
                     # Continue because FunctionsToRun are the only things that
                     # the driver should import.
                     continue
 
                 if key.startswith(b"RemoteFunction"):
-                    self.fetch_and_register_remote_function(key)
+                    with profile(
+                            "register_remote_function", worker=self.worker):
+                        self.fetch_and_register_remote_function(key)
                 elif key.startswith(b"FunctionsToRun"):
-                    self.fetch_and_execute_function_to_run(key)
+                    with profile("fetch_and_run_function", worker=self.worker):
+                        self.fetch_and_execute_function_to_run(key)
                 elif key.startswith(b"ActorClass"):
                     # Keep track of the fact that this actor class has been
                     # exported so that we know it is safe to turn this worker
@@ -93,7 +98,7 @@ class ImportThread(object):
                         if self.mode != WORKER_MODE:
                             if key.startswith(b"FunctionsToRun"):
                                 with profile(
-                                        "ray:import_function_to_run",
+                                        "fetch_and_run_function",
                                         worker=self.worker):
                                     self.fetch_and_execute_function_to_run(key)
                             # Continue because FunctionsToRun are the only
@@ -102,12 +107,12 @@ class ImportThread(object):
 
                         if key.startswith(b"RemoteFunction"):
                             with profile(
-                                    "ray:import_remote_function",
+                                    "register_remote_function",
                                     worker=self.worker):
                                 self.fetch_and_register_remote_function(key)
                         elif key.startswith(b"FunctionsToRun"):
                             with profile(
-                                    "ray:import_function_to_run",
+                                    "fetch_and_run_function",
                                     worker=self.worker):
                                 self.fetch_and_execute_function_to_run(key)
                         elif key.startswith(b"ActorClass"):

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -2,18 +2,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import redis
 import threading
 import traceback
 
+import redis
+
 import ray
 from ray import ray_constants
-import ray.cloudpickle as pickle
-from ray.utils import (
-    decode,
-    format_error_message,
-    push_error_to_driver,
-)
+from ray import cloudpickle as pickle
+from ray import utils
 
 
 class ImportThread(object):
@@ -138,9 +135,9 @@ class ImportThread(object):
              "module", "resources", "max_calls"
          ])
         function_id = ray.ObjectID(function_id_str)
-        function_name = decode(function_name)
+        function_name = utils.decode(function_name)
         max_calls = int(max_calls)
-        module = decode(module)
+        module = utils.decode(module)
 
         # This is a placeholder in case the function can't be unpickled. This
         # will be overwritten if the function is successfully registered.
@@ -157,9 +154,9 @@ class ImportThread(object):
         except Exception:
             # If an exception was thrown when the remote function was imported,
             # we record the traceback and notify the scheduler of the failure.
-            traceback_str = format_error_message(traceback.format_exc())
+            traceback_str = utils.format_error_message(traceback.format_exc())
             # Log the error message.
-            push_error_to_driver(
+            utils.push_error_to_driver(
                 self.worker,
                 ray_constants.REGISTER_REMOTE_FUNCTION_PUSH_ERROR,
                 traceback_str,
@@ -204,7 +201,7 @@ class ImportThread(object):
             # Log the error message.
             name = function.__name__ if ("function" in locals() and hasattr(
                 function, "__name__")) else ""
-            push_error_to_driver(
+            utils.push_error_to_driver(
                 self.worker,
                 ray_constants.FUNCTION_TO_RUN_PUSH_ERROR,
                 traceback_str,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -31,7 +31,7 @@ import ray.signature
 import ray.local_scheduler
 import ray.plasma
 import ray.ray_constants as ray_constants
-from ray.import_thread import ImportThread
+from ray import import_thread
 from ray.utils import (
     binary_to_hex,
     check_oversized_pickle,
@@ -2161,7 +2161,7 @@ def connect(info,
     _initialize_serialization()
 
     # Start the import thread
-    ImportThread(worker, mode).start()
+    import_thread.ImportThread(worker, mode).start()
 
     # If this is a driver running in SCRIPT_MODE, start a thread to print error
     # messages asynchronously in the background. Ideally the scheduler would


### PR DESCRIPTION
Move import thread and related functions to a separate file, and make it a class. 
Note: this PR is simply a sanitizing refactor, it doesn't change any code logic. Next RP will change the import thread to use its own redis client and local scheduler client to address multi-threading issue. Previous discussion can be found at #2248.