### PR TITLE
[tune] Add a time/timesteps since last restore metric

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -140,6 +140,7 @@ class _TFLogger(Logger):
         }, ["ray", "tune"])
         iteration_stats = tf.Summary(value=iteration_value)
         self._file_writer.add_summary(iteration_stats, t)
+        self._file_writer.flush()
 
     def flush(self):
         self._file_writer.flush()

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -1033,14 +1033,12 @@ class TrialRunnerTest(unittest.TestCase):
         self.assertEqual(trials[1].status, Trial.RUNNING)
         runner.step()
         self.assertEqual(trials[1].last_result["timesteps_since_restore"], 10)
+        self.assertEqual(trials[1].last_result["iterations_since_restore"], 1)
         self.assertGreater(trials[1].last_result["time_since_restore"], 0)
-        self.assertGreater(
-            trials[1].last_result["iterations_since_restore"], 1)
         runner.step()
         self.assertEqual(trials[1].last_result["timesteps_since_restore"], 20)
+        self.assertEqual(trials[1].last_result["iterations_since_restore"], 2)
         self.assertGreater(trials[1].last_result["time_since_restore"], 0)
-        self.assertGreater(
-            trials[1].last_result["iterations_since_restore"], 2)
         self.addCleanup(os.remove, path)
 
     def testCheckpointingAtEnd(self):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -1034,9 +1034,13 @@ class TrialRunnerTest(unittest.TestCase):
         runner.step()
         self.assertEqual(trials[1].last_result["timesteps_since_restore"], 10)
         self.assertGreater(trials[1].last_result["time_since_restore"], 0)
+        self.assertGreater(
+            trials[1].last_result["iterations_since_restore"], 1)
         runner.step()
         self.assertEqual(trials[1].last_result["timesteps_since_restore"], 20)
         self.assertGreater(trials[1].last_result["time_since_restore"], 0)
+        self.assertGreater(
+            trials[1].last_result["iterations_since_restore"], 2)
         self.addCleanup(os.remove, path)
 
     def testCheckpointingAtEnd(self):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -77,6 +77,7 @@ class Trainable(object):
         self._timesteps_total = None
         self._time_since_restore = 0.0
         self._timesteps_since_restore = 0
+        self._iterations_since_restore = 0
         self._restored = False
         self._setup()
         self._initialize_ok = True
@@ -146,6 +147,7 @@ class Trainable(object):
         result = result.copy()
 
         self._iteration += 1
+        self._iterations_since_restore += 1
 
         if result.get(TIME_THIS_ITER_S) is not None:
             time_this_iter = result[TIME_THIS_ITER_S]
@@ -183,7 +185,8 @@ class Trainable(object):
             node_ip=self._local_ip,
             config=self.config,
             time_since_restore=self._time_since_restore,
-            timesteps_since_restore=self._timesteps_since_restore)
+            timesteps_since_restore=self._timesteps_since_restore,
+            iterations_since_restore=self._iterations_since_restore)
 
         self._result_logger.on_result(result)
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -181,11 +181,9 @@ class Trainable(object):
             pid=os.getpid(),
             hostname=os.uname()[1],
             node_ip=self._local_ip,
-            config=self.config)
-        if self._restored:
-            result.update(
-                time_since_restore=self._time_since_restore,
-                timesteps_since_restore=self._timesteps_since_restore)
+            config=self.config,
+            time_since_restore=self._time_since_restore,
+            timesteps_since_restore=self._timesteps_since_restore)
 
         self._result_logger.on_result(result)
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -199,7 +199,9 @@ class Trial(object):
 
         for criteria, stop_value in self.stopping_criterion.items():
             if criteria not in result:
-                raise TuneError("Stopping Criteria not provided in result.")
+                raise TuneError(
+                    "Stopping criteria {} not provided in result {}.".format(
+                        criteria, result))
             if result[criteria] >= stop_value:
                 return True
 


### PR DESCRIPTION


## What do these changes do?

This can be pretty useful if you're restoring from checkpoints, or doing grid searches over checkpoints.