### PR TITLE
Fix the required-resources issue of actor member function in Java worker.

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/functionmanager/RayFunction.java
+++ b/java/runtime/src/main/java/org/ray/runtime/functionmanager/RayFunction.java
@@ -58,12 +58,17 @@ public class RayFunction {
   }
 
   public RayRemote getRayRemoteAnnotation() {
-    RayRemote rayRemote = executable.getAnnotation(RayRemote.class);
-    if (rayRemote == null) {
-      // If the method doesn't have a annotation, get the annotation from
-      // its wrapping class.
+    RayRemote rayRemote;
+
+    // If this method is a constructor, the task of this should be a actorCreationTask.
+    // And the annotation of actorCreationTask should extend from class.
+    // Otherwise, it's a normal method, and it shouldn't extends annotation from class.
+    if (isConstructor()) {
       rayRemote = executable.getDeclaringClass().getAnnotation(RayRemote.class);
+    } else {
+      rayRemote = executable.getAnnotation(RayRemote.class);
     }
+
     return rayRemote;
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/functionmanager/RayFunction.java
+++ b/java/runtime/src/main/java/org/ray/runtime/functionmanager/RayFunction.java
@@ -60,9 +60,9 @@ public class RayFunction {
   public RayRemote getRayRemoteAnnotation() {
     RayRemote rayRemote;
 
-    // If this method is a constructor, the task of this should be a actorCreationTask.
-    // And the annotation of actorCreationTask should extend from class.
-    // Otherwise, it's a normal method, and it shouldn't extends annotation from class.
+    // If this method is a constructor, the task of it should be a actorCreationTask.
+    // And the annotation of actorCreationTask should inherit from class.
+    // Otherwise, it's a normal method, and it shouldn't inherit annotation from class.
     if (isConstructor()) {
       rayRemote = executable.getDeclaringClass().getAnnotation(RayRemote.class);
     } else {

--- a/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
+++ b/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
@@ -74,7 +74,7 @@ public class FunctionManagerTest {
     func = functionManager.getFunction(UniqueId.NIL, barFunc);
     Assert.assertFalse(func.isConstructor());
     Assert.assertEquals(func.getFunctionDescriptor(), barDescriptor);
-    Assert.assertNotNull(func.getRayRemoteAnnotation());
+    Assert.assertNull(func.getRayRemoteAnnotation());
 
     // Test actor constructor
     func = functionManager.getFunction(UniqueId.NIL, barConstructor);
@@ -95,7 +95,7 @@ public class FunctionManagerTest {
     func = functionManager.getFunction(UniqueId.NIL, barDescriptor);
     Assert.assertFalse(func.isConstructor());
     Assert.assertEquals(func.getFunctionDescriptor(), barDescriptor);
-    Assert.assertNotNull(func.getRayRemoteAnnotation());
+    Assert.assertNull(func.getRayRemoteAnnotation());
 
     // Test actor constructor
     func = functionManager.getFunction(UniqueId.NIL, barConstructorDescriptor);

--- a/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
@@ -45,6 +45,13 @@ public class ResourcesManagementTest {
     }
   }
 
+  @RayRemote(resources = {@ResourceItem(name = "RES-A", value = 4)})
+  public static class Echo3 {
+    public Integer echo(Integer number) {
+      return number;
+    }
+  }
+
   @Test
   public void testMethods() {
     // This is a case that can satisfy required resources.
@@ -75,5 +82,14 @@ public class ResourcesManagementTest {
     Assert.assertEquals(1, waitResult.getUnready().size());
   }
 
+  @Test
+  public void testActorAndMemberMethods() {
+    // Note(qwang): This case depends on  this line.
+    // https://github.com/ray-project/ray/blob/master/java/test/src/main/java/org/ray/api/test/TestListener.java#L13
+    // If we change the static resources configuration item, this case may not pass.
+    // Then we should change this case too.
+    RayActor<Echo3> echo3 = Ray.createActor(Echo3::new);
+    Assert.assertEquals(100, (int) Ray.call(Echo3::echo, echo3, 100).get());
+  }
 }
 

--- a/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
@@ -84,7 +84,7 @@ public class ResourcesManagementTest {
 
   @Test
   public void testActorAndMemberMethods() {
-    // Note(qwang): This case depends on  this line.
+    // Note(qwang): This case depends on  the following line.
     // https://github.com/ray-project/ray/blob/master/java/test/src/main/java/org/ray/api/test/TestListener.java#L13
     // If we change the static resources configuration item, this case may not pass.
     // Then we should change this case too.

--- a/java/test/src/main/java/org/ray/api/test/TestListener.java
+++ b/java/test/src/main/java/org/ray/api/test/TestListener.java
@@ -10,7 +10,7 @@ public class TestListener extends RunListener {
   @Override
   public void testRunStarted(Description description) {
     System.setProperty("ray.home", "../..");
-    System.setProperty("ray.resources", "CPU:4");
+    System.setProperty("ray.resources", "CPU:4,RES-A:4");
     Ray.init();
   }
 


### PR DESCRIPTION
## What do these changes do?

Assume that there is only 1 node, and the node define a resource named `A` with the quantity being 1.
Consider the following case:
```java
@RayRemote(resources = {@ResourceItem(name = "A", value = 1)})
public static class Echo {
  public Integer getOne() {return 1;}
}

//main
RayActor<Echo> echoActor = Ray.createActor(Echo::new);
RayObject obj = Ray.call(Echo::getOne, echoActor);
Integer one = obj.get();
```
Before this PR, it will hang at `obj.get()`, because:
1. the actor holds the only 1 `A` resource.
2. the task `getOne` inherits the required-resource from class annotation. That means task `getOne` needs an `A` resource too. Em, but there is no `A` resource in cluster any more.

Semantically speaking, actor method shouldn't inherit the required resource from the actor class annotation.

After this PR, it will work well.

## Related issue number
N/A
