### PR TITLE
Fix Travis building failure `MAC_WHEELS=1`

### DIFF
--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -57,7 +57,7 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     $PIP_CMD install --upgrade setuptools
     # Install setuptools_scm because otherwise when building the wheel for
     # Python 3.6, we see an error.
-    $PIP_CMD install -q setuptools_scm
+    $PIP_CMD install -q setuptools_scm==2.1.0
     # Fix the numpy version because this will be the oldest numpy version we can
     # support.
     $PIP_CMD install -q numpy==1.10.4 cython==0.27.3


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Pin the setuptools_scm to a specific version to avoid following failure. This failure won't happen in Python3. It may be caused by some setuptools_scm bugs as described in [2474](https://github.com/ray-project/ray/issues/2474).
<!-- Please give a short brief about these changes. -->
```bash
import ray

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ray/__init__.py", line 28, in <module>

    import pyarrow  # noqa: F401

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ray/pyarrow_files/pyarrow/__init__.py", line 45, in <module>

    __version__ = setuptools_scm.get_version('../', parse=parse_version)

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/setuptools_scm/__init__.py", line 135, in get_version

    parsed_version = _do_parse(config)

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/setuptools_scm/__init__.py", line 77, in _do_parse

    parse_result = _call_entrypoint_fn(config, config.parse)

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/setuptools_scm/__init__.py", line 40, in _call_entrypoint_fn

    return fn(config.absolute_root)

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ray/pyarrow_files/pyarrow/__init__.py", line 40, in parse_version

    return version_from_scm(root)

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/setuptools_scm/__init__.py", line 28, in version_from_scm

    return _version_from_entrypoint(root, "setuptools_scm.parse_scm")

  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/setuptools_scm/__init__.py", line 44, in _version_from_entrypoint

    for ep in iter_matching_entrypoints(config.absolute_root, entrypoint):

AttributeError: 'str' object has no attribute 'absolute_root'
```
## Related issue number
[2474](https://github.com/ray-project/ray/issues/2474)
<!-- Are there any issues opened that will be resolved by merging this change? -->
