### PR TITLE
[xray] Fix typo concerning heartbeat_timeout_milliseconds in monitor

### DIFF
--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -16,7 +16,7 @@ namespace raylet {
 Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_address,
                  int redis_port)
     : gcs_client_(),
-      heartbeat_timeout_ms_(RayConfig::instance().num_heartbeats_timeout()),
+      heartbeat_timeout_ms_(RayConfig::instance().heartbeat_timeout_milliseconds()),
       heartbeat_timer_(io_service) {
   RAY_CHECK_OK(gcs_client_.Connect(redis_address, redis_port, /*sharding=*/true));
   RAY_CHECK_OK(gcs_client_.Attach(io_service));

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -16,7 +16,7 @@ namespace raylet {
 Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_address,
                  int redis_port)
     : gcs_client_(),
-      num_heartbeats_timeout_(RayConfig::instance().num_hearbeats_timeout()),
+      num_heartbeats_timeout_(RayConfig::instance().num_heartbeats_timeout()),
       heartbeat_timer_(io_service) {
   RAY_CHECK_OK(gcs_client_.Connect(redis_address, redis_port, /*sharding=*/true));
   RAY_CHECK_OK(gcs_client_.Attach(io_service));

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -16,14 +16,14 @@ namespace raylet {
 Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_address,
                  int redis_port)
     : gcs_client_(),
-      heartbeat_timeout_ms_(RayConfig::instance().heartbeat_timeout_milliseconds()),
+      num_heartbeats_timeout_(RayConfig::instance().num_hearbeats_timeout()),
       heartbeat_timer_(io_service) {
   RAY_CHECK_OK(gcs_client_.Connect(redis_address, redis_port, /*sharding=*/true));
   RAY_CHECK_OK(gcs_client_.Attach(io_service));
 }
 
 void Monitor::HandleHeartbeat(const ClientID &client_id) {
-  heartbeats_[client_id] = heartbeat_timeout_ms_;
+  heartbeats_[client_id] = num_heartbeats_timeout_;
 }
 
 void Monitor::Start() {

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -38,8 +38,8 @@ class Monitor {
  private:
   /// A client to the GCS, through which heartbeats are received.
   gcs::AsyncGcsClient gcs_client_;
-  /// The expected period between heartbeats, for an individual Raylet.
-  int64_t heartbeat_timeout_ms_;
+  /// The number of heartbeats that can be missed before a client is removed.
+  int64_t num_heartbeats_timeout_;
   /// A timer that ticks every heartbeat_timeout_ms_ milliseconds.
   boost::asio::deadline_timer heartbeat_timer_;
   /// For each Raylet that we receive a heartbeat from, the number of ticks


### PR DESCRIPTION
This is not affecting default behavior since the two constants are the same, but we should use the correct one (e.g. if the user changes ray_constants.h).