### PR TITLE
[Java] Implement missing methods in MockRayletClient

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
@@ -1,5 +1,6 @@
 package org.ray.runtime.raylet;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,12 +83,15 @@ public class MockRayletClient implements RayletClient {
 
   @Override
   public UniqueId generateTaskId(UniqueId driverId, UniqueId parentTaskId, int taskIndex) {
-    throw new RuntimeException("Not implemented here.");
+    return UniqueId.randomId();
   }
 
   @Override
   public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs) {
-    throw new RuntimeException("Not implemented here.");
+    return new WaitResult<T>(
+        waitFor,
+        ImmutableList.of()
+    );
   }
 
   @Override


### PR DESCRIPTION
Previous changes broke single-process mode in raylet. This PR fixes the hello-world example work in single-process mode. Follow-up diffs will completely fix single-process mode and add tests.