### PR TITLE
Enable to specify driver id by user.

### DIFF
--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2245,6 +2245,7 @@ def test_workers(shutdown_only):
         assert "stderr_file" in info
         assert "stdout_file" in info
 
+
 def test_specific_driver_id():
     dummy_driver_id = ray.ObjectID(b"00112233445566778899")
     ray.init(driver_id=dummy_driver_id)
@@ -2259,6 +2260,7 @@ def test_specific_driver_id():
     assert_equal(dummy_driver_id.id(), task_driver_id)
 
     ray.shutdown()
+
 
 @pytest.fixture
 def shutdown_only_with_initialization_check():

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2245,6 +2245,20 @@ def test_workers(shutdown_only):
         assert "stderr_file" in info
         assert "stdout_file" in info
 
+def test_specific_driver_id():
+    dummy_driver_id = ray.ObjectID(b"00112233445566778899")
+    ray.init(driver_id=dummy_driver_id)
+
+    @ray.remote
+    def f():
+        return ray.worker.global_worker.task_driver_id.id()
+
+    assert_equal(dummy_driver_id.id(), ray.worker.global_worker.worker_id)
+
+    task_driver_id = ray.get(f.remote())
+    assert_equal(dummy_driver_id.id(), task_driver_id)
+
+    ray.shutdown()
 
 @pytest.fixture
 def shutdown_only_with_initialization_check():


### PR DESCRIPTION
## What do these changes do?
It's very useful for us to specify driver id to a driver.
In Java, we could specify it by `ray.conf`, and in Python, we should do it by `def init()`:
```python
ray.init(driver=b"01234567890123456789")
```
If we don't specify one, it will generate a random for us.

## Related issue number
N/A