### PR TITLE
[rllib] Don't shuffle samples in PPO when using lstm

### DIFF
--- a/python/ray/rllib/examples/cartpole_lstm.py
+++ b/python/ray/rllib/examples/cartpole_lstm.py
@@ -166,11 +166,12 @@ if __name__ == "__main__":
     tune.run_experiments({
         "test": {
             "env": "cartpole_stateless",
-            "run": "PG",
+            "run": "PPO",
             "stop": {
                 "episode_reward_mean": args.stop
             },
             "config": {
+                "num_sgd_iter": 5,
                 "model": {
                     "use_lstm": True,
                 },

--- a/python/ray/rllib/optimizers/multi_gpu_optimizer.py
+++ b/python/ray/rllib/optimizers/multi_gpu_optimizer.py
@@ -108,7 +108,10 @@ class LocalMultiGPUOptimizer(PolicyOptimizer):
             value = samples[field]
             standardized = (value - value.mean()) / max(1e-4, value.std())
             samples[field] = standardized
-        samples.shuffle()
+
+        # Important: don't shuffle RNN sequence elements
+        if not self.policy._state_inputs:
+            samples.shuffle()
 
         with self.load_timer:
             tuples = self.policy._get_loss_inputs_dict(samples)

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -301,7 +301,7 @@ docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/rllib/examples/multiagent_two_trainers.py --num-iters=2
 
 docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
-    python /ray/python/ray/rllib/examples/cartpole_lstm.py --stop=75
+    python /ray/python/ray/rllib/examples/cartpole_lstm.py --stop=200
 
 docker run  -e "RAY_USE_XRAY=1" --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     python /ray/python/ray/experimental/sgd/test_sgd.py --num-iters=2


### PR DESCRIPTION

## What do these changes do?

Shuffling destroys the sequence ordering. 

On the partially observed cartpole example: https://github.com/ray-project/ray/blob/3a3782c39fc2e75f53515660b866e7cc501b7704/python/ray/rllib/examples/cartpole_lstm.py
Magenta: before fix
Blue: after fix
![shuf](https://user-images.githubusercontent.com/14922/46252912-b89d8d80-c424-11e8-9fc2-67fc39551836.png)

cc @llan-ml