### PR TITLE
Fix bug in import thread.

### DIFF
--- a/test/runtest.py
+++ b/test/runtest.py
@@ -955,12 +955,19 @@ class APITest(unittest.TestCase):
 
         ray.worker.global_worker.run_function_on_all_workers(f)
 
-        self.init_ray()
+        self.init_ray(num_cpus=1)
+
+        def get_modified_path():
+            return sys.path[-4], sys.path[-3], sys.path[-2], sys.path[-1]
+
+        # run_function_on_all_workers also runs on the driver, so make sure it
+        # did the right thing.
+        assert get_modified_path() == (1, 2, 3, 4)
 
         @ray.remote
         def get_state():
             time.sleep(1)
-            return sys.path[-4], sys.path[-3], sys.path[-2], sys.path[-1]
+            return get_modified_path()
 
         res1 = get_state.remote()
         res2 = get_state.remote()


### PR DESCRIPTION
In some cases, functions exported from the driver are run on the driver twice (once right when they are exported and then once when they are later imported on the same driver). We should not be importing them at all and definitely should not be executing them a second time.

Before this PR:

```python
import ray
import sys

ray.init()

def f(x):
    sys.path.append(1)

ray.worker.global_worker.run_function_on_all_workers(f)

import time
time.sleep(1)

print(sys.path)  # This used to end with [1, 1] before this PR. It should be [1].
```

Related to https://github.com/ray-project/ray/pull/2406.