### PR TITLE
[xray] Implement faster flush policy for lineage cache

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -358,7 +358,7 @@ bool LineageCache::UnsubscribeTask(const TaskID &task_id) {
 }
 
 void LineageCache::EvictTask(const TaskID &task_id) {
-  // If we haven't received a commit for this task yet. do not evict.
+  // If we haven't received a commit for this task yet, do not evict.
   auto commit_it = committed_tasks_.find(task_id);
   if (commit_it == committed_tasks_.end()) {
     return;

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -374,7 +374,6 @@ void LineageCache::EvictTask(const TaskID &task_id) {
   RAY_LOG(DEBUG) << "evicting task " << task_id << " on " << client_id_;
   lineage_.PopEntry(task_id);
   committed_tasks_.erase(commit_it);
-  UnsubscribeTask(task_id);
   // Try to evict the children of the evict task. These are the tasks that have
   // a dependency on the evicted task.
   auto children_entry = children_.find(task_id);
@@ -402,6 +401,9 @@ void LineageCache::HandleEntryCommitted(const TaskID &task_id) {
   // Record the commit acknowledgement and attempt to evict the task.
   committed_tasks_.insert(task_id);
   EvictTask(task_id);
+  // We got the notification about the task's commit, so no longer need any
+  // more notifications.
+  UnsubscribeTask(task_id);
 }
 
 const Task &LineageCache::GetTask(const TaskID &task_id) const {

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -181,9 +181,12 @@ bool LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
   // should be marked as UNCOMMITTED_READY once the task starts execution.
   auto added = lineage_.SetEntry(task, GcsStatus::UNCOMMITTED_WAITING);
 
-  // Do not subscribe to the task itself. We just added it as
+  // Do not subscribe to the waiting task itself. We just added it as
   // UNCOMMITTED_WAITING, so the task is local.
   subscribe_tasks.erase(task_id);
+  // Unsubscribe to the waiting task since we may have previously been
+  // subscribed to it.
+  UnsubscribeTask(task_id);
   // Subscribe to all other tasks that were included in the uncommitted lineage
   // and that were not already in the local stash. These tasks haven't been
   // committed yet and will be committed by a different node, so we will not

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -363,7 +363,7 @@ void LineageCache::EvictTask(const TaskID &task_id) {
   if (commit_it == committed_tasks_.end()) {
     return;
   }
-  // If the entry ahs already been evicted, exit.
+  // If the entry has already been evicted, exit.
   auto entry = lineage_.GetEntry(task_id);
   if (!entry) {
     return;

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -139,10 +139,7 @@ LineageCache::LineageCache(const ClientID &client_id,
                            gcs::TableInterface<TaskID, protocol::Task> &task_storage,
                            gcs::PubsubInterface<TaskID> &task_pubsub,
                            uint64_t max_lineage_size)
-    : client_id_(client_id),
-      task_storage_(task_storage),
-      task_pubsub_(task_pubsub),
-      max_lineage_size_(max_lineage_size) {}
+    : client_id_(client_id), task_storage_(task_storage), task_pubsub_(task_pubsub) {}
 
 /// A helper function to merge one lineage into another, in DFS order.
 ///
@@ -180,21 +177,33 @@ void MergeLineageHelper(const TaskID &task_id, const Lineage &lineage_from,
   }
 }
 
+/// A helper function to merge one lineage into another, in DFS order.
+void LineageCache::AddUncommittedLineage(const TaskID &task_id,
+                                         const Lineage &uncommitted_lineage) {
+  // If the entry is not found in the lineage to merge, then we stop since
+  // there is nothing to copy into the merged lineage.
+  auto entry = uncommitted_lineage.GetEntry(task_id);
+  if (!entry) {
+    return;
+  }
+  RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_REMOTE);
+
+  // Insert a copy of the entry into lineage_to.
+  const auto &parent_ids = entry->GetParentTaskIds();
+  // If the insert is successful, then continue the DFS. The insert will fail
+  // if the new entry has an equal or lower GCS status than the current entry
+  // in lineage_to. This also prevents us from traversing the same node twice.
+  if (lineage_.SetEntry(entry->TaskData(), entry->GetStatus())) {
+    for (const auto &parent_id : parent_ids) {
+      children_[parent_id].insert(task_id);
+      AddUncommittedLineage(parent_id, uncommitted_lineage);
+    }
+  }
+}
+
 bool LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_lineage) {
   auto task_id = task.GetTaskSpecification().TaskId();
   RAY_LOG(DEBUG) << "add waiting task " << task_id << " on " << client_id_;
-  // Merge the uncommitted lineage into the lineage cache.
-  MergeLineageHelper(task_id, uncommitted_lineage, lineage_,
-                     [](const LineageEntry &entry) {
-                       if (entry.GetStatus() != GcsStatus::NONE) {
-                         // We received the uncommitted lineage from a remote node, so
-                         // make sure that all entries in the lineage to merge have
-                         // status UNCOMMITTED_REMOTE.
-                         RAY_CHECK(entry.GetStatus() == GcsStatus::UNCOMMITTED_REMOTE);
-                       }
-                       // The only stopping condition is that an entry is not found.
-                       return false;
-                     });
 
   auto entry = lineage_.GetEntry(task_id);
   if (entry) {
@@ -205,9 +214,17 @@ bool LineageCache::AddWaitingTask(const Task &task, const Lineage &uncommitted_l
     }
   }
 
+  // Merge the uncommitted lineage into the lineage cache.
+  AddUncommittedLineage(task_id, uncommitted_lineage);
+
   // Add the submitted task to the lineage cache as UNCOMMITTED_WAITING. It
   // should be marked as UNCOMMITTED_READY once the task starts execution.
-  return lineage_.SetEntry(task, GcsStatus::UNCOMMITTED_WAITING);
+  auto added = lineage_.SetEntry(task, GcsStatus::UNCOMMITTED_WAITING);
+  entry = lineage_.GetEntry(task_id);
+  for (const auto &parent_id : entry->GetParentTaskIds()) {
+    children_[parent_id].insert(task_id);
+  }
+  return added;
 }
 
 bool LineageCache::AddReadyTask(const Task &task) {
@@ -217,40 +234,13 @@ bool LineageCache::AddReadyTask(const Task &task) {
   // Set the task to READY.
   if (lineage_.SetEntry(task, GcsStatus::UNCOMMITTED_READY)) {
     // Attempt to flush the task.
-    bool flushed = FlushTask(task_id);
-    if (!flushed) {
-      // If we fail to flush the task here, due to uncommitted parents, then add
-      // the task to a cache to be flushed in the future.
-      uncommitted_ready_tasks_.insert(task_id);
-    }
+    FlushTask(task_id);
     return true;
   } else {
     // The task was already ready to be committed (UNCOMMITTED_READY) or
     // committing (COMMITTING).
     return false;
   }
-}
-
-uint64_t LineageCache::CountUnsubscribedLineage(const TaskID &task_id,
-                                                std::unordered_set<TaskID> &seen) const {
-  if (seen.count(task_id) == 1) {
-    return 0;
-  }
-  seen.insert(task_id);
-  if (subscribed_tasks_.count(task_id) == 1) {
-    return 0;
-  }
-  auto entry = lineage_.GetEntry(task_id);
-  // Only count tasks that are remote. Tasks that are local will be evicted
-  // once they are committed in the GCS, along with their lineage.
-  if (!entry || entry->GetStatus() != GcsStatus::UNCOMMITTED_REMOTE) {
-    return 0;
-  }
-  uint64_t cnt = 1;
-  for (const auto &parent_id : entry->GetParentTaskIds()) {
-    cnt += CountUnsubscribedLineage(parent_id, seen);
-  }
-  return cnt;
 }
 
 bool LineageCache::RemoveWaitingTask(const TaskID &task_id) {
@@ -274,36 +264,7 @@ bool LineageCache::RemoveWaitingTask(const TaskID &task_id) {
   // completely in case another task is submitted locally that depends on this
   // one.
   entry->ResetStatus(GcsStatus::UNCOMMITTED_REMOTE);
-
-  // Subscribe to the task if necessary. We do this if it has any local
-  // children that must be written to the GCS, or if its uncommitted remote
-  // lineage is too large.
-  if (uncommitted_ready_children_.find(task_id) != uncommitted_ready_children_.end()) {
-    // Subscribe to the task if it has any children in UNCOMMITTED_READY. We
-    // will attempt to flush its children once we receive a notification for
-    // this task's commit.  Since this task was in state WAITING, check that we
-    // were not already subscribed to the task.
-    RAY_CHECK(SubscribeTask(task_id));
-  } else {
-    // Check if the uncommitted remote lineage is too large.  Request a
-    // notification for every max_lineage_size_ tasks, so that the task and its
-    // uncommitted lineage can be evicted once the commit notification is
-    // received.  By doing this, we make sure that the unevicted lineage won't
-    // be more than max_lineage_size_, and the number of subscribed tasks won't
-    // be more than N / max_lineage_size_, where N is the size of the task
-    // chain.
-    // NOTE(swang): The number of entries in the uncommitted lineage also
-    // includes local tasks that haven't been committed yet, not just remote
-    // tasks, so this is an overestimate.
-    std::unordered_set<TaskID> seen;
-    auto count = CountUnsubscribedLineage(task_id, seen);
-    if (count >= max_lineage_size_) {
-      // Since this task was in state WAITING, check that we were not
-      // already subscribed to the task.
-      RAY_CHECK(SubscribeTask(task_id));
-    }
-  }
-  // The task was successfully reset to UNCOMMITTED_REMOTE.
+  RAY_CHECK(SubscribeTask(task_id));
   return true;
 }
 
@@ -334,72 +295,29 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
   return uncommitted_lineage;
 }
 
-bool LineageCache::FlushTask(const TaskID &task_id) {
-  auto entry = lineage_.GetEntry(task_id);
+void LineageCache::FlushTask(const TaskID &task_id) {
+  auto entry = lineage_.GetEntryMutable(task_id);
   RAY_CHECK(entry);
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_READY);
 
-  // Check if all arguments have been committed to the GCS before writing
-  // this task.
-  bool all_arguments_committed = true;
-  for (const auto &parent_id : entry->GetParentTaskIds()) {
-    auto parent = lineage_.GetEntry(parent_id);
-    // If a parent entry exists in the lineage cache but has not been
-    // committed yet, then as far as we know, it's still in flight to the
-    // GCS. Skip this task for now.
-    if (parent) {
-      // Request notifications about the parent entry's commit in the GCS if
-      // the parent is remote. Otherwise, the parent is local and will
-      // eventually be flushed. In either case, once we receive a
-      // notification about the task's commit via HandleEntryCommitted, then
-      // this task will be ready to write on the next call to Flush().
-      if (parent->GetStatus() == GcsStatus::UNCOMMITTED_REMOTE) {
-        SubscribeTask(parent_id);
-      }
-      all_arguments_committed = false;
-      // Track the fact that this task is dependent on a parent that hasn't yet
-      // been committed, for fast lookup. Once all parents are committed, the
-      // child will be flushed.
-      uncommitted_ready_children_[parent_id].insert(task_id);
-    }
-  }
-  if (all_arguments_committed) {
-    gcs::raylet::TaskTable::WriteCallback task_callback = [this](
-        ray::gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
-      HandleEntryCommitted(id);
-    };
-    auto task = lineage_.GetEntry(task_id);
-    // TODO(swang): Make this better...
-    flatbuffers::FlatBufferBuilder fbb;
-    auto message = task->TaskData().ToFlatbuffer(fbb);
-    fbb.Finish(message);
-    auto task_data = std::make_shared<protocol::TaskT>();
-    auto root = flatbuffers::GetRoot<protocol::Task>(fbb.GetBufferPointer());
-    root->UnPackTo(task_data.get());
-    RAY_CHECK_OK(task_storage_.Add(task->TaskData().GetTaskSpecification().DriverId(),
-                                   task_id, task_data, task_callback));
+  gcs::raylet::TaskTable::WriteCallback task_callback = [this](
+      ray::gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
+    HandleEntryCommitted(id);
+  };
+  auto task = lineage_.GetEntry(task_id);
+  // TODO(swang): Make this better...
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = task->TaskData().ToFlatbuffer(fbb);
+  fbb.Finish(message);
+  auto task_data = std::make_shared<protocol::TaskT>();
+  auto root = flatbuffers::GetRoot<protocol::Task>(fbb.GetBufferPointer());
+  root->UnPackTo(task_data.get());
+  RAY_CHECK_OK(task_storage_.Add(task->TaskData().GetTaskSpecification().DriverId(),
+                                 task_id, task_data, task_callback));
 
-    // We successfully wrote the task, so mark it as committing.
-    // TODO(swang): Use a batched interface and write with all object entries.
-    auto entry = lineage_.GetEntryMutable(task_id);
-    RAY_CHECK(entry);
-    RAY_CHECK(entry->SetStatus(GcsStatus::COMMITTING));
-  }
-  return all_arguments_committed;
-}
-
-void LineageCache::Flush() {
-  // Iterate through all tasks that are PLACEABLE.
-  for (auto it = uncommitted_ready_tasks_.begin();
-       it != uncommitted_ready_tasks_.end();) {
-    bool flushed = FlushTask(*it);
-    // Erase the task from the cache of uncommitted ready tasks.
-    if (flushed) {
-      it = uncommitted_ready_tasks_.erase(it);
-    } else {
-      it++;
-    }
-  }
+  // We successfully wrote the task, so mark it as committing.
+  // TODO(swang): Use a batched interface and write with all object entries.
+  RAY_CHECK(entry->SetStatus(GcsStatus::COMMITTING));
 }
 
 bool LineageCache::SubscribeTask(const TaskID &task_id) {
@@ -429,45 +347,47 @@ bool LineageCache::UnsubscribeTask(const TaskID &task_id) {
   return subscribed;
 }
 
-boost::optional<LineageEntry> LineageCache::EvictTask(const TaskID &task_id) {
-  RAY_LOG(DEBUG) << "evicting task " << task_id << " on " << client_id_;
-  auto entry = lineage_.PopEntry(task_id);
+void LineageCache::EvictTask(const TaskID &task_id) {
+  auto commit_it = committed_tasks_.find(task_id);
+  if (commit_it == committed_tasks_.end()) {
+    return;
+  }
+  auto entry = lineage_.GetEntry(task_id);
   if (!entry) {
-    // The entry has already been evicted. Check that the entry does not have
-    // any dependent tasks, since we should've already attempted to flush these
-    // tasks on the first eviction.
-    RAY_CHECK(uncommitted_ready_children_.count(task_id) == 0);
-    // Check that we already unsubscribed from the task when handling the
-    // first eviction.
-    RAY_CHECK(subscribed_tasks_.count(task_id) == 0);
-    // Do nothing if the entry has already been evicted.
-    return entry;
+    return;
+  }
+  if (!(entry->GetStatus() == GcsStatus::UNCOMMITTED_REMOTE ||
+        entry->GetStatus() == GcsStatus::COMMITTING)) {
+    // Only evict tasks that we were subscribed to or that we were committing.
+    return;
+  }
+  for (const auto &parent_id : entry->GetParentTaskIds()) {
+    if (ContainsTask(parent_id)) {
+      return;
+    }
   }
 
-  // Stop listening for notifications about this task.
+  // Evict the task.
+  RAY_LOG(DEBUG) << "evicting task " << task_id << " on " << client_id_;
+  lineage_.PopEntry(task_id);
+  committed_tasks_.erase(commit_it);
   UnsubscribeTask(task_id);
-
-  // Try to flush the children of the committed task. These are the tasks that
+  // Try to evict the children of the committed task. These are the tasks that
   // have a dependency on the committed task.
-  auto children_entry = uncommitted_ready_children_.find(task_id);
-  if (children_entry != uncommitted_ready_children_.end()) {
+  auto children_entry = children_.find(task_id);
+  if (children_entry != children_.end()) {
     // Get the children of the committed task that are uncommitted but ready.
     auto children = std::move(children_entry->second);
-    uncommitted_ready_children_.erase(children_entry);
+    children_.erase(children_entry);
 
     // Try to flush the children.  If all of the child's parents are committed,
     // then the child will be flushed here.
     for (const auto &child_id : children) {
-      bool flushed = FlushTask(child_id);
-      // Erase the child task from the cache of uncommitted ready tasks.
-      if (flushed) {
-        auto erased = uncommitted_ready_tasks_.erase(child_id);
-        RAY_CHECK(erased == 1);
-      }
+      EvictTask(child_id);
     }
   }
 
-  return entry;
+  return;
 }
 
 void LineageCache::EvictRemoteLineage(const TaskID &task_id) {
@@ -477,33 +397,30 @@ void LineageCache::EvictRemoteLineage(const TaskID &task_id) {
   }
   // Only evict tasks that are remote. Other tasks, and their lineage, will be
   // evicted once they are committed.
+  const auto parent_ids = entry->GetParentTaskIds();
+  committed_tasks_.insert(task_id);
   if (entry->GetStatus() == GcsStatus::UNCOMMITTED_REMOTE) {
     // Remove the ancestor task.
-    auto evicted_entry = EvictTask(task_id);
-    // Recurse and remove this task's ancestors.
-    for (const auto &parent_id : evicted_entry->GetParentTaskIds()) {
-      EvictRemoteLineage(parent_id);
-    }
+    // TODO: force evict
+    EvictTask(task_id);
+  }
+  // Recurse and remove this task's ancestors.
+  for (const auto &parent_id : parent_ids) {
+    EvictRemoteLineage(parent_id);
   }
 }
 
 void LineageCache::HandleEntryCommitted(const TaskID &task_id) {
   RAY_LOG(DEBUG) << "task committed: " << task_id;
-  auto entry = EvictTask(task_id);
+  auto entry = lineage_.GetEntry(task_id);
   if (!entry) {
     // The task has already been evicted due to a previous commit notification,
     // or because one of its descendants was committed.
     return;
   }
 
-  // Evict the committed task's uncommitted lineage. Since local tasks are
-  // written in data dependency order, the uncommitted lineage should only
-  // include remote tasks, i.e. tasks that were committed by a different node.
-  // In case of reconstruction, the uncommitted lineage may also include local
-  // tasks that were resubmitted. These tasks are not evicted.
-  for (const auto &parent_id : entry->GetParentTaskIds()) {
-    EvictRemoteLineage(parent_id);
-  }
+  committed_tasks_.insert(task_id);
+  EvictTask(task_id);
 }
 
 const Task &LineageCache::GetTask(const TaskID &task_id) const {
@@ -518,6 +435,8 @@ bool LineageCache::ContainsTask(const TaskID &task_id) const {
   auto it = entries.find(task_id);
   return it != entries.end();
 }
+
+size_t LineageCache::NumEntries() const { return lineage_.GetEntries().size(); }
 
 }  // namespace raylet
 

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -276,9 +276,6 @@ class LineageCache {
   /// optional reference to the evicted task that is empty if the task was not
   /// in the lineage cache.
   void EvictTask(const TaskID &task_id);
-  /// Evict a remote task and its lineage. This should only be called if we
-  /// are sure that the remote task and its lineage are committed.
-  void EvictRemoteLineage(const TaskID &task_id);
   /// Subscribe to notifications for a task. Returns whether the operation
   /// was successful (whether we were not already subscribed).
   bool SubscribeTask(const TaskID &task_id);
@@ -299,8 +296,7 @@ class LineageCache {
   gcs::PubsubInterface<TaskID> &task_pubsub_;
   /// The set of tasks that have been committed but not evicted.
   std::unordered_set<TaskID> committed_tasks_;
-  /// A mapping from each task to its children. This mapping includes all
-  /// parents of tasks in the lineage cache.
+  /// A mapping from each task in the lineage cache to its children.
   std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -242,13 +242,6 @@ class LineageCache {
   /// includes the entry for the requested entry_id.
   Lineage GetUncommittedLineage(const TaskID &task_id, const ClientID &node_id) const;
 
-  /// Asynchronously write any tasks that are in the UNCOMMITTED_READY state
-  /// and for which all parents have been committed to the GCS. These tasks
-  /// will be transitioned in this method to state COMMITTING. Once the write
-  /// is acknowledged, the task's state will be transitioned to state
-  /// COMMITTED.
-  void Flush();
-
   /// Handle the commit of a task entry in the GCS. This sets the task to
   /// COMMITTED and cleans up any ancestor tasks that are in the cache.
   ///
@@ -267,17 +260,22 @@ class LineageCache {
   /// \return Whether the task is in the lineage cache.
   bool ContainsTask(const TaskID &task_id) const;
 
+  /// Get the number of entries in the lineage cache.
+  ///
+  /// \return The number of entries in the lineage cache.
+  size_t NumEntries() const;
+
  private:
   /// Try to flush a task that is in UNCOMMITTED_READY state. If the task has
   /// parents that are not committed yet, then the child will be flushed once
   /// the parents have been committed.
-  bool FlushTask(const TaskID &task_id);
+  void FlushTask(const TaskID &task_id);
   /// Evict a single task. This should only be called if we are sure that the
   /// task has been committed and will trigger an attempt to flush any of the
   /// evicted task's children that are in UNCOMMITTED_READY state.  Returns an
   /// optional reference to the evicted task that is empty if the task was not
   /// in the lineage cache.
-  boost::optional<LineageEntry> EvictTask(const TaskID &task_id);
+  void EvictTask(const TaskID &task_id);
   /// Evict a remote task and its lineage. This should only be called if we
   /// are sure that the remote task and its lineage are committed.
   void EvictRemoteLineage(const TaskID &task_id);
@@ -287,15 +285,7 @@ class LineageCache {
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
   bool UnsubscribeTask(const TaskID &task_id);
-  /// Count the size of unsubscribed and uncommitted lineage of the given task
-  /// excluding the values that have already been visited.
-  ///
-  /// \param task_id The task whose lineage should be counted.
-  /// \param seen This set contains the keys of lineage entries counted so far,
-  /// so that we don't revisit those nodes.
-  /// \void The number of tasks that were counted.
-  uint64_t CountUnsubscribedLineage(const TaskID &task_id,
-                                    std::unordered_set<TaskID> &seen) const;
+  void AddUncommittedLineage(const TaskID &task_id, const Lineage &uncommitted_lineage);
 
   /// The client ID, used to request notifications for specific tasks.
   /// TODO(swang): Move the ClientID into the generic Table implementation.
@@ -305,23 +295,11 @@ class LineageCache {
   /// The pubsub storage system for task information. This can be used to
   /// request notifications for the commit of a task entry.
   gcs::PubsubInterface<TaskID> &task_pubsub_;
-  /// The maximum size that a remote task's uncommitted lineage can get to. If
-  /// a remote task's uncommitted lineage exceeds this size, then a
-  /// notification will be requested from the pubsub storage system so that
-  /// the task and its lineage can be evicted from the stash.
-  uint64_t max_lineage_size_;
-  /// The set of tasks that are in UNCOMMITTED_READY state. This is a cache of
-  /// the tasks that may be flushable.
-  // TODO(swang): As an optimization, we may also want to further distinguish
-  // which tasks are flushable, to avoid iterating over tasks that are in
-  // UNCOMMITTED_READY, but that have dependencies that have not been committed
-  // yet.
-  std::unordered_set<TaskID> uncommitted_ready_tasks_;
-  /// A mapping from each task that hasn't been committed yet, to all dependent
-  /// children tasks that are in UNCOMMITTED_READY state. This is used when the
-  /// parent task is committed, for fast lookup of children that may now be
-  /// flushed.
-  std::unordered_map<TaskID, std::unordered_set<TaskID>> uncommitted_ready_children_;
+  /// The set of tasks that have been committed but not evicted.
+  std::unordered_set<TaskID> committed_tasks_;
+  /// A mapping from each task to its children. This mapping includes all
+  /// parents of tasks in the lineage cache.
+  std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.
   Lineage lineage_;

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -285,7 +285,9 @@ class LineageCache {
   /// Unsubscribe from notifications for a task. Returns whether the operation
   /// was successful (whether we were subscribed).
   bool UnsubscribeTask(const TaskID &task_id);
-  void AddUncommittedLineage(const TaskID &task_id, const Lineage &uncommitted_lineage);
+  /// Add a task and its uncommitted lineage to the local stash.
+  void AddUncommittedLineage(const TaskID &task_id, const Lineage &uncommitted_lineage,
+                             std::unordered_set<TaskID> &subscribe_tasks);
 
   /// The client ID, used to request notifications for specific tasks.
   /// TODO(swang): Move the ClientID into the generic Table implementation.

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -258,7 +258,7 @@ TEST_F(LineageCacheTest, TestWritebackOrder) {
   ASSERT_EQ(mock_gcs_.TaskTable().size(), num_tasks_flushed);
 }
 
-TEST_F(LineageCacheTest, TestEvictUncommittedLineage) {
+TEST_F(LineageCacheTest, TestEvictChain) {
   // Create a chain of 3 tasks.
   size_t num_tasks_flushed = 0;
   std::vector<Task> tasks;


### PR DESCRIPTION
## What do these changes do?

Lineage is stored locally at each node in the lineage cache, but it must be flushed to a persistent store to prevent the caches from filling up. This implements a policy that flushes each task immediately to the persistent store, rather than flushing tasks in data dependency order.

## Related issue number
This is part 1 of #2948.