### PR TITLE
[rllib] Adds agent name & env id to default logdir prefix

### DIFF
--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -7,6 +7,8 @@ import json
 import numpy as np
 import os
 import pickle
+import tempfile
+from datetime import datetime
 
 import tensorflow as tf
 from ray.rllib.evaluation.policy_evaluator import PolicyEvaluator
@@ -16,8 +18,7 @@ from ray.tune.registry import ENV_CREATOR, _global_registry
 from ray.tune.trainable import Trainable
 from ray.tune.logger import UnifiedLogger
 from ray.tune.result import DEFAULT_RESULTS_DIR
-from datetime import datetime
-import tempfile
+
 
 COMMON_CONFIG = {
     # Discount factor of the MDP
@@ -197,9 +198,8 @@ class Agent(Trainable):
 
         # Create a default logger creator if no logger_creator is specified
         if logger_creator is None:
-            logdir_prefix = self._agent_name + "_" + \
-                            self._env_id + "_" + \
-                            datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+            timestr = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+            logdir_prefix = '_'.join([self._agent_name, self._env_id, timestr])
 
             def default_logger_creator(config):
                 """Creates a Unified logger with a default logdir prefix

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -14,6 +14,10 @@ from ray.rllib.optimizers.policy_optimizer import PolicyOptimizer
 from ray.rllib.utils import FilterManager, deep_update, merge_dicts
 from ray.tune.registry import ENV_CREATOR, _global_registry
 from ray.tune.trainable import Trainable
+from ray.tune.logger import UnifiedLogger
+from ray.tune.result import DEFAULT_RESULTS_DIR
+from datetime import datetime
+import tempfile
 
 COMMON_CONFIG = {
     # Discount factor of the MDP
@@ -190,6 +194,25 @@ class Agent(Trainable):
 
         # Agents allow env ids to be passed directly to the constructor.
         self._env_id = env or config.get("env")
+
+        # Create a default logger creator if no logger_creator is specified
+        if logger_creator is None:
+            logdir_prefix = self._agent_name + "_" + \
+                            self._env_id + "_" + \
+                            datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+
+            def default_logger_creator(config):
+                """Creates a Unified logger with a default logdir prefix
+                containing the agent name and the env id
+                """
+                if not os.path.exists(DEFAULT_RESULTS_DIR):
+                    os.makedirs(DEFAULT_RESULTS_DIR)
+                logdir = tempfile.mkdtemp(
+                    prefix=logdir_prefix, dir=DEFAULT_RESULTS_DIR)
+                return UnifiedLogger(config, logdir, None)
+
+            logger_creator = default_logger_creator
+
         Trainable.__init__(self, config, logger_creator)
 
     def train(self):

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -19,7 +19,6 @@ from ray.tune.trainable import Trainable
 from ray.tune.logger import UnifiedLogger
 from ray.tune.result import DEFAULT_RESULTS_DIR
 
-
 COMMON_CONFIG = {
     # Discount factor of the MDP
     "gamma": 0.99,

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -64,9 +64,7 @@ class Trainable(object):
             self._result_logger = logger_creator(self.config)
             self.logdir = self._result_logger.logdir
         else:
-            logdir_prefix = self._agent_name + "_" + \
-                            self._env_id + "_" + \
-                            datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+            logdir_prefix = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
             if not os.path.exists(DEFAULT_RESULTS_DIR):
                 os.makedirs(DEFAULT_RESULTS_DIR)
             self.logdir = tempfile.mkdtemp(

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -64,7 +64,9 @@ class Trainable(object):
             self._result_logger = logger_creator(self.config)
             self.logdir = self._result_logger.logdir
         else:
-            logdir_prefix = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+            logdir_prefix = self._agent_name + "_" + \
+                            self._env_id + "_" + \
+                            datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
             if not os.path.exists(DEFAULT_RESULTS_DIR):
                 os.makedirs(DEFAULT_RESULTS_DIR)
             self.logdir = tempfile.mkdtemp(


### PR DESCRIPTION
## What do these changes do?

Adds the agent's name and env id to the default logdir prefix so that the experiments run using the Rllib Python API generates log directories that are much more identifiable/useful (Eg. on the log dashboard). Issue described in #2855 

**Example:**
Current prefix: `2018-09-10_19-10`
prefix enabled by this PR: `PPO_Pendulum-v0_2018-09-10_19-10`


## Related issue number
 #2855
