### PR TITLE
Bump version to 0.5.0.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -61,7 +61,7 @@ from ray.actor import method  # noqa: E402
 
 # Ray version string. TODO(rkn): This is also defined separately in setup.py.
 # Fix this.
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",

--- a/python/setup.py
+++ b/python/setup.py
@@ -125,7 +125,7 @@ class BinaryDistribution(Distribution):
 setup(
     name="ray",
     # The version string is also in __init__.py. TODO(pcm): Fix this.
-    version="0.4.0",
+    version="0.5.0",
     packages=find_packages(),
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.


### PR DESCRIPTION
This is waiting for #2159.

To test before merging:
- [x] build and run linux wheels (with tensorflow)
- [x] build and run mac wheels (with tensorflow)
- [x] stressful workload on large cluster (200 nodes)
- [x] fault tolerance on cluster
- [x] load balancing of tasks across cluster
- [x] creating many actors and load balancing actors across cluster
- [x] autoscaler successfully starts 200 node cluster