### PR TITLE
[rllib] dqn/ddpg policy customization

### DIFF
--- a/doc/source/rllib-concepts.rst
+++ b/doc/source/rllib-concepts.rst
@@ -15,7 +15,7 @@ Most interaction with deep learning frameworks is isolated to the `PolicyGraph i
 Policy Evaluation
 -----------------
 
-Given an environment and policy graph, policy evaluation produces `batches <https://github.com/ray-project/ray/blob/master/python/ray/rllib/evaluation/sample_batch.py>`__ of experiences. This is your classic "environment interaction loop". Efficient policy evaluation can be burdensome to get right, especially when leveraging vectorization, RNNs, or when operating in a multi-agent environment. RLlib provides a `PolicyEvaluator <https://github.com/ray-project/ray/blob/master/python/ray/rllib/evaluation/policy_evaluator.py>`__ class that manages all of this, and this class is used in most RLlib algorithm.
+Given an environment and policy graph, policy evaluation produces `batches <https://github.com/ray-project/ray/blob/master/python/ray/rllib/evaluation/sample_batch.py>`__ of experiences. This is your classic "environment interaction loop". Efficient policy evaluation can be burdensome to get right, especially when leveraging vectorization, RNNs, or when operating in a multi-agent environment. RLlib provides a `PolicyEvaluator <https://github.com/ray-project/ray/blob/master/python/ray/rllib/evaluation/policy_evaluator.py>`__ class that manages all of this, and this class is used in most RLlib algorithms.
 
 You can also use policy evaluation standalone to produce batches of experiences. This can be done by calling ``ev.sample()`` on an evaluator instance, or ``ev.sample.remote()`` in parallel on evaluator instances created as Ray actors (see ``PolicyEvalutor.as_remote()``).
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -116,55 +116,6 @@ It is common to need to access an agent's internal state, e.g., to set or get in
 
 You can also access just the "master" copy of the agent state through ``agent.optimizer.local_evaluator``, but note that updates here may not be reflected in remote replicas if you have configured ``num_workers > 0``.
 
-Customizing Policy Graphs
--------------------------
-
-For deeper customization of algorithms, you can modify the policy graphs of the agent classes. Here's an example of extending the DDPG policy graph to specify custom sub-network modules:
-
-.. code-block:: python
-
-    from ray.rllib.models import ModelCatalog
-    from ray.rllib.agents.ddpg.ddpg_policy_graph import DDPGPolicyGraph as BaseDDPGPolicyGraph
-
-    class CustomPNetwork(object):
-        def __init__(self, dim_actions, hiddens, activation):
-            action_out = ...
-            # Use sigmoid layer to bound values within (0, 1)
-            # shape of action_scores is [batch_size, dim_actions]
-            self.action_scores = layers.fully_connected(
-                action_out, num_outputs=dim_actions, activation_fn=tf.nn.sigmoid)
-
-    class CustomQNetwork(object):
-        def __init__(self, action_inputs, hiddens, activation):
-            q_out = ...
-            self.value = layers.fully_connected(
-                q_out, num_outputs=1, activation_fn=None)
-
-    class CustomDDPGPolicyGraph(BaseDDPGPolicyGraph):
-        def _build_p_network(self, obs):
-            return CustomPNetwork(
-                self.dim_actions,
-                self.config["actor_hiddens"],
-                self.config["actor_hidden_activation"]).action_scores
-
-        def _build_q_network(self, obs, actions):
-            return CustomQNetwork(
-                actions,
-                self.config["critic_hiddens"],
-                self.config["critic_hidden_activation"]).value
-
-Then, you can create an agent with your custom policy graph by:
-
-.. code-block:: python
-
-    from ray.rllib.agents.ddpg.ddpg import DDPGAgent
-    from custom_policy_graph import CustomDDPGPolicyGraph
-
-    DDPGAgent._policy_graph = CustomDDPGPolicyGraph
-    agent = DDPGAgent(...)
-
-That's it. In this example we overrode existing methods of the existing DDPG policy graph, i.e., `_build_q_network`, `_build_p_network`, `_build_action_network`, `_build_actor_critic_loss`, but you can also replace the entire graph class entirely.
-
 REST API
 --------
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -117,9 +117,9 @@ It is common to need to access an agent's internal state, e.g., to set or get in
 You can also access just the "master" copy of the agent state through ``agent.optimizer.local_evaluator``, but note that updates here may not be reflected in remote replicas if you have configured ``num_workers > 0``.
 
 Customizing Policy Graphs
---------
+-------------------------
 
-Additionally, Python API provides simple and flexible way of policy graphs customization, for example:
+For deeper customization of algorithms, you can modify the policy graphs of the agent classes. Here's an example of extending the DDPG policy graph to specify custom sub-network modules:
 
 .. code-block:: python
 
@@ -140,7 +140,6 @@ Additionally, Python API provides simple and flexible way of policy graphs custo
             self.value = layers.fully_connected(
                 q_out, num_outputs=1, activation_fn=None)
 
-
     class CustomDDPGPolicyGraph(BaseDDPGPolicyGraph):
         def _build_p_network(self, obs):
             return CustomPNetwork(
@@ -154,21 +153,17 @@ Additionally, Python API provides simple and flexible way of policy graphs custo
                 self.config["critic_hiddens"],
                 self.config["critic_hidden_activation"]).value
 
-
-Finally, you can simply redefine agent policy by:
+Then, you can create an agent with your custom policy graph by:
 
 .. code-block:: python
 
     from ray.rllib.agents.ddpg.ddpg import DDPGAgent
     from custom_policy_graph import CustomDDPGPolicyGraph
 
-
     DDPGAgent._policy_graph = CustomDDPGPolicyGraph
-    agent = ...
+    agent = DDPGAgent(...)
 
-That's it.
-For now, this option is only available for DQN (`_build_q_network`, `_build_q_value_policy`, `_build_q_loss`) and DDPG (`_build_q_network`, `_build_p_network`, `_build_action_network`, `_build_actor_critic_loss`) graphs.
-
+That's it. In this example we overrode existing methods of the existing DDPG policy graph, i.e., `_build_q_network`, `_build_p_network`, `_build_action_network`, `_build_actor_critic_loss`, but you can also replace the entire graph class entirely.
 
 REST API
 --------

--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -56,6 +56,7 @@ Models and Preprocessors
 * `Built-in Models and Preprocessors <rllib-models.html#built-in-models-and-preprocessors>`__
 * `Custom Models <rllib-models.html#custom-models>`__
 * `Custom Preprocessors <rllib-models.html#custom-preprocessors>`__
+* `Customizing Policy Graphs <rllib-models.html#customizing-policy-graphs>`__
 
 RLlib Concepts
 --------------

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -204,8 +204,8 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         # target q network evalution
         with tf.variable_scope(Q_TARGET_SCOPE) as scope:
-            q_tp1 = self._build_q_network(
-                self.obs_tp1, output_actions_estimated)
+            q_tp1 = self._build_q_network(self.obs_tp1,
+                                          output_actions_estimated)
             target_q_func_vars = _scope_vars(scope.name)
 
         self.loss = self._build_actor_critic_loss(q_t, q_tp1, q_tp0)

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -133,30 +133,13 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         self.config = config
         self.cur_epsilon = 1.0
-        dim_actions = action_space.shape[0]
-        low_action = action_space.low
-        high_action = action_space.high
+        self.dim_actions = action_space.shape[0]
+        self.low_action = action_space.low
+        self.high_action = action_space.high
         self.actor_optimizer = tf.train.AdamOptimizer(
             learning_rate=config["actor_lr"])
         self.critic_optimizer = tf.train.AdamOptimizer(
             learning_rate=config["critic_lr"])
-
-        def _build_q_network(obs, actions):
-            return QNetwork(
-                ModelCatalog.get_model(obs, 1, config["model"]), actions,
-                config["critic_hiddens"],
-                config["critic_hidden_activation"]).value
-
-        def _build_p_network(obs):
-            return PNetwork(
-                ModelCatalog.get_model(obs, 1, config["model"]), dim_actions,
-                config["actor_hiddens"],
-                config["actor_hidden_activation"]).action_scores
-
-        def _build_action_network(p_values, stochastic, eps):
-            return ActionNetwork(p_values, low_action, high_action, stochastic,
-                                 eps, config["exploration_theta"],
-                                 config["exploration_sigma"]).actions
 
         # Action inputs
         self.stochastic = tf.placeholder(tf.bool, (), name="stochastic")
@@ -166,18 +149,18 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         # Actor: P (policy) network
         with tf.variable_scope(P_SCOPE) as scope:
-            p_values = _build_p_network(self.cur_observations)
+            p_values = self._build_p_network(self.cur_observations)
             self.p_func_vars = _scope_vars(scope.name)
 
         # Action outputs
         with tf.variable_scope(A_SCOPE):
-            self.output_actions = _build_action_network(
+            self.output_actions = self._build_action_network(
                 p_values, self.stochastic, self.eps)
 
         with tf.variable_scope(A_SCOPE, reuse=True):
             exploration_sample = tf.get_variable(name="ornstein_uhlenbeck")
             self.reset_noise_op = tf.assign(exploration_sample,
-                                            dim_actions * [.0])
+                                            self.dim_actions * [.0])
 
         # Replay inputs
         self.obs_t = tf.placeholder(
@@ -195,39 +178,37 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         # p network evaluation
         with tf.variable_scope(P_SCOPE, reuse=True) as scope:
-            self.p_t = _build_p_network(self.obs_t)
+            self.p_t = self._build_p_network(self.obs_t)
 
         # target p network evaluation
         with tf.variable_scope(P_TARGET_SCOPE) as scope:
-            p_tp1 = _build_p_network(self.obs_tp1)
+            p_tp1 = self._build_p_network(self.obs_tp1)
             target_p_func_vars = _scope_vars(scope.name)
 
         # Action outputs
         with tf.variable_scope(A_SCOPE, reuse=True):
             deterministic_flag = tf.constant(value=False, dtype=tf.bool)
             zero_eps = tf.constant(value=.0, dtype=tf.float32)
-            output_actions = _build_action_network(
+            output_actions = self._build_action_network(
                 self.p_t, deterministic_flag, zero_eps)
 
-            output_actions_estimated = _build_action_network(
+            output_actions_estimated = self._build_action_network(
                 p_tp1, deterministic_flag, zero_eps)
 
         # q network evaluation
         with tf.variable_scope(Q_SCOPE) as scope:
-            q_t = _build_q_network(self.obs_t, self.act_t)
+            q_t = self._build_q_network(self.obs_t, self.act_t)
             self.q_func_vars = _scope_vars(scope.name)
         with tf.variable_scope(Q_SCOPE, reuse=True):
-            q_tp0 = _build_q_network(self.obs_t, output_actions)
+            q_tp0 = self._build_q_network(self.obs_t, output_actions)
 
         # target q network evalution
         with tf.variable_scope(Q_TARGET_SCOPE) as scope:
-            q_tp1 = _build_q_network(self.obs_tp1, output_actions_estimated)
+            q_tp1 = self._build_q_network(
+                self.obs_tp1, output_actions_estimated)
             target_q_func_vars = _scope_vars(scope.name)
 
-        self.loss = ActorCriticLoss(
-            q_t, q_tp1, q_tp0, self.importance_weights, self.rew_t,
-            self.done_mask, config["gamma"], config["n_step"],
-            config["use_huber"], config["huber_threshold"])
+        self.loss = self._build_actor_critic_loss(q_t, q_tp1, q_tp0)
 
         if config["l2_reg"] is not None:
             for var in self.p_func_vars:
@@ -285,6 +266,29 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         # Hard initial update
         self.update_target(tau=1.0)
+
+    def _build_q_network(self, obs, actions):
+        return QNetwork(
+            ModelCatalog.get_model(obs, 1, self.config["model"]), actions,
+            self.config["critic_hiddens"],
+            self.config["critic_hidden_activation"]).value
+
+    def _build_p_network(self, obs):
+        return PNetwork(
+            ModelCatalog.get_model(obs, 1, self.config["model"]),
+            self.dim_actions, self.config["actor_hiddens"],
+            self.config["actor_hidden_activation"]).action_scores
+
+    def _build_action_network(self, p_values, stochastic, eps):
+        return ActionNetwork(p_values, self.low_action, self.high_action,
+                             stochastic, eps, self.config["exploration_theta"],
+                             self.config["exploration_sigma"]).actions
+
+    def _build_actor_critic_loss(self, q_t, q_tp1, q_tp0):
+        return ActorCriticLoss(
+            q_t, q_tp1, q_tp0, self.importance_weights, self.rew_t,
+            self.done_mask, self.config["gamma"], self.config["n_step"],
+            self.config["use_huber"], self.config["huber_threshold"])
 
     def gradients(self, optimizer):
         if self.config["grad_norm_clipping"] is not None:

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -74,7 +74,7 @@ class QLoss(object):
         q_tp1_best_masked = (1.0 - done_mask) * q_tp1_best
 
         # compute RHS of bellman equation
-        q_t_selected_target = rewards + gamma ** n_step * q_tp1_best_masked
+        q_t_selected_target = rewards + gamma**n_step * q_tp1_best_masked
 
         # compute the error (potentially clipped)
         self.td_error = q_t_selected - tf.stop_gradient(q_t_selected_target)
@@ -98,7 +98,7 @@ class DQNPolicyGraph(TFPolicyGraph):
         self.stochastic = tf.placeholder(tf.bool, (), name="stochastic")
         self.eps = tf.placeholder(tf.float32, (), name="eps")
         self.cur_observations = tf.placeholder(
-            tf.float32, shape=(None,) + observation_space.shape)
+            tf.float32, shape=(None, ) + observation_space.shape)
 
         # Action Q network
         with tf.variable_scope(Q_SCOPE) as scope:
@@ -110,11 +110,11 @@ class DQNPolicyGraph(TFPolicyGraph):
 
         # Replay inputs
         self.obs_t = tf.placeholder(
-            tf.float32, shape=(None,) + observation_space.shape)
+            tf.float32, shape=(None, ) + observation_space.shape)
         self.act_t = tf.placeholder(tf.int32, [None], name="action")
         self.rew_t = tf.placeholder(tf.float32, [None], name="reward")
         self.obs_tp1 = tf.placeholder(
-            tf.float32, shape=(None,) + observation_space.shape)
+            tf.float32, shape=(None, ) + observation_space.shape)
         self.done_mask = tf.placeholder(tf.float32, [None], name="done")
         self.importance_weights = tf.placeholder(
             tf.float32, [None], name="weight")
@@ -138,8 +138,8 @@ class DQNPolicyGraph(TFPolicyGraph):
                 q_tp1_using_online_net = self._build_q_network(self.obs_tp1)
             q_tp1_best_using_online_net = tf.argmax(q_tp1_using_online_net, 1)
             q_tp1_best = tf.reduce_sum(
-                q_tp1 * tf.one_hot(
-                    q_tp1_best_using_online_net, self.num_actions), 1)
+                q_tp1 * tf.one_hot(q_tp1_best_using_online_net,
+                                   self.num_actions), 1)
         else:
             q_tp1_best = tf.reduce_max(q_tp1, 1)
 
@@ -177,14 +177,13 @@ class DQNPolicyGraph(TFPolicyGraph):
 
     def _build_q_network(self, obs):
         return QNetwork(
-            ModelCatalog.get_model(obs, 1, self.config["model"]),
-            self.num_actions, self.config["dueling"],
-            self.config["hiddens"]).value
+            ModelCatalog.get_model(obs, 1,
+                                   self.config["model"]), self.num_actions,
+            self.config["dueling"], self.config["hiddens"]).value
 
     def _build_q_value_policy(self, q_values):
-        return QValuePolicy(q_values, self.cur_observations,
-                            self.num_actions, self.stochastic,
-                            self.eps).action
+        return QValuePolicy(q_values, self.cur_observations, self.num_actions,
+                            self.stochastic, self.eps).action
 
     def _build_q_loss(self, q_t_selected, q_tp1_best):
         return QLoss(q_t_selected, q_tp1_best, self.importance_weights,
@@ -268,7 +267,7 @@ def adjust_nstep(n_step, gamma, obs, actions, rewards, new_obs, dones):
             continue  # episode end
         for j in range(1, n_step):
             new_obs[i] = new_obs[i + j]
-            rewards[i] += gamma ** j * rewards[i + j]
+            rewards[i] += gamma**j * rewards[i + j]
             if dones[i + j]:
                 break  # episode end
     # truncate ends of the trajectory
@@ -304,7 +303,7 @@ def _postprocess_dqn(policy_graph, sample_batch):
             batch["obs"], batch["actions"], batch["rewards"], batch["new_obs"],
             batch["dones"], batch["weights"])
         new_priorities = (
-                np.abs(td_errors) + policy_graph.config["prioritized_replay_eps"])
+            np.abs(td_errors) + policy_graph.config["prioritized_replay_eps"])
         batch.data["weights"] = new_priorities
 
     return batch


### PR DESCRIPTION
@ericl 
introduction - https://github.com/ray-project/ray/issues/2423

The simplest solution, I add several `_build` methods to DQN policy implementations. 
Just to check the idea, I decide to make as less changes as possible, so check it out.

PS. looking at `_build_q_network` and `_build_p_network` implementations, I wonder, does they use the same `ModelCatalog.get_model(obs, 1, self.config["model"])` or that is the purpose of custom preprocess model?