### PR TITLE
Some small changes

### DIFF
--- a/src/common/redis_module/redis_string.h
+++ b/src/common/redis_module/redis_string.h
@@ -4,6 +4,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "redismodule.h"
 

--- a/src/common/test/io_tests.cc
+++ b/src/common/test/io_tests.cc
@@ -13,7 +13,7 @@ SUITE(io_tests);
 
 TEST ipc_socket_test(void) {
 #ifndef _WIN32
-  const char *socket_pathname = "test-socket";
+  const char *socket_pathname = "/tmp/test-socket";
   int socket_fd = bind_ipc_sock(socket_pathname, true);
   ASSERT(socket_fd >= 0);
 
@@ -55,7 +55,7 @@ TEST ipc_socket_test(void) {
 
 TEST long_ipc_socket_test(void) {
 #ifndef _WIN32
-  const char *socket_pathname = "long-test-socket";
+  const char *socket_pathname = "/tmp/long-test-socket";
   int socket_fd = bind_ipc_sock(socket_pathname, true);
   ASSERT(socket_fd >= 0);
 

--- a/src/common/test/redis_tests.cc
+++ b/src/common/test/redis_tests.cc
@@ -56,7 +56,7 @@ void async_redis_socket_test_callback(redisAsyncContext *ac,
 }
 
 TEST redis_socket_test(void) {
-  const char *socket_pathname = "redis-test-socket";
+  const char *socket_pathname = "/tmp/redis-test-socket";
   redisContext *context = redisConnect("127.0.0.1", 6379);
   ASSERT(context != NULL);
   int socket_fd = bind_ipc_sock(socket_pathname, true);
@@ -112,7 +112,7 @@ TEST async_redis_socket_test(void) {
   event_loop *loop = event_loop_create();
 
   /* Start IPC channel. */
-  const char *socket_pathname = "async-redis-test-socket";
+  const char *socket_pathname = "/tmp/async-redis-test-socket";
   int socket_fd = bind_ipc_sock(socket_pathname, true);
   ASSERT(socket_fd >= 0);
   connections.push_back(socket_fd);
@@ -186,7 +186,7 @@ TEST logging_test(void) {
   event_loop *loop = event_loop_create();
 
   /* Start IPC channel. */
-  const char *socket_pathname = "logging-test-socket";
+  const char *socket_pathname = "/tmp/logging-test-socket";
   int socket_fd = bind_ipc_sock(socket_pathname, true);
   ASSERT(socket_fd >= 0);
   connections.push_back(socket_fd);

--- a/src/local_scheduler/local_scheduler.h
+++ b/src/local_scheduler/local_scheduler.h
@@ -1,6 +1,7 @@
 #ifndef LOCAL_SCHEDULER_H
 #define LOCAL_SCHEDULER_H
 
+#include "local_scheduler_shared.h"
 #include "task.h"
 #include "event_loop.h"
 

--- a/src/ray/constants.h
+++ b/src/ray/constants.h
@@ -2,6 +2,7 @@
 #define RAY_CONSTANTS_H_
 
 #include <limits.h>
+#include <stdint.h>
 
 /// Length of Ray IDs in bytes.
 constexpr int64_t kUniqueIDSize = 20;

--- a/src/ray/gcs/asio_test.cc
+++ b/src/ray/gcs/asio_test.cc
@@ -6,20 +6,6 @@
 
 boost::asio::io_service io_service;
 
-// For this test to work, you need to have a redis-server in your PATH
-
-class TestRedisAsioClient : public ::testing::Test {
- public:
-  TestRedisAsioClient() {
-    int r = system("redis-server > /dev/null & sleep 1");
-    RAY_LOG(INFO) << "TestRedisAsioClient: redis-server status code was " << r;
-  }
-  ~TestRedisAsioClient() {
-    int r = system("redis-cli -c shutdown");
-    RAY_LOG(INFO) << "TestRedisAsioClient: redis-cli status code was " << r;
-  }
-};
-
 void ConnectCallback(const redisAsyncContext *c, int status) {
   ASSERT_EQ(status, REDIS_OK);
 }
@@ -36,7 +22,7 @@ void GetCallback(redisAsyncContext *c, void *r, void *privdata) {
   io_service.stop();
 }
 
-TEST_F(TestRedisAsioClient, TestRedisCommands) {
+TEST(RedisAsioTest, TestRedisCommands) {
   redisAsyncContext *ac = redisAsyncConnect("127.0.0.1", 6379);
   ASSERT_TRUE(ac->err == 0);
 

--- a/src/ray/test/run_gcs_tests.sh
+++ b/src/ray/test/run_gcs_tests.sh
@@ -22,6 +22,7 @@ fi
 sleep 1s
 
 ./src/ray/gcs/client_test
+./src/ray/gcs/asio_test
 
 ./src/common/thirdparty/redis/src/redis-cli -p 6379 shutdown
 sleep 1s


### PR DESCRIPTION
## What do these changes do?

* Add some imports that make it easier to build with Bazel
* Use "/tmp" paths for sockets in tests
* Move `asio_test` into `run_gcs_tests.sh` instead of starting and stopping Redis within the test fixture with a `system` call.
