### PR TITLE
Pin the number of CPUs in failing actor test.

### DIFF
--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -484,7 +484,7 @@ class ActorNesting(unittest.TestCase):
 
     def testRemoteFunctionWithinActor(self):
         # Make sure we can use remote funtions within actors.
-        ray.init(num_cpus=100)
+        ray.init(num_cpus=10)
 
         # Create some values to close over.
         val1 = 1

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -245,11 +245,11 @@ class StartRayScriptTest(unittest.TestCase):
 
             # Test starting Ray with all arguments specified.
             run_and_get_output([
-                "ray", "start", "--head", "--num-workers", "2",
-                "--redis-port", "6379", "--redis-shard-ports",
-                "6380,6381,6382", "--object-manager-port", "12345",
-                "--num-cpus", "2", "--num-gpus", "0", "--redis-max-clients",
-                "100", "--resources", "{\"Custom\": 1}"
+                "ray", "start", "--head", "--num-workers", "2", "--redis-port",
+                "6379", "--redis-shard-ports", "6380,6381,6382",
+                "--object-manager-port", "12345", "--num-cpus", "2",
+                "--num-gpus", "0", "--redis-max-clients", "100", "--resources",
+                "{\"Custom\": 1}"
             ])
             subprocess.Popen(["ray", "stop"]).wait()
 

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -223,7 +223,7 @@ class StartRayScriptTest(unittest.TestCase):
         subprocess.Popen(["ray", "stop"]).wait()
 
         # Test starting Ray with the number of CPUs specified.
-        run_and_get_output(["ray", "start", "--head", "--num-cpus", "100"])
+        run_and_get_output(["ray", "start", "--head", "--num-cpus", "2"])
         subprocess.Popen(["ray", "stop"]).wait()
 
         # Test starting Ray with the number of GPUs specified.
@@ -245,10 +245,10 @@ class StartRayScriptTest(unittest.TestCase):
 
             # Test starting Ray with all arguments specified.
             run_and_get_output([
-                "ray", "start", "--head", "--num-workers", "20",
+                "ray", "start", "--head", "--num-workers", "2",
                 "--redis-port", "6379", "--redis-shard-ports",
                 "6380,6381,6382", "--object-manager-port", "12345",
-                "--num-cpus", "100", "--num-gpus", "0", "--redis-max-clients",
+                "--num-cpus", "2", "--num-gpus", "0", "--redis-max-clients",
                 "100", "--resources", "{\"Custom\": 1}"
             ])
             subprocess.Popen(["ray", "stop"]).wait()


### PR DESCRIPTION
This may address a test failure that was introduced in #2364. The error is

```
testRemoteFunctionWithinActor (__main__.ActorNesting) ... Process STDOUT and STDERR is being redirected to /tmp/raylogs/.
Waiting for redis server at 127.0.0.1:53145 to respond...
Waiting for redis server at 127.0.0.1:27100 to respond...
Starting local scheduler with the following resources: {'GPU': 0, 'CPU': 100}.
Failed to start the UI, you may need to run 'pip install jupyter'.
The actor with ID a1034d4ef284a01b3d1d7a5de13833682f93ff3f is taking a while to be created. It is possible that the cluster does not have enough resources to place this actor (this may be normal while an autoscaling is scaling up). Consider reducing the number of actors created, or increasing the number of slots available by using the --num-cpus, --num-gpus, and --resources flags. The actor creation task is requesting 0 CPU 
Suppressing duplicate error message.
Suppressing duplicate error message.
Suppressing duplicate error message.
Suppressing duplicate error message.
Traceback (most recent call last):
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
    import ray
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
Traceback (most recent call last):
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
    import ray
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
    import ray
    import ray
    import ray
    import ray
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
    import ray
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
/home/travis/.travis/job_stages: line 78: 20913 Killed                  python test/actor_test.py
Traceback (most recent call last):
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/workers/default_worker.py", line 8, in <module>
    import ray
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/__init__.py", line 28, in <module>
    import pyarrow  # noqa: F401
  File "/home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/__init__.py", line 58, in <module>
    from pyarrow.lib import cpu_count, set_cpu_count
ImportError: /home/travis/.local/lib/python2.7/site-packages/ray-0.4.0-py2.7-linux-x86_64.egg/ray/pyarrow_files/pyarrow/lib.so: failed to map segment from shared object: Cannot allocate memory
travis_time:end:0c0bdde4:start=1530938144299180450,finish=1530938343848302667,duration=199549122217
[0K
[31;1mThe command "python test/actor_test.py" exited with 137.
```