### PR TITLE
silence progress log from 'git clone' and 'pip install'

### DIFF
--- a/.travis/install-cython-examples.sh
+++ b/.travis/install-cython-examples.sh
@@ -12,7 +12,7 @@ cython_examples="$ROOT_DIR/../examples/cython"
 if [[ "$PYTHON" == "2.7" ]]; then
 
    pushd $cython_examples
-   pip install scipy
+   pip install --progress-bar=off scipy
    python setup.py install --user
    popd
 
@@ -20,7 +20,7 @@ elif [[ "$PYTHON" == "3.5" ]]; then
    export PATH="$HOME/miniconda/bin:$PATH"
 
    pushd $cython_examples
-   pip install scipy
+   pip install --progress-bar=off scipy
    python setup.py install --user
    popd
 

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -53,7 +53,7 @@ build_arrow() {
   fi
 
   if [[ ! -d $TP_DIR/build/arrow ]]; then
-    git clone https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
+    git clone -q https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
   fi
 
   if ! [ -x "$(command -v bison)" ]; then

--- a/thirdparty/scripts/build_credis.sh
+++ b/thirdparty/scripts/build_credis.sh
@@ -29,7 +29,7 @@ fi
 if [[ "${RAY_USE_NEW_GCS}" = "on" ]]; then
   pushd "$TP_DIR/pkg/"
     if [[ ! -d "credis" ]]; then
-      git clone --recursive https://github.com/ray-project/credis
+      git clone -q --recursive https://github.com/ray-project/credis
     fi
   popd
 

--- a/thirdparty/scripts/build_parquet.sh
+++ b/thirdparty/scripts/build_parquet.sh
@@ -51,7 +51,7 @@ build_parquet() {
 }
 
 if [ ! -d $TP_DIR/build/parquet-cpp ]; then
-  git clone https://github.com/apache/parquet-cpp.git "$TP_DIR/build/parquet-cpp"
+  git clone -q https://github.com/apache/parquet-cpp.git "$TP_DIR/build/parquet-cpp"
   pushd $TP_DIR/build/parquet-cpp
   git fetch origin master
   git checkout $TARGET_COMMIT_ID

--- a/thirdparty/scripts/build_ui.sh
+++ b/thirdparty/scripts/build_ui.sh
@@ -39,7 +39,7 @@ if [[ ! -d $CATAPULT_HOME ]]; then
   # The git clone command seems to fail in Travis, so retry up to 20 times.
   for COUNT in {1..20}; do
     # Attempt to git clone catapult and break from the retry loop if it succeeds.
-    git clone https://github.com/ray-project/catapult.git $CATAPULT_HOME && break
+    git clone -q https://github.com/ray-project/catapult.git $CATAPULT_HOME && break
     # If none of the retries succeeded at getting boost, then fail.
     if [[ $COUNT == 20 ]]; then
       exit 1


### PR DESCRIPTION
Similar as #2656, but `git clone` and `pip install` doesn't support a less-verbose mode, thus completely silence them.