### PR TITLE
Add `ray.internal.free`

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -50,11 +50,11 @@ from ray.local_scheduler import ObjectID, _config  # noqa: E402
 from ray.profiling import profile  # noqa: E402
 from ray.worker import (error_info, init, connect, disconnect, get, put, wait,
                         remote, get_gpu_ids, get_resource_ids, get_webui_url,
-                        register_custom_serializer, shutdown,
-                        free)  # noqa: E402
+                        register_custom_serializer, shutdown)  # noqa: E402
 from ray.worker import (SCRIPT_MODE, WORKER_MODE, LOCAL_MODE, SILENT_MODE,
                         PYTHON_MODE)  # noqa: E402
 from ray.worker import global_state  # noqa: E402
+import ray.internal  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
 import ray.actor  # noqa: F401
@@ -69,7 +69,7 @@ __all__ = [
     "remote", "profile", "actor", "method", "get_gpu_ids", "get_resource_ids",
     "get_webui_url", "register_custom_serializer", "shutdown", "SCRIPT_MODE",
     "WORKER_MODE", "LOCAL_MODE", "SILENT_MODE", "PYTHON_MODE", "global_state",
-    "ObjectID", "free", "_config", "__version__"
+    "ObjectID", "_config", "__version__"
 ]
 
 import ctypes  # noqa: E402

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -50,7 +50,8 @@ from ray.local_scheduler import ObjectID, _config  # noqa: E402
 from ray.profiling import profile  # noqa: E402
 from ray.worker import (error_info, init, connect, disconnect, get, put, wait,
                         remote, get_gpu_ids, get_resource_ids, get_webui_url,
-                        register_custom_serializer, shutdown)  # noqa: E402
+                        register_custom_serializer, shutdown,
+                        free)  # noqa: E402
 from ray.worker import (SCRIPT_MODE, WORKER_MODE, LOCAL_MODE, SILENT_MODE,
                         PYTHON_MODE)  # noqa: E402
 from ray.worker import global_state  # noqa: E402
@@ -68,7 +69,7 @@ __all__ = [
     "remote", "profile", "actor", "method", "get_gpu_ids", "get_resource_ids",
     "get_webui_url", "register_custom_serializer", "shutdown", "SCRIPT_MODE",
     "WORKER_MODE", "LOCAL_MODE", "SILENT_MODE", "PYTHON_MODE", "global_state",
-    "ObjectID", "_config", "__version__"
+    "ObjectID", "free", "_config", "__version__"
 ]
 
 import ctypes  # noqa: E402

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
     "remote", "profile", "actor", "method", "get_gpu_ids", "get_resource_ids",
     "get_webui_url", "register_custom_serializer", "shutdown", "SCRIPT_MODE",
     "WORKER_MODE", "LOCAL_MODE", "SILENT_MODE", "PYTHON_MODE", "global_state",
-    "ObjectID", "_config", "__version__"
+    "ObjectID", "_config", "__version__", "internal"
 ]
 
 import ctypes  # noqa: E402

--- a/python/ray/internal/__init__.py
+++ b/python/ray/internal/__init__.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ray.internal.internal_api import (
-    free
-)
+from ray.internal.internal_api import free
 
-__all__ = [
-    "free"
-]
+__all__ = ["free"]

--- a/python/ray/internal/__init__.py
+++ b/python/ray/internal/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ray.internal.internal_api import (
+    free
+)
+
+__all__ = [
+    "free"
+]

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -5,18 +5,17 @@ from __future__ import print_function
 import ray.local_scheduler
 import ray.worker
 from ray import profiling
-import pyarrow.plasma as plasma
 
 __all__ = ["free"]
 
 
-def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
+def free(object_ids, local_only=False, worker=None):
     """Free a list of IDs from object stores.
 
-    This function is low-level API which should be used in restricted
+    This function is a low-level API which should be used in restricted
     scenarios.
 
-    If spread is set, the request will spread to all object stores.
+    If local_only is false, the request will be send to all object stores.
 
     This method will not return any value to indicate whether the deletion is
     successful or not. This function is an instruction to object store. If
@@ -25,30 +24,26 @@ def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
 
     Args:
         object_ids (List[ObjectID]): List of object IDs to delete.
-        spread (bool): Whether deleting the list of objects in all object
-                       stores.
-
+        local_only (bool): Whether only deleting the list of objects in local
+                           object store or all object stores.
     """
+    if worker is None:
+        worker = ray.worker.get_global_worker()
 
     if isinstance(object_ids, ray.ObjectID):
-        raise TypeError(
-            "free() expected a list of ObjectID, got a single ObjectID")
+        free([object_ids], local_only, worker)
+        return
 
     if not isinstance(object_ids, list):
-        raise TypeError("free() expected a list of ObjectID, got {}".format(
+        raise TypeError("free() expects a list of ObjectID, got {}".format(
             type(object_ids)))
+
     worker.check_connected()
     with profiling.profile("ray.free", worker=worker):
-
         if len(object_ids) == 0:
             return
 
-        if len(object_ids) != len(set(object_ids)):
-            raise Exception("Free requires a list of unique object IDs.")
         if worker.use_raylet:
-            plain_object_ids = [
-                plasma.ObjectID(object_id.id()) for object_id in object_ids
-            ]
-            worker.local_scheduler_client.free(object_ids, spread)
+            worker.local_scheduler_client.free(object_ids, local_only)
         else:
             raise Exception("Free is not supported in legacy backend.")

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -2,15 +2,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
 import ray.local_scheduler
 import ray.worker
 from ray import profiling
 import pyarrow.plasma as plasma
 
-__all__ = [
-    "free"
-]
+__all__ = ["free"]
 
 
 def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
@@ -52,7 +49,6 @@ def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
             plain_object_ids = [
                 plasma.ObjectID(object_id.id()) for object_id in object_ids
             ]
-            worker.local_scheduler_client.free(
-                object_ids, spread)
+            worker.local_scheduler_client.free(object_ids, spread)
         else:
             raise Exception("Free is not supported in legacy backend.")

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -25,14 +25,13 @@ def free(object_ids, local_only=False, worker=None):
     Args:
         object_ids (List[ObjectID]): List of object IDs to delete.
         local_only (bool): Whether only deleting the list of objects in local
-                           object store or all object stores.
+            object store or all object stores.
     """
     if worker is None:
         worker = ray.worker.get_global_worker()
 
     if isinstance(object_ids, ray.ObjectID):
-        free([object_ids], local_only, worker)
-        return
+        object_ids = [object_ids]
 
     if not isinstance(object_ids, list):
         raise TypeError("free() expects a list of ObjectID, got {}".format(

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -7,7 +7,6 @@ import ray.local_scheduler
 import ray.worker
 from ray import profiling
 import pyarrow.plasma as plasma
-from ray.worker import check_main_thread
 
 __all__ = [
     "free"
@@ -41,10 +40,8 @@ def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
     if not isinstance(object_ids, list):
         raise TypeError("free() expected a list of ObjectID, got {}".format(
             type(object_ids)))
-
     worker.check_connected()
     with profiling.profile("ray.free", worker=worker):
-        check_main_thread()
 
         if len(object_ids) == 0:
             return
@@ -55,8 +52,6 @@ def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
             plain_object_ids = [
                 plasma.ObjectID(object_id.id()) for object_id in object_ids
             ]
-            worker.plasma_client.delete(plain_object_ids)
-            print(object_ids)
             worker.local_scheduler_client.free(
                 object_ids, spread)
         else:

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import ray.local_scheduler
+import ray.worker
+from ray import profiling
+import pyarrow.plasma as plasma
+from ray.worker import check_main_thread
+
+__all__ = [
+    "free"
+]
+
+
+def free(object_ids, spread=True, worker=ray.worker.get_global_worker()):
+    """Free a list of IDs from object stores.
+
+    This function is low-level API which should be used in restricted
+    scenarios.
+
+    If spread is set, the request will spread to all object stores.
+
+    This method will not return any value to indicate whether the deletion is
+    successful or not. This function is an instruction to object store. If
+    the some of the objects are in use, object stores will delete them later
+    when the ref count is down to 0.
+
+    Args:
+        object_ids (List[ObjectID]): List of object IDs to delete.
+        spread (bool): Whether deleting the list of objects in all object
+                       stores.
+
+    """
+
+    if isinstance(object_ids, ray.ObjectID):
+        raise TypeError(
+            "free() expected a list of ObjectID, got a single ObjectID")
+
+    if not isinstance(object_ids, list):
+        raise TypeError("free() expected a list of ObjectID, got {}".format(
+            type(object_ids)))
+
+    worker.check_connected()
+    with profiling.profile("ray.free", worker=worker):
+        check_main_thread()
+
+        if len(object_ids) == 0:
+            return
+
+        if len(object_ids) != len(set(object_ids)):
+            raise Exception("Free requires a list of unique object IDs.")
+        if worker.use_raylet:
+            plain_object_ids = [
+                plasma.ObjectID(object_id.id()) for object_id in object_ids
+            ]
+            worker.plasma_client.delete(plain_object_ids)
+            print(object_ids)
+            worker.local_scheduler_client.free(
+                object_ids, spread)
+        else:
+            raise Exception("Free is not supported in legacy backend.")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2600,51 +2600,6 @@ def wait(object_ids, num_returns=1, timeout=None, worker=global_worker):
         return ready_ids, remaining_ids
 
 
-def free(object_ids, spread=True, worker=global_worker):
-    """Free a list of IDs from object stores.
-
-    This function is low-level API which should be used in restricted
-    scenarios.
-
-    If spread is set, the request will spread to all object stores.
-
-    This method will not return any value to indicate whether the deletion is
-    successful or not. This function is an instruction to object store. If
-    the some of the objects are in use, object stores will delete them later
-    when the ref count is down to 0.
-
-    Args:
-        object_ids (List[ObjectID]): List of object IDs to delete.
-        spread (bool): Whether deleting the list of objects in all object
-                       stores.
-
-    """
-
-    if isinstance(object_ids, ray.ObjectID):
-        raise TypeError(
-            "free() expected a list of ObjectID, got a single ObjectID")
-
-    if not isinstance(object_ids, list):
-        raise TypeError("free() expected a list of ObjectID, got {}".format(
-            type(object_ids)))
-
-    worker.check_connected()
-    with profiling.profile("ray.free", worker=worker):
-        check_main_thread()
-
-        if len(object_ids) == 0:
-            return
-
-        if len(object_ids) != len(set(object_ids)):
-            raise Exception("Free requires a list of unique object IDs.")
-        if worker.use_raylet:
-            print(object_ids)
-            worker.local_scheduler_client.free(
-                object_ids, spread)
-        else:
-            raise Exception("Free is not supported in legacy backend.")
-
-
 def _mode(worker=global_worker):
     """This is a wrapper around worker.mode.
 

--- a/src/local_scheduler/lib/python/local_scheduler_extension.cc
+++ b/src/local_scheduler/lib/python/local_scheduler_extension.cc
@@ -416,13 +416,13 @@ static PyObject *PyLocalSchedulerClient_push_profile_events(PyObject *self,
 
 static PyObject *PyLocalSchedulerClient_free(PyObject *self, PyObject *args) {
   PyObject *py_object_ids;
-  PyObject *py_spread;
+  PyObject *py_local_only;
 
-  if (!PyArg_ParseTuple(args, "OO", &py_object_ids, &py_spread)) {
+  if (!PyArg_ParseTuple(args, "OO", &py_object_ids, &py_local_only)) {
     return NULL;
   }
 
-  bool spread = static_cast<bool>(PyObject_IsTrue(py_spread));
+  bool local_only = static_cast<bool>(PyObject_IsTrue(py_local_only));
 
   // Convert object ids.
   PyObject *iter = PyObject_GetIter(py_object_ids);
@@ -437,7 +437,7 @@ static PyObject *PyLocalSchedulerClient_free(PyObject *self, PyObject *args) {
       break;
     }
     if (!PyObjectToUniqueID(next, &object_id)) {
-      // Error parsing object id.
+      // Error parsing object ID.
       return NULL;
     }
     object_ids.push_back(object_id);
@@ -447,7 +447,7 @@ static PyObject *PyLocalSchedulerClient_free(PyObject *self, PyObject *args) {
   local_scheduler_free_objects_in_object_store(
       reinterpret_cast<PyLocalSchedulerClient *>(self)
           ->local_scheduler_connection,
-      object_ids, spread);
+      object_ids, local_only);
   Py_RETURN_NONE;
 }
 

--- a/src/local_scheduler/lib/python/local_scheduler_extension.cc
+++ b/src/local_scheduler/lib/python/local_scheduler_extension.cc
@@ -414,6 +414,43 @@ static PyObject *PyLocalSchedulerClient_push_profile_events(PyObject *self,
   Py_RETURN_NONE;
 }
 
+static PyObject *PyLocalSchedulerClient_free(PyObject *self, PyObject *args) {
+  PyObject *py_object_ids;
+  PyObject *py_spread;
+
+  if (!PyArg_ParseTuple(args, "OO", &py_object_ids, &py_spread)) {
+    return NULL;
+  }
+
+  bool spread = static_cast<bool>(PyObject_IsTrue(py_spread));
+
+  // Convert object ids.
+  PyObject *iter = PyObject_GetIter(py_object_ids);
+  if (!iter) {
+    return NULL;
+  }
+  std::vector<ObjectID> object_ids;
+  while (true) {
+    PyObject *next = PyIter_Next(iter);
+    ObjectID object_id;
+    if (!next) {
+      break;
+    }
+    if (!PyObjectToUniqueID(next, &object_id)) {
+      // Error parsing object id.
+      return NULL;
+    }
+    object_ids.push_back(object_id);
+  }
+
+  // Invoke local_scheduler_free_objects_in_object_store.
+  local_scheduler_free_objects_in_object_store(
+      reinterpret_cast<PyLocalSchedulerClient *>(self)
+          ->local_scheduler_connection,
+      object_ids, spread);
+  Py_RETURN_NONE;
+}
+
 static PyMethodDef PyLocalSchedulerClient_methods[] = {
     {"disconnect", (PyCFunction) PyLocalSchedulerClient_disconnect, METH_NOARGS,
      "Notify the local scheduler that this client is exiting gracefully."},
@@ -446,6 +483,8 @@ static PyMethodDef PyLocalSchedulerClient_methods[] = {
     {"push_profile_events",
      (PyCFunction) PyLocalSchedulerClient_push_profile_events, METH_VARARGS,
      "Store some profiling events in the GCS."},
+    {"free", (PyCFunction) PyLocalSchedulerClient_free, METH_VARARGS,
+     "Free a list of objects from object stores."},
     {NULL} /* Sentinel */
 };
 

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -351,3 +351,19 @@ void local_scheduler_push_profile_events(
                     ray::protocol::MessageType::PushProfileEventsRequest),
                 fbb.GetSize(), fbb.GetBufferPointer(), &conn->write_mutex);
 }
+
+void local_scheduler_free_objects_in_object_store(
+    LocalSchedulerConnection *conn,
+    const std::vector<ray::ObjectID> &object_ids,
+    bool spread) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = ray::protocol::CreateFreeObjectsRequest(
+      fbb, spread, to_flatbuf(fbb, object_ids));
+  fbb.Finish(message);
+
+  write_message(
+      conn->conn,
+      static_cast<int64_t>(
+          ray::protocol::MessageType::FreeObjectsInObjectStoreRequest),
+      fbb.GetSize(), fbb.GetBufferPointer(), &conn->write_mutex);
+}

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -355,15 +355,16 @@ void local_scheduler_push_profile_events(
 void local_scheduler_free_objects_in_object_store(
     LocalSchedulerConnection *conn,
     const std::vector<ray::ObjectID> &object_ids,
-    bool spread) {
+    bool local_only) {
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateFreeObjectsRequest(
-      fbb, spread, to_flatbuf(fbb, object_ids));
+      fbb, local_only, to_flatbuf(fbb, object_ids));
   fbb.Finish(message);
 
-  write_message(
+  int success = write_message(
       conn->conn,
       static_cast<int64_t>(
           ray::protocol::MessageType::FreeObjectsInObjectStoreRequest),
       fbb.GetSize(), fbb.GetBufferPointer(), &conn->write_mutex);
+  RAY_CHECK(success == 0) << "Failed to write message to raylet.";
 }

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -244,4 +244,15 @@ void local_scheduler_push_profile_events(
     LocalSchedulerConnection *conn,
     const ProfileTableDataT &profile_events);
 
+/// Free a list of objects from object stores.
+///
+/// \param conn The connection information.
+/// \param object_ids A list of ObjectsIDs to be deleted.
+/// \param spread Whether spread this request to all the object stores.
+/// \return Void.
+void local_scheduler_free_objects_in_object_store(
+    LocalSchedulerConnection *conn,
+    const std::vector<ray::ObjectID> &object_ids,
+    bool spread);
+
 #endif

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -249,7 +249,7 @@ void local_scheduler_push_profile_events(
 /// \param conn The connection information.
 /// \param object_ids A list of ObjectsIDs to be deleted.
 /// \param local_only Whether keep this request with local object store
-///        or send it to all the object stores.
+/// or send it to all the object stores.
 /// \return Void.
 void local_scheduler_free_objects_in_object_store(
     LocalSchedulerConnection *conn,

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -248,11 +248,12 @@ void local_scheduler_push_profile_events(
 ///
 /// \param conn The connection information.
 /// \param object_ids A list of ObjectsIDs to be deleted.
-/// \param spread Whether spread this request to all the object stores.
+/// \param local_only Whether keep this request with local object store
+///        or send it to all the object stores.
 /// \return Void.
 void local_scheduler_free_objects_in_object_store(
     LocalSchedulerConnection *conn,
     const std::vector<ray::ObjectID> &object_ids,
-    bool spread);
+    bool local_only);
 
 #endif

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -426,6 +426,10 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) const 
   }
 }
 
+const std::unordered_map<ClientID, ClientTableDataT> &ClientTable::GetAllClients() const {
+  return client_cache_;
+}
+
 template class Log<ObjectID, ObjectTableData>;
 template class Log<TaskID, ray::protocol::Task>;
 template class Table<TaskID, ray::protocol::Task>;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -653,7 +653,8 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
 
   /// Get the information of all clients.
   ///
-  /// \return The clientId to Client information map.
+  /// \return The client ID to client information map.
+  /// Note: The return value contains ClientID::nil() which should be filtered.
   const std::unordered_map<ClientID, ClientTableDataT> &GetAllClients() const;
 
  private:

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -653,8 +653,9 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
 
   /// Get the information of all clients.
   ///
-  /// \return The client ID to client information map.
   /// Note: The return value contains ClientID::nil() which should be filtered.
+  ///
+  /// \return The client ID to client information map.
   const std::unordered_map<ClientID, ClientTableDataT> &GetAllClients() const;
 
  private:

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -651,6 +651,11 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   /// \return Whether the client with ID client_id is removed.
   bool IsRemoved(const ClientID &client_id) const;
 
+  /// Get the information of all clients.
+  ///
+  /// \return The clientId to Client information map.
+  const std::unordered_map<ClientID, ClientTableDataT> &GetAllClients() const;
+
  private:
   /// Handle a client table notification.
   void HandleNotification(AsyncGcsClient *client, const ClientTableDataT &notifications);

--- a/src/ray/object_manager/format/object_manager.fbs
+++ b/src/ray/object_manager/format/object_manager.fbs
@@ -4,7 +4,8 @@ namespace ray.object_manager.protocol;
 enum MessageType:int {
   ConnectClient = 1,
   PushRequest,
-  PullRequest
+  PullRequest,
+  FreeRequest
 }
 
 table PushRequestMessage {
@@ -30,4 +31,9 @@ table ConnectClientMessage {
   client_id: string;
   // Whether this is a transfer connection.
   is_transfer: bool;
+}
+
+table FreeRequestMessage {
+  // List of IDs to be deleted.
+  object_ids: [string];
 }

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -185,4 +185,15 @@ std::vector<ObjectBufferPool::ChunkInfo> ObjectBufferPool::BuildChunks(
   return chunks;
 }
 
+void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
+  std::vector<plasma::ObjectID> plasma_ids;
+  plasma_ids.reserve(object_ids.size());
+  for (auto &id : object_ids) {
+    // After merging https://github.com/ray-project/ray/pull/2404,
+    // remove ObjectID().
+    plasma_ids.push_back(ObjectID(id).to_plasma_id());
+  }
+  ARROW_CHECK_OK(store_client_.Delete(plasma_ids));
+}
+
 }  // namespace ray

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -189,9 +189,7 @@ void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
   std::vector<plasma::ObjectID> plasma_ids;
   plasma_ids.reserve(object_ids.size());
   for (auto &id : object_ids) {
-    // After merging https://github.com/ray-project/ray/pull/2404,
-    // remove ObjectID().
-    plasma_ids.push_back(ObjectID(id).to_plasma_id());
+    plasma_ids.push_back(id.to_plasma_id());
   }
   ARROW_CHECK_OK(store_client_.Delete(plasma_ids));
 }

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -188,7 +188,7 @@ std::vector<ObjectBufferPool::ChunkInfo> ObjectBufferPool::BuildChunks(
 void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
   std::vector<plasma::ObjectID> plasma_ids;
   plasma_ids.reserve(object_ids.size());
-  for (auto &id : object_ids) {
+  for (const auto &id : object_ids) {
     plasma_ids.push_back(id.to_plasma_id());
   }
   ARROW_CHECK_OK(store_client_.Delete(plasma_ids));

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -123,6 +123,10 @@ class ObjectBufferPool {
   /// \param chunk_index The index of the chunk.
   void SealChunk(const ObjectID &object_id, uint64_t chunk_index);
 
+  /// Free a list of objects from object store.
+  /// \param object_ids the The list of ObjectIDs to be deleted.
+  void FreeObjects(const std::vector<ObjectID> &object_ids);
+
  private:
   /// Abort the create operation associated with an object. This destroys the buffer
   /// state, including create operations in progress for all chunks of the object.

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -124,7 +124,9 @@ class ObjectBufferPool {
   void SealChunk(const ObjectID &object_id, uint64_t chunk_index);
 
   /// Free a list of objects from object store.
+  ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
+  /// \return Void.
   void FreeObjects(const std::vector<ObjectID> &object_ids);
 
  private:

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -117,6 +117,23 @@ ray::Status ObjectDirectory::GetInformation(const ClientID &client_id,
   return ray::Status::OK();
 }
 
+ray::Status ObjectDirectory::GetAllClientInfo(
+    const InfoSuccessCallback &success_callback) {
+  auto clients = gcs_client_->client_table().GetAllClients();
+  for (auto &client_pair : clients) {
+    const ClientTableDataT &data = client_pair.second;
+    if (client_pair.first == ClientID::nil() || !data.is_insertion) {
+      continue;
+    } else {
+      const auto &info =
+          RemoteConnectionInfo(client_pair.first, data.node_manager_address,
+                               (uint16_t)data.object_manager_port);
+      success_callback(info);
+    }
+  }
+  return ray::Status::OK();
+}
+
 ray::Status ObjectDirectory::SubscribeObjectLocations(const UniqueID &callback_id,
                                                       const ObjectID &object_id,
                                                       const OnLocationsFound &callback) {

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -119,10 +119,12 @@ ray::Status ObjectDirectory::GetInformation(const ClientID &client_id,
 
 ray::Status ObjectDirectory::GetAllClientInfo(
     const InfoSuccessCallback &success_callback) {
-  auto clients = gcs_client_->client_table().GetAllClients();
-  for (auto &client_pair : clients) {
+  const auto &clients = gcs_client_->client_table().GetAllClients();
+  for (const auto &client_pair : clients) {
     const ClientTableDataT &data = client_pair.second;
-    if (client_pair.first == ClientID::nil() || !data.is_insertion) {
+    if (client_pair.first == ClientID::nil() ||
+        client_pair.first == gcs_client_->client_table().GetLocalClientId() ||
+        !data.is_insertion) {
       continue;
     } else {
       const auto &info =

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -117,8 +117,8 @@ ray::Status ObjectDirectory::GetInformation(const ClientID &client_id,
   return ray::Status::OK();
 }
 
-ray::Status ObjectDirectory::GetAllClientInfo(
-    const InfoSuccessCallback &success_callback) {
+void ObjectDirectory::RunFunctionForEachClient(
+    const InfoSuccessCallback &client_function) {
   const auto &clients = gcs_client_->client_table().GetAllClients();
   for (const auto &client_pair : clients) {
     const ClientTableDataT &data = client_pair.second;
@@ -129,11 +129,10 @@ ray::Status ObjectDirectory::GetAllClientInfo(
     } else {
       const auto &info =
           RemoteConnectionInfo(client_pair.first, data.node_manager_address,
-                               (uint16_t)data.object_manager_port);
-      success_callback(info);
+                               static_cast<uint16_t>(data.object_manager_port));
+      client_function(info);
     }
   }
-  return ray::Status::OK();
 }
 
 ray::Status ObjectDirectory::SubscribeObjectLocations(const UniqueID &callback_id,

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -101,6 +101,13 @@ class ObjectDirectoryInterface {
   /// \return Status of whether this method succeeded.
   virtual ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                           const ClientID &client_id) = 0;
+
+  /// Go through all the client information.
+  ///
+  /// \param success_cb A callback which handles the success of this method.
+  ///                   This function will be called multiple times.
+  /// \return Status of whether this asynchronous request succeeded.
+  virtual ray::Status GetAllClientInfo(const InfoSuccessCallback &success_cb) = 0;
 };
 
 /// Ray ObjectDirectory declaration.
@@ -114,6 +121,8 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   ray::Status GetInformation(const ClientID &client_id,
                              const InfoSuccessCallback &success_callback,
                              const InfoFailureCallback &fail_callback) override;
+
+  ray::Status GetAllClientInfo(const InfoSuccessCallback &success_cb) override;
 
   ray::Status LookupLocations(const ObjectID &object_id,
                               const OnLocationsFound &callback) override;

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -105,9 +105,9 @@ class ObjectDirectoryInterface {
   /// Go through all the client information.
   ///
   /// \param success_cb A callback which handles the success of this method.
-  ///                   This function will be called multiple times.
-  /// \return Status of whether this asynchronous request succeeded.
-  virtual ray::Status GetAllClientInfo(const InfoSuccessCallback &success_cb) = 0;
+  /// This function will be called multiple times.
+  /// \return Void.
+  virtual void RunFunctionForEachClient(const InfoSuccessCallback &client_function) = 0;
 };
 
 /// Ray ObjectDirectory declaration.
@@ -122,7 +122,7 @@ class ObjectDirectory : public ObjectDirectoryInterface {
                              const InfoSuccessCallback &success_callback,
                              const InfoFailureCallback &fail_callback) override;
 
-  ray::Status GetAllClientInfo(const InfoSuccessCallback &success_cb) override;
+  void RunFunctionForEachClient(const InfoSuccessCallback &client_function) override;
 
   ray::Status LookupLocations(const ObjectID &object_id,
                               const OnLocationsFound &callback) override;

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -769,6 +769,7 @@ void ObjectManager::ReceiveFreeRequest(std::shared_ptr<TcpClientConnection> &con
   // Keep this request local.
   bool local_only = true;
   FreeObjects(object_ids, local_only);
+  conn->ProcessMessages();
 }
 
 void ObjectManager::FreeObjects(const std::vector<ObjectID> &object_ids,

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -1,7 +1,6 @@
 #include "ray/object_manager/object_manager.h"
-#include "ray/util/util.h"
 #include "common/common_protocol.h"
-
+#include "ray/util/util.h"
 
 namespace asio = boost::asio;
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -797,11 +797,14 @@ void ObjectManager::SpreadFreeObjectRequest(const std::vector<ObjectID> &object_
       connection_pool_.RegisterSender(ConnectionPool::ConnectionType::MESSAGE,
                                       connection_info.client_id, conn);
     }
-    RAY_CHECK_OK(conn->WriteMessage(
+    status = conn->WriteMessage(
         static_cast<int64_t>(object_manager_protocol::MessageType::FreeRequest),
-        fbb.GetSize(), fbb.GetBufferPointer()));
-    RAY_CHECK_OK(
-        connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::MESSAGE, conn));
+        fbb.GetSize(), fbb.GetBufferPointer());
+    if (status.ok()) {
+      RAY_CHECK_OK(
+          connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::MESSAGE, conn));
+    }
+    // TODO(Yuhong): Implement ConnectionPool::RemoveSender and call it in "else".
   };
   object_directory_->RunFunctionForEachClient(function_on_client);
 }

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -774,7 +774,6 @@ void ObjectManager::ReceiveFreeRequest(std::shared_ptr<TcpClientConnection> &con
   // Do not spread this request.
   bool spread = false;
   FreeObjects(object_ids, spread);
-  conn->ProcessMessages();
 }
 
 void ObjectManager::FreeObjects(const std::vector<ObjectID> &object_ids, bool spread) {

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -163,6 +163,11 @@ class ObjectManager : public ObjectManagerInterface {
                    uint64_t num_required_objects, bool wait_local,
                    const WaitCallback &callback);
 
+  /// Free a list of objects from object store.
+  /// \param object_ids the The list of ObjectIDs to be deleted.
+  /// \param spread Whether send this request to all the object stores.
+  void FreeObjects(const std::vector<ObjectID> &object_ids, bool spread);
+
  private:
   friend class TestObjectManager;
 
@@ -270,6 +275,9 @@ class ObjectManager : public ObjectManagerInterface {
 
   /// Handles receiving a pull request message.
   void ReceivePullRequest(std::shared_ptr<TcpClientConnection> &conn,
+                          const uint8_t *message);
+  /// Handles freeing objects request.
+  void ReceiveFreeRequest(std::shared_ptr<TcpClientConnection> &conn,
                           const uint8_t *message);
 
   /// Handles connect message of a new client connection.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -166,12 +166,9 @@ class ObjectManager : public ObjectManagerInterface {
   /// Free a list of objects from object store.
   ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
-  /// \param spread Whether send this request to all the object stores.
-  void FreeObjects(const std::vector<ObjectID> &object_ids, bool spread);
-  /// Spread the Free request to all objects managers.
-  ///
-  /// \param object_ids the The list of ObjectIDs to be deleted.
-  void SpreadFreeObjectRequest(const std::vector<ObjectID> &object_ids);
+  /// \param local_only Whether keep this request with local object store
+  ///                   or send it to all the object stores.
+  void FreeObjects(const std::vector<ObjectID> &object_ids, bool local_only);
 
  private:
   friend class TestObjectManager;
@@ -223,6 +220,11 @@ class ObjectManager : public ObjectManagerInterface {
   void SubscribeRemainingWaitObjects(const UniqueID &wait_id);
   /// Completion handler for Wait.
   void WaitComplete(const UniqueID &wait_id);
+
+  /// Spread the Free request to all objects managers.
+  ///
+  /// \param object_ids the The list of ObjectIDs to be deleted.
+  void SpreadFreeObjectRequest(const std::vector<ObjectID> &object_ids);
 
   /// Handle starting, running, and stopping asio io_service.
   void StartIOService();

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -164,9 +164,14 @@ class ObjectManager : public ObjectManagerInterface {
                    const WaitCallback &callback);
 
   /// Free a list of objects from object store.
+  ///
   /// \param object_ids the The list of ObjectIDs to be deleted.
   /// \param spread Whether send this request to all the object stores.
   void FreeObjects(const std::vector<ObjectID> &object_ids, bool spread);
+  /// Spread the Free request to all objects managers.
+  ///
+  /// \param object_ids the The list of ObjectIDs to be deleted.
+  void SpreadFreeObjectRequest(const std::vector<ObjectID> &object_ids);
 
  private:
   friend class TestObjectManager;

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -181,8 +181,9 @@ table PushErrorRequest {
 }
 
 table FreeObjectsRequest {
-  // Whether spread this request to all the object stores that have been registered.
-  spread: bool;
+  // Whether keep this request with local object store 
+  // or send it to all the object stores.
+  local_only: bool;
   // List of object ids we'll delete from object store.
   object_ids: [string];
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -68,6 +68,8 @@ enum MessageType:int {
   // Push some profiling events to the GCS. When sending this message to the
   // node manager, the message itself is serialized as a ProfileTableData object.
   PushProfileEventsRequest,
+  // Free the objects in objects store.
+  FreeObjectsInObjectStore,
 }
 
 table TaskExecutionSpecification {
@@ -176,4 +178,11 @@ table PushErrorRequest {
   error_message: string;
   // The timestamp of the error message.
   timestamp: double;
+}
+
+table FreeObjectsRequest {
+  // Whether spread this request to all the object stores that have been registered.
+  spread: bool;
+  // List of object ids we'll delete from object store.
+  object_ids: [string];
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -69,7 +69,7 @@ enum MessageType:int {
   // node manager, the message itself is serialized as a ProfileTableData object.
   PushProfileEventsRequest,
   // Free the objects in objects store.
-  FreeObjectsInObjectStore,
+  FreeObjectsInObjectStoreRequest,
 }
 
 table TaskExecutionSpecification {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -711,7 +711,7 @@ void NodeManager::ProcessClientMessage(
   case protocol::MessageType::FreeObjectsInObjectStoreRequest: {
     auto message = flatbuffers::GetRoot<protocol::FreeObjectsRequest>(message_data);
     std::vector<ObjectID> object_ids = from_flatbuf(*message->object_ids());
-    object_manager_.FreeObjects(object_ids, message->spread());
+    object_manager_.FreeObjects(object_ids, message->local_only());
   } break;
 
   default:

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -708,6 +708,11 @@ void NodeManager::ProcessClientMessage(
 
     RAY_CHECK_OK(gcs_client_->profile_table().AddProfileEventBatch(*message));
   } break;
+  case protocol::MessageType::FreeObjectsInObjectStore: {
+    auto message = flatbuffers::GetRoot<protocol::FreeObjectsRequest>(message_data);
+    std::vector<ObjectID> object_ids = from_flatbuf(*message->object_ids());
+    object_manager_.FreeObjects(object_ids, message->spread());
+  } break;
 
   default:
     RAY_LOG(FATAL) << "Received unexpected message type " << message_type;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -708,7 +708,7 @@ void NodeManager::ProcessClientMessage(
 
     RAY_CHECK_OK(gcs_client_->profile_table().AddProfileEventBatch(*message));
   } break;
-  case protocol::MessageType::FreeObjectsInObjectStore: {
+  case protocol::MessageType::FreeObjectsInObjectStoreRequest: {
     auto message = flatbuffers::GetRoot<protocol::FreeObjectsRequest>(message_data);
     std::vector<ObjectID> object_ids = from_flatbuf(*message->object_ids());
     object_manager_.FreeObjects(object_ids, message->spread());

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -47,7 +47,7 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   MOCK_METHOD3(ReportObjectAdded,
                ray::Status(const ObjectID &, const ClientID &, const ObjectInfoT &));
   MOCK_METHOD2(ReportObjectRemoved, ray::Status(const ObjectID &, const ClientID &));
-  MOCK_METHOD1(GetAllClientInfo, ray::Status(const InfoSuccessCallback &success_cb));
+  MOCK_METHOD1(RunFunctionForEachClient, void(const InfoSuccessCallback &success_cb));
 
  private:
   std::vector<std::pair<ObjectID, OnLocationsFound>> callbacks_;

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -47,6 +47,7 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   MOCK_METHOD3(ReportObjectAdded,
                ray::Status(const ObjectID &, const ClientID &, const ObjectInfoT &));
   MOCK_METHOD2(ReportObjectRemoved, ray::Status(const ObjectID &, const ClientID &));
+  MOCK_METHOD1(GetAllClientInfo, ray::Status(const InfoSuccessCallback &success_cb));
 
  private:
   std::vector<std::pair<ObjectID, OnLocationsFound>> callbacks_;

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1213,26 +1213,32 @@ class APITest(unittest.TestCase):
             start_ray_local=True,
             num_local_schedulers=3,
             num_workers=1,
-            resources=[{"Custom0" : 1}, {"Custom1" : 1},
-                {"Custom2" : 1}],
+            num_cpus=[1, 1, 1],
+            resources=[{
+                "Custom0": 1
+            }, {
+                "Custom1": 1
+            }, {
+                "Custom2": 1
+            }],
             use_raylet=True)
 
-        @ray.remote(resources={"Custom0" : 1})
+        @ray.remote(resources={"Custom0": 1})
         def run_on_0():
             return ray.worker.global_worker.plasma_client.store_socket_name
 
-        @ray.remote(resources={"Custom1" : 1})
+        @ray.remote(resources={"Custom1": 1})
         def run_on_1():
             return ray.worker.global_worker.plasma_client.store_socket_name
 
-        @ray.remote(resources={"Custom2" : 1})
+        @ray.remote(resources={"Custom2": 1})
         def run_on_2():
             return ray.worker.global_worker.plasma_client.store_socket_name
 
         def create():
-            c = run_on_0.remote()
-            a = run_on_1.remote()
-            b = run_on_2.remote()
+            a = run_on_0.remote()
+            b = run_on_1.remote()
+            c = run_on_2.remote()
             (l1, l2) = ray.wait([a, b, c], num_returns=3)
             assert len(l1) == 3
             assert len(l2) == 0
@@ -1243,34 +1249,39 @@ class APITest(unittest.TestCase):
             # Current Plasma Client Cache will maintain 64-item list.
             # If the number changed, this will fail.
             print("Start Flush!")
-            for i in range(128):
-                run_on_0.remote()
-                run_on_1.remote()
-                run_on_2.remote()
-                # Flush the driver client cache,
-                # because the driver hold the objects by `ray.get`.
-                ray.put(1)
-            ray.wait([run_on_0.remote(), run_on_1.remote(), run_on_2.remote()])
+            for i in range(64):
+                ray.get(
+                    [run_on_0.remote(),
+                     run_on_1.remote(),
+                     run_on_2.remote()])
             print("Flush finished!")
+
         def run_one_test(local_only):
             (a, b, c) = create()
-            print("output:%s" %((a,b,c),))
             # The three objects should be generated on different object stores.
-            ray.wait([a, b, c], timeout=5)
-            #assert ray.get(a) != ray.get(b)
-            #assert ray.get(a) != ray.get(c)
-            #assert ray.get(c) != ray.get(b)
+            assert ray.get(a) != ray.get(b)
+            assert ray.get(a) != ray.get(c)
+            assert ray.get(c) != ray.get(b)
             ray.internal.free([a, b, c], local_only=local_only)
             flush()
-            return ray.wait([a, b, c], timeout=3)
-        (l1, l2) = run_one_test(False)
-        # The objects are deleted.
+            return (a, b, c)
+
+        # Case 1: run this local_only=False. All 3 objects will be deleted.
+        (a, b, c) = run_one_test(False)
+        (l1, l2) = ray.wait([a, b, c], timeout=10, num_returns=1)
+        # All the objects are deleted.
         assert len(l1) == 0
         assert len(l2) == 3
-        (l1, l2) = run_one_test(True)
-        # The objects are deleted.
-        assert len(l1) != 0
-        assert len(l2) != 3
+        # Case 2: run this local_only=True. Only 1 object will be deleted.
+        (a, b, c) = run_one_test(True)
+        (l1, l2) = ray.wait([a, b, c], timeout=10, num_returns=3)
+        # One object is deleted and 2 objects are not.
+        assert len(l1) == 2
+        assert len(l2) == 1
+        # The deleted object will have the same store with the driver.
+        local_return = ray.worker.global_worker.plasma_client.store_socket_name
+        for object_id in l1:
+            assert ray.get(object_id) != local_return
 
 
 @unittest.skipIf(

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1243,7 +1243,7 @@ class APITest(unittest.TestCase):
             # Current Plasma Client Cache will maintain 64-item list.
             # If the number changed, this will fail.
             print("Start Flush!")
-            for i in range(500):
+            for i in range(1600):
                 run_on_0.remote()
                 run_on_1.remote()
                 run_on_2.remote()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
As discussed, we will provide some low-level APIs. `ray.internal.free(object_list)` is one of them.
1. Add backend support of `ray.internal.free`.
    - Only `ObjectBufferPool` and `ObjectStoreNotificationManager` have the PlasmaClient, I choose `ObjectBufferPool` to do the free operation.
    - `ObjectManager` can connect to each other to spread the free request.
    - A driver (the python script that calls `ray.internal.free`) will send a request of `FreeObjectsInObjectStore` to `Node Manager`. This `Node Manager` will call free function of its `Object Manager` and the spread flag could be set to true, which means that this `Object Manager` will send the free requests to all the other 
`Object Managers`.
2. Script implementation: add this function to `ray.internal`
3. Add test (`APITest.testFreeObjects` in `test/runtest.py`) to cover the code path: considering current Plasma Client Cache, we need to add some more data to flush the release history to make the object deleted from Plasma server.

<!-- Please give a short brief about these changes. -->

## Related issue number
https://github.com/ray-project/ray/issues/2242
<!-- Are there any issues opened that will be resolved by merging this change? -->
