### PR TITLE
Remove dependence on psutil. Add utility functions for getting system memory.

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -7,7 +7,6 @@ numpy
 opencv-python
 pyarrow
 pyyaml
-psutil
 recommonmark
 redis
 sphinx

--- a/doc/source/resources.rst
+++ b/doc/source/resources.rst
@@ -32,8 +32,8 @@ through ``ray.init``, do the following.
   ray.init(num_cpus=8, num_gpus=1)
 
 If the number of CPUs is unspecified, Ray will automatically determine the
-number by running ``psutil.cpu_count()``. If the number of GPUs is unspecified,
-Ray will attempt to automatically detect the number of GPUs.
+number by running ``multiprocessing.cpu_count()``. If the number of GPUs is
+unspecified, Ray will attempt to automatically detect the number of GPUs.
 
 Specifying a task's CPU and GPU requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/ray/local_scheduler/local_scheduler_services.py
+++ b/python/ray/local_scheduler/local_scheduler_services.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import multiprocessing
 import os
-import psutil
 import random
 import subprocess
 import sys
@@ -108,7 +108,7 @@ def start_local_scheduler(plasma_store_name,
             for resource_name, resource_quantity in static_resources.items()
         ])
     else:
-        resource_argument = "CPU,{}".format(psutil.cpu_count())
+        resource_argument = "CPU,{}".format(multiprocessing.cpu_count())
     command += ["-c", resource_argument]
 
     if use_valgrind:

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -7,6 +7,7 @@ import functools
 import hashlib
 import numpy as np
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -264,6 +265,68 @@ def resources_from_resource_arguments(default_num_cpus, default_num_gpus,
         resources["GPU"] = default_num_gpus
 
     return resources
+
+
+# This function is copied and modified from
+# https://github.com/giampaolo/psutil/blob/5bd44f8afcecbfb0db479ce230c790fc2c56569a/psutil/tests/test_linux.py#L132-L138  # noqa: E501
+def vmstat(stat):
+    """Run vmstat and get a particular statistic.
+
+    Args:
+        stat: The statistic that we are interested in retrieving.
+
+    Returns:
+        The parsed output.
+    """
+    out = subprocess.check_output(["vmstat", "-s"])
+    stat = stat.encode("ascii")
+    for line in out.split("\n"):
+        line = line.strip()
+        if stat in line:
+            return int(line.split(b" ")[0])
+    raise ValueError("Can't find {} in 'vmstat' output.".format(stat))
+
+
+# This function is copied and modified from
+# https://github.com/giampaolo/psutil/blob/5e90b0a7f3fccb177445a186cc4fac62cfadb510/psutil/tests/test_osx.py#L29-L38  # noqa: E501
+def sysctl(command):
+    """Run a sysctl command and parse the output.
+
+    Args:
+        command: A sysctl command with an argument, for example,
+            ["sysctl", "hw.memsize"].
+
+    Returns:
+        The parsed output.
+    """
+    out = subprocess.check_output(command)
+    result = out.split(b" ")[1]
+    try:
+        return int(result)
+    except ValueError:
+        return result
+
+
+def get_system_memory():
+    """Return the total amount of system memory in bytes.
+
+    Returns:
+        The total amount of system memory in bytes.
+    """
+    # Use psutil if it is available.
+    try:
+        import psutil
+        return psutil.virtual_memory().total
+    except ImportError:
+        pass
+
+    if sys.platform == "linux" or sys.platform == "linux2":
+        # Handle Linux.
+        bytes_in_kilobyte = 1024
+        return vmstat("total memory") * bytes_in_kilobyte
+    else:
+        # Handle MacOS.
+        return sysctl(["sysctl", "hw.memsize"])
 
 
 def check_oversized_pickle(pickled, name, obj_type, worker):

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -280,7 +280,7 @@ def vmstat(stat):
     """
     out = subprocess.check_output(["vmstat", "-s"])
     stat = stat.encode("ascii")
-    for line in out.split("\n"):
+    for line in out.split(b"\n"):
         line = line.strip()
         if stat in line:
             return int(line.split(b" ")[0])

--- a/python/setup.py
+++ b/python/setup.py
@@ -134,7 +134,6 @@ setup(
         "funcsigs",
         "click",
         "colorama",
-        "psutil",
         "pytest",
         "pyyaml",
         "redis",

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -169,7 +169,7 @@ def ray_start_reconstruction(request):
         manager_stdout_file, manager_stderr_file = (ray.services.new_log_files(
             "plasma_manager_{}".format(i), True))
         plasma_addresses.append(
-            ray.services.start_objstore(
+            ray.services.start_plasma_store(
                 node_ip_address,
                 redis_address,
                 objstore_memory=objstore_memory,


### PR DESCRIPTION
This removes the dependence on psutil. We really only needed psutil to get the cpu count, which we can do with multiprocessing, and to get the memory size. Memory size is a bit trickier. I used some code from the psutil tests to try to do the same thing.

This fixes #2806.

**To look into before merging:**
- [x] Try on more platforms (e.g., CentOS).
- [x] Make sure license is ok (psutil is BSD I believe)