### PR TITLE
Fix potential boost error message corruption

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -338,7 +338,7 @@ ray::Status ObjectManager::SendObjectData(const ObjectID &object_id,
   if (ec.value() != 0) {
     // Push failed. Deal with partial objects on the receiving end.
     // TODO(hme): Try to invoke disconnect on sender connection, then remove it.
-    status = ray::Status::IOError(ec.message());
+    status = ray::Status::IOError(strerror(ec.value()));
   }
 
   // Do this regardless of whether it failed or succeeded.
@@ -646,7 +646,7 @@ void ObjectManager::ExecuteReceiveObject(const ClientID &client_id,
     boost::system::error_code ec;
     conn.ReadBuffer(buffer, ec);
     if (ec.value() != 0) {
-      RAY_LOG(ERROR) << ec.message();
+      RAY_LOG(ERROR) << strerror(ec.value());
     }
     // TODO(hme): If the object isn't local, create a pull request for this chunk.
   }

--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -47,7 +47,7 @@ void ObjectStoreNotificationManager::ProcessStoreLength(
 void ObjectStoreNotificationManager::ProcessStoreNotification(
     const boost::system::error_code &error) {
   if (error) {
-    RAY_LOG(FATAL) << error.message();
+    RAY_LOG(FATAL) << strerror(error.value());
   }
 
   const auto &object_info = flatbuffers::GetRoot<ObjectInfo>(notification_.data());


### PR DESCRIPTION
This might fix some crashes related to error string corruption in boost::system error codes.

This is currently poorly understood and more investigation needs to go into it.

See also https://github.com/ray-project/ray/pull/2526