### PR TITLE
[xray] Fix crash in case of spurious reconstruction

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -790,6 +790,13 @@ void NodeManager::TreatTaskAsFailed(const TaskSpecification &spec) {
 
 void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
                              bool forwarded) {
+  if (local_queues_.TaskInQueue(task.GetTaskSpecification().TaskId())) {
+    RAY_LOG(WARNING)
+        << "Submitted task " << task.GetTaskSpecification().TaskId()
+        << " is already queued. This is most likely due to spurious reconstruction.";
+    return;
+  }
+
   // Add the task and its uncommitted lineage to the lineage cache.
   lineage_cache_.AddWaitingTask(task, uncommitted_lineage);
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -790,10 +790,10 @@ void NodeManager::TreatTaskAsFailed(const TaskSpecification &spec) {
 
 void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineage,
                              bool forwarded) {
-  if (local_queues_.TaskInQueue(task.GetTaskSpecification().TaskId())) {
-    RAY_LOG(WARNING)
-        << "Submitted task " << task.GetTaskSpecification().TaskId()
-        << " is already queued. This is most likely due to spurious reconstruction.";
+  if (local_queues_.HasTask(task.GetTaskSpecification().TaskId())) {
+    RAY_LOG(WARNING) << "Submitted task " << task.GetTaskSpecification().TaskId()
+                     << " is already queued and will not be reconstructed. This is most "
+                        "likely due to spurious reconstruction.";
     return;
   }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -223,6 +223,32 @@ void SchedulingQueue::QueueMethodsWaitingForActorCreation(
   QueueTasks(methods_waiting_for_actor_creation_, tasks);
 }
 
+bool SchedulingQueue::TaskInQueue(const TaskID &task_id) const {
+  if (methods_waiting_for_actor_creation_.TaskInQueue(task_id)) {
+    return true;
+  }
+  if (waiting_tasks_.TaskInQueue(task_id)) {
+    return true;
+  }
+  if (placeable_tasks_.TaskInQueue(task_id)) {
+    return true;
+  }
+  if (ready_tasks_.TaskInQueue(task_id)) {
+    return true;
+  }
+  if (running_tasks_.TaskInQueue(task_id)) {
+    return true;
+  }
+  if (blocked_tasks_.TaskInQueue(task_id)) {
+    return true;
+  }
+  return false;
+}
+
+bool SchedulingQueue::TaskQueue::TaskInQueue(const TaskID &task_id) const {
+  return task_map_.find(task_id) != task_map_.end();
+}
+
 void SchedulingQueue::QueueWaitingTasks(const std::vector<Task> &tasks) {
   QueueTasks(waiting_tasks_, tasks);
 }

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -223,30 +223,11 @@ void SchedulingQueue::QueueMethodsWaitingForActorCreation(
   QueueTasks(methods_waiting_for_actor_creation_, tasks);
 }
 
-bool SchedulingQueue::TaskInQueue(const TaskID &task_id) const {
-  if (methods_waiting_for_actor_creation_.TaskInQueue(task_id)) {
-    return true;
-  }
-  if (waiting_tasks_.TaskInQueue(task_id)) {
-    return true;
-  }
-  if (placeable_tasks_.TaskInQueue(task_id)) {
-    return true;
-  }
-  if (ready_tasks_.TaskInQueue(task_id)) {
-    return true;
-  }
-  if (running_tasks_.TaskInQueue(task_id)) {
-    return true;
-  }
-  if (blocked_tasks_.TaskInQueue(task_id)) {
-    return true;
-  }
-  return false;
-}
-
-bool SchedulingQueue::TaskQueue::TaskInQueue(const TaskID &task_id) const {
-  return task_map_.find(task_id) != task_map_.end();
+bool SchedulingQueue::HasTask(const TaskID &task_id) const {
+  return (methods_waiting_for_actor_creation_.HasTask(task_id) ||
+          waiting_tasks_.HasTask(task_id) || placeable_tasks_.HasTask(task_id) ||
+          ready_tasks_.HasTask(task_id) || running_tasks_.HasTask(task_id) ||
+          blocked_tasks_.HasTask(task_id));
 }
 
 void SchedulingQueue::QueueWaitingTasks(const std::vector<Task> &tasks) {

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -26,11 +26,11 @@ class SchedulingQueue {
   /// SchedulingQueue destructor.
   virtual ~SchedulingQueue() {}
 
-  /// Return whether a task is in the queue.
+  /// \brief Check if the queue contains a specific task id.
   ///
-  /// \param task_id The ID of the task to check for.
-  /// \return Whether the task is in the queue.
-  bool TaskInQueue(const TaskID &task_id) const;
+  /// \param task_id The task ID for the task.
+  /// \return Whether the task_id exists in the queue.
+  bool HasTask(const TaskID &task_id) const;
 
   /// Get the queue of tasks that are destined for actors that have not yet
   /// been created.
@@ -160,12 +160,6 @@ class SchedulingQueue {
 
     /// Destructor for task queue.
     ~TaskQueue();
-
-    /// Return whether a task is in the queue.
-    ///
-    /// \param task_id The ID of the task to check for.
-    /// \return Whether the task is in the queue.
-    bool TaskInQueue(const TaskID &task_id) const;
 
     /// \brief Append a task to queue.
     ///

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -26,6 +26,12 @@ class SchedulingQueue {
   /// SchedulingQueue destructor.
   virtual ~SchedulingQueue() {}
 
+  /// Return whether a task is in the queue.
+  ///
+  /// \param task_id The ID of the task to check for.
+  /// \return Whether the task is in the queue.
+  bool TaskInQueue(const TaskID &task_id) const;
+
   /// Get the queue of tasks that are destined for actors that have not yet
   /// been created.
   ///
@@ -154,6 +160,12 @@ class SchedulingQueue {
 
     /// Destructor for task queue.
     ~TaskQueue();
+
+    /// Return whether a task is in the queue.
+    ///
+    /// \param task_id The ID of the task to check for.
+    /// \return Whether the task is in the queue.
+    bool TaskInQueue(const TaskID &task_id) const;
 
     /// \brief Append a task to queue.
     ///


### PR DESCRIPTION
## What do these changes do?

Reconstruction of a task may be spuriously triggered if a task lease notification arrives too late. The node that requires a return value from the task may then try to reconstruct it. If the node already has the task queued locally (e.g., because it was forwarded the original copy of the task immediately beforehand), then this will lead to a crash. This PR adds a check to make sure that a submitted task is not already queued before accepting it. A warning is logged if this happens.