### PR TITLE
Use absolute path to get to thirdparty dir

### DIFF
--- a/setup_thirdparty.sh
+++ b/setup_thirdparty.sh
@@ -21,7 +21,7 @@ fi
 $TP_DIR/thirdparty/scripts/setup.sh $PYTHON_EXECUTABLE $LANGUAGE
 
 if [[ "$LANGUAGE" == "java" ]]; then
-    pushd thirdparty/build/arrow/java
+    pushd $TP_DIR/thirdparty/build/arrow/java
     mvn clean install -pl plasma -am -Dmaven.test.skip
     popd
 fi

--- a/setup_thirdparty.sh
+++ b/setup_thirdparty.sh
@@ -4,7 +4,7 @@ set -x
 # Cause the script to exit if a single command fails.
 set -e
 
-TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 if [[ -z  "$1" ]]; then
   PYTHON_EXECUTABLE=`which python`
@@ -18,10 +18,10 @@ if [[ -n  "$2" ]]; then
   LANGUAGE=$2
 fi
 
-$TP_DIR/thirdparty/scripts/setup.sh $PYTHON_EXECUTABLE $LANGUAGE
+$ROOT_DIR/thirdparty/scripts/setup.sh $PYTHON_EXECUTABLE $LANGUAGE
 
 if [[ "$LANGUAGE" == "java" ]]; then
-    pushd $TP_DIR/thirdparty/build/arrow/java
+    pushd $ROOT_DIR/thirdparty/build/arrow/java
     mvn clean install -pl plasma -am -Dmaven.test.skip
     popd
 fi


### PR DESCRIPTION
In case this script is executed from a different directory than the Ray's directory, the `pushd` will fail. This commit uses absolute path to `thirdparty` directory.