### PR TITLE
Remove the check of java primitive types

### DIFF
--- a/java/runtime-common/src/main/java/org/ray/spi/model/RayMethod.java
+++ b/java/runtime-common/src/main/java/org/ray/spi/model/RayMethod.java
@@ -15,15 +15,6 @@ public class RayMethod {
   public final RayRemote remoteAnnotation;
   private final UniqueID funcId;
 
-  public void check() {
-    for (Class<?> paramCls : invokable.getParameterTypes()) {
-      if (paramCls.isPrimitive()) {
-        throw new RuntimeException(
-            "@RayRemote function " + fullName + " must have all non-primitive typed parameters");
-      }
-    }
-  }
-
   private RayMethod(Method m, RayRemote remoteAnnotation, UniqueID funcId) {
     this.invokable = m;
     this.remoteAnnotation = remoteAnnotation;
@@ -39,7 +30,6 @@ public class RayMethod {
     RayMethod method = new RayMethod(m,
         remoteAnnotation != null ? remoteAnnotation : parentRemoteAnnotation,
         funcId);
-    method.check();
     return method;
   }
 


### PR DESCRIPTION
This check isn't needed. Because the compiler will automatically box primitive types.

Not in this PR:
API document needs to be updated as well, which will be done in a new PR together with other changes. 

cc @salah-man 