### PR TITLE
[rllib] Fix doc links.

### DIFF
--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -26,48 +26,48 @@ You might also want to clone the Ray repo for convenient access to RLlib helper 
 
 Training APIs
 -------------
-* `Command-line <rllib-training.html>`__
-* `Python API <rllib-training.html#python-api>`__
-* `REST API <rllib-training.html#rest-api>`__
+* `Command-line <rllib-training.rst>`__
+* `Python API <rllib-training.rst#python-api>`__
+* `REST API <rllib-training.rst#rest-api>`__
 
 Environments
 ------------
-* `RLlib Environments Overview <rllib-env.html>`__
-* `OpenAI Gym <rllib-env.html#openai-gym>`__
-* `Vectorized <rllib-env.html#vectorized>`__
-* `Multi-Agent <rllib-env.html#multi-agent>`__
-* `Serving (Agent-oriented) <rllib-env.html#serving>`__
-* `Offline Data Ingest <rllib-env.html#offline-data>`__ 
-* `Batch Asynchronous <rllib-env.html#batch-asynchronous>`__
+* `RLlib Environments Overview <rllib-env.rst>`__
+* `OpenAI Gym <rllib-env.rst#openai-gym>`__
+* `Vectorized <rllib-env.rst#vectorized>`__
+* `Multi-Agent <rllib-env.rst#multi-agent>`__
+* `Serving (Agent-oriented) <rllib-env.rst#serving>`__
+* `Offline Data Ingest <rllib-env.rst#offline-data>`__ 
+* `Batch Asynchronous <rllib-env.rst#batch-asynchronous>`__
 
 Algorithms
 ----------
-* `Ape-X Distributed Prioritized Experience Replay <rllib-algorithms.html#ape-x-distributed-prioritized-experience-replay>`__
-* `Asynchronous Advantage Actor-Critic <rllib-algorithms.html#asynchronous-advantage-actor-critic>`__
-* `Deep Deterministic Policy Gradients <rllib-algorithms.html#deep-deterministic-policy-gradients>`__
-* `Deep Q Networks <rllib-algorithms.html#deep-q-networks>`__
-* `Evolution Strategies <rllib-algorithms.html#evolution-strategies>`__
-* `Policy Gradients <rllib-algorithms.html#policy-gradients>`__
-* `Proximal Policy Optimization <rllib-algorithms.html#proximal-policy-optimization>`__
+* `Ape-X Distributed Prioritized Experience Replay <rllib-algorithms.rst#ape-x-distributed-prioritized-experience-replay>`__
+* `Asynchronous Advantage Actor-Critic <rllib-algorithms.rst#asynchronous-advantage-actor-critic>`__
+* `Deep Deterministic Policy Gradients <rllib-algorithms.rst#deep-deterministic-policy-gradients>`__
+* `Deep Q Networks <rllib-algorithms.rst#deep-q-networks>`__
+* `Evolution Strategies <rllib-algorithms.rst#evolution-strategies>`__
+* `Policy Gradients <rllib-algorithms.rst#policy-gradients>`__
+* `Proximal Policy Optimization <rllib-algorithms.rst#proximal-policy-optimization>`__
 
 Models and Preprocessors
 ------------------------
-* `RLlib Models and Preprocessors Overview <rllib-models.html>`__
-* `Built-in Models and Preprocessors <rllib-models.html#built-in-models-and-preprocessors>`__
-* `Custom Models <rllib-models.html#custom-models>`__
-* `Custom Preprocessors <rllib-models.html#custom-preprocessors>`__
+* `RLlib Models and Preprocessors Overview <rllib-models.rst>`__
+* `Built-in Models and Preprocessors <rllib-models.rst#built-in-models-and-preprocessors>`__
+* `Custom Models <rllib-models.rst#custom-models>`__
+* `Custom Preprocessors <rllib-models.rst#custom-preprocessors>`__
 
 RLlib Concepts
 --------------
-* `Policy Graphs <rllib-concepts.html>`__
-* `Policy Evaluation <rllib-concepts.html#policy-evaluation>`__
-* `Policy Optimization <rllib-concepts.html#policy-optimization>`__
+* `Policy Graphs <rllib-concepts.rst>`__
+* `Policy Evaluation <rllib-concepts.rst#policy-evaluation>`__
+* `Policy Optimization <rllib-concepts.rst#policy-optimization>`__
 
 Package Reference
 -----------------
-* `ray.rllib.agents <rllib-package-ref.html#module-ray.rllib.agents>`__
-* `ray.rllib.env <rllib-package-ref.html#module-ray.rllib.env>`__
-* `ray.rllib.evaluation <rllib-package-ref.html#module-ray.rllib.evaluation>`__
-* `ray.rllib.models <rllib-package-ref.html#module-ray.rllib.models>`__
-* `ray.rllib.optimizers <rllib-package-ref.html#module-ray.rllib.optimizers>`__
-* `ray.rllib.utils <rllib-package-ref.html#module-ray.rllib.utils>`__
+* `ray.rllib.agents <rllib-package-ref.rst#module-ray.rllib.agents>`__
+* `ray.rllib.env <rllib-package-ref.rst#module-ray.rllib.env>`__
+* `ray.rllib.evaluation <rllib-package-ref.rst#module-ray.rllib.evaluation>`__
+* `ray.rllib.models <rllib-package-ref.rst#module-ray.rllib.models>`__
+* `ray.rllib.optimizers <rllib-package-ref.rst#module-ray.rllib.optimizers>`__
+* `ray.rllib.utils <rllib-package-ref.rst#module-ray.rllib.utils>`__


### PR DESCRIPTION
I've got 404 walking through links in ray/doc/source/rllib.rst.
So I replaced all links' extensions with .rst.