### PR TITLE
Batch heartbeats from node manager together in the monitor.

### DIFF
--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -109,6 +109,7 @@ AsyncGcsClient::AsyncGcsClient(const std::string &address, int port,
   client_table_.reset(new ClientTable({primary_context_}, this, client_id));
   error_table_.reset(new ErrorTable({primary_context_}, this));
   driver_table_.reset(new DriverTable({primary_context_}, this));
+  heartbeat_batch_table_.reset(new HeartbeatBatchTable({primary_context_}, this));
   // Tables below would be sharded.
   object_table_.reset(new ObjectTable(shard_contexts_, this, command_type));
   actor_table_.reset(new ActorTable(shard_contexts_, this));

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -214,6 +214,10 @@ ClassTable &AsyncGcsClient::class_table() { return *class_table_; }
 
 HeartbeatTable &AsyncGcsClient::heartbeat_table() { return *heartbeat_table_; }
 
+HeartbeatBatchTable &AsyncGcsClient::heartbeat_batch_table() {
+  return *heartbeat_batch_table_;
+}
+
 ErrorTable &AsyncGcsClient::error_table() { return *error_table_; }
 
 DriverTable &AsyncGcsClient::driver_table() { return *driver_table_; }

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -104,7 +104,6 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<RedisAsioClient> asio_async_auxiliary_client_;
   std::unique_ptr<RedisAsioClient> asio_subscribe_auxiliary_client_;
   CommandType command_type_;
-
 };
 
 class SyncGcsClient {

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -60,6 +60,7 @@ class RAY_EXPORT AsyncGcsClient {
   TaskLeaseTable &task_lease_table();
   ClientTable &client_table();
   HeartbeatTable &heartbeat_table();
+  HeartbeatBatchTable &heartbeat_batch_table();
   ErrorTable &error_table();
   DriverTable &driver_table();
   ProfileTable &profile_table();
@@ -89,6 +90,7 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<TaskReconstructionLog> task_reconstruction_log_;
   std::unique_ptr<TaskLeaseTable> task_lease_table_;
   std::unique_ptr<HeartbeatTable> heartbeat_table_;
+  std::unique_ptr<HeartbeatBatchTable> heartbeat_batch_table_;
   std::unique_ptr<ErrorTable> error_table_;
   std::unique_ptr<ProfileTable> profile_table_;
   std::unique_ptr<ClientTable> client_table_;
@@ -102,6 +104,7 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<RedisAsioClient> asio_async_auxiliary_client_;
   std::unique_ptr<RedisAsioClient> asio_subscribe_auxiliary_client_;
   CommandType command_type_;
+
 };
 
 class SyncGcsClient {

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -15,6 +15,7 @@ enum TablePrefix:int {
   FUNCTION,
   TASK_RECONSTRUCTION,
   HEARTBEAT,
+  HEARTBEAT_BATCH,
   ERROR_INFO,
   DRIVER,
   PROFILE,
@@ -30,6 +31,7 @@ enum TablePubsub:int {
   OBJECT,
   ACTOR,
   HEARTBEAT,
+  HEARTBEAT_BATCH,
   ERROR_INFO,
   TASK_LEASE,
   DRIVER,
@@ -260,6 +262,10 @@ table HeartbeatTableData {
   // Aggregate outstanding resource load on this node manager.
   resource_load_label: [string];
   resource_load_capacity: [double];
+}
+
+table HeartbeatBatchTableData {
+  batch: [HeartbeatTableData];
 }
 
 // Data for a lease on task execution.

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -479,6 +479,7 @@ template class Log<ActorID, ActorTableData>;
 template class Log<TaskID, TaskReconstructionData>;
 template class Table<TaskID, TaskLeaseData>;
 template class Table<ClientID, HeartbeatTableData>;
+template class Table<ClientID, HeartbeatBatchTableData>;
 template class Log<JobID, ErrorTableData>;
 template class Log<UniqueID, ClientTableData>;
 template class Log<JobID, DriverTableData>;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -353,9 +353,9 @@ class HeartbeatTable : public Table<ClientID, HeartbeatTableData> {
 
 class HeartbeatBatchTable : public Table<ClientID, HeartbeatBatchTableData> {
  public:
-  HeartbeatBatchTable(const std::shared_ptr<RedisContext> &context,
+  HeartbeatBatchTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
                       AsyncGcsClient *client)
-      : Table(context, client) {
+      : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::HEARTBEAT_BATCH;
     prefix_ = TablePrefix::HEARTBEAT_BATCH;
   }

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -351,6 +351,17 @@ class HeartbeatTable : public Table<ClientID, HeartbeatTableData> {
   virtual ~HeartbeatTable() {}
 };
 
+class HeartbeatBatchTable : public Table<ClientID, HeartbeatBatchTableData> {
+ public:
+  HeartbeatBatchTable(const std::shared_ptr<RedisContext> &context,
+                      AsyncGcsClient *client)
+      : Table(context, client) {
+    pubsub_channel_ = TablePubsub::HEARTBEAT_BATCH;
+    prefix_ = TablePrefix::HEARTBEAT_BATCH;
+  }
+  virtual ~HeartbeatBatchTable() {}
+};
+
 class DriverTable : public Log<JobID, DriverTableData> {
  public:
   DriverTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
@@ -359,6 +370,7 @@ class DriverTable : public Log<JobID, DriverTableData> {
     pubsub_channel_ = TablePubsub::DRIVER;
     prefix_ = TablePrefix::DRIVER;
   };
+
   virtual ~DriverTable() {}
 
   /// Appends driver data to the driver table.

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -25,6 +25,7 @@ Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_a
 
 void Monitor::HandleHeartbeat(const ClientID &client_id) {
   heartbeats_[client_id] = num_heartbeats_timeout_;
+  // TODO add to buffer
 }
 
 void Monitor::Start() {

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -26,7 +26,8 @@ Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_a
 void Monitor::HandleHeartbeat(const ClientID &client_id,
                               const HeartbeatTableDataT &heartbeat_data) {
   heartbeats_[client_id] = num_heartbeats_timeout_;
-  heartbeat_buffer_[client_id] = heartbeat_data;
+  // Buffer the heartbeat in time-order to maintain randomness at the receiving raylets.
+  heartbeat_buffer_.push_back(heartbeat_data);
 }
 
 void Monitor::Start() {
@@ -73,7 +74,7 @@ void Monitor::Tick() {
     auto batch = std::make_shared<HeartbeatBatchTableDataT>();
     for (const auto &heartbeat : heartbeat_buffer_) {
       batch->batch.push_back(std::unique_ptr<HeartbeatTableDataT>(
-          new HeartbeatTableDataT(heartbeat.second)));
+          new HeartbeatTableDataT(heartbeat)));
     }
     RAY_CHECK_OK(gcs_client_.heartbeat_batch_table().Add(UniqueID::nil(), UniqueID::nil(),
                                                          batch, nullptr));

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -26,8 +26,7 @@ Monitor::Monitor(boost::asio::io_service &io_service, const std::string &redis_a
 void Monitor::HandleHeartbeat(const ClientID &client_id,
                               const HeartbeatTableDataT &heartbeat_data) {
   heartbeats_[client_id] = num_heartbeats_timeout_;
-  // Buffer the heartbeat in time-order to maintain randomness at the receiving raylets.
-  heartbeat_buffer_.push_back(heartbeat_data);
+  heartbeat_buffer_[client_id] = heartbeat_data;
 }
 
 void Monitor::Start() {
@@ -74,7 +73,7 @@ void Monitor::Tick() {
     auto batch = std::make_shared<HeartbeatBatchTableDataT>();
     for (const auto &heartbeat : heartbeat_buffer_) {
       batch->batch.push_back(std::unique_ptr<HeartbeatTableDataT>(
-          new HeartbeatTableDataT(heartbeat)));
+          new HeartbeatTableDataT(heartbeat.second)));
     }
     RAY_CHECK_OK(gcs_client_.heartbeat_batch_table().Add(UniqueID::nil(), UniqueID::nil(),
                                                          batch, nullptr));

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -50,7 +50,8 @@ class Monitor {
   /// The Raylets that have been marked as dead in the client table.
   std::unordered_set<ClientID> dead_clients_;
   /// A buffer containing heartbeats received from node managers in the last tick.
-  std::unordered_map<ClientID, HeartbeatTableDataT> heartbeat_buffer_;
+  /// This may include multiple heartbeats from the same node.
+  std::vector<HeartbeatTableDataT> heartbeat_buffer_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -50,8 +50,7 @@ class Monitor {
   /// The Raylets that have been marked as dead in the client table.
   std::unordered_set<ClientID> dead_clients_;
   /// A buffer containing heartbeats received from node managers in the last tick.
-  /// This may include multiple heartbeats from the same node.
-  std::vector<HeartbeatTableDataT> heartbeat_buffer_;
+  std::unordered_map<ClientID, HeartbeatTableDataT> heartbeat_buffer_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -33,7 +33,9 @@ class Monitor {
   /// Handle a heartbeat from a Raylet.
   ///
   /// \param client_id The client ID of the Raylet that sent the heartbeat.
-  void HandleHeartbeat(const ClientID &client_id, const HeartbeatTableDataT &heartbeat_data);
+  /// \param heartbeat_data The heartbeat sent by the client.
+  void HandleHeartbeat(const ClientID &client_id,
+                       const HeartbeatTableDataT &heartbeat_data);
 
  private:
   /// A client to the GCS, through which heartbeats are received.
@@ -47,6 +49,7 @@ class Monitor {
   std::unordered_map<ClientID, int64_t> heartbeats_;
   /// The Raylets that have been marked as dead in the client table.
   std::unordered_set<ClientID> dead_clients_;
+  /// A buffer containing heartbeats received from node managers in the last tick.
   std::unordered_map<ClientID, HeartbeatTableDataT> heartbeat_buffer_;
 };
 

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -33,7 +33,7 @@ class Monitor {
   /// Handle a heartbeat from a Raylet.
   ///
   /// \param client_id The client ID of the Raylet that sent the heartbeat.
-  void HandleHeartbeat(const ClientID &client_id);
+  void HandleHeartbeat(const ClientID &client_id, const HeartbeatTableDataT &heartbeat_data);
 
  private:
   /// A client to the GCS, through which heartbeats are received.
@@ -47,6 +47,7 @@ class Monitor {
   std::unordered_map<ClientID, int64_t> heartbeats_;
   /// The Raylets that have been marked as dead in the client table.
   std::unordered_set<ClientID> dead_clients_;
+  std::unordered_map<ClientID, HeartbeatTableDataT> heartbeat_buffer_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -156,13 +156,14 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
-  // Subscribe to node manager heartbeats.
-  const auto heartbeat_added = [this](gcs::AsyncGcsClient *client, const ClientID &id,
-                                      const HeartbeatTableDataT &heartbeat_data) {
-    HeartbeatAdded(client, id, heartbeat_data);
+  // Subscribe to node manager heartbeat batch.
+  const auto heartbeat_batch_added =
+      [this](gcs::AsyncGcsClient *client, const ClientID &id,
+             const HeartbeatBatchTableDataT &heartbeat_batch) {
+    HeartbeatBatchAdded(client, id, heartbeat_batch);
   };
-  RAY_RETURN_NOT_OK(gcs_client_->heartbeat_table().Subscribe(
-      UniqueID::nil(), UniqueID::nil(), heartbeat_added, nullptr,
+  RAY_RETURN_NOT_OK(gcs_client_->heartbeat_batch_table().Subscribe(
+      UniqueID::nil(), UniqueID::nil(), heartbeat_batch_added, nullptr,
       [](gcs::AsyncGcsClient *client) {
         RAY_LOG(DEBUG) << "heartbeat table subscription done callback called.";
       }));
@@ -445,6 +446,14 @@ void NodeManager::HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &cl
     // Attempt to forward the task. If this fails to forward the task,
     // the task will be resubmit locally.
     ForwardTaskOrResubmit(task, client_id);
+  }
+}
+
+void NodeManager::HeartbeatBatchAdded(gcs::AsyncGcsClient *client,
+                                      const ClientID &client_id,
+                                      const HeartbeatBatchTableDataT& heartbeat_batch) {
+  for (auto& heartbeat_data : heartbeat_batch.batch) {
+    this->HeartbeatAdded(client, client_id, *heartbeat_data);
   }
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -450,9 +450,10 @@ void NodeManager::HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &cl
 }
 
 void NodeManager::HeartbeatBatchAdded(gcs::AsyncGcsClient *client,
-                                      const ClientID &client_id,
+                                      const UniqueID &publish_key,
                                       const HeartbeatBatchTableDataT& heartbeat_batch) {
   for (auto& heartbeat_data : heartbeat_batch.batch) {
+    ClientID client_id = ClientID::from_binary(heartbeat_data->client_id);
     this->HeartbeatAdded(client, client_id, *heartbeat_data);
   }
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -451,7 +451,7 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
 
 void NodeManager::HeartbeatBatchAdded(const HeartbeatBatchTableDataT &heartbeat_batch) {
   for (const auto &heartbeat_data : heartbeat_batch.batch) {
-    ClientID client_id = ClientID::from_binary(heartbeat_data->client_id);
+    const ClientID &client_id = ClientID::from_binary(heartbeat_data->client_id);
     HeartbeatAdded(client_id, *heartbeat_data);
   }
 }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -133,6 +133,9 @@ class NodeManager {
   /// \return Void.
   void HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &id,
                       const HeartbeatTableDataT &data);
+  /// Handler for a heartbeat batch notification from the GCS
+  void HeartbeatBatchAdded(gcs::AsyncGcsClient *client, const ClientID &client_id,
+                           const HeartbeatBatchTableDataT &heartbeat_batch);
 
   /// Methods for task scheduling.
 
@@ -404,6 +407,7 @@ class NodeManager {
   /// A mapping from actor ID to registration information about that actor
   /// (including which node manager owns it).
   std::unordered_map<ActorID, ActorRegistration> actor_registry_;
+
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -127,15 +127,14 @@ class NodeManager {
 
   /// Handler for a heartbeat notification from the GCS.
   ///
-  /// \param client The GCS client.
   /// \param id The ID of the node manager that sent the heartbeat.
   /// \param data The heartbeat data including load information.
   /// \return Void.
-  void HeartbeatAdded(gcs::AsyncGcsClient *client, const ClientID &id,
-                      const HeartbeatTableDataT &data);
+  void HeartbeatAdded(const ClientID &id, const HeartbeatTableDataT &data);
   /// Handler for a heartbeat batch notification from the GCS
-  void HeartbeatBatchAdded(gcs::AsyncGcsClient *client, const ClientID &client_id,
-                           const HeartbeatBatchTableDataT &heartbeat_batch);
+  ///
+  /// \param heartbeat_batch The batch of heartbeat data.
+  void HeartbeatBatchAdded(const HeartbeatBatchTableDataT &heartbeat_batch);
 
   /// Methods for task scheduling.
 
@@ -407,7 +406,6 @@ class NodeManager {
   /// A mapping from actor ID to registration information about that actor
   /// (including which node manager owns it).
   std::unordered_map<ActorID, ActorRegistration> actor_registry_;
-
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -141,7 +141,7 @@ std::vector<TaskID> SchedulingPolicy::SpillOver(
     if (!spec.IsActorTask()) {
       // Make sure the node has enough available resources to prevent forwarding cycles.
       if (spec.GetRequiredPlacementResources().IsSubset(
-          remote_scheduling_resources.GetAvailableResources())) {
+              remote_scheduling_resources.GetAvailableResources())) {
         decision.push_back(spec.TaskId());
         new_load.AddResources(spec.GetRequiredResources());
         break;

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -36,7 +36,20 @@ class SchedulingPolicy {
       std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
       const ClientID &local_client_id);
 
-  std::vector<TaskID> SpillOver(SchedulingResources &remote_scheduling_resources) const;
+
+  /// \brief Given a set of cluster resources and subset of cluster nodes,
+  /// perform a spill-over scheduling operation. This is a light-weight decision.
+  ///
+  /// \param cluster_resources: a set of cluster resources containing resource and load
+  /// information for some subset of the cluster. For all client IDs in the returned
+  /// placement map, the corresponding SchedulingResources::resources_load_ is
+  /// incremented by the aggregate resource demand of the tasks assigned to it.
+  /// \param remote_client_ids a list of IDs corresponding to raylets that participate
+  /// in this scheduling decision.
+  /// \return Scheduling decision, mapping tasks to raylets for placement.
+  std::unordered_map<TaskID, ClientID> SpillOver(
+      std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
+      const std::vector<ClientID> &remote_client_ids);
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -37,19 +37,14 @@ class SchedulingPolicy {
       const ClientID &local_client_id);
 
 
-  /// \brief Given a set of cluster resources and subset of cluster nodes,
-  /// perform a spill-over scheduling operation. This is a light-weight decision.
+  /// \brief Given a set of cluster resources perform a spill-over scheduling operation.
   ///
   /// \param cluster_resources: a set of cluster resources containing resource and load
   /// information for some subset of the cluster. For all client IDs in the returned
   /// placement map, the corresponding SchedulingResources::resources_load_ is
   /// incremented by the aggregate resource demand of the tasks assigned to it.
-  /// \param remote_client_ids a list of IDs corresponding to raylets that participate
-  /// in this scheduling decision.
   /// \return Scheduling decision, mapping tasks to raylets for placement.
-  std::unordered_map<TaskID, ClientID> SpillOver(
-      std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-      std::vector<ClientID> &remote_client_ids);
+  std::vector<TaskID> SpillOver(SchedulingResources &remote_scheduling_resources) const;
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -49,7 +49,7 @@ class SchedulingPolicy {
   /// \return Scheduling decision, mapping tasks to raylets for placement.
   std::unordered_map<TaskID, ClientID> SpillOver(
       std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
-      const std::vector<ClientID> &remote_client_ids);
+      std::vector<ClientID> &remote_client_ids);
 
   /// \brief SchedulingPolicy destructor.
   virtual ~SchedulingPolicy();

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -36,7 +36,6 @@ class SchedulingPolicy {
       std::unordered_map<ClientID, SchedulingResources> &cluster_resources,
       const ClientID &local_client_id);
 
-
   /// \brief Given a set of cluster resources perform a spill-over scheduling operation.
   ///
   /// \param cluster_resources: a set of cluster resources containing resource and load

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -145,8 +145,8 @@ const std::string ResourceSet::ToString() const {
   // Convert the first element to a string.
   if (it != resource_capacity_.end()) {
     return_string += "{" + it->first + "," + std::to_string(it->second) + "}";
+    it++;
   }
-  it++;
 
   // Add the remaining elements to the string (along with a comma).
   for (; it != resource_capacity_.end(); ++it) {

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -921,7 +921,9 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
         redirect_output=True,
         num_cpus=(num_local_schedulers * [10 * num_gpus_per_scheduler]),
         num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]),
-        _internal_config=json.dumps({"num_heartbeats_timeout": 1000}))
+        _internal_config=json.dumps({
+            "num_heartbeats_timeout": 1000
+        }))
 
     @ray.remote
     def create_actors(i, n):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import json
 import random
 import numpy as np
 import os
@@ -919,7 +920,8 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
         num_local_schedulers=num_local_schedulers,
         redirect_output=True,
         num_cpus=(num_local_schedulers * [10 * num_gpus_per_scheduler]),
-        num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]))
+        num_gpus=(num_local_schedulers * [num_gpus_per_scheduler]),
+        _internal_config=json.dumps({"num_heartbeats_timeout": 1000}))
 
     @ray.remote
     def create_actors(i, n):

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -927,12 +927,11 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
         class Actor(object):
             def __init__(self, i, j):
                 self.gpu_ids = ray.get_gpu_ids()
-                print("created actor", i, j, self.gpu_ids)
 
             def get_location_and_ids(self):
                 return ((
                     ray.worker.global_worker.plasma_client.store_socket_name),
-                    tuple(self.gpu_ids))
+                        tuple(self.gpu_ids))
 
             def sleep(self):
                 time.sleep(100)
@@ -942,15 +941,13 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
         for j in range(n):
             actors.append(Actor.remote(i, j))
 
-        locations = ray.get([actor.get_location_and_ids.remote() for actor in
-                             actors])
-        print("got locations", i)
+        locations = ray.get(
+            [actor.get_location_and_ids.remote() for actor in actors])
 
         # Put each actor to sleep for a long time to prevent them from getting
         # terminated.
         for actor in actors:
             actor.sleep.remote()
-        print("sleeping", i)
 
         return locations
 
@@ -960,8 +957,10 @@ def test_actor_multiple_gpus_from_multiple_tasks(shutdown_only):
     ])
 
     # Make sure that no two actors are assigned to the same GPU.
-    node_names = {location for locations in all_locations for location, gpu_id
-                  in locations}
+    node_names = {
+        location
+        for locations in all_locations for location, gpu_id in locations
+    }
     assert len(node_names) == num_local_schedulers
 
     # Keep track of which GPU IDs are being used for each location.


### PR DESCRIPTION
Instead of sending n^2 heartbeats from each node manager to each other node manager, send 2n heartbeats by sending heartbeats from each node manager to the monitor, batching them together in the monitor, and sending them out to all the node managers. #2949
