### PR TITLE
Evaluate debug logging only in debug mode

### DIFF
--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -346,7 +346,7 @@ uint8_t *read_message_async(event_loop *loop, int sock) {
   int error = read_bytes(sock, (uint8_t *) &size, sizeof(int64_t));
   if (error < 0) {
     /* The other side has closed the socket. */
-    RAY_LOG(DEBUG) << "Socket has been closed, or some other error has "
+    RAY_DLOG(INFO) << "Socket has been closed, or some other error has "
                    << "occurred.";
     if (loop != NULL) {
       event_loop_remove_file(loop, sock);
@@ -358,7 +358,7 @@ uint8_t *read_message_async(event_loop *loop, int sock) {
   error = read_bytes(sock, message, size);
   if (error < 0) {
     /* The other side has closed the socket. */
-    RAY_LOG(DEBUG) << "Socket has been closed, or some other error has "
+    RAY_DLOG(INFO) << "Socket has been closed, or some other error has "
                    << "occurred.";
     if (loop != NULL) {
       event_loop_remove_file(loop, sock);

--- a/src/common/state/redis.cc
+++ b/src/common/state/redis.cc
@@ -651,7 +651,7 @@ void redis_object_table_lookup_callback(redisAsyncContext *c,
                                         void *privdata) {
   REDIS_CALLBACK_HEADER(db, callback_data, r);
   redisReply *reply = (redisReply *) r;
-  RAY_LOG(DEBUG) << "Object table lookup callback";
+  RAY_DLOG(INFO) << "Object table lookup callback";
   RAY_CHECK(reply->type == REDIS_REPLY_NIL || reply->type == REDIS_REPLY_ARRAY);
 
   object_table_lookup_done_callback done_callback =
@@ -711,7 +711,7 @@ void object_table_redis_subscribe_to_notifications_callback(
   RAY_CHECK(reply->type == REDIS_REPLY_ARRAY);
   RAY_CHECK(reply->elements == 3);
   redisReply *message_type = reply->element[0];
-  RAY_LOG(DEBUG) << "Object table subscribe to notifications callback, message"
+  RAY_DLOG(INFO) << "Object table subscribe to notifications callback, message"
                  << message_type->str;
 
   if (strcmp(message_type->str, "message") == 0) {
@@ -1323,7 +1323,7 @@ void redis_local_scheduler_table_subscribe_callback(redisAsyncContext *c,
   RAY_CHECK(reply->type == REDIS_REPLY_ARRAY);
   RAY_CHECK(reply->elements == 3);
   redisReply *message_type = reply->element[0];
-  RAY_LOG(DEBUG) << "Local scheduler table subscribe callback, message "
+  RAY_DLOG(INFO) << "Local scheduler table subscribe callback, message "
                  << message_type->str;
 
   if (strcmp(message_type->str, "message") == 0) {
@@ -1387,7 +1387,7 @@ void redis_local_scheduler_table_send_info_callback(redisAsyncContext *c,
 
   redisReply *reply = (redisReply *) r;
   RAY_CHECK(reply->type == REDIS_REPLY_INTEGER);
-  RAY_LOG(DEBUG) << reply->integer << " subscribers received this publish.";
+  RAY_DLOG(INFO) << reply->integer << " subscribers received this publish.";
 
   RAY_CHECK(callback_data->done_callback == NULL);
   /* Clean up the timer and callback. */
@@ -1429,7 +1429,7 @@ void redis_local_scheduler_table_disconnect(DBHandle *db) {
       (size_t) fbb.GetSize());
   RAY_CHECK(reply->type != REDIS_REPLY_ERROR) << "reply->str is " << reply->str;
   RAY_CHECK(reply->type == REDIS_REPLY_INTEGER);
-  RAY_LOG(DEBUG) << reply->integer << " subscribers received this publish.";
+  RAY_DLOG(INFO) << reply->integer << " subscribers received this publish.";
   freeReplyObject(reply);
 }
 
@@ -1442,7 +1442,7 @@ void redis_driver_table_subscribe_callback(redisAsyncContext *c,
   RAY_CHECK(reply->type == REDIS_REPLY_ARRAY);
   RAY_CHECK(reply->elements == 3);
   redisReply *message_type = reply->element[0];
-  RAY_LOG(DEBUG) << "Driver table subscribe callback, message "
+  RAY_DLOG(INFO) << "Driver table subscribe callback, message "
                  << message_type->str;
 
   if (strcmp(message_type->str, "message") == 0) {
@@ -1489,7 +1489,7 @@ void redis_driver_table_send_driver_death_callback(redisAsyncContext *c,
 
   redisReply *reply = (redisReply *) r;
   RAY_CHECK(reply->type == REDIS_REPLY_INTEGER);
-  RAY_LOG(DEBUG) << reply->integer << " subscribers received this publish.";
+  RAY_DLOG(INFO) << reply->integer << " subscribers received this publish.";
   /* At the very least, the local scheduler that publishes this message should
    * also receive it. */
   RAY_CHECK(reply->integer >= 1);
@@ -1543,7 +1543,7 @@ void redis_publish_actor_creation_notification_callback(redisAsyncContext *c,
 
   redisReply *reply = (redisReply *) r;
   RAY_CHECK(reply->type == REDIS_REPLY_INTEGER);
-  RAY_LOG(DEBUG) << reply->integer << " subscribers received this publish.";
+  RAY_DLOG(INFO) << reply->integer << " subscribers received this publish.";
   // At the very least, the local scheduler that publishes this message should
   // also receive it.
   RAY_CHECK(reply->integer >= 1);
@@ -1579,7 +1579,7 @@ void redis_actor_notification_table_subscribe_callback(redisAsyncContext *c,
   RAY_CHECK(reply->type == REDIS_REPLY_ARRAY);
   RAY_CHECK(reply->elements == 3);
   redisReply *message_type = reply->element[0];
-  RAY_LOG(DEBUG) << "Local scheduler table subscribe callback, message "
+  RAY_DLOG(INFO) << "Local scheduler table subscribe callback, message "
                  << message_type->str;
 
   if (strcmp(message_type->str, "message") == 0) {

--- a/src/common/state/redis.h
+++ b/src/common/state/redis.h
@@ -16,7 +16,7 @@
                  << "; " << M
 
 #define LOG_REDIS_DEBUG(context, M, ...)                                     \
-  RAY_LOG(DEBUG) << "Redis error " << context->err << " " << context->errstr \
+  RAY_DLOG(INFO) << "Redis error " << context->err << " " << context->errstr \
                  << "; " << M;
 
 struct DBHandle {

--- a/src/common/state/table.cc
+++ b/src/common/state/table.cc
@@ -70,7 +70,7 @@ TableCallbackData *init_table_callback(DBHandle *db_handle,
   callback_data->timer_id = callback_data_id++;
   outstanding_callbacks_add(callback_data);
 
-  RAY_LOG(DEBUG) << "Initializing table command " << callback_data->label
+  RAY_DLOG(INFO) << "Initializing table command " << callback_data->label
                  << " with timer ID " << callback_data->timer_id;
   callback_data->retry_callback(callback_data);
 

--- a/src/common/test/object_table_tests.cc
+++ b/src/common/test/object_table_tests.cc
@@ -277,7 +277,7 @@ int64_t reconnect_context_callback(event_loop *loop,
   db->sync_context = redisConnect("127.0.0.1", 6379);
   /* Re-attach the database to the event loop (the file descriptor changed). */
   db_attach(db, loop, true);
-  RAY_LOG(DEBUG) << "Reconnected to Redis";
+  RAY_DLOG(INFO) << "Reconnected to Redis";
   return EVENT_LOOP_TIMER_DONE;
 }
 

--- a/src/global_scheduler/global_scheduler.cc
+++ b/src/global_scheduler/global_scheduler.cc
@@ -66,11 +66,11 @@ void assign_task_to_local_scheduler(GlobalSchedulerState *state,
                                     Task *task,
                                     DBClientID local_scheduler_id) {
   TaskSpec *spec = Task_task_execution_spec(task)->Spec();
-  RAY_LOG(DEBUG) << "assigning task to local_scheduler_id = "
+  RAY_DLOG(INFO) << "assigning task to local_scheduler_id = "
                  << local_scheduler_id;
   Task_set_state(task, TaskStatus::SCHEDULED);
   Task_set_local_scheduler(task, local_scheduler_id);
-  RAY_LOG(DEBUG) << "Issuing a task table update for task = "
+  RAY_DLOG(INFO) << "Issuing a task table update for task = "
                  << Task_task_id(task);
 
   auto retryInfo = RetryInfo{
@@ -185,7 +185,7 @@ void signal_handler(int signal) {
 
 void process_task_waiting(Task *waiting_task, void *user_context) {
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
-  RAY_LOG(DEBUG) << "Task waiting callback is called.";
+  RAY_DLOG(INFO) << "Task waiting callback is called.";
   bool successfully_assigned =
       handle_task_waiting(state, state->policy_state, waiting_task);
   /* If the task was not successfully submitted to a local scheduler, add the
@@ -252,7 +252,7 @@ std::unordered_map<DBClientID, LocalScheduler>::iterator remove_local_scheduler(
  */
 void process_new_db_client(DBClient *db_client, void *user_context) {
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
-  RAY_LOG(DEBUG) << "db client table callback for db client = "
+  RAY_DLOG(INFO) << "db client table callback for db client = "
                  << db_client->id;
   if (strncmp(db_client->client_type.c_str(), "local_scheduler",
               strlen("local_scheduler")) == 0) {
@@ -292,14 +292,14 @@ void object_table_subscribe_callback(ObjectID object_id,
                                      void *user_context) {
   /* Extract global scheduler state from the callback context. */
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
-  RAY_LOG(DEBUG) << "object table subscribe callback for OBJECT = "
+  RAY_DLOG(INFO) << "object table subscribe callback for OBJECT = "
                  << object_id;
 
   const std::vector<std::string> managers =
       db_client_table_get_ip_addresses(state->db, manager_ids);
-  RAY_LOG(DEBUG) << "\tManagers<" << managers.size() << ">:";
+  RAY_DLOG(INFO) << "\tManagers<" << managers.size() << ">:";
   for (size_t i = 0; i < managers.size(); i++) {
-    RAY_LOG(DEBUG) << "\t\t" << managers[i];
+    RAY_DLOG(INFO) << "\t\t" << managers[i];
   }
 
   if (state->scheduler_object_info_table.find(object_id) ==
@@ -309,11 +309,11 @@ void object_table_subscribe_callback(ObjectID object_id,
         state->scheduler_object_info_table[object_id];
     obj_info_entry.data_size = data_size;
 
-    RAY_LOG(DEBUG) << "New object added to object_info_table with id = "
+    RAY_DLOG(INFO) << "New object added to object_info_table with id = "
                    << object_id;
-    RAY_LOG(DEBUG) << "\tmanager locations:";
+    RAY_DLOG(INFO) << "\tmanager locations:";
     for (size_t i = 0; i < managers.size(); i++) {
-      RAY_LOG(DEBUG) << "\t\t" << managers[i];
+      RAY_DLOG(INFO) << "\t\t" << managers[i];
     }
   }
 
@@ -333,8 +333,8 @@ void local_scheduler_table_handler(DBClientID client_id,
   /* Extract global scheduler state from the callback context. */
   GlobalSchedulerState *state = (GlobalSchedulerState *) user_context;
   ARROW_UNUSED(state);
-  RAY_LOG(DEBUG) << "Local scheduler heartbeat from db_client_id " << client_id;
-  RAY_LOG(DEBUG) << "total workers = " << info.total_num_workers
+  RAY_DLOG(INFO) << "Local scheduler heartbeat from db_client_id " << client_id;
+  RAY_DLOG(INFO) << "total workers = " << info.total_num_workers
                  << ", task queue length = " << info.task_queue_length
                  << ", available workers = " << info.available_workers;
 

--- a/src/local_scheduler/local_scheduler_algorithm.cc
+++ b/src/local_scheduler/local_scheduler_algorithm.cc
@@ -232,7 +232,7 @@ void create_actor(SchedulingAlgorithmState *algorithm_state,
   algorithm_state->local_actor_infos[actor_id] = entry;
 
   /* Log some useful information about the actor that we created. */
-  RAY_LOG(DEBUG) << "Creating actor with ID " << actor_id;
+  RAY_DLOG(INFO) << "Creating actor with ID " << actor_id;
 }
 
 void remove_actor(SchedulingAlgorithmState *algorithm_state, ActorID actor_id) {
@@ -921,7 +921,7 @@ void dispatch_tasks(LocalSchedulerState *state,
     }
 
     /* Dispatch this task to an available worker and dequeue the task. */
-    RAY_LOG(DEBUG) << "Dispatching task";
+    RAY_DLOG(INFO) << "Dispatching task";
     /* Get the last available worker in the available worker queue. */
     LocalSchedulerClient *worker = algorithm_state->available_workers.back();
     /* Tell the available worker to execute the task. */
@@ -1048,7 +1048,7 @@ void queue_waiting_task(LocalSchedulerState *state,
     }
   }
 
-  RAY_LOG(DEBUG) << "Queueing task in waiting queue";
+  RAY_DLOG(INFO) << "Queueing task in waiting queue";
   auto it = queue_task(state, algorithm_state->waiting_task_queue,
                        execution_spec, from_global_scheduler);
   fetch_missing_dependencies(state, algorithm_state, it);
@@ -1069,7 +1069,7 @@ void queue_dispatch_task(LocalSchedulerState *state,
                          SchedulingAlgorithmState *algorithm_state,
                          TaskExecutionSpec &execution_spec,
                          bool from_global_scheduler) {
-  RAY_LOG(DEBUG) << "Queueing task in dispatch queue";
+  RAY_DLOG(INFO) << "Queueing task in dispatch queue";
   TaskSpec *spec = execution_spec.Spec();
   if (TaskSpec_is_actor_task(spec)) {
     queue_actor_task(state, algorithm_state, execution_spec,
@@ -1631,7 +1631,7 @@ void handle_object_removed(LocalSchedulerState *state,
        it != algorithm_state->dispatch_task_queue->end();) {
     if (it->DependsOn(removed_object_id)) {
       /* This task was dependent on the removed object. */
-      RAY_LOG(DEBUG) << "Moved task from dispatch queue back to waiting queue";
+      RAY_DLOG(INFO) << "Moved task from dispatch queue back to waiting queue";
       algorithm_state->waiting_task_queue->push_back(std::move(*it));
       /* Remove the task from the dispatch queue, but do not free the task
        * spec. */
@@ -1650,7 +1650,7 @@ void handle_object_removed(LocalSchedulerState *state,
          queue_it != actor_info.task_queue->end();) {
       if (queue_it->DependsOn(removed_object_id)) {
         /* This task was dependent on the removed object. */
-        RAY_LOG(DEBUG) << "Moved task from actor dispatch queue back to "
+        RAY_DLOG(INFO) << "Moved task from actor dispatch queue back to "
                        << "waiting queue";
         algorithm_state->waiting_task_queue->push_back(std::move(*queue_it));
         /* Remove the task from the dispatch queue, but do not free the task
@@ -1767,7 +1767,7 @@ int num_dispatch_tasks(SchedulingAlgorithmState *algorithm_state) {
 
 void print_worker_info(const char *message,
                        SchedulingAlgorithmState *algorithm_state) {
-  RAY_LOG(DEBUG) << message << ": " << algorithm_state->available_workers.size()
+  RAY_DLOG(INFO) << message << ": " << algorithm_state->available_workers.size()
                  << " available, " << algorithm_state->executing_workers.size()
                  << " executing, " << algorithm_state->blocked_workers.size()
                  << " blocked";

--- a/src/local_scheduler/local_scheduler_client.cc
+++ b/src/local_scheduler/local_scheduler_client.cc
@@ -118,7 +118,7 @@ TaskSpec *local_scheduler_get_task(LocalSchedulerConnection *conn,
     read_message(conn->conn, &type, &reply_size, &reply);
   }
   if (type == static_cast<int64_t>(CommonMessageType::DISCONNECT_CLIENT)) {
-    RAY_LOG(DEBUG) << "Exiting because local scheduler closed connection.";
+    RAY_DLOG(INFO) << "Exiting because local scheduler closed connection.";
     exit(1);
   }
   RAY_CHECK(static_cast<MessageType>(type) == MessageType::ExecuteTask);
@@ -164,7 +164,7 @@ TaskSpec *local_scheduler_get_task_raylet(LocalSchedulerConnection *conn,
     read_message(conn->conn, &type, &reply_size, &reply);
   }
   if (type == static_cast<int64_t>(CommonMessageType::DISCONNECT_CLIENT)) {
-    RAY_LOG(DEBUG) << "Exiting because local scheduler closed connection.";
+    RAY_DLOG(INFO) << "Exiting because local scheduler closed connection.";
     exit(1);
   }
   RAY_CHECK(type == static_cast<int64_t>(MessageType::ExecuteTask));
@@ -272,7 +272,7 @@ const std::vector<uint8_t> local_scheduler_get_actor_frontier(
   }
   if (static_cast<CommonMessageType>(type) ==
       CommonMessageType::DISCONNECT_CLIENT) {
-    RAY_LOG(DEBUG) << "Exiting because local scheduler closed connection.";
+    RAY_DLOG(INFO) << "Exiting because local scheduler closed connection.";
     exit(1);
   }
   RAY_CHECK(static_cast<MessageType>(type) ==

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -230,7 +230,7 @@ Status ErrorTable::PushErrorToDriver(const JobID &job_id, const std::string &typ
   data->timestamp = timestamp;
   return Append(job_id, job_id, data, [](ray::gcs::AsyncGcsClient *client,
                                          const JobID &id, const ErrorTableDataT &data) {
-    RAY_LOG(DEBUG) << "Error message pushed callback";
+    RAY_DLOG(INFO) << "Error message pushed callback";
   });
 }
 
@@ -256,7 +256,7 @@ Status ProfileTable::AddProfileEvent(const std::string &event_type,
   return Append(JobID::nil(), component_id, data,
                 [](ray::gcs::AsyncGcsClient *client, const JobID &id,
                    const ProfileTableDataT &data) {
-                  RAY_LOG(DEBUG) << "Profile message pushed callback";
+                  RAY_DLOG(INFO) << "Profile message pushed callback";
                 });
 }
 
@@ -269,7 +269,7 @@ Status ProfileTable::AddProfileEventBatch(const ProfileTableData &profile_events
   return Append(JobID::nil(), from_flatbuf(*profile_events.component_id()), data,
                 [](ray::gcs::AsyncGcsClient *client, const JobID &id,
                    const ProfileTableDataT &data) {
-                  RAY_LOG(DEBUG) << "Profile message pushed callback";
+                  RAY_DLOG(INFO) << "Profile message pushed callback";
                 });
 }
 
@@ -280,7 +280,7 @@ Status DriverTable::AppendDriverData(const JobID &driver_id, bool is_dead) {
   return Append(driver_id, driver_id, data,
                 [](ray::gcs::AsyncGcsClient *client, const JobID &id,
                    const DriverTableDataT &data) {
-                  RAY_LOG(DEBUG) << "Driver entry added callback";
+                  RAY_DLOG(INFO) << "Driver entry added callback";
                 });
 }
 

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -97,14 +97,14 @@ std::shared_ptr<SenderConnection> ConnectionPool::Borrow(SenderMapType &conn_map
                                                          const ClientID &client_id) {
   std::shared_ptr<SenderConnection> conn = std::move(conn_map[client_id].back());
   conn_map[client_id].pop_back();
-  RAY_LOG(DEBUG) << "Borrow " << client_id << " " << conn_map[client_id].size();
+  RAY_DLOG(INFO) << "Borrow " << client_id << " " << conn_map[client_id].size();
   return conn;
 }
 
 void ConnectionPool::Return(SenderMapType &conn_map, const ClientID &client_id,
                             std::shared_ptr<SenderConnection> conn) {
   conn_map[client_id].push_back(std::move(conn));
-  RAY_LOG(DEBUG) << "Return " << client_id << " " << conn_map[client_id].size();
+  RAY_DLOG(INFO) << "Return " << client_id << " " << conn_map[client_id].size();
 }
 
 }  // namespace ray

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -38,7 +38,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Ge
     const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
     uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
-  RAY_LOG(DEBUG) << "GetChunk " << object_id << " " << data_size << " " << metadata_size;
+  RAY_DLOG(INFO) << "GetChunk " << object_id << " " << data_size << " " << metadata_size;
   if (get_buffer_state_.count(object_id) == 0) {
     plasma::ObjectBuffer object_buffer;
     plasma::ObjectID plasma_id = object_id.to_plasma_id();
@@ -69,7 +69,7 @@ void ObjectBufferPool::ReleaseGetChunk(const ObjectID &object_id, uint64_t chunk
   std::lock_guard<std::mutex> lock(pool_mutex_);
   GetBufferState &buffer_state = get_buffer_state_[object_id];
   buffer_state.references--;
-  RAY_LOG(DEBUG) << "ReleaseBuffer " << object_id << " " << buffer_state.references;
+  RAY_DLOG(INFO) << "ReleaseBuffer " << object_id << " " << buffer_state.references;
   if (buffer_state.references == 0) {
     ARROW_CHECK_OK(store_client_.Release(object_id.to_plasma_id()));
     get_buffer_state_.erase(object_id);
@@ -86,7 +86,7 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
     const ObjectID &object_id, uint64_t data_size, uint64_t metadata_size,
     uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);
-  RAY_LOG(DEBUG) << "CreateChunk " << object_id << " " << data_size << " "
+  RAY_DLOG(INFO) << "CreateChunk " << object_id << " " << data_size << " "
                  << metadata_size;
   if (create_buffer_state_.count(object_id) == 0) {
     const plasma::ObjectID plasma_id = object_id.to_plasma_id();
@@ -150,7 +150,7 @@ void ObjectBufferPool::SealChunk(const ObjectID &object_id, const uint64_t chunk
             CreateChunkState::REFERENCED);
   create_buffer_state_[object_id].chunk_state[chunk_index] = CreateChunkState::SEALED;
   create_buffer_state_[object_id].num_seals_remaining--;
-  RAY_LOG(DEBUG) << "SealChunk" << object_id << " "
+  RAY_DLOG(INFO) << "SealChunk" << object_id << " "
                  << create_buffer_state_[object_id].num_seals_remaining;
   if (create_buffer_state_[object_id].num_seals_remaining == 0) {
     const plasma::ObjectID plasma_id = object_id.to_plasma_id();

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -372,7 +372,7 @@ void ObjectManager::ExecuteSendObject(const ClientID &client_id,
                                       const ObjectID &object_id, uint64_t data_size,
                                       uint64_t metadata_size, uint64_t chunk_index,
                                       const RemoteConnectionInfo &connection_info) {
-  RAY_LOG(DEBUG) << "ExecuteSendObject " << client_id << " " << object_id << " "
+  RAY_DLOG(INFO) << "ExecuteSendObject " << client_id << " " << object_id << " "
                  << chunk_index;
   ray::Status status;
   std::shared_ptr<SenderConnection> conn;
@@ -432,7 +432,7 @@ ray::Status ObjectManager::SendObjectData(const ObjectID &object_id,
 
   if (status.ok()) {
     connection_pool_.ReleaseSender(ConnectionPool::ConnectionType::TRANSFER, conn);
-    RAY_LOG(DEBUG) << "SendCompleted " << client_id_ << " " << object_id << " "
+    RAY_DLOG(INFO) << "SendCompleted " << client_id_ << " " << object_id << " "
                    << config_.max_sends;
   }
   return status;
@@ -721,7 +721,7 @@ void ObjectManager::ExecuteReceiveObject(const ClientID &client_id,
                                          const ObjectID &object_id, uint64_t data_size,
                                          uint64_t metadata_size, uint64_t chunk_index,
                                          TcpClientConnection &conn) {
-  RAY_LOG(DEBUG) << "ExecuteReceiveObject " << client_id << " " << object_id << " "
+  RAY_DLOG(INFO) << "ExecuteReceiveObject " << client_id << " " << object_id << " "
                  << chunk_index;
 
   std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
@@ -756,7 +756,7 @@ void ObjectManager::ExecuteReceiveObject(const ClientID &client_id,
     // TODO(hme): If the object isn't local, create a pull request for this chunk.
   }
   conn.ProcessMessages();
-  RAY_LOG(DEBUG) << "ReceiveCompleted " << client_id_ << " " << object_id << " "
+  RAY_DLOG(INFO) << "ReceiveCompleted " << client_id_ << " " << object_id << " "
                  << "/" << config_.max_receives;
 }
 

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -99,7 +99,7 @@ class TestObjectManagerBase : public ::testing::Test {
                                  " 1> /dev/null 2> /dev/null &" + " echo $! > " +
                                  store_pid;
 
-    RAY_LOG(DEBUG) << plasma_command;
+    RAY_DLOG(INFO) << plasma_command;
     int ec = system(plasma_command.c_str());
     RAY_CHECK(ec == 0);
     sleep(1);
@@ -171,7 +171,7 @@ class TestObjectManagerBase : public ::testing::Test {
 
   ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size) {
     ObjectID object_id = ObjectID::from_random();
-    RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
+    RAY_DLOG(INFO) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
     int64_t metadata_size = sizeof(metadata);
     std::shared_ptr<Buffer> data;
@@ -306,7 +306,7 @@ class StressTestObjectManager : public TestObjectManagerBase {
     ASSERT_EQ(object_buffer_1.data->size(), object_buffer_2.data->size());
     ASSERT_EQ(object_buffer_1.metadata->size(), object_buffer_2.metadata->size());
     int64_t total_size = object_buffer_1.data->size() + object_buffer_1.metadata->size();
-    RAY_LOG(DEBUG) << "total_size " << total_size;
+    RAY_DLOG(INFO) << "total_size " << total_size;
     for (int i = -1; ++i < total_size;) {
       ASSERT_TRUE(data_1[i] == data_2[i]);
     }
@@ -422,23 +422,23 @@ class StressTestObjectManager : public TestObjectManagerBase {
   }
 
   void TestConnections() {
-    RAY_LOG(DEBUG) << "\n"
+    RAY_DLOG(INFO) << "\n"
                    << "Server client ids:"
                    << "\n";
     ClientID client_id_1 = gcs_client_1->client_table().GetLocalClientId();
     ClientID client_id_2 = gcs_client_2->client_table().GetLocalClientId();
-    RAY_LOG(DEBUG) << "Server 1: " << client_id_1 << "\n"
+    RAY_DLOG(INFO) << "Server 1: " << client_id_1 << "\n"
                    << "Server 2: " << client_id_2;
 
-    RAY_LOG(DEBUG) << "\n"
+    RAY_DLOG(INFO) << "\n"
                    << "All connected clients:"
                    << "\n";
     const ClientTableDataT &data = gcs_client_1->client_table().GetClient(client_id_1);
-    RAY_LOG(DEBUG) << "ClientID=" << ClientID::from_binary(data.client_id) << "\n"
+    RAY_DLOG(INFO) << "ClientID=" << ClientID::from_binary(data.client_id) << "\n"
                    << "ClientIp=" << data.node_manager_address << "\n"
                    << "ClientPort=" << data.node_manager_port;
     const ClientTableDataT &data2 = gcs_client_1->client_table().GetClient(client_id_2);
-    RAY_LOG(DEBUG) << "ClientID=" << ClientID::from_binary(data2.client_id) << "\n"
+    RAY_DLOG(INFO) << "ClientID=" << ClientID::from_binary(data2.client_id) << "\n"
                    << "ClientIp=" << data2.node_manager_address << "\n"
                    << "ClientPort=" << data2.node_manager_port;
   }

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -90,7 +90,7 @@ class TestObjectManagerBase : public ::testing::Test {
                                  " 1> /dev/null 2> /dev/null &" + " echo $! > " +
                                  store_pid;
 
-    RAY_LOG(DEBUG) << plasma_command;
+    RAY_DLOG(INFO) << plasma_command;
     int ec = system(plasma_command.c_str());
     RAY_CHECK(ec == 0);
     sleep(1);
@@ -160,7 +160,7 @@ class TestObjectManagerBase : public ::testing::Test {
 
   ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size,
                              ObjectID object_id) {
-    RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
+    RAY_DLOG(INFO) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
     int64_t metadata_size = sizeof(metadata);
     std::shared_ptr<Buffer> data;
@@ -309,9 +309,9 @@ class TestObjectManager : public TestObjectManagerBase {
             const std::vector<ray::ObjectID> &remaining) {
           int64_t elapsed = (boost::posix_time::second_clock::local_time() - start_time)
                                 .total_milliseconds();
-          RAY_LOG(DEBUG) << "elapsed " << elapsed;
-          RAY_LOG(DEBUG) << "found " << found.size();
-          RAY_LOG(DEBUG) << "remaining " << remaining.size();
+          RAY_DLOG(INFO) << "elapsed " << elapsed;
+          RAY_DLOG(INFO) << "found " << found.size();
+          RAY_DLOG(INFO) << "remaining " << remaining.size();
           RAY_CHECK(found.size() == 1);
           // There's nothing more to test. A check will fail if unexpected behavior is
           // triggered.
@@ -380,9 +380,9 @@ class TestObjectManager : public TestObjectManagerBase {
             const std::vector<ray::ObjectID> &remaining) {
           int64_t elapsed = (boost::posix_time::second_clock::local_time() - start_time)
                                 .total_milliseconds();
-          RAY_LOG(DEBUG) << "elapsed " << elapsed;
-          RAY_LOG(DEBUG) << "found " << found.size();
-          RAY_LOG(DEBUG) << "remaining " << remaining.size();
+          RAY_DLOG(INFO) << "elapsed " << elapsed;
+          RAY_DLOG(INFO) << "found " << found.size();
+          RAY_DLOG(INFO) << "remaining " << remaining.size();
 
           // Ensure object order is preserved for all invocations.
           uint j = 0;
@@ -444,19 +444,19 @@ class TestObjectManager : public TestObjectManagerBase {
   void TestWaitComplete() { main_service.stop(); }
 
   void TestConnections() {
-    RAY_LOG(DEBUG) << "\n"
+    RAY_DLOG(INFO) << "\n"
                    << "Server client ids:"
                    << "\n";
     const ClientTableDataT &data = gcs_client_1->client_table().GetClient(client_id_1);
-    RAY_LOG(DEBUG) << (ClientID::from_binary(data.client_id) == ClientID::nil());
-    RAY_LOG(DEBUG) << "Server 1 ClientID=" << ClientID::from_binary(data.client_id);
-    RAY_LOG(DEBUG) << "Server 1 ClientIp=" << data.node_manager_address;
-    RAY_LOG(DEBUG) << "Server 1 ClientPort=" << data.node_manager_port;
+    RAY_DLOG(INFO) << (ClientID::from_binary(data.client_id) == ClientID::nil());
+    RAY_DLOG(INFO) << "Server 1 ClientID=" << ClientID::from_binary(data.client_id);
+    RAY_DLOG(INFO) << "Server 1 ClientIp=" << data.node_manager_address;
+    RAY_DLOG(INFO) << "Server 1 ClientPort=" << data.node_manager_port;
     ASSERT_EQ(client_id_1, ClientID::from_binary(data.client_id));
     const ClientTableDataT &data2 = gcs_client_1->client_table().GetClient(client_id_2);
-    RAY_LOG(DEBUG) << "Server 2 ClientID=" << ClientID::from_binary(data2.client_id);
-    RAY_LOG(DEBUG) << "Server 2 ClientIp=" << data2.node_manager_address;
-    RAY_LOG(DEBUG) << "Server 2 ClientPort=" << data2.node_manager_port;
+    RAY_DLOG(INFO) << "Server 2 ClientID=" << ClientID::from_binary(data2.client_id);
+    RAY_DLOG(INFO) << "Server 2 ClientIp=" << data2.node_manager_address;
+    RAY_DLOG(INFO) << "Server 2 ClientPort=" << data2.node_manager_port;
     ASSERT_EQ(client_id_2, ClientID::from_binary(data2.client_id));
   }
 };

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -182,7 +182,7 @@ void MergeLineageHelper(const TaskID &task_id, const Lineage &lineage_from,
 
 bool LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_lineage) {
   auto task_id = task.GetTaskSpecification().TaskId();
-  RAY_LOG(DEBUG) << "add waiting task " << task_id << " on " << client_id_;
+  RAY_DLOG(INFO) << "add waiting task " << task_id << " on " << client_id_;
   // Merge the uncommitted lineage into the lineage cache.
   MergeLineageHelper(task_id, uncommitted_lineage, lineage_,
                      [](const LineageEntry &entry) {
@@ -212,7 +212,7 @@ bool LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
 
 bool LineageCache::AddReadyTask(const Task &task) {
   const TaskID task_id = task.GetTaskSpecification().TaskId();
-  RAY_LOG(DEBUG) << "add ready task " << task_id << " on " << client_id_;
+  RAY_DLOG(INFO) << "add ready task " << task_id << " on " << client_id_;
 
   // Set the task to READY.
   if (lineage_.SetEntry(task, GcsStatus::UNCOMMITTED_READY)) {
@@ -254,7 +254,7 @@ uint64_t LineageCache::CountUnsubscribedLineage(const TaskID &task_id,
 }
 
 bool LineageCache::RemoveWaitingTask(const TaskID &task_id) {
-  RAY_LOG(DEBUG) << "remove waiting task " << task_id << " on " << client_id_;
+  RAY_DLOG(INFO) << "remove waiting task " << task_id << " on " << client_id_;
   auto entry = lineage_.GetEntryMutable(task_id);
   if (!entry) {
     // The task was already evicted.
@@ -430,7 +430,7 @@ bool LineageCache::UnsubscribeTask(const TaskID &task_id) {
 }
 
 boost::optional<LineageEntry> LineageCache::EvictTask(const TaskID &task_id) {
-  RAY_LOG(DEBUG) << "evicting task " << task_id << " on " << client_id_;
+  RAY_DLOG(INFO) << "evicting task " << task_id << " on " << client_id_;
   auto entry = lineage_.PopEntry(task_id);
   if (!entry) {
     // The entry has already been evicted. Check that the entry does not have
@@ -488,7 +488,7 @@ void LineageCache::EvictRemoteLineage(const TaskID &task_id) {
 }
 
 void LineageCache::HandleEntryCommitted(const TaskID &task_id) {
-  RAY_LOG(DEBUG) << "task committed: " << task_id;
+  RAY_DLOG(INFO) << "task committed: " << task_id;
   auto entry = EvictTask(task_id);
   if (!entry) {
     // The task has already been evicted due to a previous commit notification,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
   }
   node_manager_config.resource_config =
       ray::raylet::ResourceSet(std::move(static_resource_conf));
-  RAY_LOG(DEBUG) << "Starting raylet with static resource configuration: "
+  RAY_DLOG(INFO) << "Starting raylet with static resource configuration: "
                  << node_manager_config.resource_config.ToString();
   node_manager_config.num_initial_workers = num_initial_workers;
   node_manager_config.num_workers_per_process =
@@ -86,14 +86,14 @@ int main(int argc, char *argv[]) {
   object_manager_config.object_chunk_size =
       RayConfig::instance().object_manager_default_chunk_size();
 
-  RAY_LOG(DEBUG) << "Starting object manager with configuration: \n"
+  RAY_DLOG(INFO) << "Starting object manager with configuration: \n"
                  << "max_sends = " << object_manager_config.max_sends << "\n"
                  << "max_receives = " << object_manager_config.max_receives << "\n"
                  << "object_chunk_size = " << object_manager_config.object_chunk_size;
 
   //  initialize mock gcs & object directory
   auto gcs_client = std::make_shared<ray::gcs::AsyncGcsClient>(redis_address, redis_port);
-  RAY_LOG(DEBUG) << "Initializing GCS client "
+  RAY_DLOG(INFO) << "Initializing GCS client "
                  << gcs_client->client_table().GetLocalClientId();
 
   // Initialize the node manager.

--- a/src/ray/raylet/mock_gcs_client.cc
+++ b/src/ray/raylet/mock_gcs_client.cc
@@ -8,7 +8,7 @@ namespace ray {
 ray::Status ObjectTable::GetObjectClientIDs(const ray::ObjectID &object_id,
                                             const ClientIDsCallback &success,
                                             const FailCallback &fail) {
-  RAY_LOG(DEBUG) << "GetObjectClientIDs " << object_id;
+  RAY_DLOG(INFO) << "GetObjectClientIDs " << object_id;
   if (client_lookup.count(object_id) > 0) {
     if (!client_lookup[object_id].empty()) {
       std::vector<ClientID> v;
@@ -30,12 +30,12 @@ ray::Status ObjectTable::GetObjectClientIDs(const ray::ObjectID &object_id,
 ray::Status ObjectTable::Add(const ObjectID &object_id, const ClientID &client_id,
                              const DoneCallback &done_callback) {
   if (client_lookup.count(object_id) == 0) {
-    RAY_LOG(DEBUG) << "Add ObjectID set " << object_id;
+    RAY_DLOG(INFO) << "Add ObjectID set " << object_id;
     client_lookup[object_id] = std::unordered_set<ClientID>();
   } else if (client_lookup[object_id].count(client_id) != 0) {
     return ray::Status::KeyError("ClientID already exists.");
   }
-  RAY_LOG(DEBUG) << "Insert ClientID " << client_id;
+  RAY_DLOG(INFO) << "Insert ClientID " << client_id;
   client_lookup[object_id].insert(client_id);
   done_callback();
   return ray::Status::OK();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -191,7 +191,7 @@ ray::Status NodeManager::RegisterGcs() {
   RAY_RETURN_NOT_OK(gcs_client_->heartbeat_table().Subscribe(
       UniqueID::nil(), UniqueID::nil(), heartbeat_added, nullptr,
       [](gcs::AsyncGcsClient *client) {
-        RAY_LOG(DEBUG) << "heartbeat table subscription done callback called.";
+        RAY_DLOG(INFO) << "heartbeat table subscription done callback called.";
       }));
 
   // Subscribe to driver table updates.
@@ -221,7 +221,7 @@ void NodeManager::KillWorker(std::shared_ptr<Worker> worker) {
       RayConfig::instance().kill_worker_timeout_milliseconds());
   retry_timer->expires_from_now(retry_duration);
   retry_timer->async_wait([retry_timer, worker](const boost::system::error_code &error) {
-    RAY_LOG(DEBUG) << "Send SIGKILL to worker, pid=" << worker->Pid();
+    RAY_DLOG(INFO) << "Send SIGKILL to worker, pid=" << worker->Pid();
     // Force kill worker.
     kill(worker->Pid(), SIGKILL);
   });
@@ -230,7 +230,7 @@ void NodeManager::KillWorker(std::shared_ptr<Worker> worker) {
 void NodeManager::HandleDriverTableUpdate(
     const ClientID &id, const std::vector<DriverTableDataT> &driver_data) {
   for (const auto &entry : driver_data) {
-    RAY_LOG(DEBUG) << "HandleDriverTableUpdate " << UniqueID::from_binary(entry.driver_id)
+    RAY_DLOG(INFO) << "HandleDriverTableUpdate " << UniqueID::from_binary(entry.driver_id)
                    << " " << entry.is_dead;
     if (entry.is_dead) {
       auto driver_id = UniqueID::from_binary(entry.driver_id);
@@ -264,7 +264,7 @@ void NodeManager::Heartbeat() {
   }
   last_heartbeat_at_ms_ = now_ms;
 
-  RAY_LOG(DEBUG) << "[Heartbeat] sending heartbeat.";
+  RAY_DLOG(INFO) << "[Heartbeat] sending heartbeat.";
   auto &heartbeat_table = gcs_client_->heartbeat_table();
   auto heartbeat_data = std::make_shared<HeartbeatTableDataT>();
   const auto &my_client_id = gcs_client_->client_table().GetLocalClientId();
@@ -272,7 +272,7 @@ void NodeManager::Heartbeat() {
   heartbeat_data->client_id = my_client_id.binary();
   // TODO(atumanov): modify the heartbeat table protocol to use the ResourceSet directly.
   // TODO(atumanov): implement a ResourceSet const_iterator.
-  RAY_LOG(DEBUG) << "[Heartbeat] resources available: "
+  RAY_DLOG(INFO) << "[Heartbeat] resources available: "
                  << local_resources.GetAvailableResources().ToString();
   for (const auto &resource_pair :
        local_resources.GetAvailableResources().GetResourceMap()) {
@@ -294,7 +294,7 @@ void NodeManager::Heartbeat() {
       UniqueID::nil(), gcs_client_->client_table().GetLocalClientId(), heartbeat_data,
       [](ray::gcs::AsyncGcsClient *client, const ClientID &id,
          const HeartbeatTableDataT &data) {
-        RAY_LOG(DEBUG) << "[HEARTBEAT] heartbeat sent callback";
+        RAY_DLOG(INFO) << "[HEARTBEAT] heartbeat sent callback";
       });
 
   if (!status.ok()) {
@@ -314,7 +314,7 @@ void NodeManager::Heartbeat() {
 void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   ClientID client_id = ClientID::from_binary(client_data.client_id);
 
-  RAY_LOG(DEBUG) << "[ClientAdded] received callback from client id " << client_id;
+  RAY_DLOG(INFO) << "[ClientAdded] received callback from client id " << client_id;
   if (client_id == gcs_client_->client_table().GetLocalClientId()) {
     // We got a notification for ourselves, so we are connected to the GCS now.
     // Save this NodeManager's resource information in the cluster resource map.
@@ -325,11 +325,11 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   // TODO(atumanov): make remote client lookup O(1)
   if (std::find(remote_clients_.begin(), remote_clients_.end(), client_id) ==
       remote_clients_.end()) {
-    RAY_LOG(DEBUG) << "a new client: " << client_id;
+    RAY_DLOG(INFO) << "a new client: " << client_id;
     remote_clients_.push_back(client_id);
   } else {
     // NodeManager connection to this client was already established.
-    RAY_LOG(DEBUG) << "received a new client connection that already exists: "
+    RAY_DLOG(INFO) << "received a new client connection that already exists: "
                    << client_id;
     return;
   }
@@ -340,7 +340,7 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
 
   // Establish a new NodeManager connection to this GCS client.
   auto client_info = gcs_client_->client_table().GetClient(client_id);
-  RAY_LOG(DEBUG) << "[ClientAdded] CONNECTING TO: "
+  RAY_DLOG(INFO) << "[ClientAdded] CONNECTING TO: "
                  << " " << client_info.node_manager_address << " "
                  << client_info.node_manager_port;
 
@@ -355,7 +355,7 @@ void NodeManager::ClientRemoved(const ClientTableDataT &client_data) {
   // TODO(swang): If we receive a notification for our own death, clean up and
   // exit immediately.
   const ClientID client_id = ClientID::from_binary(client_data.client_id);
-  RAY_LOG(DEBUG) << "[ClientRemoved] received callback from client id " << client_id;
+  RAY_DLOG(INFO) << "[ClientRemoved] received callback from client id " << client_id;
 
   RAY_CHECK(client_id != gcs_client_->client_table().GetLocalClientId())
       << "Exiting because this node manager has mistakenly been marked dead by the "
@@ -377,7 +377,7 @@ void NodeManager::ClientRemoved(const ClientTableDataT &client_data) {
 
 void NodeManager::HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &client_id,
                                  const HeartbeatTableDataT &heartbeat_data) {
-  RAY_LOG(DEBUG) << "[HeartbeatAdded]: received heartbeat from client id " << client_id;
+  RAY_DLOG(INFO) << "[HeartbeatAdded]: received heartbeat from client id " << client_id;
   const ClientID &local_client_id = gcs_client_->client_table().GetLocalClientId();
   if (client_id == local_client_id) {
     // Skip heartbeats from self.
@@ -399,7 +399,7 @@ void NodeManager::HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &cl
   ResourceSet remote_load(heartbeat_data.resource_load_label,
                           heartbeat_data.resource_load_capacity);
   // TODO(atumanov): assert that the load is a non-empty ResourceSet.
-  RAY_LOG(DEBUG) << "[HeartbeatAdded]: received load: " << remote_load.ToString();
+  RAY_DLOG(INFO) << "[HeartbeatAdded]: received load: " << remote_load.ToString();
   remote_resources.SetAvailableResources(std::move(remote_available));
   // Extract the load information and save it locally.
   remote_resources.SetLoadResources(std::move(remote_load));
@@ -421,7 +421,7 @@ void NodeManager::HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &cl
 
 void NodeManager::HandleActorCreation(const ActorID &actor_id,
                                       const std::vector<ActorTableDataT> &data) {
-  RAY_LOG(DEBUG) << "Actor creation notification received: " << actor_id;
+  RAY_DLOG(INFO) << "Actor creation notification received: " << actor_id;
 
   // TODO(swang): In presence of failures, data may have size > 1, since the
   // actor will have been created multiple times. In that case, we should
@@ -522,7 +522,7 @@ void NodeManager::DispatchTasks() {
 void NodeManager::ProcessClientMessage(
     const std::shared_ptr<LocalClientConnection> &client, int64_t message_type,
     const uint8_t *message_data) {
-  RAY_LOG(DEBUG) << "Message of type " << message_type;
+  RAY_DLOG(INFO) << "Message of type " << message_type;
 
   auto registered_worker = worker_pool_.GetRegisteredWorker(client);
   if (registered_worker && registered_worker->IsDead()) {
@@ -622,7 +622,7 @@ void NodeManager::ProcessClientMessage(
       if (!actor_id.is_nil()) {
         // TODO(rkn): Consider broadcasting a message to all of the other
         // node managers so that they can mark the actor as dead.
-        RAY_LOG(DEBUG) << "The actor with ID " << actor_id << " died.";
+        RAY_DLOG(INFO) << "The actor with ID " << actor_id << " died.";
         auto actor_entry = actor_registry_.find(actor_id);
         RAY_CHECK(actor_entry != actor_registry_.end());
         actor_entry->second.MarkDead();
@@ -644,7 +644,7 @@ void NodeManager::ProcessClientMessage(
       cluster_resource_map_[client_id].Release(lifetime_resources.ToResourceSet());
       worker->ResetLifetimeResourceIds();
 
-      RAY_LOG(DEBUG) << "Worker (pid=" << worker->Pid() << ") is disconnected. "
+      RAY_DLOG(INFO) << "Worker (pid=" << worker->Pid() << ") is disconnected. "
                      << "driver_id: " << worker->GetAssignedDriverId();
 
       // Since some resources may have been released, we can try to dispatch more tasks.
@@ -660,7 +660,7 @@ void NodeManager::ProcessClientMessage(
       local_queues_.RemoveDriverTaskId(driver_id);
       worker_pool_.DisconnectDriver(driver);
 
-      RAY_LOG(DEBUG) << "Driver (pid=" << driver->Pid() << ") is disconnected. "
+      RAY_DLOG(INFO) << "Driver (pid=" << driver->Pid() << ") is disconnected. "
                      << "driver_id: " << driver->GetAssignedDriverId();
     }
     return;
@@ -815,13 +815,13 @@ void NodeManager::ProcessNodeManagerMessage(TcpClientConnection &node_manager_cl
 
     Lineage uncommitted_lineage(*message);
     const Task &task = uncommitted_lineage.GetEntry(task_id)->TaskData();
-    RAY_LOG(DEBUG) << "got task " << task.GetTaskSpecification().TaskId()
+    RAY_DLOG(INFO) << "got task " << task.GetTaskSpecification().TaskId()
                    << " spillback=" << task.GetTaskExecutionSpec().NumForwards();
     SubmitTask(task, uncommitted_lineage, /* forwarded = */ true);
   } break;
   case protocol::MessageType::DisconnectClient: {
     // TODO(rkn): We need to do some cleanup here.
-    RAY_LOG(DEBUG) << "Received disconnect message from remote node manager. "
+    RAY_DLOG(INFO) << "Received disconnect message from remote node manager. "
                    << "We need to do some cleanup here.";
     // Do not process any more messages from this node manager.
     return;
@@ -844,11 +844,11 @@ void NodeManager::ScheduleTasks(
   auto policy_decision = scheduling_policy_.Schedule(resource_map, local_client_id);
 
 #ifndef NDEBUG
-  RAY_LOG(DEBUG) << "[NM ScheduleTasks] policy decision:";
+  RAY_DLOG(INFO) << "[NM ScheduleTasks] policy decision:";
   for (const auto &task_client_pair : policy_decision) {
     TaskID task_id = task_client_pair.first;
     ClientID client_id = task_client_pair.second;
-    RAY_LOG(DEBUG) << task_id << " --> " << client_id;
+    RAY_DLOG(INFO) << task_id << " --> " << client_id;
   }
 #endif
 
@@ -926,7 +926,7 @@ bool NodeManager::CheckDependencyManagerInvariant() const {
 }
 
 void NodeManager::TreatTaskAsFailed(const TaskSpecification &spec) {
-  RAY_LOG(DEBUG) << "Treating task " << spec.TaskId() << " as failed.";
+  RAY_DLOG(INFO) << "Treating task " << spec.TaskId() << " as failed.";
   // Loop over the return IDs (except the dummy ID) and store a fake object in
   // the object store.
   int64_t num_returns = spec.NumReturns();
@@ -1166,7 +1166,7 @@ void NodeManager::AssignTask(Task &task) {
     return;
   }
 
-  RAY_LOG(DEBUG) << "Assigning task to worker with pid " << worker->Pid();
+  RAY_DLOG(INFO) << "Assigning task to worker with pid " << worker->Pid();
   flatbuffers::FlatBufferBuilder fbb;
 
   // Resource accounting: acquire resources for the assigned task.
@@ -1245,7 +1245,7 @@ void NodeManager::AssignTask(Task &task) {
 
 void NodeManager::FinishAssignedTask(Worker &worker) {
   TaskID task_id = worker.GetAssignedTaskId();
-  RAY_LOG(DEBUG) << "Finished task " << task_id;
+  RAY_DLOG(INFO) << "Finished task " << task_id;
 
   // (See design_docs/task_states.rst for the state transition diagram.)
   const auto task = local_queues_.RemoveTask(task_id);
@@ -1266,7 +1266,7 @@ void NodeManager::FinishAssignedTask(Worker &worker) {
     actor_notification->node_manager_id =
         gcs_client_->client_table().GetLocalClientId().binary();
     auto driver_id = task.GetTaskSpecification().DriverId();
-    RAY_LOG(DEBUG) << "Publishing actor creation: " << actor_id
+    RAY_DLOG(INFO) << "Publishing actor creation: " << actor_id
                    << " driver_id: " << driver_id;
     RAY_CHECK_OK(gcs_client_->actor_table().Append(JobID::nil(), actor_id,
                                                    actor_notification, nullptr));
@@ -1437,7 +1437,7 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
             // Timer killing will receive the boost::asio::error::operation_aborted,
             // we only handle the timeout event.
             RAY_CHECK(!error);
-            RAY_LOG(DEBUG) << "Resubmitting task " << task_id
+            RAY_DLOG(INFO) << "Resubmitting task " << task_id
                            << " because ForwardTask failed.";
             SubmitTask(task, Lineage());
           });
@@ -1470,7 +1470,7 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
   auto request = uncommitted_lineage.ToFlatbuffer(fbb, task_id);
   fbb.Finish(request);
 
-  RAY_LOG(DEBUG) << "Forwarding task " << task_id << " to " << node_id << " spillback="
+  RAY_DLOG(INFO) << "Forwarding task " << task_id << " to " << node_id << " spillback="
                  << lineage_cache_entry_task.GetTaskExecutionSpec().NumForwards();
 
   auto client_info = gcs_client_->client_table().GetClient(node_id);

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -98,7 +98,7 @@ class TestObjectManagerBase : public ::testing::Test {
 
   ObjectID WriteDataToClient(plasma::PlasmaClient &client, int64_t data_size) {
     ObjectID object_id = ObjectID::from_random();
-    RAY_LOG(DEBUG) << "ObjectID Created: " << object_id;
+    RAY_DLOG(INFO) << "ObjectID Created: " << object_id;
     uint8_t metadata[] = {5};
     int64_t metadata_size = sizeof(metadata);
     std::shared_ptr<Buffer> data;

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -68,7 +68,7 @@ ray::Status Raylet::RegisterGcs(const std::string &node_ip_address,
     client_info.resources_total_capacity.push_back(resource_pair.second);
   }
 
-  RAY_LOG(DEBUG) << "Node manager listening on: IP " << client_info.node_manager_address
+  RAY_DLOG(INFO) << "Node manager listening on: IP " << client_info.node_manager_address
                  << " port " << client_info.node_manager_port;
   RAY_RETURN_NOT_OK(gcs_client_->client_table().Connect(client_info));
 

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -18,14 +18,14 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
   // The policy decision to be returned.
   std::unordered_map<TaskID, ClientID> decision;
   // TODO(atumanov): protect DEBUG code blocks with ifdef DEBUG
-  RAY_LOG(DEBUG) << "[Schedule] cluster resource map: ";
+  RAY_DLOG(INFO) << "[Schedule] cluster resource map: ";
 
 #ifndef NDEBUG
   for (const auto &client_resource_pair : cluster_resources) {
     // pair = ClientID, SchedulingResources
     const ClientID &client_id = client_resource_pair.first;
     const SchedulingResources &resources = client_resource_pair.second;
-    RAY_LOG(DEBUG) << "client_id: " << client_id << " "
+    RAY_DLOG(INFO) << "client_id: " << client_id << " "
                    << resources.GetAvailableResources().ToString();
   }
 #endif
@@ -37,7 +37,7 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
     // Get task's resource demand
     const auto &resource_demand = t.GetTaskSpecification().GetRequiredResources();
     const TaskID &task_id = t.GetTaskSpecification().TaskId();
-    RAY_LOG(DEBUG) << "[SchedulingPolicy]: task=" << task_id
+    RAY_DLOG(INFO) << "[SchedulingPolicy]: task=" << task_id
                    << " numforwards=" << t.GetTaskExecutionSpec().NumForwards()
                    << " resources="
                    << t.GetTaskSpecification().GetRequiredResources().ToString();
@@ -53,7 +53,7 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
       available_node_resources.SubtractResourcesStrict(node_resources.GetLoadResources());
-      RAY_LOG(DEBUG) << "client_id " << node_client_id
+      RAY_DLOG(INFO) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()
                      << " load: " << node_resources.GetLoadResources().ToString()
                      << " avail-load: " << available_node_resources.ToString();

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -74,7 +74,7 @@ void TaskDependencyManager::HandleRemoteDependencyCanceled(const ObjectID &objec
 
 std::vector<TaskID> TaskDependencyManager::HandleObjectLocal(
     const ray::ObjectID &object_id) {
-  RAY_LOG(DEBUG) << "object ready " << object_id.hex();
+  RAY_DLOG(INFO) << "object ready " << object_id.hex();
   // Add the object to the table of locally available objects.
   auto inserted = local_objects_.insert(object_id);
   RAY_CHECK(inserted.second);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -106,20 +106,20 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   if (static_cast<int>(starting_worker_processes_.size()) >=
       maximum_startup_concurrency_) {
     // Workers have been started, but not registered. Force start disabled -- returning.
-    RAY_LOG(DEBUG) << starting_worker_processes_.size()
+    RAY_DLOG(INFO) << starting_worker_processes_.size()
                    << " worker processes pending registration";
     return;
   }
   auto &state = GetStateForLanguage(language);
   // Either there are no workers pending registration or the worker start is being forced.
-  RAY_LOG(DEBUG) << "Starting new worker process, current pool has "
+  RAY_DLOG(INFO) << "Starting new worker process, current pool has "
                  << state.idle_actor.size() << " actor workers, and " << state.idle.size()
                  << " non-actor workers";
 
   // Launch the process to create the worker.
   pid_t pid = fork();
   if (pid != 0) {
-    RAY_LOG(DEBUG) << "Started worker process with pid " << pid;
+    RAY_DLOG(INFO) << "Started worker process with pid " << pid;
     starting_worker_processes_.emplace(std::make_pair(pid, num_workers_per_process_));
     return;
   }
@@ -143,7 +143,7 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
 
 void WorkerPool::RegisterWorker(std::shared_ptr<Worker> worker) {
   auto pid = worker->Pid();
-  RAY_LOG(DEBUG) << "Registering worker with pid " << pid;
+  RAY_DLOG(INFO) << "Registering worker with pid " << pid;
   auto &state = GetStateForLanguage(worker->GetLanguage());
   state.registered_workers.push_back(std::move(worker));
 
@@ -238,7 +238,7 @@ std::vector<std::shared_ptr<Worker>> WorkerPool::GetWorkersRunningTasksForDriver
 
   for (const auto &entry : states_by_lang_) {
     for (const auto &worker : entry.second.registered_workers) {
-      RAY_LOG(DEBUG) << "worker: pid : " << worker->Pid()
+      RAY_DLOG(INFO) << "worker: pid : " << worker->Pid()
                      << " driver_id: " << worker->GetAssignedDriverId();
       if (worker->GetAssignedDriverId() == driver_id) {
         workers.push_back(worker);

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -20,12 +20,12 @@ class WorkerPoolMock : public WorkerPool {
   void StartWorkerProcess(pid_t pid, const Language &language = Language::PYTHON) {
     if (starting_worker_processes_.size() > 0) {
       // Workers have been started, but not registered. Force start disabled -- returning.
-      RAY_LOG(DEBUG) << starting_worker_processes_.size()
+      RAY_DLOG(INFO) << starting_worker_processes_.size()
                      << " worker processes pending registration";
       return;
     }
     // Either no workers are pending registration or the worker start is being forced.
-    RAY_LOG(DEBUG) << "starting new worker process, worker pool size " << Size(language);
+    RAY_DLOG(INFO) << "starting new worker process, worker pool size " << Size(language);
     starting_worker_processes_.emplace(std::make_pair(pid, num_workers_per_process_));
   }
 

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -13,12 +13,10 @@ namespace ray {
 // which is independent of any libs.
 class CerrLog {
  public:
-  CerrLog(int severity) : severity_(severity), has_logged_(false) {}
+  CerrLog(int severity) : severity_(severity) {}
 
   virtual ~CerrLog() {
-    if (has_logged_) {
-      std::cerr << std::endl;
-    }
+    std::cerr << std::endl;
     if (severity_ == RAY_FATAL) {
       PrintBackTrace();
       std::abort();
@@ -26,22 +24,17 @@ class CerrLog {
   }
 
   std::ostream &Stream() {
-    has_logged_ = true;
     return std::cerr;
   }
 
   template <class T>
   CerrLog &operator<<(const T &t) {
-    if (severity_ != RAY_DEBUG) {
-      has_logged_ = true;
-      std::cerr << t;
-    }
+    std::cerr << t;
     return *this;
   }
 
  protected:
   const int severity_;
-  bool has_logged_;
 
   void PrintBackTrace() {
 #if defined(_EXECINFO_H) || !defined(_WIN32)
@@ -61,8 +54,6 @@ using namespace google;
 // Glog's severity map.
 static int GetMappedSeverity(int severity) {
   switch (severity) {
-  case RAY_DEBUG:
-    return GLOG_INFO;
   case RAY_INFO:
     return GLOG_INFO;
   case RAY_WARNING:

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -27,7 +27,6 @@ typedef ray::CerrLog LoggingProvider;
 namespace ray {
 // Log levels. LOG ignores them, so their values are abitrary.
 
-#define RAY_DEBUG (-1)
 #define RAY_INFO 0
 #define RAY_WARNING 1
 #define RAY_ERROR 2
@@ -36,6 +35,17 @@ namespace ray {
 #define RAY_LOG_INTERNAL(level) ::ray::RayLog(__FILE__, __LINE__, level)
 
 #define RAY_LOG(level) RAY_LOG_INTERNAL(RAY_##level)
+#ifndef NDEBUG
+#define RAY_DLOG(level) RAY_LOG_INTERNAL(RAY_##level)
+#else
+// The following makes sure that the whole statement will be optimized out
+// by the compiler. We need the RAY_LOG_INTERNAL line so the statement after
+// macro substitution will still be well-formed. This trick is borrowed from
+// glog, see the definition of RAW_DLOG in src/glog/raw_logging.h.in.
+#define RAY_DLOG(level)           \
+  while (false)                   \
+    RAY_LOG_INTERNAL(RAY_##level)
+#endif
 #define RAY_IGNORE_EXPR(expr) ((void)(expr))
 
 #define RAY_CHECK(condition)                                                          \

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -42,9 +42,8 @@ namespace ray {
 // by the compiler. We need the RAY_LOG_INTERNAL line so the statement after
 // macro substitution will still be well-formed. This trick is borrowed from
 // glog, see the definition of RAW_DLOG in src/glog/raw_logging.h.in.
-#define RAY_DLOG(level)           \
-  while (false)                   \
-    RAY_LOG_INTERNAL(RAY_##level)
+#define RAY_DLOG(level) \
+  while (false) RAY_LOG_INTERNAL(RAY_##level)
 #endif
 #define RAY_IGNORE_EXPR(expr) ((void)(expr))
 

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -18,7 +18,7 @@ int64_t current_time_ms() {
 // This file just print some information using the logging macro.
 
 void PrintLog() {
-  RAY_LOG(DEBUG) << "This is the"
+  RAY_DLOG(INFO) << "This is the"
                  << " DEBUG"
                  << " message";
   RAY_LOG(INFO) << "This is the"
@@ -41,7 +41,7 @@ TEST(PrintLogTest, LogTestWithoutInit) {
 
 TEST(PrintLogTest, LogTestWithInit) {
   // Test empty app name.
-  RayLog::StartRayLog("", RAY_DEBUG);
+  RayLog::StartRayLog("", RAY_INFO);
   PrintLog();
   RayLog::ShutDownRayLog();
 }
@@ -53,7 +53,7 @@ TEST(LogPerfTest, PerfTest) {
 
   int64_t start_time = current_time_ms();
   for (int i = 0; i < rounds; ++i) {
-    RAY_LOG(DEBUG) << "This is the "
+    RAY_DLOG(INFO) << "This is the "
                    << "RAY_DEBUG message";
   }
   int64_t elapsed = current_time_ms() - start_time;


### PR DESCRIPTION
This PR makes it so debugging logs are only evaluated during debugging. We found that for the current code, functions called in debug logging code are evaluated even in release mode (even though nothing is printed).

(see also "Debug Mode" in http://rpg.ifi.uzh.ch/docs/glog.html)

cc @stephanie-wang