### PR TITLE
Fix common dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src/global_scheduler/)
 # final target copy_ray
 add_custom_target(copy_ray ALL)
 
-# Make sure redis-server is ready before copying.
-add_dependencies(copy_ray copy_redis)
+# Make sure redis module is ready before copying.
 add_dependencies(copy_ray ray_redis_module)
 
 # copy plasma_store_server
@@ -131,7 +130,7 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     list(APPEND build_ray_file_list ${CMAKE_BINARY_DIR}/${file})
   endforeach()
 
-  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list})
+  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis)
   add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.
@@ -160,4 +159,3 @@ if ("${CMAKE_RAY_LANG_JAVA}" STREQUAL "YES")
   add_custom_command(TARGET copy_ray POST_BUILD
     COMMAND bash -c "cp ${ARROW_HOME}/lib/libplasma_java.* ${CMAKE_CURRENT_BINARY_DIR}/src/plasma")
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,6 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src/global_scheduler/)
 # final target copy_ray
 add_custom_target(copy_ray ALL)
 
-# Make sure redis module is ready before copying.
-add_dependencies(copy_ray ray_redis_module)
-
 # copy plasma_store_server
 add_custom_command(TARGET copy_ray POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E
@@ -130,7 +127,7 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     list(APPEND build_ray_file_list ${CMAKE_BINARY_DIR}/${file})
   endforeach()
 
-  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis)
+  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
   add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -20,6 +20,8 @@ set(OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/format/)
 set(COMMON_FBS_OUTPUT_FILES
   "${OUTPUT_DIR}/common_generated.h")
 
+add_custom_target(gen_common_fbs DEPENDS ${COMMON_FBS_OUTPUT_FILES})
+
 add_custom_command(
   OUTPUT ${COMMON_FBS_OUTPUT_FILES}
   # The --gen-object-api flag generates a C++ class MessageT for each

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(local_scheduler_client STATIC local_scheduler_client.cc)
 add_dependencies(local_scheduler_client gen_local_scheduler_fbs ${COMMON_FBS_OUTPUT_FILES} gen_gcs_fbs gen_node_manager_fbs)
 
 add_executable(local_scheduler local_scheduler.cc local_scheduler_algorithm.cc)
+add_dependencies(local_scheduler hiredis)
 target_link_libraries(local_scheduler local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})
 
 add_executable(local_scheduler_tests test/local_scheduler_tests.cc local_scheduler.cc local_scheduler_algorithm.cc)

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -47,13 +47,14 @@ add_dependencies(gen_local_scheduler_fbs arrow_ep)
 add_library(local_scheduler_client STATIC local_scheduler_client.cc)
 
 # local_scheduler_shared.h includes ray/gcs/client.h which requires gen_gcs_fbs & gen_node_manager_fbs.
-add_dependencies(local_scheduler_client gen_local_scheduler_fbs ${COMMON_FBS_OUTPUT_FILES} gen_gcs_fbs gen_node_manager_fbs)
+add_dependencies(local_scheduler_client hiredis gen_local_scheduler_fbs ${COMMON_FBS_OUTPUT_FILES} gen_gcs_fbs gen_node_manager_fbs)
 
 add_executable(local_scheduler local_scheduler.cc local_scheduler_algorithm.cc)
 add_dependencies(local_scheduler hiredis)
 target_link_libraries(local_scheduler local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})
 
 add_executable(local_scheduler_tests test/local_scheduler_tests.cc local_scheduler.cc local_scheduler_algorithm.cc)
+add_dependencies(local_scheduler_tests hiredis)
 target_link_libraries(local_scheduler_tests local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})
 target_compile_options(local_scheduler_tests PUBLIC "-DLOCAL_SCHEDULER_TEST")
 

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -67,7 +67,7 @@ set(RAY_LIB_DEPENDENCIES
     gen_object_manager_fbs
     gen_node_manager_fbs
     gen_local_scheduler_fbs
-    ${COMMON_FBS_OUTPUT_FILES})
+    gen_common_fbs)
 
 if(RAY_USE_GLOG)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DRAY_USE_GLOG")


### PR DESCRIPTION
This might fix the following issue:

```
    [ 22%] Running flatc compiler on /home/ubuntu/ray/src/ray/raylet/format/node_manager.fbs
    Running flatc compiler on /home/ubuntu/ray/src/ray/raylet/format/node_manager.fbs
    [ 22%] Built target gen_node_manager_fbs
    Scanning dependencies of target ray_objlib
    [ 23%] Building CXX object src/ray/CMakeFiles/ray_objlib.dir/id.cc.o
    [ 23%] Building CXX object src/ray/CMakeFiles/ray_objlib.dir/status.cc.o
    [ 24%] Building CXX object src/ray/CMakeFiles/ray_objlib.dir/gcs/client.cc.o
    In file included from /home/ubuntu/ray/src/ray/gcs/tables.h:22:0,
                     from /home/ubuntu/ray/src/ray/gcs/client.h:9,
                     from /home/ubuntu/ray/src/ray/gcs/client.cc:1:
    /home/ubuntu/ray/src/common/task.h:12:37: fatal error: format/common_generated.h: No such file or directory
    compilation terminated.
    src/ray/CMakeFiles/ray_objlib.dir/build.make:110: recipe for target 'src/ray/CMakeFiles/ray_objlib.dir/gcs/client.cc.o' failed
    make[2]: *** [src/ray/CMakeFiles/ray_objlib.dir/gcs/client.cc.o] Error 1
    CMakeFiles/Makefile2:522: recipe for target 'src/ray/CMakeFiles/ray_objlib.dir/all' failed
    make[1]: *** [src/ray/CMakeFiles/ray_objlib.dir/all] Error 2
    Makefile:138: recipe for target 'all' failed
    make: *** [all] Error 2
```

I thought the code that is there already does the right thing, but maybe not. This is how we do it for the other fbs headers so it should work.

cc @richardliaw 