### PR TITLE
[WIP] Allow wait_for_compute_zone_operation to run in parallel

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -219,7 +219,7 @@ class NodeLauncher(threading.Thread):
         tag_filters = {TAG_RAY_NODE_TYPE: "worker"}
         before = self.provider.nodes(tag_filters=tag_filters)
         launch_hash = hash_launch_conf(config["worker_nodes"], config["auth"])
-        self.provider.create_node(
+        self.provider.create_nodes(
             config["worker_nodes"], {
                 TAG_RAY_NODE_NAME: "ray-{}-worker".format(
                     config["cluster_name"]),

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -114,7 +114,7 @@ class AWSNodeProvider(NodeProvider):
             })
         node.create_tags(Tags=tag_pairs)
 
-    def create_node(self, node_config, tags, count):
+    def create_nodes(self, node_config, tags, count):
         tags = to_aws_format(tags)
         conf = node_config.copy()
         tag_pairs = [{

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -176,14 +176,16 @@ class AWSNodeProvider(NodeProvider):
 
         non_cached_node_ids = [k for k, v in nodes_by_id.items() if v is None]
 
-        non_cached_nodes = list(self.ec2.instances.filter(
-            non_cached_node_ids))
+        if non_cached_node_ids:
+            non_cached_nodes = list(self.ec2.instances.filter(
+                InstanceIds=non_cached_node_ids))
 
-        assert len(non_cached_nodes) == len(non_cached_node_ids), (
-            "Could not find one of the instances: {}"
-            "".format(non_cached_node_ids))
+            assert len(non_cached_nodes) == len(non_cached_node_ids), (
+                "Could not find one of the instances: {}"
+                "".format(non_cached_node_ids))
 
-        nodes_by_id.update(dict(zip(non_cached_node_ids, non_cached_nodes)))
+            nodes_by_id.update(
+                dict(zip(non_cached_node_ids, non_cached_nodes)))
 
         result = [nodes_by_id[key] for key in node_ids]
 

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -162,9 +162,11 @@ class AWSNodeProvider(NodeProvider):
         })
         self.ec2.create_instances(**conf)
 
+    def terminate_nodes(self, node_ids):
+        self.ec2.instances.filter(InstanceIds=node_ids).terminate()
+
     def terminate_node(self, node_id):
-        node = self._node(node_id)
-        node.terminate()
+        self.terminate_nodes([node_id])
 
     def _node(self, node_id):
         if node_id in self.cached_nodes:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -101,7 +101,7 @@ def get_or_create_head_node(config, no_restart, yes):
         head_node_tags[TAG_RAY_LAUNCH_CONFIG] = launch_hash
         head_node_tags[TAG_RAY_NODE_NAME] = "ray-{}-head".format(
             config["cluster_name"])
-        provider.create_node(config["head_node"], head_node_tags, 1)
+        provider.create_nodes(config["head_node"], head_node_tags, 1)
 
     nodes = provider.nodes(head_node_tags)
     assert len(nodes) == 1, "Failed to create head node."

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -59,14 +59,15 @@ def teardown_cluster(config_file, yes):
     head_node_tags = {
         TAG_RAY_NODE_TYPE: "head",
     }
+
     for node in provider.nodes(head_node_tags):
         print("Terminating head node {}".format(node))
         provider.terminate_node(node)
+
     nodes = provider.nodes({})
     while nodes:
-        for node in nodes:
-            print("Terminating worker {}".format(node))
-            provider.terminate_node(node)
+        print("Terminating workers: {}".format(nodes))
+        provider.terminate_nodes(nodes)
         time.sleep(5)
         nodes = provider.nodes({})
 

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -27,7 +27,7 @@ def raise_for_errors(results):
 
 
 def wait_for_compute_zone_operations(compute, project_name, operations, zone):
-    """Poll for compute zone operation until finished."""
+    """Poll for a set of compute zone operations until finished."""
     print("Waiting for {} operations to finish...".format(len(operations)))
 
     for _ in range(MAX_POLLS):
@@ -48,7 +48,7 @@ def wait_for_compute_zone_operations(compute, project_name, operations, zone):
 
 
 def wait_for_compute_zone_operation(compute, project_name, operation, zone):
-    """Poll for compute zone operation until finished."""
+    """Poll for a compute zone operation until finished."""
     return wait_for_compute_zone_operations(
         compute, project_name, [operation], zone)[0]
 

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -15,24 +15,42 @@ INSTANCE_NAME_MAX_LEN = 64
 INSTANCE_NAME_UUID_LEN = 8
 
 
-def wait_for_compute_zone_operation(compute, project_name, operation, zone):
+def raise_for_errors(results):
+    exceptions = [
+        Exception(result["error"])
+        for result in results
+        if "error" in result
+    ]
+
+    if exceptions:
+        raise Exception(exceptions)
+
+
+def wait_for_compute_zone_operations(compute, project_name, operations, zone):
     """Poll for compute zone operation until finished."""
-    print("Waiting for operation {} to finish...".format(operation["name"]))
+    print("Waiting for {} operations to finish...".format(len(operations)))
 
     for _ in range(MAX_POLLS):
-        result = compute.zoneOperations().get(
-            project=project_name, operation=operation["name"],
-            zone=zone).execute()
-        if "error" in result:
-            raise Exception(result["error"])
+        results = [
+            compute.zoneOperations().get(
+                project=project_name, operation=operation["name"],
+                zone=zone).execute()
+            for operation in operations
+        ]
 
-        if result["status"] == "DONE":
-            print("Done.")
-            break
+        raise_for_errors(results)
+
+        if all(result["status"] == "DONE" for result in results):
+            print("All operations finished.")
+            return results
 
         time.sleep(POLL_INTERVAL)
 
-    return result
+
+def wait_for_compute_zone_operation(compute, project_name, operation, zone):
+    """Poll for compute zone operation until finished."""
+    return wait_for_compute_zone_operations(
+        compute, project_name, [operation], zone)[0]
 
 
 class GCPNodeProvider(NodeProvider):
@@ -177,11 +195,8 @@ class GCPNodeProvider(NodeProvider):
                     })).execute() for i in range(count)
         ]
 
-        results = [
-            wait_for_compute_zone_operation(self.compute, project_id,
-                                            operation, availability_zone)
-            for operation in operations
-        ]
+        results = wait_for_compute_zone_operations(
+            self.compute, project_id, operations, availability_zone)
 
         return results
 

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -203,20 +203,25 @@ class GCPNodeProvider(NodeProvider):
 
         return results
 
-    def terminate_node(self, node_id):
+    def terminate_nodes(self, node_ids):
         project_id = self.provider_config["project_id"]
         availability_zone = self.provider_config["availability_zone"]
 
-        operation = self.compute.instances().delete(
-            project=project_id,
-            zone=availability_zone,
-            instance=node_id,
-        ).execute()
+        operations = [
+            self.compute.instances().delete(
+                project=project_id,
+                zone=availability_zone,
+                instance=node_id,
+            ).execute() for node_id in node_ids
+        ]
 
-        result = wait_for_compute_zone_operation(self.compute, project_id,
-                                                 operation, availability_zone)
+        results = wait_for_compute_zone_operations(
+            self.compute, project_id, operations, availability_zone)
 
-        return result
+        return results
+
+    def terminate_node(self, node_id):
+        return self.terminate_nodes([node_id])[0]
 
     def _node(self, node_id):
         if node_id in self.cached_nodes:

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -46,6 +46,9 @@ def wait_for_compute_zone_operations(compute, project_name, operations, zone):
 
         time.sleep(POLL_INTERVAL)
 
+    print("MAX_POLLS ({}) exceeded. Could not finish all the operations.")
+    return results
+
 
 def wait_for_compute_zone_operation(compute, project_name, operation, zone):
     """Poll for a compute zone operation until finished."""

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -164,7 +164,7 @@ class GCPNodeProvider(NodeProvider):
             self.internal_ip_cache[node_id] = ip
         return ip
 
-    def create_node(self, base_config, tags, count):
+    def create_nodes(self, base_config, tags, count):
         labels = tags  # gcp uses "labels" instead of aws "tags"
         project_id = self.provider_config["project_id"]
         availability_zone = self.provider_config["availability_zone"]

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -233,19 +233,21 @@ class GCPNodeProvider(NodeProvider):
 
         non_cached_node_ids = [k for k, v in nodes_by_id.items() if v is None]
 
-        non_cached_nodes = [
-            self.compute.instances().get(
-                project=self.provider_config["project_id"],
-                zone=self.provider_config["availability_zone"],
-                instance=node_id,
-            ).execute() for node_id in non_cached_node_ids
-        ]
+        if non_cached_node_ids:
+            non_cached_nodes = [
+                self.compute.instances().get(
+                    project=self.provider_config["project_id"],
+                    zone=self.provider_config["availability_zone"],
+                    instance=node_id,
+                ).execute() for node_id in non_cached_node_ids
+            ]
 
-        assert len(non_cached_nodes) == len(non_cached_node_ids), (
-            "Could not find one of the instances: {}"
-            "".format(non_cached_node_ids))
+            assert len(non_cached_nodes) == len(non_cached_node_ids), (
+                "Could not find one of the instances: {}"
+                "".format(non_cached_node_ids))
 
-        nodes_by_id.update(dict(zip(non_cached_node_ids, non_cached_nodes)))
+            nodes_by_id.update(
+                dict(zip(non_cached_node_ids, non_cached_nodes)))
 
         result = [nodes_by_id[key] for key in node_ids]
 

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -28,7 +28,8 @@ def raise_for_errors(results):
 
 def wait_for_compute_zone_operations(compute, project_name, operations, zone):
     """Poll for a set of compute zone operations until finished."""
-    print("Waiting for {} operations to finish...".format(len(operations)))
+    print("Waiting for {} {} to finish...".format(
+        len(operations), "operations" if len(operations) > 1 else "operation"))
 
     for _ in range(MAX_POLLS):
         results = [
@@ -46,7 +47,8 @@ def wait_for_compute_zone_operations(compute, project_name, operations, zone):
 
         time.sleep(POLL_INTERVAL)
 
-    print("MAX_POLLS ({}) exceeded. Could not finish all the operations.")
+    print("MAX_POLLS ({}) exceeded. Could not finish all the {}."
+          "".format("operations" if len(operations) > 1 else "operation"))
     return results
 
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -109,7 +109,7 @@ class NodeProvider(object):
     operate on nodes within that namespace.
 
     Nodes may be in one of three states: {pending, running, terminated}. Nodes
-    appear immediately once started by `create_node`, and transition
+    appear immediately once started by `create_nodes`, and transition
     immediately to terminated when `terminate_node` is called.
     """
 
@@ -151,7 +151,7 @@ class NodeProvider(object):
         """Returns the internal ip (Ray ip) of the given node."""
         raise NotImplementedError
 
-    def create_node(self, node_config, tags, count):
+    def create_nodes(self, node_config, tags, count):
         """Creates a number of nodes within the namespace."""
         raise NotImplementedError
 

--- a/test/autoscaler_test.py
+++ b/test/autoscaler_test.py
@@ -79,7 +79,7 @@ class MockProvider(NodeProvider):
     def external_ip(self, node_id):
         return self.mock_nodes[node_id].external_ip
 
-    def create_node(self, node_config, tags, count):
+    def create_nodes(self, node_config, tags, count):
         self.ready_to_create.wait()
         if self.fail_creates:
             return
@@ -270,7 +270,7 @@ class AutoscalingTest(unittest.TestCase):
         config["max_workers"] = 5
         config_path = self.write_config(config)
         self.provider = MockProvider()
-        self.provider.create_node({}, {TAG_RAY_NODE_TYPE: "worker"}, 10)
+        self.provider.create_nodes({}, {TAG_RAY_NODE_TYPE: "worker"}, 10)
         autoscaler = StandardAutoscaler(
             config_path, LoadMetrics(), max_failures=0, update_interval_s=0)
         self.waitForNodes(10)


### PR DESCRIPTION
These changes will:
* Allow multiple GCP operations to be waited at the same time.
* Add  `_nodes` and `terminate_nodes` methods that allow listing/terminating multiple nodes at once, as opposed to the old singular `_node` and `terminate_node`.
* Make autoscaler use the `terminate_nodes` in teardown command to delete all the workers at once instead of looping over them.

These functions could be use for creating/terminating multiple instances at once in the autoscaler `_update`, but I haven't done that yet.

- [x] Test GCP up/down 
- [ ] Test AWS up/down