### PR TITLE
Add test that tasks sent to actor on dead node raise exceptions.

### DIFF
--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1253,6 +1253,8 @@ class ActorsWithGPUs(unittest.TestCase):
         assert remaining_ids == [x_id]
 
 
+@unittest.skipIf(
+    os.environ.get("RAY_USE_XRAY") != "1", "This test only works with xray.")
 class ActorExceptionFailures(unittest.TestCase):
     def tearDown(self):
         ray.shutdown()

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1286,16 +1286,17 @@ class ActorExceptionFailures(unittest.TestCase):
             ray.services.PROCESS_TYPE_PLASMA_STORE][1]
         process.kill()
 
-        # Submit a new actor task.
-        x_id = actor.inc.remote()
+        # Submit some new actor tasks.
+        x_ids = [actor.inc.remote() for _ in range(100)]
 
         # Make sure that getting the result raises an exception.
-        for _ in range(1000):
-            with pytest.raises(ray.worker.RayGetError):
-                # There is some small chance that ray.get will actually
-                # succeed (if the object is transferred before the raylet
-                # dies).
-                ray.get(x_id)
+        for _ in range(100):
+            for x_id in x_ids:
+                with pytest.raises(ray.worker.RayGetError):
+                    # There is some small chance that ray.get will actually
+                    # succeed (if the object is transferred before the raylet
+                    # dies).
+                    ray.get(x_id)
 
         # Make sure the process has exited.
         process.wait()

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1290,7 +1290,7 @@ class ActorExceptionFailures(unittest.TestCase):
         x_ids = [actor.inc.remote() for _ in range(100)]
 
         # Make sure that getting the result raises an exception.
-        for _ in range(100):
+        for _ in range(10):
             for x_id in x_ids:
                 with pytest.raises(ray.worker.RayGetError):
                     # There is some small chance that ray.get will actually


### PR DESCRIPTION
This test currently seems to hang. It can be run with

```
RAY_USE_XRAY=1 python test/actor_test.py ActorExceptionFailures
```

cc @stephanie-wang @elibol 