### PR TITLE
[Java] Enable default driver

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
@@ -1,27 +1,47 @@
 package org.ray.runtime.runner.worker;
 
-import org.ray.api.Ray;
-
 /**
  * The main function of DefaultDriver.
  */
 public class DefaultDriver {
 
-  //
-  // " --node-ip-address=" + ip
-  // + " --redis-address=" + redisAddress
-  // + " --driver-class" + className
-  //
+  /**
+   * Command line:
+   *
+   * <p>java -ea org.ray.runtime.runner.worker driverClassName [driverArg1, ...]
+   *
+   * <p>1. If you want to set `driver.id` to this driver, you should set it in system property,
+   * like this:
+   *       java -ea -Dray.driver.id=0123456789ABCDEF0123
+   *             org.ray.runtime.runner.worker driverClassName [driverArg1, ...]
+   *
+   * <p>2. DefaultDriver also needs `ray.conf` in classpath. You must specify
+   *        driver jar package in classpath that DefaultDriver can load it to execute.
+   */
+
   public static void main(String[] args) {
+
+    if (args.length < 1) {
+      throw new IllegalArgumentException(
+          "Failed to start DefaultDriver: driverClassName was not specified.");
+    }
+
+    String driverClassName = args[0];
+    final int driverArgsLength = args.length - 1;
+
+    String[] dirverArgs;
+    if (driverArgsLength > 0) {
+      dirverArgs = new String[args.length - 1];
+      System.arraycopy(args, 1, dirverArgs, 0, args.length - 1);
+    } else {
+      dirverArgs = new String [] {};
+    }
+
     try {
       System.setProperty("ray.worker.mode", "DRIVER");
-      Ray.init();
 
-      String driverClass = null;
-      String driverArgs = null;
-      Class<?> cls = Class.forName(driverClass);
-      String[] argsArray = (driverArgs != null) ? driverArgs.split(",") : (new String[] {});
-      cls.getMethod("main", String[].class).invoke(null, (Object) argsArray);
+      Class<?> cls = Class.forName(driverClassName);
+      cls.getMethod("main", String[].class).invoke(null, (Object) dirverArgs);
     } catch (Throwable e) {
       e.printStackTrace();
       System.exit(-1);

--- a/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
@@ -1,5 +1,7 @@
 package org.ray.runtime.runner.worker;
 
+import org.ray.api.Ray;
+
 /**
  * The main function of DefaultDriver.
  */
@@ -8,12 +10,12 @@ public class DefaultDriver {
   /**
    * Command line:
    *
-   * <p>java -ea org.ray.runtime.runner.worker driverClassName [driverArg1,driverArgs2,...]
+   * <p>java org.ray.runtime.runner.worker driverClassName [driverArg1, ...]
    *
    * <p>1. If you want to set `driver.id` to this driver, you should set it in system property,
    * like this:
-   *       java -ea -Dray.driver.id=0123456789ABCDEF0123
-   *             org.ray.runtime.runner.worker driverClassName [driverArg1,driverArgs2,...]
+   *       java -Dray.driver.id=0123456789ABCDEF0123
+   *             org.ray.runtime.runner.worker.DefaultDriver driverClassName [driverArg1, ...]
    *
    * <p>2. DefaultDriver also needs `ray.conf` in classpath. You must specify
    *        driver jar package in classpath that DefaultDriver can load it to execute.
@@ -27,20 +29,25 @@ public class DefaultDriver {
     }
 
     String driverClassName = args[0];
-    String driverArgs = null;
-    if (args.length > 1) {
-      driverArgs = args[1];
+    final int driverArgsLength = args.length - 1;
+
+    String[] driverArgs;
+    if (driverArgsLength > 0) {
+      driverArgs = new String[driverArgsLength];
+      System.arraycopy(args, 1, driverArgs, 0, driverArgsLength);
+    } else {
+      driverArgs = new String[] {};
     }
-    String[] argsArray = (driverArgs != null) ? driverArgs.split(",") : (new String[] {});
 
     try {
       System.setProperty("ray.worker.mode", "DRIVER");
-
+      Ray.init();
       Class<?> cls = Class.forName(driverClassName);
-      cls.getMethod("main", String[].class).invoke(null, (Object) argsArray);
-    } catch (Throwable e) {
-      e.printStackTrace();
-      System.exit(-1);
+      cls.getMethod("main", String[].class).invoke(null, (Object) driverArgs);
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      Ray.shutdown();
     }
   }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
@@ -29,19 +29,19 @@ public class DefaultDriver {
     String driverClassName = args[0];
     final int driverArgsLength = args.length - 1;
 
-    String[] dirverArgs;
+    String[] driverArgs;
     if (driverArgsLength > 0) {
-      dirverArgs = new String[args.length - 1];
-      System.arraycopy(args, 1, dirverArgs, 0, args.length - 1);
+      driverArgs = new String[args.length - 1];
+      System.arraycopy(args, 1, driverArgs, 0, args.length - 1);
     } else {
-      dirverArgs = new String [] {};
+      driverArgs = new String [] {};
     }
 
     try {
       System.setProperty("ray.worker.mode", "DRIVER");
 
       Class<?> cls = Class.forName(driverClassName);
-      cls.getMethod("main", String[].class).invoke(null, (Object) dirverArgs);
+      cls.getMethod("main", String[].class).invoke(null, (Object) driverArgs);
     } catch (Throwable e) {
       e.printStackTrace();
       System.exit(-1);

--- a/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/worker/DefaultDriver.java
@@ -8,12 +8,12 @@ public class DefaultDriver {
   /**
    * Command line:
    *
-   * <p>java -ea org.ray.runtime.runner.worker driverClassName [driverArg1, ...]
+   * <p>java -ea org.ray.runtime.runner.worker driverClassName [driverArg1,driverArgs2,...]
    *
    * <p>1. If you want to set `driver.id` to this driver, you should set it in system property,
    * like this:
    *       java -ea -Dray.driver.id=0123456789ABCDEF0123
-   *             org.ray.runtime.runner.worker driverClassName [driverArg1, ...]
+   *             org.ray.runtime.runner.worker driverClassName [driverArg1,driverArgs2,...]
    *
    * <p>2. DefaultDriver also needs `ray.conf` in classpath. You must specify
    *        driver jar package in classpath that DefaultDriver can load it to execute.
@@ -27,21 +27,17 @@ public class DefaultDriver {
     }
 
     String driverClassName = args[0];
-    final int driverArgsLength = args.length - 1;
-
-    String[] driverArgs;
-    if (driverArgsLength > 0) {
-      driverArgs = new String[args.length - 1];
-      System.arraycopy(args, 1, driverArgs, 0, args.length - 1);
-    } else {
-      driverArgs = new String [] {};
+    String driverArgs = null;
+    if (args.length > 1) {
+      driverArgs = args[1];
     }
+    String[] argsArray = (driverArgs != null) ? driverArgs.split(",") : (new String[] {});
 
     try {
       System.setProperty("ray.worker.mode", "DRIVER");
 
       Class<?> cls = Class.forName(driverClassName);
-      cls.getMethod("main", String[].class).invoke(null, (Object) driverArgs);
+      cls.getMethod("main", String[].class).invoke(null, (Object) argsArray);
     } catch (Throwable e) {
       e.printStackTrace();
       System.exit(-1);


### PR DESCRIPTION
## What do these changes do?
We can run an user code as a driver directly, but for more flexibility, we should retain `DefaultDriver` as well.

Since the refactor in Java worker, the default driver can not be used right now. This PR fixed it.

Command line to run a default driver:
```shell
java org.ray.runtime.runner.worker.DefaultDriver driverClassName [driverArg1, driverArgs2...]
```

Also, you must make sure that this process can find `ray.conf` in classpath.


## Related issue number
N/A
