### PR TITLE
[rllib] Fix corner case in rnn episode handling

### DIFF
--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from collections import defaultdict, namedtuple
 import numpy as np
+import random
 import six.moves.queue as queue
 import threading
 
@@ -258,6 +259,7 @@ def _env_runner(async_vector_env,
                         agent_id,
                         policy_id,
                         t=episode.length - 1,
+                        eps_id=episode.episode_id,
                         obs=last_observation,
                         actions=episode.last_action_for(agent_id),
                         rewards=rewards[env_id][agent_id],
@@ -367,6 +369,7 @@ class _MultiAgentEpisode(object):
         self.batch_builder = batch_builder_factory()
         self.total_reward = 0.0
         self.length = 0
+        self.episode_id = random.randrange(2e9)
         self.agent_rewards = defaultdict(float)
         self._policies = policies
         self._policy_mapping_fn = policy_mapping_fn

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -140,7 +140,7 @@ class TFPolicyGraph(PolicyGraph):
             "state_in_{}".format(i) for i in range(len(self._state_inputs))
         ]
         feature_sequences, initial_states, seq_lens = chop_into_sequences(
-            batch["t"], [batch[k] for k in feature_keys],
+            batch["eps_id"], [batch[k] for k in feature_keys],
             [batch[k] for k in state_keys], self._max_seq_len)
         for k, v in zip(feature_keys, feature_sequences):
             feed_dict[self._loss_input_dict[k]] = v

--- a/python/ray/rllib/test/test_lstm.py
+++ b/python/ray/rllib/test/test_lstm.py
@@ -9,11 +9,11 @@ from ray.rllib.models.lstm import chop_into_sequences
 
 class LSTMUtilsTest(unittest.TestCase):
     def testBasic(self):
-        t = [1, 2, 3, 1, 2, 3, 4, 5]
+        eps_ids = [1, 1, 1, 5, 5, 5, 5, 5]
         f = [[101, 102, 103, 201, 202, 203, 204, 205],
              [[101], [102], [103], [201], [202], [203], [204], [205]]]
         s = [[209, 208, 207, 109, 108, 107, 106, 105]]
-        f_pad, s_init, seq_lens = chop_into_sequences(t, f, s, 4)
+        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids, f, s, 4)
         self.assertEqual([f.tolist() for f in f_pad], [
             [101, 102, 103, 0, 201, 202, 203, 204, 205, 0, 0, 0],
             [[101], [102], [103], [0], [201], [202], [203], [204], [205], [0],
@@ -23,10 +23,10 @@ class LSTMUtilsTest(unittest.TestCase):
         self.assertEqual(seq_lens.tolist(), [3, 4, 1])
 
     def testDynamicMaxLen(self):
-        t = [1, 1, 2]
+        eps_ids = [5, 2, 2]
         f = [[1, 1, 1]]
         s = [[1, 1, 1]]
-        f_pad, s_init, seq_lens = chop_into_sequences(t, f, s, 4)
+        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids, f, s, 4)
         self.assertEqual([f.tolist() for f in f_pad], [[1, 0, 1, 1]])
         self.assertEqual([s.tolist() for s in s_init], [[1, 1]])
         self.assertEqual(seq_lens.tolist(), [1, 2])


### PR DESCRIPTION

## What do these changes do?

We should use episode ids instead of the timestep to determine when sequences should be cut, since when batches are concatenated, increasing t does not guarantee we are part of the same episode.