### PR TITLE
Override user-specified name tag.

### DIFF
--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -131,19 +131,23 @@ class AWSNodeProvider(NodeProvider):
             "Tags": tag_pairs,
         }]
         user_tag_specs = conf.get("TagSpecifications", [])
+        # Allow users to add tags and override values of existing
+        # tags with their own. This only applies to the resource type
+        # "instance". All other resource types are appended to the list of
+        # tag specs.
         for user_tag_spec in user_tag_specs:
-            if user_tag_spec['ResourceType'] == 'instance':
-                for user_tag in user_tag_spec['Tags']:
+            if user_tag_spec["ResourceType"] == "instance":
+                for user_tag in user_tag_spec["Tags"]:
                     exists = False
-                    for tag in tag_specs[0]['Tags']:
+                    for tag in tag_specs[0]["Tags"]:
                         if user_tag["Key"] == tag["Key"]:
                             exists = True
                             tag["Value"] = user_tag["Value"]
                             break
                     if not exists:
-                        tag_specs[0]['Tags'] += user_tag
+                        tag_specs[0]["Tags"] += [user_tag]
             else:
-                tag_specs += user_tag_spec
+                tag_specs += [user_tag_spec]
 
         # SubnetIds is not a real config key: we must resolve to a
         # single SubnetId before invoking the AWS API.


### PR DESCRIPTION
Overrides default tags with user-specific tag key/value pairs. For example, the following yaml code would override the tag "Name" with value "worker" for worker nodes.

```
worker_nodes:
    InstanceType: m5.large
    ImageId: ami-123
    KeyName: some_key
    TagSpecifications: [{"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "worker"}]}]
    SecurityGroupIds: ["secure"]
```