### PR TITLE
Fix error installing library targets.

### DIFF
--- a/src/ray/object_manager/CMakeLists.txt
+++ b/src/ray/object_manager/CMakeLists.txt
@@ -27,4 +27,4 @@ target_link_libraries(object_manager common ray_static ${PLASMA_STATIC_LIB} ${AR
 
 install(TARGETS
         object_manager
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ray/object_manager")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/src/ray/object_manager/CMakeLists.txt
+++ b/src/ray/object_manager/CMakeLists.txt
@@ -25,6 +25,6 @@ ADD_RAY_TEST(test/object_manager_stress_test STATIC_LINK_LIBS ray_static ${PLASM
 add_library(object_manager object_manager.cc object_manager.h ${OBJECT_MANAGER_FBS_OUTPUT_FILES})
 target_link_libraries(object_manager common ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY})
 
-install(FILES
+install(TARGETS
         object_manager
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ray/object_manager")

--- a/src/ray/raylet/CMakeLists.txt
+++ b/src/ray/raylet/CMakeLists.txt
@@ -48,6 +48,6 @@ target_link_libraries(raylet rayletlib ${Boost_SYSTEM_LIBRARY} pthread)
 add_executable(raylet_monitor monitor_main.cc)
 target_link_libraries(raylet_monitor rayletlib ${Boost_SYSTEM_LIBRARY} pthread)
 
-install(FILES
+install(TARGETS
         raylet
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ray/raylet")

--- a/src/ray/raylet/CMakeLists.txt
+++ b/src/ray/raylet/CMakeLists.txt
@@ -50,4 +50,4 @@ target_link_libraries(raylet_monitor rayletlib ${Boost_SYSTEM_LIBRARY} pthread)
 
 install(TARGETS
         raylet
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ray/raylet")
+        DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
A typo caused CMake to look for the files `object_manager`, `raylet`, etc. in the source directory, instead of built targets.