### PR TITLE
Change ray.worker.cleanup -> ray.shutdown and improve API documentation.

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -11,5 +11,6 @@ psutil
 recommonmark
 redis
 sphinx
+sphinx-click
 sphinx_rtd_theme
 pandas

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,284 +1,49 @@
 The Ray API
 ===========
 
-Starting Ray
-------------
-
-There are two main ways in which Ray can be used. First, you can start all of
-the relevant Ray processes and shut them all down within the scope of a single
-script. Second, you can connect to and use an existing Ray cluster.
-
-Starting and stopping a cluster within a script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One use case is to start all of the relevant Ray processes when you call
-``ray.init`` and shut them down when the script exits. These processes include
-local and global schedulers, an object store and an object manager, a redis
-server, and more.
-
-**Note:** this approach is limited to a single machine.
-
-This can be done as follows.
-
-.. code-block:: python
-
-  ray.init()
-
-If there are GPUs available on the machine, you should specify this with the
-``num_gpus`` argument. Similarly, you can also specify the number of CPUs with
-``num_cpus``.
-
-.. code-block:: python
-
-  ray.init(num_cpus=20, num_gpus=2)
-
-By default, Ray will use ``psutil.cpu_count()`` to determine the number of CPUs.
-Ray will also attempt to automatically determine the number of GPUs.
-
-Instead of thinking about the number of "worker" processes on each node, we
-prefer to think in terms of the quantities of CPU and GPU resources on each
-node and to provide the illusion of an infinite pool of workers. Tasks will be
-assigned to workers based on the availability of resources so as to avoid
-contention and not based on the number of available worker processes.
-
-Connecting to an existing cluster
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Once a Ray cluster has been started, the only thing you need in order to connect
-to it is the address of the Redis server in the cluster. In this case, your
-script will not start up or shut down any processes. The cluster and all of its
-processes may be shared between multiple scripts and multiple users. To do this,
-you simply need to know the address of the cluster's Redis server. This can be
-done with a command like the following.
-
-.. code-block:: python
-
-  ray.init(redis_address="12.345.67.89:6379")
-
-In this case, you cannot specify ``num_cpus`` or ``num_gpus`` in ``ray.init``
-because that information is passed into the cluster when the cluster is started,
-not when your script is started.
-
-View the instructions for how to `start a Ray cluster`_ on multiple nodes.
-
-.. _`start a Ray cluster`: http://ray.readthedocs.io/en/latest/using-ray-on-a-cluster.html
-
 .. autofunction:: ray.init
-
-Defining remote functions
--------------------------
-
-Remote functions are used to create tasks. To define a remote function, the
-``@ray.remote`` decorator is placed over the function definition.
-
-The function can then be invoked with ``f.remote``. Invoking the function
-creates a **task** which will be scheduled on and executed by some worker
-process in the Ray cluster. The call will return an **object ID** (essentially a
-future) representing the eventual return value of the task. Anyone with the
-object ID can retrieve its value, regardless of where the task was executed (see
-`Getting values from object IDs`_).
-
-When a task executes, its outputs will be serialized into a string of bytes and
-stored in the object store.
-
-Note that arguments to remote functions can be values or object IDs.
-
-.. code-block:: python
-
-  @ray.remote
-  def f(x):
-      return x + 1
-
-  x_id = f.remote(0)
-  ray.get(x_id)  # 1
-
-  y_id = f.remote(x_id)
-  ray.get(y_id)  # 2
-
-If you want a remote function to return multiple object IDs, you can do that by
-passing the ``num_return_vals`` argument into the remote decorator.
-
-.. code-block:: python
-
-  @ray.remote(num_return_vals=2)
-  def f():
-      return 1, 2
-
-  x_id, y_id = f.remote()
-  ray.get(x_id)  # 1
-  ray.get(y_id)  # 2
 
 .. autofunction:: ray.remote
 
-Getting values from object IDs
-------------------------------
-
-Object IDs can be converted into objects by calling ``ray.get`` on the object
-ID. Note that ``ray.get`` accepts either a single object ID or a list of object
-IDs.
-
-.. code-block:: python
-
-  @ray.remote
-  def f():
-      return {'key1': ['value']}
-
-  # Get one object ID.
-  ray.get(f.remote())  # {'key1': ['value']}
-
-  # Get a list of object IDs.
-  ray.get([f.remote() for _ in range(2)])  # [{'key1': ['value']}, {'key1': ['value']}]
-
-Numpy arrays
-~~~~~~~~~~~~
-
-Numpy arrays are handled more efficiently than other data types, so **use numpy
-arrays whenever possible**.
-
-Any numpy arrays that are part of the serialized object will not be copied out
-of the object store. They will remain in the object store and the resulting
-deserialized object will simply have a pointer to the relevant place in the
-object store's memory.
-
-Since objects in the object store are immutable, this means that if you want to
-mutate a numpy array that was returned by a remote function, you will have to
-first copy it.
-
 .. autofunction:: ray.get
-
-Putting objects in the object store
------------------------------------
-
-The primary way that objects are placed in the object store is by being returned
-by a task. However, it is also possible to directly place objects in the object
-store using ``ray.put``.
-
-.. code-block:: python
-
-  x_id = ray.put(1)
-  ray.get(x_id)  # 1
-
-The main reason to use ``ray.put`` is that you want to pass the same large
-object into a number of tasks. By first doing ``ray.put`` and then passing the
-resulting object ID into each of the tasks, the large object is copied into the
-object store only once, whereas when we directly pass the object in, it is
-copied multiple times.
-
-.. code-block:: python
-
-  import numpy as np
-
-  @ray.remote
-  def f(x):
-      pass
-
-  x = np.zeros(10 ** 6)
-
-  # Alternative 1: Here, x is copied into the object store 10 times.
-  [f.remote(x) for _ in range(10)]
-
-  # Alternative 2: Here, x is copied into the object store once.
-  x_id = ray.put(x)
-  [f.remote(x_id) for _ in range(10)]
-
-Note that ``ray.put`` is called under the hood in a couple situations.
-
-- It is called on the values returned by a task.
-- It is called on the arguments to a task, unless the arguments are Python
-  primitives like integers or short strings, lists, tuples, or dictionaries.
-
-.. autofunction:: ray.put
-
-Waiting for a subset of tasks to finish
----------------------------------------
-
-It is often desirable to adapt the computation being done based on when
-different tasks finish. For example, if a bunch of tasks each take a variable
-length of time, and their results can be processed in any order, then it makes
-sense to simply process the results in the order that they finish. In other
-settings, it makes sense to discard straggler tasks whose results may not be
-needed.
-
-To do this, we introduce the ``ray.wait`` primitive, which takes a list of
-object IDs and returns when a subset of them are available. By default it blocks
-until a single object is available, but the ``num_returns`` value can be
-specified to wait for a different number. If a ``timeout`` argument is passed
-in, it will block for at most that many milliseconds and may return a list with
-fewer than ``num_returns`` elements.
-
-The ``ray.wait`` function returns two lists. The first list is a list of object
-IDs of available objects (of length at most ``num_returns``), and the second
-list is a list of the remaining object IDs, so the combination of these two
-lists is equal to the list passed in to ``ray.wait`` (up to ordering).
-
-.. code-block:: python
-
-  import time
-  import numpy as np
-
-  @ray.remote
-  def f(n):
-      time.sleep(n)
-      return n
-
-  # Start 3 tasks with different durations.
-  results = [f.remote(i) for i in range(3)]
-  # Block until 2 of them have finished.
-  ready_ids, remaining_ids = ray.wait(results, num_returns=2)
-
-  # Start 5 tasks with different durations.
-  results = [f.remote(i) for i in range(5)]
-  # Block until 4 of them have finished or 2.5 seconds pass.
-  ready_ids, remaining_ids = ray.wait(results, num_returns=4, timeout=2500)
-
-It is easy to use this construct to create an infinite loop in which multiple
-tasks are executing, and whenever one task finishes, a new one is launched.
-
-.. code-block:: python
-
-  @ray.remote
-  def f():
-      return 1
-
-  # Start 5 tasks.
-  remaining_ids = [f.remote() for i in range(5)]
-  # Whenever one task finishes, start a new one.
-  for _ in range(100):
-      ready_ids, remaining_ids = ray.wait(remaining_ids)
-      # Get the available object and do something with it.
-      print(ray.get(ready_ids))
-      # Start a new task.
-      remaining_ids.append(f.remote())
 
 .. autofunction:: ray.wait
 
-Viewing errors
---------------
+.. autofunction:: ray.put
 
-Keeping track of errors that occur in different processes throughout a cluster
-can be challenging. There are a couple mechanisms to help with this.
+.. autofunction:: ray.get_gpu_ids
 
-1. If a task throws an exception, that exception will be printed in the
-   background of the driver process.
+.. autofunction:: ray.get_resource_ids
 
-2. If ``ray.get`` is called on an object ID whose parent task threw an exception
-   before creating the object, the exception will be re-raised by ``ray.get``.
+.. autofunction:: ray.get_webui_url
 
-The errors will also be accumulated in Redis and can be accessed with
-``ray.error_info``. Normally, you shouldn't need to do this, but it is possible.
+.. autofunction:: ray.shutdown
 
-.. code-block:: python
+.. autofunction:: ray.register_custom_serializer
 
-  @ray.remote
-  def f():
-      raise Exception("This task failed!!")
+.. autofunction:: ray.profile
 
-  f.remote()  # An error message will be printed in the background.
+.. autofunction:: ray.method
 
-  # Wait for the error to propagate to Redis.
-  import time
-  time.sleep(1)
+The Ray Command Line API
+------------------------
 
-  ray.error_info()  # This returns a list containing the error message.
+.. click:: ray.scripts.scripts:start
+   :prog: ray start
+   :show-nested:
 
-.. autofunction:: ray.error_info
+.. click:: ray.scripts.scripts:stop
+   :prog: ray stop
+   :show-nested:
+
+.. click:: ray.scripts.scripts:create_or_update
+   :prog: ray create_or_update
+   :show-nested:
+
+.. click:: ray.scripts.scripts:teardown
+   :prog: ray teardown
+   :show-nested:
+
+.. click:: ray.scripts.scripts:get_head_ip
+   :prog: ray get_head_ip
+   :show-nested:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,6 +72,7 @@ sys.path.insert(0, os.path.abspath("../../python/"))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinx_click.ext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -50,8 +50,8 @@ from ray.local_scheduler import ObjectID, _config  # noqa: E402
 from ray.worker import (error_info, init, connect, disconnect, get, put, wait,
                         remote, profile, flush_profile_data, get_gpu_ids,
                         get_resource_ids, get_webui_url,
-                        register_custom_serializer)  # noqa: E402
-from ray.worker import (SCRIPT_MODE, WORKER_MODE, PYTHON_MODE,
+                        register_custom_serializer, shutdown)  # noqa: E402
+from ray.worker import (SCRIPT_MODE, WORKER_MODE, LOCAL_MODE,
                         SILENT_MODE)  # noqa: E402
 from ray.worker import global_state  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
@@ -67,8 +67,9 @@ __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",
     "remote", "profile", "flush_profile_data", "actor", "method",
     "get_gpu_ids", "get_resource_ids", "get_webui_url",
-    "register_custom_serializer", "SCRIPT_MODE", "WORKER_MODE", "PYTHON_MODE",
-    "SILENT_MODE", "global_state", "ObjectID", "_config", "__version__"
+    "register_custom_serializer", "shutdown", "SCRIPT_MODE", "WORKER_MODE",
+    "LOCAL_MODE", "SILENT_MODE", "global_state", "ObjectID", "_config",
+    "__version__"
 ]
 
 import ctypes  # noqa: E402

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -421,6 +421,24 @@ def export_actor_class(class_id, Class, actor_method_names,
 
 
 def method(*args, **kwargs):
+    """Annotate an actor method.
+
+    .. code-block:: python
+
+        @ray.remote
+        class Foo(object):
+            @ray.method(num_return_vals=2)
+            def bar(self):
+                return 1, 2
+
+        f = Foo.remote()
+
+        _, _ = f.bar.remote()
+
+    Args:
+        num_return_vals: The number of object IDs that should be returned by
+            invocations of this actor method.
+    """
     assert len(args) == 0
     assert len(kwargs) == 1
     assert "num_return_vals" in kwargs
@@ -588,10 +606,10 @@ class ActorClass(object):
         # updated to reflect the new invocation.
         actor_cursor = None
 
-        # Do not export the actor class or the actor if run in PYTHON_MODE
+        # Do not export the actor class or the actor if run in LOCAL_MODE
         # Instead, instantiate the actor locally and add it to the worker's
         # dictionary
-        if worker.mode == ray.PYTHON_MODE:
+        if worker.mode == ray.LOCAL_MODE:
             worker.actors[actor_id] = self._modified_class.__new__(
                 self._modified_class)
         else:
@@ -764,9 +782,9 @@ class ActorHandle(object):
             kwargs = {}
         args = signature.extend_args(function_signature, args, kwargs)
 
-        # Execute functions locally if Ray is run in PYTHON_MODE
+        # Execute functions locally if Ray is run in LOCAL_MODE
         # Copy args to prevent the function from mutating them.
-        if worker.mode == ray.PYTHON_MODE:
+        if worker.mode == ray.LOCAL_MODE:
             return getattr(worker.actors[self._ray_actor_id],
                            method_name)(*copy.deepcopy(args))
 
@@ -963,7 +981,7 @@ def make_actor(cls, num_cpus, num_gpus, resources, actor_method_cpus,
     class Class(cls):
         def __ray_terminate__(self):
             worker = ray.worker.get_global_worker()
-            if worker.mode != ray.PYTHON_MODE:
+            if worker.mode != ray.LOCAL_MODE:
                 # Disconnect the worker from the local scheduler. The point of
                 # this is so that when the worker kills itself below, the local
                 # scheduler won't push an error message to the driver.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -125,8 +125,8 @@ class RemoteFunction(object):
         resources = ray.utils.resources_from_resource_arguments(
             self._num_cpus, self._num_gpus, self._resources, num_cpus,
             num_gpus, resources)
-        if worker.mode == ray.worker.PYTHON_MODE:
-            # In PYTHON_MODE, remote calls simply execute the function.
+        if worker.mode == ray.worker.LOCAL_MODE:
+            # In LOCAL_MODE, remote calls simply execute the function.
             # We copy the arguments to prevent the function call from
             # mutating them and to match the usual behavior of
             # immutable remote objects.

--- a/python/ray/rllib/test/test_catalog.py
+++ b/python/ray/rllib/test/test_catalog.py
@@ -29,7 +29,7 @@ class CustomModel(Model):
 
 class ModelCatalogTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testGymPreprocessors(self):
         p1 = ModelCatalog.get_preprocessor(gym.make("CartPole-v0"))

--- a/python/ray/rllib/test/test_filters.py
+++ b/python/ray/rllib/test/test_filters.py
@@ -78,7 +78,7 @@ class FilterManagerTest(unittest.TestCase):
         ray.init(num_cpus=1)
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testSynchronize(self):
         """Synchronize applies filter buffer onto own filter"""

--- a/python/ray/rllib/test/test_optimizers.py
+++ b/python/ray/rllib/test/test_optimizers.py
@@ -14,7 +14,7 @@ from ray.rllib.evaluation import SampleBatch
 
 class AsyncOptimizerTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testBasic(self):
         ray.init(num_cpus=4)

--- a/python/ray/rllib/tuned_examples/regression_tests/regression_test.py
+++ b/python/ray/rllib/tuned_examples/regression_tests/regression_test.py
@@ -43,7 +43,7 @@ class Regression():
         raise NotImplementedError
 
     def teardown(self, *args):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def track_time(self, result):
         return result["time_total_s"]

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -147,7 +147,7 @@ def cli():
     "--use-raylet",
     is_flag=True,
     default=None,
-    help="use the raylet code path, this is not supported yet")
+    help="use the raylet code path")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_shard_ports, object_manager_port,
           object_store_memory, num_workers, num_cpus, num_gpus, resources,

--- a/python/ray/test/test_functions.py
+++ b/python/ray/test/test_functions.py
@@ -90,12 +90,12 @@ def throw_exception_fct3(x):
 
 
 @ray.remote
-def python_mode_f():
+def local_mode_f():
     return np.array([0, 0])
 
 
 @ray.remote
-def python_mode_g(x):
+def local_mode_g(x):
     x[0] = 1
     return x
 

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -26,7 +26,7 @@ class TrainableFunctionApiTest(unittest.TestCase):
         ray.init(num_cpus=4, num_gpus=0)
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def testPinObject(self):
@@ -366,7 +366,7 @@ class RunExperimentTest(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def testDict(self):
@@ -441,7 +441,7 @@ class VariantGeneratorTest(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def testParseToTrials(self):
@@ -575,7 +575,7 @@ class VariantGeneratorTest(unittest.TestCase):
 
 class TrialRunnerTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def testTrialStatus(self):

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -29,7 +29,7 @@ class EarlyStoppingSuite(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def basicSetup(self, rule):
@@ -196,7 +196,7 @@ class HyperbandSuite(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def schedulerSetup(self, num_trials):
@@ -561,7 +561,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def basicSetup(self, resample_prob=0.0, explore=None):
@@ -781,7 +781,7 @@ class AsyncHyperBandSuite(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()  # re-register the evicted objects
 
     def basicSetup(self, scheduler):

--- a/python/ray/tune/test/tune_server_test.py
+++ b/python/ray/tune/test/tune_server_test.py
@@ -51,7 +51,7 @@ class TuneServerSuite(unittest.TestCase):
             self.runner = None
         except Exception as e:
             print(e)
-        ray.worker.cleanup()
+        ray.shutdown()
         _register_all()
 
     def testAddTrial(self):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1783,6 +1783,12 @@ def init(redis_address=None,
 _post_init_hooks = []
 
 
+def cleanup(worker=global_worker):
+    raise DeprecationWarning(
+        "The function ray.worker.cleanup() has been deprecated. Instead, "
+        "please call ray.shutdown().")
+
+
 def shutdown(worker=global_worker):
     """Disconnect the worker, and terminate processes started by ray.init().
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1563,8 +1563,8 @@ def _init(address_info=None,
             num_cpus, num_gpus, resources, num_local_schedulers)
 
         # Start the scheduler, object store, and some workers. These will be
-        # killed by the call to shutdown(), which happens when the Python script
-        # exits.
+        # killed by the call to shutdown(), which happens when the Python
+        # script exits.
         address_info = services.start_ray_head(
             address_info=address_info,
             node_ip_address=node_ip_address,
@@ -3013,8 +3013,8 @@ def remote(*args, **kwargs):
 
     It can also be used with specific keyword arguments:
 
-    * **num_return_vals:** This is only for *remote functions*. It specifies the
-      number of object IDs returned by the remote function invocation.
+    * **num_return_vals:** This is only for *remote functions*. It specifies
+      the number of object IDs returned by the remote function invocation.
     * **num_cpus:** The quantity of CPU cores to reserve for this task or for
       the lifetime of the actor.
     * **num_gpus:** The quantity of GPUs to reserve for this task or for the

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -17,7 +17,7 @@ import ray.test.test_utils
 
 class ActorAPI(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testKeywordArgs(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
@@ -314,7 +314,7 @@ class ActorAPI(unittest.TestCase):
 
 class ActorMethods(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testDefineActor(self):
         ray.init()
@@ -480,7 +480,7 @@ class ActorMethods(unittest.TestCase):
 
 class ActorNesting(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testRemoteFunctionWithinActor(self):
         # Make sure we can use remote funtions within actors.
@@ -656,7 +656,7 @@ class ActorNesting(unittest.TestCase):
 
 class ActorInheritance(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testInheritActorFromClass(self):
         # Make sure we can define an actor by inheriting from a regular class.
@@ -688,7 +688,7 @@ class ActorInheritance(unittest.TestCase):
 
 class ActorSchedulingProperties(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testRemoteFunctionsNotScheduledOnActors(self):
         # Make sure that regular remote functions are not scheduled on actors.
@@ -715,7 +715,7 @@ class ActorSchedulingProperties(unittest.TestCase):
 
 class ActorsOnMultipleNodes(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testActorsOnNodesWithNoCPUs(self):
         ray.init(num_cpus=0)
@@ -774,7 +774,7 @@ class ActorsOnMultipleNodes(unittest.TestCase):
 
 class ActorsWithGPUs(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False), "Crashing with new GCS API.")
@@ -1276,7 +1276,7 @@ class ActorsWithGPUs(unittest.TestCase):
     "This test does not work with xray yet.")
 class ActorReconstruction(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False), "Hanging with new GCS API.")
@@ -1799,7 +1799,7 @@ class ActorReconstruction(unittest.TestCase):
 
 class DistributedActorHandles(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def setup_queue_actor(self):
         ray.init()
@@ -1967,7 +1967,7 @@ class DistributedActorHandles(unittest.TestCase):
 
 class ActorPlacementAndResources(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     @unittest.skipIf(
         os.environ.get("RAY_USE_XRAY") == "1",

--- a/test/array_test.py
+++ b/test/array_test.py
@@ -18,7 +18,7 @@ if sys.version_info >= (3, 0):
 
 class RemoteArrayTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testMethods(self):
         for module in [
@@ -55,7 +55,7 @@ class RemoteArrayTest(unittest.TestCase):
 
 class DistributedArrayTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testAssemble(self):
         for module in [

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -178,7 +178,7 @@ class AutoscalingTest(unittest.TestCase):
     def tearDown(self):
         del NODE_PROVIDERS["mock"]
         shutil.rmtree(self.tmpdir)
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def waitFor(self, condition):
         for _ in range(50):

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 
 class ComponentFailureTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     # This test checks that when a worker dies in the middle of a get, the
     # plasma store and manager will not die.

--- a/test/credis_test.py
+++ b/test/credis_test.py
@@ -20,7 +20,7 @@ class CredisTest(unittest.TestCase):
         self.config = ray.init(num_workers=0)
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def test_credis_started(self):
         assert "redis_address" in self.config

--- a/test/cython_test.py
+++ b/test/cython_test.py
@@ -19,7 +19,7 @@ class CythonTest(unittest.TestCase):
         ray.init()
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def assertEqualHelper(self, cython_func, expected, *args):
         self.assertEqual(get_ray_result(cython_func, *args), expected)

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -32,7 +32,7 @@ def wait_for_errors(error_type, num_errors, timeout=10):
 
 class TaskStatusTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testFailedTask(self):
         reload(test_functions)
@@ -195,7 +195,7 @@ def temporary_helper_function():
 
 class ActorTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testFailedActorInit(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
@@ -267,7 +267,7 @@ class ActorTest(unittest.TestCase):
 
 class WorkerDeath(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testWorkerRaisingException(self):
         ray.init(num_workers=1, driver_mode=ray.SILENT_MODE)
@@ -370,7 +370,7 @@ class WorkerDeath(unittest.TestCase):
     "This test does not work with xray yet.")
 class PutErrorTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testPutError1(self):
         store_size = 10**6
@@ -467,7 +467,7 @@ class PutErrorTest(unittest.TestCase):
 
 class ConfigurationTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testVersionMismatch(self):
         ray_version = ray.__version__
@@ -482,7 +482,7 @@ class ConfigurationTest(unittest.TestCase):
 
 class WarningTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testExportLargeObjects(self):
         import ray.ray_constants as ray_constants

--- a/test/microbenchmarks.py
+++ b/test/microbenchmarks.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 0):
 
 class MicroBenchmarkTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testTiming(self):
         reload(test_functions)

--- a/test/monitor_test.py
+++ b/test/monitor_test.py
@@ -60,7 +60,7 @@ class MonitorTest(unittest.TestCase):
             if (4, 2, summary_start[2] + 1) != StateSummary():
                 success.value = False
 
-            ray.worker.cleanup()
+            ray.shutdown()
 
         success = multiprocessing.Value('b', False)
         driver = multiprocessing.Process(target=Driver, args=(success, ))
@@ -81,7 +81,7 @@ class MonitorTest(unittest.TestCase):
         # the global state.
         self.assertEqual((0, 1), StateSummary()[:2])
 
-        ray.worker.cleanup()
+        ray.shutdown()
         subprocess.Popen(["ray", "stop"]).wait()
 
     @unittest.skipIf(

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -40,7 +40,7 @@ class MultiNodeTest(unittest.TestCase):
         self.redis_address = redis_address.split("\"")[0]
 
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
         # Kill the Ray cluster.
         subprocess.Popen(["ray", "stop"]).wait()
 
@@ -281,7 +281,7 @@ class StartRayScriptTest(unittest.TestCase):
 
 class MiscellaneousTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testConnectingInLocalCase(self):
         address_info = ray.init(num_cpus=0)

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -17,7 +17,7 @@ def ray_start_regular():
     ray.init(num_cpus=10)
     yield None
     # The code after the yield will run as teardown code.
-    ray.worker.cleanup()
+    ray.shutdown()
 
 
 @pytest.fixture(params=[(1, 4), (4, 4)])
@@ -32,7 +32,7 @@ def ray_start_combination(request):
         num_cpus=10)
     yield num_local_schedulers, num_workers_per_scheduler
     # The code after the yield will run as teardown code.
-    ray.worker.cleanup()
+    ray.shutdown()
 
 
 def test_submitting_tasks(ray_start_combination):
@@ -224,7 +224,7 @@ def ray_start_reconstruction(request):
         assert len(local_scheduler_ids) == num_local_schedulers + 1
 
     # Clean up the Ray cluster.
-    ray.worker.cleanup()
+    ray.shutdown()
 
 
 @pytest.mark.skipif(
@@ -529,7 +529,7 @@ def test_driver_put_errors(ray_start_reconstruction):
 # class WorkerPoolTests(unittest.TestCase):
 #
 #   def tearDown(self):
-#     ray.worker.cleanup()
+#     ray.shutdown()
 #
 #   def testBlockingTasks(self):
 #     @ray.remote
@@ -545,4 +545,4 @@ def test_driver_put_errors(ray_start_reconstruction):
 #
 #     ray.init(num_workers=1)
 #     ray.get([g.remote(i) for i in range(1000)])
-#     ray.worker.cleanup()
+#     ray.shutdown()

--- a/test/tensorflow_test.py
+++ b/test/tensorflow_test.py
@@ -95,7 +95,7 @@ class TrainActor(object):
 
 class TensorFlowTest(unittest.TestCase):
     def tearDown(self):
-        ray.worker.cleanup()
+        ray.shutdown()
 
     def testTensorFlowVariables(self):
         ray.init(num_workers=2)

--- a/test/xray_test.py
+++ b/test/xray_test.py
@@ -14,7 +14,7 @@ def ray_start():
     ray.init(num_cpus=1, use_raylet=True)
     yield None
     # The code after the yield will run as teardown code.
-    ray.worker.cleanup()
+    ray.shutdown()
 
 
 def test_basic_task_api(ray_start):


### PR DESCRIPTION
**TODO:**
- [x] Deprecate `ray.worker.cleanup`

This also renames `ray.PYTHON_MODE` to `ray.LOCAL_MODE`.

**TODO later:**
- Document the global state API.

This fixes #2372 and #1814.