### PR TITLE
Speed up wheel building by not redoing work for boost and catapult an…

### DIFF
--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -37,7 +37,13 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
   # The -f flag is passed twice to also run git clean in the arrow subdirectory.
   # The -d flag removes directories. The -x flag ignores the .gitignore file,
   # and the -e flag ensures that we don't remove the .whl directory.
-  git clean -f -f -x -d -e .whl -e $DOWNLOAD_DIR
+  git clean -f -f -x -d \
+      -e .whl \
+      -e $DOWNLOAD_DIR \
+      -e thirdparty/pkg/boost \
+      -e thirdparty/build/boost_1_65_1 \
+      -e thirdparty/pkg/catapult \
+      -e thirdparty/pkg/redis
 
   # Install Python.
   INST_PATH=python_downloads/$PY_INST

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -17,7 +17,13 @@ for PYTHON in cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m; do
   # The -f flag is passed twice to also run git clean in the arrow subdirectory.
   # The -d flag removes directories. The -x flag ignores the .gitignore file,
   # and the -e flag ensures that we don't remove the .whl directory.
-  git clean -f -f -x -d -e .whl
+  git clean -f -f -x -d \
+      -e .whl \
+      -e thirdparty/pkg/boost \
+      -e thirdparty/build/boost_1_65_1 \
+      -e thirdparty/pkg/catapult \
+      -e thirdparty/pkg/redis
+
   pushd python
     # Fix the numpy version because this will be the oldest numpy version we can
     # support.


### PR DESCRIPTION
This should speed up building wheels a little bit not not rebuilding boost and redownloading catapult for each Python version. However, it doesn't speed things up by that much.

We should test that the wheels work before merging.