### PR TITLE
[xray] Unsubscribe to task dependencies when task starts execution

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -809,6 +809,9 @@ void NodeManager::AssignTask(Task &task) {
     lineage_cache_.AddReadyTask(task);
     // Mark the task as running.
     local_queues_.QueueRunningTasks(std::vector<Task>({task}));
+    // Notify the task dependency manager that we no longer need this task's
+    // object dependencies.
+    task_dependency_manager_.UnsubscribeDependencies(task_id);
   } else {
     RAY_LOG(WARNING) << "Failed to send task to worker, disconnecting client";
     // We failed to send the task to the worker, so disconnect the worker.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -811,7 +811,7 @@ void NodeManager::AssignTask(Task &task) {
     local_queues_.QueueRunningTasks(std::vector<Task>({task}));
     // Notify the task dependency manager that we no longer need this task's
     // object dependencies.
-    task_dependency_manager_.UnsubscribeDependencies(task_id);
+    task_dependency_manager_.UnsubscribeDependencies(spec.TaskId());
   } else {
     RAY_LOG(WARNING) << "Failed to send task to worker, disconnecting client";
     // We failed to send the task to the worker, so disconnect the worker.


### PR DESCRIPTION
## What do these changes do?

#2302 incorrectly removed a call to unsubscribe from a task's object dependencies. This means that even after a task has finished, the node manager will continue to think that the task's object dependencies must be made available locally. This PR adds back the unsubscribe once the task has been assigned.