### PR TITLE
Fix bug: Init RayLog before using it.

### DIFF
--- a/java/cli/src/main/java/org/ray/cli/RayCli.java
+++ b/java/cli/src/main/java/org/ray/cli/RayCli.java
@@ -71,6 +71,9 @@ public class RayCli {
     PathConfig paths = new PathConfig(config);
     RayParameters params = new RayParameters(config);
 
+    // Init RayLog before using it.
+    RayLog.init(params.working_directory);
+
     RayLog.core.info("Using IP address " + params.node_ip_address + " for this node.");
     RunManager manager;
     if (cmdStart.head) {
@@ -165,6 +168,10 @@ public class RayCli {
     //    .getInstance().getRemoteFunctionManager();
 
     UniqueID resourceId = functionManager.registerResource(zip);
+
+    // Init RayLog before using it.
+    RayLog.init(params.working_directory);
+
     RayLog.rapp.debug(
         "registerResource " + resourceId + " for package " + packageName + " done");
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Call **RayLog.init()** before using **RayLog** in **RayCli.java**.
This PR fixed the problem of **RayCli** process's crash.

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->
