### PR TITLE
[rllib] Better support and add two-trainer example for multiagent

### DIFF
--- a/doc/source/rllib-env.rst
+++ b/doc/source/rllib-env.rst
@@ -112,7 +112,7 @@ If all the agents will be using the same algorithm class to train, then you can 
 
 RLlib will create three distinct policies and route agent decisions to its bound policy. When an agent first appears in the env, ``policy_mapping_fn`` will be called to determine which policy it is bound to. RLlib reports separate training statistics for each policy in the return from ``train()``, along with the combined reward.
 
-Here is a simple `example training script <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_cartpole.py>`__ in which you can vary the number of agents and policies in the environment. For more advanced usage, e.g., different classes of policies per agent, or more control over the training process, you can use the lower-level RLlib APIs directly to define custom policy graphs or algorithms.
+Here is a simple `example training script <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_cartpole.py>`__ in which you can vary the number of agents and policies in the environment. For an example of using multiple training methods at once (here DQN and PPO), see the `two-trainer example <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_two_trainers.py>`__.
 
 To scale to hundreds of agents, MultiAgentEnv batches policy evaluations across multiple agents internally. It can also be auto-vectorized by setting ``num_envs_per_worker > 1``.
 

--- a/doc/source/rllib-env.rst
+++ b/doc/source/rllib-env.rst
@@ -112,7 +112,7 @@ If all the agents will be using the same algorithm class to train, then you can 
 
 RLlib will create three distinct policies and route agent decisions to its bound policy. When an agent first appears in the env, ``policy_mapping_fn`` will be called to determine which policy it is bound to. RLlib reports separate training statistics for each policy in the return from ``train()``, along with the combined reward.
 
-Here is a simple `example training script <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_cartpole.py>`__ in which you can vary the number of agents and policies in the environment. For an example of using multiple training methods at once (here DQN and PPO), see the `two-trainer example <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_two_trainers.py>`__.
+Here is a simple `example training script <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_cartpole.py>`__ in which you can vary the number of agents and policies in the environment. For how to use multiple training methods at once (here DQN and PPO), see the `two-trainer example <https://github.com/ray-project/ray/blob/master/python/ray/rllib/examples/multiagent_two_trainers.py>`__.
 
 To scale to hundreds of agents, MultiAgentEnv batches policy evaluations across multiple agents internally. It can also be auto-vectorized by setting ``num_envs_per_worker > 1``.
 

--- a/python/ray/rllib/agents/dqn/dqn.py
+++ b/python/ray/rllib/agents/dqn/dqn.py
@@ -166,7 +166,8 @@ class DQNAgent(Agent):
     def update_target_if_needed(self):
         if self.global_timestep - self.last_target_update_ts > \
                 self.config["target_network_update_freq"]:
-            self.local_evaluator.foreach_policy(lambda p, _: p.update_target())
+            self.local_evaluator.foreach_trainable_policy(
+                lambda p, _: p.update_target())
             self.last_target_update_ts = self.global_timestep
             self.num_target_updates += 1
 
@@ -179,11 +180,12 @@ class DQNAgent(Agent):
             self.update_target_if_needed()
 
         exp_vals = [self.exploration0.value(self.global_timestep)]
-        self.local_evaluator.foreach_policy(
+        self.local_evaluator.foreach_trainable_policy(
             lambda p, _: p.set_epsilon(exp_vals[0]))
         for i, e in enumerate(self.remote_evaluators):
             exp_val = self.explorations[i].value(self.global_timestep)
-            e.foreach_policy.remote(lambda p, _: p.set_epsilon(exp_val))
+            e.foreach_trainable_policy.remote(
+                lambda p, _: p.set_epsilon(exp_val))
             exp_vals.append(exp_val)
 
         if self.config["per_worker_exploration"]:

--- a/python/ray/rllib/agents/ppo/ppo_policy_graph.py
+++ b/python/ray/rllib/agents/ppo/ppo_policy_graph.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import tensorflow as tf
 
+import ray
 from ray.rllib.evaluation.postprocessing import compute_advantages
 from ray.rllib.evaluation.tf_policy_graph import TFPolicyGraph
 from ray.rllib.models.catalog import ModelCatalog
@@ -96,6 +97,7 @@ class PPOPolicyGraph(TFPolicyGraph):
             existing_inputs (list): Optional list of tuples that specify the
                 placeholders upon which the graph should be built upon.
         """
+        config = dict(ray.rllib.agents.ppo.ppo.DEFAULT_CONFIG, **config)
         self.sess = tf.get_default_session()
         self.action_space = action_space
         self.config = config

--- a/python/ray/rllib/evaluation/policy_evaluator.py
+++ b/python/ray/rllib/evaluation/policy_evaluator.py
@@ -162,8 +162,6 @@ class PolicyEvaluator(EvaluatorInterface):
         policy_mapping_fn = (policy_mapping_fn
                              or (lambda agent_id: DEFAULT_POLICY_ID))
         self.env_creator = env_creator
-        self.policy_graph = policy_graph
-        self.policies_to_train = policies_to_train or list(policy_graph.keys())
         self.batch_steps = batch_steps
         self.batch_mode = batch_mode
         self.compress_observations = compress_observations
@@ -195,6 +193,7 @@ class PolicyEvaluator(EvaluatorInterface):
 
         self.tf_sess = None
         policy_dict = _validate_and_canonicalize(policy_graph, self.env)
+        self.policies_to_train = policies_to_train or list(policy_dict.keys())
         if _has_tensorflow_graph(policy_dict):
             with tf.Graph().as_default():
                 if tf_session_creator:

--- a/python/ray/rllib/evaluation/policy_evaluator.py
+++ b/python/ray/rllib/evaluation/policy_evaluator.py
@@ -86,6 +86,7 @@ class PolicyEvaluator(EvaluatorInterface):
                  env_creator,
                  policy_graph,
                  policy_mapping_fn=None,
+                 policies_to_train=None,
                  tf_session_creator=None,
                  batch_steps=100,
                  batch_mode="truncate_episodes",
@@ -113,6 +114,8 @@ class PolicyEvaluator(EvaluatorInterface):
                 policy ids in multi-agent mode. This function will be called
                 each time a new agent appears in an episode, to bind that agent
                 to a policy for the duration of the episode.
+            policies_to_train (list): Optional whitelist of policies to train,
+                or None for all policies.
             tf_session_creator (func): A function that returns a TF session.
                 This is optional and only useful with TFPolicyGraph.
             batch_steps (int): The target number of env transitions to include
@@ -160,6 +163,7 @@ class PolicyEvaluator(EvaluatorInterface):
                              or (lambda agent_id: DEFAULT_POLICY_ID))
         self.env_creator = env_creator
         self.policy_graph = policy_graph
+        self.policies_to_train = policies_to_train or list(policy_graph.keys())
         self.batch_steps = batch_steps
         self.batch_mode = batch_mode
         self.compress_observations = compress_observations
@@ -300,6 +304,16 @@ class PolicyEvaluator(EvaluatorInterface):
 
         return [func(policy, pid) for pid, policy in self.policy_map.items()]
 
+    def foreach_trainable_policy(self, func):
+        """Apply the given function to each (policy, policy_id) tuple.
+
+        This only applies func to policies in `self.policies_to_train`."""
+
+        return [
+            func(policy, pid) for pid, policy in self.policy_map.items()
+            if pid in self.policies_to_train
+        ]
+
     def sync_filters(self, new_filters):
         """Changes self's filter to given and rebases any accumulated delta.
 
@@ -326,10 +340,12 @@ class PolicyEvaluator(EvaluatorInterface):
                 f.clear_buffer()
         return return_filters
 
-    def get_weights(self):
+    def get_weights(self, policies=None):
+        if policies is None:
+            policies = self.policy_map.keys()
         return {
             pid: policy.get_weights()
-            for pid, policy in self.policy_map.items()
+            for pid, policy in self.policy_map.items() if pid in policies
         }
 
     def set_weights(self, weights):
@@ -342,6 +358,8 @@ class PolicyEvaluator(EvaluatorInterface):
             if self.tf_sess is not None:
                 builder = TFRunBuilder(self.tf_sess, "compute_gradients")
                 for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
                     grad_out[pid], info_out[pid] = (
                         self.policy_map[pid].build_compute_gradients(
                             builder, batch))
@@ -381,6 +399,8 @@ class PolicyEvaluator(EvaluatorInterface):
             if self.tf_sess is not None:
                 builder = TFRunBuilder(self.tf_sess, "compute_apply")
                 for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
                     info_out[pid], _ = (
                         self.policy_map[pid].build_compute_apply(
                             builder, batch))

--- a/python/ray/rllib/examples/multiagent_two_trainers.py
+++ b/python/ray/rllib/examples/multiagent_two_trainers.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
 """Example of using two different training methods at once in multi-agent.
 
 Here we create a number of CartPole agents, some of which are trained with
@@ -16,18 +15,16 @@ import argparse
 import gym
 
 import ray
-from ray.rllib.agents.dqn.dqn import DQNAgent, DEFAULT_CONFIG as DQN_CONFIG
+from ray.rllib.agents.dqn.dqn import DQNAgent
 from ray.rllib.agents.dqn.dqn_policy_graph import DQNPolicyGraph
-from ray.rllib.agents.ppo.ppo import PPOAgent, DEFAULT_CONFIG as PPO_CONFIG
+from ray.rllib.agents.ppo.ppo import PPOAgent
 from ray.rllib.agents.ppo.ppo_policy_graph import PPOPolicyGraph
-from ray.rllib.test.test_multi_agent_env import MultiCartpole
 from ray.rllib.test.test_multi_agent_env import MultiCartpole
 from ray.tune.logger import pretty_print
 from ray.tune.registry import register_env
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--num-iters", type=int, default=20)
-
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/python/ray/rllib/examples/multiagent_two_trainers.py
+++ b/python/ray/rllib/examples/multiagent_two_trainers.py
@@ -83,6 +83,11 @@ if __name__ == "__main__":
         lambda ev: ev.for_policy(
             lambda pi: pi.set_epsilon(0.0), policy_id="dqn_policy"))
 
+    # You should see both the printed X and Y approach 200 as this trains:
+    # info:
+    #   policy_reward_mean:
+    #     dqn_policy: X
+    #     ppo_policy: Y
     for i in range(args.num_iters):
         print("== Iteration", i, "==")
 

--- a/python/ray/rllib/examples/multiagent_two_trainers.py
+++ b/python/ray/rllib/examples/multiagent_two_trainers.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+"""Example of using two different training methods at once in multi-agent.
+
+Here we create a number of CartPole agents, some of which are trained with
+DQN, and some of which are trained with PPO. We periodically sync weights
+between the two trainers (note that no such syncing is needed when using just
+a single training method).
+
+For a simpler example, see also: multiagent_cartpole.py
+"""
+
+import argparse
+import gym
+
+import ray
+from ray.rllib.agents.dqn.dqn import DQNAgent, DEFAULT_CONFIG as DQN_CONFIG
+from ray.rllib.agents.dqn.dqn_policy_graph import DQNPolicyGraph
+from ray.rllib.agents.ppo.ppo import PPOAgent, DEFAULT_CONFIG as PPO_CONFIG
+from ray.rllib.agents.ppo.ppo_policy_graph import PPOPolicyGraph
+from ray.rllib.test.test_multi_agent_env import MultiCartpole
+from ray.rllib.test.test_multi_agent_env import MultiCartpole
+from ray.tune.logger import pretty_print
+from ray.tune.registry import register_env
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--num-iters", type=int, default=20)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    ray.init()
+
+    # Simple environment with 4 independent cartpole entities
+    register_env("multi_cartpole", lambda _: MultiCartpole(4))
+    single_env = gym.make("CartPole-v0")
+    obs_space = single_env.observation_space
+    act_space = single_env.action_space
+
+    # You can also have multiple policy graphs per trainer, but here we just
+    # show one each for PPO and DQN.
+    policy_graphs = {
+        "ppo_policy": (PPOPolicyGraph, obs_space, act_space, {}),
+        "dqn_policy": (DQNPolicyGraph, obs_space, act_space, {}),
+    }
+
+    def policy_mapping_fn(agent_id):
+        if agent_id % 2 == 0:
+            return "ppo_policy"
+        else:
+            return "dqn_policy"
+
+    ppo_trainer = PPOAgent(
+        env="multi_cartpole",
+        config={
+            "multiagent": {
+                "policy_graphs": policy_graphs,
+                "policy_mapping_fn": policy_mapping_fn,
+                "policies_to_train": ["ppo_policy"],
+            },
+            "simple_optimizer": True,
+            # disable filters, otherwise we would need to synchronize those
+            # as well to the DQN agent
+            "observation_filter": "NoFilter",
+        })
+
+    dqn_trainer = DQNAgent(
+        env="multi_cartpole",
+        config={
+            "multiagent": {
+                "policy_graphs": policy_graphs,
+                "policy_mapping_fn": policy_mapping_fn,
+                "policies_to_train": ["dqn_policy"],
+            },
+            "gamma": 0.95,
+            "n_step": 3,
+        })
+
+    # disable DQN exploration when used by the PPO trainer
+    ppo_trainer.optimizer.foreach_evaluator(
+        lambda ev: ev.for_policy(
+            lambda pi: pi.set_epsilon(0.0), policy_id="dqn_policy"))
+
+    for i in range(args.num_iters):
+        print("== Iteration", i, "==")
+
+        # improve the DQN policy
+        print("-- DQN --")
+        print(pretty_print(dqn_trainer.train()))
+
+        # improve the PPO policy
+        print("-- PPO --")
+        print(pretty_print(ppo_trainer.train()))
+
+        # swap weights to synchronize
+        dqn_trainer.set_weights(ppo_trainer.get_weights(["ppo_policy"]))
+        ppo_trainer.set_weights(dqn_trainer.get_weights(["dqn_policy"]))

--- a/python/ray/rllib/optimizers/multi_gpu_optimizer.py
+++ b/python/ray/rllib/optimizers/multi_gpu_optimizer.py
@@ -58,13 +58,15 @@ class LocalMultiGPUOptimizer(PolicyOptimizer):
 
         print("LocalMultiGPUOptimizer devices", self.devices)
 
-        assert set(self.local_evaluator.policy_map.keys()) == {"default"}, \
-            ("Multi-agent is not supported with multi-GPU. Try using the "
-             "simple optimizer instead.")
+        if set(self.local_evaluator.policy_map.keys()) != {"default"}:
+            raise ValueError(
+                "Multi-agent is not supported with multi-GPU. Try using the "
+                "simple optimizer instead.")
         self.policy = self.local_evaluator.policy_map["default"]
-        assert isinstance(self.policy, TFPolicyGraph), \
-            ("Only TF policies are supported with multi-GPU. Try using the "
-             "simple optimizer instead.")
+        if not isinstance(self.policy, TFPolicyGraph):
+            raise ValueError(
+                "Only TF policies are supported with multi-GPU. Try using the "
+                "simple optimizer instead.")
 
         # per-GPU graph copies created below must share vars with the policy
         # reuse is set to AUTO_REUSE because Adam nodes are created after

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -261,6 +261,9 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
 docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/multiagent_cartpole.py --num-iters=2
 
+docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+    python /ray/python/ray/rllib/examples/multiagent_different_trainers.py --num-iters=2
+
 python $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -262,7 +262,7 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/multiagent_cartpole.py --num-iters=2
 
 docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
-    python /ray/python/ray/rllib/examples/multiagent_different_trainers.py --num-iters=2
+    python /ray/python/ray/rllib/examples/multiagent_two_trainers.py --num-iters=2
 
 python $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This adds a simple DQN+PPO example for multi-agent. We don't do anything fancy here, just syncing weights between two separate trainers. This potentially is wasting some compute, but is very simple to set up.

It might be nice to share experience collection between the top-level trainers in the future.