### PR TITLE
 Modularize NodeManager::ProcessClientMessage

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -163,9 +163,11 @@ ray::Status NodeManager::RegisterGcs() {
       task_lease_notification_callback, task_lease_empty_callback, nullptr));
 
   // Register a callback for actor creation notifications.
-  auto actor_creation_callback = [this](
-      gcs::AsyncGcsClient *client, const ActorID &actor_id,
-      const std::vector<ActorTableDataT> &data) { HandleActorCreation(actor_id, data); };
+  auto actor_creation_callback = [this](gcs::AsyncGcsClient *client,
+                                        const ActorID &actor_id,
+                                        const std::vector<ActorTableDataT> &data) {
+    HandleActorCreation(actor_id, data);
+  };
 
   RAY_RETURN_NOT_OK(gcs_client_->actor_table().Subscribe(
       UniqueID::nil(), UniqueID::nil(), actor_creation_callback, nullptr));
@@ -177,10 +179,9 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientAddedCallback(node_manager_client_added);
   // Register a callback on the client table for removed clients.
-  auto node_manager_client_removed = [this](
-      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
-    ClientRemoved(data);
-  };
+  auto node_manager_client_removed =
+      [this](gcs::AsyncGcsClient *client, const UniqueID &id,
+             const ClientTableDataT &data) { ClientRemoved(data); };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
   // Subscribe to node manager heartbeats.
@@ -195,11 +196,11 @@ ray::Status NodeManager::RegisterGcs() {
       }));
 
   // Subscribe to driver table updates.
-  const auto driver_table_handler = [this](
-      gcs::AsyncGcsClient *client, const ClientID &client_id,
-      const std::vector<DriverTableDataT> &driver_data) {
-    HandleDriverTableUpdate(client_id, driver_data);
-  };
+  const auto driver_table_handler =
+      [this](gcs::AsyncGcsClient *client, const ClientID &client_id,
+             const std::vector<DriverTableDataT> &driver_data) {
+        HandleDriverTableUpdate(client_id, driver_data);
+      };
   RAY_RETURN_NOT_OK(gcs_client_->driver_table().Subscribe(JobID::nil(), UniqueID::nil(),
                                                           driver_table_handler, nullptr));
 
@@ -1388,7 +1389,6 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);
-
       }));
 }
 
@@ -1553,9 +1553,8 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
     // lineage cache since the receiving node is now responsible for writing
     // the task to the GCS.
     if (!lineage_cache_.RemoveWaitingTask(task_id)) {
-      RAY_LOG(WARNING) << "Task " << task_id << " already removed from the lineage "
-                                                "cache. This is most likely due to "
-                                                "reconstruction.";
+      RAY_LOG(WARNING) << "Task " << task_id << " already removed from the lineage cache."
+                       << " This is most likely due to reconstruction.";
     }
     // Mark as forwarded so that the task and its lineage is not re-forwarded
     // in the future to the receiving node.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -546,6 +546,8 @@ void NodeManager::ProcessClientMessage(
   } break;
   case protocol::MessageType::DisconnectClient: {
     ProcessDisconnectClientMessage(client);
+    // We don't need to receive future messages from this client,
+    // because it's already disconnected.
     return;
   } break;
   case protocol::MessageType::SubmitTask: {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -163,11 +163,9 @@ ray::Status NodeManager::RegisterGcs() {
       task_lease_notification_callback, task_lease_empty_callback, nullptr));
 
   // Register a callback for actor creation notifications.
-  auto actor_creation_callback = [this](gcs::AsyncGcsClient *client,
-                                        const ActorID &actor_id,
-                                        const std::vector<ActorTableDataT> &data) {
-    HandleActorCreation(actor_id, data);
-  };
+  auto actor_creation_callback = [this](
+      gcs::AsyncGcsClient *client, const ActorID &actor_id,
+      const std::vector<ActorTableDataT> &data) { HandleActorCreation(actor_id, data); };
 
   RAY_RETURN_NOT_OK(gcs_client_->actor_table().Subscribe(
       UniqueID::nil(), UniqueID::nil(), actor_creation_callback, nullptr));
@@ -179,9 +177,10 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientAddedCallback(node_manager_client_added);
   // Register a callback on the client table for removed clients.
-  auto node_manager_client_removed =
-      [this](gcs::AsyncGcsClient *client, const UniqueID &id,
-             const ClientTableDataT &data) { ClientRemoved(data); };
+  auto node_manager_client_removed = [this](
+      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
+    ClientRemoved(data);
+  };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
   // Subscribe to node manager heartbeats.
@@ -196,11 +195,11 @@ ray::Status NodeManager::RegisterGcs() {
       }));
 
   // Subscribe to driver table updates.
-  const auto driver_table_handler =
-      [this](gcs::AsyncGcsClient *client, const ClientID &client_id,
-             const std::vector<DriverTableDataT> &driver_data) {
-        HandleDriverTableUpdate(client_id, driver_data);
-      };
+  const auto driver_table_handler = [this](
+      gcs::AsyncGcsClient *client, const ClientID &client_id,
+      const std::vector<DriverTableDataT> &driver_data) {
+    HandleDriverTableUpdate(client_id, driver_data);
+  };
   RAY_RETURN_NOT_OK(gcs_client_->driver_table().Subscribe(JobID::nil(), UniqueID::nil(),
                                                           driver_table_handler, nullptr));
 
@@ -1391,6 +1390,7 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);
+
       }));
 }
 
@@ -1555,8 +1555,9 @@ ray::Status NodeManager::ForwardTask(const Task &task, const ClientID &node_id) 
     // lineage cache since the receiving node is now responsible for writing
     // the task to the GCS.
     if (!lineage_cache_.RemoveWaitingTask(task_id)) {
-      RAY_LOG(WARNING) << "Task " << task_id << " already removed from the lineage cache."
-                       << " This is most likely due to reconstruction.";
+      RAY_LOG(WARNING) << "Task " << task_id << " already removed from the lineage "
+                                                "cache. This is most likely due to "
+                                                "reconstruction.";
     }
     // Mark as forwarded so that the task and its lineage is not re-forwarded
     // in the future to the receiving node.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -266,6 +266,24 @@ class NodeManager {
   /// \return True if the invariants are satisfied and false otherwise.
   bool CheckDependencyManagerInvariant() const;
 
+  void ProcessRegisterClientRequestMessage(
+      const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
+
+  void ProcessGetTaskMessage(const std::shared_ptr<LocalClientConnection> &client);
+
+  void ProcessDisconnectClientMessage(
+      const std::shared_ptr<LocalClientConnection> &client);
+
+  void ProcessSubmitTaskMessage(const uint8_t *message_data);
+
+  void ProcessReconstructObjectsMessage(
+      const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
+
+  void ProcessWaitRequestMessage(const std::shared_ptr<LocalClientConnection> &client,
+                                 const uint8_t *message_data);
+
+  void ProcessPushErrorRequestMessage(const uint8_t *message_data);
+
   boost::asio::io_service &io_service_;
   ObjectManager &object_manager_;
   /// A Plasma object store client. This is used exclusively for creating new

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -59,10 +59,10 @@ class NodeManager {
   ///
   /// \param client The client that sent the message.
   /// \param message_type The message type (e.g., a flatbuffer enum).
-  /// \param message A pointer to the message data.
+  /// \param message_data A pointer to the message data.
   /// \return Void.
   void ProcessClientMessage(const std::shared_ptr<LocalClientConnection> &client,
-                            int64_t message_type, const uint8_t *message);
+                            int64_t message_type, const uint8_t *message_data);
 
   /// Handle a new node manager connection.
   ///
@@ -266,22 +266,53 @@ class NodeManager {
   /// \return True if the invariants are satisfied and false otherwise.
   bool CheckDependencyManagerInvariant() const;
 
+  /// Process client message of RegisterClientRequest
+  //
+  /// \param client The client that sent the message.
+  /// \param message_data A pointer to the message data.
+  /// \return Void.
   void ProcessRegisterClientRequestMessage(
       const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
 
+  /// Process client message of GetTask
+  //
+  /// \param client The client that sent the message.
+  /// \return Void.
   void ProcessGetTaskMessage(const std::shared_ptr<LocalClientConnection> &client);
 
+  /// Process client message of DisconnectClient
+  //
+  /// \param client The client that sent the message.
+  /// \return Void.
   void ProcessDisconnectClientMessage(
       const std::shared_ptr<LocalClientConnection> &client);
 
+  /// Process client message of SubmitTask
+  //
+  /// \param message_data A pointer to the message data.
+  /// \return Void.
   void ProcessSubmitTaskMessage(const uint8_t *message_data);
 
+  /// Process client message of ReconstructObjects
+  //
+  /// \param client The client that sent the message.
+  /// \param message_data A pointer to the message data.
+  /// \return Void.
   void ProcessReconstructObjectsMessage(
       const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
 
+  /// Process client message of WaitRequest
+  //
+  /// \param client The client that sent the message.
+  /// \param message_data A pointer to the message data.
+  /// \return Void.
   void ProcessWaitRequestMessage(const std::shared_ptr<LocalClientConnection> &client,
                                  const uint8_t *message_data);
 
+  /// Process client message of PushErrorRequest
+  //
+  /// \param message_data A pointer to the message data.
+  /// \return Void.
   void ProcessPushErrorRequestMessage(const uint8_t *message_data);
 
   boost::asio::io_service &io_service_;


### PR DESCRIPTION
Split NodeManager::ProcessClientMessage into a couple of smaller functions, each of which handles one type of message.