### PR TITLE
[xray] Object manager retries Pull requests

### DIFF
--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -149,10 +149,7 @@ class RayConfig {
         max_tasks_to_spillback_(10),
         actor_creation_num_spillbacks_warning_(100),
         node_manager_forward_task_retry_timeout_milliseconds_(1000),
-        // TODO: Setting this to large values results in latency, which needs to
-        // be addressed. This timeout is often on the critical path for object
-        // transfers.
-        object_manager_pull_timeout_ms_(20),
+        object_manager_pull_timeout_ms_(100),
         object_manager_push_timeout_ms_(10000),
         object_manager_default_chunk_size_(1000000),
         num_workers_per_process_(1) {}

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -53,14 +53,15 @@ void ObjectDirectory::RegisterBackend() {
     std::vector<ClientID> client_id_vec =
         UpdateObjectLocations(object_id_listener_pair->second.current_object_locations,
                               location_history, gcs_client_->client_table());
-    if (!client_id_vec.empty()) {
-      // Copy the callbacks so that the callbacks can unsubscribe without interrupting
-      // looping over the callbacks.
-      auto callbacks = object_id_listener_pair->second.callbacks;
-      // Call all callbacks associated with the object id locations we have received.
-      for (const auto &callback_pair : callbacks) {
-        callback_pair.second(client_id_vec, object_id);
-      }
+    // Copy the callbacks so that the callbacks can unsubscribe without interrupting
+    // looping over the callbacks.
+    auto callbacks = object_id_listener_pair->second.callbacks;
+    // Call all callbacks associated with the object id locations we have
+    // received.  This notifies the client even if the list of locations is
+    // empty, since this may indicate that the objects have been evicted from
+    // all nodes.
+    for (const auto &callback_pair : callbacks) {
+      callback_pair.second(client_id_vec, object_id);
     }
   };
   RAY_CHECK_OK(gcs_client_->object_table().Subscribe(
@@ -131,12 +132,12 @@ ray::Status ObjectDirectory::SubscribeObjectLocations(const UniqueID &callback_i
     return ray::Status::OK();
   }
   listener_state.callbacks.emplace(callback_id, callback);
-  // Immediately notify of found object locations.
-  if (!listener_state.current_object_locations.empty()) {
-    std::vector<ClientID> client_id_vec(listener_state.current_object_locations.begin(),
-                                        listener_state.current_object_locations.end());
-    callback(client_id_vec, object_id);
-  }
+  // Immediately notify of object locations. This notifies the client even if
+  // the list of locations is empty, since this may indicate that the objects
+  // have been evicted from all nodes.
+  std::vector<ClientID> client_id_vec(listener_state.current_object_locations.begin(),
+                                      listener_state.current_object_locations.end());
+  callback(client_id_vec, object_id);
   return status;
 }
 

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -58,11 +58,13 @@ class ObjectDirectoryInterface {
                                       const OnLocationsFound &callback) = 0;
 
   /// Subscribe to be notified of locations (ClientID) of the given object.
-  /// The callback will be invoked whenever locations are obtained for the
-  /// specified object. The callback provided to this method may fire immediately,
-  /// within the call to this method, if any other listener is subscribed to the same
-  /// object: This occurs when location data for the object has already been obtained.
-  ///
+  /// The callback will be invoked with the complete list of known locations
+  /// whenever the set of locations changes. The callback will also be fired if
+  /// the list of known locations is empty. The callback provided to this
+  /// method may fire immediately, within the call to this method, if any other
+  /// listener is subscribed to the same object: This occurs when location data
+  /// for the object has already been obtained.
+  //
   /// \param callback_id The id associated with the specified callback. This is
   /// needed when UnsubscribeObjectLocations is called.
   /// \param object_id The required object's ObjectID.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -571,6 +571,8 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
           }));
     }
     if (wait_state.timeout_ms != -1) {
+      auto timeout = boost::posix_time::milliseconds(wait_state.timeout_ms);
+      wait_state.timeout_timer->expires_from_now(timeout);
       wait_state.timeout_timer->async_wait(
           [this, wait_id](const boost::system::error_code &error_code) {
             if (error_code.value() != 0) {

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -161,6 +161,9 @@ ray::Status ObjectManager::Pull(const ObjectID &object_id) {
         // trying the new client locations.
         bool timer_was_set = !it->second.client_locations.empty();
         // Reset the list of clients that are now expected to have the object.
+        // NOTE(swang): Since we are overwriting the previous list of clients,
+        // we may end up sending a duplicate request to the same client as
+        // before.
         it->second.client_locations = client_ids;
         if (it->second.client_locations.empty()) {
           // The object locations are now empty, so we should wait for the next

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -50,7 +50,7 @@ struct ObjectManagerConfig {
 class ObjectManagerInterface {
  public:
   virtual ray::Status Pull(const ObjectID &object_id) = 0;
-  virtual void Cancel(const ObjectID &object_id) = 0;
+  virtual void CancelPull(const ObjectID &object_id) = 0;
   virtual ~ObjectManagerInterface(){};
 };
 
@@ -143,7 +143,7 @@ class ObjectManager : public ObjectManagerInterface {
   ///
   /// \param object_id The ObjectID.
   /// \return Void.
-  void Cancel(const ObjectID &object_id);
+  void CancelPull(const ObjectID &object_id);
 
   /// Callback definition for wait.
   using WaitCallback = std::function<void(const std::vector<ray::ObjectID> &found,
@@ -167,8 +167,9 @@ class ObjectManager : public ObjectManagerInterface {
   friend class TestObjectManager;
 
   struct PullRequest {
-    PullRequest() : retry_timer(nullptr), client_locations() {}
+    PullRequest() : retry_timer(nullptr), timer_set(false), client_locations() {}
     std::unique_ptr<boost::asio::deadline_timer> retry_timer;
+    bool timer_set;
     std::vector<ClientID> client_locations;
   };
 

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -284,9 +284,11 @@ class TestObjectManager : public TestObjectManagerBase {
 
     RAY_CHECK_OK(server1->object_manager_.object_directory_->SubscribeObjectLocations(
         sub_id, object_1,
-        [this, sub_id, object_1, object_2](const std::vector<ray::ClientID> &,
+        [this, sub_id, object_1, object_2](const std::vector<ray::ClientID> &clients,
                                            const ray::ObjectID &object_id) {
-          TestWaitWhileSubscribed(sub_id, object_1, object_2);
+          if (!clients.empty()) {
+            TestWaitWhileSubscribed(sub_id, object_1, object_2);
+          }
         }));
   }
 

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -65,7 +65,7 @@ void TaskDependencyManager::HandleRemoteDependencyCanceled(const ObjectID &objec
   if (!required) {
     auto it = required_objects_.find(object_id);
     if (it != required_objects_.end()) {
-      object_manager_.Cancel(object_id);
+      object_manager_.CancelPull(object_id);
       reconstruction_policy_.Cancel(object_id);
       required_objects_.erase(it);
     }

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -65,7 +65,7 @@ void TaskDependencyManager::HandleRemoteDependencyCanceled(const ObjectID &objec
   if (!required) {
     auto it = required_objects_.find(object_id);
     if (it != required_objects_.end()) {
-      RAY_CHECK_OK(object_manager_.Cancel(object_id));
+      object_manager_.Cancel(object_id);
       reconstruction_policy_.Cancel(object_id);
       required_objects_.erase(it);
     }

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -16,7 +16,7 @@ using ::testing::_;
 class MockObjectManager : public ObjectManagerInterface {
  public:
   MOCK_METHOD1(Pull, ray::Status(const ObjectID &object_id));
-  MOCK_METHOD1(Cancel, ray::Status(const ObjectID &object_id));
+  MOCK_METHOD1(Cancel, void(const ObjectID &object_id));
 };
 
 class MockReconstructionPolicy : public ReconstructionPolicyInterface {

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -16,7 +16,7 @@ using ::testing::_;
 class MockObjectManager : public ObjectManagerInterface {
  public:
   MOCK_METHOD1(Pull, ray::Status(const ObjectID &object_id));
-  MOCK_METHOD1(Cancel, void(const ObjectID &object_id));
+  MOCK_METHOD1(CancelPull, void(const ObjectID &object_id));
 };
 
 class MockReconstructionPolicy : public ReconstructionPolicyInterface {
@@ -119,7 +119,7 @@ TEST_F(TaskDependencyManagerTest, TestSimpleTask) {
 
   // All arguments should be canceled as they become available locally.
   for (const auto &argument_id : arguments) {
-    EXPECT_CALL(object_manager_mock_, Cancel(argument_id));
+    EXPECT_CALL(object_manager_mock_, CancelPull(argument_id));
     EXPECT_CALL(reconstruction_policy_mock_, Cancel(argument_id));
   }
   // For each argument except the last, tell the task dependency manager that
@@ -156,7 +156,7 @@ TEST_F(TaskDependencyManagerTest, TestDuplicateSubscribe) {
 
   // All arguments should be canceled as they become available locally.
   for (const auto &argument_id : arguments) {
-    EXPECT_CALL(object_manager_mock_, Cancel(argument_id));
+    EXPECT_CALL(object_manager_mock_, CancelPull(argument_id));
     EXPECT_CALL(reconstruction_policy_mock_, Cancel(argument_id));
   }
   // For each argument except the last, tell the task dependency manager that
@@ -191,7 +191,7 @@ TEST_F(TaskDependencyManagerTest, TestMultipleTasks) {
   }
 
   // Tell the task dependency manager that the object is local.
-  EXPECT_CALL(object_manager_mock_, Cancel(argument_id));
+  EXPECT_CALL(object_manager_mock_, CancelPull(argument_id));
   EXPECT_CALL(reconstruction_policy_mock_, Cancel(argument_id));
   auto ready_task_ids = task_dependency_manager_.HandleObjectLocal(argument_id);
   // Check that all tasks are now ready to run.
@@ -213,7 +213,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskChain) {
   // locally queued task.
   EXPECT_CALL(object_manager_mock_, Pull(_)).Times(0);
   EXPECT_CALL(reconstruction_policy_mock_, ListenAndMaybeReconstruct(_)).Times(0);
-  EXPECT_CALL(object_manager_mock_, Cancel(_)).Times(0);
+  EXPECT_CALL(object_manager_mock_, CancelPull(_)).Times(0);
   EXPECT_CALL(reconstruction_policy_mock_, Cancel(_)).Times(0);
   for (const auto &task : tasks) {
     // Subscribe to each of the tasks' arguments.
@@ -279,7 +279,7 @@ TEST_F(TaskDependencyManagerTest, TestDependentPut) {
 
   // The put object should be considered local as soon as the task that creates
   // it is pending execution.
-  EXPECT_CALL(object_manager_mock_, Cancel(put_id));
+  EXPECT_CALL(object_manager_mock_, CancelPull(put_id));
   EXPECT_CALL(reconstruction_policy_mock_, Cancel(put_id));
   EXPECT_CALL(gcs_mock_, Add(_, task1.GetTaskSpecification().TaskId(), _, _));
   task_dependency_manager_.TaskPending(task1);
@@ -312,7 +312,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskForwarding) {
 
   // Simulate the task executing on a remote node and its return value
   // appearing locally.
-  EXPECT_CALL(object_manager_mock_, Cancel(return_id));
+  EXPECT_CALL(object_manager_mock_, CancelPull(return_id));
   EXPECT_CALL(reconstruction_policy_mock_, Cancel(return_id));
   auto ready_tasks = task_dependency_manager_.HandleObjectLocal(return_id);
   // Check that the task that we kept is now ready to run.
@@ -341,7 +341,7 @@ TEST_F(TaskDependencyManagerTest, TestEviction) {
   // Tell the task dependency manager that each of the arguments is now
   // available.
   for (const auto &argument_id : arguments) {
-    EXPECT_CALL(object_manager_mock_, Cancel(argument_id));
+    EXPECT_CALL(object_manager_mock_, CancelPull(argument_id));
     EXPECT_CALL(reconstruction_policy_mock_, Cancel(argument_id));
   }
   for (size_t i = 0; i < arguments.size(); i++) {
@@ -379,7 +379,7 @@ TEST_F(TaskDependencyManagerTest, TestEviction) {
   // Tell the task dependency manager that each of the arguments is available
   // again.
   for (const auto &argument_id : arguments) {
-    EXPECT_CALL(object_manager_mock_, Cancel(argument_id));
+    EXPECT_CALL(object_manager_mock_, CancelPull(argument_id));
     EXPECT_CALL(reconstruction_policy_mock_, Cancel(argument_id));
   }
   for (size_t i = 0; i < arguments.size(); i++) {

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -163,27 +163,26 @@ class ComponentFailureTest(unittest.TestCase):
         def g(*xs):
             return 1
 
-        xs = [g.remote(1)]
-        for _ in range(100):
-            xs.append(g.remote(*xs))
-            xs.append(g.remote(1))
-
         # Kill the component on all nodes except the head node as the tasks
         # execute.
         time.sleep(0.1)
         components = ray.services.all_processes[component_type]
         for process in components[1:]:
+            xs = [g.remote(1)]
+            for _ in range(100):
+                xs.append(g.remote(*xs))
+                xs.append(g.remote(1))
+
             process.terminate()
             time.sleep(1)
 
-        for process in components[1:]:
             process.kill()
             process.wait()
             assert not process.poll() is None
 
-        # Make sure that we can still get the objects after the executing tasks
-        # died.
-        ray.get(xs)
+            # Make sure that we can still get the objects after the executing
+            # tasks died.
+            ray.get(xs)
 
     def check_components_alive(self, component_type, check_component_alive):
         """Check that a given component type is alive on all worker nodes.

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -200,8 +200,8 @@ class ComponentFailureTest(unittest.TestCase):
             # Submit more tasks than there are workers so that all workers and
             # cores are utilized.
             object_ids = [
-                f.remote(i, 0) for i in range(
-                    num_workers_per_scheduler * num_local_schedulers)
+                f.remote(i, 0) for i in range(num_workers_per_scheduler *
+                                              num_local_schedulers)
             ]
             object_ids += [f.remote(object_id, 1) for object_id in object_ids]
             object_ids += [f.remote(object_id, 2) for object_id in object_ids]

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -138,6 +138,8 @@ class ComponentFailureTest(unittest.TestCase):
 
     def _testComponentFailed(self, component_type):
         """Kill a component on all worker nodes and check workload succeeds."""
+        # Raylet is able to pass a harder failure test than legacy ray.
+        use_raylet = os.environ.get("RAY_USE_XRAY") == "1"
 
         # Start with 4 workers and 4 cores.
         num_local_schedulers = 4
@@ -149,41 +151,80 @@ class ComponentFailureTest(unittest.TestCase):
             num_cpus=[num_workers_per_scheduler] * num_local_schedulers,
             redirect_output=True)
 
-        # Submit many tasks with many dependencies.
-        @ray.remote
-        def f(x):
-            return x
+        if use_raylet:
+            # Submit many tasks with many dependencies.
+            @ray.remote
+            def f(x):
+                return x
 
-        @ray.remote
-        def g(*xs):
-            return 1
+            @ray.remote
+            def g(*xs):
+                return 1
 
-        # Kill the component on all nodes except the head node as the tasks
-        # execute.
-        time.sleep(0.1)
-        components = ray.services.all_processes[component_type]
-        for process in components[1:]:
-            # Submit a round of tasks with many dependencies.
-            x = 1
-            for _ in range(1000):
-                x = f.remote(x)
+            # Kill the component on all nodes except the head node as the tasks
+            # execute. Do this in a loop while submitting tasks between each
+            # component failure.
+            # NOTE(swang): Legacy ray hangs on this test if the plasma manager
+            # is killed.
+            time.sleep(0.1)
+            components = ray.services.all_processes[component_type]
+            for process in components[1:]:
+                # Submit a round of tasks with many dependencies.
+                x = 1
+                for _ in range(1000):
+                    x = f.remote(x)
 
-            xs = [g.remote(1)]
-            for _ in range(100):
-                xs.append(g.remote(*xs))
-                xs.append(g.remote(1))
+                xs = [g.remote(1)]
+                for _ in range(100):
+                    xs.append(g.remote(*xs))
+                    xs.append(g.remote(1))
 
-            # Kill a component on one of the nodes.
-            process.terminate()
-            time.sleep(1)
-            process.kill()
-            process.wait()
-            assert not process.poll() is None
+                # Kill a component on one of the nodes.
+                process.terminate()
+                time.sleep(1)
+                process.kill()
+                process.wait()
+                assert not process.poll() is None
+
+                # Make sure that we can still get the objects after the
+                # executing tasks died.
+                ray.get(x)
+                ray.get(xs)
+        else:
+
+            @ray.remote
+            def f(x, j):
+                time.sleep(0.2)
+                return x
+
+            # Submit more tasks than there are workers so that all workers and
+            # cores are utilized.
+            object_ids = [
+                f.remote(i, 0) for i in range(
+                    num_workers_per_scheduler * num_local_schedulers)
+            ]
+            object_ids += [f.remote(object_id, 1) for object_id in object_ids]
+            object_ids += [f.remote(object_id, 2) for object_id in object_ids]
+
+            # Kill the component on all nodes except the head node as the tasks
+            # execute.
+            time.sleep(0.1)
+            components = ray.services.all_processes[component_type]
+            for process in components[1:]:
+                process.terminate()
+                time.sleep(1)
+
+            for process in components[1:]:
+                process.kill()
+                process.wait()
+                assert not process.poll() is None
 
             # Make sure that we can still get the objects after the executing
             # tasks died.
-            ray.get(x)
-            ray.get(xs)
+            results = ray.get(object_ids)
+            expected_results = 4 * list(
+                range(num_workers_per_scheduler * num_local_schedulers))
+            assert results == expected_results
 
     def check_components_alive(self, component_type, check_component_alive):
         """Check that a given component type is alive on all worker nodes.


### PR DESCRIPTION
## What do these changes do?

This modifies the object manager to keep track of `Pull` requests and retry ones that have not succeeded within a certain timeout.

For every `Pull` request, the object manager will subscribe to the object's locations with the GCS. On each notification from the GCS, the object manager will reset its list of known locations for the object.

Once the object manager has a list of known locations, it will try sending a `Pull` request to each client successively. Once a client has been tried, a timer is set. If the object is received, or the request is `Cancel`ed, within the timeout, then the timer is canceled and the `Pull` request is cleaned up. Else, the next client in the list is tried, and so on.
