### PR TITLE
[xray] Try to flush children of a task that is evicted from the lineage cache

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -27,8 +27,8 @@ const TaskID LineageEntry::GetEntryId() const {
   return task_.GetTaskSpecification().TaskId();
 }
 
-const std::unordered_set<UniqueID> LineageEntry::GetParentTaskIds() const {
-  std::unordered_set<UniqueID> parent_ids;
+const std::unordered_set<TaskID> LineageEntry::GetParentTaskIds() const {
+  std::unordered_set<TaskID> parent_ids;
   // A task's parents are the tasks that created its arguments.
   auto dependencies = task_.GetDependencies();
   for (auto &dependency : dependencies) {
@@ -52,7 +52,7 @@ Lineage::Lineage(const protocol::ForwardTaskRequest &task_request) {
   }
 }
 
-boost::optional<const LineageEntry &> Lineage::GetEntry(const UniqueID &task_id) const {
+boost::optional<const LineageEntry &> Lineage::GetEntry(const TaskID &task_id) const {
   auto entry = entries_.find(task_id);
   if (entry != entries_.end()) {
     return entry->second;
@@ -61,7 +61,7 @@ boost::optional<const LineageEntry &> Lineage::GetEntry(const UniqueID &task_id)
   }
 }
 
-boost::optional<LineageEntry &> Lineage::GetEntryMutable(const UniqueID &task_id) {
+boost::optional<LineageEntry &> Lineage::GetEntryMutable(const TaskID &task_id) {
   auto entry = entries_.find(task_id);
   if (entry != entries_.end()) {
     return entry->second;
@@ -89,7 +89,7 @@ bool Lineage::SetEntry(const Task &task, GcsStatus status) {
   }
 }
 
-boost::optional<LineageEntry> Lineage::PopEntry(const UniqueID &task_id) {
+boost::optional<LineageEntry> Lineage::PopEntry(const TaskID &task_id) {
   auto entry = entries_.find(task_id);
   if (entry != entries_.end()) {
     LineageEntry entry = std::move(entries_.at(task_id));
@@ -100,7 +100,7 @@ boost::optional<LineageEntry> Lineage::PopEntry(const UniqueID &task_id) {
   }
 }
 
-const std::unordered_map<const UniqueID, LineageEntry> &Lineage::GetEntries() const {
+const std::unordered_map<const TaskID, LineageEntry> &Lineage::GetEntries() const {
   return entries_;
 }
 
@@ -137,7 +137,7 @@ LineageCache::LineageCache(const ClientID &client_id,
 /// \param lineage_to The lineage to merge entries into.
 /// \param stopping_condition A stopping condition for the DFS over
 /// lineage_from. This should return true if the merge should stop.
-void MergeLineageHelper(const UniqueID &task_id, const Lineage &lineage_from,
+void MergeLineageHelper(const TaskID &task_id, const Lineage &lineage_from,
                         Lineage &lineage_to,
                         std::function<bool(GcsStatus)> stopping_condition) {
   // If the entry is not found in the lineage to merge, then we stop since
@@ -338,7 +338,7 @@ void LineageCache::Flush() {
   }
 }
 
-bool LineageCache::SubscribeTask(const UniqueID &task_id) {
+bool LineageCache::SubscribeTask(const TaskID &task_id) {
   auto inserted = subscribed_tasks_.insert(task_id);
   bool unsubscribed = inserted.second;
   if (unsubscribed) {
@@ -351,7 +351,7 @@ bool LineageCache::SubscribeTask(const UniqueID &task_id) {
   return unsubscribed;
 }
 
-bool LineageCache::UnsubscribeTask(const UniqueID &task_id) {
+bool LineageCache::UnsubscribeTask(const TaskID &task_id) {
   auto it = subscribed_tasks_.find(task_id);
   bool subscribed = (it != subscribed_tasks_.end());
   if (subscribed) {
@@ -365,7 +365,7 @@ bool LineageCache::UnsubscribeTask(const UniqueID &task_id) {
   return subscribed;
 }
 
-boost::optional<LineageEntry> LineageCache::EvictTask(const UniqueID &task_id) {
+boost::optional<LineageEntry> LineageCache::EvictTask(const TaskID &task_id) {
   auto entry = lineage_.PopEntry(task_id);
   if (!entry) {
     return entry;
@@ -397,7 +397,7 @@ boost::optional<LineageEntry> LineageCache::EvictTask(const UniqueID &task_id) {
   return entry;
 }
 
-void LineageCache::EvictRemoteLineage(const UniqueID &task_id) {
+void LineageCache::EvictRemoteLineage(const TaskID &task_id) {
   // Remove the ancestor task.
   auto entry = EvictTask(task_id);
   if (!entry) {
@@ -413,7 +413,7 @@ void LineageCache::EvictRemoteLineage(const UniqueID &task_id) {
   }
 }
 
-void LineageCache::HandleEntryCommitted(const UniqueID &task_id) {
+void LineageCache::HandleEntryCommitted(const TaskID &task_id) {
   RAY_LOG(DEBUG) << "task committed: " << task_id;
   auto entry = EvictTask(task_id);
   if (!entry) {

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -113,7 +113,7 @@ class Lineage {
   /// \return An optional reference to the entry. If this is empty, then the
   /// entry ID is not in the lineage.
   boost::optional<const LineageEntry &> GetEntry(const TaskID &entry_id) const;
-  boost::optional<LineageEntry &> GetEntryMutable(const UniqueID &task_id);
+  boost::optional<LineageEntry &> GetEntryMutable(const TaskID &task_id);
 
   /// Set an entry in the lineage. If an entry with this ID already exists,
   /// then the entry is overwritten if and only if the new entry has a higher
@@ -216,18 +216,18 @@ class LineageCache {
   /// evicted task's children that are in UNCOMMITTED_READY state.  Returns an
   /// optional reference to the evicted task that is empty if the task was not
   /// in the lineage cache.
-  boost::optional<LineageEntry> EvictTask(const UniqueID &task_id);
+  boost::optional<LineageEntry> EvictTask(const TaskID &task_id);
   /// Evict a remote task and its lineage. This should only be called if we
   /// are sure that the remote task and its lineage are committed.
-  void EvictRemoteLineage(const UniqueID &task_id);
+  void EvictRemoteLineage(const TaskID &task_id);
   /// Subscribe to notifications for a task. Returns whether the operation
   /// was successful (whether we were not already subscribed).
-  bool SubscribeTask(const UniqueID &task_id);
+  bool SubscribeTask(const TaskID &task_id);
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
-  bool UnsubscribeTask(const UniqueID &task_id);
+  bool UnsubscribeTask(const TaskID &task_id);
   /// Count the size of unsubscribed and uncommitted lineage
-  uint64_t CountUnsubscribedLineage(const UniqueID &task_id) const;
+  uint64_t CountUnsubscribedLineage(const TaskID &task_id) const;
 
   /// The client ID, used to request notifications for specific tasks.
   /// TODO(swang): Move the ClientID into the generic Table implementation.

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -211,6 +211,12 @@ class LineageCache {
   /// parents that are not committed yet, then the child will be flushed once
   /// the parents have been committed.
   bool FlushTask(const TaskID &task_id);
+  /// Evict a single task. This should only be called if we are sure that the
+  /// task has been committed and will trigger an attempt to flush any of the
+  /// evicted task's children that are in UNCOMMITTED_READY state.  Returns an
+  /// optional reference to the evicted task that is empty if the task was not
+  /// in the lineage cache.
+  boost::optional<LineageEntry> EvictTask(const UniqueID &task_id);
   /// Evict a remote task and its lineage. This should only be called if we
   /// are sure that the remote task and its lineage are committed.
   void EvictRemoteLineage(const UniqueID &task_id);


### PR DESCRIPTION
## What do these changes do?

This fixes a bug in the lineage cache where we assumed that evicted tasks did not have any children (i.e. dependent tasks) that could be flushed. This PR factors out the common code for evicting a task, which includes attempting to flush any children of the evicted task.

## Related issue number

Fixes #2519.
