### PR TITLE
Delete empty pubsub keys

### DIFF
--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -544,6 +544,11 @@ int TableCancelNotifications_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
   if (RedisModule_KeyType(notification_key) != REDISMODULE_KEYTYPE_EMPTY) {
     RAY_CHECK(RedisModule_ZsetRem(notification_key, client_channel, NULL) ==
               REDISMODULE_OK);
+    size_t size = RedisModule_ValueLength(notification_key);
+    if (size == 0) {
+      CHECK_ERROR(RedisModule_DeleteKey(notification_key),
+                "Unable to delete zset key.");
+    }
   }
 
   RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -546,8 +546,7 @@ int TableCancelNotifications_RedisCommand(RedisModuleCtx *ctx, RedisModuleString
               REDISMODULE_OK);
     size_t size = RedisModule_ValueLength(notification_key);
     if (size == 0) {
-      CHECK_ERROR(RedisModule_DeleteKey(notification_key),
-                "Unable to delete zset key.");
+      CHECK_ERROR(RedisModule_DeleteKey(notification_key), "Unable to delete zset key.");
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
We found that there are large amount of pub-sub keys with no content in it (This case is worse when wait-id is used in the key name.).
This logic of deleting empty pub-sub keys from GCS was in legacy ray but not in raylet.

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
