### PR TITLE
fix misleading comment

### DIFF
--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -25,7 +25,7 @@ EPISODES_TOTAL = "episodes_total"
 # Number of timesteps in this iteration.
 TIMESTEPS_THIS_ITER = "timesteps_this_iter"
 
-# (Optional/Auto-filled) Accumulated time in seconds for this experiment.
+# (Auto-filled) Accumulated number of timesteps for this entire experiment.
 TIMESTEPS_TOTAL = "timesteps_total"
 
 # (Auto-filled) Time in seconds this iteration took to run.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fixes the comment for `TIMESTEPS_TOTAL` which seems to refer to an integer. 
<!-- Please give a short brief about these changes. -->

## Related issue number
None
<!-- Are there any issues opened that will be resolved by merging this change? -->
