### PR TITLE
Fix ObjectManager Crash

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -586,7 +586,14 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
 }
 
 void ObjectManager::WaitComplete(const UniqueID &wait_id) {
-  auto &wait_state = active_wait_requests_.find(wait_id)->second;
+  auto iter = active_wait_requests_.find(wait_id);
+  if (iter == active_wait_requests_.end()) {
+    // This is possible if an object's location is obtained immediately,
+    // within the current callstack. In this case, WaitComplete has been
+    // invoked already, so we're done.
+    return;
+  }
+  auto &wait_state = iter->second;
   // If we complete with outstanding requests, then timeout_ms should be non-zero or -1
   // (infinite wait time).
   if (!wait_state.requested_objects.empty()) {

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -580,7 +580,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
             if (error_code.value() != 0) {
               return;
             }
-            if (active_wait_requests_.find(wait_id) == active_wait_requests_.end()) {
+            if (active_wait_requests_.find(wait_id) != active_wait_requests_.end()) {
               // This is possible if an object's subscrition callback is call first,
               // then the timer goes off and the timer callback is post into the queue.
               // In this case, WaitComplete is invoked already, so we're done.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -593,6 +593,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
 
 void ObjectManager::WaitComplete(const UniqueID &wait_id) {
   auto iter = active_wait_requests_.find(wait_id);
+  RAY_CHECK(iter != active_wait_requests_.end());
   auto wait_state = iter->second;
   active_wait_requests_.erase(iter);
   // Cancel the timer. This is okay even if the timer hasn't been started.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -566,18 +566,6 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
               RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(
                   wait_id, subscribe_object_id));
               if (wait_state.found.size() >= wait_state.num_required_objects) {
-                // Test code.
-                if (wait_record_.find(wait_id) != wait_record_.end()) {
-                  RAY_LOG(ERROR) << "WaitComplete is called for the second time. "
-                                 << "wait_id=" << wait_id.hex() << ". "
-                                 << "Previous message is \"" << wait_record_[wait_id]
-                                 << "\". Current is in Subscription callback. ";
-                } else {
-                  // The first time to call WaitComplete for wait_id.
-                  std::ostringstream ostream;
-                  ostream << "First time to call WaitComplete in Subscription callback.";
-                  wait_record_[wait_id] = ostream.str();
-                }
                 WaitComplete(wait_id);
               }
             }
@@ -592,23 +580,11 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
               return;
             }
             if (active_wait_requests_.find(wait_id) == active_wait_requests_.end()) {
-              // When a subscription callback is triggered first, this function will be
+              // When a subscription callback is triggered first, WaitComplete will be
               // called. The timer may at the same time goes off and may be an
-              // interruption will post this function to main_service_ the second time.
+              // interruption will post WaitComplete to main_service_ the second time.
               // This check will avoid the duplicated call of this function.
               return;
-            }
-            // Test code.
-            if (wait_record_.find(wait_id) != wait_record_.end()) {
-              RAY_LOG(ERROR) << "WaitComplete is called for the second time. "
-                             << "wait_id=" << wait_id.hex() << ". "
-                             << "Previous message is \"" << wait_record_[wait_id]
-                             << "\". Current is in Timer callback. ";
-            } else {
-              // The first time to call WaitComplete for wait_id.
-              std::ostringstream ostream;
-              ostream << "First time to call WaitComplete in Timer callback.";
-              wait_record_[wait_id] = ostream.str();
             }
             WaitComplete(wait_id);
           });
@@ -618,7 +594,6 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
 
 void ObjectManager::WaitComplete(const UniqueID &wait_id) {
   auto iter = active_wait_requests_.find(wait_id);
-  // Test code.
   RAY_CHECK(iter != active_wait_requests_.end());
   auto &wait_state = iter->second;
   // If we complete with outstanding requests, then timeout_ms should be non-zero or -1

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -478,8 +478,9 @@ ray::Status ObjectManager::AddWaitRequest(const UniqueID &wait_id,
   }
 
   // Initialize fields.
-  active_wait_requests_.emplace(wait_id, WaitState(*main_service_, timeout_ms, callback));
-  auto &wait_state = active_wait_requests_.find(wait_id)->second;
+  active_wait_requests_.emplace(
+      wait_id, std::make_shared<WaitState>(*main_service_, timeout_ms, callback));
+  auto &wait_state = *active_wait_requests_.find(wait_id)->second;
   wait_state.object_id_order = object_ids;
   wait_state.timeout_ms = timeout_ms;
   wait_state.num_required_objects = num_required_objects;
@@ -495,7 +496,7 @@ ray::Status ObjectManager::AddWaitRequest(const UniqueID &wait_id,
 }
 
 ray::Status ObjectManager::LookupRemainingWaitObjects(const UniqueID &wait_id) {
-  auto &wait_state = active_wait_requests_.find(wait_id)->second;
+  auto &wait_state = *active_wait_requests_.find(wait_id)->second;
 
   if (wait_state.remaining.empty()) {
     WaitComplete(wait_id);
@@ -511,7 +512,7 @@ ray::Status ObjectManager::LookupRemainingWaitObjects(const UniqueID &wait_id) {
       RAY_RETURN_NOT_OK(object_directory_->LookupLocations(
           object_id, [this, wait_id](const std::vector<ClientID> &client_ids,
                                      const ObjectID &lookup_object_id) {
-            auto &wait_state = active_wait_requests_.find(wait_id)->second;
+            auto &wait_state = *active_wait_requests_.find(wait_id)->second;
             if (!client_ids.empty()) {
               wait_state.remaining.erase(lookup_object_id);
               wait_state.found.insert(lookup_object_id);
@@ -527,7 +528,7 @@ ray::Status ObjectManager::LookupRemainingWaitObjects(const UniqueID &wait_id) {
 }
 
 void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
-  auto &wait_state = active_wait_requests_.find(wait_id)->second;
+  auto &wait_state = *active_wait_requests_.find(wait_id)->second;
   if (wait_state.found.size() >= wait_state.num_required_objects ||
       wait_state.timeout_ms == 0) {
     // Requirements already satisfied.
@@ -559,7 +560,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
               // We never expect to handle a subscription notification for a wait that has
               // already completed.
               RAY_CHECK(object_id_wait_state != active_wait_requests_.end());
-              auto &wait_state = object_id_wait_state->second;
+              auto &wait_state = *object_id_wait_state->second;
               RAY_CHECK(wait_state.remaining.erase(subscribe_object_id));
               wait_state.found.insert(subscribe_object_id);
               wait_state.requested_objects.erase(subscribe_object_id);
@@ -579,40 +580,46 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
             if (error_code.value() != 0) {
               return;
             }
-            WaitComplete(wait_id);
+            if (active_wait_requests_.find(wait_id) == active_wait_requests_.end()) {
+              // This is possible if an object's subscrition callback is call first,
+              // then the timer goes off and the timer callback is post into the queue.
+              // In this case, WaitComplete is invoked already, so we're done.
+              WaitComplete(wait_id);
+            }
           });
     }
   }
 }
 
 void ObjectManager::WaitComplete(const UniqueID &wait_id) {
-  auto &wait_state = active_wait_requests_.find(wait_id)->second;
+  auto iter = active_wait_requests_.find(wait_id);
+  auto wait_state = iter->second;
+  active_wait_requests_.erase(iter);
   // Cancel the timer. This is okay even if the timer hasn't been started.
   // The timer handler will be given a non-zero error code. The handler
   // will do nothing on non-zero error codes.
-  wait_state.timeout_timer->cancel();
+  wait_state->timeout_timer->cancel();
   // If we complete with outstanding requests, then timeout_ms should be non-zero or -1
   // (infinite wait time).
-  if (!wait_state.requested_objects.empty()) {
-    RAY_CHECK(wait_state.timeout_ms > 0 || wait_state.timeout_ms == -1);
+  if (!wait_state->requested_objects.empty()) {
+    RAY_CHECK(wait_state->timeout_ms > 0 || wait_state->timeout_ms == -1);
   }
   // Unsubscribe to any objects that weren't found in the time allotted.
-  for (const auto &object_id : wait_state.requested_objects) {
+  for (const auto &object_id : wait_state->requested_objects) {
     RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(wait_id, object_id));
   }
   // Order objects according to input order.
   std::vector<ObjectID> found;
   std::vector<ObjectID> remaining;
-  for (const auto &item : wait_state.object_id_order) {
-    if (found.size() < wait_state.num_required_objects &&
-        wait_state.found.count(item) > 0) {
+  for (const auto &item : wait_state->object_id_order) {
+    if (found.size() < wait_state->num_required_objects &&
+        wait_state->found.count(item) > 0) {
       found.push_back(item);
     } else {
       remaining.push_back(item);
     }
   }
-  wait_state.callback(found, remaining);
-  active_wait_requests_.erase(wait_id);
+  wait_state->callback(found, remaining);
 }
 
 std::shared_ptr<SenderConnection> ObjectManager::CreateSenderConnection(

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -338,9 +338,6 @@ class ObjectManager : public ObjectManagerInterface {
   /// A set of active wait requests.
   std::unordered_map<UniqueID, WaitState> active_wait_requests_;
 
-  /// Test code to record wait_id.
-  std::unordered_map<UniqueID, std::string> wait_record_;
-
   /// Maintains a map of push requests that have not been fulfilled due to an object not
   /// being local. Objects are removed from this map after push_timeout_ms have elapsed.
   std::unordered_map<

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -338,6 +338,9 @@ class ObjectManager : public ObjectManagerInterface {
   /// A set of active wait requests.
   std::unordered_map<UniqueID, WaitState> active_wait_requests_;
 
+  /// Test code to record wait_id.
+  std::unordered_map<UniqueID, std::string> wait_record_;
+
   /// Maintains a map of push requests that have not been fulfilled due to an object not
   /// being local. Objects are removed from this map after push_timeout_ms have elapsed.
   std::unordered_map<

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -336,7 +336,7 @@ class ObjectManager : public ObjectManagerInterface {
   UniqueID object_directory_pull_callback_id_ = UniqueID::from_random();
 
   /// A set of active wait requests.
-  std::unordered_map<UniqueID, WaitState> active_wait_requests_;
+  std::unordered_map<UniqueID, std::shared_ptr<WaitState>> active_wait_requests_;
 
   /// Maintains a map of push requests that have not been fulfilled due to an object not
   /// being local. Objects are removed from this map after push_timeout_ms have elapsed.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -336,7 +336,7 @@ class ObjectManager : public ObjectManagerInterface {
   UniqueID object_directory_pull_callback_id_ = UniqueID::from_random();
 
   /// A set of active wait requests.
-  std::unordered_map<UniqueID, std::shared_ptr<WaitState>> active_wait_requests_;
+  std::unordered_map<UniqueID, WaitState> active_wait_requests_;
 
   /// Maintains a map of push requests that have not been fulfilled due to an object not
   /// being local. Objects are removed from this map after push_timeout_ms have elapsed.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
There are Object Manager crashes in Jenkins tests. I added some test code and caught the error: `F0906 06:48:10.513653 27 object_manager.cc:590] Check failed: iter != active_wait_requests_.end()` in 
https://amplab.cs.berkeley.edu/jenkins//job/Ray-PRB/8011/console .

In [this code snippet](https://github.com/ray-project/ray/blob/master/src/ray/object_manager/object_manager.cc#L546), it also says that `WaitComplete` may be twice. Therefore, this check is necessary.
<!-- Please give a short brief about these changes. -->

## Related issue number
#2832
<!-- Are there any issues opened that will be resolved by merging this change? -->
