### PR TITLE
[tune] Adds option to checkpoint at end of trials

### DIFF
--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -254,6 +254,20 @@ Additionally, checkpointing can be used to provide fault-tolerance for experimen
         },
     })
 
+The checkpoint_freq may not coincide with the exact end of an experiment. If you want a checkpoint to be created at the end
+of a trial, you can additionally set the checkpoint_at_end to True. An example is shown below:
+
+.. code-block:: python
+   :emphasize-lines: 5
+
+    run_experiments({
+        "my_experiment_name": {
+            "run": my_trainable
+            "checkpoint_freq": 10,
+            "checkpoint_at_end": True,
+            "max_failures": 5,
+        },
+    })
 
 Handling Large Datasets
 -----------------------

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -113,6 +113,12 @@ def make_parser(parser_creator=None, **kwargs):
         help="How many training iterations between checkpoints. "
         "A value of 0 (default) disables checkpointing.")
     parser.add_argument(
+        "--checkpoint-at-end",
+        default=False,
+        type=bool,
+        help="Whether to checkpoint at the end of the experiment. "
+        "Default is False.")
+    parser.add_argument(
         "--max-failures",
         default=3,
         type=int,
@@ -186,6 +192,7 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
         # json.load leads to str -> unicode in py2.7
         stopping_criterion=spec.get("stop", {}),
         checkpoint_freq=args.checkpoint_freq,
+        checkpoint_at_end=args.checkpoint_at_end,
         # str(None) doesn't create None
         restore_path=spec.get("restore"),
         upload_dir=args.upload_dir,

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -155,6 +155,8 @@ def to_argv(config):
         argv.append("--{}".format(k.replace("_", "-")))
         if isinstance(v, string_types):
             argv.append(v)
+        elif isinstance(v, bool):
+            argv.append(v)
         else:
             argv.append(json.dumps(v, cls=_SafeFallbackEncoder))
     return argv

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -44,8 +44,7 @@ class Experiment(object):
         checkpoint_freq (int): How many training iterations between
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
-            experiment. Default is False. Enabled only when
-            checkpoint_freq is not 0.
+            experiment regardless of the checkpoint_freq. Default is False.
         max_failures (int): Try to recover a trial from its last
             checkpoint at least this many times. Only applies if
             checkpointing is enabled. Defaults to 3.

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -43,6 +43,8 @@ class Experiment(object):
             to (e.g. ``s3://bucket``).
         checkpoint_freq (int): How many training iterations between
             checkpoints. A value of 0 (default) disables checkpointing.
+        checkpoint_at_end (bool): Whether to checkpoint at the end of the
+            experiment. Default is False.
         max_failures (int): Try to recover a trial from its last
             checkpoint at least this many times. Only applies if
             checkpointing is enabled. Defaults to 3.
@@ -82,6 +84,7 @@ class Experiment(object):
                  local_dir=None,
                  upload_dir="",
                  checkpoint_freq=0,
+                 checkpoint_at_end=False,
                  max_failures=3,
                  restore=None):
         spec = {
@@ -93,6 +96,7 @@ class Experiment(object):
             "local_dir": local_dir or DEFAULT_RESULTS_DIR,
             "upload_dir": upload_dir,
             "checkpoint_freq": checkpoint_freq,
+            "checkpoint_at_end": checkpoint_at_end,
             "max_failures": max_failures,
             "restore": restore
         }

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -44,7 +44,8 @@ class Experiment(object):
         checkpoint_freq (int): How many training iterations between
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
-            experiment. Default is False.
+            experiment. Default is False. Enabled only when
+            checkpoint_freq is not 0.
         max_failures (int): Try to recover a trial from its last
             checkpoint at least this many times. Only applies if
             checkpointing is enabled. Defaults to 3.

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -958,7 +958,6 @@ class TrialRunnerTest(unittest.TestCase):
         self.assertEqual(trials[0].last_result[DONE], True)
         self.assertEqual(trials[0].has_checkpoint(), True)
 
-
     def testResultDone(self):
         """Tests that last_result is marked `done` after trial is complete."""
         ray.init(num_cpus=1, num_gpus=1)

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -942,7 +942,7 @@ class TrialRunnerTest(unittest.TestCase):
         ray.init(num_cpus=1, num_gpus=1)
         runner = TrialRunner(BasicVariantGenerator())
         kwargs = {
-            "stopping_criterion":{
+            "stopping_criterion": {
                 "training_iteration": 2
             },
             "checkpoint_freq": 5,

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -938,6 +938,29 @@ class TrialRunnerTest(unittest.TestCase):
         self.assertEqual(ray.get(trials[1].runner.get_info.remote()), 1)
         self.addCleanup(os.remove, path)
 
+    def testCheckpointingAtEnd(self):
+        ray.init(num_cpus=1, num_gpus=1)
+        runner = TrialRunner(BasicVariantGenerator())
+        kwargs = {
+            "stopping_criterion":{
+                "training_iteration": 2
+            },
+            "checkpoint_freq": 5,
+            "checkpoint_at_end": True,
+            "resources": Resources(cpu=1, gpu=1),
+        }
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        runner.step()
+        runner.step()
+        self.assertEqual(trials[0].last_result[DONE], True)
+        path = runner.trial_executor.save(trials[0])
+        #self.assertEqual(path[-1], 3)
+        self.assertGreater(path[-1], 1, "checkpoint_at_end failed")
+
     def testResultDone(self):
         """Tests that last_result is marked `done` after trial is complete."""
         ray.init(num_cpus=1, num_gpus=1)

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -958,7 +958,6 @@ class TrialRunnerTest(unittest.TestCase):
         runner.step()
         self.assertEqual(trials[0].last_result[DONE], True)
         path = runner.trial_executor.save(trials[0])
-        #self.assertEqual(path[-1], 3)
         self.assertGreater(path[-1], 1, "checkpoint_at_end failed")
 
     def testResultDone(self):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -940,20 +940,16 @@ class TrialRunnerTest(unittest.TestCase):
 
     def testCheckpointingAtEnd(self):
         ray.init(num_cpus=1, num_gpus=1)
-        experiment_spec = {
-            "test_end_checkpoint": {
-                "run": "__fake",
-                "stopping_criterion": {
-                    "training_iteration": 2
-                },
-                "checkpoint_at_end": True,
-                "resources": Resources(cpu=1, gpu=1)
+        runner = TrialRunner(BasicVariantGenerator())
+        kwargs = {
+            "stopping_criterion": {
+                "training_iteration": 2
             },
+            "checkpoint_freq": 5,
+            "checkpoint_at_end": True,
+            "resources": Resources(cpu=1, gpu=1),
         }
-        experiments = [Experiment.from_json("test", experiment_spec)]
-        searcher = _MockSuggestionAlgorithm(max_concurrent=2)
-        searcher.add_configurations(experiments)
-        runner = TrialRunner(search_alg=searcher)
+        runner.add_trial(Trial("__fake", **kwargs))
         trials = runner.get_trials()
 
         runner.step()

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -945,7 +945,6 @@ class TrialRunnerTest(unittest.TestCase):
             "stopping_criterion": {
                 "training_iteration": 2
             },
-            "checkpoint_freq": 5,
             "checkpoint_at_end": True,
             "resources": Resources(cpu=1, gpu=1),
         }
@@ -957,8 +956,8 @@ class TrialRunnerTest(unittest.TestCase):
         runner.step()
         runner.step()
         self.assertEqual(trials[0].last_result[DONE], True)
-        path = runner.trial_executor.save(trials[0])
-        self.assertGreater(path[-1], 1, "checkpoint_at_end failed")
+        self.assertEqual(trials[0].has_checkpoint(), True)
+
 
     def testResultDone(self):
         """Tests that last_result is marked `done` after trial is complete."""

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -940,16 +940,20 @@ class TrialRunnerTest(unittest.TestCase):
 
     def testCheckpointingAtEnd(self):
         ray.init(num_cpus=1, num_gpus=1)
-        runner = TrialRunner(BasicVariantGenerator())
-        kwargs = {
-            "stopping_criterion": {
-                "training_iteration": 2
+        experiment_spec = {
+            "test_end_checkpoint": {
+                "run": "__fake",
+                "stopping_criterion": {
+                    "training_iteration": 2
+                },
+                "checkpoint_at_end": True,
+                "resources": Resources(cpu=1, gpu=1)
             },
-            "checkpoint_freq": 5,
-            "checkpoint_at_end": True,
-            "resources": Resources(cpu=1, gpu=1),
         }
-        runner.add_trial(Trial("__fake", **kwargs))
+        experiments = [Experiment.from_json("test", experiment_spec)]
+        searcher = _MockSuggestionAlgorithm(max_concurrent=2)
+        searcher.add_configurations(experiments)
+        runner = TrialRunner(search_alg=searcher)
         trials = runner.get_trials()
 
         runner.step()

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -112,6 +112,7 @@ class Trial(object):
                  resources=None,
                  stopping_criterion=None,
                  checkpoint_freq=0,
+                 checkpoint_at_end=False,
                  restore_path=None,
                  upload_dir=None,
                  max_failures=0):
@@ -142,6 +143,7 @@ class Trial(object):
         # Local trial state that is updated during the run
         self.last_result = None
         self.checkpoint_freq = checkpoint_freq
+        self.checkpoint_at_end = checkpoint_at_end
         self._checkpoint = Checkpoint(
             storage=Checkpoint.DISK, value=restore_path)
         self.status = Trial.PENDING
@@ -203,11 +205,14 @@ class Trial(object):
 
         return False
 
-    def should_checkpoint(self):
+    def should_checkpoint(self, result):
         """Whether this trial is due for checkpointing."""
 
         if not self.checkpoint_freq:
             return False
+
+        if result.get(DONE) and self.checkpoint_at_end:
+            return True
 
         return self.last_result[TRAINING_ITERATION] % self.checkpoint_freq == 0
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -208,11 +208,11 @@ class Trial(object):
     def should_checkpoint(self, result):
         """Whether this trial is due for checkpointing."""
 
-        if not self.checkpoint_freq:
-            return False
-
         if result.get(DONE) and self.checkpoint_at_end:
             return True
+
+        if not self.checkpoint_freq:
+            return False
 
         return self.last_result[TRAINING_ITERATION] % self.checkpoint_freq == 0
 

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -235,8 +235,8 @@ class TrialRunner(object):
                 result, terminate=(decision == TrialScheduler.STOP))
 
             if trial.should_checkpoint(result):
-                    # TODO(rliaw): This is a blocking call
-                    self.trial_executor.save(trial)
+                # TODO(rliaw): This is a blocking call
+                self.trial_executor.save(trial)
 
             if decision == TrialScheduler.CONTINUE:
                 self.trial_executor.continue_training(trial)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -235,12 +235,8 @@ class TrialRunner(object):
                 result, terminate=(decision == TrialScheduler.STOP))
 
             if trial.should_checkpoint(result):
-                try:
-                    # TODO(rliaw): This is a blocking call
-                    self.trial_executor.save(trial)
-                except NotImplementedError:
-                    print("Trainable does not have _save implemented."
-                          "No checkpoints will be saved.")
+                # TODO(rliaw): This is a blocking call
+                self.trial_executor.save(trial)
 
             if decision == TrialScheduler.CONTINUE:
                 self.trial_executor.continue_training(trial)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -223,6 +223,7 @@ class TrialRunner(object):
                 self._search_alg.on_trial_complete(
                     trial.trial_id, result=result)
                 decision = TrialScheduler.STOP
+
             else:
                 decision = self._scheduler_alg.on_trial_result(
                     self, trial, result)
@@ -234,13 +235,16 @@ class TrialRunner(object):
                 result, terminate=(decision == TrialScheduler.STOP))
 
             if decision == TrialScheduler.CONTINUE:
-                if trial.should_checkpoint():
+                if trial.should_checkpoint(result):
                     # TODO(rliaw): This is a blocking call
                     self.trial_executor.save(trial)
                 self.trial_executor.continue_training(trial)
             elif decision == TrialScheduler.PAUSE:
                 self.trial_executor.pause_trial(trial)
             elif decision == TrialScheduler.STOP:
+                # Checkpoint the state before ending the trial if checkpoint_at_end experiment option is set to True
+                if trial.should_checkpoint(result):
+                    self.trial_executor.save(trial)
                 self.trial_executor.stop_trial(trial)
             else:
                 assert False, "Invalid scheduling decision: {}".format(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -235,8 +235,12 @@ class TrialRunner(object):
                 result, terminate=(decision == TrialScheduler.STOP))
 
             if trial.should_checkpoint(result):
-                # TODO(rliaw): This is a blocking call
-                self.trial_executor.save(trial)
+                try:
+                    # TODO(rliaw): This is a blocking call
+                    self.trial_executor.save(trial)
+                except NotImplementedError:
+                    print("Trainable does not have _save implemented."
+                          "No checkpoints will be saved.")
 
             if decision == TrialScheduler.CONTINUE:
                 self.trial_executor.continue_training(trial)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -234,17 +234,15 @@ class TrialRunner(object):
             trial.update_last_result(
                 result, terminate=(decision == TrialScheduler.STOP))
 
-            if decision == TrialScheduler.CONTINUE:
-                if trial.should_checkpoint(result):
+            if trial.should_checkpoint(result):
                     # TODO(rliaw): This is a blocking call
                     self.trial_executor.save(trial)
+
+            if decision == TrialScheduler.CONTINUE:
                 self.trial_executor.continue_training(trial)
             elif decision == TrialScheduler.PAUSE:
                 self.trial_executor.pause_trial(trial)
             elif decision == TrialScheduler.STOP:
-                # Checkpoint the state before ending the trial if checkpoint_at_end experiment option is set to True
-                if trial.should_checkpoint(result):
-                    self.trial_executor.save(trial)
                 self.trial_executor.stop_trial(trial)
             else:
                 assert False, "Invalid scheduling decision: {}".format(


### PR DESCRIPTION
## What do these changes do?

Adds a Tune experiment option to enable checkpointing at the end of trials in-addition-to/irrespective of the usual checkpointing done periodically at checkpoint_freq. The option configuration is consistent with the Experiment interface and the config_parser through which the `checkpoint_freq` is set currently.


Example usage:

```python
run_experiments({
    "my_experiment_name": {
            "run": my_trainable
            "checkpoint_freq": 10,
            "checkpoint_at_end": True,
            "max_failures": 5,
        },
 })
```
## Related issue number

This PR addresses issue #2740, #2742 
