### PR TITLE
mark all remaining placeable tasks pending with task dependency manager

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -750,6 +750,12 @@ void NodeManager::ScheduleTasks() {
       EnqueuePlaceableTask(t);
     }
   }
+
+  // All remaining placeable tasks should be registered with the task dependency
+  // manager.
+  for (const auto &task : local_queues_.GetPlaceableTasks()) {
+    task_dependency_manager_.TaskPending(task);
+  }
 }
 
 void NodeManager::TreatTaskAsFailed(const TaskSpecification &spec) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -753,6 +753,8 @@ void NodeManager::ScheduleTasks() {
 
   // All remaining placeable tasks should be registered with the task dependency
   // manager. TaskDependencyManager::TaskPending() is assumed to be idempotent.
+  // TODO(atumanov): evaluate performance implications of registering all new tasks on
+  // submission vs. registering remaining queued placeable tasks here.
   for (const auto &task : local_queues_.GetPlaceableTasks()) {
     task_dependency_manager_.TaskPending(task);
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -752,7 +752,7 @@ void NodeManager::ScheduleTasks() {
   }
 
   // All remaining placeable tasks should be registered with the task dependency
-  // manager.
+  // manager. TaskDependencyManager::TaskPending() is assumed to be idempotent.
   for (const auto &task : local_queues_.GetPlaceableTasks()) {
     task_dependency_manager_.TaskPending(task);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This PR registers all _remaining_ placeable tasks with the task dependency manager, to ensure reconstruction policy is not triggered on them. 

## Related issue number

https://github.com/ray-project/ray/issues/2527
