### PR TITLE
Hotfix for glog PR

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -116,7 +116,7 @@ void RayLog::ShutDownRayLog() {
 
 RayLog::RayLog(const char *file_name, int line_number, int severity)
     // glog does not have DEBUG level, we can handle it here.
-    : is_enable_(severity >= severity_threshold_) {
+    : is_enabled_(severity >= severity_threshold_) {
 #ifdef RAY_USE_GLOG
   // Stream() is public, make sure the pointer is set.
   logging_provider_.reset(
@@ -135,7 +135,7 @@ std::ostream &RayLog::Stream() {
 #endif
 }
 
-bool RayLog::IsEnable() { return is_enable_; }
+bool RayLog::IsEnabled() { return is_enabled_; }
 
 RayLog::~RayLog() { logging_provider_.reset(); }
 

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -118,9 +118,10 @@ RayLog::RayLog(const char *file_name, int line_number, int severity)
     // glog does not have DEBUG level, we can handle it here.
     : is_enabled_(severity >= severity_threshold_) {
 #ifdef RAY_USE_GLOG
-  // Stream() is public, make sure the pointer is set.
-  logging_provider_.reset(
-      new google::LogMessage(file_name, line_number, GetMappedSeverity(severity)));
+  if (is_enabled_) {
+    logging_provider_.reset(
+        new google::LogMessage(file_name, line_number, GetMappedSeverity(severity)));
+  }
 #else
   logging_provider_.reset(new CerrLog(severity));
   *logging_provider_ << file_name << ":" << line_number << ": ";
@@ -129,6 +130,8 @@ RayLog::RayLog(const char *file_name, int line_number, int severity)
 
 std::ostream &RayLog::Stream() {
 #ifdef RAY_USE_GLOG
+  // Before calling this function, user should check IsEnabled.
+  // When IsEnabled == false, logging_provider_ will be empty.
   return logging_provider_->stream();
 #else
   return logging_provider_->Stream();

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -138,7 +138,7 @@ std::ostream &RayLog::Stream() {
 #endif
 }
 
-bool RayLog::IsEnabled() { return is_enabled_; }
+bool RayLog::IsEnabled() const { return is_enabled_; }
 
 RayLog::~RayLog() { logging_provider_.reset(); }
 

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -114,13 +114,13 @@ void RayLog::ShutDownRayLog() {
 #endif
 }
 
-RayLog::RayLog(const char *file_name, int line_number, int severity) {
+RayLog::RayLog(const char *file_name, int line_number, int severity)
+    // glog does not have DEBUG level, we can handle it here.
+    : is_enable_(severity >= severity_threshold_) {
 #ifdef RAY_USE_GLOG
-  // glog does not have DEBUG level, we can handle it here.
-  if (severity >= severity_threshold_) {
-    logging_provider_.reset(
-        new google::LogMessage(file_name, line_number, GetMappedSeverity(severity)));
-  }
+  // Stream() is public, make sure the pointer is set.
+  logging_provider_.reset(
+      new google::LogMessage(file_name, line_number, GetMappedSeverity(severity)));
 #else
   logging_provider_.reset(new CerrLog(severity));
   *logging_provider_ << file_name << ":" << line_number << ": ";
@@ -134,6 +134,8 @@ std::ostream &RayLog::Stream() {
   return logging_provider_->Stream();
 #endif
 }
+
+bool RayLog::IsEnable() { return is_enable_; }
 
 RayLog::~RayLog() { logging_provider_.reset(); }
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -67,11 +67,11 @@ class RayLogBase {
 
   virtual std::ostream &Stream() { return std::cerr; };
 
-  virtual bool IsEnable() { return false; };
+  virtual bool IsEnabled() { return false; };
 
   template <typename T>
   RayLogBase &operator<<(const T &t) {
-    if (IsEnable()) {
+    if (IsEnabled()) {
       Stream() << t;
     } else {
       RAY_IGNORE_EXPR(t);
@@ -86,7 +86,10 @@ class RayLog : public RayLogBase {
 
   virtual ~RayLog();
 
-  virtual bool IsEnable();
+  /// Return whether or not logging is enabled.
+  ///
+  /// \return True if logging is enabled and false otherwise.
+  virtual bool IsEnabled();
 
   virtual std::ostream &Stream();
 
@@ -99,7 +102,8 @@ class RayLog : public RayLogBase {
 
  private:
   std::unique_ptr<LoggingProvider> logging_provider_;
-  bool is_enable_;
+  /// True if log messages should be logged and false if they should be ignored.
+  bool is_enabled_;
   static int severity_threshold_;
 };
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -65,7 +65,7 @@ class RayLogBase {
  public:
   virtual ~RayLogBase(){};
 
-  virtual bool IsEnabled() { return false; };
+  virtual bool IsEnabled() const { return false; };
 
   template <typename T>
   RayLogBase &operator<<(const T &t) {
@@ -90,7 +90,7 @@ class RayLog : public RayLogBase {
   /// Return whether or not logging is enabled.
   ///
   /// \return True if logging is enabled and false otherwise.
-  virtual bool IsEnabled();
+  virtual bool IsEnabled() const;
 
   // The init function of ray log for a program which should be called only once.
   // If logDir is empty, the log won't output to file.

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -65,8 +65,6 @@ class RayLogBase {
  public:
   virtual ~RayLogBase(){};
 
-  virtual std::ostream &Stream() { return std::cerr; };
-
   virtual bool IsEnabled() { return false; };
 
   template <typename T>
@@ -78,6 +76,9 @@ class RayLogBase {
     }
     return *this;
   }
+
+ protected:
+  virtual std::ostream &Stream() { return std::cerr; };
 };
 
 class RayLog : public RayLogBase {
@@ -91,8 +92,6 @@ class RayLog : public RayLogBase {
   /// \return True if logging is enabled and false otherwise.
   virtual bool IsEnabled();
 
-  virtual std::ostream &Stream();
-
   // The init function of ray log for a program which should be called only once.
   // If logDir is empty, the log won't output to file.
   static void StartRayLog(const std::string &appName, int severity_threshold = RAY_ERROR,
@@ -105,6 +104,9 @@ class RayLog : public RayLogBase {
   /// True if log messages should be logged and false if they should be ignored.
   bool is_enabled_;
   static int severity_threshold_;
+
+ protected:
+  virtual std::ostream &Stream();
 };
 
 // This class make RAY_CHECK compilation pass to change the << operator to void.

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -18,11 +18,17 @@ int64_t current_time_ms() {
 // This file just print some information using the logging macro.
 
 void PrintLog() {
-  RAY_LOG(DEBUG) << "This is the DEBUG message";
-  RAY_LOG(INFO) << "This is the INFO message";
-  RAY_LOG(WARNING) << "This is the WARNING message";
-  RAY_LOG(ERROR) << "This is the ERROR message";
-  RAY_CHECK(true) << "This is a RAY_CHECK message but it won't show up";
+  RAY_LOG(DEBUG) << "This is the"
+                 << " DEBUG"
+                 << " message";
+  RAY_LOG(INFO) << "This is the"
+                << " INFO message";
+  RAY_LOG(WARNING) << "This is the"
+                   << " WARNING message";
+  RAY_LOG(ERROR) << "This is the"
+                 << " ERROR message";
+  RAY_CHECK(true) << "This is a RAY_CHECK"
+                  << " message but it won't show up";
   // The following 2 lines should not run since it will cause program failure.
   // RAY_LOG(FATAL) << "This is the FATAL message";
   // RAY_CHECK(false) << "This is a RAY_CHECK message but it won't show up";
@@ -47,7 +53,8 @@ TEST(LogPerfTest, PerfTest) {
 
   int64_t start_time = current_time_ms();
   for (int i = 0; i < rounds; ++i) {
-    RAY_LOG(DEBUG) << "This is the RAY_DEBUG message";
+    RAY_LOG(DEBUG) << "This is the "
+                   << "RAY_DEBUG message";
   }
   int64_t elapsed = current_time_ms() - start_time;
   std::cout << "Testing DEBUG log for " << rounds << " rounds takes " << elapsed << " ms."
@@ -55,7 +62,8 @@ TEST(LogPerfTest, PerfTest) {
 
   start_time = current_time_ms();
   for (int i = 0; i < rounds; ++i) {
-    RAY_LOG(ERROR) << "This is the RAY_ERROR message";
+    RAY_LOG(ERROR) << "This is the "
+                   << "RAY_ERROR message";
   }
   elapsed = current_time_ms() - start_time;
   std::cout << "Testing RAY_ERROR log for " << rounds << " rounds takes " << elapsed
@@ -63,7 +71,8 @@ TEST(LogPerfTest, PerfTest) {
 
   start_time = current_time_ms();
   for (int i = 0; i < rounds; ++i) {
-    RAY_CHECK(i >= 0) << "This is a RAY_CHECK message but it won't show up";
+    RAY_CHECK(i >= 0) << "This is a RAY_CHECK "
+                      << "message but it won't show up";
   }
   elapsed = current_time_ms() - start_time;
   std::cout << "Testing RAY_CHECK(true) for " << rounds << " rounds takes " << elapsed


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
The bug happens because the template function cannot be specified as virtual but the return value is he base class. Therefore, when a second "<<" operate is called, this will invoke the base class function, which is undesired. 
<!-- Please give a short brief about these changes. -->

## Related issue number
https://github.com/ray-project/ray/issues/2731
<!-- Are there any issues opened that will be resolved by merging this change? -->
