### PR TITLE
Deprecate num_workers argument to ray.init and ray start.

### DIFF
--- a/python/benchmarks/benchmark_actor.py
+++ b/python/benchmarks/benchmark_actor.py
@@ -9,7 +9,7 @@ NUM_WORKERS = 4
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=NUM_WORKERS, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmark_get.py
+++ b/python/benchmarks/benchmark_get.py
@@ -9,7 +9,7 @@ import ray
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=4, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmark_put.py
+++ b/python/benchmarks/benchmark_put.py
@@ -9,7 +9,7 @@ import ray
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=4, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmark_queue.py
+++ b/python/benchmarks/benchmark_queue.py
@@ -8,7 +8,7 @@ from ray.experimental.queue import Queue
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=4, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmark_task.py
+++ b/python/benchmarks/benchmark_task.py
@@ -7,7 +7,7 @@ import ray
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=10, num_cpus=10, resources={"foo": 1})
+        ray.init(num_cpus=10, resources={"foo": 1})
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmark_wait.py
+++ b/python/benchmarks/benchmark_wait.py
@@ -9,7 +9,7 @@ import ray
 
 def setup(*args):
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=4, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/benchmarks/benchmarks.py
+++ b/python/benchmarks/benchmarks.py
@@ -7,7 +7,7 @@ import ray
 
 def setup():
     if not hasattr(setup, "is_initialized"):
-        ray.init(num_workers=4, num_cpus=4)
+        ray.init(num_cpus=4)
         setup.is_initialized = True
 
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1395,7 +1395,8 @@ def start_ray_processes(address_info=None,
         resources = num_local_schedulers * [resources]
 
     if num_workers is not None:
-        workers_per_local_scheduler = num_local_schedulers * [num_workers]
+        raise Exception("The 'num_workers' argument is deprecated. Please use "
+                        "'num_cpus' instead.")
     else:
         workers_per_local_scheduler = []
         for resource_dict in resources:
@@ -1698,7 +1699,7 @@ def start_ray_head(address_info=None,
                    node_ip_address="127.0.0.1",
                    redis_port=None,
                    redis_shard_ports=None,
-                   num_workers=0,
+                   num_workers=None,
                    num_local_schedulers=1,
                    object_store_memory=None,
                    worker_path=None,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1534,8 +1534,6 @@ def _init(address_info=None,
             object IDs. The same value can be used across multiple runs of the
             same job in order to generate the object IDs in a consistent
             manner. However, the same ID should not be used for different jobs.
-        num_workers (int): The number of workers to start. This is only
-            provided if start_ray_local is True.
         num_local_schedulers (int): The number of local schedulers to start.
             This is only provided if start_ray_local is True.
         object_store_memory: The maximum amount of memory (in bytes) to
@@ -1774,8 +1772,6 @@ def init(redis_address=None,
             object IDs. The same value can be used across multiple runs of the
             same job in order to generate the object IDs in a consistent
             manner. However, the same ID should not be used for different jobs.
-        num_workers (int): The number of workers to start. This is only
-            provided if redis_address is not provided.
         local_mode (bool): True if the code should be executed serially
             without Ray. This is useful for debugging.
         redirect_worker_output: True if the stdout and stderr of worker

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -700,7 +700,7 @@ def test_actor_load_balancing(shutdown_only):
     num_local_schedulers = 3
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
+        num_cpus=2,
         num_local_schedulers=num_local_schedulers)
 
     @ray.remote
@@ -746,7 +746,6 @@ def test_actor_gpus(shutdown_only):
     num_gpus_per_scheduler = 4
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
         num_local_schedulers=num_local_schedulers,
         num_cpus=(num_local_schedulers * [10 * num_gpus_per_scheduler]),
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
@@ -789,7 +788,6 @@ def test_actor_multiple_gpus(shutdown_only):
     num_gpus_per_scheduler = 5
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
         num_local_schedulers=num_local_schedulers,
         num_cpus=(num_local_schedulers * [10 * num_gpus_per_scheduler]),
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
@@ -860,7 +858,6 @@ def test_actor_different_numbers_of_gpus(shutdown_only):
     # numbers of GPUs.
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
         num_local_schedulers=3,
         num_cpus=[10, 10, 10],
         num_gpus=[0, 5, 10])
@@ -901,7 +898,6 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
     num_gpus_per_scheduler = 10
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
         num_local_schedulers=num_local_schedulers,
         redirect_output=True,
         num_cpus=(num_local_schedulers * [10 * num_gpus_per_scheduler]),
@@ -950,7 +946,6 @@ def test_actors_and_tasks_with_gpus(shutdown_only):
     num_gpus_per_scheduler = 6
     ray.worker._init(
         start_ray_local=True,
-        num_workers=0,
         num_local_schedulers=num_local_schedulers,
         num_cpus=num_gpus_per_scheduler,
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
@@ -1270,7 +1265,7 @@ def test_local_scheduler_dying(shutdown_only):
     ray.worker._init(
         start_ray_local=True,
         num_local_schedulers=2,
-        num_workers=0,
+        num_cpus=2,
         redirect_output=True)
 
     @ray.remote
@@ -1388,7 +1383,7 @@ def setup_counter_actor(test_checkpoint=False,
     ray.worker._init(
         start_ray_local=True,
         num_local_schedulers=2,
-        num_workers=0,
+        num_cpus=2,
         redirect_output=True)
 
     # Only set the checkpoint interval if we're testing with checkpointing.
@@ -1734,7 +1729,7 @@ def _test_nondeterministic_reconstruction(num_forks, num_items_per_fork,
     ray.worker._init(
         start_ray_local=True,
         num_local_schedulers=2,
-        num_workers=0,
+        num_cpus=2,
         redirect_output=True)
 
     # Make a shared queue.
@@ -2018,7 +2013,7 @@ def test_custom_label_placement(shutdown_only):
     ray.worker._init(
         start_ray_local=True,
         num_local_schedulers=2,
-        num_workers=0,
+        num_cpus=5,
         resources=[{
             "CustomResource1": 2
         }, {
@@ -2049,11 +2044,7 @@ def test_custom_label_placement(shutdown_only):
 
 
 def test_creating_more_actors_than_resources(shutdown_only):
-    ray.init(
-        num_workers=0,
-        num_cpus=10,
-        num_gpus=2,
-        resources={"CustomResource1": 1})
+    ray.init(num_cpus=10, num_gpus=2, resources={"CustomResource1": 1})
 
     @ray.remote(num_gpus=1)
     class ResourceActor1(object):

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -101,7 +101,6 @@ def ray_start_workers_separate_multinode(request):
     num_initial_workers = request.param[1]
     # Start the Ray processes.
     ray.worker._init(
-        num_workers=(num_initial_workers * num_local_schedulers),
         num_local_schedulers=num_local_schedulers,
         start_workers_from_local_scheduler=False,
         start_ray_local=True,
@@ -148,7 +147,6 @@ def _test_component_failed(component_type):
     num_local_schedulers = 4
     num_workers_per_scheduler = 8
     ray.worker._init(
-        num_workers=num_workers_per_scheduler,
         num_local_schedulers=num_local_schedulers,
         start_ray_local=True,
         num_cpus=[num_workers_per_scheduler] * num_local_schedulers,

--- a/test/credis_test.py
+++ b/test/credis_test.py
@@ -17,7 +17,7 @@ def parse_client(addr_port_str):
                  "Tests functionality of the new GCS.")
 class CredisTest(unittest.TestCase):
     def setUp(self):
-        self.config = ray.init(num_workers=0)
+        self.config = ray.init(num_cpus=0)
 
     def tearDown(self):
         ray.shutdown()

--- a/test/jenkins_tests/multi_node_tests/large_memory_test.py
+++ b/test/jenkins_tests/multi_node_tests/large_memory_test.py
@@ -7,7 +7,7 @@ import numpy as np
 import ray
 
 if __name__ == "__main__":
-    ray.init(num_workers=0)
+    ray.init(num_cpus=0)
 
     A = np.ones(2**31 + 1, dtype="int8")
     a = ray.put(A)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -300,7 +300,7 @@ class WorkerTest(unittest.TestCase):
         # purposes only.
         num_workers = 4
         ray.worker._init(
-            num_workers=num_workers,
+            num_cpus=num_workers,
             start_workers_from_local_scheduler=False,
             start_ray_local=True)
 
@@ -312,7 +312,7 @@ class WorkerTest(unittest.TestCase):
         assert values == [1] * (num_workers * 2)
 
     def testPutGet(self):
-        ray.init(num_workers=0)
+        ray.init(num_cpus=0)
 
         for i in range(100):
             value_before = i * 10**6
@@ -349,7 +349,7 @@ class APITest(unittest.TestCase):
         ray.shutdown()
 
     def testCustomSerializers(self):
-        self.init_ray(num_workers=1)
+        self.init_ray(num_cpus=1)
 
         class Foo(object):
             def __init__(self):
@@ -385,7 +385,7 @@ class APITest(unittest.TestCase):
         assert ray.get(f.remote()) == ((3, "string1", Bar.__name__), "string2")
 
     def testRegisterClass(self):
-        self.init_ray(num_workers=2)
+        self.init_ray(num_cpus=2)
 
         # Check that putting an object of a class that has not been registered
         # throws an exception.
@@ -732,7 +732,7 @@ class APITest(unittest.TestCase):
         assert ray.get(m.remote(1)) == 2
 
     def testSubmitAPI(self):
-        self.init_ray(num_gpus=1, resources={"Custom": 1}, num_workers=1)
+        self.init_ray(num_gpus=1, resources={"Custom": 1}, num_cpus=1)
 
         @ray.remote
         def f(n):
@@ -1214,7 +1214,6 @@ class APITest(unittest.TestCase):
         ray.worker._init(
             start_ray_local=True,
             num_local_schedulers=3,
-            num_workers=1,
             num_cpus=[1, 1, 1],
             resources=[{
                 "Custom0": 1
@@ -1397,7 +1396,7 @@ class ResourcesTest(unittest.TestCase):
 
     def testResourceConstraints(self):
         num_workers = 20
-        ray.init(num_workers=num_workers, num_cpus=10, num_gpus=2)
+        ray.init(num_cpus=10, num_gpus=2)
 
         @ray.remote(num_cpus=0)
         def get_worker_id():
@@ -1472,7 +1471,7 @@ class ResourcesTest(unittest.TestCase):
 
     def testMultiResourceConstraints(self):
         num_workers = 20
-        ray.init(num_workers=num_workers, num_cpus=10, num_gpus=10)
+        ray.init(num_cpus=10, num_gpus=10)
 
         @ray.remote(num_cpus=0)
         def get_worker_id():
@@ -1762,7 +1761,6 @@ class ResourcesTest(unittest.TestCase):
         address_info = ray.worker._init(
             start_ray_local=True,
             num_local_schedulers=3,
-            num_workers=1,
             num_cpus=[100, 5, 10],
             num_gpus=[0, 5, 1])
 
@@ -2040,19 +2038,6 @@ class WorkerPoolTests(unittest.TestCase):
     def tearDown(self):
         ray.shutdown()
 
-    def testNoWorkers(self):
-        ray.init(num_workers=0)
-
-        @ray.remote
-        def f():
-            return 1
-
-        # Make sure we can call a remote function. This will require starting a
-        # new worker.
-        ray.get(f.remote())
-
-        ray.get([f.remote() for _ in range(100)])
-
     def testBlockingTasks(self):
         ray.init(num_cpus=1)
 
@@ -2148,11 +2133,11 @@ class SchedulingAlgorithm(unittest.TestCase):
         # This test ensures that tasks are being assigned to all local
         # schedulers in a roughly equal manner even when the tasks have
         # dependencies.
-        num_workers = 3
+        num_cpus = 3
         num_local_schedulers = 3
         ray.worker._init(
             start_ray_local=True,
-            num_workers=num_workers,
+            num_cpus=num_cpus,
             num_local_schedulers=num_local_schedulers)
 
         @ray.remote
@@ -2407,10 +2392,7 @@ class GlobalStateAPI(unittest.TestCase):
 
     def testWorkers(self):
         num_workers = 3
-        ray.init(
-            redirect_worker_output=True,
-            num_cpus=num_workers,
-            num_workers=num_workers)
+        ray.init(redirect_worker_output=True, num_cpus=num_workers)
 
         @ray.remote
         def f():

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -20,16 +20,15 @@ def ray_start_regular():
     ray.shutdown()
 
 
-@pytest.fixture(params=[(1, 4), (4, 4)])
+@pytest.fixture(params=[1, 4])
 def ray_start_combination(request):
-    num_local_schedulers = request.param[0]
-    num_workers_per_scheduler = request.param[1]
+    num_local_schedulers = request.param
+    num_workers_per_scheduler = 10
     # Start the Ray processes.
     ray.worker._init(
         start_ray_local=True,
-        num_workers=num_workers_per_scheduler,
         num_local_schedulers=num_local_schedulers,
-        num_cpus=10)
+        num_cpus=num_workers_per_scheduler)
     yield num_local_schedulers, num_workers_per_scheduler
     # The code after the yield will run as teardown code.
     ray.shutdown()
@@ -187,7 +186,6 @@ def ray_start_reconstruction(request):
     ray.worker._init(
         address_info=address_info,
         start_ray_local=True,
-        num_workers=1,
         num_local_schedulers=num_local_schedulers,
         num_cpus=[1] * num_local_schedulers,
         redirect_output=True)
@@ -537,6 +535,6 @@ def test_driver_put_errors(ray_start_driver_put_errors):
 #       object_ids = [f.remote(i, j) for j in range(10)]
 #       return ray.get(object_ids)
 #
-#     ray.init(num_workers=1)
+#     ray.init(num_cpus=1)
 #     ray.get([g.remote(i) for i in range(1000)])
 #     ray.shutdown()


### PR DESCRIPTION
This deprecates `ray.init(num_workers=...)` and `ray start --num-workers=...`. The preferred way to control the degree of concurrency is to use `num_cpus` and `--num-cpus`. The `num_workers` argument was confusing and never particularly meaningful since it was just the *initial* number of workers started. See https://github.com/ray-project/ray/issues/2759.