### PR TITLE
[rllib] Entropy calculation for diag gaussian missing 0.5 term

### DIFF
--- a/python/ray/rllib/models/action_dist.py
+++ b/python/ray/rllib/models/action_dist.py
@@ -125,7 +125,7 @@ class DiagGaussian(ActionDistribution):
 
     def entropy(self):
         return tf.reduce_sum(
-            self.log_std + .5 * np.log(2.0 * np.pi * np.e),
+            .5 * self.log_std + .5 * np.log(2.0 * np.pi * np.e),
             reduction_indices=[1])
 
     def sample(self):


### PR DESCRIPTION


## What do these changes do?

See: https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Entropy

## Related issue number

https://github.com/ray-project/ray/issues/2920