### PR TITLE
[multi-language part 2] Change the command line arguments to start raylet

### DIFF
--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -198,11 +198,12 @@ public class RunManager {
     }
 
     int processIndex = runInfo.allProcesses.get(type.ordinal()).size();
+
     ProcessBuilder builder;
-    List<String> newCmd = Arrays.stream(cmd).filter(s -> s.length() > 0)
-        .collect(Collectors.toList());
-    builder = new ProcessBuilder(newCmd);
+    List<String> newCommand = Arrays.asList(cmd);
+    builder = new ProcessBuilder(newCommand);
     builder.directory(new File(workDir));
+
     if (redirect) {
       String stdoutFile;
       String stderrFile;
@@ -689,10 +690,12 @@ public class RunManager {
     String rayletSocketName = "/tmp/raylet" + rpcPort;
 
     String filePath = paths.raylet;
-    
-    String workerCmd = null;
-    workerCmd = buildWorkerCommandRaylet(info.storeName, rayletSocketName, UniqueID.nil,
-            "", workDir + rpcPort, ip, redisAddress);
+
+    //Create the java worker command that the raylet will use to start workers.
+    String javaWorkerCommand  = buildWorkerCommandRaylet(info.storeName, rayletSocketName,
+        UniqueID.nil, "", workDir + rpcPort, ip, redisAddress);
+    // Create the python worker command, This is just a placeholder.
+    String pythonWorkerCommand = "";
 
     int sep = redisAddress.indexOf(':');
     assert (sep != -1);
@@ -702,7 +705,8 @@ public class RunManager {
     String resourceArgument = ResourceUtil.getResourcesStringFromMap(staticResources);
 
     String[] cmds = new String[]{filePath, rayletSocketName, storeName, ip, gcsIp,
-                                 gcsPort, "" + numWorkers, workerCmd, resourceArgument};
+                                 gcsPort, "" + numWorkers, resourceArgument,
+                                 javaWorkerCommand, pythonWorkerCommand};
 
     Process p = startProcess(cmds, null, RunInfo.ProcessType.PT_RAYLET,
         workDir + rpcPort, redisAddress, ip, redirect, cleanup);

--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -691,8 +691,8 @@ public class RunManager {
 
     String filePath = paths.raylet;
 
-    //Create the java worker command that the raylet will use to start workers.
-    String javaWorkerCommand  = buildWorkerCommandRaylet(info.storeName, rayletSocketName,
+    //Create the worker command that the raylet will use to start workers.
+    String workerCommand  = buildWorkerCommandRaylet(info.storeName, rayletSocketName,
         UniqueID.nil, "", workDir + rpcPort, ip, redisAddress);
 
     int sep = redisAddress.indexOf(':');
@@ -705,7 +705,7 @@ public class RunManager {
     // The second-last arugment is the worker command for Python, not needed for Java.
     String[] cmds = new String[]{filePath,rayletSocketName, storeName, ip, gcsIp,
                                  gcsPort, "" + numWorkers, resourceArgument,
-                                 "", javaWorkerCommand};
+                                 "", workerCommand};
 
     Process p = startProcess(cmds, null, RunInfo.ProcessType.PT_RAYLET,
         workDir + rpcPort, redisAddress, ip, redirect, cleanup);

--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -694,8 +694,6 @@ public class RunManager {
     //Create the java worker command that the raylet will use to start workers.
     String javaWorkerCommand  = buildWorkerCommandRaylet(info.storeName, rayletSocketName,
         UniqueID.nil, "", workDir + rpcPort, ip, redisAddress);
-    // Create the python worker command, This is just a placeholder.
-    String pythonWorkerCommand = "";
 
     int sep = redisAddress.indexOf(':');
     assert (sep != -1);
@@ -704,9 +702,9 @@ public class RunManager {
 
     String resourceArgument = ResourceUtil.getResourcesStringFromMap(staticResources);
 
-    String[] cmds = new String[]{filePath, rayletSocketName, storeName, ip, gcsIp,
+    String[] cmds = new String[]{filePath,rayletSocketName, storeName, ip, gcsIp,
                                  gcsPort, "" + numWorkers, resourceArgument,
-                                 javaWorkerCommand, pythonWorkerCommand};
+                                 "", javaWorkerCommand};
 
     Process p = startProcess(cmds, null, RunInfo.ProcessType.PT_RAYLET,
         workDir + rpcPort, redisAddress, ip, redirect, cleanup);

--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -702,6 +702,7 @@ public class RunManager {
 
     String resourceArgument = ResourceUtil.getResourcesStringFromMap(staticResources);
 
+    // The second-last arugment is the worker command for Python, not needed for Java.
     String[] cmds = new String[]{filePath,rayletSocketName, storeName, ip, gcsIp,
                                  gcsPort, "" + numWorkers, resourceArgument,
                                  "", javaWorkerCommand};

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -982,9 +982,6 @@ def start_raylet(redis_address,
                                    sys.executable, worker_path, node_ip_address,
                                    plasma_store_name, raylet_name, redis_address))
 
-    # Create the java command.  This is just a placeholder.
-    start_java_worker_command = ""
-
     command = [
         RAYLET_EXECUTABLE,
         raylet_name,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -973,14 +973,14 @@ def start_raylet(redis_address,
     gcs_ip_address, gcs_port = redis_address.split(":")
     raylet_name = "/tmp/raylet{}".format(random_name())
 
-    # Create the python command that the Raylet will use to start workers.
-    start_python_worker_command = ("{} {} "
-                                   "--node-ip-address={} "
-                                   "--object-store-name={} "
-                                   "--raylet-name={} "
-                                   "--redis-address={}".format(
-                                       sys.executable, worker_path, node_ip_address,
-                                       plasma_store_name, raylet_name, redis_address))
+    # Create the command that the Raylet will use to start workers.
+    start_worker_command = ("{} {} "
+                            "--node-ip-address={} "
+                            "--object-store-name={} "
+                            "--raylet-name={} "
+                            "--redis-address={}".format(
+                                sys.executable, worker_path, node_ip_address,
+                                plasma_store_name, raylet_name, redis_address))
 
     command = [
         RAYLET_EXECUTABLE,
@@ -991,7 +991,7 @@ def start_raylet(redis_address,
         gcs_port,
         str(num_workers),
         resource_argument,
-        start_python_worker_command,
+        start_worker_command,
         ""    # Worker command for Java, not needed for Python.
     ]
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -992,7 +992,7 @@ def start_raylet(redis_address,
         str(num_workers),
         resource_argument,
         start_worker_command,
-        ""    # Worker command for Java, not needed for Python.
+        "",  # Worker command for Java, not needed for Python.
     ]
 
     if use_valgrind:

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -979,8 +979,8 @@ def start_raylet(redis_address,
                                    "--object-store-name={} "
                                    "--raylet-name={} "
                                    "--redis-address={}".format(
-                                   sys.executable, worker_path, node_ip_address,
-                                   plasma_store_name, raylet_name, redis_address))
+                                       sys.executable, worker_path, node_ip_address,
+                                       plasma_store_name, raylet_name, redis_address))
 
     command = [
         RAYLET_EXECUTABLE,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -973,14 +973,17 @@ def start_raylet(redis_address,
     gcs_ip_address, gcs_port = redis_address.split(":")
     raylet_name = "/tmp/raylet{}".format(random_name())
 
-    # Create the command that the Raylet will use to start workers.
-    start_worker_command = ("{} {} "
-                            "--node-ip-address={} "
-                            "--object-store-name={} "
-                            "--raylet-name={} "
-                            "--redis-address={}".format(
-                                sys.executable, worker_path, node_ip_address,
-                                plasma_store_name, raylet_name, redis_address))
+    # Create the python command that the Raylet will use to start workers.
+    start_python_worker_command = ("{} {} "
+                                   "--node-ip-address={} "
+                                   "--object-store-name={} "
+                                   "--raylet-name={} "
+                                   "--redis-address={}".format(
+                                   sys.executable, worker_path, node_ip_address,
+                                   plasma_store_name, raylet_name, redis_address))
+
+    # Create the java command.  This is just a placeholder.
+    start_java_worker_command = ""
 
     command = [
         RAYLET_EXECUTABLE,
@@ -990,8 +993,9 @@ def start_raylet(redis_address,
         gcs_ip_address,
         gcs_port,
         str(num_workers),
-        start_worker_command,
         resource_argument,
+        start_java_worker_command,
+        start_python_worker_command
     ]
 
     if use_valgrind:

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -994,8 +994,8 @@ def start_raylet(redis_address,
         gcs_port,
         str(num_workers),
         resource_argument,
-        start_java_worker_command,
-        start_python_worker_command
+        start_python_worker_command,
+        ""    # Worker command for Java, not needed for Python.
     ]
 
     if use_valgrind:

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -46,7 +46,8 @@ int main(int argc, char *argv[]) {
   } else if (!java_worker_command.empty()) {
     worker_command = python_worker_command;
   } else {
-    RAY_CHECK(0) << "Either Python worker command or Java worker command should be provided.";
+    RAY_CHECK(0)
+        << "Either Python worker command or Java worker command should be provided.";
   }
 
   std::istringstream iss(worker_command);

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -42,9 +42,9 @@ int main(int argc, char *argv[]) {
 
   std::string worker_command;
   if (!python_worker_command.empty()) {
-    worker_command = java_worker_command;
-  } else if (!java_worker_command.empty()) {
     worker_command = python_worker_command;
+  } else if (!java_worker_command.empty()) {
+    worker_command = java_worker_command;
   } else {
     RAY_CHECK(0)
         << "Either Python worker command or Java worker command should be provided.";

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -15,8 +15,8 @@ int main(int argc, char *argv[]) {
   int redis_port = std::stoi(argv[5]);
   int num_initial_workers = std::stoi(argv[6]);
   const std::string static_resource_list = std::string(argv[7]);
-  const std::string java_worker_command = std::string(argv[8]);
-  const std::string python_worker_command = std::string(argv[9]);
+  const std::string python_worker_command = std::string(argv[8]);
+  const std::string java_worker_command = std::string(argv[9]);
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
@@ -41,9 +41,9 @@ int main(int argc, char *argv[]) {
   // Use a default worker that can execute empty tasks with dependencies.
 
   std::string worker_command;
-  if (!java_worker_command.empty()) {
+  if (!python_worker_command.empty()) {
     worker_command = java_worker_command;
-  } else if (!python_worker_command.empty()) {
+  } else if (!java_worker_command.empty()) {
     worker_command = python_worker_command;
   }
 

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -45,6 +45,8 @@ int main(int argc, char *argv[]) {
     worker_command = java_worker_command;
   } else if (!java_worker_command.empty()) {
     worker_command = python_worker_command;
+  } else {
+    RAY_CHECK(0) << "Either Python worker command or Java worker command should be provided.";
   }
 
   std::istringstream iss(worker_command);

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -6,7 +6,7 @@
 
 #ifndef RAYLET_TEST
 int main(int argc, char *argv[]) {
-  RAY_CHECK(argc == 9);
+  RAY_CHECK(argc == 10);
 
   const std::string raylet_socket_name = std::string(argv[1]);
   const std::string store_socket_name = std::string(argv[2]);
@@ -14,8 +14,9 @@ int main(int argc, char *argv[]) {
   const std::string redis_address = std::string(argv[4]);
   int redis_port = std::stoi(argv[5]);
   int num_initial_workers = std::stoi(argv[6]);
-  const std::string worker_command = std::string(argv[7]);
-  const std::string static_resource_list = std::string(argv[8]);
+  const std::string static_resource_list = std::string(argv[7]);
+  const std::string java_worker_command = std::string(argv[8]);
+  const std::string python_worker_command = std::string(argv[9]);
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
@@ -38,6 +39,13 @@ int main(int argc, char *argv[]) {
   node_manager_config.num_workers_per_process =
       RayConfig::instance().num_workers_per_process();
   // Use a default worker that can execute empty tasks with dependencies.
+
+  std::string worker_command;
+  if (!java_worker_command.empty()) {
+    worker_command = java_worker_command;
+  } else if (!python_worker_command.empty()) {
+    worker_command = python_worker_command;
+  }
 
   std::istringstream iss(worker_command);
   std::vector<std::string> results(std::istream_iterator<std::string>{iss},


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
To support multiple languages in the raylet backend, we need to pass the worker commands for each language from command line.

This PR changes the command line arguments of raylet, and use 2 different arguments for Python and Java.

Note: currently one of these arguments has to be empty, the non-empty one will be used. In the next PR, we'll use both and pass them to WorkerPool.
<!-- Please give a short brief about these changes. -->

## Related issue number
[#2576](https://github.com/ray-project/ray/issues/2576)
<!-- Are there any issues opened that will be resolved by merging this change? -->
