### PR TITLE
raylet memory corruption fixes

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -84,7 +84,7 @@ ray::Status ServerConnection<T>::WriteMessage(int64_t type, int64_t length,
   boost::system::error_code error;
   WriteBuffer(message_buffers, error);
   if (error) {
-    return ray::Status::IOError(error.message());
+    return ray::Status::IOError("Failed to write message to the socket");
   } else {
     return ray::Status::OK();
   }

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -4,6 +4,7 @@
 
 #include "common.h"
 #include "ray/raylet/format/node_manager_generated.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -83,11 +84,7 @@ ray::Status ServerConnection<T>::WriteMessage(int64_t type, int64_t length,
   // TODO(swang): Does this need to be an async write?
   boost::system::error_code error;
   WriteBuffer(message_buffers, error);
-  if (error) {
-    return ray::Status::IOError("Failed to write message to the socket");
-  } else {
-    return ray::Status::OK();
-  }
+  return boost_to_ray_status(error);
 }
 
 template <class T>

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -15,11 +15,7 @@ ray::Status TcpConnect(boost::asio::ip::tcp::socket &socket,
   boost::asio::ip::tcp::endpoint endpoint(ip_address, port);
   boost::system::error_code error;
   socket.connect(endpoint, error);
-  if (error) {
-    return ray::Status::IOError(error.message());
-  } else {
-    return ray::Status::OK();
-  }
+  return boost_to_ray_status(error);
 }
 
 template <class T>

--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -9,6 +9,7 @@
 #include "common/common_protocol.h"
 
 #include "ray/object_manager/object_store_notification_manager.h"
+#include "ray/util/util.h"
 
 namespace ray {
 
@@ -46,8 +47,8 @@ void ObjectStoreNotificationManager::ProcessStoreLength(
 
 void ObjectStoreNotificationManager::ProcessStoreNotification(
     const boost::system::error_code &error) {
-  if (error) {
-    RAY_LOG(FATAL) << error.message();
+  if (error.value() != boost::system::errc::success) {
+    RAY_LOG(FATAL) << boost_to_ray_status(error).ToString();
   }
 
   const auto &object_info = flatbuffers::GetRoot<ObjectInfo>(notification_.data());

--- a/src/ray/raylet/reconstruction_policy.cc
+++ b/src/ray/raylet/reconstruction_policy.cc
@@ -160,12 +160,12 @@ void ReconstructionPolicy::Cancel(const ObjectID &object_id) {
   // If there are no more needed objects created by this task, stop listening
   // for notifications.
   if (it->second.created_objects.empty()) {
-    listening_tasks_.erase(it);
     // Cancel notifications for the task lease if we were subscribed to them.
     if (it->second.subscribed) {
       RAY_CHECK_OK(
           task_lease_pubsub_.CancelNotifications(JobID::nil(), task_id, client_id_));
     }
+    listening_tasks_.erase(it);
   }
 }
 

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -26,4 +26,13 @@ inline int64_t current_sys_time_ms() {
   return ms_since_epoch.count();
 }
 
+inline ray::Status boost_to_ray_status(const boost::system::error_code & error) {
+  switch (error.value()) {
+    case boost::system::errc::success:
+      return ray::Status::OK();
+    default:
+      return ray::Status::IOError(strerror(error.value()));
+  }
+}
+
 #endif  // RAY_UTIL_UTIL_H

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -26,12 +26,12 @@ inline int64_t current_sys_time_ms() {
   return ms_since_epoch.count();
 }
 
-inline ray::Status boost_to_ray_status(const boost::system::error_code & error) {
+inline ray::Status boost_to_ray_status(const boost::system::error_code &error) {
   switch (error.value()) {
-    case boost::system::errc::success:
-      return ray::Status::OK();
-    default:
-      return ray::Status::IOError(strerror(error.value()));
+  case boost::system::errc::success:
+    return ray::Status::OK();
+  default:
+    return ray::Status::IOError(strerror(error.value()));
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
There are two memory corruption fixes here:
1. `boost::system::error_code` message() call returns a corrupted string, even immediately after initializing the error as follows:
`boost::system::error_code error;`
The (temp?) fix is just to replace it with a generic message indicating failure to write message to the socket.
2. an `erase` is called on an unordered_map iterator, which is then subsequently accessed. 
Iterators to the erased element are invalidated:
https://stackoverflow.com/questions/38854265/unordered-map-element-being-deleted
Valgrind was reporting a bad read, which is fixed by this PR. 

## Related issue number
fixes : https://github.com/ray-project/ray/issues/2584
subsumes: https://github.com/ray-project/ray/pull/2548
