### PR TITLE
Fix node manager failure when ClientTable has a  disconnected entry.

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -341,8 +341,8 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
                  << client_info.node_manager_port;
 
   boost::asio::ip::tcp::socket socket(io_service_);
-  auto status = TcpConnect(socket, client_info.node_manager_address,
-                           client_info.node_manager_port);
+  auto status =
+      TcpConnect(socket, client_info.node_manager_address, client_info.node_manager_port);
   // ClientTable is Log<ActorID, ActorTableData>, which has multiple entries for
   // a disconnected client. The first one has is_insertion=true and the second
   // one has is_insertion=false. We must make sure this is not a close client.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -336,8 +336,8 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
 
   // Establish a new NodeManager connection to this GCS client.
   auto client_info = gcs_client_->client_table().GetClient(client_id);
-  RAY_LOG(DEBUG) << "[ClientAdded] Trying to connect to client " << client_id
-                 << " at " << client_info.node_manager_address << ":"
+  RAY_LOG(DEBUG) << "[ClientAdded] Trying to connect to client " << client_id << " at "
+                 << client_info.node_manager_address << ":"
                  << client_info.node_manager_port;
 
   boost::asio::ip::tcp::socket socket(io_service_);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -343,10 +343,10 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   boost::asio::ip::tcp::socket socket(io_service_);
   auto status =
       TcpConnect(socket, client_info.node_manager_address, client_info.node_manager_port);
-  // ClientTable is Log<ActorID, ActorTableData>, a disconnected client has 2 entries.
-  // The first one has is_insertion=true and the second one has is_insertion=false.
-  // When a new raylet starts, ClientAdded will be called with the disconnected client's
-  // first entry, which will cause IOError and "Connection refused".
+  // A disconnected client has 2 entries in the client table (one for being
+  // inserted and one for being removed). When a new raylet starts, ClientAdded
+  // will be called with the disconnected client's first entry, which will cause
+  // IOError and "Connection refused".
   if (!status.ok()) {
     RAY_CHECK(status.message() == "Connection refused");
     RAY_LOG(WARNING) << "Failed to connect to client " << client_id

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -348,7 +348,6 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   // will be called with the disconnected client's first entry, which will cause
   // IOError and "Connection refused".
   if (!status.ok()) {
-    RAY_CHECK(status.message() == "Connection refused");
     RAY_LOG(WARNING) << "Failed to connect to client " << client_id
                      << " in ClientAdded. TcpConnect returned status: "
                      << status.ToString() << ". This may be caused by "


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
ClientTable is Log<ActorID, ActorTableData>, which has multiple entries for a disconnected client. The first one has is_insertion=true and the second one has is_insertion=false. We must make sure this is not a closed client.

When a new raylet starts, the ClientAdded will be called with the disconnected client data. However, since the client was closed, the connection will fail. The following message shows the example log:
```
I0918 17:16:41.168637 2961466240 tables.cc:335] ClientTable::HandleNotification with client: 0e92265aedc9194e66469a0743558f32e77e86f5 is_new=1 is_insertion=1
I0918 17:16:41.170995 2961466240 node_manager.cc:317] [ClientAdded] received callback from client id 0e92265aedc9194e66469a0743558f32e77e86f5
I0918 17:16:41.171082 2961466240 node_manager.cc:328] a new client: 0e92265aedc9194e66469a0743558f32e77e86f5
I0918 17:16:41.171145 2961466240 node_manager.cc:343] [ClientAdded] CONNECTING TO:  30.50.100.140 61838
I0918 17:16:41.171489 2961466240 tables.cc:335] ClientTable::HandleNotification with client: 8fcca9d6b3122effeb2424faa315713b79829ca9 is_new=1 is_insertion=1
I0918 17:16:41.171558 2961466240 node_manager.cc:317] [ClientAdded] received callback from client id 8fcca9d6b3122effeb2424faa315713b79829ca9
I0918 17:16:41.171686 2961466240 node_manager.cc:328] a new client: 8fcca9d6b3122effeb2424faa315713b79829ca9
I0918 17:16:41.171814 2961466240 node_manager.cc:343] [ClientAdded] CONNECTING TO:  30.50.100.140 61881
I0918 17:16:41.172071 2961466240 tables.cc:335] ClientTable::HandleNotification with client: 397783a6eddf33c74007a4cbabb156cbcfd0220d is_new=1 is_insertion=1
I0918 17:16:41.172159 2961466240 node_manager.cc:317] [ClientAdded] received callback from client id 397783a6eddf33c74007a4cbabb156cbcfd0220d
I0918 17:16:41.172209 2961466240 node_manager.cc:328] a new client: 397783a6eddf33c74007a4cbabb156cbcfd0220d
I0918 17:16:41.172261 2961466240 node_manager.cc:343] [ClientAdded] CONNECTING TO:  30.50.100.140 61923
I0918 17:16:41.172420 2961466240 tables.cc:335] ClientTable::HandleNotification with client: 8fcca9d6b3122effeb2424faa315713b79829ca9 is_new=1 is_insertion=0
I0918 17:16:41.172549 2961466240 node_manager.cc:361] [ClientRemoved] received callback from client id 8fcca9d6b3122effeb2424faa315713b79829ca9
I0918 17:16:41.172675 2961466240 tables.cc:335] ClientTable::HandleNotification with client: 397783a6eddf33c74007a4cbabb156cbcfd0220d is_new=1 is_insertion=0
I0918 17:16:41.172762 2961466240 node_manager.cc:361] [ClientRemoved] received callback from client id 397783a6eddf33c74007a4cbabb156cbcfd0220d
I0918 17:16:41.172847 2961466240 tables.cc:335] ClientTable::HandleNotification with client: e3c2435282712dca6d33f715aa7e3a4847a33f50 is_new=1 is_insertion=1
I0918 17:16:41.172936 2961466240 node_manager.cc:317] [ClientAdded] received callback from client id e3c2435282712dca6d33f715aa7e3a4847a33f50
```
Client **`8fcca9d6b3122effeb2424faa315713b79829ca9`** and **`397783a6eddf33c74007a4cbabb156cbcfd0220d`** has 2 entries.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/ray-project/ray/issues/2878