### PR TITLE
Prevent hasher from running out of memory on large files

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -650,7 +650,11 @@ def hash_runtime_conf(file_mounts, extra_objs):
                 for name in filenames:
                     hasher.update(name.encode("utf-8"))
                     with open(os.path.join(dirpath, name), "rb") as f:
-                        hasher.update(binascii.hexlify(f.read()))
+                        if os.path.getsize(os.path.join(dirpath, name)) < 1000000000:
+                            hasher.update(binascii.hexlify(f.read()))
+                        else:
+                            for chunk in iter(lambda: f.read(8192), b''):
+                                hasher.update(binascii.hexlify(chunk))
         else:
             with open(path, "rb") as f:
                 hasher.update(binascii.hexlify(f.read()))

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -650,7 +650,8 @@ def hash_runtime_conf(file_mounts, extra_objs):
                 for name in filenames:
                     hasher.update(name.encode("utf-8"))
                     with open(os.path.join(dirpath, name), "rb") as f:
-                        if os.path.getsize(os.path.join(dirpath, name)) < 1000000000:
+                        if os.path.getsize(os.path.join(dirpath,
+                                                        name)) < 1000000000:
                             hasher.update(binascii.hexlify(f.read()))
                         else:
                             for chunk in iter(lambda: f.read(8192), b''):

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -308,9 +308,6 @@ class Monitor(object):
         else:
             print("Warning: could not find ip for client {}."
                   .format(client_id))
-            for keys, values in self.local_scheduler_id_to_ip_map.items():
-                print(keys)
-                print(values)
 
     def xray_heartbeat_handler(self, unused_channel, data):
         """Handle an xray heartbeat message from Redis."""

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -301,7 +301,6 @@ class Monitor(object):
 
         # Update the load metrics for this local scheduler.
         client_id = binascii.hexlify(message.DbClientId()).decode("utf-8")
-
         ip = self.local_scheduler_id_to_ip_map.get(client_id)
         if ip:
             self.load_metrics.update(ip, static_resources, dynamic_resources)

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -301,6 +301,11 @@ class Monitor(object):
 
         # Update the load metrics for this local scheduler.
         client_id = binascii.hexlify(message.DbClientId()).decode("utf-8")
+
+        for keys, values in self.local_scheduler_id_to_ip_map.items():
+            print(keys)
+            print(values)
+
         ip = self.local_scheduler_id_to_ip_map.get(client_id)
         if ip:
             self.load_metrics.update(ip, static_resources, dynamic_resources)

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -302,16 +302,15 @@ class Monitor(object):
         # Update the load metrics for this local scheduler.
         client_id = binascii.hexlify(message.DbClientId()).decode("utf-8")
 
-        for keys, values in self.local_scheduler_id_to_ip_map.items():
-            print(keys)
-            print(values)
-
         ip = self.local_scheduler_id_to_ip_map.get(client_id)
         if ip:
             self.load_metrics.update(ip, static_resources, dynamic_resources)
         else:
             print("Warning: could not find ip for client {}."
                   .format(client_id))
+            for keys, values in self.local_scheduler_id_to_ip_map.items():
+                print(keys)
+                print(values)
 
     def xray_heartbeat_handler(self, unused_channel, data):
         """Handle an xray heartbeat message from Redis."""


### PR DESCRIPTION
## What do these changes do?

When the autoscaler calculates the hash it can run out of memory on large files (3GB in my case). I added support for incremental hashing on files larger than 1GB to fix this. I just picked this threshold arbitrarily and we could turn it down if that is desired.

## Related issue number

I did not open an issue.