### PR TITLE
[Java] Fix out-dated signatures of JNI methods

### DIFF
--- a/java/runtime-common/src/main/java/org/ray/spi/LocalSchedulerLink.java
+++ b/java/runtime-common/src/main/java/org/ray/spi/LocalSchedulerLink.java
@@ -11,7 +11,7 @@ public interface LocalSchedulerLink {
 
   void submitTask(TaskSpec task);
 
-  TaskSpec getTaskTodo();
+  TaskSpec getTask();
 
   void markTaskPutDependency(UniqueID taskId, UniqueID objectId);
 

--- a/java/runtime-common/src/main/java/org/ray/spi/LocalSchedulerProxy.java
+++ b/java/runtime-common/src/main/java/org/ray/spi/LocalSchedulerProxy.java
@@ -80,7 +80,7 @@ public class LocalSchedulerProxy {
   }
 
   public TaskSpec getTask() {
-    TaskSpec ts = scheduler.getTaskTodo();
+    TaskSpec ts = scheduler.getTask();
     RayLog.core.info("Task " + ts.taskId.toString() + " received");
     return ts;
   }

--- a/java/runtime-dev/src/main/java/org/ray/spi/impl/MockLocalScheduler.java
+++ b/java/runtime-dev/src/main/java/org/ray/spi/impl/MockLocalScheduler.java
@@ -65,7 +65,7 @@ public class MockLocalScheduler implements LocalSchedulerLink {
   }
 
   @Override
-  public TaskSpec getTaskTodo() {
+  public TaskSpec getTask() {
     throw new RuntimeException("invalid execution flow here");
   }
 

--- a/java/runtime-native/src/main/java/org/ray/core/impl/RayNativeRuntime.java
+++ b/java/runtime-native/src/main/java/org/ray/core/impl/RayNativeRuntime.java
@@ -114,10 +114,8 @@ public class RayNativeRuntime extends RayRuntime {
         LocalSchedulerLink slink = new DefaultLocalSchedulerClient(
             params.local_scheduler_name,
             WorkerContext.currentWorkerId(),
-            UniqueID.NIL,
             isWorker,
             WorkerContext.currentTask().taskId,
-            0,
             false
         );
 
@@ -133,10 +131,8 @@ public class RayNativeRuntime extends RayRuntime {
         LocalSchedulerLink slink = new DefaultLocalSchedulerClient(
             params.raylet_socket_name,
             WorkerContext.currentWorkerId(),
-            UniqueID.NIL,
             isWorker,
             WorkerContext.currentTask().taskId,
-            0,
             true
         );
 

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
@@ -32,16 +32,14 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
   boolean useRaylet = false;
 
   public DefaultLocalSchedulerClient(String schedulerSockName, UniqueID clientId,
-                                     UniqueID actorId, boolean isWorker, UniqueID driverId,
-                                     long numGpus, boolean useRaylet) {
-    client = _init(schedulerSockName, clientId.getBytes(), actorId.getBytes(), isWorker,
-        driverId.getBytes(), numGpus, useRaylet);
+      boolean isWorker, UniqueID driverId, boolean useRaylet) {
+    client = _init(schedulerSockName, clientId.getBytes(),
+        isWorker, driverId.getBytes(), useRaylet);
     this.useRaylet = useRaylet;
   }
 
   private static native long _init(String localSchedulerSocket, byte[] workerId,
-                                   byte[] actorId, boolean isWorker, byte[] driverTaskId,
-                                   long numGpus, boolean useRaylet);
+      boolean isWorker, byte[] driverTaskId, boolean useRaylet);
 
   private static native byte[] _computePutId(long client, byte[] taskId, int putIndex);
 
@@ -49,7 +47,7 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
 
   private static native void _taskDone(long client);
 
-  private static native boolean[] _waitObject(long conn, byte[][] objectIds, 
+  private static native boolean[] _waitObject(long conn, byte[][] objectIds,
        int numReturns, int timeout, boolean waitLocal);
 
   @Override
@@ -282,9 +280,8 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
     return buffer;
   }
 
-  // task -> TaskInfo (with FlatBuffer)
-  private static native void _submitTask(long client, byte[] cursorId, /*Direct*/ByteBuffer task,
-                                         int pos, int sz, boolean useRaylet);
+  private static native void _submitTask(long client, byte[] cursorId, ByteBuffer taskBuff,
+      int pos, int taskSize, boolean useRaylet);
 
   private static byte[][] getIdBytes(List<UniqueID> objectIds) {
     int size = objectIds.size();

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
@@ -38,18 +38,6 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
     this.useRaylet = useRaylet;
   }
 
-  private static native long _init(String localSchedulerSocket, byte[] workerId,
-      boolean isWorker, byte[] driverTaskId, boolean useRaylet);
-
-  private static native byte[] _computePutId(long client, byte[] taskId, int putIndex);
-
-  private static native byte[] _generateTaskId(byte[] driverId, byte[] parentTaskId, int taskIndex);
-
-  private static native void _taskDone(long client);
-
-  private static native boolean[] _waitObject(long conn, byte[][] objectIds,
-       int numReturns, int timeout, boolean waitLocal);
-
   @Override
   public List<byte[]> wait(byte[][] objectIds, int timeoutMs, int numReturns) {
     assert (useRaylet == true);
@@ -131,16 +119,6 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
   public void notifyUnblocked() {
     _notifyUnblocked(client);
   }
-
-  private static native void _notifyUnblocked(long client);
-
-  private static native void _reconstructObjects(long client, byte[][] objectIds,
-                                                 boolean fetchOnly);
-
-  private static native void _putObject(long client, byte[] taskId, byte[] objectId);
-
-  // return TaskInfo (in FlatBuffer)
-  private static native byte[] _getTaskTodo(long client, boolean useRaylet);
 
   public static TaskSpec taskInfo2Spec(ByteBuffer bb) {
     bb.order(ByteOrder.LITTLE_ENDIAN);
@@ -280,9 +258,6 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
     return buffer;
   }
 
-  private static native void _submitTask(long client, byte[] cursorId, ByteBuffer taskBuff,
-      int pos, int taskSize, boolean useRaylet);
-
   private static byte[][] getIdBytes(List<UniqueID> objectIds) {
     int size = objectIds.size();
     byte[][] ids = new byte[size][];
@@ -296,5 +271,35 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
     _destroy(client);
   }
 
+
+  // Native method declarations.
+
+  private static native long _init(String localSchedulerSocket, byte[] workerId,
+      boolean isWorker, byte[] driverTaskId, boolean useRaylet);
+
+  private static native void _submitTask(long client, byte[] cursorId, ByteBuffer taskBuff,
+      int pos, int taskSize, boolean useRaylet);
+
+  // return TaskInfo (in FlatBuffer)
+  private static native byte[] _getTaskTodo(long client, boolean useRaylet);
+
+  private static native byte[] _computePutId(long client, byte[] taskId, int putIndex);
+
   private static native void _destroy(long client);
+
+  private static native void _taskDone(long client);
+
+  private static native void _reconstructObjects(long client, byte[][] objectIds,
+      boolean fetchOnly);
+
+  private static native void _notifyUnblocked(long client);
+
+  private static native void _putObject(long client, byte[] taskId, byte[] objectId);
+
+  private static native boolean[] _waitObject(long conn, byte[][] objectIds,
+      int numReturns, int timeout, boolean waitLocal);
+
+  private static native byte[] _generateTaskId(byte[] driverId, byte[] parentTaskId,
+      int taskIndex);
+
 }

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
@@ -47,7 +47,7 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
 
   private static native byte[] _generateTaskId(byte[] driverId, byte[] parentTaskId, int taskIndex);
 
-  private static native void _task_done(long client);
+  private static native void _taskDone(long client);
 
   private static native boolean[] _waitObject(long conn, byte[][] objectIds, 
        int numReturns, int timeout, boolean waitLocal);
@@ -104,14 +104,14 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
 
   @Override
   public void markTaskPutDependency(UniqueID taskId, UniqueID objectId) {
-    _put_object(client, taskId.getBytes(), objectId.getBytes());
+    _putObject(client, taskId.getBytes(), objectId.getBytes());
   }
 
   @Override
   public void reconstructObject(UniqueID objectId, boolean fetchOnly) {
     List<UniqueID> objects = new ArrayList<>();
     objects.add(objectId);
-    _reconstruct_objects(client, getIdBytes(objects), fetchOnly);
+    _reconstructObjects(client, getIdBytes(objects), fetchOnly);
   }
 
   @Override
@@ -120,7 +120,7 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
       RayLog.core.info("Reconstructing objects for task {}, object IDs are {}",
           UniqueIdHelper.computeTaskId(objectIds.get(0)), objectIds);
     }
-    _reconstruct_objects(client, getIdBytes(objectIds), fetchOnly);
+    _reconstructObjects(client, getIdBytes(objectIds), fetchOnly);
   }
 
   @Override
@@ -131,15 +131,15 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
 
   @Override
   public void notifyUnblocked() {
-    _notify_unblocked(client);
+    _notifyUnblocked(client);
   }
 
-  private static native void _notify_unblocked(long client);
+  private static native void _notifyUnblocked(long client);
 
-  private static native void _reconstruct_objects(long client, byte[][] objectIds,
-                                                  boolean fetchOnly);
+  private static native void _reconstructObjects(long client, byte[][] objectIds,
+                                                 boolean fetchOnly);
 
-  private static native void _put_object(long client, byte[] taskId, byte[] objectId);
+  private static native void _putObject(long client, byte[] taskId, byte[] objectId);
 
   // return TaskInfo (in FlatBuffer)
   private static native byte[] _getTaskTodo(long client, boolean useRaylet);
@@ -283,7 +283,7 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
   }
 
   // task -> TaskInfo (with FlatBuffer)
-  protected static native void _submitTask(long client, byte[] cursorId, /*Direct*/ByteBuffer task,
+  private static native void _submitTask(long client, byte[] cursorId, /*Direct*/ByteBuffer task,
                                          int pos, int sz, boolean useRaylet);
 
   private static byte[][] getIdBytes(List<UniqueID> objectIds) {

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
@@ -81,8 +81,8 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
   }
 
   @Override
-  public TaskSpec getTaskTodo() {
-    byte[] bytes = nativeGetTaskTodo(client, useRaylet);
+  public TaskSpec getTask() {
+    byte[] bytes = nativeGetTask(client, useRaylet);
     assert (null != bytes);
     ByteBuffer bb = ByteBuffer.wrap(bytes);
     return taskInfo2Spec(bb);
@@ -281,13 +281,11 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
       int pos, int taskSize, boolean useRaylet);
 
   // return TaskInfo (in FlatBuffer)
-  private static native byte[] nativeGetTaskTodo(long client, boolean useRaylet);
+  private static native byte[] nativeGetTask(long client, boolean useRaylet);
 
   private static native byte[] nativeComputePutId(long client, byte[] taskId, int putIndex);
 
   private static native void nativeDestroy(long client);
-
-  private static native void nativeTaskDone(long client);
 
   private static native void nativeReconstructObjects(long client, byte[][] objectIds,
       boolean fetchOnly);

--- a/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
+++ b/java/runtime-native/src/main/java/org/ray/spi/impl/DefaultLocalSchedulerClient.java
@@ -272,7 +272,18 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
   }
 
 
-  // Native method declarations.
+  /// Native method declarations.
+  ///
+  /// If you change the signature of any native methods, please re-generate
+  /// the C++ header file and update the C++ implementation accordingly:
+  ///
+  /// Suppose that $Dir is your ray root directory.
+  /// 1) pushd $Dir/java/runtime-native/target/classes
+  /// 2) javah -classpath .:$Dir/java/runtime-common/target/classes/:$Dir/java/api/target/classes/
+  ///    org.ray.spi.impl.DefaultLocalSchedulerClient
+  /// 3) cp org_ray_spi_impl_DefaultLocalSchedulerClient.h $Dir/src/local_scheduler/lib/java/
+  /// 4) vim $Dir/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+  /// 5) popd
 
   private static native long nativeInit(String localSchedulerSocket, byte[] workerId,
       boolean isWorker, byte[] driverTaskId, boolean useRaylet);
@@ -282,8 +293,6 @@ public class DefaultLocalSchedulerClient implements LocalSchedulerLink {
 
   // return TaskInfo (in FlatBuffer)
   private static native byte[] nativeGetTask(long client, boolean useRaylet);
-
-  private static native byte[] nativeComputePutId(long client, byte[] taskId, int putIndex);
 
   private static native void nativeDestroy(long client);
 

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -153,7 +153,8 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
-    jbyteArray object_id_bytes = (jbyteArray) env->GetObjectArrayElement(objectIds, i);
+    jbyteArray object_id_bytes =
+        (jbyteArray) env->GetObjectArrayElement(objectIds, i);
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
@@ -168,9 +169,10 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(JNIEnv *,
-                                                                        jclass,
-                                                                        jlong client) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(
+    JNIEnv *,
+    jclass,
+    jlong client) {
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_notify_unblocked(conn);
 }
@@ -209,7 +211,8 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
-    jbyteArray object_id_bytes = (jbyteArray) env->GetObjectArrayElement(objectIds, i);
+    jbyteArray object_id_bytes =
+        (jbyteArray) env->GetObjectArrayElement(objectIds, i);
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
@@ -252,7 +255,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
  * Signature: ([B[BI)[B
  */
 JNIEXPORT jbyteArray JNICALL
-    Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId(
     JNIEnv *env,
     jclass,
     jbyteArray driverId,

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -183,9 +183,9 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1task_1done(JNIEnv *,
-                                                               jclass,
-                                                               jlong c) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
+                                                             jclass,
+                                                             jlong c) {
   // native private static void _task_done(long client);
   auto client = reinterpret_cast<LocalSchedulerConnection *>(c);
   local_scheduler_task_done(client);
@@ -197,7 +197,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1task_1done(JNIEnv *,
  * Signature: (J[B)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstruct_1objects(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
     JNIEnv *env,
     jclass,
     jlong c,
@@ -224,9 +224,9 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstruct_1objects(
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notify_1unblocked(JNIEnv *,
-                                                                      jclass,
-                                                                      jlong c) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
+                                                                    jclass,
+                                                                    jlong c) {
   // native private static void _notify_unblocked(long client);
   auto client = reinterpret_cast<LocalSchedulerConnection *>(c);
   local_scheduler_notify_unblocked(client);
@@ -238,12 +238,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notify_1unblocked(JNIEnv *,
  * Signature: (J[B[B)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1put_1object(
-    JNIEnv *env,
-    jclass,
-    jlong c,
-    jbyteArray tid,
-    jbyteArray oid) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *env,
+                                                              jclass,
+                                                              jlong c,
+                                                              jbyteArray tid,
+                                                              jbyteArray oid) {
   // native private static void _put_object(long client, byte[] taskId, byte[]
   // objectId);
   UniqueIdFromJByteArray o(env, oid), t(env, tid);

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -154,7 +154,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
     jbyteArray object_id_bytes =
-        static_cast<jbyteArray> (env->GetObjectArrayElement(objectIds, i));
+        static_cast<jbyteArray>(env->GetObjectArrayElement(objectIds, i));
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
@@ -212,7 +212,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
     jbyteArray object_id_bytes =
-        static_cast<jbyteArray> (env->GetObjectArrayElement(objectIds, i));
+        static_cast<jbyteArray>(env->GetObjectArrayElement(objectIds, i));
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -34,7 +34,7 @@ class UniqueIdFromJByteArray {
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _init
- * Signature: (Ljava/lang/String;[B[BZJ)J
+ * Signature: (Ljava/lang/String;[B[BZ[BJZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
@@ -61,7 +61,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _submitTask
- * Signature: (JLjava/nio/ByteBuffer;II)V
+ * Signature: (J[BLjava/nio/ByteBuffer;IIZ)V
  */
 JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(
@@ -100,7 +100,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _getTaskTodo
- * Signature: (J)[B
+ * Signature: (JZ)[B
  */
 JNIEXPORT jbyteArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1getTaskTodo(
@@ -179,7 +179,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _task_done
+ * Method:    _taskDone
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
@@ -193,8 +193,8 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _reconstruct_objects
- * Signature: (J[B)V
+ * Method:    _reconstructObjects
+ * Signature: (J[BZ)V
  */
 JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
@@ -220,7 +220,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _notify_unblocked
+ * Method:    _notifyUnblocked
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
@@ -234,7 +234,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _put_object
+ * Method:    _putObject
  * Signature: (J[B[B)V
  */
 JNIEXPORT void JNICALL
@@ -250,6 +250,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *env,
   local_scheduler_put_object(client, *t.PID, *o.PID);
 }
 
+/*
+ * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
+ * Method:    _waitObject
+ * Signature: (J[BIIZ)[Z
+ */
 JNIEXPORT jbooleanArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(
     JNIEnv *env,
@@ -299,6 +304,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(
   return resultArray;
 }
 
+/*
+ * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
+ * Method:    _generateTaskId
+ * Signature: ([B[BI)[B
+ */
 JNIEXPORT jbyteArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1generateTaskId(
     JNIEnv *env,

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -37,13 +37,14 @@ class UniqueIdFromJByteArray {
  * Signature: (Ljava/lang/String;[BZ[BZ)J
  */
 JNIEXPORT jlong JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit(JNIEnv *env,
-                                                         jclass,
-                                                         jstring sockName,
-                                                         jbyteArray workerId,
-                                                         jboolean isWorker,
-                                                         jbyteArray driverId,
-                                                         jboolean useRaylet) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit(
+    JNIEnv *env,
+    jclass,
+    jstring sockName,
+    jbyteArray workerId,
+    jboolean isWorker,
+    jbyteArray driverId,
+    jboolean useRaylet) {
 // private static native long _init(String localSchedulerSocket, byte[] workerId,
 //     boolean isWorker, byte[] driverTaskId, boolean useRaylet);
   UniqueIdFromJByteArray worker_id(env, workerId);
@@ -96,11 +97,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeGetTaskTodo
+ * Method:    nativeGetTask
  * Signature: (JZ)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTaskTodo(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask(
     JNIEnv *env,
     jclass,
     jlong client,
@@ -136,10 +137,10 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTaskTodo(
  */
 JNIEXPORT jbyteArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId(JNIEnv *env,
-                                                                 jclass,
-                                                                 jlong client,
-                                                                 jbyteArray taskId,
-                                                                 jint putIndex) {
+                                                                     jclass,
+                                                                     jlong client,
+                                                                     jbyteArray taskId,
+                                                                     jint putIndex) {
   // private static native byte[] _computePutId(long client, byte[] taskId,
   //     int putIndex);
   UniqueIdFromJByteArray task(env, taskId);
@@ -167,26 +168,12 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId(JNIEnv *env
  */
 JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy(JNIEnv *,
-                                                            jclass,
-                                                            jlong client) {
+                                                                jclass,
+                                                                jlong client) {
   // private static native void _destroy(long client);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_disconnect_client(conn);
   LocalSchedulerConnection_free(conn);
-}
-
-/*
- * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeTaskDone
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeTaskDone(JNIEnv *,
-                                                             jclass,
-                                                             jlong client) {
-  // private static native void _taskDone(long client);
-  auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  local_scheduler_task_done(conn);
 }
 
 /*
@@ -200,7 +187,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
     jclass,
     jlong client,
     jobjectArray objectIds,
-    jboolean fetch_only) {
+    jboolean fetchOnly) {
   // private static native void _reconstructObjects(long client, byte[][] objectIds,
   //     boolean fetchOnly);
 
@@ -213,7 +200,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
     env->DeleteLocalRef(object_id_bytes);
   }
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  local_scheduler_reconstruct_objects(conn, object_ids, fetch_only);
+  local_scheduler_reconstruct_objects(conn, object_ids, fetchOnly);
 }
 
 /*
@@ -223,8 +210,8 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
  */
 JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(JNIEnv *,
-                                                                    jclass,
-                                                                    jlong client) {
+                                                                        jclass,
+                                                                        jlong client) {
   // private static native void _notifyUnblocked(long client);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_notify_unblocked(conn);
@@ -236,11 +223,12 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(JNIEnv *
  * Signature: (J[B[B)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject(JNIEnv *env,
-                                                              jclass,
-                                                              jlong client,
-                                                              jbyteArray taskId,
-                                                              jbyteArray objectId) {
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject(
+    JNIEnv *env,
+    jclass,
+    jlong client,
+    jbyteArray taskId,
+    jbyteArray objectId) {
   // private static native void _putObject(long client, byte[] taskId,
   // byte[] objectId);
   UniqueIdFromJByteArray object_id(env, objectId), task_id(env, taskId);
@@ -281,22 +269,22 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
                            static_cast<bool>(isWaitLocal));
 
   // Convert result to java object.
-  jboolean putValue = true;
+  jboolean put_value = true;
   jbooleanArray resultArray = env->NewBooleanArray(object_ids.size());
   for (uint i = 0; i < result.first.size(); ++i) {
     for (uint j = 0; j < object_ids.size(); ++j) {
       if (result.first[i] == object_ids[j]) {
-        env->SetBooleanArrayRegion(resultArray, j, 1, &putValue);
+        env->SetBooleanArrayRegion(resultArray, j, 1, &put_value);
         break;
       }
     }
   }
 
-  putValue = false;
+  put_value = false;
   for (uint i = 0; i < result.second.size(); ++i) {
     for (uint j = 0; j < object_ids.size(); ++j) {
       if (result.second[i] == object_ids[j]) {
-        env->SetBooleanArrayRegion(resultArray, j, 1, &putValue);
+        env->SetBooleanArrayRegion(resultArray, j, 1, &put_value);
         break;
       }
     }

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -33,11 +33,11 @@ class UniqueIdFromJByteArray {
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _init
+ * Method:    nativeInit
  * Signature: (Ljava/lang/String;[BZ[BZ)J
  */
 JNIEXPORT jlong JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit(JNIEnv *env,
                                                          jclass,
                                                          jstring sockName,
                                                          jbyteArray workerId,
@@ -58,11 +58,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *env,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _submitTask
+ * Method:    nativeSubmitTask
  * Signature: (J[BLjava/nio/ByteBuffer;IIZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask(
     JNIEnv *env,
     jclass,
     jlong client,
@@ -96,11 +96,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _getTaskTodo
+ * Method:    nativeGetTaskTodo
  * Signature: (JZ)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1getTaskTodo(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTaskTodo(
     JNIEnv *env,
     jclass,
     jlong client,
@@ -131,11 +131,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1getTaskTodo(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _computePutId
+ * Method:    nativeComputePutId
  * Signature: (J[BI)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1computePutId(JNIEnv *env,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId(JNIEnv *env,
                                                                  jclass,
                                                                  jlong client,
                                                                  jbyteArray taskId,
@@ -162,11 +162,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1computePutId(JNIEnv *env,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _destroy
+ * Method:    nativeDestroy
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy(JNIEnv *,
                                                             jclass,
                                                             jlong client) {
   // private static native void _destroy(long client);
@@ -177,11 +177,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _taskDone
+ * Method:    nativeTaskDone
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeTaskDone(JNIEnv *,
                                                              jclass,
                                                              jlong client) {
   // private static native void _taskDone(long client);
@@ -191,11 +191,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _reconstructObjects
- * Signature: (J[BZ)V
+ * Method:    nativeReconstructObjects
+ * Signature: (J[[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
     JNIEnv *env,
     jclass,
     jlong client,
@@ -218,11 +218,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _notifyUnblocked
+ * Method:    nativeNotifyUnblocked
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(JNIEnv *,
                                                                     jclass,
                                                                     jlong client) {
   // private static native void _notifyUnblocked(long client);
@@ -232,11 +232,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _putObject
+ * Method:    nativePutObject
  * Signature: (J[B[B)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *env,
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject(JNIEnv *env,
                                                               jclass,
                                                               jlong client,
                                                               jbyteArray taskId,
@@ -250,11 +250,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *env,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _waitObject
- * Signature: (J[BIIZ)[Z
+ * Method:    nativeWaitObject
+ * Signature: (J[[BIIZ)[Z
  */
 JNIEXPORT jbooleanArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
     JNIEnv *env,
     jclass,
     jlong client,
@@ -306,11 +306,11 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _generateTaskId
+ * Method:    nativeGenerateTaskId
  * Signature: ([B[BI)[B
  */
 JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1generateTaskId(
+    Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId(
     JNIEnv *env,
     jclass,
     jbyteArray driverId,

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -45,8 +45,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit(
     jboolean isWorker,
     jbyteArray driverId,
     jboolean useRaylet) {
-// private static native long _init(String localSchedulerSocket, byte[] workerId,
-//     boolean isWorker, byte[] driverTaskId, boolean useRaylet);
   UniqueIdFromJByteArray worker_id(env, workerId);
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
@@ -72,8 +70,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask(
     jint pos,
     jint taskSize,
     jboolean useRaylet) {
-  // private static native void _submitTask(long client, byte[] cursorId,
-  //     ByteBuffer taskBuff, int pos, int taskSize, boolean useRaylet);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
 
   std::vector<ObjectID> execution_dependencies;
@@ -106,8 +102,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask(
     jclass,
     jlong client,
     jboolean useRaylet) {
-  // private static native byte[] _getTaskTodo(long client,
-  //     boolean useRaylet);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   int64_t task_size = 0;
 
@@ -132,37 +126,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeComputePutId
- * Signature: (J[BI)[B
- */
-JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId(JNIEnv *env,
-                                                                     jclass,
-                                                                     jlong client,
-                                                                     jbyteArray taskId,
-                                                                     jint putIndex) {
-  // private static native byte[] _computePutId(long client, byte[] taskId,
-  //     int putIndex);
-  UniqueIdFromJByteArray task(env, taskId);
-
-  auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  ObjectID put_id = task_compute_put_id(*task.PID, putIndex);
-  local_scheduler_put_object(conn, *task.PID, put_id);
-
-  jbyteArray result;
-  result = env->NewByteArray(sizeof(ObjectID));
-  if (result == nullptr) {
-    return nullptr; /* out of memory error thrown */
-  }
-
-  // move from task spec structure to the java structure
-  env->SetByteArrayRegion(result, 0, sizeof(ObjectID),
-                          reinterpret_cast<jbyte *>(&put_id));
-  return result;
-}
-
-/*
- * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeDestroy
  * Signature: (J)V
  */
@@ -170,7 +133,6 @@ JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy(JNIEnv *,
                                                                 jclass,
                                                                 jlong client) {
-  // private static native void _destroy(long client);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_disconnect_client(conn);
   LocalSchedulerConnection_free(conn);
@@ -188,9 +150,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
     jlong client,
     jobjectArray objectIds,
     jboolean fetchOnly) {
-  // private static native void _reconstructObjects(long client, byte[][] objectIds,
-  //     boolean fetchOnly);
-
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
@@ -212,7 +171,6 @@ JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(JNIEnv *,
                                                                         jclass,
                                                                         jlong client) {
-  // private static native void _notifyUnblocked(long client);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_notify_unblocked(conn);
 }
@@ -229,8 +187,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject(
     jlong client,
     jbyteArray taskId,
     jbyteArray objectId) {
-  // private static native void _putObject(long client, byte[] taskId,
-  // byte[] objectId);
   UniqueIdFromJByteArray object_id(env, objectId), task_id(env, taskId);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
   local_scheduler_put_object(conn, *task_id.PID, *object_id.PID);
@@ -250,8 +206,6 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
     jint numReturns,
     jint timeoutMillis,
     jboolean isWaitLocal) {
-  // private static native boolean[] _waitObject(long conn, byte[][] objectIds,
-  //     int numReturns, int timeout, boolean waitLocal);
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
@@ -304,8 +258,6 @@ JNIEXPORT jbyteArray JNICALL
     jbyteArray driverId,
     jbyteArray parentTaskId,
     jint parent_task_counter) {
-  // private static native byte[] _generateTaskId(byte[] driverId,
-  //     byte[] parentTaskId, int taskIndex);
   UniqueIdFromJByteArray object_id1(env, driverId);
   ray::DriverID driver_id = *object_id1.PID;
 

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.cc
@@ -154,7 +154,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
     jbyteArray object_id_bytes =
-        (jbyteArray) env->GetObjectArrayElement(objectIds, i);
+        static_cast<jbyteArray> (env->GetObjectArrayElement(objectIds, i));
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
@@ -212,7 +212,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
     jbyteArray object_id_bytes =
-        (jbyteArray) env->GetObjectArrayElement(objectIds, i);
+        static_cast<jbyteArray> (env->GetObjectArrayElement(objectIds, i));
     UniqueIdFromJByteArray object_id(env, object_id_bytes);
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -10,17 +10,15 @@ extern "C" {
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _init
- * Signature: (Ljava/lang/String;[B[BZ[BJZ)J
+ * Signature: (Ljava/lang/String;[BZ[BJZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *,
                                                          jclass,
                                                          jstring,
                                                          jbyteArray,
-                                                         jbyteArray,
                                                          jboolean,
                                                          jbyteArray,
-                                                         jlong,
                                                          jboolean);
 
 /*

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -33,14 +33,6 @@ JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_n
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeComputePutId
- * Signature: (J[BI)[B
- */
-JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId
-    (JNIEnv *, jclass, jlong, jbyteArray, jint);
-
-/*
- * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeDestroy
  * Signature: (J)V
  */

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -12,72 +12,113 @@ extern "C" {
  * Method:    nativeInit
  * Signature: (Ljava/lang/String;[BZ[BZ)J
  */
-JNIEXPORT jlong JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit
-    (JNIEnv *, jclass, jstring, jbyteArray, jboolean, jbyteArray, jboolean);
+JNIEXPORT jlong JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit(JNIEnv *,
+                                                             jclass,
+                                                             jstring,
+                                                             jbyteArray,
+                                                             jboolean,
+                                                             jbyteArray,
+                                                             jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeSubmitTask
  * Signature: (J[BLjava/nio/ByteBuffer;IIZ)V
  */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask
-(JNIEnv *, jclass, jlong, jbyteArray, jobject, jint, jint, jboolean);
+JNIEXPORT void JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask(JNIEnv *,
+                                                                   jclass,
+                                                                   jlong,
+                                                                   jbyteArray,
+                                                                   jobject,
+                                                                   jint,
+                                                                   jint,
+                                                                   jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeGetTask
  * Signature: (JZ)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask
-    (JNIEnv *, jclass, jlong, jboolean);
+JNIEXPORT jbyteArray JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask(JNIEnv *,
+                                                                jclass,
+                                                                jlong,
+                                                                jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeDestroy
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy
-(JNIEnv *, jclass, jlong);
+JNIEXPORT void JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy(JNIEnv *,
+                                                                jclass,
+                                                                jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeReconstructObjects
  * Signature: (J[[BZ)V
  */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects
-(JNIEnv *, jclass, jlong, jobjectArray, jboolean);
+JNIEXPORT void JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects(
+    JNIEnv *,
+    jclass,
+    jlong,
+    jobjectArray,
+    jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeNotifyUnblocked
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked
-(JNIEnv *, jclass, jlong);
+JNIEXPORT void JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked(
+    JNIEnv *,
+    jclass,
+    jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativePutObject
  * Signature: (J[B[B)V
  */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject
-(JNIEnv *, jclass, jlong, jbyteArray, jbyteArray);
+JNIEXPORT void JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject(JNIEnv *,
+                                                                  jclass,
+                                                                  jlong,
+                                                                  jbyteArray,
+                                                                  jbyteArray);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeWaitObject
  * Signature: (J[[BIIZ)[Z
  */
-JNIEXPORT jbooleanArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject
-    (JNIEnv *, jclass, jlong, jobjectArray, jint, jint, jboolean);
+JNIEXPORT jbooleanArray JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject(JNIEnv *,
+                                                                   jclass,
+                                                                   jlong,
+                                                                   jobjectArray,
+                                                                   jint,
+                                                                   jint,
+                                                                   jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    nativeGenerateTaskId
  * Signature: ([B[BI)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId
-    (JNIEnv *, jclass, jbyteArray, jbyteArray, jint);
+JNIEXPORT jbyteArray JNICALL
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId(
+    JNIEnv *,
+    jclass,
+    jbyteArray,
+    jbyteArray,
+    jint);
 
 #ifdef __cplusplus
 }

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -10,7 +10,7 @@ extern "C" {
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _init
- * Signature: (Ljava/lang/String;[B[BZJ)J
+ * Signature: (Ljava/lang/String;[B[BZ[BJZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *,
@@ -26,7 +26,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *,
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _submitTask
- * Signature: (JLjava/nio/ByteBuffer;II)V
+ * Signature: (J[BLjava/nio/ByteBuffer;IIZ)V
  */
 JNIEXPORT void JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(JNIEnv *,
@@ -41,7 +41,7 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(JNIEnv *,
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _getTaskTodo
- * Signature: (J)[B
+ * Signature: (JZ)[B
  */
 JNIEXPORT jbyteArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1getTaskTodo(JNIEnv *,
@@ -73,21 +73,21 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _task_done
+ * Method:    _taskDone
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1task_1done(JNIEnv *,
-                                                               jclass,
-                                                               jlong);
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
+                                                             jclass,
+                                                             jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _reconstruct_objects
- * Signature: (J[B)V
+ * Method:    _reconstructObjects
+ * Signature: (J[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstruct_1objects(
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
     JNIEnv *,
     jclass,
     jlong,
@@ -96,30 +96,30 @@ Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstruct_1objects(
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _notify_unblocked
+ * Method:    _notifyUnblocked
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notify_1unblocked(JNIEnv *,
-                                                                      jclass,
-                                                                      jlong);
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
+                                                                    jclass,
+                                                                    jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _put_object
+ * Method:    _putObject
  * Signature: (J[B[B)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1put_1object(JNIEnv *,
-                                                                jclass,
-                                                                jlong,
-                                                                jbyteArray,
-                                                                jbyteArray);
+Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *,
+                                                              jclass,
+                                                              jlong,
+                                                              jbyteArray,
+                                                              jbyteArray);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
  * Method:    _waitObject
- * Signature: (J[[BIIZ)[Z
+ * Signature: (J[BIIZ)[Z
  */
 JNIEXPORT jbooleanArray JNICALL
 Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(JNIEnv *,

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -25,10 +25,10 @@ JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeS
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeGetTaskTodo
+ * Method:    nativeGetTask
  * Signature: (JZ)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTaskTodo
+JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTask
     (JNIEnv *, jclass, jlong, jboolean);
 
 /*
@@ -45,14 +45,6 @@ JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_n
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy
-(JNIEnv *, jclass, jlong);
-
-/*
- * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    nativeTaskDone
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeTaskDone
 (JNIEnv *, jclass, jlong);
 
 /*

--- a/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
+++ b/src/local_scheduler/lib/java/org_ray_spi_impl_DefaultLocalSchedulerClient.h
@@ -9,136 +9,91 @@ extern "C" {
 #endif
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _init
- * Signature: (Ljava/lang/String;[BZ[BJZ)J
+ * Method:    nativeInit
+ * Signature: (Ljava/lang/String;[BZ[BZ)J
  */
-JNIEXPORT jlong JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1init(JNIEnv *,
-                                                         jclass,
-                                                         jstring,
-                                                         jbyteArray,
-                                                         jboolean,
-                                                         jbyteArray,
-                                                         jboolean);
+JNIEXPORT jlong JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeInit
+    (JNIEnv *, jclass, jstring, jbyteArray, jboolean, jbyteArray, jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _submitTask
+ * Method:    nativeSubmitTask
  * Signature: (J[BLjava/nio/ByteBuffer;IIZ)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1submitTask(JNIEnv *,
-                                                               jclass,
-                                                               jlong,
-                                                               jbyteArray,
-                                                               jobject,
-                                                               jint,
-                                                               jint,
-                                                               jboolean);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeSubmitTask
+(JNIEnv *, jclass, jlong, jbyteArray, jobject, jint, jint, jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _getTaskTodo
+ * Method:    nativeGetTaskTodo
  * Signature: (JZ)[B
  */
-JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1getTaskTodo(JNIEnv *,
-                                                                jclass,
-                                                                jlong,
-                                                                jboolean);
+JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGetTaskTodo
+    (JNIEnv *, jclass, jlong, jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _computePutId
+ * Method:    nativeComputePutId
  * Signature: (J[BI)[B
  */
-JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1computePutId(JNIEnv *,
-                                                                 jclass,
-                                                                 jlong,
-                                                                 jbyteArray,
-                                                                 jint);
+JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeComputePutId
+    (JNIEnv *, jclass, jlong, jbyteArray, jint);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _destroy
+ * Method:    nativeDestroy
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1destroy(JNIEnv *,
-                                                            jclass,
-                                                            jlong);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeDestroy
+(JNIEnv *, jclass, jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _taskDone
+ * Method:    nativeTaskDone
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1taskDone(JNIEnv *,
-                                                             jclass,
-                                                             jlong);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeTaskDone
+(JNIEnv *, jclass, jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _reconstructObjects
- * Signature: (J[BZ)V
+ * Method:    nativeReconstructObjects
+ * Signature: (J[[BZ)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1reconstructObjects(
-    JNIEnv *,
-    jclass,
-    jlong,
-    jobjectArray,
-    jboolean);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeReconstructObjects
+(JNIEnv *, jclass, jlong, jobjectArray, jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _notifyUnblocked
+ * Method:    nativeNotifyUnblocked
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1notifyUnblocked(JNIEnv *,
-                                                                    jclass,
-                                                                    jlong);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeNotifyUnblocked
+(JNIEnv *, jclass, jlong);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _putObject
+ * Method:    nativePutObject
  * Signature: (J[B[B)V
  */
-JNIEXPORT void JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1putObject(JNIEnv *,
-                                                              jclass,
-                                                              jlong,
-                                                              jbyteArray,
-                                                              jbyteArray);
+JNIEXPORT void JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativePutObject
+(JNIEnv *, jclass, jlong, jbyteArray, jbyteArray);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _waitObject
- * Signature: (J[BIIZ)[Z
+ * Method:    nativeWaitObject
+ * Signature: (J[[BIIZ)[Z
  */
-JNIEXPORT jbooleanArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1waitObject(JNIEnv *,
-                                                               jclass,
-                                                               jlong,
-                                                               jobjectArray,
-                                                               jint,
-                                                               jint,
-                                                               jboolean);
+JNIEXPORT jbooleanArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeWaitObject
+    (JNIEnv *, jclass, jlong, jobjectArray, jint, jint, jboolean);
 
 /*
  * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
- * Method:    _generateTaskId
+ * Method:    nativeGenerateTaskId
  * Signature: ([B[BI)[B
  */
-JNIEXPORT jbyteArray JNICALL
-Java_org_ray_spi_impl_DefaultLocalSchedulerClient__1generateTaskId(JNIEnv *,
-                                                                   jclass,
-                                                                   jbyteArray,
-                                                                   jbyteArray,
-                                                                   jint);
+JNIEXPORT jbyteArray JNICALL Java_org_ray_spi_impl_DefaultLocalSchedulerClient_nativeGenerateTaskId
+    (JNIEnv *, jclass, jbyteArray, jbyteArray, jint);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
When Java code invoke native code by JNI, it will find the function by the function name which is declared in native code(`org_ray_spi_impl_DefaultLocalSchedulerClient.cc`). If there are some overloading functions, the JNI will find the most matching one by the `signature` in the comment, like this:
```c++
/*
 * Class:     org_ray_spi_impl_DefaultLocalSchedulerClient
 * Method:    _reconstructObjects
 * Signature: (J[BZ)V   /******This is the Signature declaration.******/
 */
```
Many signatures are not correct yet. 
But because there are no overloading, this issue is not triggered.

In this PR, I do these things:
1) Renamed the native JNI methods and some parameters of JNI methods. 
2) Fixed native JNI methods' signatures by `javah` tool.
3) Removed some useless native methods.

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->
