### PR TITLE
default num_return_vals=1 in _actor_method_call

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -729,7 +729,7 @@ class ActorHandle(object):
                            method_name,
                            args=None,
                            kwargs=None,
-                           num_return_vals=None,
+                           num_return_vals=1,
                            dependency=None):
         """Method execution stub for an actor handle.
 


### PR DESCRIPTION
I find it very useful to call _actor_method_call directly. The default value of num_return_vals causes an exception, so I changed it to 1.