### PR TITLE
[Java] Add jvm-parameters in Config.

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -130,10 +130,10 @@ public class RayConfig {
     // custom classpath
     classpath = config.getStringList("ray.classpath");
     // custom worker jvm parameters
-    if (config.hasPath("ray.jvm-parameters")) {
-      jvmParameters = config.getStringList("ray.jvm-parameters");
+    if (config.hasPath("ray.worker.jvm-parameters")) {
+      jvmParameters = config.getStringList("ray.worker.jvm-parameters");
     } else {
-      jvmParameters = null;
+      jvmParameters = ImmutableList.of();
     }
 
     // redis configurations

--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
+
 import java.util.List;
 import java.util.Map;
 import org.ray.api.id.UniqueId;
@@ -35,6 +36,7 @@ public class RayConfig {
   public final boolean redirectOutput;
   public final List<String> libraryPath;
   public final List<String> classpath;
+  public final List<String> jvmParameters;
 
   private String redisAddress;
   private String redisIp;
@@ -127,6 +129,12 @@ public class RayConfig {
     List<String> customLibraryPath = config.getStringList("ray.library.path");
     // custom classpath
     classpath = config.getStringList("ray.classpath");
+    // custom worker jvm parameters
+    if (config.hasPath("ray.jvm-parameters")) {
+      jvmParameters = config.getStringList("ray.jvm-parameters");
+    } else {
+      jvmParameters = null;
+    }
 
     // redis configurations
     String redisAddress = config.getString("ray.redis.address");

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -227,6 +227,10 @@ public class RunManager {
     // Config overwrite
     cmd.add("-Dray.redis.address=" + rayConfig.getRedisAddress());
 
+    if (rayConfig.jvmParameters != null) {
+      cmd.addAll(rayConfig.jvmParameters);
+    }
+
     // Main class
     cmd.add(WORKER_CLASS);
     String command = Joiner.on(" ").join(cmd);

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -205,8 +205,8 @@ public class RunManager {
 
     // Generate classpath based on current classpath + user-defined classpath.
     String classpath = concatPath(Stream.concat(
-        Stream.of(System.getProperty("java.class.path").split(":")),
-        rayConfig.classpath.stream()
+        rayConfig.classpath.stream(),
+        Stream.of(System.getProperty("java.class.path").split(":"))
     ));
     cmd.add(classpath);
 

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -227,9 +227,7 @@ public class RunManager {
     // Config overwrite
     cmd.add("-Dray.redis.address=" + rayConfig.getRedisAddress());
 
-    if (rayConfig.jvmParameters != null) {
-      cmd.addAll(rayConfig.jvmParameters);
-    }
+    cmd.addAll(rayConfig.jvmParameters);
 
     // Main class
     cmd.add(WORKER_CLASS);

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -44,7 +44,7 @@ ray {
   redirect-output: true
 
   // Custom worker jvm parameters.
-  jvm-parameters: []
+  worker.jvm-parameters: []
 
   // Custom `java.library.path`
   // Note, do not use `dir1:dir2` format, put each dir as a list item.

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -43,6 +43,9 @@ ray {
   // Otherwise, output will be printed to console.
   redirect-output: true
 
+  // Custom worker jvm parameters.
+  jvm-parameters: []
+
   // Custom `java.library.path`
   // Note, do not use `dir1:dir2` format, put each dir as a list item.
   library.path: []


### PR DESCRIPTION
## What do these changes do?

We couldn't specify the system properties for a Java worker now. If we want to do this, we must write the `ray.conf` in worker classpathes. Obviously,  it's not convenient.

This PR add a `jvm-parameters` item in config that we can specify the system properties for a Java worker.

## Related issue number
This fixed the 2nd point in the issue #3062 : 
`can not set worker jvm parameters in config file.`