### PR TITLE
[xray] Fix bug when counting a task's lineage size

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -211,7 +211,12 @@ void LineageCache::AddReadyTask(const Task &task) {
   }
 }
 
-uint64_t LineageCache::CountUnsubscribedLineage(const TaskID &task_id) const {
+uint64_t LineageCache::CountUnsubscribedLineage(const TaskID &task_id,
+                                                std::unordered_set<TaskID> &seen) const {
+  if (seen.count(task_id) == 1) {
+    return 0;
+  }
+  seen.insert(task_id);
   if (subscribed_tasks_.count(task_id) == 1) {
     return 0;
   }
@@ -221,7 +226,7 @@ uint64_t LineageCache::CountUnsubscribedLineage(const TaskID &task_id) const {
   }
   uint64_t cnt = 1;
   for (const auto &parent_id : entry->GetParentTaskIds()) {
-    cnt += CountUnsubscribedLineage(parent_id);
+    cnt += CountUnsubscribedLineage(parent_id, seen);
   }
   return cnt;
 }
@@ -249,7 +254,9 @@ void LineageCache::RemoveWaitingTask(const TaskID &task_id) {
   // NOTE(swang): The number of entries in the uncommitted lineage also
   // includes local tasks that haven't been committed yet, not just remote
   // tasks, so this is an overestimate.
-  if (CountUnsubscribedLineage(task_id) > max_lineage_size_) {
+  std::unordered_set<TaskID> seen;
+  auto count = CountUnsubscribedLineage(task_id, seen);
+  if (count > max_lineage_size_) {
     // Since this task was in state WAITING, check that we were not
     // already subscribed to the task.
     RAY_CHECK(SubscribeTask(task_id));

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -226,9 +226,13 @@ class LineageCache {
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
   bool UnsubscribeTask(const TaskID &task_id);
-  /// Count the size of unsubscribed and uncommitted lineage. The seen map
-  /// contains the keys of lineage entries counted so far, so that we don't
-  /// revisit those nodes.
+  /// Count the size of unsubscribed and uncommitted lineage of the given task
+  /// excluding the values that have already been visited.
+  ///
+  /// \param task_id The task whose lineage should be counted.
+  /// \param seen This set contains the keys of lineage entries counted so far,
+  /// so that we don't revisit those nodes.
+  /// \void The number of tasks that were counted.
   uint64_t CountUnsubscribedLineage(const TaskID &task_id,
                                     std::unordered_set<TaskID> &seen) const;
 

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -226,8 +226,11 @@ class LineageCache {
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
   bool UnsubscribeTask(const TaskID &task_id);
-  /// Count the size of unsubscribed and uncommitted lineage
-  uint64_t CountUnsubscribedLineage(const TaskID &task_id) const;
+  /// Count the size of unsubscribed and uncommitted lineage. The seen map
+  /// contains the keys of lineage entries counted so far, so that we don't
+  /// revisit those nodes.
+  uint64_t CountUnsubscribedLineage(const TaskID &task_id,
+                                    std::unordered_set<TaskID> &seen) const;
 
   /// The client ID, used to request notifications for specific tasks.
   /// TODO(swang): Move the ClientID into the generic Table implementation.

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -55,9 +55,6 @@ def test_submitting_tasks(ray_start_combination):
     assert ray.services.all_processes_alive()
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_USE_XRAY") == "1",
-    reason="This test does not work with xray yet.")
 def test_dependencies(ray_start_combination):
     @ray.remote
     def f(x):
@@ -81,9 +78,6 @@ def test_dependencies(ray_start_combination):
     assert ray.services.all_processes_alive()
 
 
-@pytest.mark.skipif(
-    os.environ.get("RAY_USE_XRAY") == "1",
-    reason="This test does not work with xray yet.")
 def test_submitting_many_tasks(ray_start_regular):
     @ray.remote
     def f(x):


### PR DESCRIPTION
## What do these changes do?

In the lineage cache, we sometimes count the size of the uncommitted lineage of a task so that we can decide whether we should evict it. The method to count the size walks the task's lineage tree but does not consider whether a node has been seen before, so it ends up double-counting any nodes that appear twice in the tree.

In the test case `python -m pytest test/stress_tests.py::test_dependencies[ray_start_combination1]`, which submits tasks with many interleaving dependencies, this resulted in crashes of the raylet because a handler on the event loop could end up spending minutes in the `CountUnsubscribedLineage` method. Then, heartbeats were not sent quickly enough and the raylet would be marked as dead.

This PR adds back the `test/stress_tests.py::test_dependencies` and `test/stress_tests.py::test_submitting_many_tasks` tests for raylet.