### PR TITLE
[tune] Fix bug in example where config hyperparameters were ignored

### DIFF
--- a/python/ray/tune/examples/pbt_tune_cifar10_with_keras.py
+++ b/python/ray/tune/examples/pbt_tune_cifar10_with_keras.py
@@ -110,7 +110,8 @@ class Cifar10Model(Trainable):
         x_train = self.train_data[0]
         model = self._build_model(x_train.shape[1:])
 
-        opt = tf.keras.optimizers.Adadelta()
+        opt = tf.keras.optimizers.Adadelta(
+            lr=self.config["lr"], decay=self.config["decay"])
         model.compile(
             loss="categorical_crossentropy",
             optimizer=opt,


### PR DESCRIPTION
## What do these changes do?
A fix to an example for tune (`python/ray/tune/examples/pbt_tune_cifar10_with_keras.py`) where the hyperparameters for the optimizer, learning rate and decay, were not being passed into the optimizer. 

This means that the current optimizer uses default values for the hyperparameters no matter the config.

## Related issue number
