### PR TITLE
[xray] make local_scheduler_wait() only trigger reconstruction when w…

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -50,7 +50,7 @@ public class RayletClientImpl implements RayletClient {
       ids.add(element.getId());
     }
 
-    boolean[] ready = nativeWaitObject(client, getIdBytes(ids), numReturns, timeoutMs, false);
+    boolean[] ready = nativeWaitObject(client, getIdBytes(ids), numReturns, timeoutMs, true);
     List<RayObject<T>> readyList = new ArrayList<>();
     List<RayObject<T>> unreadyList = new ArrayList<>();
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2613,7 +2613,7 @@ def wait(object_ids, num_returns=1, timeout=None, worker=global_worker):
         timeout = timeout if timeout is not None else 2**30
         if worker.use_raylet:
             ready_ids, remaining_ids = worker.local_scheduler_client.wait(
-                object_ids, num_returns, timeout, False)
+                object_ids, num_returns, timeout, True)
         else:
             object_id_strs = [
                 plasma.ObjectID(object_id.id()) for object_id in object_ids

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -466,9 +466,6 @@ ray::Status ObjectManager::AddWaitRequest(const UniqueID &wait_id,
                                           int64_t timeout_ms,
                                           uint64_t num_required_objects, bool wait_local,
                                           const WaitCallback &callback) {
-  if (wait_local) {
-    return ray::Status::NotImplemented("Wait for local objects is not yet implemented.");
-  }
 
   RAY_CHECK(timeout_ms >= 0 || timeout_ms == -1);
   RAY_CHECK(num_required_objects != 0);

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -303,7 +303,7 @@ class TestObjectManager : public TestObjectManagerBase {
     UniqueID wait_id = UniqueID::from_random();
 
     RAY_CHECK_OK(server1->object_manager_.AddWaitRequest(
-        wait_id, object_ids, timeout_ms, required_objects, false,
+        wait_id, object_ids, timeout_ms, required_objects, true,
         [this, sub_id, object_1, object_ids, start_time](
             const std::vector<ray::ObjectID> &found,
             const std::vector<ray::ObjectID> &remaining) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -775,12 +775,15 @@ void NodeManager::ProcessWaitRequestMessage(
   bool wait_local = message->wait_local();
 
   std::vector<ObjectID> required_object_ids;
-  for (auto const &object_id : object_ids) {
-    if (!task_dependency_manager_.CheckObjectLocal(object_id)) {
-      // Add any missing objects to the list to subscribe to in the task
-      // dependency manager. These objects will be pulled from remote node
-      // managers and reconstructed if necessary.
-      required_object_ids.push_back(object_id);
+  // Only trigger reconstruction if wait local flag is set.
+  if (wait_local) {
+    for (auto const &object_id : object_ids) {
+      if (!task_dependency_manager_.CheckObjectLocal(object_id)) {
+        // Add any missing objects to the list to subscribe to in the task
+        // dependency manager. These objects will be pulled from remote node
+        // managers and reconstructed if necessary.
+        required_object_ids.push_back(object_id);
+      }
     }
   }
 


### PR DESCRIPTION
Currently ray.wait() triggers reconstruction when objects are not local (after #2864), while in some cases users want to just wait without reconstruction. 

This change allows user to decided whether to trigger reconstruction at C++ API level, by using the existing `wait_local` flag in `local_scheduler_client` - reconstruction is only triggered when this flag is set to true, which matches the intent of this flag. 

Behavior of user code in python & java remain unchanged with this change.