### PR TITLE
[rllib] Better error message when action space dim too high

### DIFF
--- a/python/ray/rllib/evaluation/policy_evaluator.py
+++ b/python/ray/rllib/evaluation/policy_evaluator.py
@@ -432,6 +432,8 @@ class PolicyEvaluator(EvaluatorInterface):
                 info_out = {k: builder.get(v) for k, v in info_out.items()}
             else:
                 for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
                     grad_out[pid], info_out[pid] = (
                         self.policy_map[pid].compute_gradients(batch))
         else:
@@ -472,6 +474,8 @@ class PolicyEvaluator(EvaluatorInterface):
                 info_out = {k: builder.get(v) for k, v in info_out.items()}
             else:
                 for pid, batch in samples.policy_batches.items():
+                    if pid not in self.policies_to_train:
+                        continue
                     info_out[pid], _ = (
                         self.policy_map[pid].compute_apply(batch))
             return info_out

--- a/python/ray/rllib/models/catalog.py
+++ b/python/ray/rllib/models/catalog.py
@@ -109,8 +109,8 @@ class ModelCatalog(object):
                 raise ValueError(
                     "Action space has multiple dimensions "
                     "{}. ".format(action_space.shape) +
-                    " Please reshape this into a single dimension, or "
-                    "use a Tuple action space instead.")
+                    " Consider reshaping this into a single dimension, "
+                    "using a Tuple action space, or the multi-agent API.")
             if dist_type is None:
                 dist = DiagGaussian
                 if config.get("squash_to_range"):

--- a/python/ray/rllib/models/catalog.py
+++ b/python/ray/rllib/models/catalog.py
@@ -105,6 +105,12 @@ class ModelCatalog(object):
 
         config = config or MODEL_DEFAULTS
         if isinstance(action_space, gym.spaces.Box):
+            if len(action_space.shape) > 1:
+                raise ValueError(
+                    "Action space has multiple dimensions "
+                    "{}. ".format(action_space.shape) +
+                    " Please reshape this into a single dimension, or "
+                    "use a Tuple / Dict action space instead.")
             if dist_type is None:
                 dist = DiagGaussian
                 if config.get("squash_to_range"):

--- a/python/ray/rllib/models/catalog.py
+++ b/python/ray/rllib/models/catalog.py
@@ -110,7 +110,7 @@ class ModelCatalog(object):
                     "Action space has multiple dimensions "
                     "{}. ".format(action_space.shape) +
                     " Please reshape this into a single dimension, or "
-                    "use a Tuple / Dict action space instead.")
+                    "use a Tuple action space instead.")
             if dist_type is None:
                 dist = DiagGaussian
                 if config.get("squash_to_range"):

--- a/python/ray/rllib/models/catalog.py
+++ b/python/ray/rllib/models/catalog.py
@@ -109,7 +109,7 @@ class ModelCatalog(object):
                 raise ValueError(
                     "Action space has multiple dimensions "
                     "{}. ".format(action_space.shape) +
-                    " Consider reshaping this into a single dimension, "
+                    "Consider reshaping this into a single dimension, "
                     "using a Tuple action space, or the multi-agent API.")
             if dist_type is None:
                 dist = DiagGaussian


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

We don't support multi-dimensional action spaces. Raise an error telling the user to use a Tuple space instead.

## Related issue number

https://github.com/ray-project/ray/issues/3111