### PR TITLE
[Java] support python worker command in raylet

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -54,6 +54,7 @@ public class RayConfig {
   public final String plasmaStoreExecutablePath;
   public final String rayletExecutablePath;
   public final String driverResourcePath;
+  public final String pythonWorkerCommand;
 
   private void validate() {
     if (workerMode == WorkerMode.WORKER) {
@@ -134,6 +135,12 @@ public class RayConfig {
       jvmParameters = config.getStringList("ray.worker.jvm-parameters");
     } else {
       jvmParameters = ImmutableList.of();
+    }
+
+    if (config.hasPath("ray.worker.python-command")) {
+      pythonWorkerCommand = config.getString("ray.worker.python-command");
+    } else {
+      pythonWorkerCommand = null;
     }
 
     // redis configurations

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -185,7 +185,7 @@ public class RunManager {
         "0", // number of initial workers
         String.valueOf(maximumStartupConcurrency),
         ResourceUtil.getResourcesStringFromMap(rayConfig.resources),
-        "", // python worker command
+        buildPythonWorkerCommand(), // python worker command
         buildWorkerCommandRaylet() // java worker command
     );
 
@@ -245,6 +245,24 @@ public class RunManager {
         rayConfig.objectStoreSize.toString()
     );
     startProcess(command, null, "plasma_store");
+  }
+
+  private String buildPythonWorkerCommand() {
+    // disable python worker start from raylet, which starts from java
+    if (rayConfig.pythonWorkerCommand == null) {
+      return "";
+    }
+
+    List<String> cmd = new ArrayList<>();
+    cmd.add(rayConfig.pythonWorkerCommand);
+    cmd.add("--node-ip-address=" + rayConfig.nodeIp);
+    cmd.add("--object-store-name=" + rayConfig.objectStoreSocketName);
+    cmd.add("--raylet-name=" + rayConfig.rayletSocketName);
+    cmd.add("--redis-address=" + rayConfig.getRedisAddress());
+
+    String command = cmd.stream().collect(Collectors.joining(" "));
+    LOGGER.debug("python worker command: {}", command);
+    return command;
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

support raylet, which is started by java runManager, to start python default_worker.py . 

So when doing local test of java call python task, it helps auto start python worker.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
