### PR TITLE
[Java] Add loadResourcesFromLocal field in RayConfig.

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -48,7 +48,9 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   public AbstractRayRuntime(RayConfig rayConfig) {
     this.rayConfig = rayConfig;
-    functionManager = new FunctionManager(rayConfig.driverResourcePath);
+    functionManager = new FunctionManager(rayConfig.loadResourcesFromLocal,
+        rayConfig.driverResourcePath);
+
     worker = new Worker(this);
     workerContext = new WorkerContext(rayConfig.workerMode, rayConfig.driverId);
   }

--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -51,6 +51,7 @@ public class RayConfig {
   public final String redisModulePath;
   public final String plasmaStoreExecutablePath;
   public final String rayletExecutablePath;
+  public final boolean loadResourcesFromLocal;
   public final String driverResourcePath;
 
   private void validate() {
@@ -157,10 +158,14 @@ public class RayConfig {
     plasmaStoreExecutablePath = rayHome + "/build/src/plasma/plasma_store_server";
     rayletExecutablePath = rayHome + "/build/src/ray/raylet/raylet";
 
+    // This flag represents whether a worker should
+    // load the driver resources from local path.
+    loadResourcesFromLocal = config.getBoolean("ray.driver.resource.from-local");
+
     // driver resource path
     String localDriverResourcePath;
-    if (config.hasPath("ray.driver.resource-path")) {
-      localDriverResourcePath = config.getString("ray.driver.resource-path");
+    if (config.hasPath("ray.driver.resource.path")) {
+      localDriverResourcePath = config.getString("ray.driver.resource.path");
     } else {
       localDriverResourcePath = rayHome + "/driver/resource";
       LOGGER.warn("Didn't configure ray.driver.resource-path, set it to default value: {}",

--- a/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java
@@ -42,6 +42,11 @@ public class FunctionManager {
   private Map<UniqueId, DriverFunctionTable> driverFunctionTables = new HashMap<>();
 
   /**
+   * Whether load resources from local path.
+   */
+  private boolean loadResourcesfromLocal;
+
+  /**
    * The resource path which we can load the driver's jar resources.
    */
   private String driverResourcePath;
@@ -52,7 +57,8 @@ public class FunctionManager {
    * @param driverResourcePath The specified driver resource that
    *     can store the driver's resources.
    */
-  public FunctionManager(String driverResourcePath) {
+  public FunctionManager(boolean loadResourcesfromLocal, String driverResourcePath) {
+    this.loadResourcesfromLocal = loadResourcesfromLocal;
     this.driverResourcePath = driverResourcePath;
   }
 
@@ -89,13 +95,11 @@ public class FunctionManager {
       String resourcePath = driverResourcePath + "/" + driverId.toString() + "/";
       ClassLoader classLoader;
 
-      try {
+      if (loadResourcesfromLocal) {
         classLoader = JarLoader.loadJars(resourcePath, false);
         LOGGER.info("Succeeded to load driver({}) resource. Resource path is {}",
             driverId, resourcePath);
-      } catch (Exception e) {
-        LOGGER.error("Failed to load driver({}) resource. Resource path is {}",
-            driverId, resourcePath);
+      } else {
         classLoader = getClass().getClassLoader();
       }
 

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -25,15 +25,21 @@ ray {
   // Available resources on this node, for example "CPU:4,GPU:0".
   resources: ""
 
-    // Configuration items about driver.
-    driver {
-      // If worker.mode is DRIVER, specify the driver id.
-      // If not provided, a random id will be used.
-      id: ""
-      // If worker.mode is WORKER, it means that worker will load
-      // the resources from this path to execute tasks.
-      resource-path: /tmp/ray/driver/resource
+  // Configuration items about driver.
+  driver {
+    // If worker.mode is DRIVER, specify the driver id.
+    // If not provided, a random id will be used.
+    id: ""
+
+    // If worker.mode is WORKER, this field will be enabled.
+    // And if worker.mode is  DRIVER, this field will not.
+    resource {
+      // Whether the worker should load resources from local path.
+      from-local: false
+      // Worker will load the resources from this path for tasks.
+      path: /tmp/ray/driver/resource
     }
+  }
 
   // Root dir of log files.
   log-dir: /tmp/ray/logs

--- a/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
+++ b/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
@@ -45,9 +45,7 @@ public class FunctionManagerTest {
   private static FunctionDescriptor barDescriptor;
   private static FunctionDescriptor barConstructorDescriptor;
 
-  private final static String resourcePath = "/tmp/ray/test/resource";
-
-  private FunctionManager functionManager;
+  private final static String RESOURCE_PATH = "/tmp/ray/test/resource";
 
   @BeforeClass
   public static void beforeClass() {
@@ -63,13 +61,9 @@ public class FunctionManagerTest {
         "()V");
   }
 
-  @Before
-  public void before() {
-    functionManager = new FunctionManager(FunctionManagerTest.resourcePath);
-  }
-
   @Test
   public void testGetFunctionFromRayFunc() {
+    FunctionManager functionManager = new FunctionManager(false, FunctionManagerTest.RESOURCE_PATH);
     // Test normal function.
     RayFunction func = functionManager.getFunction(UniqueId.NIL, fooFunc);
     Assert.assertFalse(func.isConstructor());
@@ -91,6 +85,7 @@ public class FunctionManagerTest {
 
   @Test
   public void testGetFunctionFromFunctionDescriptor() {
+    FunctionManager functionManager = new FunctionManager(false, FunctionManagerTest.RESOURCE_PATH);
     // Test normal function.
     RayFunction func = functionManager.getFunction(UniqueId.NIL, fooDescriptor);
     Assert.assertFalse(func.isConstructor());
@@ -131,16 +126,17 @@ public class FunctionManagerTest {
     //TODO(qwang): We should use a independent app demo instead of `tutorial`.
     final String srcJarPath = System.getProperty("user.dir") +
                                   "/../tutorial/target/ray-tutorial-0.1-SNAPSHOT.jar";
-    final String destJarPath = resourcePath + "/" + driverId.toString() +
+    final String destJarPath = RESOURCE_PATH + "/" + driverId.toString() +
                                    "/ray-tutorial-0.1-SNAPSHOT.jar";
 
-    File file = new File(resourcePath + "/" + driverId.toString());
+    File file = new File(RESOURCE_PATH + "/" + driverId.toString());
     file.mkdirs();
 
     Files.copy(Paths.get(srcJarPath), Paths.get(destJarPath), StandardCopyOption.REPLACE_EXISTING);
 
     FunctionDescriptor sayHelloDescriptor = new FunctionDescriptor("org.ray.exercise.Exercise02",
         "sayHello", "()Ljava/lang/String;");
+    FunctionManager functionManager = new FunctionManager(true, FunctionManagerTest.RESOURCE_PATH);
     RayFunction func = functionManager.getFunction(driverId, sayHelloDescriptor);
     Assert.assertEquals(func.getFunctionDescriptor(), sayHelloDescriptor);
   }

--- a/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
@@ -11,7 +11,7 @@ public class RayConfigTest {
   @Test
   public void testCreateRayConfig() {
     System.setProperty("ray.home", "/path/to/ray");
-    System.setProperty("ray.driver.resource-path", "path/to/ray/driver/resource/path");
+    System.setProperty("ray.driver.resource.path", "path/to/ray/driver/resource/path");
     RayConfig rayConfig = RayConfig.create();
 
     Assert.assertEquals("/path/to/ray", rayConfig.rayHome);


### PR DESCRIPTION
## What do these changes do?

https://github.com/ray-project/ray/blob/master/java/runtime/src/main/java/org/ray/runtime/functionmanager/FunctionManager.java#L92-L100

If user don't specify the driver resources path, it will catch an exception and set the classLoader to a default one. But it doesn't make sense: we shouldn't choose the code path by exception.

This PR added a field in config that user can specify the way the worker load resources: from local or not.


## Related issue number
N/A
