### PR TITLE
Evaluate debug logging only in debug mode

### DIFF
--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -35,9 +35,8 @@ namespace ray {
 
 #define RAY_LOG_INTERNAL(level) ::ray::RayLog(__FILE__, __LINE__, level)
 
-#define RAY_LOG(level)                            \
-  if (ray::RayLog::IsLevelEnabled(RAY_##level))   \
-    RAY_LOG_INTERNAL(RAY_##level)
+#define RAY_LOG(level) \
+  if (ray::RayLog::IsLevelEnabled(RAY_##level)) RAY_LOG_INTERNAL(RAY_##level)
 
 #define RAY_IGNORE_EXPR(expr) ((void)(expr))
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -35,7 +35,10 @@ namespace ray {
 
 #define RAY_LOG_INTERNAL(level) ::ray::RayLog(__FILE__, __LINE__, level)
 
-#define RAY_LOG(level) RAY_LOG_INTERNAL(RAY_##level)
+#define RAY_LOG(level)                            \
+  if (ray::RayLog::IsLevelEnabled(RAY_##level))   \
+    RAY_LOG_INTERNAL(RAY_##level)
+
 #define RAY_IGNORE_EXPR(expr) ((void)(expr))
 
 #define RAY_CHECK(condition)                                                          \


### PR DESCRIPTION
This PR makes it so debugging logs are only evaluated during debugging. We found that for the current code, functions called in debug logging code are evaluated even in release mode (even though nothing is printed).

cc @stephanie-wang
