### PR TITLE
Fix link failure in java readme file.

### DIFF
--- a/java/README.rst
+++ b/java/README.rst
@@ -6,9 +6,9 @@ Configuration
 Ray will read your configurations in the following order:
 
 * Java system properties: e.g., ``-Dray.home=/path/to/ray``.
-* A ``ray.conf`` file in the classpath: `example <https://github.com/ray-project/ray/java/example.conf>`_.
+* A ``ray.conf`` file in the classpath: `example <https://github.com/ray-project/ray/blob/master/java/example.conf>`_.
 
-For all available config items and default values, see `this file <https://github.com/ray-project/ray/java/runtime/src/main/resources/ray.default.conf>`_.
+For all available config items and default values, see `this file <https://github.com/ray-project/ray/blob/master/java/runtime/src/main/resources/ray.default.conf>`_.
 
 Starting Ray
 ------------


### PR DESCRIPTION

## What do these changes do?

Fix the link failure in `java/Readme.rst`.


## Related issue number
N/A

