### PR TITLE
Move profile data flushing to background thread on workers.

### DIFF
--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -108,8 +108,6 @@ class Profiler(object):
             # This is to suppress errors that occur at shutdown.
             pass
 
-    # TODO(rkn): Support calling this function in the middle of a task, and
-    # also call this periodically in the background from the driver.
     def flush_profile_data(self):
         """Push the logged profiling data to the global control store.
 


### PR DESCRIPTION
This makes the workers push profiling information to the GCS on a background thread (as opposed to after every task) as is done on the driver. This has several advantages.
- For short tasks, there is more batching and hence fewer GCS calls (so this should improve performance).
- For long tasks, we can push profiling information incrementally to the GCS and hence have more visibility into performance before the task ends (which is important e.g., for long-running training tasks).

@raulchen can you please take a look?