### PR TITLE
Fix password authentication in worker

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1216,6 +1216,8 @@ def start_raylet_monitor(redis_address,
     gcs_ip_address, gcs_port = redis_address.split(":")
     redis_password = redis_password or ""
     command = [RAYLET_MONITOR_EXECUTABLE, gcs_ip_address, gcs_port]
+    if redis_password:
+        command += [redis_password]
     p = subprocess.Popen(command, stdout=stdout_file, stderr=stderr_file)
     if cleanup:
         all_processes[PROCESS_TYPE_MONITOR].append(p)

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -15,8 +15,7 @@ class Cluster(object):
     def __init__(self,
                  initialize_head=False,
                  connect=False,
-                 head_node_args=None,
-                 redis_password=None):
+                 head_node_args=None):
         """Initializes the cluster.
 
         Args:
@@ -31,7 +30,6 @@ class Cluster(object):
         self.head_node = None
         self.worker_nodes = {}
         self.redis_address = None
-        self.redis_password = redis_password
         if not initialize_head and connect:
             raise RuntimeError("Cannot connect to uninitialized cluster.")
 
@@ -39,9 +37,10 @@ class Cluster(object):
             head_node_args = head_node_args or {}
             self.add_node(**head_node_args)
             if connect:
+                redis_password = head_node_args.get("redis_password")
                 ray.init(
                     redis_address=self.redis_address,
-                    redis_password=self.redis_password)
+                    redis_password=redis_password)
 
     def add_node(self, **override_kwargs):
         """Adds a node to the local Ray Cluster.
@@ -70,7 +69,6 @@ class Cluster(object):
         if self.head_node is None:
             address_info = services.start_ray_head(
                 node_ip_address=services.get_node_ip_address(),
-                redis_password=self.redis_password,
                 include_webui=False,
                 **node_kwargs)
             self.redis_address = address_info["redis_address"]
@@ -82,9 +80,7 @@ class Cluster(object):
             self.head_node = node
         else:
             address_info = services.start_ray_node(
-                services.get_node_ip_address(),
-                self.redis_address,
-                redis_password=self.redis_password,
+                services.get_node_ip_address(), self.redis_address,
                 **node_kwargs)
             # TODO(rliaw): Find a more stable way than modifying global state.
             process_dict_copy = services.all_processes.copy()

--- a/python/ray/test/test_ray_init.py
+++ b/python/ray/test/test_ray_init.py
@@ -30,7 +30,6 @@ class TestRedisPassword(object):
         os.environ.get("RAY_USE_NEW_GCS") == "on",
         reason="New GCS API doesn't support Redis authentication yet.")
     def test_redis_password(self, password, shutdown_only):
-        # Workaround for https://github.com/ray-project/ray/issues/3045
         @ray.remote
         def f():
             return 1
@@ -58,7 +57,6 @@ class TestRedisPassword(object):
         os.environ.get("RAY_USE_NEW_GCS") == "on",
         reason="New GCS API doesn't support Redis authentication yet.")
     def test_redis_password_cluster(self, password, shutdown_only):
-        # Workaround for https://github.com/ray-project/ray/issues/3045
         @ray.remote
         def f():
             return 1

--- a/python/ray/test/test_ray_init.py
+++ b/python/ray/test/test_ray_init.py
@@ -61,9 +61,10 @@ class TestRedisPassword(object):
         def f():
             return 1
 
+        node_args = {"redis_password": password}
         cluster = Cluster(
-            initialize_head=True, connect=True, redis_password=password)
-        cluster.add_node()
+            initialize_head=True, connect=True, head_node_args=node_args)
+        cluster.add_node(**node_args)
 
         object_id = f.remote()
         ray.get(object_id)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1935,7 +1935,7 @@ def connect(info,
             services.record_log_files_in_redis(
                 info["redis_address"],
                 info["node_ip_address"], [log_stdout_file, log_stderr_file],
-                redis_password=redis_password)
+                password=redis_password)
 
     # Create an object for interfacing with the global state.
     global_state._initialize_global_state(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1933,8 +1933,9 @@ def connect(info,
             sys.stdout = log_stdout_file
             sys.stderr = log_stderr_file
             services.record_log_files_in_redis(
-                info["redis_address"], info["node_ip_address"],
-                [log_stdout_file, log_stderr_file])
+                info["redis_address"],
+                info["node_ip_address"], [log_stdout_file, log_stderr_file],
+                redis_password=redis_password)
 
     # Create an object for interfacing with the global state.
     global_state._initialize_global_state(


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Passes redis password to `services.record_log_files_in_redis` in `connect()`.

Thanks to @igoriokas for finding this bug!

Follow up to #2952. Fixes #3141.