### PR TITLE
Improve a log message.

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -138,7 +138,9 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   int rv = execvp(worker_command_args[0],
                   const_cast<char *const *>(worker_command_args.data()));
   // The worker failed to start. This is a fatal error.
-  RAY_LOG(FATAL) << "Failed to start worker: " << strerror(errno);
+  if (rv < 0) {
+    RAY_LOG(FATAL) << "Failed to start worker: " << strerror(errno);
+  }
 }
 
 void WorkerPool::RegisterWorker(std::shared_ptr<Worker> worker) {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -138,7 +138,7 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   int rv = execvp(worker_command_args[0],
                   const_cast<char *const *>(worker_command_args.data()));
   // The worker failed to start. This is a fatal error.
-  RAY_LOG(FATAL) << "Failed to start worker with return value " << rv;
+  RAY_LOG(FATAL) << "Failed to start worker: " << strerror(errno);
 }
 
 void WorkerPool::RegisterWorker(std::shared_ptr<Worker> worker) {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -120,7 +120,7 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   pid_t pid = fork();
   if (pid < 0) {
     // Failure case.
-    RAY_LOG(FATAL) << "Failed to create new process: " << strerror(errno);
+    RAY_LOG(FATAL) << "Failed to fork worker process: " << strerror(errno);
     return;
   } else if (pid > 0) {
     // Parent process case.
@@ -144,8 +144,8 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   int rv = execvp(worker_command_args[0],
                   const_cast<char *const *>(worker_command_args.data()));
   // The worker failed to start. This is a fatal error.
-  RAY_LOG(FATAL) << "Failed to start worker with return value " << rv
-                 << ": " << strerror(errno);
+  RAY_LOG(FATAL) << "Failed to start worker with return value " << rv << ": "
+                 << strerror(errno);
 }
 
 void WorkerPool::RegisterWorker(std::shared_ptr<Worker> worker) {


### PR DESCRIPTION
## What do these changes do?
```c++
  // Try to execute the worker command.
  int rv = execvp(worker_command_args[0],
                  const_cast<char *const *>(worker_command_args.data()));
  // The worker failed to start. This is a fatal error.
  RAY_LOG(FATAL) << "Failed to start worker with return value " << rv;
```
When starting a process fails, the return value `rv` always be set to -1.
It is useless for us.
The log message should show some meaningful infos.

For example, If we did't install java. The message showed for us should be:
```shell
 Failed to start worker: No such file or directory.
```
This could help us to locate issue quickly.

## Related issue number
N/A