### PR TITLE
Raise application-level exceptions for some failure scenarios.

### DIFF
--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -88,6 +88,10 @@ class RayConfig {
     return actor_creation_num_spillbacks_warning_;
   }
 
+  int node_manager_forward_task_retry_timeout_milliseconds() const {
+    return node_manager_forward_task_retry_timeout_milliseconds_;
+  }
+
   int object_manager_pull_timeout_ms() const {
     return object_manager_pull_timeout_ms_;
   }
@@ -131,6 +135,7 @@ class RayConfig {
         L3_cache_size_bytes_(100000000),
         max_tasks_to_spillback_(10),
         actor_creation_num_spillbacks_warning_(100),
+        node_manager_forward_task_retry_timeout_milliseconds_(1000),
         // TODO: Setting this to large values results in latency, which needs to
         // be addressed. This timeout is often on the critical path for object
         // transfers.
@@ -225,6 +230,10 @@ class RayConfig {
   /// corresponding driver. Since spillback currently occurs on a 100ms timer,
   /// a value of 100 corresponds to a warning every 10 seconds.
   int64_t actor_creation_num_spillbacks_warning_;
+
+  /// If a node manager attempts to forward a task to another node manager and
+  /// the forward fails, then it will resubmit the task after this duration.
+  int64_t node_manager_forward_task_retry_timeout_milliseconds_;
 
   /// Timeout, in milliseconds, to wait before retrying a failed pull in the
   /// ObjectManager.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -38,7 +38,7 @@ struct ObjectManagerConfig {
   int max_receives;
   /// Object chunk size, in bytes
   uint64_t object_chunk_size;
-  /// The stored socked name.
+  /// The store socket name.
   std::string store_socket_name;
   /// The time in milliseconds to wait until a Push request
   /// fails due to unsatisfied local object. Special value:

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -101,8 +101,8 @@ class ObjectManager : public ObjectManagerInterface {
   ///
   /// \param object_id The object's object id.
   /// \param client_id The remote node's client id.
-  /// \return Status of whether the push request successfully initiated.
-  ray::Status Push(const ObjectID &object_id, const ClientID &client_id);
+  /// \return Void.
+  void Push(const ObjectID &object_id, const ClientID &client_id);
 
   /// Pull an object from ClientID. Returns UniqueID asociated with
   /// an invocation of this method.

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -362,21 +362,21 @@ class StressTestObjectManager : public TestObjectManagerBase {
     case TransferPattern::PUSH_A_B: {
       for (int i = -1; ++i < num_trials;) {
         ObjectID oid1 = WriteDataToClient(client1, data_size);
-        status = server1->object_manager_.Push(oid1, client_id_2);
+        server1->object_manager_.Push(oid1, client_id_2);
       }
     } break;
     case TransferPattern::PUSH_B_A: {
       for (int i = -1; ++i < num_trials;) {
         ObjectID oid2 = WriteDataToClient(client2, data_size);
-        status = server2->object_manager_.Push(oid2, client_id_1);
+         server2->object_manager_.Push(oid2, client_id_1);
       }
     } break;
     case TransferPattern::BIDIRECTIONAL_PUSH: {
       for (int i = -1; ++i < num_trials;) {
         ObjectID oid1 = WriteDataToClient(client1, data_size);
-        status = server1->object_manager_.Push(oid1, client_id_2);
+        server1->object_manager_.Push(oid1, client_id_2);
         ObjectID oid2 = WriteDataToClient(client2, data_size);
-        status = server2->object_manager_.Push(oid2, client_id_1);
+        server2->object_manager_.Push(oid2, client_id_1);
       }
     } break;
     case TransferPattern::PULL_A_B: {

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -368,7 +368,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
     case TransferPattern::PUSH_B_A: {
       for (int i = -1; ++i < num_trials;) {
         ObjectID oid2 = WriteDataToClient(client2, data_size);
-         server2->object_manager_.Push(oid2, client_id_1);
+        server2->object_manager_.Push(oid2, client_id_1);
       }
     } break;
     case TransferPattern::BIDIRECTIONAL_PUSH: {

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -246,14 +246,14 @@ class TestObjectManager : public TestObjectManagerBase {
 
     // dummy_id is not local. The push function will timeout.
     ObjectID dummy_id = ObjectID::from_random();
-    server1->object_manager_.Push(
-        dummy_id, gcs_client_2->client_table().GetLocalClientId());
+    server1->object_manager_.Push(dummy_id,
+                                  gcs_client_2->client_table().GetLocalClientId());
 
     created_object_id1 = ObjectID::from_random();
     WriteDataToClient(client1, data_size, created_object_id1);
     // Server1 holds Object1 so this Push call will success.
-    server1->object_manager_.Push(
-        created_object_id1, gcs_client_2->client_table().GetLocalClientId());
+    server1->object_manager_.Push(created_object_id1,
+                                  gcs_client_2->client_table().GetLocalClientId());
 
     // This timer is used to guarantee that the Push function for dummy_id will timeout.
     timer.reset(new boost::asio::deadline_timer(main_service));

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -246,13 +246,13 @@ class TestObjectManager : public TestObjectManagerBase {
 
     // dummy_id is not local. The push function will timeout.
     ObjectID dummy_id = ObjectID::from_random();
-    status = server1->object_manager_.Push(
+    server1->object_manager_.Push(
         dummy_id, gcs_client_2->client_table().GetLocalClientId());
 
     created_object_id1 = ObjectID::from_random();
     WriteDataToClient(client1, data_size, created_object_id1);
     // Server1 holds Object1 so this Push call will success.
-    status = server1->object_manager_.Push(
+    server1->object_manager_.Push(
         created_object_id1, gcs_client_2->client_table().GetLocalClientId());
 
     // This timer is used to guarantee that the Push function for dummy_id will timeout.

--- a/src/ray/raylet/actor_registration.cc
+++ b/src/ray/raylet/actor_registration.cc
@@ -8,6 +8,7 @@ namespace raylet {
 
 ActorRegistration::ActorRegistration(const ActorTableDataT &actor_table_data)
     : actor_table_data_(actor_table_data),
+      alive_(true),
       execution_dependency_(ObjectID::nil()),
       frontier_() {}
 
@@ -34,6 +35,14 @@ void ActorRegistration::ExtendFrontier(const ActorHandleID &handle_id,
   frontier_entry.task_counter++;
   frontier_entry.execution_dependency = execution_dependency;
   execution_dependency_ = execution_dependency;
+}
+
+bool ActorRegistration::IsAlive() const {
+  return alive_;
+}
+
+void ActorRegistration::MarkDead() {
+  alive_ = false;
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/actor_registration.cc
+++ b/src/ray/raylet/actor_registration.cc
@@ -37,13 +37,9 @@ void ActorRegistration::ExtendFrontier(const ActorHandleID &handle_id,
   execution_dependency_ = execution_dependency;
 }
 
-bool ActorRegistration::IsAlive() const {
-  return alive_;
-}
+bool ActorRegistration::IsAlive() const { return alive_; }
 
-void ActorRegistration::MarkDead() {
-  alive_ = false;
-}
+void ActorRegistration::MarkDead() { alive_ = false; }
 
 }  // namespace raylet
 

--- a/src/ray/raylet/actor_registration.h
+++ b/src/ray/raylet/actor_registration.h
@@ -14,7 +14,8 @@ namespace raylet {
 ///
 /// Information about an actor registered in the system. This includes the
 /// actor's current node manager location, and if local, information about its
-/// current execution state, used for reconstruction purposes.
+/// current execution state, used for reconstruction purposes, and whether the
+/// actor is currently alive or not.
 class ActorRegistration {
  public:
   /// Create an actor registration.
@@ -74,10 +75,22 @@ class ActorRegistration {
   void ExtendFrontier(const ActorHandleID &handle_id,
                       const ObjectID &execution_dependency);
 
+  /// Return whether the actor is alive or not. This should only be called on
+  /// local actors.
+  ///
+  /// \return True if the local actor is alive and false if it is dead.
+  bool IsAlive() const;
+
+  /// Mark the actor as dead.
+  /// \return Void.
+  void MarkDead();
+
  private:
   /// Information from the global actor table about this actor, including the
   /// node manager location.
   ActorTableDataT actor_table_data_;
+  /// True if the actor is alive and false otherwise.
+  bool alive_;
   /// The object representing the state following the actor's most recently
   /// executed task. The next task to execute on the actor should be marked as
   /// execution-dependent on this object.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -48,6 +48,7 @@ int main(int argc, char *argv[]) {
   node_manager_config.heartbeat_period_ms =
       RayConfig::instance().heartbeat_timeout_milliseconds();
   node_manager_config.max_lineage_size = RayConfig::instance().max_lineage_size();
+  node_manager_config.store_socket_name = store_socket_name;
 
   // Configuration for the object manager.
   ray::ObjectManagerConfig object_manager_config;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -387,7 +387,9 @@ void NodeManager::CleanUpTasksForDeadActor(const ActorID &actor_id) {
 
   auto removed_tasks = local_queues_.RemoveTasks(tasks_to_remove);
   for (auto const &task : removed_tasks) {
-    TreatTaskAsFailed(task.GetTaskSpecification());
+    const TaskSpecification &spec = task.GetTaskSpecification();
+    TreatTaskAsFailed(spec);
+    task_dependency_manager_.TaskCanceled(spec.TaskId());
   }
 }
 
@@ -482,6 +484,7 @@ void NodeManager::ProcessClientMessage(
         // Handle the task failure in order to raise an exception in the
         // application.
         TreatTaskAsFailed(spec);
+        task_dependency_manager_.TaskCanceled(spec.TaskId());
         local_queues_.RemoveTasks({spec.TaskId()});
       }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -485,7 +485,7 @@ void NodeManager::ProcessClientMessage(
         // application.
         TreatTaskAsFailed(spec);
         task_dependency_manager_.TaskCanceled(spec.TaskId());
-        local_queues_.RemoveTasks({spec.TaskId()});
+        local_queues_.RemoveTask(spec.TaskId());
       }
 
       worker_pool_.DisconnectWorker(worker);
@@ -705,13 +705,13 @@ void NodeManager::ScheduleTasks() {
   std::unordered_set<TaskID> local_task_ids;
   // Iterate over (taskid, clientid) pairs, extract tasks assigned to the local node.
   for (const auto &task_schedule : policy_decision) {
-    TaskID task_id = task_schedule.first;
-    ClientID client_id = task_schedule.second;
+    const TaskID task_id = task_schedule.first;
+    const ClientID client_id = task_schedule.second;
     if (client_id == gcs_client_->client_table().GetLocalClientId()) {
       local_task_ids.insert(task_id);
     } else {
       // TODO(atumanov): need a better interface for task exit on forward.
-      const auto task = local_queues_.RemoveTasks(task_id);
+      const auto task = local_queues_.RemoveTask(task_id);
       // Attempt to forward the task. If this fails to forward the task,
       // the task will be resubmit locally.
       ForwardTaskOrResubmit(task, client_id);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -754,8 +754,9 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
                           << " to node manager " << node_manager_id;
             // TODO(rkn): Confirm that io_service_ is the right place to do this.........................
             boost::asio::deadline_timer timer(io_service_);
-            int64_t forward_task_retry_duration_milliseconds_ = 1000;  // Define this elsewhere..............
-            auto retry_duration = boost::posix_time::milliseconds(forward_task_retry_duration_milliseconds_);
+            auto retry_duration = boost::posix_time::milliseconds(
+                RayConfig::instance()
+                    .node_manager_forward_task_retry_timeout_milliseconds());
             timer.expires_from_now(retry_duration);
             timer.async_wait(
                 [this, task](const boost::system::error_code &error) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -379,16 +379,11 @@ void NodeManager::CleanUpTasksForDeadActor(const ActorID &actor_id) {
 
   GetActorTasksFromList(actor_id, local_queues_.GetUncreatedActorMethods(),
                         tasks_to_remove);
-  GetActorTasksFromList(actor_id, local_queues_.GetWaitingTasks(),
-                        tasks_to_remove);
-  GetActorTasksFromList(actor_id, local_queues_.GetPlaceableTasks(),
-                        tasks_to_remove);
-  GetActorTasksFromList(actor_id, local_queues_.GetReadyTasks(),
-                        tasks_to_remove);
-  GetActorTasksFromList(actor_id, local_queues_.GetRunningTasks(),
-                        tasks_to_remove);
-  GetActorTasksFromList(actor_id, local_queues_.GetBlockedTasks(),
-                        tasks_to_remove);
+  GetActorTasksFromList(actor_id, local_queues_.GetWaitingTasks(), tasks_to_remove);
+  GetActorTasksFromList(actor_id, local_queues_.GetPlaceableTasks(), tasks_to_remove);
+  GetActorTasksFromList(actor_id, local_queues_.GetReadyTasks(), tasks_to_remove);
+  GetActorTasksFromList(actor_id, local_queues_.GetRunningTasks(), tasks_to_remove);
+  GetActorTasksFromList(actor_id, local_queues_.GetBlockedTasks(), tasks_to_remove);
 
   auto removed_tasks = local_queues_.RemoveTasks(tasks_to_remove);
   for (auto const &task : removed_tasks) {
@@ -1144,18 +1139,16 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
     // Create a timer to resubmit the task in a little bit.
     boost::asio::deadline_timer timer(io_service_);
     auto retry_duration = boost::posix_time::milliseconds(
-        RayConfig::instance()
-            .node_manager_forward_task_retry_timeout_milliseconds());
+        RayConfig::instance().node_manager_forward_task_retry_timeout_milliseconds());
     timer.expires_from_now(retry_duration);
-    timer.async_wait(
-        [this, task, task_id](const boost::system::error_code &error) {
-          // Timer killing will receive the boost::asio::error::operation_aborted,
-          // we only handle the timeout event.
-          if (!error) {
-            RAY_LOG(INFO) << "In ForwardTask retry callback for task " << task_id;
-            EnqueuePlaceableTask(task);
-          }
-        });
+    timer.async_wait([this, task, task_id](const boost::system::error_code &error) {
+      // Timer killing will receive the boost::asio::error::operation_aborted,
+      // we only handle the timeout event.
+      if (!error) {
+        RAY_LOG(INFO) << "In ForwardTask retry callback for task " << task_id;
+        EnqueuePlaceableTask(task);
+      }
+    });
   }
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -493,6 +493,8 @@ void NodeManager::ProcessClientMessage(
       // If the worker was an actor, add it to the list of dead actors.
       const ActorID actor_id = worker->GetActorId();
       if (!actor_id.is_nil()) {
+        // TODO(rkn): Consider broadcasting a message to all of the other
+        // node managers so that they can mark the actor as dead.
         RAY_LOG(DEBUG) << "The actor with ID " << actor_id << " died.";
         auto actor_entry = actor_registry_.find(actor_id);
         RAY_CHECK(actor_entry != actor_registry_.end());

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -440,7 +440,7 @@ void NodeManager::ProcessClientMessage(
         RAY_CHECK(running_tasks.size() != 0);
         RAY_CHECK(it != running_tasks.end());
         const TaskSpecification &spec = it->GetTaskSpecification();
-        JobID job_id = spec.DriverId();
+        const JobID job_id = spec.DriverId();
         // TODO(rkn): Define this constant somewhere else.
         std::string type = "worker_died";
         std::ostringstream error_message;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -187,12 +187,6 @@ class NodeManager {
   /// A mapping from actor ID to registration information about that actor
   /// (including which node manager owns it).
   std::unordered_map<ActorID, ActorRegistration> actor_registry_;
-  /// If we attempt to forward a task to another node and the forward fails,
-  /// then we create a timer to resubmit the task after some time. That timer is
-  /// stored here and is deallocated once the timer fires. TODO(rkn): This feels
-  /// too much like manual memory management. There must be a cleaner way of
-  /// doing this.
-  std::unordered_map<TaskID, boost::asio::deadline_timer> task_resubmission_timers_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -127,8 +127,7 @@ class NodeManager {
   /// \param tasks A list of tasks to extract from.
   /// \param tasks_to_remove The task IDs of the extracted tasks are inserted in
   /// this vector.
-  void GetActorTasksFromList(const ActorID &actor_id,
-                             const std::list<Task> &tasks,
+  void GetActorTasksFromList(const ActorID &actor_id, const std::list<Task> &tasks,
                              std::unordered_set<TaskID> &tasks_to_remove);
 
   /// When an actor dies, loop over all of the queued tasks for that actor and

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -94,6 +94,12 @@ class NodeManager {
   void ScheduleTasks();
   /// Resubmit a task whose return value needs to be reconstructed.
   void ResubmitTask(const TaskID &task_id);
+  /// Attempt to forward a task to a remote different node manager. If this
+  /// fails, the task will be resubmit locally.
+  ///
+  /// \param task The task in question.
+  /// \param node_manager_id The ID of the remote node manager.
+  void ForwardTaskOrResubmit(const Task &task, const ClientID &node_manager_id);
   /// Forward a task to another node to execute. The task is assumed to not be
   /// queued in local_queues_.
   ray::Status ForwardTask(const Task &task, const ClientID &node_id);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -116,6 +116,28 @@ class NodeManager {
   void HandleActorCreation(const ActorID &actor_id,
                            const std::vector<ActorTableDataT> &data);
 
+  /// TODO(rkn): This should probably be removed when we improve the
+  /// SchedulingQueue API. This is a helper function for
+  /// CleanUpTasksForDeadActor.
+  ///
+  /// This essentially loops over all of the tasks in the provided list and
+  /// finds The IDs of the tasks that belong to the given actor.
+  ///
+  /// \param actor_id The actor to get the tasks for.
+  /// \param tasks A list of tasks to extract from.
+  /// \param tasks_to_remove The task IDs of the extracted tasks are inserted in
+  /// this vector.
+  void GetActorTasksFromList(const ActorID &actor_id,
+                             const std::list<Task> &tasks,
+                             std::unordered_set<TaskID> &tasks_to_remove);
+
+  /// When an actor dies, loop over all of the queued tasks for that actor and
+  /// treat them as failed.
+  ///
+  /// \param actor_id The actor that died.
+  /// \return Void.
+  void CleanUpTasksForDeadActor(const ActorID &actor_id);
+
   /// Methods for managing object dependencies.
   /// Handle a dependency required by a queued task that is missing locally.
   /// The dependency is (1) on a remote node, (2) pending creation on a remote

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -188,9 +188,6 @@ class NodeManager {
   /// A mapping from actor ID to registration information about that actor
   /// (including which node manager owns it).
   std::unordered_map<ActorID, ActorRegistration> actor_registry_;
-  /// A list of the actors on this node that have died. In principle, this could
-  /// grow unbounded.
-  std::unordered_set<ActorID> dead_actors_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -187,6 +187,12 @@ class NodeManager {
   /// A mapping from actor ID to registration information about that actor
   /// (including which node manager owns it).
   std::unordered_map<ActorID, ActorRegistration> actor_registry_;
+  /// If we attempt to forward a task to another node and the forward fails,
+  /// then we create a timer to resubmit the task after some time. That timer is
+  /// stored here and is deallocated once the timer fires. TODO(rkn): This feels
+  /// too much like manual memory management. There must be a cleaner way of
+  /// doing this.
+  std::unordered_map<TaskID, boost::asio::deadline_timer> task_resubmission_timers_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -75,8 +75,14 @@ class NodeManager {
   /// Methods for task scheduling.
   /// Enqueue a placeable task to wait on object dependencies or be ready for dispatch.
   void EnqueuePlaceableTask(const Task &task);
-  /// Handle an actor task that cannot be executed because the actor is dead.
-  void HandleTaskForDeadActor(const TaskSpecification &spec);
+  /// This will treat the task as if it had been executed and failed. This is
+  /// done by looping over the task return IDs and for each ID storing an object
+  /// that represents a failure in the object store. When clients retrieve these
+  /// objects, they will raise application-level exceptions.
+  ///
+  /// \param spec The specification of the task.
+  /// \return Void.
+  void TreatTaskAsFailed(const TaskSpecification &spec);
   /// Handle specified task's submission to the local node manager.
   void SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
                   bool forwarded = false);

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -174,7 +174,7 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
 
     num_expected_objects = (uint)1;
     ObjectID oid1 = WriteDataToClient(client1, data_size);
-    status = server1->object_manager_.Push(oid1, client_id_2);
+    server1->object_manager_.Push(oid1, client_id_2);
   }
 
   void TestPushComplete() {

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -300,9 +300,6 @@ class WorkerDeath(unittest.TestCase):
         self.assertIn("died or was killed while executing",
                       ray.error_info()[0]["message"])
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorWorkerDying(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
 
@@ -321,9 +318,6 @@ class WorkerDeath(unittest.TestCase):
         self.assertRaises(Exception, lambda: ray.get(consume.remote(obj)))
         wait_for_errors(ray_constants.WORKER_DIED_PUSH_ERROR, 1)
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorWorkerDyingFutureTasks(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
 
@@ -346,9 +340,6 @@ class WorkerDeath(unittest.TestCase):
 
         wait_for_errors(ray_constants.WORKER_DIED_PUSH_ERROR, 1)
 
-    @unittest.skipIf(
-        os.environ.get("RAY_USE_XRAY") == "1",
-        "This test does not work with xray yet.")
     def testActorWorkerDyingNothingInProgress(self):
         ray.init(num_workers=0, driver_mode=ray.SILENT_MODE)
 


### PR DESCRIPTION
**In this PR**
- Node managers keep track of all local actors that have died or exited.
- If a task is submitted for an actor that has died, then we raise an application-level exception (by storing "failure" objects in the object store for that task's outputs).
- If a task is submitted for an actor that lives on a node manager that has been marked dead by the monitor, then we raise an application-level exception (via the same mechanism).
- If we attempt to forward a task to a remote node manager and the forward fails, then we resubmit the task locally after 1 second. Note that the forwarding won't necessarily fail if the remote node manager is dead, so we need to rely on other mechanisms to ensure that the task is not lost.
- We give the node manager it's own plasma client so that it can create failure objects.

**TODO in this PR**
- [x] Add tests, e.g., maybe enable the tests from #1224.
- [x] Cleanup for actor deaths (when an actor dies, we need to handle all of the queued tasks for that actor).
- [x] Some of the functionality in `NodeManager::FinishAssignedTask` needs to be performed when we treat a task as failed. For example, removing it from `local_queues_` and notifying the `task_dependency_manager_`.

**Not done in this PR**
- Currently, we do not handle the case where we successfully forward a task to an actor that lives on a remote node manager and then the remote node manager dies. That's because we currently don't do anything when a worker calls "reconstruct object" on an object, and we rely on that mechanism to handle that case.
- One thing we should figure out how to do in a subsequent PR is how to treat actor tasks as failed when the objects have been evicted and are needed but can't be created because the actor is still running.

Note that this is similar to what @ericl did in #1224.