### PR TITLE
[Java] Fix: task spec's resource map should contains CPU

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -1,5 +1,6 @@
 package org.ray.runtime;
 
+import java.util.HashMap;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.WorkerMode;
 import org.ray.runtime.task.TaskSpec;
@@ -83,7 +84,7 @@ public class WorkerContext {
         0,
         null,
         null,
-        null,
+        new HashMap<>(),
         null);
   }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/util/ResourceUtil.java
+++ b/java/runtime/src/main/java/org/ray/runtime/util/ResourceUtil.java
@@ -18,15 +18,16 @@ public class ResourceUtil {
    */
   public static Map<String, Double> getResourcesMapFromArray(RayRemote remoteAnnotation) {
     Map<String, Double> resourceMap = new HashMap<>();
-    if (remoteAnnotation == null) {
-      return resourceMap;
-    }
-    for (ResourceItem item : remoteAnnotation.resources()) {
-      if (!item.name().isEmpty()) {
-        resourceMap.put(item.name(), item.value());
+    if (remoteAnnotation != null) {
+      for (ResourceItem item : remoteAnnotation.resources()) {
+        if (!item.name().isEmpty()) {
+          resourceMap.put(item.name(), item.value());
+        }
       }
     }
-
+    if (!resourceMap.containsKey(CPU_LITERAL)) {
+      resourceMap.put(CPU_LITERAL, 1.0);
+    }
     return resourceMap;
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/util/ResourceUtil.java
+++ b/java/runtime/src/main/java/org/ray/runtime/util/ResourceUtil.java
@@ -26,7 +26,7 @@ public class ResourceUtil {
       }
     }
     if (!resourceMap.containsKey(CPU_LITERAL)) {
-      resourceMap.put(CPU_LITERAL, 1.0);
+      resourceMap.put(CPU_LITERAL, 0.0);
     }
     return resourceMap;
   }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -28,8 +28,7 @@ public class WaitTest {
     return "hi";
   }
 
-  @Test
-  public void test() {
+  private static void testWait() {
     RayObject<String> obj1 = Ray.call(WaitTest::hi);
     RayObject<String> obj2 = Ray.call(WaitTest::delayedHi);
 
@@ -43,4 +42,20 @@ public class WaitTest {
     Assert.assertEquals("hi", readyList.get(0).get());
   }
 
+  @Test
+  public void testWaitInDriver() {
+    testWait();
+  }
+
+  @RayRemote
+  public static Object waitInWorker() {
+    testWait();
+    return null;
+  }
+
+  @Test
+  public void testWaitInWorker() {
+    RayObject<Object> res = Ray.call(WaitTest::waitInWorker);
+    res.get();
+  }
 }


### PR DESCRIPTION
Otherwise it will cause a RAY_CHECK to fail here: https://github.com/ray-project/ray/blob/68cf194e902a948a772f1dd0368029c2d7a7760f/src/ray/raylet/scheduling_resources.cc#L132