### PR TITLE
[Java] Update maven version to 0.1-SNAPSHOT

### DIFF
--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -3,13 +3,12 @@
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>org.ray.parent</groupId>
+    <groupId>org.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.0</version>
+    <version>0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.ray</groupId>
   <artifactId>ray-api</artifactId>
   <name>ray api</name>
   <description>java api for ray</description>

--- a/java/cli/pom.xml
+++ b/java/cli/pom.xml
@@ -4,14 +4,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>org.ray.parent</groupId>
+    <groupId>org.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.0</version>
+    <version>0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.ray</groupId>
-  <artifactId>ray-cli</artifactId>
 
+  <artifactId>ray-cli</artifactId>
   <name>java cli</name>
   <description>java cli for ray</description>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,9 +5,9 @@
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
 
-  <groupId>org.ray.parent</groupId>
+  <groupId>org.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>1.0</version>
+  <version>0.1-SNAPSHOT</version>
   <modules>
     <module>api</module>
     <module>runtime</module>
@@ -19,7 +19,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <projetct.version>1.0</projetct.version>
+    <projetct.version>0.1-SNAPSHOT</projetct.version>
     <slf4j.version>1.7.25</slf4j.version>
   </properties>
 

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -3,14 +3,13 @@
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>org.ray.parent</groupId>
+    <groupId>org.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.0</version>
+    <version>0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.ray</groupId>
-  <artifactId>ray-runtime</artifactId>
 
+  <artifactId>ray-runtime</artifactId>
   <name>ray runtime</name>
   <description>ray runtime implementation</description>
 

--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -1,100 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <groupId>org.ray.parent</groupId>
-        <artifactId>ray-superpom</artifactId>
-        <version>1.0</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
     <groupId>org.ray</groupId>
-    <artifactId>ray-test</artifactId>
+    <artifactId>ray-superpom</artifactId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <name>java test cases for ray</name>
-    <description>java test cases for ray</description>
-    <url></url>
+  <artifactId>ray-test</artifactId>
+  <name>java test cases for ray</name>
+  <description>java test cases for ray</description>
 
-    <packaging>jar</packaging>
+  <packaging>jar</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.ray</groupId>
-            <artifactId>ray-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.ray</groupId>
+      <artifactId>ray-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
-        <dependency>
-            <groupId>org.ray</groupId>
-            <artifactId>ray-runtime</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+    <dependency>
+      <groupId>org.ray</groupId>
+      <artifactId>ray-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
 
-        <!-- https://mvnrepository.com/artifact/commons-collections/commons-collections -->
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-    </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
-                <configuration>
-                    <!-- <properties>
-                      <property>
-                        <name>listener</name>
-                        <value>org.ray.api.test.TestListener</value>
-                      </property>
-                    </properties> -->
-                    <environmentVariables>
-                        <RAY_CONFIG>${basedir}/../ray.config.ini</RAY_CONFIG>
-                    </environmentVariables>
-                    <argLine>-ea
-                        -Djava.library.path=${basedir}/../../build/src/plasma:${basedir}/../../build/src/local_scheduler
-                        -noverify
-                        -DlogOutput=console
-                    </argLine>
-                    <testSourceDirectory>${basedir}/src/main/java/</testSourceDirectory>
-                    <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
-                </configuration>
-            </plugin>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.21.0</version>
+        <configuration>
+          <environmentVariables>
+            <RAY_CONFIG>${basedir}/../ray.config.ini</RAY_CONFIG>
+          </environmentVariables>
+          <argLine>-ea
+            -Djava.library.path=${basedir}/../../build/src/plasma:${basedir}/../../build/src/local_scheduler
+            -noverify
+            -DlogOutput=console
+          </argLine>
+          <testSourceDirectory>${basedir}/src/main/java/</testSourceDirectory>
+          <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
+        </configuration>
+      </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/lib</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-        </plugins>
-    </build>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/lib</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java/tutorial/pom.xml
+++ b/java/tutorial/pom.xml
@@ -4,13 +4,12 @@
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>org.ray.parent</groupId>
+    <groupId>org.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>1.0</version>
+    <version>0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.ray</groupId>
   <artifactId>ray-tutorial</artifactId>
 
   <name>java tutorial</name>


### PR DESCRIPTION

## What do these changes do?

Update the version in maven from `0.1` to `0.1-SNAPSHOT`, because `SNAPSHOT` is the conventional version name in dev process. Non-snapshot versions are only used for release. 

## Related issue number
N/A
