### PR TITLE
[multi-language part 3] support multiple languages in raylet backend

### DIFF
--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -51,7 +51,8 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
   auto client = LocalSchedulerConnection_init(
-      nativeString, *worker_id.PID, isWorker, *driver_id.PID, useRaylet);
+      nativeString, *worker_id.PID, isWorker, *driver_id.PID, useRaylet,
+      Language::JAVA);
   env->ReleaseStringUTFChars(sockName, nativeString);
   return reinterpret_cast<jlong>(client);
 }

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -50,9 +50,9 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
   UniqueIdFromJByteArray worker_id(env, wid);
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
-  auto client = LocalSchedulerConnection_init(
-      nativeString, *worker_id.PID, isWorker, *driver_id.PID, useRaylet,
-      Language::JAVA);
+  auto client =
+      LocalSchedulerConnection_init(nativeString, *worker_id.PID, isWorker,
+                                    *driver_id.PID, useRaylet, Language::JAVA);
   env->ReleaseStringUTFChars(sockName, nativeString);
   return reinterpret_cast<jlong>(client);
 }

--- a/src/local_scheduler/lib/python/local_scheduler_extension.cc
+++ b/src/local_scheduler/lib/python/local_scheduler_extension.cc
@@ -31,7 +31,8 @@ static int PyLocalSchedulerClient_init(PyLocalSchedulerClient *self,
   /* Connect to the local scheduler. */
   self->local_scheduler_connection = LocalSchedulerConnection_init(
       socket_name, client_id, static_cast<bool>(PyObject_IsTrue(is_worker)),
-      driver_id, static_cast<bool>(PyObject_IsTrue(use_raylet)));
+      driver_id, static_cast<bool>(PyObject_IsTrue(use_raylet)),
+      Language::PYTHON);
   return 0;
 }
 

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -28,14 +28,14 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
    * worker, we will get killed. */
   flatbuffers::FlatBufferBuilder fbb;
   if (use_raylet) {
-    auto message = ray::local_scheduler::protocol::CreateRegisterClientRequest(
-        fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
-        to_flatbuf(fbb, driver_id));
-    fbb.Finish(message);
-  } else {
     auto message = ray::protocol::CreateRegisterClientRequest(
         fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
         to_flatbuf(fbb, driver_id), language);
+    fbb.Finish(message);
+  } else {
+    auto message = ray::local_scheduler::protocol::CreateRegisterClientRequest(
+        fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
+        to_flatbuf(fbb, driver_id));
     fbb.Finish(message);
   }
   /* Register the process ID with the local scheduler. */

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -17,7 +17,8 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
     const UniqueID &client_id,
     bool is_worker,
     const JobID &driver_id,
-    bool use_raylet) {
+    bool use_raylet,
+    const Language &language) {
   LocalSchedulerConnection *result = new LocalSchedulerConnection();
   result->use_raylet = use_raylet;
   result->conn = connect_ipc_sock_retry(local_scheduler_socket, -1, -1);
@@ -26,10 +27,19 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
    * NOTE(swang): If the local scheduler exits and we are registered as a
    * worker, we will get killed. */
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = ray::local_scheduler::protocol::CreateRegisterClientRequest(
-      fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
-      to_flatbuf(fbb, driver_id));
-  fbb.Finish(message);
+  if (use_raylet) {
+    auto message = ray::local_scheduler::protocol::CreateRegisterClientRequest(
+        fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
+        to_flatbuf(fbb, driver_id));
+    fbb.Finish(message);
+  }
+  else {
+    auto message = ray::protocol::CreateRegisterClientRequest(
+        fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
+        to_flatbuf(fbb, driver_id), language);
+    fbb.Finish(message);
+
+  }
   /* Register the process ID with the local scheduler. */
   int success = write_message(
       result->conn, static_cast<int64_t>(MessageType::RegisterClientRequest),

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -32,13 +32,11 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
         fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
         to_flatbuf(fbb, driver_id));
     fbb.Finish(message);
-  }
-  else {
+  } else {
     auto message = ray::protocol::CreateRegisterClientRequest(
         fbb, is_worker, to_flatbuf(fbb, client_id), getpid(),
         to_flatbuf(fbb, driver_id), language);
     fbb.Finish(message);
-
   }
   /* Register the process ID with the local scheduler. */
   int success = write_message(

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -46,7 +46,8 @@ LocalSchedulerConnection *LocalSchedulerConnection_init(
     const UniqueID &worker_id,
     bool is_worker,
     const JobID &driver_id,
-    bool use_raylet);
+    bool use_raylet,
+    const Language &language);
 
 /**
  * Disconnect from the local scheduler.

--- a/src/local_scheduler/test/local_scheduler_tests.cc
+++ b/src/local_scheduler/test/local_scheduler_tests.cc
@@ -126,7 +126,7 @@ LocalSchedulerMock *LocalSchedulerMock_init(int num_workers,
   for (int i = 0; i < num_mock_workers; ++i) {
     mock->conns[i] = LocalSchedulerConnection_init(
         local_scheduler_socket_name.c_str(), WorkerID::nil(), true,
-        JobID::nil(), false);
+        JobID::nil(), false, Language::PYTHON);
   }
 
   background_thread.join();

--- a/src/ray/gcs/format/util.h
+++ b/src/ray/gcs/format/util.h
@@ -8,14 +8,14 @@ namespace std {
 template <>
 struct hash<Language> {
   size_t operator()(const Language &language) const {
-	return std::hash<int32_t>()(static_cast<int32_t>(language));
+    return std::hash<int32_t>()(static_cast<int32_t>(language));
   }
 };
 
 template <>
 struct hash<const Language> {
   size_t operator()(const Language &language) const {
-	return std::hash<int32_t>()(static_cast<int32_t>(language));
+    return std::hash<int32_t>()(static_cast<int32_t>(language));
   }
 };
 

--- a/src/ray/gcs/format/util.h
+++ b/src/ray/gcs/format/util.h
@@ -1,0 +1,24 @@
+#ifndef RAY_RAYLET_GCS_FORMAT_UTIL_H
+#define RAY_RAYLET_GCS_FORMAT_UTIL_H
+
+#include "ray/gcs/format/gcs_generated.h"
+
+namespace std {
+
+template <>
+struct hash<Language> {
+  size_t operator()(const Language &language) const {
+	return std::hash<int32_t>()(static_cast<int32_t>(language));
+  }
+};
+
+template <>
+struct hash<const Language> {
+  size_t operator()(const Language &language) const {
+	return std::hash<int32_t>()(static_cast<int32_t>(language));
+  }
+};
+
+}  // namespace std
+
+#endif  // RAY_RAYLET_GCS_FORMAT_UTIL_H

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -123,6 +123,8 @@ table RegisterClientRequest {
   worker_pid: long;
   // The driver ID. This is non-nil if the client is a driver.
   driver_id: string;
+  // Language of this worker.
+  language: Language;
 }
 
 table RegisterClientReply {

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -53,7 +53,8 @@ int main(int argc, char *argv[]) {
   std::istringstream iss(worker_command);
   std::vector<std::string> results(std::istream_iterator<std::string>{iss},
                                    std::istream_iterator<std::string>());
-  node_manager_config.worker_command.swap(results);
+  // TODO haochen
+  node_manager_config.worker_command.emplace(make_pair(Language::PYTHON, results));
 
   node_manager_config.heartbeat_period_ms =
       RayConfig::instance().heartbeat_timeout_milliseconds();

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::string> results(std::istream_iterator<std::string>{iss},
                                    std::istream_iterator<std::string>());
   // TODO haochen
-  node_manager_config.worker_command.emplace(make_pair(Language::PYTHON, results));
+  node_manager_config.worker_commands.emplace(make_pair(Language::PYTHON, results));
 
   node_manager_config.heartbeat_period_ms =
       RayConfig::instance().heartbeat_timeout_milliseconds();

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -53,7 +53,7 @@ int main(int argc, char *argv[]) {
   std::istringstream iss(worker_command);
   std::vector<std::string> results(std::istream_iterator<std::string>{iss},
                                    std::istream_iterator<std::string>());
-  // TODO haochen
+  // TODO
   node_manager_config.worker_commands.emplace(make_pair(Language::PYTHON, results));
 
   node_manager_config.heartbeat_period_ms =

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -87,7 +87,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       local_available_resources_(config.resource_config),
       worker_pool_(config.num_initial_workers, config.num_workers_per_process,
                    static_cast<int>(config.resource_config.GetNumCpus()),
-                   config.worker_command),
+                   config.worker_commands),
       local_queues_(SchedulingQueue()),
       scheduling_policy_(local_queues_),
       reconstruction_policy_(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -485,7 +485,8 @@ void NodeManager::ProcessClientMessage(
   case protocol::MessageType::RegisterClientRequest: {
     auto message = flatbuffers::GetRoot<protocol::RegisterClientRequest>(message_data);
     client->SetClientID(from_flatbuf(*message->client_id()));
-    auto worker = std::make_shared<Worker>(message->worker_pid(), message->language(), client);
+    auto worker =
+        std::make_shared<Worker>(message->worker_pid(), message->language(), client);
     if (message->is_worker()) {
       // Register the new worker.
       worker_pool_.RegisterWorker(std::move(worker));

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -26,7 +26,8 @@ struct NodeManagerConfig {
   ResourceSet resource_config;
   int num_initial_workers;
   int num_workers_per_process;
-  std::unordered_map<Language, std::vector<std::string>> worker_command;
+  /// The commands used to start the worker process, grouped by language.
+  std::unordered_map<Language, std::vector<std::string>> worker_commands;
   uint64_t heartbeat_period_ms;
   uint64_t max_lineage_size;
   /// The store socket name.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -7,6 +7,7 @@
 #include "ray/raylet/task.h"
 #include "ray/object_manager/object_manager.h"
 #include "ray/common/client_connection.h"
+#include "ray/gcs/format/util.h"
 #include "ray/raylet/actor_registration.h"
 #include "ray/raylet/lineage_cache.h"
 #include "ray/raylet/scheduling_policy.h"
@@ -25,7 +26,7 @@ struct NodeManagerConfig {
   ResourceSet resource_config;
   int num_initial_workers;
   int num_workers_per_process;
-  std::vector<std::string> worker_command;
+  std::unordered_map<Language, std::vector<std::string>> worker_command;
   uint64_t heartbeat_period_ms;
   uint64_t max_lineage_size;
   /// The store socket name.

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -39,11 +39,13 @@ class TestObjectManagerBase : public ::testing::Test {
     node_manager_config.num_initial_workers = 0;
     node_manager_config.num_workers_per_process = 1;
     // Use a default worker that can execute empty tasks with dependencies.
-    node_manager_config.worker_command.push_back("python");
-    node_manager_config.worker_command.push_back(
+    std::vector<std::string> py_worker_command;
+    py_worker_command.push_back("python");
+    py_worker_command.push_back(
         "../python/ray/workers/default_worker.py");
-    node_manager_config.worker_command.push_back(raylet_socket_name.c_str());
-    node_manager_config.worker_command.push_back(store_socket_name.c_str());
+    py_worker_command.push_back(raylet_socket_name.c_str());
+    py_worker_command.push_back(store_socket_name.c_str());
+    node_manager_config.worker_command[Language::PYTHON] = py_worker_command;
     return node_manager_config;
   };
 

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -44,7 +44,7 @@ class TestObjectManagerBase : public ::testing::Test {
     py_worker_command.push_back("../python/ray/workers/default_worker.py");
     py_worker_command.push_back(raylet_socket_name.c_str());
     py_worker_command.push_back(store_socket_name.c_str());
-    node_manager_config.worker_command[Language::PYTHON] = py_worker_command;
+    node_manager_config.worker_commands[Language::PYTHON] = py_worker_command;
     return node_manager_config;
   };
 

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -41,8 +41,7 @@ class TestObjectManagerBase : public ::testing::Test {
     // Use a default worker that can execute empty tasks with dependencies.
     std::vector<std::string> py_worker_command;
     py_worker_command.push_back("python");
-    py_worker_command.push_back(
-        "../python/ray/workers/default_worker.py");
+    py_worker_command.push_back("../python/ray/workers/default_worker.py");
     py_worker_command.push_back(raylet_socket_name.c_str());
     py_worker_command.push_back(store_socket_name.c_str());
     node_manager_config.worker_command[Language::PYTHON] = py_worker_command;

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -11,8 +11,9 @@ namespace ray {
 namespace raylet {
 
 /// A constructor responsible for initializing the state of a worker.
-Worker::Worker(pid_t pid, std::shared_ptr<LocalClientConnection> connection)
+Worker::Worker(pid_t pid, const Language& language, std::shared_ptr<LocalClientConnection> connection)
     : pid_(pid),
+      language_(language),
       connection_(connection),
       assigned_task_id_(TaskID::nil()),
       actor_id_(ActorID::nil()),
@@ -25,6 +26,8 @@ void Worker::MarkUnblocked() { blocked_ = false; }
 bool Worker::IsBlocked() const { return blocked_; }
 
 pid_t Worker::Pid() const { return pid_; }
+
+Language Worker::GetLanguage() const { return language_; }
 
 void Worker::AssignTaskId(const TaskID &task_id) { assigned_task_id_ = task_id; }
 

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -11,7 +11,8 @@ namespace ray {
 namespace raylet {
 
 /// A constructor responsible for initializing the state of a worker.
-Worker::Worker(pid_t pid, const Language& language, std::shared_ptr<LocalClientConnection> connection)
+Worker::Worker(pid_t pid, const Language &language,
+               std::shared_ptr<LocalClientConnection> connection)
     : pid_(pid),
       language_(language),
       connection_(connection),

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -17,7 +17,7 @@ namespace raylet {
 class Worker {
  public:
   /// A constructor that initializes a worker object.
-  Worker(pid_t pid, std::shared_ptr<LocalClientConnection> connection);
+  Worker(pid_t pid, const Language& language, std::shared_ptr<LocalClientConnection> connection);
   /// A destructor responsible for freeing all worker state.
   ~Worker() {}
   void MarkBlocked();
@@ -25,6 +25,7 @@ class Worker {
   bool IsBlocked() const;
   /// Return the worker's PID.
   pid_t Pid() const;
+  Language GetLanguage() const;
   void AssignTaskId(const TaskID &task_id);
   const TaskID &GetAssignedTaskId() const;
   void AssignActorId(const ActorID &actor_id);
@@ -45,6 +46,7 @@ class Worker {
  private:
   /// The worker's PID.
   pid_t pid_;
+  Language language_;
   /// Connection state of a worker.
   std::shared_ptr<LocalClientConnection> connection_;
   /// The worker's currently assigned task.

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -47,6 +47,7 @@ class Worker {
  private:
   /// The worker's PID.
   pid_t pid_;
+  /// The language type of this worker.
   Language language_;
   /// Connection state of a worker.
   std::shared_ptr<LocalClientConnection> connection_;

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -17,7 +17,8 @@ namespace raylet {
 class Worker {
  public:
   /// A constructor that initializes a worker object.
-  Worker(pid_t pid, const Language& language, std::shared_ptr<LocalClientConnection> connection);
+  Worker(pid_t pid, const Language &language,
+         std::shared_ptr<LocalClientConnection> connection);
   /// A destructor responsible for freeing all worker state.
   ~Worker() {}
   void MarkBlocked();

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -42,15 +42,15 @@ namespace raylet {
 /// (num_worker_processes * num_workers_per_process) workers
 WorkerPool::WorkerPool(
     int num_worker_processes, int num_workers_per_process, int num_cpus,
-    const std::unordered_map<Language, std::vector<std::string>> &worker_command)
+    const std::unordered_map<Language, std::vector<std::string>> &worker_commands)
     : num_workers_per_process_(num_workers_per_process),
       num_cpus_(num_cpus),
-      worker_command_(worker_command) {
+      worker_commands_(worker_commands) {
   RAY_CHECK(num_workers_per_process > 0) << "num_workers_per_process must be positive.";
   // Ignore SIGCHLD signals. If we don't do this, then worker processes will
   // become zombies instead of dying gracefully.
   signal(SIGCHLD, SIG_IGN);
-  for (const auto &entry : worker_command) {
+  for (const auto &entry : worker_commands) {
     // Initialize the pools for each language.
     pools_[entry.first];
     // Force-start num_workers workers.
@@ -89,7 +89,7 @@ uint32_t WorkerPool::Size(const Language &language) const {
 }
 
 void WorkerPool::StartWorkerProcess(const Language &language, bool force_start) {
-  RAY_CHECK(!worker_command_.empty()) << "No worker command provided";
+  RAY_CHECK(!worker_commands_.empty()) << "No worker command provided";
   // The first condition makes sure that we are always starting up to
   // num_cpus_ number of processes in parallel.
   if (static_cast<int>(starting_worker_processes_.size()) >= num_cpus_ && !force_start) {
@@ -116,7 +116,7 @@ void WorkerPool::StartWorkerProcess(const Language &language, bool force_start) 
 
   // Extract pointers from the worker command to pass into execvp.
   std::vector<const char *> worker_command_args;
-  auto command = worker_command_.find(language);
+  auto command = worker_commands_.find(language);
   for (auto const &token : command->second) {
     worker_command_args.push_back(token.c_str());
   }
@@ -214,7 +214,7 @@ void WorkerPool::DisconnectDriver(std::shared_ptr<Worker> driver) {
   RAY_CHECK(RemoveWorker(pool.registered_drivers, driver));
 }
 
-WorkerPool::SingleLangPool &WorkerPool::GetPoolForLanguage(const Language &language) {
+WorkerPool::Pool &WorkerPool::GetPoolForLanguage(const Language &language) {
   auto pool = pools_.find(language);
   RAY_CHECK(pool != pools_.end()) << "Required Language isn't supported.";
   return pool->second;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -44,7 +44,7 @@ WorkerPool::WorkerPool(
     int num_worker_processes, int num_workers_per_process, int num_cpus,
     const std::unordered_map<Language, std::vector<std::string>> &worker_commands)
     : num_workers_per_process_(num_workers_per_process),
-      num_cpus_(num_cpus),
+      num_cpus_(num_cpus) {
   RAY_CHECK(num_workers_per_process > 0) << "num_workers_per_process must be positive.";
   // Ignore SIGCHLD signals. If we don't do this, then worker processes will
   // become zombies instead of dying gracefully.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -71,7 +71,7 @@ WorkerPool::~WorkerPool() {
   }
   // Kill all the workers that have been started but not registered.
   for (const auto &entry : starting_worker_processes_) {
-	pids_to_kill.insert(entry.first);
+    pids_to_kill.insert(entry.first);
   }
   for (const auto &pid : pids_to_kill) {
     RAY_CHECK(pid > 0);
@@ -162,7 +162,7 @@ std::shared_ptr<Worker> WorkerPool::GetRegisteredWorker(
 
 std::shared_ptr<Worker> WorkerPool::GetRegisteredDriver(
     const std::shared_ptr<LocalClientConnection> &connection) const {
-  for (const auto &entry : pools_){
+  for (const auto &entry : pools_) {
     auto it = GetWorker(entry.second.registered_drivers, connection);
     if (it != nullptr) {
       return it;
@@ -214,8 +214,7 @@ void WorkerPool::DisconnectDriver(std::shared_ptr<Worker> driver) {
   RAY_CHECK(RemoveWorker(pool.registered_drivers, driver));
 }
 
-WorkerPool::SingleLangPool &WorkerPool::GetPoolForLanguage(
-    const Language &language) {
+WorkerPool::SingleLangPool &WorkerPool::GetPoolForLanguage(const Language &language) {
   auto pool = pools_.find(language);
   RAY_CHECK(pool != pools_.end()) << "Required Language isn't supported.";
   return pool->second;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -133,7 +133,8 @@ class WorkerPool {
     std::list<std::shared_ptr<Worker>> registered_drivers;
   };
 
-  /// A helper function that gets the pool for the given language.
+  /// A helper function that returns the reference of the pool state
+  /// for a given language.
   inline State &GetStateForLanguage(const Language &language);
 
   /// The number of CPUs this Raylet has available.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -118,7 +118,7 @@ class WorkerPool {
 
  private:
   /// An internal data structure that maintains the pool state per language.
-  struct Pool {
+  struct State {
     /// The commands and arguments used to start the worker process
     std::vector<std::string>> worker_command;
     /// The pool of idle non-actor workers.
@@ -134,13 +134,13 @@ class WorkerPool {
   };
 
   /// A helper function that gets the pool for the given language.
-  inline Pool &GetPoolForLanguage(const Language &language);
+  inline State &GetStateForLanguage(const Language &language);
 
   /// The number of CPUs this Raylet has available.
   int num_cpus_;
 
   /// Pool states per language.
-  std::unordered_map<Language, Pool> pools_;
+  std::unordered_map<Language, State> state_per_lang_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -119,6 +119,8 @@ class WorkerPool {
  private:
   /// An internal data structure that maintains the pool state per language.
   struct Pool {
+    /// The commands and arguments used to start the worker process
+    std::vector<std::string>> worker_command;
     /// The pool of idle non-actor workers.
     std::list<std::shared_ptr<Worker>> idle;
     /// The pool of idle actor workers.
@@ -136,8 +138,6 @@ class WorkerPool {
 
   /// The number of CPUs this Raylet has available.
   int num_cpus_;
-  /// The commands and arguments used to start the worker process, grouped by language.
-  std::unordered_map<Language, std::vector<std::string>> worker_commands_;
 
   /// Pool states per language.
   std::unordered_map<Language, Pool> pools_;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -120,7 +120,7 @@ class WorkerPool {
   /// An internal data structure that maintains the pool state per language.
   struct State {
     /// The commands and arguments used to start the worker process
-    std::vector<std::string>> worker_command;
+    std::vector<std::string> worker_command;
     /// The pool of idle non-actor workers.
     std::list<std::shared_ptr<Worker>> idle;
     /// The pool of idle actor workers.
@@ -140,7 +140,7 @@ class WorkerPool {
   int num_cpus_;
 
   /// Pool states per language.
-  std::unordered_map<Language, State> state_per_lang_;
+  std::unordered_map<Language, State> states_by_lang_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -28,7 +28,7 @@ class WorkerPool {
   /// the process should create and register the specified number of workers,
   /// and add them to the pool.
   ///
-  /// \param num_worker_processes The number of worker processes to start.
+  /// \param num_worker_processes The number of worker processes to start, per language.
   /// \param num_workers_per_process The number of workers per process.
   /// \param worker_commands The commands used to start the worker process, grouped by
   /// language.
@@ -132,7 +132,7 @@ class WorkerPool {
   };
 
   /// A helper function that gets the pool for the given language.
-  Pool &GetPoolForLanguage(const Language &language);
+  inline Pool &GetPoolForLanguage(const Language &language);
 
   /// The number of CPUs this Raylet has available.
   int num_cpus_;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -135,7 +135,7 @@ class WorkerPool {
   std::unordered_map<Language, SingleLangPool> pools_;
 
   /// A helper function that gets the pool for the given language.
-  SingleLangPool& GetPoolForLanguage(const Language &language);
+  SingleLangPool &GetPoolForLanguage(const Language &language);
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -12,9 +12,10 @@ int NUM_WORKERS_PER_PROCESS = 3;
 
 class WorkerPoolMock : public WorkerPool {
  public:
-  WorkerPoolMock() : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 0, {}) {}
+  WorkerPoolMock() : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 0, {{Language::PYTHON, {}}, {Language::JAVA, {}}}) {}
 
-  void StartWorkerProcess(pid_t pid, bool force_start = false) {
+  void StartWorkerProcess(pid_t pid, const Language &language = Language::PYTHON,
+                          bool force_start = false) {
     if (starting_worker_processes_.size() > 0 && !force_start) {
       // Workers have been started, but not registered. Force start disabled -- returning.
       RAY_LOG(DEBUG) << starting_worker_processes_.size()
@@ -22,7 +23,7 @@ class WorkerPoolMock : public WorkerPool {
       return;
     }
     // Either no workers are pending registration or the worker start is being forced.
-    RAY_LOG(DEBUG) << "starting new worker process, worker pool size " << Size();
+    RAY_LOG(DEBUG) << "starting new worker process, worker pool size " << Size(language);
     starting_worker_processes_.emplace(std::make_pair(pid, num_workers_per_process_));
   }
 
@@ -33,7 +34,7 @@ class WorkerPoolTest : public ::testing::Test {
  public:
   WorkerPoolTest() : worker_pool_(), io_service_() {}
 
-  std::shared_ptr<Worker> CreateWorker(pid_t pid) {
+  std::shared_ptr<Worker> CreateWorker(pid_t pid, const Language &language = Language::PYTHON) {
     std::function<void(LocalClientConnection &)> client_handler =
         [this](LocalClientConnection &client) { HandleNewClient(client); };
     std::function<void(std::shared_ptr<LocalClientConnection>, int64_t, const uint8_t *)>
@@ -44,7 +45,7 @@ class WorkerPoolTest : public ::testing::Test {
     boost::asio::local::stream_protocol::socket socket(io_service_);
     auto client = LocalClientConnection::Create(client_handler, message_handler,
                                                 std::move(socket), "worker");
-    return std::shared_ptr<Worker>(new Worker(pid, client));
+    return std::shared_ptr<Worker>(new Worker(pid, language, client));
   }
 
  protected:
@@ -55,6 +56,12 @@ class WorkerPoolTest : public ::testing::Test {
   void HandleNewClient(LocalClientConnection &){};
   void HandleMessage(std::shared_ptr<LocalClientConnection>, int64_t, const uint8_t *){};
 };
+
+static TaskSpecification ExampleTaskSpec(const ActorID actor_id = ActorID::nil(), const Language &language = Language::PYTHON) {
+  return TaskSpecification(UniqueID::nil(), UniqueID::nil(), 0, ActorID::nil(), ObjectID::nil(),
+                          actor_id, ActorHandleID::nil(), 0, FunctionID::nil(), {}, 0, {},
+                          language);
+}
 
 TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
   pid_t pid = 1234;
@@ -85,7 +92,8 @@ TEST_F(WorkerPoolTest, HandleWorkerRegistration) {
 TEST_F(WorkerPoolTest, HandleWorkerPushPop) {
   // Try to pop a worker from the empty pool and make sure we don't get one.
   std::shared_ptr<Worker> popped_worker;
-  popped_worker = worker_pool_.PopWorker(ActorID::nil());
+  const auto task_spec = ExampleTaskSpec();
+  popped_worker = worker_pool_.PopWorker(task_spec);
   ASSERT_EQ(popped_worker, nullptr);
 
   // Create some workers.
@@ -98,13 +106,13 @@ TEST_F(WorkerPoolTest, HandleWorkerPushPop) {
   }
 
   // Pop two workers and make sure they're one of the workers we created.
-  popped_worker = worker_pool_.PopWorker(ActorID::nil());
+  popped_worker = worker_pool_.PopWorker(task_spec);
   ASSERT_NE(popped_worker, nullptr);
   ASSERT_TRUE(workers.count(popped_worker) > 0);
-  popped_worker = worker_pool_.PopWorker(ActorID::nil());
+  popped_worker = worker_pool_.PopWorker(task_spec);
   ASSERT_NE(popped_worker, nullptr);
   ASSERT_TRUE(workers.count(popped_worker) > 0);
-  popped_worker = worker_pool_.PopWorker(ActorID::nil());
+  popped_worker = worker_pool_.PopWorker(task_spec);
   ASSERT_EQ(popped_worker, nullptr);
 }
 
@@ -115,17 +123,24 @@ TEST_F(WorkerPoolTest, PopActorWorker) {
   worker_pool_.PushWorker(worker);
 
   // Assign an actor ID to the worker.
-  auto actor = worker_pool_.PopWorker(ActorID::nil());
+  const auto task_spec = ExampleTaskSpec();
+  auto actor = worker_pool_.PopWorker(task_spec);
   auto actor_id = ActorID::from_random();
   actor->AssignActorId(actor_id);
   worker_pool_.PushWorker(actor);
 
   // Check that there are no more non-actor workers.
-  ASSERT_EQ(worker_pool_.PopWorker(ActorID::nil()), nullptr);
+  ASSERT_EQ(worker_pool_.PopWorker(task_spec), nullptr);
   // Check that we can pop the actor worker.
-  actor = worker_pool_.PopWorker(actor_id);
+  const auto actor_task_spec = ExampleTaskSpec(actor_id);
+  actor = worker_pool_.PopWorker(actor_task_spec);
   ASSERT_EQ(actor, worker);
   ASSERT_EQ(actor->GetActorId(), actor_id);
+}
+
+TEST_F(WorkerPoolTest, PopWorkersOfMultipleLanguages) {
+
+
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -14,7 +14,8 @@ class WorkerPoolMock : public WorkerPool {
  public:
   WorkerPoolMock()
       : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 0,
-                   {{Language::PYTHON, {}}, {Language::JAVA, {}}}) {}
+                   {{Language::PYTHON, {"dummy_py_worker_command"}},
+                    {Language::JAVA, {"dummy_java_worker_command"}}}) {}
 
   void StartWorkerProcess(pid_t pid, const Language &language = Language::PYTHON,
                           bool force_start = false) {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -60,8 +60,9 @@ class WorkerPoolTest : public ::testing::Test {
   void HandleMessage(std::shared_ptr<LocalClientConnection>, int64_t, const uint8_t *){};
 };
 
-static TaskSpecification ExampleTaskSpec(const ActorID actor_id = ActorID::nil(),
-                                         const Language &language = Language::PYTHON) {
+static inline TaskSpecification ExampleTaskSpec(
+    const ActorID actor_id = ActorID::nil(),
+    const Language &language = Language::PYTHON) {
   return TaskSpecification(UniqueID::nil(), UniqueID::nil(), 0, ActorID::nil(),
                            ObjectID::nil(), actor_id, ActorHandleID::nil(), 0,
                            FunctionID::nil(), {}, 0, {}, language);
@@ -146,7 +147,7 @@ TEST_F(WorkerPoolTest, PopWorkersOfMultipleLanguages) {
   // Create a Python Worker, and add it to the pool
   auto py_worker = CreateWorker(1234, Language::PYTHON);
   worker_pool_.PushWorker(py_worker);
-  // Check that no worker is popped if the given task is a Java task
+  // Check that no worker will be popped if the given task is a Java task
   const auto java_task_spec = ExampleTaskSpec(ActorID::nil(), Language::JAVA);
   ASSERT_EQ(worker_pool_.PopWorker(java_task_spec), nullptr);
   // Check that the worker can be popped if the given task is a Python task


### PR DESCRIPTION
This PR enables multi-language support in the raylet backend.
- `Worker` class now has a `language` label;
- `WorkerPool`:
	- It now maintains one set of states for each language.
	- `PopWorker` function's parameter type is changed to `TaskSpecification`, and it will choose a worker to pop based on both task's language and actor id.
    -  `Size` and `StartWorkerProcess` functions now have an extra `language` parameter.
- `RegisterClientRequest` message now has an extra `language` field in raylet mode, which tells the node manager which language the worker is.