### PR TITLE
generate webui_url with ip address

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -816,7 +816,7 @@ def start_ui(redis_address, stdout_file=None, stderr_file=None, cleanup=True):
     # We generate the token used for authentication ourselves to avoid
     # querying the jupyter server.
     new_notebook_directory, webui_url, token = (
-        get_ipython_notebook_path(port))
+        get_ipython_notebook_path(get_node_ip_address(), port))
     # The --ip=0.0.0.0 flag is intended to enable connecting to a notebook
     # running within a docker container (from the outside).
     command = [

--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -138,7 +138,7 @@ def get_local_scheduler_socket_name(suffix=""):
     return raylet_socket_name
 
 
-def get_ipython_notebook_path(port):
+def get_ipython_notebook_path(ip, port):
     """Get a new ipython notebook path"""
 
     notebook_filepath = os.path.join(
@@ -151,8 +151,8 @@ def get_ipython_notebook_path(port):
     shutil.copy(notebook_filepath, new_notebook_filepath)
     new_notebook_directory = os.path.dirname(new_notebook_filepath)
     token = ray.utils.decode(binascii.hexlify(os.urandom(24)))
-    webui_url = ("http://localhost:{}/notebooks/{}?token={}".format(
-        port, os.path.basename(notebook_name), token))
+    webui_url = ("http://{}:{}/notebooks/{}?token={}".format(
+        ip, port, os.path.basename(notebook_name), token))
     return new_notebook_directory, webui_url, token
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When we start ray, it will generate the web UI for jupyter, such as:
```
======================================================================
View the web UI at http://localhost:8888/notebooks/ray_ui.ipynb?token=ff1c08d8cf2bdfb1b6fa2aa385ca0d114ee6513582777990
======================================================================
```
The web UI is start with "http://localhost", so we can't access the url in other machine.
We should generate the web UI with ip address, such as:
```
======================================================================
View the web UI at http://10.*.*.17:8889/notebooks/ray_ui.ipynb?token=654690e18f4541e17aea90721e7e6fe28ec5b0d9dd7f955e
======================================================================
```
Then, we can access the url in other machine:
![image](https://user-images.githubusercontent.com/35217964/46943495-57232300-d0a2-11e8-8cd4-27d5de444173.png)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#3066 
