### PR TITLE
[Java] Load driver resources from local path.

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -48,7 +48,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   public AbstractRayRuntime(RayConfig rayConfig) {
     this.rayConfig = rayConfig;
-    functionManager = new FunctionManager();
+    functionManager = new FunctionManager(rayConfig.driverResourcePath);
     worker = new Worker(this);
     workerContext = new WorkerContext(rayConfig.workerMode, rayConfig.driverId);
   }

--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -51,6 +51,7 @@ public class RayConfig {
   public final String redisModulePath;
   public final String plasmaStoreExecutablePath;
   public final String rayletExecutablePath;
+  public final String driverResourcePath;
 
   private void validate() {
     if (workerMode == WorkerMode.WORKER) {
@@ -155,6 +156,18 @@ public class RayConfig {
     redisModulePath = rayHome + "/build/src/common/redis_module/libray_redis_module.so";
     plasmaStoreExecutablePath = rayHome + "/build/src/plasma/plasma_store_server";
     rayletExecutablePath = rayHome + "/build/src/ray/raylet/raylet";
+
+    // driver resource path
+    String localDriverResourcePath;
+    if (config.hasPath("ray.driver.resource-path")) {
+      localDriverResourcePath = config.getString("ray.driver.resource-path");
+    } else {
+      localDriverResourcePath = rayHome + "/driver/resource";
+      LOGGER.warn("Didn't configure ray.driver.resource-path, set it to default value: {}",
+          localDriverResourcePath);
+    }
+
+    driverResourcePath = localDriverResourcePath;
 
     // validate config
     validate();

--- a/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
@@ -15,12 +15,17 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.objectweb.asm.Type;
 import org.ray.api.function.RayFunc;
 import org.ray.api.id.UniqueId;
+import org.ray.runtime.util.JarLoader;
 import org.ray.runtime.util.LambdaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages functions by driver id.
  */
 public class FunctionManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FunctionManager.class);
 
   static final String CONSTRUCTOR_NAME = "<init>";
 
@@ -35,6 +40,21 @@ public class FunctionManager {
    * Mapping from the driver id to the functions that belong to this driver.
    */
   private Map<UniqueId, DriverFunctionTable> driverFunctionTables = new HashMap<>();
+
+  /**
+   * The resource path which we can load the driver's jar resources.
+   */
+  private String driverResourcePath;
+
+  /**
+   * Construct a FunctionManager with the specified driver resource path.
+   *
+   * @param driverResourcePath The specified driver resource that
+   *     can store the driver's resources.
+   */
+  public FunctionManager(String driverResourcePath) {
+    this.driverResourcePath = driverResourcePath;
+  }
 
   /**
    * Get the RayFunction from a RayFunc instance (a lambda).
@@ -65,8 +85,19 @@ public class FunctionManager {
   public RayFunction getFunction(UniqueId driverId, FunctionDescriptor functionDescriptor) {
     DriverFunctionTable driverFunctionTable = driverFunctionTables.get(driverId);
     if (driverFunctionTable == null) {
-      //TODO(hchen): distinguish class loader by driver id.
-      ClassLoader classLoader = getClass().getClassLoader();
+      String resourcePath = driverResourcePath + "/" + driverId.toString() + "/";
+      ClassLoader classLoader;
+
+      try {
+        classLoader = JarLoader.loadJars(resourcePath, false);
+        LOGGER.info("Succeeded to load driver({}) resource. Resource path is {}",
+            driverId, resourcePath);
+      } catch (Exception e) {
+        LOGGER.error("Failed to load driver({}) resource. Resource path is {}",
+            driverId, resourcePath);
+        classLoader = getClass().getClassLoader();
+      }
+
       driverFunctionTable = new DriverFunctionTable(classLoader);
       driverFunctionTables.put(driverId, driverFunctionTable);
     }

--- a/java/runtime/src/main/java/org/ray/runtime/util/JarLoader.java
+++ b/java/runtime/src/main/java/org/ray/runtime/util/JarLoader.java
@@ -14,12 +14,15 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.ray.runtime.util.logger.RayLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * load and unload jars from a dir.
  */
 public class JarLoader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JarLoader.class);
 
   public static URLClassLoader loadJars(String dir, boolean explicitLoad) {
     // get all jars
@@ -42,7 +45,7 @@ public class JarLoader {
 
     for (File appJar : appJars) {
       try {
-        RayLog.core.info("load jar " + appJar.getAbsolutePath());
+        LOGGER.info("succeeded to load jar {}.", appJar.getAbsolutePath());
         JarFile jar = new JarFile(appJar.getAbsolutePath());
         jars.add(jar);
         urls.add(appJar.toURI().toURL());

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -25,9 +25,15 @@ ray {
   // Available resources on this node, for example "CPU:4,GPU:0".
   resources: ""
 
-  // If worker.mode is DRIVER, specify the driver id.
-  // If not provided, a random id will be used.
-  driver.id: ""
+    // Configuration items about driver.
+    driver {
+      // If worker.mode is DRIVER, specify the driver id.
+      // If not provided, a random id will be used.
+      id: ""
+      // If worker.mode is WORKER, it means that worker will load
+      // the resources from this path to execute tasks.
+      resource-path: /tmp/ray/driver/resource
+    }
 
   // Root dir of log files.
   log-dir: /tmp/ray/logs
@@ -76,4 +82,5 @@ ray {
     // RPC socket name of Raylet
     socket-name: /tmp/ray/sockets/raylet
   }
+
 }

--- a/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
@@ -11,6 +11,7 @@ public class RayConfigTest {
   @Test
   public void testCreateRayConfig() {
     System.setProperty("ray.home", "/path/to/ray");
+    System.setProperty("ray.driver.resource-path", "path/to/ray/driver/resource/path");
     RayConfig rayConfig = RayConfig.create();
 
     Assert.assertEquals("/path/to/ray", rayConfig.rayHome);
@@ -19,8 +20,12 @@ public class RayConfigTest {
 
     System.setProperty("ray.home", "");
     rayConfig = RayConfig.create();
+
     Assert.assertEquals(System.getProperty("user.dir"), rayConfig.rayHome);
     Assert.assertEquals(System.getProperty("user.dir") +
         "/build/src/common/thirdparty/redis/src/redis-server", rayConfig.redisServerExecutablePath);
+
+    Assert.assertEquals("path/to/ray/driver/resource/path", rayConfig.driverResourcePath);
+
   }
 }


### PR DESCRIPTION
## What do these changes do?
1. Add a configuration item `driver.resource-path`.
2. Load driver resources from the local path which is specified in the `ray.conf`.

Before this change, we should add all driver resources(like user's jar package, dependencies package and config files) into `classpath`.

After this change, we should add the driver resources into the mount path which we can configure it in `ray.conf`, and we shouldn't configure `classpath` for driver resources any more.





## Related issue number
N/A