### PR TITLE
Fix copying the plasma fbs directory from arrow

### DIFF
--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -28,7 +28,7 @@ add_dependencies(gen_plasma_fbs flatbuffers_ep)
 # Copy the fbs files from Arrow project to local directory.
 add_custom_command(
   OUTPUT ${PLASMA_FBS_SRC}
-  COMMAND cp -rf ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/ ${CMAKE_CURRENT_LIST_DIR}/format/
+  COMMAND cp -rf ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/ ${CMAKE_CURRENT_LIST_DIR}/
   COMMENT "Copying ${PLASMA_FBS_SRC} to local"
   VERBATIM)
 

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -28,7 +28,7 @@ add_dependencies(gen_plasma_fbs flatbuffers_ep)
 # Copy the fbs files from Arrow project to local directory.
 add_custom_command(
   OUTPUT ${PLASMA_FBS_SRC}
-  COMMAND cp -rf ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/ ${CMAKE_CURRENT_LIST_DIR}/
+  COMMAND cp -rf ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/* ${CMAKE_CURRENT_LIST_DIR}/format/
   COMMENT "Copying ${PLASMA_FBS_SRC} to local"
   VERBATIM)
 

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -28,7 +28,8 @@ add_dependencies(gen_plasma_fbs flatbuffers_ep)
 # Copy the fbs files from Arrow project to local directory.
 add_custom_command(
   OUTPUT ${PLASMA_FBS_SRC}
-  COMMAND cp -rf ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/* ${CMAKE_CURRENT_LIST_DIR}/format/
+  COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/plasma.fbs ${CMAKE_CURRENT_LIST_DIR}/format/
+  COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/common.fbs ${CMAKE_CURRENT_LIST_DIR}/format/
   COMMENT "Copying ${PLASMA_FBS_SRC} to local"
   VERBATIM)
 

--- a/src/plasma/CMakeLists.txt
+++ b/src/plasma/CMakeLists.txt
@@ -28,6 +28,7 @@ add_dependencies(gen_plasma_fbs flatbuffers_ep)
 # Copy the fbs files from Arrow project to local directory.
 add_custom_command(
   OUTPUT ${PLASMA_FBS_SRC}
+  COMMAND mkdir -p ${CMAKE_CURRENT_LIST_DIR}/format/
   COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/plasma.fbs ${CMAKE_CURRENT_LIST_DIR}/format/
   COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/build/arrow/cpp/src/plasma/format/common.fbs ${CMAKE_CURRENT_LIST_DIR}/format/
   COMMENT "Copying ${PLASMA_FBS_SRC} to local"


### PR DESCRIPTION
The format/ directory from arrow was copied into ray/src/plasma/format/format, i.e. an additional layer of directories was created.