### PR TITLE
[xray] raylet scheduling mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,46 +125,46 @@ matrix:
         # module is only found if the test directory is in the PYTHONPATH.
         - export PYTHONPATH="$PYTHONPATH:./test/"
 
-        - python -m pytest python/ray/common/test/test.py
-        - python -m pytest python/ray/common/redis_module/runtest.py
-        - python -m pytest python/ray/plasma/test/test.py
-        # - python -m pytest python/ray/local_scheduler/test/test.py
-        # - python -m pytest python/ray/global_scheduler/test/test.py
+        - python -m pytest -v python/ray/common/test/test.py
+        - python -m pytest -v python/ray/common/redis_module/runtest.py
+        - python -m pytest -v python/ray/plasma/test/test.py
+        # - python -m pytest -v python/ray/local_scheduler/test/test.py
+        # - python -m pytest -v python/ray/global_scheduler/test/test.py
 
-        - python -m pytest python/ray/test/test_queue.py
-        - python -m pytest test/xray_test.py
+        - python -m pytest -v python/ray/test/test_queue.py
+        - python -m pytest -v test/xray_test.py
 
         # The --assert=plain here is because pytest's assertion
         # rewriting mechanism seems to mess up on this file,
         # see https://github.com/ray-project/ray/issues/2514
         - python -m pytest -v --assert=plain test/runtest.py
-        - python -m pytest test/array_test.py
-        - python -m pytest test/actor_test.py
-        - python -m pytest test/autoscaler_test.py
-        - python -m pytest test/tensorflow_test.py
-        - python -m pytest test/failure_test.py
-        - python -m pytest test/microbenchmarks.py
-        - python -m pytest test/stress_tests.py
+        - python -m pytest -v test/array_test.py
+        - python -m pytest -v test/actor_test.py
+        - python -m pytest -v test/autoscaler_test.py
+        - python -m pytest -v test/tensorflow_test.py
+        - python -m pytest -v test/failure_test.py
+        - python -m pytest -v test/microbenchmarks.py
+        - python -m pytest -v test/stress_tests.py
         - pytest test/component_failures_test.py
         - python test/multi_node_test.py
-        - python -m pytest test/recursion_test.py
+        - python -m pytest -v test/recursion_test.py
         - pytest test/monitor_test.py
-        - python -m pytest test/cython_test.py
-        - python -m pytest test/credis_test.py
+        - python -m pytest -v test/cython_test.py
+        - python -m pytest -v test/credis_test.py
 
         # ray tune tests
         - python python/ray/tune/test/dependency_test.py
-        - python -m pytest python/ray/tune/test/trial_runner_test.py
-        - python -m pytest python/ray/tune/test/trial_scheduler_test.py
-        - python -m pytest python/ray/tune/test/experiment_test.py
-        - python -m pytest python/ray/tune/test/tune_server_test.py
-        - python -m pytest python/ray/tune/test/ray_trial_executor_test.py
+        - python -m pytest -v python/ray/tune/test/trial_runner_test.py
+        - python -m pytest -v python/ray/tune/test/trial_scheduler_test.py
+        - python -m pytest -v python/ray/tune/test/experiment_test.py
+        - python -m pytest -v python/ray/tune/test/tune_server_test.py
+        - python -m pytest -v python/ray/tune/test/ray_trial_executor_test.py
 
         # ray rllib tests
-        - python -m pytest python/ray/rllib/test/test_catalog.py
-        - python -m pytest python/ray/rllib/test/test_filters.py
-        - python -m pytest python/ray/rllib/test/test_optimizers.py
-        - python -m pytest python/ray/rllib/test/test_evaluators.py
+        - python -m pytest -v python/ray/rllib/test/test_catalog.py
+        - python -m pytest -v python/ray/rllib/test/test_filters.py
+        - python -m pytest -v python/ray/rllib/test/test_optimizers.py
+        - python -m pytest -v python/ray/rllib/test/test_evaluators.py
 
 
 install:
@@ -197,46 +197,46 @@ script:
   # module is only found if the test directory is in the PYTHONPATH.
   - export PYTHONPATH="$PYTHONPATH:./test/"
 
-  - python -m pytest python/ray/common/test/test.py
-  - python -m pytest python/ray/common/redis_module/runtest.py
-  - python -m pytest python/ray/plasma/test/test.py
-  - python -m pytest python/ray/local_scheduler/test/test.py
-  - python -m pytest python/ray/global_scheduler/test/test.py
+  - python -m pytest -v python/ray/common/test/test.py
+  - python -m pytest -v python/ray/common/redis_module/runtest.py
+  - python -m pytest -v python/ray/plasma/test/test.py
+  - python -m pytest -v python/ray/local_scheduler/test/test.py
+  - python -m pytest -v python/ray/global_scheduler/test/test.py
 
-  - python -m pytest python/ray/test/test_queue.py
-  - python -m pytest test/xray_test.py
+  - python -m pytest -v python/ray/test/test_queue.py
+  - python -m pytest -v test/xray_test.py
 
   # The --assert=plain here is because pytest's assertion
   # rewriting mechanism seems to mess up on this file,
   # see https://github.com/ray-project/ray/issues/2514
   - python -m pytest --assert=plain -v test/runtest.py
-  - python -m pytest test/array_test.py
-  - python -m pytest test/actor_test.py
-  - python -m pytest test/autoscaler_test.py
-  - python -m pytest test/tensorflow_test.py
-  - python -m pytest test/failure_test.py
-  - python -m pytest test/microbenchmarks.py
-  - python -m pytest test/stress_tests.py
-  - python -m pytest test/component_failures_test.py
+  - python -m pytest -v test/array_test.py
+  - python -m pytest -v test/actor_test.py
+  - python -m pytest -v test/autoscaler_test.py
+  - python -m pytest -v test/tensorflow_test.py
+  - python -m pytest -v test/failure_test.py
+  - python -m pytest -v test/microbenchmarks.py
+  - python -m pytest -v test/stress_tests.py
+  - python -m pytest -v test/component_failures_test.py
   - python test/multi_node_test.py
-  - python -m pytest test/recursion_test.py
-  - python -m pytest test/monitor_test.py
-  - python -m pytest test/cython_test.py
-  - python -m pytest test/credis_test.py
+  - python -m pytest -v test/recursion_test.py
+  - python -m pytest -v test/monitor_test.py
+  - python -m pytest -v test/cython_test.py
+  - python -m pytest -v test/credis_test.py
 
   # ray tune tests
   - python python/ray/tune/test/dependency_test.py
-  - python -m pytest python/ray/tune/test/trial_runner_test.py
-  - python -m pytest python/ray/tune/test/trial_scheduler_test.py
-  - python -m pytest python/ray/tune/test/experiment_test.py
-  - python -m pytest python/ray/tune/test/tune_server_test.py
-  - python -m pytest python/ray/tune/test/ray_trial_executor_test.py
+  - python -m pytest -v python/ray/tune/test/trial_runner_test.py
+  - python -m pytest -v python/ray/tune/test/trial_scheduler_test.py
+  - python -m pytest -v python/ray/tune/test/experiment_test.py
+  - python -m pytest -v python/ray/tune/test/tune_server_test.py
+  - python -m pytest -v python/ray/tune/test/ray_trial_executor_test.py
 
   # ray rllib tests
-  - python -m pytest python/ray/rllib/test/test_catalog.py
-  - python -m pytest python/ray/rllib/test/test_filters.py
-  - python -m pytest python/ray/rllib/test/test_optimizers.py
-  - python -m pytest python/ray/rllib/test/test_evaluators.py
+  - python -m pytest -v python/ray/rllib/test/test_catalog.py
+  - python -m pytest -v python/ray/rllib/test/test_filters.py
+  - python -m pytest -v python/ray/rllib/test/test_optimizers.py
+  - python -m pytest -v python/ray/rllib/test/test_evaluators.py
 
 deploy:
   - provider: s3

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -337,7 +337,7 @@ class Monitor(object):
             static_resources[static] = message.ResourcesTotalCapacity(i)
 
         # Update the load metrics for this local scheduler.
-        client_id = message.ClientId().decode("utf-8")
+        client_id = ray.utils.binary_to_hex(message.ClientId())
         ip = self.local_scheduler_id_to_ip_map.get(client_id)
         if ip:
             self.load_metrics.update(ip, static_resources, dynamic_resources)

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -194,6 +194,9 @@ table HeartbeatTableData {
   // Total resource capacity configured for this node manager.
   resources_total_label: [string];
   resources_total_capacity: [double];
+  // Aggregate outstanding resource load on this node manager.
+  resource_load_label: [string];
+  resource_load_capacity: [double];
 }
 
 // Data for a lease on task execution.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -95,7 +95,7 @@ class NodeManager {
   /// Handle a worker finishing its assigned task.
   void FinishAssignedTask(Worker &worker);
   /// Perform a placement decision on placeable tasks.
-  void ScheduleTasks();
+  void ScheduleTasks(std::unordered_map<ClientID, SchedulingResources> &resource_map);
   /// Handle a task whose return value(s) must be reconstructed.
   void HandleTaskReconstruction(const TaskID &task_id);
   /// Resubmit a task for execution. This is a task that was previously already

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -13,12 +13,13 @@ SchedulingPolicy::SchedulingPolicy(const SchedulingQueue &scheduling_queue)
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
-    const std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-    const ClientID &local_client_id, const std::vector<ClientID> &others) {
+    std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
+    const ClientID &local_client_id) {
   // The policy decision to be returned.
   std::unordered_map<TaskID, ClientID> decision;
   // TODO(atumanov): protect DEBUG code blocks with ifdef DEBUG
   RAY_LOG(DEBUG) << "[Schedule] cluster resource map: ";
+
   for (const auto &client_resource_pair : cluster_resources) {
     // pair = ClientID, SchedulingResources
     const ClientID &client_id = client_resource_pair.first;
@@ -36,12 +37,8 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
                    << " numforwards=" << t.GetTaskExecutionSpec().NumForwards()
                    << " resources="
                    << t.GetTaskSpecification().GetRequiredResources().ToString();
-    // TODO(atumanov): replace the simple spillback policy with exponential backoff based
-    // policy.
-    if (t.GetTaskExecutionSpec().NumForwards() >= 1) {
-      decision[task_id] = local_client_id;
-      continue;
-    }
+
+    // TODO(atumanov): try to place tasks locally first.
     // Construct a set of viable node candidates and randomly pick between them.
     // Get all the client id keys and randomly pick.
     std::vector<ClientID> client_keys;
@@ -49,9 +46,15 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       // pair = ClientID, SchedulingResources
       ClientID node_client_id = client_resource_pair.first;
       const auto &node_resources = client_resource_pair.second;
-      RAY_LOG(DEBUG) << "client_id " << node_client_id << " resources: "
-                     << node_resources.GetAvailableResources().ToString();
-      if (resource_demand.IsSubset(node_resources.GetTotalResources())) {
+      ResourceSet available_node_resources =
+          ResourceSet(node_resources.GetAvailableResources());
+      available_node_resources.SubtractResourcesStrict(node_resources.GetLoadResources());
+      RAY_LOG(DEBUG) << "client_id " << node_client_id
+                     << " avail: " << node_resources.GetAvailableResources().ToString()
+                     << " load: " << node_resources.GetLoadResources().ToString()
+                     << " avail-load: " << available_node_resources.ToString();
+
+      if (resource_demand.IsSubset(available_node_resources)) {
         // This node is a feasible candidate.
         client_keys.push_back(node_client_id);
       }
@@ -63,15 +66,22 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       // TODO(atumanov): change uniform random to discrete, weighted by resource capacity.
       std::uniform_int_distribution<int> distribution(0, client_keys.size() - 1);
       int client_key_index = distribution(gen_);
-      decision[task_id] = client_keys[client_key_index];
+      const ClientID &dst_client_id = client_keys[client_key_index];
+      decision[task_id] = dst_client_id;
+      // Update dst_client_id's load to keep track of remote task load until
+      // the next heartbeat.
+      ResourceSet new_load(cluster_resources[dst_client_id].GetLoadResources());
+      new_load.AddResources(resource_demand);
+      cluster_resources[dst_client_id].SetLoadResources(std::move(new_load));
       RAY_LOG(DEBUG) << "[SchedulingPolicy] idx=" << client_key_index << " " << task_id
                      << " --> " << client_keys[client_key_index];
     } else {
-      // There are no nodes that can feasibily execute this task. TODO(rkn): Propagate a
-      // warning to the user.
-      RAY_LOG(WARNING) << "This task requires "
-                       << t.GetTaskSpecification().GetRequiredResources().ToString()
-                       << ", but no nodes have the necessary resources.";
+      // There are no nodes that can feasibly execute this task. The task remains
+      // placeable until cluster capacity becomes available.
+      // TODO(rkn): Propagate a warning to the user.
+      RAY_LOG(DEBUG) << "This task requires "
+                     << t.GetTaskSpecification().GetRequiredResources().ToString()
+                     << ", but no nodes have the necessary resources.";
     }
   }
   return decision;

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -22,15 +22,18 @@ class SchedulingPolicy {
   /// \return Void.
   SchedulingPolicy(const SchedulingQueue &scheduling_queue);
 
-  /// Perform a scheduling operation, given a set of cluster resources and
-  /// producing a mapping of tasks to node managers.
+  /// \brief Perform a scheduling operation, given a set of cluster resources and
+  /// producing a mapping of tasks to raylets.
   ///
-  ///  \param cluster_resources: a set of cluster resources representing
-  ///         configured and current resource capacity on each node.
-  /// \return Scheduling decision, mapping tasks to node managers for placement.
+  /// \param cluster_resources: a set of cluster resources containing resource and load
+  /// information for some subset of the cluster. For all client IDs in the returned
+  /// placement map, the corresponding SchedulingResources::resources_load_ is
+  /// incremented by the aggregate resource demand of the tasks assigned to it.
+  ///
+  /// \return Scheduling decision, mapping tasks to raylets for placement.
   std::unordered_map<TaskID, ClientID> Schedule(
-      const std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-      const ClientID &local_client_id, const std::vector<ClientID> &others);
+      std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
+      const ClientID &local_client_id);
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -105,6 +105,27 @@ const std::list<Task> &SchedulingQueue::GetReadyTasks() const {
   return this->ready_tasks_.GetTasks();
 }
 
+ResourceSet SchedulingQueue::GetQueueResources(const TaskQueue &task_queue) const {
+  // Iterate over all tasks of the specified queue and aggregate total resource
+  // demand in a resource set.
+  ResourceSet queue_resources;
+  for (const auto &task : task_queue.GetTasks()) {
+    queue_resources.AddResources(task.GetTaskSpecification().GetRequiredResources());
+  }
+  return queue_resources;
+}
+
+ResourceSet SchedulingQueue::GetReadyQueueResources() const {
+  return GetQueueResources(ready_tasks_);
+}
+
+ResourceSet SchedulingQueue::GetResourceLoad() const {
+  ResourceSet load_resource_set;
+  load_resource_set.AddResources(GetReadyQueueResources());
+  // TODO(atumanov): consider other types of tasks as part of load.
+  return load_resource_set;
+}
+
 const std::list<Task> &SchedulingQueue::GetRunningTasks() const {
   return this->running_tasks_.GetTasks();
 }
@@ -262,6 +283,24 @@ void SchedulingQueue::RemoveDriverTaskId(const TaskID &driver_id) {
 
 const std::unordered_set<TaskID> &SchedulingQueue::GetDriverTaskIds() const {
   return driver_task_ids_;
+}
+
+const std::string SchedulingQueue::ToString() const {
+  std::string result;
+
+  result += "placeable_tasks_ size is " +
+            std::to_string(placeable_tasks_.GetTasks().size()) + "\n";
+  result +=
+      "waiting_tasks_ size is " + std::to_string(waiting_tasks_.GetTasks().size()) + "\n";
+  result +=
+      "ready_tasks_ size is " + std::to_string(ready_tasks_.GetTasks().size()) + "\n";
+  result +=
+      "running_tasks_ size is " + std::to_string(running_tasks_.GetTasks().size()) + "\n";
+  result +=
+      "blocked_tasks_ size is " + std::to_string(blocked_tasks_.GetTasks().size()) + "\n";
+  result += "methods_waiting_for_actor_creation_ size is " +
+            std::to_string(methods_waiting_for_actor_creation_.GetTasks().size()) + "\n";
+  return result;
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -51,6 +51,12 @@ class SchedulingQueue {
   /// dependencies local and that are waiting to be scheduled.
   const std::list<Task> &GetPlaceableTasks() const;
 
+  /// \brief Return an aggregate resource set for all tasks exerting load on this raylet.
+  ///
+  /// \return A resource set with aggregate resource information about resource load on
+  /// this raylet.
+  ResourceSet GetResourceLoad() const;
+
   /// Get the queue of tasks in the ready state.
   ///
   /// \return A const reference to the queue of tasks ready
@@ -153,6 +159,18 @@ class SchedulingQueue {
   /// \param filter_state The task state to filter out.
   void FilterState(std::unordered_set<TaskID> &task_ids, TaskState filter_state) const;
 
+  /// \brief Return all resource demand associated with the ready queue.
+  ///
+  /// \return Aggregate resource demand from ready tasks.
+  ResourceSet GetReadyQueueResources() const;
+
+  /// Return a human-readable string indicating the number of tasks in each
+  /// queue.
+  ///
+  /// \return A string that can be used to display the contents of the queues
+  /// for debugging purposes.
+  const std::string ToString() const;
+
   class TaskQueue {
    public:
     /// Creating a task queue.
@@ -217,6 +235,12 @@ class SchedulingQueue {
   /// The set of currently running driver tasks. These are empty tasks that are
   /// started by a driver process on initialization.
   std::unordered_set<TaskID> driver_task_ids_;
+
+  /// \brief Return all resource demand associated with the specified task queue.
+  ///
+  /// \param task_queue The task queue for which aggregate resource demand is calculated.
+  /// \return Aggregate resource demand.
+  ResourceSet GetQueueResources(const TaskQueue &task_queue) const;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -80,18 +80,26 @@ class ResourceSet {
   /// \return True, if the resource was successfully removed. False otherwise.
   bool RemoveResource(const std::string &resource_name);
 
-  /// \brief Add a set of resources to the current set of resources.
+  /// \brief Add a set of resources to the current set of resources only if the resource
+  /// labels match.
   ///
   /// \param other: The other resource set to add.
   /// \return True if the resource set was added successfully. False otherwise.
-  bool AddResources(const ResourceSet &other);
+  bool AddResourcesStrict(const ResourceSet &other);
 
-  /// \brief Subtract a set of resources from the current set of resources.
+  /// \brief Aggregate resources from the other set into this set, adding any missing
+  /// resource labels to this set.
+  ///
+  /// \param other: The other resource set to add.
+  void AddResources(const ResourceSet &other);
+
+  /// \brief Subtract a set of resources from the current set of resources, only if
+  /// resource labels match.
   ///
   /// \param other: The resource set to subtract from the current resource set.
   /// \return True if the resource set was subtracted successfully.
   /// False otherwise.
-  bool SubtractResources(const ResourceSet &other);
+  bool SubtractResourcesStrict(const ResourceSet &other);
 
   /// Return the capacity value associated with the specified resource.
   ///
@@ -340,6 +348,17 @@ class SchedulingResources {
 
   const ResourceSet &GetTotalResources() const;
 
+  /// \brief Overwrite information about resource load with new resource load set.
+  ///
+  /// \param newset: The set of resources that replaces resource load information.
+  /// \return Void.
+  void SetLoadResources(ResourceSet &&newset);
+
+  /// \brief Request the resource load information.
+  ///
+  /// \return Immutable set of resources describing the load information.
+  const ResourceSet &GetLoadResources() const;
+
   /// \brief Release the amount of resources specified.
   ///
   /// \param resources: the amount of resources to be released.
@@ -359,7 +378,8 @@ class SchedulingResources {
   ResourceSet resources_total_;
   /// Dynamic resource capacity (e.g., dynamic_resources).
   ResourceSet resources_available_;
-  /// gpu_map - replace with ResourceMap (for generality).
+  /// Resource load.
+  ResourceSet resources_load_;
 };
 
 }  // namespace raylet

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -766,9 +766,6 @@ class ActorsWithGPUs(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False), "Crashing with new GCS API.")
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorGPUs(self):
         num_local_schedulers = 3
         num_gpus_per_scheduler = 4
@@ -812,9 +809,6 @@ class ActorsWithGPUs(unittest.TestCase):
         ready_ids, _ = ray.wait([a.get_location_and_ids.remote()], timeout=10)
         assert ready_ids == []
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorMultipleGPUs(self):
         num_local_schedulers = 3
         num_gpus_per_scheduler = 5
@@ -887,9 +881,6 @@ class ActorsWithGPUs(unittest.TestCase):
         ready_ids, _ = ray.wait([a.get_location_and_ids.remote()], timeout=10)
         assert ready_ids == []
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorDifferentNumbersOfGPUs(self):
         # Test that we can create actors on two nodes that have different
         # numbers of GPUs.
@@ -932,9 +923,6 @@ class ActorsWithGPUs(unittest.TestCase):
         ready_ids, _ = ray.wait([a.get_location_and_ids.remote()], timeout=10)
         assert ready_ids == []
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorMultipleGPUsFromMultipleTasks(self):
         num_local_schedulers = 10
         num_gpus_per_scheduler = 10
@@ -982,9 +970,6 @@ class ActorsWithGPUs(unittest.TestCase):
         assert ready_ids == []
 
     @unittest.skipIf(sys.version_info < (3, 0), "This test requires Python 3.")
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorsAndTasksWithGPUs(self):
         num_local_schedulers = 3
         num_gpus_per_scheduler = 6

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2150,6 +2150,7 @@ class SchedulingAlgorithm(unittest.TestCase):
 
         @ray.remote
         def f(x):
+            time.sleep(0.010)
             return ray.worker.global_worker.plasma_client.store_socket_name
 
         # This object will be local to one of the local schedulers. Make sure


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
* distribute load and resource information on a heartbeat
* for each raylet, maintain total and available resource capacity as well as measure of current load
* this PR introduces a new notion of load, defined as a sum of all resource demand induced by queued ready tasks on the local raylet. This provides a heterogeneity-aware measure of load that supersedes legacy Ray's task count as a proxy for load.
* modify the scheduling policy to perform *capacity-based*, *load-aware*, *optimistically concurrent* resource allocation
* perform task spillover to the heartbeating node in response to a heartbeat, implementing  heterogeneity-aware late-binding/work-stealing.