### PR TITLE
[Java] Java worker cluster support

### DIFF
--- a/java/cli/assembly.xml
+++ b/java/cli/assembly.xml
@@ -1,0 +1,15 @@
+<assembly>
+  <id>ear</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <dependencySets>
+    <dependencySet>
+      <useProjectArtifact>true</useProjectArtifact>
+      <outputDirectory>lib</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+
+  </fileSets>
+</assembly>

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.ray.parent</groupId>
+    <artifactId>ray-superpom</artifactId>
+    <version>1.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.ray</groupId>
+  <artifactId>ray-cli</artifactId>
+
+  <name>java cli for ray</name>
+  <description>java cli for ray</description>
+  <url></url>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ray</groupId>
+      <artifactId>ray-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ray</groupId>
+      <artifactId>ray-runtime-native</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>de.ruedigermoeller</groupId>
+      <artifactId>fst</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.davidmoten</groupId>
+      <artifactId>flatbuffers-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.beust/jcommander -->
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>ray-cli</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>     
+	  <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/lib</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.ray</groupId>
       <artifactId>ray-api</artifactId>
-      <version>1.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ray</groupId>
       <artifactId>ray-runtime-native</artifactId>
-      <version>1.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>de.ruedigermoeller</groupId>

--- a/java/cli/src/main/java/org/ray/cli/CommandStart.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandStart.java
@@ -12,9 +12,6 @@ public class CommandStart {
   @Parameter(names = "--head", description = "start the head node")
   public boolean head;
 
-  @Parameter(names = "--work", description = "start the work node including local scheduler, plasma and worker")
-  public boolean work;
-
   @Parameter(names = "--config", description = "the config file of ray")
   public String config = "";
 

--- a/java/cli/src/main/java/org/ray/cli/CommandStart.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandStart.java
@@ -1,0 +1,24 @@
+package org.ray.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+/**
+ * Arguments for command start
+ */
+@Parameters(separators = "= ", commandDescription = "start ray daemons")
+public class CommandStart {
+
+  @Parameter(names = "--head", description = "start the head node")
+  public boolean head;
+
+  @Parameter(names = "--work", description = "start the work node including local scheduler, plasma and worker")
+  public boolean work;
+
+  @Parameter(names = "--config", description = "the config file of ray")
+  public String config = "";
+
+  @Parameter(names = "--overwrite", description = "the overwrite items of config")
+  public String overwrite = "";
+
+}

--- a/java/cli/src/main/java/org/ray/cli/CommandStart.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandStart.java
@@ -4,7 +4,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
 /**
- * Arguments for command start
+ * Arguments for command start.
  */
 @Parameters(separators = "= ", commandDescription = "start ray daemons")
 public class CommandStart {

--- a/java/cli/src/main/java/org/ray/cli/CommandStop.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandStop.java
@@ -1,0 +1,11 @@
+package org.ray.cli;
+
+import com.beust.jcommander.Parameters;
+
+/**
+ * Arguments for command stop
+ */
+@Parameters(separators = "= ", commandDescription = "stop ray daemons")
+public class CommandStop {
+
+}

--- a/java/cli/src/main/java/org/ray/cli/CommandStop.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandStop.java
@@ -3,7 +3,7 @@ package org.ray.cli;
 import com.beust.jcommander.Parameters;
 
 /**
- * Arguments for command stop
+ * Arguments for command stop.
  */
 @Parameters(separators = "= ", commandDescription = "stop ray daemons")
 public class CommandStop {

--- a/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
@@ -1,0 +1,27 @@
+package org.ray.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+/**
+ * Arguments for command submit
+ */
+@Parameters(separators = "= ", commandDescription = "submit a job to ray cluster")
+public class CommandSubmit {
+
+  // must exist.
+  @Parameter(names = "--package", description = "java jar package zip file")
+  public String packageZip ;
+
+  // must exist
+  @Parameter(names = "--class", description = "java class name")
+  public String className;
+
+  @Parameter(names = "--config", description = "the config file of ray")
+  public String config;
+
+  // must exist.
+  @Parameter(names = "--redis-address", description = "ip & port for redis service")
+  public String redis_address;
+
+}

--- a/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
@@ -9,18 +9,23 @@ import com.beust.jcommander.Parameters;
 @Parameters(separators = "= ", commandDescription = "submit a job to ray cluster")
 public class CommandSubmit {
 
-  // must exist.
+  // required
   @Parameter(names = "--package", description = "java jar package zip file")
   public String packageZip ;
 
-  // must exist
+  // required
   @Parameter(names = "--class", description = "java class name")
   public String className;
 
+  // optional
+  @Parameter(names = "--args", description = "arguments for the java class")
+  public String classArgs;
+
+  // optional
   @Parameter(names = "--config", description = "the config file of ray")
   public String config;
 
-  // must exist.
+  // required
   @Parameter(names = "--redis-address", description = "ip & port for redis service")
   public String redis_address;
 

--- a/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
@@ -9,24 +9,19 @@ import com.beust.jcommander.Parameters;
 @Parameters(separators = "= ", commandDescription = "submit a job to ray cluster")
 public class CommandSubmit {
 
-  // required
-  @Parameter(names = "--package", description = "java jar package zip file")
+  @Parameter(names = "--package", description = "java jar package zip file", required = true)
   public String packageZip ;
 
-  // required
-  @Parameter(names = "--class", description = "java class name")
+  @Parameter(names = "--class", description = "java class name", required = true)
   public String className;
 
-  // optional
   @Parameter(names = "--args", description = "arguments for the java class")
   public String classArgs;
 
-  // optional
   @Parameter(names = "--config", description = "the config file of ray")
   public String config;
 
-  // required
-  @Parameter(names = "--redis-address", description = "ip & port for redis service")
+  @Parameter(names = "--redis-address", description = "ip & port for redis service", required = true)
   public String redis_address;
 
 }

--- a/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
+++ b/java/cli/src/main/java/org/ray/cli/CommandSubmit.java
@@ -4,13 +4,13 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
 /**
- * Arguments for command submit
+ * Arguments for command submit.
  */
 @Parameters(separators = "= ", commandDescription = "submit a job to ray cluster")
 public class CommandSubmit {
 
   @Parameter(names = "--package", description = "java jar package zip file", required = true)
-  public String packageZip ;
+  public String packageZip;
 
   @Parameter(names = "--class", description = "java class name", required = true)
   public String className;
@@ -21,7 +21,7 @@ public class CommandSubmit {
   @Parameter(names = "--config", description = "the config file of ray")
   public String config;
 
-  @Parameter(names = "--redis-address", description = "ip & port for redis service", required = true)
-  public String redis_address;
+  @Parameter(names = "--redis-address", description = "ip:port for redis service", required = true)
+  public String redisAddress;
 
 }

--- a/java/cli/src/main/java/org/ray/cli/RayCli.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCli.java
@@ -1,0 +1,326 @@
+package org.ray.cli;
+
+import com.beust.jcommander.JCommander;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import org.ray.api.UniqueID;
+import org.ray.cli.CommandStart;
+import org.ray.cli.CommandStop;
+import org.ray.core.RayRuntime;
+import org.ray.core.model.RunMode;
+import org.ray.core.model.RayParameters;
+import org.ray.runner.RunInfo;
+import org.ray.runner.RunManager;
+import org.ray.runner.worker.DefaultDriver;
+import org.ray.spi.KeyValueStoreLink;
+import org.ray.spi.PathConfig;
+import org.ray.spi.RemoteFunctionManager;
+import org.ray.spi.StateStoreProxy;
+import org.ray.spi.impl.NativeRemoteFunctionManager;
+import org.ray.spi.impl.RedisClient;
+import org.ray.spi.impl.StateStoreProxyImpl;
+import org.ray.util.NetworkUtil;
+import org.ray.util.config.ConfigReader;
+import org.ray.util.logger.RayLog;
+import org.ray.util.FileUtil;
+
+/**
+ * Ray command line interface
+ */
+public class RayCli {
+
+  private static RayCliArgs rayArgs = new RayCliArgs();
+
+  private static RunManager startRayHead(RayParameters params, PathConfig paths,
+      ConfigReader configReader) {
+    RunManager manager = new RunManager(params, paths, configReader);
+
+    try {
+      manager.startRayHead();
+    } catch (Exception e) {
+      e.printStackTrace();
+      RayLog.core.error("error at RayCli startRayHead", e);
+      throw new RuntimeException("Ray head node start failed, err = " + e.getMessage());
+    }
+
+    RayLog.core.info("Started Ray head node. Redis address: " + manager.info().redisAddress);
+    return manager;
+  }
+
+  private static RunManager startRayNode(RayParameters params, PathConfig paths,
+      ConfigReader configReader) {
+    RunManager manager = new RunManager(params, paths, configReader);
+
+    try {
+      manager.startRayNode();
+    } catch (Exception e) {
+      e.printStackTrace();
+      RayLog.core.error("error at RayCli startRayNode", e);
+      throw new RuntimeException("Ray work node start failed, err = " + e.getMessage());
+    }
+
+    RayLog.core.info("Started Ray work node.");
+    return manager;
+  }
+
+  private static RunManager startProcess(CommandStart cmdStart, ConfigReader config) {
+    PathConfig paths = new PathConfig(config);
+    RayParameters params = new RayParameters(config);
+
+    // Get the node IP address if one is not provided.
+    //if (params.node_ip_address.length() == 0) {
+    //    params.node_ip_address = NetworkUtil.getIpAddress(null);
+    //}
+    RayLog.core.info("Using IP address " + params.node_ip_address + " for this node.");
+    RunManager manager;
+    if (cmdStart.head) {
+      manager = startRayHead(params, paths, config);
+    } else if (cmdStart.work) {
+      manager = startRayNode(params, paths, config);
+    } else {
+      throw new RuntimeException(
+          "Ray must be started with at least a role. Seeing --help for more details.");
+    }
+    return manager;
+  }
+
+  private static void start(CommandStart cmdStart, ConfigReader reader) {
+    RayParameters params = new RayParameters(reader);
+
+    RunManager manager = null;
+
+    manager = startProcess(cmdStart, reader);
+
+    // monitoring all processes, throwing an exception when any process fails
+    while (true) {
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+      }
+
+      HashSet<RunInfo.ProcessType> excludeTypes = new HashSet<>();
+      if (!manager.checkAlive(excludeTypes)) {
+
+        //ray components fail-over
+        RayLog.core.error("Something error in Ray processes.");
+
+        if (!manager.tryRecoverDeadProcess()) {
+          RayLog.core.error("Restart all the processes in this node.");
+          manager.cleanup(true);
+          manager = startProcess(cmdStart, reader);
+        }
+      }
+    }
+  }
+
+  private static void stop(CommandStop cmdStop) {
+    String[] cmd = {"/bin/sh", "-c", ""};
+
+    cmd[2] = "killall global_scheduler local_scheduler plasma_store plasma_manager";
+    try {
+      Runtime.getRuntime().exec(cmd);
+    } catch (IOException e) {
+    }
+
+    cmd[2] = "kill $(ps aux | grep redis-server | grep -v grep | " +
+        "awk \'{ print $2 }\') 2> /dev/null";
+    try {
+      Runtime.getRuntime().exec(cmd);
+    } catch (IOException e) {
+    }
+
+    cmd[2] = "kill -9 $(ps aux | grep DefaultWorker | grep -v grep | " +
+        "awk \'{ print $2 }\') 2> /dev/null";
+    try {
+      Runtime.getRuntime().exec(cmd);
+    } catch (IOException e) {
+    }
+  }
+
+  private static String[] buildRayRuntimeArgs(CommandSubmit cmdSubmit) {
+
+    if (cmdSubmit.redis_address == null) {
+      throw new RuntimeException(
+          "--redis-address must be specified to submit a job");      
+    }
+
+    List<String> argList = new ArrayList<String>();
+    String section = "ray.java.start.";
+    String overwrite = "--overwrite="
+      + section + "redis_address=" + cmdSubmit.redis_address + ";"
+      + section + "run_mode=" + "CLUSTER";
+
+    argList.add(overwrite);
+
+    if (cmdSubmit.config != null) {
+      String config = "--config=" + cmdSubmit.config;
+      argList.add(config);
+    }
+
+    String args[] = new String[argList.size()];
+    argList.toArray(args);
+
+    return args;
+  }
+ 
+  private static void submit(CommandSubmit cmdSubmit, String configPath) throws Exception {
+    ConfigReader config = new ConfigReader(configPath, "ray.java.start.deploy=true");
+    PathConfig paths = new PathConfig(config);
+    RayParameters params = new RayParameters(config);
+
+    params.redis_address = cmdSubmit.redis_address;
+    params.run_mode = RunMode.CLUSTER;
+
+
+    KeyValueStoreLink kvStore = new RedisClient();
+    kvStore.setAddr(cmdSubmit.redis_address);
+    StateStoreProxy stateStoreProxy = new StateStoreProxyImpl(kvStore);
+    //stateStoreProxy.setStore(kvStore);
+    stateStoreProxy.initializeGlobalState();
+
+    RemoteFunctionManager functionManager = new NativeRemoteFunctionManager(kvStore);
+
+    // Init ray runtime with --redis_address and --run_mode=CLUSTER set.
+    // RayRuntime.init(buildRayRuntimeArgs(cmdSubmit));
+
+    // RayParameters params = new RayParameters(config);
+    // params.redis_address = cmdSubmit.redis_address;
+    // params.run_mode = RunMode.CLUSTER;
+
+    // Register app to Redis. 
+    byte[] zip = FileUtil.fileToBytes(cmdSubmit.packageZip);
+
+    String packageName = cmdSubmit.packageZip.substring(
+      cmdSubmit.packageZip.lastIndexOf('/') + 1,
+      cmdSubmit.packageZip.lastIndexOf('.'));
+
+    //final RemoteFunctionManager functionManager = RayRuntime
+    //    .getInstance().getRemoteFunctionManager();
+
+    UniqueID resourceId = functionManager.registerResource(zip);
+    RayLog.rapp.debug(
+        "registerResource " + resourceId + " for package " + packageName + " done");
+
+    UniqueID appId = params.driver_id;
+    functionManager.registerApp(appId, resourceId);
+    RayLog.rapp.debug("registerApp " + appId + " for resouorce " + resourceId + " done");
+  
+    // Unzip the package file.
+    String appDir = "/tmp/" + cmdSubmit.className;
+    String extPath = appDir + "/" + packageName;
+    if (!FileUtil.createDir(extPath, false)) {
+      throw new RuntimeException("create dir " + extPath + " failed ");
+    }
+
+    ZipFile zipFile = new ZipFile(cmdSubmit.packageZip);
+    zipFile.extractAll(extPath);
+
+    // Build the args for driver process.
+    File originDirFile = new File(extPath);
+    File[] topFiles = originDirFile.listFiles();
+    String topDir = null;
+    for (File file : topFiles) {
+      if (file.isDirectory()) {
+        topDir = file.getName();
+      }
+    }
+    RayLog.rapp.debug("topDir of app classes: "+ topDir);
+    if (topDir == null) {
+      RayLog.rapp.error("Can't find topDir of app classes, the app directory " + appDir);
+      return;
+    }
+
+    String additionalClassPath = appDir + "/" + packageName  + "/" + topDir + "/*";
+    RayLog.rapp.debug("Find app class path  " + additionalClassPath);
+
+    // Start driver process.
+    //RunManager runManager = new RunManager(params, RayRuntime.getInstance().getPaths(),
+    //  RayRuntime.configReader);
+    RunManager runManager = new RunManager(params, paths, config);
+    Process proc = runManager.startDriver(
+      DefaultDriver.class.getName(),
+      cmdSubmit.redis_address,
+      appId,
+      appDir,
+      params.node_ip_address,
+      cmdSubmit.className,
+      additionalClassPath,
+      null);
+
+    if (null == proc) { 
+      RayLog.rapp.error(
+        "Create process for app " + packageName + " in local directory " + appDir
+            + " failed");
+      return;
+    }
+
+    RayLog.rapp
+    .info("Create app " + appDir + " for package " + packageName + " succeeded");
+  }
+
+  private static String getConfigPath(String config) throws Exception {
+    String configPath;
+
+    if (config != null && !config.equals("")) {
+      configPath = config;
+    } else {
+      configPath = System.getenv("RAY_CONFIG");
+      if (configPath == null) {
+        configPath = System.getProperty("ray.config");
+      }
+      if (configPath == null) {
+        throw new Exception("Please set config file path in env RAY_CONFIG or property ray.config");
+      }
+    }
+    return configPath;
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    CommandStart cmdStart = new CommandStart();
+    CommandStop cmdStop = new CommandStop();
+    CommandSubmit cmdSubmit = new CommandSubmit();
+    JCommander rayCommander = JCommander.newBuilder().addObject(rayArgs)
+        .addCommand("start", cmdStart)
+        .addCommand("stop", cmdStop)
+        .addCommand("submit", cmdSubmit)
+        .build();
+    rayCommander.parse(args);
+
+    if (rayArgs.help) {
+      rayCommander.usage();
+      System.exit(0);
+    }
+
+    String cmd = rayCommander.getParsedCommand();
+    if (cmd == null) {
+      rayCommander.usage();
+      System.exit(0);
+    }
+
+    String configPath;
+    switch (cmd) {
+      case "start": {
+        configPath = getConfigPath(cmdStart.config);
+        ConfigReader config = new ConfigReader(configPath, cmdStart.overwrite);
+        start(cmdStart, config);
+      }
+      break;
+      case "stop":
+        stop(cmdStop);
+        break;
+      case "submit":
+        configPath = getConfigPath(cmdSubmit.config);
+        submit(cmdSubmit, configPath);
+        break;
+      default:
+        rayCommander.usage();
+    }
+  }
+
+}

--- a/java/cli/src/main/java/org/ray/cli/RayCli.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCli.java
@@ -173,17 +173,9 @@ public class RayCli {
     KeyValueStoreLink kvStore = new RedisClient();
     kvStore.setAddr(cmdSubmit.redis_address);
     StateStoreProxy stateStoreProxy = new StateStoreProxyImpl(kvStore);
-    //stateStoreProxy.setStore(kvStore);
     stateStoreProxy.initializeGlobalState();
 
     RemoteFunctionManager functionManager = new NativeRemoteFunctionManager(kvStore);
-
-    // Init ray runtime with --redis_address and --run_mode=CLUSTER set.
-    // RayRuntime.init(buildRayRuntimeArgs(cmdSubmit));
-
-    // RayParameters params = new RayParameters(config);
-    // params.redis_address = cmdSubmit.redis_address;
-    // params.run_mode = RunMode.CLUSTER;
 
     // Register app to Redis. 
     byte[] zip = FileUtil.fileToBytes(cmdSubmit.packageZip);
@@ -257,7 +249,7 @@ public class RayCli {
     .info("Create app " + appDir + " for package " + packageName + " succeeded");
   }
 
-  private static String getConfigPath(String config) throws Exception {
+  private static String getConfigPath(String config) {
     String configPath;
 
     if (config != null && !config.equals("")) {
@@ -268,7 +260,7 @@ public class RayCli {
         configPath = System.getProperty("ray.config");
       }
       if (configPath == null) {
-        throw new Exception("Please set config file path in env RAY_CONFIG or property ray.config");
+        throw new RuntimeException("Please set config file path in env RAY_CONFIG or property ray.config");
       }
     }
     return configPath;

--- a/java/cli/src/main/java/org/ray/cli/RayCli.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCli.java
@@ -45,7 +45,7 @@ public class RayCli {
     } catch (Exception e) {
       e.printStackTrace();
       RayLog.core.error("error at RayCli startRayHead", e);
-      throw new RuntimeException("Ray head node start failed, err = " + e.getMessage());
+      throw new RuntimeException("Ray head node start failed", e);
     }
 
     RayLog.core.info("Started Ray head node. Redis address: " + manager.info().redisAddress);
@@ -72,19 +72,12 @@ public class RayCli {
     PathConfig paths = new PathConfig(config);
     RayParameters params = new RayParameters(config);
 
-    // Get the node IP address if one is not provided.
-    //if (params.node_ip_address.length() == 0) {
-    //    params.node_ip_address = NetworkUtil.getIpAddress(null);
-    //}
     RayLog.core.info("Using IP address " + params.node_ip_address + " for this node.");
     RunManager manager;
     if (cmdStart.head) {
       manager = startRayHead(params, paths, config);
-    } else if (cmdStart.work) {
-      manager = startRayNode(params, paths, config);
     } else {
-      throw new RuntimeException(
-          "Ray must be started with at least a role. Seeing --help for more details.");
+      manager = startRayNode(params, paths, config);
     }
     return manager;
   }
@@ -249,6 +242,7 @@ public class RayCli {
       appDir,
       params.node_ip_address,
       cmdSubmit.className,
+      cmdSubmit.classArgs,
       additionalClassPath,
       null);
 

--- a/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
@@ -1,0 +1,12 @@
+package org.ray.cli;
+
+import com.beust.jcommander.Parameter;
+
+/**
+ * Arguments for Ray adm cli
+ */
+public class RayCliArgs {
+
+  @Parameter(names = {"-h", "-help", "--help"}, description = "print this usage", help = true)
+  public boolean help;
+}

--- a/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
@@ -3,7 +3,7 @@ package org.ray.cli;
 import com.beust.jcommander.Parameter;
 
 /**
- * Arguments for Ray adm cli
+ * Arguments for Ray cli
  */
 public class RayCliArgs {
 

--- a/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCliArgs.java
@@ -3,7 +3,7 @@ package org.ray.cli;
 import com.beust.jcommander.Parameter;
 
 /**
- * Arguments for Ray cli
+ * Arguments for Ray cli.
  */
 public class RayCliArgs {
 

--- a/java/example/src/main/java/org/ray/example/HelloWorld.java
+++ b/java/example/src/main/java/org/ray/example/HelloWorld.java
@@ -33,6 +33,12 @@ public class HelloWorld implements Serializable {
   public static void main(String[] args) throws Exception {
     try {
       Ray.init();
+
+      RayLog.rapp.info("HelloWorld.main() has " + args.length + " args");
+      for (String arg: args) {
+        RayLog.rapp.info("arg: " + arg);
+      }
+
       String helloWorld = HelloWorld.sayHelloWorld();
       RayLog.rapp.info(helloWorld);
       assert helloWorld.equals("hello,world!");
@@ -41,8 +47,6 @@ public class HelloWorld implements Serializable {
     } finally {
       RayRuntime.getInstance().cleanUp();
     }
-
-
   }
 
   public static String sayHelloWorld() {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,6 +15,7 @@
         <module>runtime-common</module>
         <module>runtime-native</module>
         <module>runtime-dev</module>
+        <module>cli</module>
         <module>test</module>
         <module>example</module>
     </modules>
@@ -67,6 +68,13 @@
                 <groupId>com.github.davidmoten</groupId>
                 <artifactId>flatbuffers-java</artifactId>
                 <version>1.7.0.1</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/com.beust/jcommander -->
+            <dependency>
+              <groupId>com.beust</groupId>
+              <artifactId>jcommander</artifactId>
+              <version>1.72</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/redis.clients/jedis -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <projetct.version>1.0</projetct.version>
+        <project.version>1.0</project.version>
     </properties>
 
 

--- a/java/prepare.sh
+++ b/java/prepare.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-scripts_path=`realpath $0`
-ray_dir=`dirname $scripts_path`
-ray_dir=`dirname $ray_dir`
-
-# echo "ray_dir = $ray_dir"
 
 function usage() {
     echo " -t|--target-dir <dir> local target directory for prepare a Ray cluster deployment package"
+    echo " [-s|--source-dir] <dir> local source directory to prepare a Ray cluster deployment package"
 }
 
 while [ $# -gt 0 ];do
@@ -18,6 +11,10 @@ while [ $# -gt 0 ];do
         -h|--help)
             usage
             exit 0
+            ;;
+        -s|--source-dir)
+            ray_dir=$2
+            shift 2
             ;;
         -t|--target-dir)
             t_dir=$2
@@ -31,6 +28,18 @@ while [ $# -gt 0 ];do
             ;;
     esac
 done
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+if [ -z $ray_dir ];then
+    scripts_path=`realpath $0`
+    ray_dir=`dirname $scripts_path`
+    ray_dir=`dirname $ray_dir`
+fi
+
+# echo "ray_dir = $ray_dir"
 
 declare -a nativeBinaries=(
     "./src/common/thirdparty/redis/src/redis-server"
@@ -77,10 +86,9 @@ function prepare_source()
 
     # prepare java components under /ray/java/lib
     mkdir -p $t_dir"/ray/java/lib/"
-    unzip -q cli/target/ray-cli-ear.zip
-    cp ray-cli/lib/* $t_dir/ray/java/lib/
-    rm -rf ray-cli
-    #cp -rf $ray_dir/java/ray-cli/lib/* $t_dir/ray/java/lib/
+    unzip -q $ray_dir/java/cli/target/ray-cli-ear.zip -d $ray_dir/java
+    cp $ray_dir/java/ray-cli/lib/* $t_dir/ray/java/lib/
+    rm -rf $ray_dir/java/ray-cli
 
     cp -rf $ray_dir/java/ray.config.ini $t_dir/ray/
 

--- a/java/prepare.sh
+++ b/java/prepare.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+scripts_path=`realpath $0`
+ray_dir=`dirname $scripts_path`
+ray_dir=`dirname $ray_dir`
+
+# echo "ray_dir = $ray_dir"
+
+function usage() {
+    echo " -t|--target-dir <dir> local target directory for prepare a Ray cluster deployment package"
+}
+
+while [ $# -gt 0 ];do
+    key=$1
+    case $key in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -t|--target-dir)
+            t_dir=$2
+            shift 2
+            ;;
+        *)
+            echo "ERROR: unknown option $key"
+            echo
+            usage
+            exit -1
+            ;;
+    esac
+done
+
+declare -a nativeBinaries=(
+    "./src/common/thirdparty/redis/src/redis-server"
+    "./src/plasma/plasma_store"
+    "./src/plasma/plasma_manager"
+    "./src/local_scheduler/local_scheduler"
+    "./src/global_scheduler/global_scheduler"
+)
+
+declare -a nativeLibraries=(
+    "./src/common/redis_module/libray_redis_module.so"
+    "./src/local_scheduler/liblocal_scheduler_library_java.*"
+    "./src/plasma/libplasma_java.*"
+)
+
+declare -a javaBinaries=(
+    "api"
+    "common"
+    "worker"
+    "test"
+)
+
+function prepare_source()
+{
+    if [ -z $t_dir ];then
+        echo "--target-dir not specified"
+        usage
+        exit -1
+    fi
+
+    # prepare native components under /ray/native/bin
+    mkdir -p $t_dir"/ray/native/bin/"
+    for i in "${!nativeBinaries[@]}"
+    do
+        cp $ray_dir/build/${nativeBinaries[$i]} $t_dir/ray/native/bin/
+    done
+
+    # prepare native libraries under /ray/native/lib
+    mkdir -p $t_dir"/ray/native/lib/"
+    for i in "${!nativeLibraries[@]}"
+    do
+        cp $ray_dir/build/${nativeLibraries[$i]} $t_dir/ray/native/lib/
+    done
+
+    # prepare java components under /ray/java/lib
+    mkdir -p $t_dir"/ray/java/lib/"
+    unzip -q cli/target/ray-cli-ear.zip
+    cp ray-cli/lib/* $t_dir/ray/java/lib/
+    rm -rf ray-cli
+    #cp -rf $ray_dir/java/ray-cli/lib/* $t_dir/ray/java/lib/
+
+    cp -rf $ray_dir/java/ray.config.ini $t_dir/ray/
+
+    # prepare java apps directory
+    mkdir -p $t_dir"/ray/java/apps/"
+
+    # prepare run.sh
+    cp $ray_dir/java/run.sh $t_dir/
+}
+
+prepare_source

--- a/java/ray.config.ini
+++ b/java/ray.config.ini
@@ -72,10 +72,14 @@ max_java_log_file_size = 500MB
 
 onebox_delay_seconds_before_run_app_logic = 0
 
-[ray.java.start.job]
-
 ; java class which main is served as the driver in a java worker
 driver_class =
+
+; arguments for the java class main function which is served at the driver
+; the arguments are separated by ','
+driver_args =
+
+[ray.java.start.job]
 
 [ray.java.path.classes.source]
 %CONFIG_FILE_DIR%/common/target/classes =

--- a/java/run.sh
+++ b/java/run.sh
@@ -3,6 +3,6 @@ scripts_dir=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 cd $scripts_dir
 
 export RAY_CONFIG=$scripts_dir/ray/ray.config.ini
-export LD_LIBRARY_PATH=$scripts_dir/ray/native/lib:\$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$scripts_dir/ray/native/lib:$LD_LIBRARY_PATH
 java -ea -classpath ray/java/lib/*:ray/java/lib/commons-cli-1.3.1.jar org.ray.cli.RayCli "$@"
 

--- a/java/run.sh
+++ b/java/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+scripts_dir=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+cd $scripts_dir
+
+export RAY_CONFIG=$scripts_dir/ray/ray.config.ini
+export LD_LIBRARY_PATH=$scripts_dir/ray/native/lib:\$LD_LIBRARY_PATH
+java -ea -classpath ray/java/lib/*:ray/java/lib/commons-cli-1.3.1.jar org.ray.cli.RayCli "$@"
+

--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -175,7 +175,8 @@ public class RunManager {
         + section + "redis_address=" + redisAddr + ";"
         + section + "working_directory=" + workDir + ";"
         + section + "logging_directory=" + params.logging_directory + ";"
-        + section + "working_directory=" + workDir;
+        + section + "working_directory=" + workDir + ";"
+        + section + "run_mode=" + params.run_mode;
 
     if (additionalConfigs.length() > 0) {
       cmd += ";" + additionalConfigs;

--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -110,10 +110,14 @@ public class RunManager {
 
   public Process startDriver(String mainClass, String redisAddress, UniqueID driverId,
                              String workDir, String ip,
-                             String driverClass, String additonalClassPaths, String
-                                 additionalConfigs) {
+                             String driverClass, String driverArgs, String additonalClassPaths, 
+                             String additionalConfigs) {
     String driverConfigs =
         "ray.java.start.driver_id=" + driverId + ";ray.java.start.driver_class=" + driverClass;
+    if (driverArgs != null) {
+      driverConfigs += ";ray.java.start.driver_args=" + driverArgs;
+    }
+
     if (null != additionalConfigs) {
       additionalConfigs += ";" + driverConfigs;
     } else {

--- a/java/runtime-native/src/main/java/org/ray/runner/worker/DefaultDriver.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/worker/DefaultDriver.java
@@ -21,8 +21,12 @@ public class DefaultDriver {
       String driverClass = RayRuntime.configReader
           .getStringValue("ray.java.start", "driver_class", "",
               "java class which main is served as the driver in a java worker");
+      String driverArgs = RayRuntime.configReader
+          .getStringValue("ray.java.start", "driver_args", "",
+              "arguments for the java class main function which is served at the driver");
       Class<?> cls = Class.forName(driverClass);
-      cls.getMethod("main", String[].class).invoke(null, (Object) new String[] {});
+      String[] argsArray = (driverArgs != null) ? driverArgs.split(",") : (new String[] {});
+      cls.getMethod("main", String[].class).invoke(null, (Object) argsArray);
     } catch (Throwable e) {
       e.printStackTrace();
       System.exit(-1);

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/StateStoreProxyImpl.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/StateStoreProxyImpl.java
@@ -80,6 +80,7 @@ public class StateStoreProxyImpl implements StateStoreProxy {
         return getAddressInfoHelper(nodeIpAddress);
       } catch (Exception e) {
         try {
+          RayLog.core.warn("StateStoreProxyImpl getAddressInfo", e);
           TimeUnit.MILLISECONDS.sleep(1000);
         } catch (InterruptedException ie) {
           RayLog.core.error("error at StateStoreProxyImpl getAddressInfo", e);
@@ -100,7 +101,7 @@ public class StateStoreProxyImpl implements StateStoreProxy {
    *        The hash contains the following：
    *        "deleted" : 0/1
    *        "ray_client_id"
-   *        "nodeIpAddress"
+   *        "node_ip_address"
    *        "client_type" : plasma_manager/local_scheduler
    *        "store_socket_name"(op)
    *        "manager_socket_name"(op)
@@ -129,27 +130,27 @@ public class StateStoreProxyImpl implements StateStoreProxy {
 
       if (!info.containsKey("ray_client_id".getBytes())) {
         throw new Exception("no ray_client_id in any client");
-      } else if (!info.containsKey("nodeIpAddress".getBytes())) {
-        throw new Exception("no nodeIpAddress in any client");
+      } else if (!info.containsKey("node_ip_address".getBytes())) {
+        throw new Exception("no node_ip_address in any client");
       } else if (!info.containsKey("client_type".getBytes())) {
         throw new Exception("no client_type in any client");
       }
-
-      if (charsetDecode(info.get("nodeIpAddress".getBytes()), "US-ASCII")
+  
+      if (charsetDecode(info.get("node_ip_address".getBytes()), "US-ASCII")
           .equals(nodeIpAddress)) {
         String clientType = charsetDecode(info.get("client_type".getBytes()), "US-ASCII");
-        if (clientType.equals("plasmaManager")) {
+        if (clientType.equals("plasma_manager")) {
           plasmaManager.add(info);
-        } else if (clientType.equals("localScheduler")) {
+        } else if (clientType.equals("local_scheduler")) {
           localScheduler.add(info);
         }
       }
     }
 
     if (plasmaManager.size() < 1 || localScheduler.size() < 1) {
-      throw new Exception("no plasmaManager or localScheduler");
+      throw new Exception("no plasma_manager or local_scheduler");
     } else if (plasmaManager.size() != localScheduler.size()) {
-      throw new Exception("plasmaManager number not Equal localScheduler number");
+      throw new Exception("plasma_manager number not Equal local_scheduler number");
     }
 
     for (int i = 0; i < plasmaManager.size(); i++) {
@@ -173,7 +174,7 @@ public class StateStoreProxyImpl implements StateStoreProxy {
           "US-ASCII");
       si.managerPort = Integer.parseInt(managerAddr.split(":")[1]);
       si.schedulerName = charsetDecode(
-          localScheduler.get(i).get("local_scheduler_socket_name".getBytes()), "US-ASCII");
+        localScheduler.get(i).get("local_scheduler_socket_name".getBytes()), "US-ASCII");
 
       rpc = localScheduler.get(i).get("local_scheduler_rpc_name".getBytes());
       if (rpc != null) {

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/StateStoreProxyImpl.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/StateStoreProxyImpl.java
@@ -80,7 +80,8 @@ public class StateStoreProxyImpl implements StateStoreProxy {
         return getAddressInfoHelper(nodeIpAddress);
       } catch (Exception e) {
         try {
-          RayLog.core.warn("StateStoreProxyImpl getAddressInfo", e);
+          RayLog.core.warn("Error occurred in StateStoreProxyImpl getAddressInfo, " 
+              + (numRetries - count) + " retries remaining", e);
           TimeUnit.MILLISECONDS.sleep(1000);
         } catch (InterruptedException ie) {
           RayLog.core.error("error at StateStoreProxyImpl getAddressInfo", e);

--- a/java/test_cluster.sh
+++ b/java/test_cluster.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#############################
+# build deploy file and deploy cluster
+sh cleanup.sh
+rm -rf local_deploy
+./prepare.sh -t local_deploy
+pushd local_deploy
+local_ip=`ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"`
+echo "use local_ip" $local_ip
+# ray.java.start.node_ip_address=127.0.0.1
+OVERWRITE="ray.java.start.redis_port=34222;ray.java.start.node_ip_address=$local_ip;ray.java.start.deploy=true;ray.java.start.run_mode=CLUSTER"
+echo OVERWRITE is $OVERWRITE
+./run.sh start --head --overwrite=$OVERWRITE > cli.log 2>&1 &
+popd
+sleep 10
+
+# auto-pack zip for app example
+pushd example
+if [ ! -d "app1/" ];then
+    mkdir app1
+fi
+cp -rf target/ray-example-1.0.jar app1/
+zip -r app1.zip app1
+#zip target/ray-example-1.0.jar.zip target/ray-example-1.0.jar
+popd
+
+# run with cluster mode
+pushd local_deploy
+export RAY_CONFIG=ray/ray.config.ini
+#echo "RUNNING echo VIA app proxy ...."
+ARGS=" --package ../example/app1.zip --class org.ray.example.HelloWorld --redis-address=$local_ip:34222"
+../local_deploy/run.sh submit $ARGS
+#java -Djava.library.path=../../build/src/plasma:../../build/src/local_scheduler -cp .:target/ray-example-1.0.jar:lib/* org.ray.example.HelloWorld  --overwrite="ray.java.start.redis_address=$local_ip:34222;ray.java.start.run_mode=CLUSTER" --package=app1.zip --class=org.ray.example.HelloWorld
+popd

--- a/java/test_cluster.sh
+++ b/java/test_cluster.sh
@@ -7,8 +7,7 @@ rm -rf local_deploy
 ./prepare.sh -t local_deploy
 pushd local_deploy
 local_ip=`ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"`
-echo "use local_ip" $local_ip
-# ray.java.start.node_ip_address=127.0.0.1
+#echo "use local_ip" $local_ip
 OVERWRITE="ray.java.start.redis_port=34222;ray.java.start.node_ip_address=$local_ip;ray.java.start.deploy=true;ray.java.start.run_mode=CLUSTER"
 echo OVERWRITE is $OVERWRITE
 ./run.sh start --head --overwrite=$OVERWRITE > cli.log 2>&1 &
@@ -28,8 +27,7 @@ popd
 # run with cluster mode
 pushd local_deploy
 export RAY_CONFIG=ray/ray.config.ini
-#echo "RUNNING echo VIA app proxy ...."
-ARGS=" --package ../example/app1.zip --class org.ray.example.HelloWorld --redis-address=$local_ip:34222"
+ARGS=" --package ../example/app1.zip --class org.ray.example.HelloWorld --args=test1,test2  --redis-address=$local_ip:34222"
 ../local_deploy/run.sh submit $ARGS
 #java -Djava.library.path=../../build/src/plasma:../../build/src/local_scheduler -cp .:target/ray-example-1.0.jar:lib/* org.ray.example.HelloWorld  --overwrite="ray.java.start.redis_address=$local_ip:34222;ray.java.start.run_mode=CLUSTER" --package=app1.zip --class=org.ray.example.HelloWorld
 popd

--- a/java/test_cluster.sh
+++ b/java/test_cluster.sh
@@ -21,7 +21,6 @@ if [ ! -d "app1/" ];then
 fi
 cp -rf target/ray-example-1.0.jar app1/
 zip -r app1.zip app1
-#zip target/ray-example-1.0.jar.zip target/ray-example-1.0.jar
 popd
 
 # run with cluster mode
@@ -29,5 +28,4 @@ pushd local_deploy
 export RAY_CONFIG=ray/ray.config.ini
 ARGS=" --package ../example/app1.zip --class org.ray.example.HelloWorld --args=test1,test2  --redis-address=$local_ip:34222"
 ../local_deploy/run.sh submit $ARGS
-#java -Djava.library.path=../../build/src/plasma:../../build/src/local_scheduler -cp .:target/ray-example-1.0.jar:lib/* org.ray.example.HelloWorld  --overwrite="ray.java.start.redis_address=$local_ip:34222;ray.java.start.run_mode=CLUSTER" --package=app1.zip --class=org.ray.example.HelloWorld
 popd


### PR DESCRIPTION
## What do these changes do?

Right now only python worker supports cluster, and this change adds cluster support for java worker as well.

A cli command is introduced to:

start / stop ray processes on head or non-head node
submit a user task, in this case this command starts a driver process to run the program.

## Related issue number

N/A
