### PR TITLE
[cmake] bugfix: rerun build.sh will cause pyarrow files missing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,12 +101,15 @@ fi
 
 pushd "$BUILD_DIR"
 
+# avoid the command failed and exits
+# and cmake will check some directories to determine whether some targets built
+make clean || true
+
 cmake -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \
       -DCMAKE_RAY_LANG_PYTHON=$RAY_BUILD_PYTHON \
       -DRAY_USE_NEW_GCS=$RAY_USE_NEW_GCS \
       -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON_EXECUTABLE $ROOT_DIR
 
-make clean
 make -j${PARALLEL}
 popd

--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -9,6 +9,7 @@
 #  - ARROW_INCLUDE_DIR
 #  - ARROW_SHARED_LIB
 #  - ARROW_STATIC_LIB
+#  - ARROW_LIBRARY_DIR
 #  - PLASMA_INCLUDE_DIR
 #  - PLASMA_STATIC_LIB
 #  - PLASMA_SHARED_LIB
@@ -95,12 +96,16 @@ ExternalProject_Add(arrow_ep
   BUILD_BYPRODUCTS "${ARROW_SHARED_LIB}" "${ARROW_STATIC_LIB}")
 
 if ("${CMAKE_RAY_LANG_JAVA}" STREQUAL "YES")
-  ExternalProject_Add_Step(arrow_ep arrow_ep_install_java_lib
-    COMMAND bash -c "cd ${ARROW_SOURCE_DIR}/java && mvn clean install -pl plasma -am -Dmaven.test.skip > /dev/null"
-    DEPENDEES build)
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${ARROW_SOURCE_DIR}/java/target/")
+
+  if(NOT EXISTS ${ARROW_SOURCE_DIR}/java/target/)
+    ExternalProject_Add_Step(arrow_ep arrow_ep_install_java_lib
+      COMMAND bash -c "cd ${ARROW_SOURCE_DIR}/java && mvn clean install -pl plasma -am -Dmaven.test.skip > /dev/null"
+      DEPENDEES build)
+  endif()
 
   # add install of library plasma_java, it is not configured in plasma CMakeLists.txt
   ExternalProject_Add_Step(arrow_ep arrow_ep_install_plasma_java
-    COMMAND bash -c "cp ${CMAKE_CURRENT_BINARY_DIR}/external/arrow/src/arrow_ep-build/release/libplasma_java.* ${ARROW_LIBRARY_DIR}/"
+    COMMAND bash -c "cp -rf ${CMAKE_CURRENT_BINARY_DIR}/external/arrow/src/arrow_ep-build/release/libplasma_java.* ${ARROW_LIBRARY_DIR}/"
     DEPENDEES install)
 endif ()


### PR DESCRIPTION


<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. move make clean before cmake command, because cmake will build some modules by checking some directories exist or not
2. avoid always running mvn install plasma java lib

question: do we have better solution of skipping build of some modules? including pyarrow, plasma_java.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
