### PR TITLE
reduce noisy log messages from wget

### DIFF
--- a/thirdparty/scripts/build_boost.sh
+++ b/thirdparty/scripts/build_boost.sh
@@ -15,7 +15,7 @@ if [[ ! -d $TP_DIR/pkg/boost ]]; then
   # The wget command frequently fails, so retry up to 20 times.
   for COUNT in {1..20}; do
     # Attempt to wget boost and break from the retry loop if it succeeds.
-    wget --no-check-certificate http://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -O $TP_DIR/build/boost_$BOOST_VERSION_UNDERSCORE.tar.gz && break
+    wget --progress=dot:giga --no-check-certificate http://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_UNDERSCORE.tar.gz -O $TP_DIR/build/boost_$BOOST_VERSION_UNDERSCORE.tar.gz && break
     # If none of the retries succeeded at getting boost, then fail.
     if [[ $COUNT == 20 ]]; then
       exit 1


### PR DESCRIPTION
Currently, wget prints tons of progress messages (roughly 1900 lines, see below), which makes the log hard to read. 
This is because, by default, wget prints a dot for each 10k received data. With this change, it prints a dot for every 1M data.

```
         0K .......... .......... .......... .......... ..........  0% 60.2K 26m20s
        50K .......... .......... .......... .......... ..........  0%  171K 17m47s
       100K .......... .......... .......... .......... ..........  0%  257K 13m54s
       150K .......... .......... .......... .......... ..........  0%  330K 11m37s
       200K .......... .......... .......... .......... ..........  0%  438K 10m1s
       250K .......... .......... .......... .......... ..........  0%  503K 8m52s
       300K .......... .......... .......... .......... ..........  0%  483K 8m4s
       350K .......... .......... .......... .......... ..........  0%  815K 7m17s
       400K .......... .......... .......... .......... ..........  0%  554K 6m48s
       450K .......... .......... .......... .......... ..........  0%  454K 6m28s
...
```