### PR TITLE
The function get_node_ip_address while catch an exception and return …

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -246,12 +246,15 @@ def get_node_ip_address(address="8.8.8.8:53"):
         s.connect((ip_address, int(port)))
         node_ip_address = s.getsockname()[0]
     except Exception as e:
-        try:
-            # try get node ip address from host name
-            host_name = socket.getfqdn(socket.gethostname())
-            node_ip_address = socket.gethostbyname(host_name)
-        except Exception as e:
-            node_ip_address = "127.0.0.1"
+        node_ip_address = "127.0.0.1"
+        # [Errno 101] Network is unreachable
+        if e.errno == 101:
+            try:
+                # try get node ip address from host name
+                host_name = socket.getfqdn(socket.gethostname())
+                node_ip_address = socket.gethostbyname(host_name)
+            except Exception:
+                pass
 
     return node_ip_address
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -246,7 +246,12 @@ def get_node_ip_address(address="8.8.8.8:53"):
         s.connect((ip_address, int(port)))
         node_ip_address = s.getsockname()[0]
     except Exception as e:
-        node_ip_address = "127.0.0.1"
+        try:
+            # try get node ip address from host name
+            host_name = socket.getfqdn(socket.gethostname())
+            node_ip_address = socket.gethostbyname(host_name)
+        except Exception as e:
+            node_ip_address = "127.0.0.1"
 
     return node_ip_address
 


### PR DESCRIPTION
…'127.0.0.1',

when we forbid the external network. Instead of we can get ip address from hostname.

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The function get_node_ip_address while catch an exception and return '127.0.0.1' when we forbid the external network. Instead of we can get ip address from hostname.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/ray-project/ray/issues/2721
