### PR TITLE
[java] fix a bug that cache result isn't set in FunctionManager

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
@@ -28,7 +28,7 @@ public class FunctionManager {
    * Cache from a RayFunc object to its corresponding FunctionDescriptor. Because
    * `LambdaUtils.getSerializedLambda` is expensive.
    */
-  private static final ThreadLocal<WeakHashMap<Class<RayFunc>, FunctionDescriptor>>
+  private static final ThreadLocal<WeakHashMap<Class<? extends RayFunc>, FunctionDescriptor>>
       RAY_FUNC_CACHE = ThreadLocal.withInitial(WeakHashMap::new);
 
   /**
@@ -51,6 +51,7 @@ public class FunctionManager {
       final String methodName = serializedLambda.getImplMethodName();
       final String typeDescriptor = serializedLambda.getImplMethodSignature();
       functionDescriptor = new FunctionDescriptor(className, methodName, typeDescriptor);
+      RAY_FUNC_CACHE.get().put(func.getClass(),functionDescriptor);
     }
     return getFunction(driverId, functionDescriptor);
   }


### PR DESCRIPTION

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

  before fix,RAY_FUN_CACHE use only get method ,can only get null, LambdaUtils.getSerializedLambda  will always run
  fix : put in RAY_FUN_CACHE  after create FunctionDescriptor ,LambdaUtils.getSerializedLambda  will only run if can't get from cache


## Related issue number

not that i know of 
