### PR TITLE
[xray] Don't process any more messages from dead node managers

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -748,6 +748,8 @@ void NodeManager::ProcessNodeManagerMessage(TcpClientConnection &node_manager_cl
     // TODO(rkn): We need to do some cleanup here.
     RAY_LOG(DEBUG) << "Received disconnect message from remote node manager. "
                    << "We need to do some cleanup here.";
+    // Do not process any more messages from this node manager.
+    return;
   } break;
   default:
     RAY_LOG(FATAL) << "Received unexpected message type " << message_type;


### PR DESCRIPTION
## What do these changes do?

This fixes a bug where a node manager continues to try to process messages from a node manager that has disconnected. This bug leads to an infinite loop, since the next attempt to process a message from the dead node manager adds the same message handler back onto the event loop.