### PR TITLE
Fix build failure of Arrow and Parquet when the directory is empty.

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -45,7 +45,10 @@ build_arrow() {
     rm -rf $TP_DIR/build/arrow/cpp/build/CMakeCache.txt
   fi
 
-  if [[ ! -d $TP_DIR/build/arrow ]]; then
+  if [[ ! -d $TP_DIR/build/arrow/.git ]]; then
+    if [[ -d $TP_DIR/build/arrow ]]; then
+      rm -rf $TP_DIR/build/arrow
+    fi
     git clone -q https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
   fi
 

--- a/thirdparty/scripts/build_parquet.sh
+++ b/thirdparty/scripts/build_parquet.sh
@@ -50,7 +50,10 @@ build_parquet() {
   fi
 }
 
-if [ ! -d $TP_DIR/build/parquet-cpp ]; then
+if [ ! -d $TP_DIR/build/parquet-cpp/.git ]; then
+  if [[ -d $TP_DIR/build/parquet-cpp ]]; then
+      rm -rf $TP_DIR/build/parquet-cpp
+  fi
   git clone -q https://github.com/apache/parquet-cpp.git "$TP_DIR/build/parquet-cpp"
   pushd $TP_DIR/build/parquet-cpp
   git fetch origin master


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->
## Problem description:
Sometimes, there are empty directories of `thirdparty/build/arrow/` & `thirdparty/build/parquet-cpp/`, which may be caused by unthorough cleaning.

According to current rule, when these 2 directories exist, no `git clone` will be called. Then, `git rev-parse HEAD` will get the current commit ID from `ray` project. Then, the following error will happen.
```bash
+ pushd /Users/username/git/ray/thirdparty/scripts/..//build/arrow
~/git/ray/thirdparty/build/arrow ~/git/ray
+ git fetch origin master
From https://github.com/ray-project/ray
 * branch              master     -> FETCH_HEAD
+ git checkout 4660833b2c5ef63a97445e304b8f72a2e0170f9c
fatal: reference is not a tree: 4660833b2c5ef63a97445e304b8f72a2e0170f9c
```

## What do these changes do?
This change fixes this problem by checking the existence of `thirdparty/build/arrow/.git` & `thirdparty/build/parquet-cpp/.git`.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
