### PR TITLE
Update jekyll

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -9,7 +9,7 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.4.3"
+gem "jekyll", ">= 3.6.3"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"


### PR DESCRIPTION
There seems to be a security vulnerability in older versions of jekyll and Github asks us to upgrade it.