### PR TITLE
Add cython to requirements

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -13,3 +13,4 @@ sphinx
 sphinx-click
 sphinx_rtd_theme
 pandas
+cython


### PR DESCRIPTION
## What do these changes do?

Adds cython to the list of requirements in doc/requirements-doc.txt.

When installing with `pip install git+https://github.com/ray-project/ray.git#subdirectory=python`, I got the error
```
  Traceback (most recent call last):
    File "setup.py", line 29, in <module>
      from Cython.Distutils import build_ext as _build_ext
  ImportError: No module named 'Cython'
```
Running `pip install cython` fixed the problem.

## Related issue number

N/A
