### PR TITLE
Test dying_worker_get and dying_worker_wait for xray.

### DIFF
--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -14,10 +14,10 @@
 #  - PLASMA_SHARED_LIB
 
 set(arrow_URL https://github.com/apache/arrow.git)
-# The PR for this commit is https://github.com/apache/arrow/pull/2522. We
+# The PR for this commit is https://github.com/apache/arrow/pull/2650. We
 # include the link here to make it easier to find the right commit because
 # Arrow often rewrites git history and invalidates certain commits.
-set(arrow_TAG 7104d64ff2cd6c20e29d3cf4ec5c58bc10798f66)
+set(arrow_TAG f981a114f3e3b7d886a8d37bc7d5ab0d0c1bfb69)
 
 set(ARROW_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/arrow-install)
 set(ARROW_HOME ${ARROW_INSTALL_PREFIX})

--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -14,10 +14,10 @@
 #  - PLASMA_SHARED_LIB
 
 set(arrow_URL https://github.com/apache/arrow.git)
-# The PR for this commit is https://github.com/apache/arrow/pull/2650. We
+# The PR for this commit is https://github.com/apache/arrow/pull/2664. We
 # include the link here to make it easier to find the right commit because
 # Arrow often rewrites git history and invalidates certain commits.
-set(arrow_TAG f981a114f3e3b7d886a8d37bc7d5ab0d0c1bfb69)
+set(arrow_TAG 3545186d6997b943ffc3d79634f2d08eefbd7322)
 
 set(ARROW_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/arrow-install)
 set(ARROW_HOME ${ARROW_INSTALL_PREFIX})

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -114,7 +114,7 @@ class ClientConnection : public ServerConnection<T>,
   MessageHandler<T> message_handler_;
   /// A label used for debug messages.
   const std::string debug_label_;
-  /// Buffers for the current message being read rom the client.
+  /// Buffers for the current message being read from the client.
   int64_t read_version_;
   int64_t read_type_;
   uint64_t read_length_;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -652,8 +652,9 @@ void NodeManager::ProcessDisconnectClientMessage(
     return;
   }
 
-  // If the client is blocked, we need to process the fact that it is no longer
-  // blocked. This won't do anything if the client is not blocked.
+  // If the client is blocked, we need to treat it as unblocked. In particular,
+  // we are no longer waiting for its dependencies. If the client is not
+  // blocked, this won't do anything.
   HandleClientUnblocked(client);
 
   // Remove the dead client from the pool and stop listening for messages.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -647,6 +647,8 @@ void NodeManager::ProcessDisconnectClientMessage(
   // If both worker and driver are null, then this method has already been
   // called, so just return.
   if (worker == nullptr && driver == nullptr) {
+    RAY_LOG(INFO) << "Ignoring client disconnect because the client has already "
+                  << "been disconnected.";
     return;
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -809,9 +809,9 @@ void NodeManager::ProcessWaitRequestMessage(
             fbb, to_flatbuf(fbb, found), to_flatbuf(fbb, remaining));
         fbb.Finish(wait_reply);
 
-        auto status = client->WriteMessage(
-            static_cast<int64_t>(protocol::MessageType::WaitReply), fbb.GetSize(),
-            fbb.GetBufferPointer());
+        auto status =
+            client->WriteMessage(static_cast<int64_t>(protocol::MessageType::WaitReply),
+                                 fbb.GetSize(), fbb.GetBufferPointer());
         if (status.ok()) {
           // The client is unblocked now because the wait call has returned.
           if (client_blocked) {
@@ -819,7 +819,8 @@ void NodeManager::ProcessWaitRequestMessage(
           }
         } else {
           // We failed to write to the client, so disconnect the client.
-          RAY_LOG(WARNING) << "Failed to send WaitReply to client, so disconnecting client";
+          RAY_LOG(WARNING)
+              << "Failed to send WaitReply to client, so disconnecting client";
           // We failed to send the reply to the client, so disconnect the worker.
           ProcessDisconnectClientMessage(client);
         }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -267,7 +267,7 @@ class NodeManager {
   bool CheckDependencyManagerInvariant() const;
 
   /// Process client message of RegisterClientRequest
-  //
+  ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
@@ -275,26 +275,29 @@ class NodeManager {
       const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
 
   /// Process client message of GetTask
-  //
+  ///
   /// \param client The client that sent the message.
   /// \return Void.
   void ProcessGetTaskMessage(const std::shared_ptr<LocalClientConnection> &client);
 
-  /// Process client message of DisconnectClient
-  //
+  /// Handle a client that has disconnected. This can be called multiple times
+  /// on the same client because this is triggered both when a client
+  /// disconnects and when the node manager fails to write a message to the
+  /// client.
+  ///
   /// \param client The client that sent the message.
   /// \return Void.
   void ProcessDisconnectClientMessage(
       const std::shared_ptr<LocalClientConnection> &client);
 
   /// Process client message of SubmitTask
-  //
+  ///
   /// \param message_data A pointer to the message data.
   /// \return Void.
   void ProcessSubmitTaskMessage(const uint8_t *message_data);
 
   /// Process client message of ReconstructObjects
-  //
+  ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
@@ -302,7 +305,7 @@ class NodeManager {
       const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
 
   /// Process client message of WaitRequest
-  //
+  ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
@@ -310,7 +313,7 @@ class NodeManager {
                                  const uint8_t *message_data);
 
   /// Process client message of PushErrorRequest
-  //
+  ///
   /// \param message_data A pointer to the message data.
   /// \return Void.
   void ProcessPushErrorRequestMessage(const uint8_t *message_data);

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pytest
 import os
 import signal
 import time
 
+import pytest
+
 import ray
+from ray.test.test_utils import run_string_as_driver_nonblocking
 import pyarrow as pa
 
 
@@ -31,8 +33,8 @@ def shutdown_only():
     ray.shutdown()
 
 
-# This test checks that when a worker dies in the middle of a get, the
-# plasma store and raylet will not die.
+# This test checks that when a worker dies in the middle of a get, the plasma
+# store and raylet will not die.
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_XRAY") != "1",
     reason="This test only works with xray.")
@@ -62,18 +64,65 @@ def test_dying_worker_get_raylet(shutdown_only):
 
     # Have the worker wait in a get call.
     result_id = f.remote([x_id])
-
-    # Kill the worker.
     time.sleep(1)
 
     # Make sure the task hasn't finished.
     ready_ids, _ = ray.wait([result_id], timeout=0)
     assert len(ready_ids) == 0
 
+    # Kill the worker.
     os.kill(worker_pid, signal.SIGKILL)
-
     time.sleep(0.1)
 
+    # Make sure the sleep task hasn't finished.
+    ready_ids, _ = ray.wait([x_id], timeout=0)
+    assert len(ready_ids) == 0
+    # Seal the object so the store attempts to notify the worker that the
+    # get has been fulfilled.
+    ray.worker.global_worker.put_object(x_id, 1)
+    time.sleep(0.1)
+
+    # Make sure that nothing has died.
+    assert ray.services.all_processes_alive()
+
+
+# This test checks that when a driver dies in the middle of a get, the plasma
+# store and raylet will not die.
+@pytest.mark.skipif(
+    os.environ.get("RAY_USE_XRAY") != "1",
+    reason="This test only works with xray.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_USE_NEW_GCS") == "on",
+    reason="Not working with new GCS API.")
+def test_dying_driver_get(shutdown_only):
+    # Start the Ray processes.
+    address_info = ray.init(num_cpus=1)
+
+    @ray.remote
+    def sleep_forever():
+        time.sleep(10**6)
+
+    x_id = sleep_forever.remote()
+
+    driver = """
+import ray
+ray.init("{}")
+ray.get(ray.ObjectID({}))
+""".format(address_info["redis_address"], x_id.id())
+
+    p = run_string_as_driver_nonblocking(driver)
+    # Make sure the driver is running.
+    time.sleep(1)
+    assert p.poll() is None
+
+    # Kill the driver process.
+    p.kill()
+    p.wait()
+    time.sleep(0.1)
+
+    # Make sure the original task hasn't finished.
+    ready_ids, _ = ray.wait([x_id], timeout=0)
+    assert len(ready_ids) == 0
     # Seal the object so the store attempts to notify the worker that the
     # get has been fulfilled.
     ray.worker.global_worker.put_object(x_id, 1)
@@ -119,8 +168,8 @@ def test_dying_worker_get(ray_start_workers_separate):
         exclude=[ray.services.PROCESS_TYPE_WORKER])
 
 
-# This test checks that when a worker dies in the middle of a wait, the
-# plasma store and raylet will not die.
+# This test checks that when a worker dies in the middle of a wait, the plasma
+# store and raylet will not die.
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_XRAY") != "1",
     reason="This test only works with xray.")
@@ -148,16 +197,61 @@ def test_dying_worker_wait_raylet(shutdown_only):
     def block_in_wait(object_id_in_list):
         ray.wait(object_id_in_list)
 
-    # Have the worker wait in a get call.
+    # Have the worker wait in a wait call.
     block_in_wait.remote([x_id])
-
-    # Kill the worker.
     time.sleep(0.1)
 
+    # Kill the worker.
     os.kill(worker_pid, signal.SIGKILL)
     time.sleep(0.1)
 
     # Create the object.
+    ray.worker.global_worker.put_object(x_id, 1)
+    time.sleep(0.1)
+
+    # Make sure that nothing has died.
+    assert ray.services.all_processes_alive()
+
+
+# This test checks that when a driver dies in the middle of a wait, the plasma
+# store and raylet will not die.
+@pytest.mark.skipif(
+    os.environ.get("RAY_USE_XRAY") != "1",
+    reason="This test only works with xray.")
+@pytest.mark.skipif(
+    os.environ.get("RAY_USE_NEW_GCS") == "on",
+    reason="Not working with new GCS API.")
+def test_dying_driver_wait(shutdown_only):
+    # Start the Ray processes.
+    address_info = ray.init(num_cpus=1)
+
+    @ray.remote
+    def sleep_forever():
+        time.sleep(10**6)
+
+    x_id = sleep_forever.remote()
+
+    driver = """
+import ray
+ray.init("{}")
+ray.wait([ray.ObjectID({})])
+""".format(address_info["redis_address"], x_id.id())
+
+    p = run_string_as_driver_nonblocking(driver)
+    # Make sure the driver is running.
+    time.sleep(1)
+    assert p.poll() is None
+
+    # Kill the driver process.
+    p.kill()
+    p.wait()
+    time.sleep(0.1)
+
+    # Make sure the original task hasn't finished.
+    ready_ids, _ = ray.wait([x_id], timeout=0)
+    assert len(ready_ids) == 0
+    # Seal the object so the store attempts to notify the worker that the
+    # wait can return.
     ray.worker.global_worker.put_object(x_id, 1)
     time.sleep(0.1)
 

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -45,7 +45,7 @@ def test_dying_worker_get_raylet(shutdown_only):
 
     @ray.remote
     def sleep_forever():
-        time.sleep(10 ** 6)
+        time.sleep(10**6)
 
     @ray.remote
     def get_worker_pid():
@@ -132,7 +132,7 @@ def test_dying_worker_wait_raylet(shutdown_only):
 
     @ray.remote
     def sleep_forever():
-        time.sleep(10 ** 6)
+        time.sleep(10**6)
 
     @ray.remote
     def get_pid():
@@ -150,7 +150,6 @@ def test_dying_worker_wait_raylet(shutdown_only):
 
     # Have the worker wait in a get call.
     block_in_wait.remote([x_id])
-
 
     # Kill the worker.
     time.sleep(0.1)

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -5,49 +5,11 @@ from __future__ import print_function
 import os
 import pytest
 import subprocess
-import sys
-import tempfile
 import time
 
 import ray
-from ray.test.test_utils import run_and_get_output
-
-
-def run_string_as_driver(driver_script):
-    """Run a driver as a separate process.
-
-    Args:
-        driver_script: A string to run as a Python script.
-
-    Returns:
-        The script's output.
-    """
-    # Save the driver script as a file so we can call it using subprocess.
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(driver_script.encode("ascii"))
-        f.flush()
-        out = ray.utils.decode(
-            subprocess.check_output([sys.executable, f.name]))
-    return out
-
-
-def run_string_as_driver_nonblocking(driver_script):
-    """Start a driver as a separate process and return immediately.
-
-    Args:
-        driver_script: A string to run as a Python script.
-
-    Returns:
-        A handle to the driver process.
-    """
-    # Save the driver script as a file so we can call it using subprocess. We
-    # do not delete this file because if we do then it may get removed before
-    # the Python process tries to run it.
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        f.write(driver_script.encode("ascii"))
-        f.flush()
-        return subprocess.Popen(
-            [sys.executable, f.name], stdout=subprocess.PIPE)
+from ray.test.test_utils import (run_and_get_output, run_string_as_driver,
+                                 run_string_as_driver_nonblocking)
 
 
 @pytest.fixture


### PR DESCRIPTION
This tests the case in which a worker is blocked in a call to ray.get or ray.wait, and then the worker dies. Then later, the object that the worker was waiting for becomes available. We need to make sure not to try to send a message to the dead worker and then die. Related to #2790.