### PR TITLE
close files opened by new_log_files function

### DIFF
--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -168,19 +168,21 @@ def ray_start_reconstruction(request):
     plasma_addresses = []
     objstore_memory = plasma_store_memory // num_local_schedulers
     for i in range(num_local_schedulers):
-        store_stdout_file, store_stderr_file = ray.services.new_log_files(
-            "plasma_store_{}".format(i), True)
-        manager_stdout_file, manager_stderr_file = (ray.services.new_log_files(
-            "plasma_manager_{}".format(i), True))
-        plasma_addresses.append(
-            ray.services.start_objstore(
-                node_ip_address,
-                redis_address,
-                objstore_memory=objstore_memory,
-                store_stdout_file=store_stdout_file,
-                store_stderr_file=store_stderr_file,
-                manager_stdout_file=manager_stdout_file,
-                manager_stderr_file=manager_stderr_file))
+        with ray.services.new_log_files("plasma_store_{}".format(i),
+                                        True) as (store_stdout_file,
+                                                  store_stderr_file):
+            with ray.services.new_log_files("plasma_manager_{}".format(i),
+                                            True) as (manager_stdout_file,
+                                                      manager_stderr_file):
+                plasma_addresses.append(
+                    ray.services.start_objstore(
+                        node_ip_address,
+                        redis_address,
+                        objstore_memory=objstore_memory,
+                        store_stdout_file=store_stdout_file,
+                        store_stderr_file=store_stderr_file,
+                        manager_stdout_file=manager_stdout_file,
+                        manager_stderr_file=manager_stderr_file))
 
     # Start the rest of the services in the Ray cluster.
     address_info = {


### PR DESCRIPTION
This bug fix can eliminate the annoying warning messages in tests:
`/home/travis/.local/lib/python3.6/site-packages/ray-0.4.0-py3.6-linux-x86_64.egg/ray/services.py:1510: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/raylogs/worker_0_0-2018-07-06_08-19-29-04610.out' mode='a' encoding='UTF-8'>
  "worker_{}_{}".format(i, j), redirect_output)`