### PR TITLE
[xray] Fix valgrind crash when memory profiling raylet

### DIFF
--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -27,11 +27,15 @@ class GlobalSchedulerPolicyState {
  public:
   GlobalSchedulerPolicyState(int64_t round_robin_index)
       : round_robin_index_(round_robin_index),
-        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+        gen_(std::chrono::high_resolution_clock::now()
+                 .time_since_epoch()
+                 .count()) {}
 
   GlobalSchedulerPolicyState()
       : round_robin_index_(0),
-        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+        gen_(std::chrono::high_resolution_clock::now()
+                 .time_since_epoch()
+                 .count()) {}
 
   /// Return the policy's random number generator.
   ///

--- a/src/global_scheduler/global_scheduler_algorithm.h
+++ b/src/global_scheduler/global_scheduler_algorithm.h
@@ -1,6 +1,7 @@
 #ifndef GLOBAL_SCHEDULER_ALGORITHM_H
 #define GLOBAL_SCHEDULER_ALGORITHM_H
 
+#include <chrono>
 #include <random>
 
 #include "common.h"
@@ -25,9 +26,12 @@ enum class GlobalSchedulerAlgorithm {
 class GlobalSchedulerPolicyState {
  public:
   GlobalSchedulerPolicyState(int64_t round_robin_index)
-      : round_robin_index_(round_robin_index), gen_(rd_()) {}
+      : round_robin_index_(round_robin_index),
+        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
-  GlobalSchedulerPolicyState() : round_robin_index_(0), gen_(rd_()) {}
+  GlobalSchedulerPolicyState()
+      : round_robin_index_(0),
+        gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
   /// Return the policy's random number generator.
   ///
@@ -42,8 +46,6 @@ class GlobalSchedulerPolicyState {
  private:
   /// The index of the next local scheduler to assign a task to.
   int64_t round_robin_index_;
-  /// Internally maintained random number engine device.
-  std::random_device rd_;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
 };

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -15,9 +15,15 @@ UniqueID::UniqueID(const plasma::UniqueID &from) {
 UniqueID UniqueID::from_random() {
   UniqueID id;
   uint8_t *data = id.mutable_data();
-  std::random_device engine;
+  // NOTE(pcm): The right way to do this is to have one std::mt19937 per
+  // thread (using the thread_local keyword), but that's not supported on
+  // older versions of macOS (see https://stackoverflow.com/a/29929949)
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+  static std::mt19937 generator;
+  std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
-    data[i] = static_cast<uint8_t>(engine());
+    data[i] = static_cast<uint8_t>(dist(generator));
   }
   return id;
 }

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -1,12 +1,20 @@
 #include "ray/id.h"
 
 #include <limits.h>
+
+#include <chrono>
 #include <random>
 
 #include "ray/constants.h"
 #include "ray/status.h"
 
 namespace ray {
+
+std::mt19937 RandomlySeededMersenneTwister() {
+  auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  std::mt19937 seeded_engine (seed);
+  return seeded_engine;
+}
 
 UniqueID::UniqueID(const plasma::UniqueID &from) {
   std::memcpy(&id_, from.data(), kUniqueIDSize);
@@ -20,7 +28,7 @@ UniqueID UniqueID::from_random() {
   // older versions of macOS (see https://stackoverflow.com/a/29929949)
   static std::mutex mutex;
   std::lock_guard<std::mutex> lock(mutex);
-  static std::mt19937 generator;
+  static std::mt19937 generator = RandomlySeededMersenneTwister();
   std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
     data[i] = static_cast<uint8_t>(dist(generator));

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -3,6 +3,7 @@
 #include <limits.h>
 
 #include <chrono>
+#include <mutex>
 #include <random>
 
 #include "ray/constants.h"

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -27,8 +27,8 @@ UniqueID UniqueID::from_random() {
   // NOTE(pcm): The right way to do this is to have one std::mt19937 per
   // thread (using the thread_local keyword), but that's not supported on
   // older versions of macOS (see https://stackoverflow.com/a/29929949)
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> lock(mutex);
+  static std::mutex random_engine_mutex;
+  std::lock_guard<std::mutex> lock(random_engine_mutex);
   static std::mt19937 generator = RandomlySeededMersenneTwister();
   std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -12,7 +12,7 @@ namespace ray {
 
 std::mt19937 RandomlySeededMersenneTwister() {
   auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-  std::mt19937 seeded_engine (seed);
+  std::mt19937 seeded_engine(seed);
   return seeded_engine;
 }
 

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -1,5 +1,7 @@
 #include "scheduling_policy.h"
 
+#include <chrono>
+
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -7,7 +9,8 @@ namespace ray {
 namespace raylet {
 
 SchedulingPolicy::SchedulingPolicy(const SchedulingQueue &scheduling_queue)
-    : scheduling_queue_(scheduling_queue), gen_(rd_()) {}
+    : scheduling_queue_(scheduling_queue),
+      gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
     const std::unordered_map<ClientID, SchedulingResources> &cluster_resources,

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -38,8 +38,6 @@ class SchedulingPolicy {
  private:
   /// An immutable reference to the scheduling task queues.
   const SchedulingQueue &scheduling_queue_;
-  /// Internally maintained random number engine device.
-  std::random_device rd_;
   /// Internally maintained random number generator.
   std::mt19937_64 gen_;
 };


### PR DESCRIPTION
This happens on some old versions of valgrind:
```
==507== 
vex amd64->IR: unhandled instruction bytes: 0xF 0xC7 0xF0 0x89 0x6 0xF 0x42 0xC1
vex amd64->IR:   REX=0 REX.W=0 REX.R=0 REX.X=0 REX.B=0
vex amd64->IR:   VEX=0 VEX.L=0 VEX.nVVVV=0x0 ESC=0F
vex amd64->IR:   PFX.66=0 PFX.F2=0 PFX.F3=0
==507== valgrind: Unrecognised instruction at address 0x510eb15.
==507==    at 0x510EB15: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==507==    by 0x510ECB1: std::random_device::_M_getval() (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==507==    by 0x501D97: operator() (random.h:1612)
==507==    by 0x501D97: ray::UniqueID::from_random() (id.cc:20)
==507==    by 0x482140: ray::gcs::AsyncGcsClient::AsyncGcsClient() (client.cc:38)
==507==    by 0x46811C: construct<ray::gcs::AsyncGcsClient> (new_allocator.h:104)
==507==    by 0x46811C: construct<ray::gcs::AsyncGcsClient> (alloc_traits.h:530)
==507==    by 0x46811C: _Sp_counted_ptr_inplace<> (shared_ptr_base.h:522)
==507==    by 0x46811C: __shared_count<ray::gcs::AsyncGcsClient, std::allocator<ray::gcs::AsyncGcsClient> > (shared_ptr_base.h:617)
==507==    by 0x46811C: __shared_ptr<std::allocator<ray::gcs::AsyncGcsClient> > (shared_ptr_base.h:1097)
==507==    by 0x46811C: shared_ptr<std::allocator<ray::gcs::AsyncGcsClient> > (shared_ptr.h:319)
==507==    by 0x46811C: allocate_shared<ray::gcs::AsyncGcsClient, std::allocator<ray::gcs::AsyncGcsClient> > (shared_ptr.h:620)
==507==    by 0x46811C: make_shared<ray::gcs::AsyncGcsClient> (shared_ptr.h:636)
==507==    by 0x46811C: main (main.cc:72)
```