### PR TITLE
[ray] Add --new flag for ray attach

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -210,16 +210,22 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
                                        provider.external_ip(head_node)))
 
 
-def attach_cluster(config_file, start, override_cluster_name):
+def attach_cluster(config_file, start, override_cluster_name, new):
     """Attaches to a screen for the specified cluster.
 
     Arguments:
         config_file: path to the cluster yaml
         start: whether to start the cluster if it isn't up
         override_cluster_name: set the name of the cluster
+        new: whether to force a new screen
     """
 
-    exec_cluster(config_file, "screen -L -xRR", False, False, start,
+    if new:
+        cmd = "screen -L"
+    else:
+        cmd = "screen -L -xRR"
+
+    exec_cluster(config_file, cmd, False, False, start,
                  override_cluster_name, None)
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -476,8 +476,13 @@ def teardown(cluster_config_file, yes, workers_only, cluster_name):
     required=False,
     type=str,
     help=("Override the configured cluster name."))
-def attach(cluster_config_file, start, cluster_name):
-    attach_cluster(cluster_config_file, start, cluster_name)
+@click.option(
+    "--new",
+    "-N",
+    is_flag=True,
+    help=("Force creation of a new screen."))
+def attach(cluster_config_file, start, cluster_name, new):
+    attach_cluster(cluster_config_file, start, cluster_name, new)
 
 
 @cli.command()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -479,10 +479,7 @@ def teardown(cluster_config_file, yes, workers_only, cluster_name):
     type=str,
     help=("Override the configured cluster name."))
 @click.option(
-    "--new",
-    "-N",
-    is_flag=True,
-    help=("Force creation of a new screen."))
+    "--new", "-N", is_flag=True, help=("Force creation of a new screen."))
 def attach(cluster_config_file, start, tmux, cluster_name, new):
     attach_cluster(cluster_config_file, start, tmux, cluster_name, new)
 


### PR DESCRIPTION

## What do these changes do?

This lets you open a new screen on a cluster without the awkward `ray exec cluster.yaml bash` command.