### PR TITLE
Fix regression in directing worker output to stdout/stderr.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1544,7 +1544,7 @@ def start_ray_processes(address_info=None,
             local_scheduler_stdout_file, local_scheduler_stderr_file = (
                 new_log_files(
                     "local_scheduler_{}".format(i),
-                    redirect_output=redirect_output))
+                    redirect_output=redirect_worker_output))
             local_scheduler_name = start_local_scheduler(
                 redis_address,
                 node_ip_address,


### PR DESCRIPTION
This fixes a bug introduced in #2853. Currently, if you define

```python
import ray
ray.init()

@ray.remote
def f():
    print('XXXXXX')
```

and then run `f.remote()` it will print nothing.

After this PR, it will print `XXXXXX` (in STDOUT).

cc @chuxi @ericl 