### PR TITLE
Re-raise actor initialization errors on method invocation

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -24,22 +24,6 @@ from ray.utils import (
 
 DEFAULT_ACTOR_METHOD_NUM_RETURN_VALS = 1
 
-_actor_init_error = None
-
-
-def mark_actor_init_failed(error):
-    """Called to mark this actor as failed during initialization."""
-
-    global _actor_init_error
-    _actor_init_error = error
-
-
-def reraise_actor_init_error():
-    """Raises any previous actor initialization error."""
-
-    if _actor_init_error is not None:
-        raise _actor_init_error
-
 
 def is_classmethod(f):
     """Returns whether the given method is a classmethod."""
@@ -382,7 +366,7 @@ def fetch_and_register_actor(actor_class_key, worker):
             traceback_str,
             driver_id,
             data={"actor_id": actor_id_str})
-        mark_actor_init_failed(e)
+        worker.mark_actor_init_failed(e)
 
 
 def publish_actor_class_to_key(key, actor_class_info, worker):
@@ -1085,6 +1069,4 @@ def make_actor(cls, num_cpus, num_gpus, resources, actor_method_cpus,
 
 
 ray.worker.global_worker.fetch_and_register_actor = fetch_and_register_actor
-ray.worker.global_worker.mark_actor_init_failed = mark_actor_init_failed
-ray.worker.global_worker.reraise_actor_init_error = reraise_actor_init_error
 ray.worker.global_worker.make_actor = make_actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -6,7 +6,6 @@ import copy
 import hashlib
 import inspect
 import json
-import sys
 import traceback
 
 import ray.cloudpickle as pickle

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -57,7 +57,6 @@ class Trainable(object):
                 object. If unspecified, a default logger is created.
         """
 
-        self._initialize_ok = False
         self._experiment_id = uuid.uuid4().hex
         self.config = config or {}
 
@@ -76,7 +75,6 @@ class Trainable(object):
         self._time_total = 0.0
         self._timesteps_total = None
         self._setup()
-        self._initialize_ok = True
         self._local_ip = ray.services.get_node_ip_address()
 
     @classmethod
@@ -133,10 +131,6 @@ class Trainable(object):
         Returns:
             A dict that describes training progress.
         """
-
-        if not self._initialize_ok:
-            raise ValueError(
-                "Trainable initialization failed, see previous errors")
 
         start = time.time()
         result = self._train()
@@ -271,9 +265,8 @@ class Trainable(object):
     def stop(self):
         """Releases all resources used by this trainable."""
 
-        if self._initialize_ok:
-            self._result_logger.close()
-            self._stop()
+        self._result_logger.close()
+        self._stop()
 
     def _train(self):
         """Subclasses should override this to implement train().

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -909,7 +909,8 @@ class Worker(object):
 
         # Get task arguments from the object store.
         try:
-            self.reraise_actor_init_error()
+            if function_name != "__ray_terminate__":
+                self.reraise_actor_init_error()
             with profiling.profile("task:deserialize_arguments", worker=self):
                 arguments = self._get_arguments_for_execution(
                     function_name, args)
@@ -977,7 +978,7 @@ class Worker(object):
                 "function_name": function_name
             })
         # Mark the actor init as failed
-        if self.actor_id and function_name == "__init__":
+        if self.actor_id != NIL_ACTOR_ID and function_name == "__init__":
             self.mark_actor_init_failed(error)
 
     def _become_actor(self, task):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1031,6 +1031,7 @@ class Worker(object):
         # because that may indicate that the system is hanging, and it'd be
         # good to know where the system is hanging.
         with self.lock:
+
             function_name = (self.function_execution_info[driver_id][
                 function_id.id()]).function_name
             if not self.use_raylet:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -233,8 +233,7 @@ class Worker(object):
         self.cached_remote_functions_and_actors = []
         self.cached_functions_to_run = []
         self.fetch_and_register_actor = None
-        self.mark_actor_init_failed = None
-        self.reraise_actor_init_error = None
+        self.actor_init_error = None
         self.make_actor = None
         self.actors = {}
         self.actor_task_counter = 0
@@ -255,6 +254,17 @@ class Worker(object):
         self.serialization_context_map = {}
         # Identity of the driver that this worker is processing.
         self.task_driver_id = None
+
+    def mark_actor_init_failed(self, error):
+        """Called to mark this actor as failed during initialization."""
+
+        self.actor_init_error = error
+
+    def reraise_actor_init_error(self):
+        """Raises any previous actor initialization error."""
+
+        if self.actor_init_error is not None:
+            raise self.actor_init_error
 
     def get_serialization_context(self, driver_id):
         """Get the SerializationContext of the driver that this worker is processing.

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -31,6 +31,24 @@ def shutdown_only():
     ray.shutdown()
 
 
+def test_actor_init_error_propagated(ray_start_regular):
+    @ray.remote
+    class Actor(object):
+        def __init__(self, error=False):
+            if error:
+                raise Exception("oops")
+
+        def foo(self):
+            return "OK"
+
+    actor = Actor.remote(error=False)
+    ray.get(actor.foo.remote())
+
+    actor = Actor.remote(error=True)
+    with pytest.raises(Exception, match=".*oops.*"):
+        ray.get(actor.foo.remote())
+
+
 def test_keyword_args(ray_start_regular):
     @ray.remote
     class Actor(object):


### PR DESCRIPTION
## What do these changes do?

If an actor constructor fails, save that error and re-raise it on any subsequent attempts to interact with the actor.

## Related issue number

https://github.com/ray-project/ray/issues/282
https://github.com/ray-project/ray/issues/1093