### PR TITLE
fix a bug in killing unregistered workers

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -65,11 +65,14 @@ WorkerPool::~WorkerPool() {
   }
   // Kill all the workers that have been started but not registered.
   for (const auto &entry : starting_worker_processes_) {
-    pids_to_kill.insert(entry.second);
+    pids_to_kill.insert(entry.first);
   }
   for (const auto &pid : pids_to_kill) {
     RAY_CHECK(pid > 0);
     kill(pid, SIGKILL);
+  }
+  // Waiting for the workers to be killed
+  for (const auto &pid : pids_to_kill) {
     waitpid(pid, NULL, 0);
   }
 }


### PR DESCRIPTION
This PR fixes the bug that unregistered workers won't be killed. The reason is because a wrong parameter is used (`entry.first` is the pid, while `entry.second` is the number of remaining unregistered workers).

However, after fixing this place, I found only 1 worker could be killed. The main process would exit at the first `waitpid` call, thus remaining workers won't get killed. This issue can be fixed by sending kill signals to all workers first and then do `waitpid`. I'm not totally sure why. My guess is that `waitpid` may block for too long and the main process is somehow killed. 

cc @guoyuhong 