### PR TITLE
Add test (currently skipped) that drivers release resources when exiting.

### DIFF
--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -22,9 +22,7 @@ def run_string_as_driver(driver_script):
     Returns:
         The script's output.
     """
-    # Save the driver script as a file so we can call it using subprocess. If
-    # blocking is false, we do not delete this file in order to make sure that
-    # it doesn't get removed before the Python process tries to run it.
+    # Save the driver script as a file so we can call it using subprocess.
     with tempfile.NamedTemporaryFile() as f:
         f.write(driver_script.encode("ascii"))
         f.flush()


### PR DESCRIPTION
This adds a test to make sure that multiple drivers are able to start a bunch of work (e.g., tasks and actors) and then exit (gracefully and ungracefully). If the test runs, that should indicate that resources are being released and that tasks and actors are being cleaned up for dead drivers.