### PR TITLE
Limit CPU utilization of jenkins tests.

### DIFF
--- a/test/jenkins_tests/multi_node_tests/many_drivers_test.py
+++ b/test/jenkins_tests/multi_node_tests/many_drivers_test.py
@@ -9,14 +9,14 @@ import ray
 from ray.test.test_utils import (_wait_for_nodes_to_join, _broadcast_event,
                                  _wait_for_event)
 
-# This test should be run with 5 nodes, which have 0, 0, 5, 6, and 50 GPUs for
-# a total of 61 GPUs. It should be run with a large number of drivers (e.g.,
+# This test should be run with 5 nodes, which have 0, 0, 1, 5, and 10 GPUs for
+# a total of 16 GPUs. It should be run with a large number of drivers (e.g.,
 # 100). At most 10 drivers will run at a time, and each driver will use at most
-# 5 GPUs (this is ceil(61 / 15), which guarantees that we will always be able
+# 3 GPUs (this is ceil(16 / 7), which guarantees that we will always be able
 # to make progress).
 total_num_nodes = 5
-max_concurrent_drivers = 15
-num_gpus_per_driver = 5
+max_concurrent_drivers = 7
+num_gpus_per_driver = 3
 
 
 @ray.remote(num_cpus=0, num_gpus=1)

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -116,23 +116,6 @@ docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCK
 
 docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
-<<<<<<< aaf5456b3d766f20d4b9a0b18448885f03ac28ac
-=======
-    --env PongDeterministic-v4 \
-    --run A3C \
-    --stop '{"training_iteration": 2}' \
-    --config '{"num_workers": 2, "use_pytorch": true, "model": {"use_lstm": false, "grayscale": true, "zero_mean": false, "dim": 80, "channel_major": true}}'
-
-docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
-    python /ray/python/ray/rllib/train.py \
-    --env CartPole-v1 \
-    --run A3C \
-    --stop '{"training_iteration": 2}' \
-    --config '{"num_workers": 2, "use_pytorch": true}'
-
-docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
-    python /ray/python/ray/rllib/train.py \
->>>>>>> Limit CPU utilization of jenkins tests.
     --env CartPole-v1 \
     --run A3C \
     --stop '{"training_iteration": 2}' \

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -11,194 +11,211 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 DOCKER_SHA=$($ROOT_DIR/../../build-docker.sh --output-sha --no-cache)
 echo "Using Docker image" $DOCKER_SHA
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env PongDeterministic-v0 \
     --run A3C \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 16}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v1 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"kl_coeff": 1.0, "num_sgd_iter": 10, "sgd_stepsize": 1e-4, "sgd_batchsize": 64, "timesteps_per_batch": 2000, "num_workers": 1, "model": {"free_log_std": true}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v1 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"simple_optimizer": false, "num_sgd_iter": 2, "model": {"use_lstm": true}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v1 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"simple_optimizer": true, "num_sgd_iter": 2, "model": {"use_lstm": true}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v1 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"kl_coeff": 1.0, "num_sgd_iter": 10, "sgd_stepsize": 1e-4, "sgd_batchsize": 64, "timesteps_per_batch": 2000, "num_workers": 1, "use_gae": false}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env Pendulum-v0 \
     --run ES \
     --stop '{"training_iteration": 2}' \
     --config '{"stepsize": 0.01, "episodes_per_batch": 20, "timesteps_per_batch": 100}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env Pong-v0 \
     --run ES \
     --stop '{"training_iteration": 2}' \
     --config '{"stepsize": 0.01, "episodes_per_batch": 20, "timesteps_per_batch": 100}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run A3C \
     --stop '{"training_iteration": 2}' \
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run DQN \
     --stop '{"training_iteration": 2}' \
     --config '{"lr": 1e-3, "schedule_max_timesteps": 100000, "exploration_fraction": 0.1, "exploration_final_eps": 0.02, "dueling": false, "hiddens": [], "model": {"fcnet_hiddens": [64], "fcnet_activation": "relu"}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run DQN \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run APEX \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "timesteps_per_iteration": 1000, "gpu": false, "min_iter_time_s": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env FrozenLake-v0 \
     --run DQN \
     --stop '{"training_iteration": 2}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env FrozenLake-v0 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"num_sgd_iter": 10, "sgd_batchsize": 64, "timesteps_per_batch": 1000, "num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env PongDeterministic-v4 \
     --run DQN \
     --stop '{"training_iteration": 2}' \
     --config '{"lr": 1e-4, "schedule_max_timesteps": 2000000, "buffer_size": 10000, "exploration_fraction": 0.1, "exploration_final_eps": 0.01, "sample_batch_size": 4, "learning_starts": 10000, "target_network_update_freq": 1000, "gamma": 0.99, "prioritized_replay": true}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env MontezumaRevenge-v0 \
     --run PPO \
     --stop '{"training_iteration": 2}' \
     --config '{"kl_coeff": 1.0, "num_sgd_iter": 10, "sgd_stepsize": 1e-4, "sgd_batchsize": 64, "timesteps_per_batch": 2000, "num_workers": 1, "model": {"dim": 40, "conv_filters": [[16, [8, 8], 4], [32, [4, 4], 2], [512, [5, 5], 1]]}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
+<<<<<<< aaf5456b3d766f20d4b9a0b18448885f03ac28ac
+=======
+    --env PongDeterministic-v4 \
+    --run A3C \
+    --stop '{"training_iteration": 2}' \
+    --config '{"num_workers": 2, "use_pytorch": true, "model": {"use_lstm": false, "grayscale": true, "zero_mean": false, "dim": 80, "channel_major": true}}'
+
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
+    python /ray/python/ray/rllib/train.py \
+    --env CartPole-v1 \
+    --run A3C \
+    --stop '{"training_iteration": 2}' \
+    --config '{"num_workers": 2, "use_pytorch": true}'
+
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
+    python /ray/python/ray/rllib/train.py \
+>>>>>>> Limit CPU utilization of jenkins tests.
     --env CartPole-v1 \
     --run A3C \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "model": {"use_lstm": true}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run DQN \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run PG \
     --stop '{"training_iteration": 2}' \
     --config '{"sample_batch_size": 500, "num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run PG \
     --stop '{"training_iteration": 2}' \
     --config '{"sample_batch_size": 500, "num_workers": 1, "model": {"use_lstm": true, "max_seq_len": 100}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run PG \
     --stop '{"training_iteration": 2}' \
     --config '{"sample_batch_size": 500, "num_workers": 1, "num_envs_per_worker": 10}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env Pong-v0 \
     --run PG \
     --stop '{"training_iteration": 2}' \
     --config '{"sample_batch_size": 500, "num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env FrozenLake-v0 \
     --run PG \
     --stop '{"training_iteration": 2}' \
     --config '{"sample_batch_size": 500, "num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env Pendulum-v0 \
     --run DDPG \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run IMPALA \
     --stop '{"training_iteration": 2}' \
     --config '{"gpu": false, "num_workers": 2, "min_iter_time_s": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env CartPole-v0 \
     --run IMPALA \
     --stop '{"training_iteration": 2}' \
     --config '{"gpu": false, "num_workers": 2, "min_iter_time_s": 1, "model": {"use_lstm": true}}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env MountainCarContinuous-v0 \
     --run DDPG \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     rllib train \
     --env MountainCarContinuous-v0 \
     --run DDPG \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env Pendulum-v0 \
     --run APEX_DDPG \
@@ -206,69 +223,69 @@ docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "optimizer": {"num_replay_buffer_shards": 1}, "learning_starts": 100, "min_iter_time_s": 1}'
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     sh /ray/test/jenkins_tests/multi_node_tests/test_rllib_eval.sh
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_checkpoint_restore.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_policy_evaluator.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_serving_env.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_lstm.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_multi_agent_env.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/test/test_supported_spaces.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/tune_mnist_ray.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/pbt_example.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/hyperband_example.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/async_hyperband_example.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/tune_mnist_ray_hyperband.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/tune_mnist_async_hyperband.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/hyperopt_example.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/tune/examples/tune_mnist_keras.py \
     --smoke-test
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/legacy_multiagent/multiagent_mountaincar.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/legacy_multiagent/multiagent_pendulum.py
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/multiagent_cartpole.py --num-iters=2
 
-docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
+docker run  -e "RAY_USE_XRAY=1" --rm --cpus=12 --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/multiagent_two_trainers.py --num-iters=2
 
 docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
@@ -288,6 +305,7 @@ docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \
+    --num-cpus=4,4,4,4,4 \
     --num-redis-shards=10 \
     --use-raylet \
     --test-script=/ray/test/jenkins_tests/multi_node_tests/test_0.py
@@ -297,6 +315,7 @@ python3 $ROOT_DIR/multi_node_docker_test.py \
     --num-nodes=5 \
     --num-redis-shards=5 \
     --num-gpus=0,1,2,3,4 \
+    --num-cpus=5,5,5,5,5 \
     --num-drivers=7 \
     --driver-locations=0,1,0,1,2,3,4 \
     --test-script=/ray/test/jenkins_tests/multi_node_tests/remove_driver_test.py
@@ -305,7 +324,8 @@ python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \
     --num-redis-shards=2 \
-    --num-gpus=0,0,5,6,50 \
+    --num-gpus=0,0,1,5,10 \
+    --num-cpus=2,2,3,7,12 \
     --num-drivers=100 \
     --use-raylet \
     --test-script=/ray/test/jenkins_tests/multi_node_tests/many_drivers_test.py
@@ -313,6 +333,7 @@ python3 $ROOT_DIR/multi_node_docker_test.py \
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=1 \
+    --num-cpus=2 \
     --mem-size=60G \
     --shm-size=60G \
     --use-raylet \


### PR DESCRIPTION
This attempts to address #2595. cc @shaneknapp 

Note that passing `--cpus=12` into `docker run` is not *exactly* the behavior that we want. I think it will limit the docker containers CPU utilization, but `nproc` will still return the full number of CPUs so Ray will still try to create 48 workers (or however many cores there are).