### PR TITLE
[xray] Make sure raylet does not crash if remote raylet dies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ matrix:
         - python -m pytest test/failure_test.py
         - python -m pytest test/microbenchmarks.py
         - python -m pytest test/stress_tests.py
-        # - pytest test/component_failures_test.py
+        - pytest test/component_failures_test.py
         - python test/multi_node_test.py
         - python -m pytest test/recursion_test.py
         - pytest test/monitor_test.py

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -43,8 +43,7 @@ class ServerConnection {
   ///
   /// \param buffer The buffer.
   /// \param ec The error code object in which to store error codes.
-  void WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer,
-                   boost::system::error_code &ec);
+  Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer);
 
   /// Read a buffer from this connection.
   ///

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -51,14 +51,13 @@ void ConnectionPool::GetSender(ConnectionType type, const ClientID &client_id,
   }
 }
 
-ray::Status ConnectionPool::ReleaseSender(ConnectionType type,
-                                          std::shared_ptr<SenderConnection> &conn) {
+void ConnectionPool::ReleaseSender(ConnectionType type,
+                                   std::shared_ptr<SenderConnection> &conn) {
   std::unique_lock<std::mutex> guard(connection_mutex);
   SenderMapType &conn_map = (type == ConnectionType::MESSAGE)
                                 ? available_message_send_connections_
                                 : available_transfer_send_connections_;
   Return(conn_map, conn->GetClientID(), conn);
-  return ray::Status::OK();
 }
 
 void ConnectionPool::Add(ReceiverMapType &conn_map, const ClientID &client_id,

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -38,8 +38,8 @@ void ConnectionPool::RegisterSender(ConnectionType type, const ClientID &client_
   // Don't add to available connections. It will become available once it is released.
 }
 
-ray::Status ConnectionPool::GetSender(ConnectionType type, const ClientID &client_id,
-                                      std::shared_ptr<SenderConnection> *conn) {
+void ConnectionPool::GetSender(ConnectionType type, const ClientID &client_id,
+                               std::shared_ptr<SenderConnection> *conn) {
   std::unique_lock<std::mutex> guard(connection_mutex);
   SenderMapType &avail_conn_map = (type == ConnectionType::MESSAGE)
                                       ? available_message_send_connections_
@@ -49,7 +49,6 @@ ray::Status ConnectionPool::GetSender(ConnectionType type, const ClientID &clien
   } else {
     *conn = nullptr;
   }
-  return ray::Status::OK();
 }
 
 ray::Status ConnectionPool::ReleaseSender(ConnectionType type,

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -65,9 +65,9 @@ class ConnectionPool {
   /// \param[in] type The type of connection.
   /// \param[in] client_id The ClientID of the remote object manager.
   /// \param[out] conn An empty pointer to a shared pointer.
-  /// \return Status of invoking this method.
-  ray::Status GetSender(ConnectionType type, const ClientID &client_id,
-                        std::shared_ptr<SenderConnection> *conn);
+  /// \return Void.
+  void GetSender(ConnectionType type, const ClientID &client_id,
+                 std::shared_ptr<SenderConnection> *conn);
 
   /// Releases a sender connection, allowing it to be used by another operation.
   ///

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -73,8 +73,8 @@ class ConnectionPool {
   ///
   /// \param type The type of connection.
   /// \param conn The actual connection.
-  /// \return Status of invoking this method.
-  ray::Status ReleaseSender(ConnectionType type, std::shared_ptr<SenderConnection> &conn);
+  /// \return Void.
+  void ReleaseSender(ConnectionType type, std::shared_ptr<SenderConnection> &conn);
 
   // TODO(hme): Implement with error handling.
   /// Remove a sender connection. This is invoked if the connection is no longer

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -107,7 +107,7 @@ ray::Status ObjectDirectory::GetInformation(const ClientID &client_id,
   const ClientTableDataT &data = gcs_client_->client_table().GetClient(client_id);
   ClientID result_client_id = ClientID::from_binary(data.client_id);
   if (result_client_id == ClientID::nil() || !data.is_insertion) {
-    fail_callback(ray::Status::RedisError("ClientID not found."));
+    fail_callback();
   } else {
     const auto &info = RemoteConnectionInfo(client_id, data.node_manager_address,
                                             (uint16_t)data.object_manager_port);

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -31,7 +31,7 @@ class ObjectDirectoryInterface {
 
   /// Callbacks for GetInformation.
   using InfoSuccessCallback = std::function<void(const ray::RemoteConnectionInfo &info)>;
-  using InfoFailureCallback = std::function<void(ray::Status status)>;
+  using InfoFailureCallback = std::function<void()>;
 
   virtual void RegisterBackend() = 0;
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -116,8 +116,8 @@ class ObjectManager : public ObjectManagerInterface {
   ///
   /// \param object_id The object's object id.
   /// \param client_id The remote node's client id.
-  /// \return Status of whether the pull request successfully initiated.
-  ray::Status Pull(const ObjectID &object_id, const ClientID &client_id);
+  /// \return Void.
+  void Pull(const ObjectID &object_id, const ClientID &client_id);
 
   /// Add a connection to a remote object manager.
   /// This is invoked by an external server.
@@ -273,8 +273,7 @@ class ObjectManager : public ObjectManagerInterface {
   /// Part of an asynchronous sequence of Pull methods.
   /// Uses an existing connection or creates a connection to ClientID.
   /// Executes on main_service_ thread.
-  ray::Status PullEstablishConnection(const ObjectID &object_id,
-                                      const ClientID &client_id);
+  void PullEstablishConnection(const ObjectID &object_id, const ClientID &client_id);
 
   /// Private callback implementation for success on get location. Called from
   /// ObjectDirectory.

--- a/src/ray/object_manager/object_manager_client_connection.cc
+++ b/src/ray/object_manager/object_manager_client_connection.cc
@@ -8,10 +8,14 @@ std::shared_ptr<SenderConnection> SenderConnection::Create(
     boost::asio::io_service &io_service, const ClientID &client_id, const std::string &ip,
     uint16_t port) {
   boost::asio::ip::tcp::socket socket(io_service);
-  RAY_CHECK_OK(TcpConnect(socket, ip, port));
-  std::shared_ptr<TcpServerConnection> conn =
-      std::make_shared<TcpServerConnection>(std::move(socket));
-  return std::make_shared<SenderConnection>(std::move(conn), client_id);
+  Status status = TcpConnect(socket, ip, port);
+  if (status.ok()) {
+    std::shared_ptr<TcpServerConnection> conn =
+        std::make_shared<TcpServerConnection>(std::move(socket));
+    return std::make_shared<SenderConnection>(std::move(conn), client_id);
+  } else {
+    return nullptr;
+  }
 };
 
 SenderConnection::SenderConnection(std::shared_ptr<TcpServerConnection> conn,

--- a/src/ray/object_manager/object_manager_client_connection.h
+++ b/src/ray/object_manager/object_manager_client_connection.h
@@ -24,7 +24,8 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   /// \param client_id The ClientID of the remote node.
   /// \param ip The ip address of the remote node server.
   /// \param port The port of the remote node server.
-  /// \return A connection to the remote object manager.
+  /// \return A connection to the remote object manager. This is null if the
+  /// connection was unsuccessful.
   static std::shared_ptr<SenderConnection> Create(boost::asio::io_service &io_service,
                                                   const ClientID &client_id,
                                                   const std::string &ip, uint16_t port);
@@ -47,9 +48,8 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   ///
   /// \param buffer The buffer.
   /// \param ec The error code object in which to store error codes.
-  void WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer,
-                   boost::system::error_code &ec) {
-    return conn_->WriteBuffer(buffer, ec);
+  Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer) {
+    return conn_->WriteBuffer(buffer);
   }
 
   /// Read a buffer from this connection.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1259,6 +1259,11 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
   if (!ForwardTask(task, node_manager_id).ok()) {
     RAY_LOG(INFO) << "Failed to forward task " << task_id << " to node manager "
                   << node_manager_id;
+    // Mark the failed task as pending to let other raylets know that we still
+    // have the task. Once the task is successfully retried, it will be
+    // canceled. TaskDependencyManager::TaskPending() is assumed to be
+    // idempotent.
+    task_dependency_manager_.TaskPending(task);
 
     // Create a timer to resubmit the task in a little bit. TODO(rkn): Really
     // this should be a unique_ptr instead of a shared_ptr. However, it's a

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -200,9 +200,8 @@ class ComponentFailureTest(unittest.TestCase):
                       str(component.pid) + "to terminate")
                 assert not component.poll() is None
 
-    @unittest.skipIf(
-        not os.environ.get('RAY_USE_XRAY', False),
-        "Only tests Raylet failure.")
+    @unittest.skipIf(not os.environ.get('RAY_USE_XRAY', False),
+                     "Only tests Raylet failure.")
     def testRayletFailed(self):
         # Kill all local schedulers on worker nodes.
         self._testComponentFailed(ray.services.PROCESS_TYPE_RAYLET)
@@ -261,8 +260,7 @@ class ComponentFailureTest(unittest.TestCase):
                                     False)
         self.check_components_alive(ray.services.PROCESS_TYPE_LOCAL_SCHEDULER,
                                     False)
-        self.check_components_alive(ray.services.PROCESS_TYPE_RAYLET,
-                                    False)
+        self.check_components_alive(ray.services.PROCESS_TYPE_RAYLET, False)
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False),
@@ -273,9 +271,8 @@ class ComponentFailureTest(unittest.TestCase):
         processes = (all_processes[ray.services.PROCESS_TYPE_PLASMA_STORE] +
                      all_processes[ray.services.PROCESS_TYPE_PLASMA_MANAGER] +
                      all_processes[ray.services.PROCESS_TYPE_LOCAL_SCHEDULER] +
-                     all_processes[
-                         ray.services.PROCESS_TYPE_GLOBAL_SCHEDULER] +
-                     all_processes[ray.services.PROCESS_TYPE_RAYLET])
+                     all_processes[ray.services.PROCESS_TYPE_GLOBAL_SCHEDULER]
+                     + all_processes[ray.services.PROCESS_TYPE_RAYLET])
 
         # Kill all the components sequentially.
         for process in processes:
@@ -295,9 +292,8 @@ class ComponentFailureTest(unittest.TestCase):
         processes = (all_processes[ray.services.PROCESS_TYPE_PLASMA_STORE] +
                      all_processes[ray.services.PROCESS_TYPE_PLASMA_MANAGER] +
                      all_processes[ray.services.PROCESS_TYPE_LOCAL_SCHEDULER] +
-                     all_processes[
-                         ray.services.PROCESS_TYPE_GLOBAL_SCHEDULER] +
-                     all_processes[ray.services.PROCESS_TYPE_RAYLET])
+                     all_processes[ray.services.PROCESS_TYPE_GLOBAL_SCHEDULER]
+                     + all_processes[ray.services.PROCESS_TYPE_RAYLET])
 
         # Kill all the components in parallel.
         for process in processes:

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -133,11 +133,6 @@ class ComponentFailureTest(unittest.TestCase):
     def _testComponentFailed(self, component_type):
         """Kill a component on all worker nodes and check workload succeeds."""
 
-        @ray.remote
-        def f(x, j):
-            time.sleep(0.2)
-            return x
-
         # Start with 4 workers and 4 cores.
         num_local_schedulers = 4
         num_workers_per_scheduler = 8
@@ -146,16 +141,27 @@ class ComponentFailureTest(unittest.TestCase):
             num_local_schedulers=num_local_schedulers,
             start_ray_local=True,
             num_cpus=[num_workers_per_scheduler] * num_local_schedulers,
-            redirect_output=True)
+            redirect_output=False,
+            use_raylet=True)
 
-        # Submit more tasks than there are workers so that all workers and
-        # cores are utilized.
-        object_ids = [
-            f.remote(i, 0)
-            for i in range(num_workers_per_scheduler * num_local_schedulers)
-        ]
-        object_ids += [f.remote(object_id, 1) for object_id in object_ids]
-        object_ids += [f.remote(object_id, 2) for object_id in object_ids]
+        # Submit many tasks with many dependencies.
+        @ray.remote
+        def f(x):
+            return x
+
+        x = 1
+        for _ in range(1000):
+            x = f.remote(x)
+        ray.get(x)
+
+        @ray.remote
+        def g(*xs):
+            return 1
+
+        xs = [g.remote(1)]
+        for _ in range(100):
+            xs.append(g.remote(*xs))
+            xs.append(g.remote(1))
 
         # Kill the component on all nodes except the head node as the tasks
         # execute.
@@ -172,10 +178,7 @@ class ComponentFailureTest(unittest.TestCase):
 
         # Make sure that we can still get the objects after the executing tasks
         # died.
-        results = ray.get(object_ids)
-        expected_results = 4 * list(
-            range(num_workers_per_scheduler * num_local_schedulers))
-        assert results == expected_results
+        ray.get(xs)
 
     def check_components_alive(self, component_type, check_component_alive):
         """Check that a given component type is alive on all worker nodes.
@@ -191,6 +194,15 @@ class ComponentFailureTest(unittest.TestCase):
                 print("done waiting for " + component_type + " with PID " +
                       str(component.pid) + "to terminate")
                 assert not component.poll() is None
+
+    def testRayletFailed(self):
+        # Kill all local schedulers on worker nodes.
+        self._testComponentFailed(ray.services.PROCESS_TYPE_RAYLET)
+
+        # The plasma stores and plasma managers should still be alive on the
+        # worker nodes.
+        self.check_components_alive(ray.services.PROCESS_TYPE_PLASMA_STORE,
+                                    True)
 
     @unittest.skipIf(
         os.environ.get('RAY_USE_NEW_GCS', False), "Hanging with new GCS API.")


### PR DESCRIPTION
## What do these changes do?

This makes sure that a raylet will not crash if a remote raylet dies. In places where an object manager tries to contact a failed remote manager, the fatal check is replaced with a logged warning that the connection failed.

Basic task reconstruction will work in some cases, but may not always work since the object manager does not retry failed requests to `Pull` an object from a remote manager (this will be filed as a separate issue).

This also adds back the relevant tests from `test/component_failures_test.py` for when `use_raylet = True`.