### PR TITLE
Improve error message when flex or bison is not installed

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -56,6 +56,16 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
       git clone https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
     fi
 
+    if ! [ -x "$(command -v bison)" ]; then
+      echo 'Error: bison is not installed.' >&2
+      exit 1
+    fi
+
+    if ! [ -x "$(command -v flex)" ]; then
+      echo 'Error: flex is not installed.' >&2
+      exit 1
+    fi
+
     pushd $TP_DIR/build/arrow
     git fetch origin master
     # The PR for this commit is https://github.com/apache/arrow/pull/2065. We


### PR DESCRIPTION
Without this patch, we get a cryptic error message if these are not installed:

```
    CMake Error at cmake_modules/FindParquet.cmake:67 (string):
      string sub-command REGEX, mode MATCH needs at least 5 arguments total to
      command.
    Call Stack (most recent call first):
      CMakeLists.txt:338 (find_package)
    
    
    --  Could not find the parquet library. Looked in  system search paths.
    CMake Error at CMakeLists.txt:341 (message):
      Unable to locate Parquet libraries
    
    
    -- Configuring incomplete, errors occurred!
```

cc @richardliaw 