### PR TITLE
[xray] Cache a task's object dependencies

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -323,7 +323,7 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
         // The stopping condition for recursion is that the entry has
         // been committed to the GCS or has already been forwarded.
         // The lineage always includes the requested task id.
-        return entry.WasExplicitlyForwarded(node_id);
+        return entry.WasExplicitlyForwarded(node_id) && !(entry.GetEntryId() == task_id);
       });
   return uncommitted_lineage;
 }

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -38,8 +38,7 @@ const TaskID LineageEntry::GetEntryId() const {
 const std::unordered_set<TaskID> LineageEntry::GetParentTaskIds() const {
   std::unordered_set<TaskID> parent_ids;
   // A task's parents are the tasks that created its arguments.
-  auto dependencies = task_.GetDependencies();
-  for (auto &dependency : dependencies) {
+  for (const auto &dependency : task_.GetDependencies()) {
     parent_ids.insert(ComputeTaskId(dependency));
   }
   return parent_ids;

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -43,7 +43,6 @@ const std::unordered_set<TaskID> &LineageEntry::GetParentTaskIds() const {
 
 void LineageEntry::ComputeParentTaskIds() {
   parent_task_ids_.clear();
-  std::unordered_set<TaskID> parent_ids;
   // A task's parents are the tasks that created its arguments.
   for (const auto &dependency : task_.GetDependencies()) {
     parent_task_ids_.insert(ComputeTaskId(dependency));

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -54,6 +54,11 @@ const Task &LineageEntry::TaskData() const { return task_; }
 
 Task &LineageEntry::TaskDataMutable() { return task_; }
 
+void LineageEntry::UpdateTaskData(const Task &task) {
+  task_.CopyTaskExecutionSpec(task);
+  ComputeParentTaskIds();
+}
+
 Lineage::Lineage() {}
 
 Lineage::Lineage(const protocol::ForwardTaskRequest &task_request) {
@@ -91,7 +96,7 @@ bool Lineage::SetEntry(const Task &task, GcsStatus status) {
     if (current_entry->SetStatus(status)) {
       // SetStatus() would check if the new status is greater,
       // if it succeeds, go ahead to update the task field.
-      current_entry->TaskDataMutable().CopyTaskExecutionSpec(task);
+      current_entry->UpdateTaskData(task);
       return true;
     }
     return false;

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -84,14 +84,23 @@ class LineageEntry {
   /// that created its arguments.
   ///
   /// \return The IDs of the parent entries.
-  const std::unordered_set<TaskID> GetParentTaskIds() const;
+  const std::unordered_set<TaskID> &GetParentTaskIds() const;
 
   /// Get the task data.
   ///
   /// \return The task data.
   const Task &TaskData() const;
 
+  /// Get a mutable version of the task data.
+  ///
+  /// \return The task data.
+  /// TODO(swang): This is pretty ugly.
   Task &TaskDataMutable();
+
+ private:
+  /// Compute cached parent task IDs. This task is dependent on values returned
+  /// by these tasks.
+  void ComputeParentTaskIds();
 
   /// The current state of this entry according to its status in the GCS.
   GcsStatus status_;
@@ -99,7 +108,9 @@ class LineageEntry {
   /// an object.
   //  const Task task_;
   Task task_;
-
+  /// A cached copy of the parent task IDs. This task is dependent on values
+  /// returned by these tasks.
+  std::unordered_set<TaskID> parent_task_ids_;
   /// IDs of node managers that this task has been explicitly forwarded to.
   std::unordered_set<ClientID> forwarded_to_;
 };

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -97,6 +97,11 @@ class LineageEntry {
   /// TODO(swang): This is pretty ugly.
   Task &TaskDataMutable();
 
+  /// Update the task data with a new task.
+  ///
+  /// \return Void.
+  void UpdateTaskData(const Task &task);
+
  private:
   /// Compute cached parent task IDs. This task is dependent on values returned
   /// by these tasks.

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -217,7 +217,7 @@ TEST_F(LineageCacheTest, TestMarkTaskAsForwarded) {
   // Check that lineage of requested task includes itself, regardless of whether
   // it has been forwarded before.
   auto uncommitted_lineage_forwarded =
-      lineage_cache_.GetUncommittedLineage(remaining_task_id, node_id);
+      lineage_cache_.GetUncommittedLineage(forwarded_task_id, node_id);
   ASSERT_EQ(1, uncommitted_lineage_forwarded.GetEntries().size());
 }
 

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -284,7 +284,6 @@ TEST_F(LineageCacheTest, TestWritebackPartiallyReady) {
     returns.push_back(task2.GetTaskSpecification().ReturnId(i));
   }
   auto dependent_task = ExampleTask(returns, 1);
-  auto dependencies = dependent_task.GetDependencies();
 
   // Insert all tasks as waiting for execution.
   ASSERT_TRUE(lineage_cache_.AddWaitingTask(task1, Lineage()));

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -33,12 +33,12 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
     const auto &resource_demand = t.GetTaskSpecification().GetRequiredResources();
     const TaskID &task_id = t.GetTaskSpecification().TaskId();
     RAY_LOG(DEBUG) << "[SchedulingPolicy]: task=" << task_id
-                   << " numforwards=" << t.GetTaskExecutionSpecReadonly().NumForwards()
+                   << " numforwards=" << t.GetTaskExecutionSpec().NumForwards()
                    << " resources="
                    << t.GetTaskSpecification().GetRequiredResources().ToString();
     // TODO(atumanov): replace the simple spillback policy with exponential backoff based
     // policy.
-    if (t.GetTaskExecutionSpecReadonly().NumForwards() >= 1) {
+    if (t.GetTaskExecutionSpec().NumForwards() >= 1) {
       decision[task_id] = local_client_id;
       continue;
     }

--- a/src/ray/raylet/task.cc
+++ b/src/ray/raylet/task.cc
@@ -11,55 +11,39 @@ flatbuffers::Offset<protocol::Task> Task::ToFlatbuffer(
   return task;
 }
 
-TaskExecutionSpecification &Task::GetTaskExecutionSpec() { return task_execution_spec_; }
-
-const TaskExecutionSpecification &Task::GetTaskExecutionSpecReadonly() const {
+const TaskExecutionSpecification &Task::GetTaskExecutionSpec() const {
   return task_execution_spec_;
 }
 
 const TaskSpecification &Task::GetTaskSpecification() const { return task_spec_; }
 
-const std::vector<ObjectID> Task::GetDependencies() const {
-  std::vector<ObjectID> dependencies;
+void Task::SetExecutionDependencies(const std::vector<ObjectID> &dependencies) {
+  task_execution_spec_.SetExecutionDependencies(dependencies);
+  ComputeDependencies();
+}
+
+void Task::IncrementNumForwards() { task_execution_spec_.IncrementNumForwards(); }
+
+const std::vector<ObjectID> &Task::GetDependencies() const { return dependencies_; }
+
+void Task::ComputeDependencies() {
+  dependencies_.clear();
   for (int i = 0; i < task_spec_.NumArgs(); ++i) {
     int count = task_spec_.ArgIdCount(i);
     for (int j = 0; j < count; j++) {
-      dependencies.push_back(task_spec_.ArgId(i, j));
+      dependencies_.push_back(task_spec_.ArgId(i, j));
     }
   }
   // TODO(atumanov): why not just return a const reference to ExecutionDependencies() and
   // avoid a copy.
   auto execution_dependencies = task_execution_spec_.ExecutionDependencies();
-  dependencies.insert(dependencies.end(), execution_dependencies.begin(),
-                      execution_dependencies.end());
-  return dependencies;
-}
-
-bool Task::DependsOn(const ObjectID &object_id) const {
-  // Iterate through the task arguments to see if it contains object_id.
-  int64_t num_args = task_spec_.NumArgs();
-  for (int i = 0; i < num_args; ++i) {
-    int count = task_spec_.ArgIdCount(i);
-    for (int j = 0; j < count; j++) {
-      ObjectID arg_id = task_spec_.ArgId(i, j);
-      if (arg_id == object_id) {
-        return true;
-      }
-    }
-  }
-  // Iterate through the execution dependencies to see if it contains object_id.
-  for (const auto &dependency_id : task_execution_spec_.ExecutionDependencies()) {
-    if (dependency_id == object_id) {
-      return true;
-    }
-  }
-  // The requested object ID was not a task argument or an execution dependency.
-  // This task is not dependent on it.
-  return false;
+  dependencies_.insert(dependencies_.end(), execution_dependencies.begin(),
+                       execution_dependencies.end());
 }
 
 void Task::CopyTaskExecutionSpec(const Task &task) {
-  task_execution_spec_ = task.GetTaskExecutionSpecReadonly();
+  task_execution_spec_ = task.GetTaskExecutionSpec();
+  ComputeDependencies();
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -217,7 +217,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskChain) {
   EXPECT_CALL(reconstruction_policy_mock_, Cancel(_)).Times(0);
   for (const auto &task : tasks) {
     // Subscribe to each of the tasks' arguments.
-    auto arguments = task.GetDependencies();
+    const auto &arguments = task.GetDependencies();
     bool ready = task_dependency_manager_.SubscribeDependencies(
         task.GetTaskSpecification().TaskId(), arguments);
     if (i < num_ready_tasks) {
@@ -291,7 +291,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskForwarding) {
   auto tasks = MakeTaskChain(num_tasks, {}, 1);
   for (const auto &task : tasks) {
     // Subscribe to each of the tasks' arguments.
-    auto arguments = task.GetDependencies();
+    const auto &arguments = task.GetDependencies();
     static_cast<void>(task_dependency_manager_.SubscribeDependencies(
         task.GetTaskSpecification().TaskId(), arguments));
     EXPECT_CALL(gcs_mock_, Add(_, task.GetTaskSpecification().TaskId(), _, _));


### PR DESCRIPTION
## What do these changes do?

When a task has many dependencies, calling `task.GetDependencies()` may take a very long time (10s of ms). The same is true for calling `GetParentTaskIds` on a `LineageEntry`, which computes the IDs of the tasks that produced the object dependencies. This PR caches these values as part of the `Task` or `LineageEntry`.

## Related issue number
This partially resolves #2622.