### PR TITLE
Use real callback index in subscribe_callback_index_

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -309,9 +309,8 @@ Status RedisContext::SubscribeAsync(const ClientID &client_id,
       << "Client requested subscribe on a table that does not support pubsub";
 
   int64_t callback_index = RedisCallbackManager::instance().add(redisCallback);
-  if (out_callback_index != nullptr) {
-    *out_callback_index = callback_index;
-  }
+  RAY_CHECK(out_callback_index != nullptr);
+  *out_callback_index = callback_index;
   int status = 0;
   if (client_id.is_nil()) {
     // Subscribe to all messages.

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -303,11 +303,15 @@ Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
 
 Status RedisContext::SubscribeAsync(const ClientID &client_id,
                                     const TablePubsub pubsub_channel,
-                                    const RedisCallback &redisCallback) {
+                                    const RedisCallback &redisCallback,
+                                    int64_t *out_callback_index) {
   RAY_CHECK(pubsub_channel != TablePubsub::NO_PUBLISH)
       << "Client requested subscribe on a table that does not support pubsub";
 
   int64_t callback_index = RedisCallbackManager::instance().add(redisCallback);
+  if (out_callback_index != nullptr) {
+    *out_callback_index = callback_index;
+  }
   int status = 0;
   if (client_id.is_nil()) {
     // Subscribe to all messages.

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -73,7 +73,7 @@ class RedisContext {
                   int log_length = -1);
 
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
-                        const RedisCallback &redisCallback);
+                        const RedisCallback &redisCallback, int64_t *out_callback_index);
   redisAsyncContext *async_context() { return async_context_; }
   redisAsyncContext *subscribe_context() { return subscribe_context_; };
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -57,7 +57,7 @@ class RedisContext {
   /// Run an operation on some table key.
   ///
   /// \param command The command to run. This must match a registered Ray Redis
-  ///        command. These are strings of the format "RAY.TABLE_*".
+  /// command. These are strings of the format "RAY.TABLE_*".
   /// \param id The table key to run the operation at.
   /// \param data The data to add to the table key, if any.
   /// \param length The length of the data to be added, if data is provided.
@@ -65,18 +65,21 @@ class RedisContext {
   /// \param pubsub_channel
   /// \param redisCallback The Redis callback function.
   /// \param log_length The RAY.TABLE_APPEND command takes in an optional index
-  ///        at which the data must be appended. For all other commands, set to
-  ///        -1 for unused. If set, then data must be provided.
+  /// at which the data must be appended. For all other commands, set to
+  /// -1 for unused. If set, then data must be provided.
+  /// \return Status.
   Status RunAsync(const std::string &command, const UniqueID &id, const uint8_t *data,
                   int64_t length, const TablePrefix prefix,
                   const TablePubsub pubsub_channel, RedisCallback redisCallback,
                   int log_length = -1);
 
-  /// Subscribe the message from a specific Pub-Sub channel.
+  /// Subscribe to a specific Pub-Sub channel.
+  ///
   /// \param client_id The client ID that subscribe this message.
-  /// \param pubsub_channel The Pub-Sub channel to subscribe.
+  /// \param pubsub_channel The Pub-Sub channel to subscribe to.
   /// \param redisCallback The callback function that the notification calls.
   /// \param out_callback_index The output pointer to callback index.
+  /// \return Status.
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         const RedisCallback &redisCallback, int64_t *out_callback_index);
   redisAsyncContext *async_context() { return async_context_; }

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -72,6 +72,11 @@ class RedisContext {
                   const TablePubsub pubsub_channel, RedisCallback redisCallback,
                   int log_length = -1);
 
+  /// Subscribe the message from a specific Pub-Sub channel.
+  /// \param client_id The client ID that subscribe this message.
+  /// \param pubsub_channel The Pub-Sub channel to subscribe.
+  /// \param redisCallback The callback function that the notification calls.
+  /// \param out_callback_index The output pointer to callback index.
   Status SubscribeAsync(const ClientID &client_id, const TablePubsub pubsub_channel,
                         const RedisCallback &redisCallback, int64_t *out_callback_index);
   redisAsyncContext *async_context() { return async_context_; }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -136,8 +136,8 @@ Status Log<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id,
     // more subscription messages.
     return false;
   };
-  subscribe_callback_index_ = 1;
-  return context_->SubscribeAsync(client_id, pubsub_channel_, std::move(callback));
+  return context_->SubscribeAsync(client_id, pubsub_channel_, std::move(callback),
+                                  &subscribe_callback_index_);
 }
 
 template <typename ID, typename Data>


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This is a very small change.`subscribe_callback_index_` in `tables.h` is used to represent the callback index in RedisCallbackManager. However, current index only have two values: -1 means not subscribed and 1 means subscribed. There is a mismatch between the meaning and the usage.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
