### PR TITLE
[xray] Prevent sending excessive uncommitted lineage on task forwarding

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -147,7 +147,7 @@ LineageCache::LineageCache(const ClientID &client_id,
 /// lineage_from. This should return true if the merge should stop.
 void MergeLineageHelper(const TaskID &task_id, const Lineage &lineage_from,
                         Lineage &lineage_to,
-                        std::function<bool(const LineageEntry&)> stopping_condition) {
+                        std::function<bool(const LineageEntry &)> stopping_condition) {
   // If the entry is not found in the lineage to merge, then we stop since
   // there is nothing to copy into the merged lineage.
   auto entry = lineage_from.GetEntry(task_id);
@@ -175,16 +175,16 @@ void LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
   auto task_id = task.GetTaskSpecification().TaskId();
   // Merge the uncommitted lineage into the lineage cache.
   MergeLineageHelper(task_id, uncommitted_lineage, lineage_,
-                     [](const LineageEntry& entry) {
-    if (entry.GetStatus() != GcsStatus::NONE) {
-      // We received the uncommitted lineage from a remote node, so make sure
-      // that all entries in the lineage to merge have status
-      // UNCOMMITTED_REMOTE.
-      RAY_CHECK(entry.GetStatus() == GcsStatus::UNCOMMITTED_REMOTE);
-    }
-    // The only stopping condition is that an entry is not found.
-    return false;
-  });
+                     [](const LineageEntry &entry) {
+                       if (entry.GetStatus() != GcsStatus::NONE) {
+                         // We received the uncommitted lineage from a remote node, so
+                         // make sure that all entries in the lineage to merge have
+                         // status UNCOMMITTED_REMOTE.
+                         RAY_CHECK(entry.GetStatus() == GcsStatus::UNCOMMITTED_REMOTE);
+                       }
+                       // The only stopping condition is that an entry is not found.
+                       return false;
+                     });
 
   // If the task was previously remote, then we may have been subscribed to
   // it. Unsubscribe since we are now responsible for committing the task.
@@ -274,11 +274,11 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
   // Add all uncommitted ancestors from the lineage cache to the uncommitted
   // lineage of the requested task.
   MergeLineageHelper(task_id, lineage_, uncommitted_lineage,
-                     [&](const LineageEntry& entry) {
-    // The stopping condition for recursion is that the entry has either been
-    // committed to the GCS, or has already been forwarded to the node.
-    return entry.WasExplicitlyForwarded(node_id);
-  });
+                     [&](const LineageEntry &entry) {
+                       // The stopping condition for recursion is that the entry has
+                       // been committed to the GCS or has already been forwarded.
+                       return entry.WasExplicitlyForwarded(node_id);
+                     });
   return uncommitted_lineage;
 }
 

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -265,6 +265,7 @@ void LineageCache::RemoveWaitingTask(const TaskID &task_id) {
 }
 
 void LineageCache::MarkTaskAsForwarded(const TaskID &task_id, const ClientID &node_id) {
+  RAY_CHECK(!node_id.is_nil());
   lineage_.GetEntryMutable(task_id)->MarkExplicitlyForwarded(node_id);
 }
 

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -274,12 +274,13 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
   Lineage uncommitted_lineage;
   // Add all uncommitted ancestors from the lineage cache to the uncommitted
   // lineage of the requested task.
-  MergeLineageHelper(task_id, lineage_, uncommitted_lineage,
-                     [&](const LineageEntry &entry) {
-                       // The stopping condition for recursion is that the entry has
-                       // been committed to the GCS or has already been forwarded.
-                       return entry.WasExplicitlyForwarded(node_id);
-                     });
+  MergeLineageHelper(
+      task_id, lineage_, uncommitted_lineage, [&](const LineageEntry &entry) {
+        // The stopping condition for recursion is that the entry has
+        // been committed to the GCS or has already been forwarded.
+        // The lineage always includes the requested task id.
+        return entry.WasExplicitlyForwarded(node_id) && !(entry.GetEntryId() == task_id);
+      });
   return uncommitted_lineage;
 }
 

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -64,6 +64,18 @@ class LineageEntry {
   /// \param new_status This must be lower than the current status.
   void ResetStatus(GcsStatus new_status);
 
+  /// Mark this entry as having been explicitly forwarded to a remote node manager.
+  ///
+  /// \param node_id The ID of the remote node manager.
+  void MarkExplicitlyForwarded(const ClientID &node_id);
+
+  /// Get this entry's explicit forwarding status corresponding to a node.
+  /// Ancestors of a forwarded task have an implicitly forwarded status.
+  ///
+  /// \param node_id The ID of the remote node manager.
+  /// \return Whether this node has explicitly been forwarded to the remote node.
+  bool GetExplicitForwardingStatus(const ClientID &node_id) const;
+
   /// Get this entry's ID.
   ///
   /// \return The entry's ID.
@@ -88,6 +100,10 @@ class LineageEntry {
   /// an object.
   //  const Task task_;
   Task task_;
+
+  /// Node managers that this task and its lineage has been forwarded to.
+  std::unordered_set<ClientID> forwarded_to_;
+
 };
 
 /// \class Lineage
@@ -183,6 +199,23 @@ class LineageCache {
   ///
   /// \param task_id The ID of the waiting task to remove.
   void RemoveWaitingTask(const TaskID &task_id);
+
+  /// Mark a task as having been forwarded to a node. The lineage of the task
+  /// is implicitly assumed to have also been forwarded.
+  ///
+  /// \param task_id
+  /// \param node_id
+  void MarkTaskAsForwarded(const TaskID &task_id, const ClientID &node_id);
+
+  /// Get the uncommitted lineage of a task that hasn't been forwarded to a task.
+  /// The uncommitted lineage consists of all tasks in the given task's lineage
+  /// that have not been committed in the GCS, as far as we know.
+  ///
+  /// \param task_id The ID of the task to get the uncommitted lineage for.
+  /// \param node_id
+  /// \return
+  Lineage GetUnforwardedUncommittedLineage(const TaskID &task_id,
+                                           const ClientID &node_id) const;
 
   /// Get the uncommitted lineage of a task. The uncommitted lineage consists
   /// of all tasks in the given task's lineage that have not been committed in

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -102,7 +102,6 @@ class LineageEntry {
 
   /// IDs of node managers that this task has been explicitly forwarded to.
   std::unordered_set<ClientID> forwarded_to_;
-
 };
 
 /// \class Lineage
@@ -214,8 +213,7 @@ class LineageCache {
   /// \param node_id The ID of the receiving node.
   /// \return The uncommitted, unforwarded lineage of the task. The returned lineage
   /// includes the entry for the requested entry_id.
-  Lineage GetUncommittedLineage(const TaskID &task_id,
-                                const ClientID &node_id) const;
+  Lineage GetUncommittedLineage(const TaskID &task_id, const ClientID &node_id) const;
 
   /// Asynchronously write any tasks that are in the UNCOMMITTED_READY state
   /// and for which all parents have been committed to the GCS. These tasks

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -100,8 +100,7 @@ class LineageEntry {
   //  const Task task_;
   Task task_;
 
-  /// Node managers that this task and its lineage has been forwarded to.
-  /// Does not include nodes that this entry was not explicitly forwarded to.
+  /// IDs of node managers that this task has been explicitly forwarded to.
   std::unordered_set<ClientID> forwarded_to_;
 
 };

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -69,12 +69,11 @@ class LineageEntry {
   /// \param node_id The ID of the remote node manager.
   void MarkExplicitlyForwarded(const ClientID &node_id);
 
-  /// Get this entry's explicit forwarding status corresponding to a node.
-  /// Ancestors of a forwarded task have an implicitly forwarded status.
+  /// Gets whether this entry was explicitly forwarded to a remote node.
   ///
   /// \param node_id The ID of the remote node manager.
-  /// \return Whether this node has explicitly been forwarded to the remote node.
-  bool GetExplicitForwardingStatus(const ClientID &node_id) const;
+  /// \return Whether this entry was explicitly forwarded to the remote node.
+  bool WasExplicitlyForwarded(const ClientID &node_id) const;
 
   /// Get this entry's ID.
   ///
@@ -102,6 +101,7 @@ class LineageEntry {
   Task task_;
 
   /// Node managers that this task and its lineage has been forwarded to.
+  /// Does not include nodes that this entry was not explicitly forwarded to.
   std::unordered_set<ClientID> forwarded_to_;
 
 };
@@ -200,31 +200,23 @@ class LineageCache {
   /// \param task_id The ID of the waiting task to remove.
   void RemoveWaitingTask(const TaskID &task_id);
 
-  /// Mark a task as having been forwarded to a node. The lineage of the task
-  /// is implicitly assumed to have also been forwarded.
+  /// Mark a task as having been explicitly forwarded to a node.
+  /// The lineage of the task is implicitly assumed to have also been forwarded.
   ///
-  /// \param task_id
-  /// \param node_id
+  /// \param task_id The ID of the task to get the uncommitted lineage for.
+  /// \param node_id The ID of the node to get the uncommitted lineage for.
   void MarkTaskAsForwarded(const TaskID &task_id, const ClientID &node_id);
 
-  /// Get the uncommitted lineage of a task that hasn't been forwarded to a task.
+  /// Get the uncommitted lineage of a task that hasn't been forwarded to a node yet.
   /// The uncommitted lineage consists of all tasks in the given task's lineage
   /// that have not been committed in the GCS, as far as we know.
   ///
   /// \param task_id The ID of the task to get the uncommitted lineage for.
-  /// \param node_id
-  /// \return
-  Lineage GetUnforwardedUncommittedLineage(const TaskID &task_id,
-                                           const ClientID &node_id) const;
-
-  /// Get the uncommitted lineage of a task. The uncommitted lineage consists
-  /// of all tasks in the given task's lineage that have not been committed in
-  /// the GCS, as far as we know.
-  ///
-  /// \param entry_id The ID of the task to get the uncommitted lineage for.
-  /// \return The uncommitted lineage of the task. The returned lineage
+  /// \param node_id The ID of the receiving node.
+  /// \return The uncommitted, unforwarded lineage of the task. The returned lineage
   /// includes the entry for the requested entry_id.
-  Lineage GetUncommittedLineage(const TaskID &entry_id) const;
+  Lineage GetUncommittedLineage(const TaskID &task_id,
+                                const ClientID &node_id) const;
 
   /// Asynchronously write any tasks that are in the UNCOMMITTED_READY state
   /// and for which all parents have been committed to the GCS. These tasks

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -201,13 +201,18 @@ TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   }
 
   auto node_id = ClientID::from_random();
+  auto node_id2 = ClientID::from_random();
   auto forwarded_task_id = task_ids[task_ids.size() - 2];
   auto remaining_task_id = task_ids[task_ids.size() - 1];
   lineage_cache_.MarkTaskAsForwarded(forwarded_task_id, node_id);
+
   auto uncommitted_lineage =
           lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
+  auto uncommitted_lineage_all =
+          lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id2);
 
   ASSERT_EQ(1, uncommitted_lineage.GetEntries().size());
+  ASSERT_EQ(4, uncommitted_lineage_all.GetEntries().size());
   ASSERT_TRUE(uncommitted_lineage.GetEntry(remaining_task_id));
 }
 

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -159,7 +159,7 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
 
   // Get the uncommitted lineage for the last task (the leaf) of one of the chains.
   auto uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(task_ids1.back(), ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(task_ids1.back(), ClientID::nil());
   // Check that the uncommitted lineage is exactly equal to the first chain of tasks.
   ASSERT_EQ(task_ids1.size(), uncommitted_lineage.GetEntries().size());
   for (auto &task_id : task_ids1) {
@@ -180,21 +180,20 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
 
   // Get the uncommitted lineage for the inserted task.
   uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(combined_task_ids.back(), ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(combined_task_ids.back(), ClientID::nil());
   // Check that the uncommitted lineage is exactly equal to the entire set of
   // tasks inserted so far.
   ASSERT_EQ(combined_task_ids.size(), uncommitted_lineage.GetEntries().size());
   for (auto &task_id : combined_task_ids) {
     ASSERT_TRUE(uncommitted_lineage.GetEntry(task_id));
   }
-
 }
 
 TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   // Insert chain of tasks.
   std::vector<Task> tasks;
   auto return_values =
-          InsertTaskChain(lineage_cache_, tasks, 4, std::vector<ObjectID>(), 1);
+      InsertTaskChain(lineage_cache_, tasks, 4, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids;
   for (const auto &task : tasks) {
     task_ids.push_back(task.GetTaskSpecification().TaskId());
@@ -207,13 +206,19 @@ TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   lineage_cache_.MarkTaskAsForwarded(forwarded_task_id, node_id);
 
   auto uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
+      lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
   auto uncommitted_lineage_all =
-          lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id2);
+      lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id2);
 
   ASSERT_EQ(1, uncommitted_lineage.GetEntries().size());
   ASSERT_EQ(4, uncommitted_lineage_all.GetEntries().size());
   ASSERT_TRUE(uncommitted_lineage.GetEntry(remaining_task_id));
+
+  // Check that lineage of requested task includes itself, regardless of whether
+  // it has been forwarded before.
+  auto uncommitted_lineage_forwarded =
+      lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
+  ASSERT_EQ(1, uncommitted_lineage_forwarded.GetEntries().size());
 }
 
 void CheckFlush(LineageCache &lineage_cache, MockGcs &mock_gcs,
@@ -226,8 +231,7 @@ TEST_F(LineageCacheTest, TestWritebackNoneReady) {
   // Insert a chain of dependent tasks.
   size_t num_tasks_flushed = 0;
   std::vector<Task> tasks;
-  auto return_values1 =
-      InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
+  InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
 
   // Check that when no tasks have been marked as ready, we do not flush any
   // entries.
@@ -238,8 +242,7 @@ TEST_F(LineageCacheTest, TestWritebackReady) {
   // Insert a chain of dependent tasks.
   size_t num_tasks_flushed = 0;
   std::vector<Task> tasks;
-  auto return_values1 =
-      InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
+  InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
 
   // Check that after marking the first task as ready, we flush only that task.
   lineage_cache_.AddReadyTask(tasks.front());
@@ -251,8 +254,7 @@ TEST_F(LineageCacheTest, TestWritebackOrder) {
   // Insert a chain of dependent tasks.
   size_t num_tasks_flushed = 0;
   std::vector<Task> tasks;
-  auto return_values1 =
-      InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
+  InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
 
   // Mark all tasks as ready. The first task, which has no dependencies, should
   // be flushed.
@@ -315,8 +317,7 @@ TEST_F(LineageCacheTest, TestForwardTasksRoundTrip) {
   // Insert a chain of dependent tasks.
   uint64_t lineage_size = max_lineage_size_ + 1;
   std::vector<Task> tasks;
-  auto return_values1 =
-      InsertTaskChain(lineage_cache_, tasks, lineage_size, std::vector<ObjectID>(), 1);
+  InsertTaskChain(lineage_cache_, tasks, lineage_size, std::vector<ObjectID>(), 1);
 
   // Simulate removing each task, forwarding it to another node, then
   // receiving the task back again.
@@ -324,7 +325,7 @@ TEST_F(LineageCacheTest, TestForwardTasksRoundTrip) {
     const auto task_id = it->GetTaskSpecification().TaskId();
     // Simulate removing the task and forwarding it to another node.
     auto uncommitted_lineage =
-            lineage_cache_.GetUncommittedLineage(task_id, ClientID::nil());
+        lineage_cache_.GetUncommittedLineage(task_id, ClientID::nil());
     lineage_cache_.RemoveWaitingTask(task_id);
     // Simulate receiving the task again. Make sure we can add the task back.
     flatbuffers::FlatBufferBuilder fbb;
@@ -340,8 +341,7 @@ TEST_F(LineageCacheTest, TestForwardTask) {
   // Insert a chain of dependent tasks.
   size_t num_tasks_flushed = 0;
   std::vector<Task> tasks;
-  auto return_values1 =
-      InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
+  InsertTaskChain(lineage_cache_, tasks, 3, std::vector<ObjectID>(), 1);
 
   // Simulate removing the task and forwarding it to another node.
   auto it = tasks.begin() + 1;
@@ -349,7 +349,7 @@ TEST_F(LineageCacheTest, TestForwardTask) {
   tasks.erase(it);
   auto task_id_to_remove = forwarded_task.GetTaskSpecification().TaskId();
   auto uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(task_id_to_remove, ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(task_id_to_remove, ClientID::nil());
   lineage_cache_.RemoveWaitingTask(task_id_to_remove);
 
   // Simulate executing the remaining tasks.
@@ -395,8 +395,8 @@ TEST_F(LineageCacheTest, TestEviction) {
   // Check that the last task in the chain still has all tasks in its
   // uncommitted lineage.
   const auto last_task_id = tasks.back().GetTaskSpecification().TaskId();
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(last_task_id,
-                                                                  ClientID::nil());
+  auto uncommitted_lineage =
+      lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_EQ(uncommitted_lineage.GetEntries().size(), lineage_size);
 
   // Simulate executing the first task on a remote node and adding it to the
@@ -425,7 +425,7 @@ TEST_F(LineageCacheTest, TestEviction) {
   // All tasks have now been flushed. Check that enough lineage has been
   // evicted that the uncommitted lineage is now less than the maximum size.
   uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_TRUE(uncommitted_lineage.GetEntries().size() <= max_lineage_size_);
 }
 
@@ -450,7 +450,7 @@ TEST_F(LineageCacheTest, TestOutOfOrderEviction) {
   // uncommitted lineage.
   const auto last_task_id = tasks.back().GetTaskSpecification().TaskId();
   auto uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_EQ(uncommitted_lineage.GetEntries().size(), lineage_size);
 
   // Simulate executing the tasks at the remote node and receiving the
@@ -479,7 +479,7 @@ TEST_F(LineageCacheTest, TestOutOfOrderEviction) {
   // All tasks have now been flushed. Check that enough lineage has been
   // evicted that the uncommitted lineage is now less than the maximum size.
   uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_TRUE(uncommitted_lineage.GetEntries().size() <= max_lineage_size_);
 }
 
@@ -513,7 +513,7 @@ TEST_F(LineageCacheTest, TestEvictionUncommittedChildren) {
   // uncommitted lineage.
   const auto last_task_id = tasks.back().GetTaskSpecification().TaskId();
   auto uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
+      lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_EQ(uncommitted_lineage.GetEntries().size(), lineage_size);
 
   // Simulate executing the last task on a remote node and adding it to the

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -158,8 +158,8 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
   }
 
   // Get the uncommitted lineage for the last task (the leaf) of one of the chains.
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_ids1.back(),
-                                                                  ClientID::nil());
+  auto uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(task_ids1.back(), ClientID::nil());
   // Check that the uncommitted lineage is exactly equal to the first chain of tasks.
   ASSERT_EQ(task_ids1.size(), uncommitted_lineage.GetEntries().size());
   for (auto &task_id : task_ids1) {
@@ -179,8 +179,8 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
   }
 
   // Get the uncommitted lineage for the inserted task.
-  uncommitted_lineage = lineage_cache_.GetUncommittedLineage(combined_task_ids.back(),
-                                                             ClientID::nil());
+  uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(combined_task_ids.back(), ClientID::nil());
   // Check that the uncommitted lineage is exactly equal to the entire set of
   // tasks inserted so far.
   ASSERT_EQ(combined_task_ids.size(), uncommitted_lineage.GetEntries().size());
@@ -193,8 +193,8 @@ TEST_F(LineageCacheTest, TestGetUncommittedLineage) {
 TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   // Insert chain of tasks.
   std::vector<Task> tasks;
-  auto return_values = InsertTaskChain(lineage_cache_, tasks, 4,
-                                       std::vector<ObjectID>(), 1);
+  auto return_values =
+          InsertTaskChain(lineage_cache_, tasks, 4, std::vector<ObjectID>(), 1);
   std::vector<TaskID> task_ids;
   for (const auto &task : tasks) {
     task_ids.push_back(task.GetTaskSpecification().TaskId());
@@ -204,12 +204,11 @@ TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   auto forwarded_task_id = task_ids[task_ids.size() - 2];
   auto remaining_task_id = task_ids[task_ids.size() - 1];
   lineage_cache_.MarkTaskAsForwarded(forwarded_task_id, node_id);
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(remaining_task_id,
-                                                                  node_id);
+  auto uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
 
   ASSERT_EQ(1, uncommitted_lineage.GetEntries().size());
   ASSERT_TRUE(uncommitted_lineage.GetEntry(remaining_task_id));
-
 }
 
 void CheckFlush(LineageCache &lineage_cache, MockGcs &mock_gcs,
@@ -319,8 +318,8 @@ TEST_F(LineageCacheTest, TestForwardTasksRoundTrip) {
   for (auto it = tasks.begin(); it != tasks.end(); it++) {
     const auto task_id = it->GetTaskSpecification().TaskId();
     // Simulate removing the task and forwarding it to another node.
-    auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id,
-                                                                    ClientID::nil());
+    auto uncommitted_lineage =
+            lineage_cache_.GetUncommittedLineage(task_id, ClientID::nil());
     lineage_cache_.RemoveWaitingTask(task_id);
     // Simulate receiving the task again. Make sure we can add the task back.
     flatbuffers::FlatBufferBuilder fbb;
@@ -344,8 +343,8 @@ TEST_F(LineageCacheTest, TestForwardTask) {
   auto forwarded_task = *it;
   tasks.erase(it);
   auto task_id_to_remove = forwarded_task.GetTaskSpecification().TaskId();
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id_to_remove,
-                                                                  ClientID::nil());
+  auto uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(task_id_to_remove, ClientID::nil());
   lineage_cache_.RemoveWaitingTask(task_id_to_remove);
 
   // Simulate executing the remaining tasks.
@@ -420,8 +419,8 @@ TEST_F(LineageCacheTest, TestEviction) {
   }
   // All tasks have now been flushed. Check that enough lineage has been
   // evicted that the uncommitted lineage is now less than the maximum size.
-  uncommitted_lineage = lineage_cache_.GetUncommittedLineage(last_task_id,
-                                                             ClientID::nil());
+  uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_TRUE(uncommitted_lineage.GetEntries().size() <= max_lineage_size_);
 }
 
@@ -445,8 +444,8 @@ TEST_F(LineageCacheTest, TestOutOfOrderEviction) {
   // Check that the last task in the chain still has all tasks in its
   // uncommitted lineage.
   const auto last_task_id = tasks.back().GetTaskSpecification().TaskId();
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(last_task_id,
-                                                                  ClientID::nil());
+  auto uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_EQ(uncommitted_lineage.GetEntries().size(), lineage_size);
 
   // Simulate executing the tasks at the remote node and receiving the
@@ -474,8 +473,8 @@ TEST_F(LineageCacheTest, TestOutOfOrderEviction) {
   }
   // All tasks have now been flushed. Check that enough lineage has been
   // evicted that the uncommitted lineage is now less than the maximum size.
-  uncommitted_lineage = lineage_cache_.GetUncommittedLineage(last_task_id,
-                                                             ClientID::nil());
+  uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_TRUE(uncommitted_lineage.GetEntries().size() <= max_lineage_size_);
 }
 
@@ -508,8 +507,8 @@ TEST_F(LineageCacheTest, TestEvictionUncommittedChildren) {
   // Check that the last task in the chain still has all tasks in its
   // uncommitted lineage.
   const auto last_task_id = tasks.back().GetTaskSpecification().TaskId();
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(last_task_id,
-                                                                  ClientID::nil());
+  auto uncommitted_lineage =
+          lineage_cache_.GetUncommittedLineage(last_task_id, ClientID::nil());
   ASSERT_EQ(uncommitted_lineage.GetEntries().size(), lineage_size);
 
   // Simulate executing the last task on a remote node and adding it to the

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1115,8 +1115,7 @@ void NodeManager::ResubmitTask(const TaskID &task_id) {
 void NodeManager::HandleObjectLocal(const ObjectID &object_id) {
   // Notify the task dependency manager that this object is local.
   const auto ready_task_ids = task_dependency_manager_.HandleObjectLocal(object_id);
-  // Transition the tasks whose dependencies are now fulfilled to the ready
-  // state.
+  // Transition the tasks whose dependencies are now fulfilled to the ready state.
   if (ready_task_ids.size() > 0) {
     std::unordered_set<TaskID> ready_task_id_set(ready_task_ids.begin(),
                                                  ready_task_ids.end());
@@ -1190,15 +1189,15 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
   auto task_id = spec.TaskId();
 
   // Get and serialize the task's unforwarded, uncommitted lineage.
-  auto unforwarded_uncommitted_lineage =
-          lineage_cache_.GetUncommittedLineage(task_id, node_id);
+  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
   Task &lineage_cache_entry_task =
-      unforwarded_uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
+          uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
+
   // Increment forward count for the forwarded task.
   lineage_cache_entry_task.GetTaskExecutionSpec().IncrementNumForwards();
 
   flatbuffers::FlatBufferBuilder fbb;
-  auto request = unforwarded_uncommitted_lineage.ToFlatbuffer(fbb, task_id);
+  auto request = uncommitted_lineage.ToFlatbuffer(fbb, task_id);
   fbb.Finish(request);
 
   RAY_LOG(DEBUG) << "Forwarding task " << task_id << " to " << node_id << " spillback="

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1191,7 +1191,7 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
   // Get and serialize the task's unforwarded, uncommitted lineage.
   auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
   Task &lineage_cache_entry_task =
-          uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
+      uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
 
   // Increment forward count for the forwarded task.
   lineage_cache_entry_task.GetTaskExecutionSpec().IncrementNumForwards();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1191,7 +1191,7 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
 
   // Get and serialize the task's unforwarded, uncommitted lineage.
   auto unforwarded_uncommitted_lineage =
-          lineage_cache_.GetUnforwardedUncommittedLineage(task_id, node_id);
+          lineage_cache_.GetUncommittedLineage(task_id, node_id);
   Task &lineage_cache_entry_task =
       unforwarded_uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
   // Increment forward count for the forwarded task.


### PR DESCRIPTION
## What do these changes do?

Adds a set to the lineage entry that keeps track of nodes that have already been sent the entry to prevent future forwards of the same entry. 

## Related issue number

#2530