### PR TITLE
[autoscaler] Also grant roles to worker nodes

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -101,6 +101,7 @@ def _configure_iam_role(config):
     logger.info("Role not specified for head node, using {}".format(
         profile.arn))
     config["head_node"]["IamInstanceProfile"] = {"Arn": profile.arn}
+    config["worker_nodes"]["IamInstanceProfile"] = {"Arn": profile.arn}
 
     return config
 

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -168,12 +168,16 @@ def _configure_iam_role(config):
 
     _add_iam_policy_binding(service_account, DEFAULT_SERVICE_ACCOUNT_ROLES)
 
+    # NOTE: The amount of access is determined by the scope + IAM
+    # role of the service account. Even if the cloud-platform scope
+    # gives (scope) access to the whole cloud-platform, the service
+    # account is limited by the IAM rights specified below.
     config["head_node"]["serviceAccounts"] = [{
         "email": service_account["email"],
-        # NOTE: The amount of access is determined by the scope + IAM
-        # role of the service account. Even if the cloud-platform scope
-        # gives (scope) access to the whole cloud-platform, the service
-        # account is limited by the IAM rights specified below.
+        "scopes": ["https://www.googleapis.com/auth/cloud-platform"]
+    }]
+    config["worker_nodes"]["serviceAccounts"] = [{
+        "email": service_account["email"],
         "scopes": ["https://www.googleapis.com/auth/cloud-platform"]
     }]
 


### PR DESCRIPTION


## What do these changes do?

While not necessary for scaling, access to storage is pretty useful for user code, and the create node access is unlikely to be a security issue.

## Related issue number

https://github.com/ray-project/ray/issues/3115