### PR TITLE
seed the random number generator

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -9,6 +9,7 @@ import hashlib
 import inspect
 import numpy as np
 import os
+import random
 import redis
 import signal
 import sys
@@ -1799,6 +1800,10 @@ def init(redis_address=None,
         Exception: An exception is raised if an inappropriate combination of
             arguments is passed in.
     """
+
+    from datetime import datetime
+    random.seed(datetime.now())
+
     if global_worker.connected:
         if ignore_reinit_error:
             logger.error("Calling ray.init() again after it has already been "


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR seeds the random number generator using the system clock. We determined that rerunning `ray.init` in the same development environment has a high probability of generating the same raylet socket names, causing naming collisions and corresponding failures to bind to the socket by raylet.

## Related issue number
potentially related/causing: https://github.com/ray-project/ray/issues/2594 