### PR TITLE
Use /tmp instead of /dev/shm for object store on Linux if /dev/shm is too small.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -962,10 +962,18 @@ def determine_plasma_store_config(object_store_memory=None,
                                   huge_pages=False):
     """Figure out how to configure the plasma object store.
 
+    This will determine which directory to use for the plasma store (e.g.,
+    /tmp or /dev/shm) and how much memory to start the store with. On Linux,
+    we will try to use /dev/shm unless the shared memory file system is too
+    small, in which case we will fall back to /tmp. If any of the object store
+    memory or plasma directory parameters are specified by the user, then those
+    values will be preserved.
+
     Args:
-        object_store_memory: The user-specified object store memory parameter.
-        plasma_directory: The user-specified plasma directory parameter.
-        huge_pages: The user-specified huge pages parameter.
+        object_store_memory (int): The user-specified object store memory
+            parameter.
+        plasma_directory (str): The user-specified plasma directory parameter.
+        huge_pages (bool): The user-specified huge pages parameter.
 
     Returns:
         A tuple of the object store memory to use and the plasma directory to
@@ -1058,8 +1066,9 @@ def start_plasma_store(node_ip_address,
         object_store_memory, plasma_directory, huge_pages)
 
     # Start the Plasma store.
-    logger.info("Starting the Plasma object store with {0:.2f} GB memory."
-                .format(object_store_memory / 10**9))
+    logger.info("Starting the Plasma object store with {0:.2f} GB memory "
+                "using {}.".format(object_store_memory / 10**9,
+                                   plasma_directory))
     plasma_store_name, p1 = ray.plasma.start_plasma_store(
         plasma_store_memory=object_store_memory,
         use_profiler=RUN_PLASMA_STORE_PROFILER,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1065,10 +1065,11 @@ def start_plasma_store(node_ip_address,
     object_store_memory, plasma_directory = determine_plasma_store_config(
         object_store_memory, plasma_directory, huge_pages)
 
+    # Print the object store memory using two decimal places.
+    object_store_memory_str = (object_store_memory / 10**7) / 10**2
+    logger.info("Starting the Plasma object store with {} GB memory "
+                "using {}.".format(object_store_memory_str, plasma_directory))
     # Start the Plasma store.
-    logger.info("Starting the Plasma object store with {0:.2f} GB memory "
-                "using {}.".format(object_store_memory / 10**9,
-                                   plasma_directory))
     plasma_store_name, p1 = ray.plasma.start_plasma_store(
         plasma_store_memory=object_store_memory,
         use_profiler=RUN_PLASMA_STORE_PROFILER,

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -324,6 +324,28 @@ def get_system_memory():
         return sysctl(["sysctl", "hw.memsize"])
 
 
+def get_shared_memory_bytes():
+    """Get the size of the shared memory file system.
+
+    Returns:
+        The size of the shared memory file system in bytes.
+    """
+    # Make sure this is only called on Linux.
+    assert sys.platform == "linux" or sys.platform == "linux2"
+
+    shm_fd = os.open("/dev/shm", os.O_RDONLY)
+    try:
+        shm_fs_stats = os.fstatvfs(shm_fd)
+        # The value shm_fs_stats.f_bsize is the block size and the
+        # value shm_fs_stats.f_bavail is the number of available
+        # blocks.
+        shm_avail = shm_fs_stats.f_bsize * shm_fs_stats.f_bavail
+    finally:
+        os.close(shm_fd)
+
+    return shm_avail
+
+
 def check_oversized_pickle(pickled, name, obj_type, worker):
     """Send a warning message if the pickled object is too large.
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -721,7 +721,7 @@ class Worker(object):
             arguments.append(argument)
         return arguments
 
-    def _store_outputs_in_objstore(self, object_ids, outputs):
+    def _store_outputs_in_object_store(self, object_ids, outputs):
         """Store the outputs of a remote function in the local object store.
 
         This stores the values that were returned by a remote function in the
@@ -819,7 +819,7 @@ class Worker(object):
                 num_returns = len(return_object_ids)
                 if num_returns == 1:
                     outputs = (outputs, )
-                self._store_outputs_in_objstore(return_object_ids, outputs)
+                self._store_outputs_in_object_store(return_object_ids, outputs)
         except Exception as e:
             self._handle_process_task_failure(
                 function_id, function_name, return_object_ids, e,
@@ -831,7 +831,7 @@ class Worker(object):
         failure_objects = [
             failure_object for _ in range(len(return_object_ids))
         ]
-        self._store_outputs_in_objstore(return_object_ids, failure_objects)
+        self._store_outputs_in_object_store(return_object_ids, failure_objects)
         # Log the error message.
         ray.utils.push_error_to_driver(
             self,

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -170,7 +170,7 @@ def ray_start_reconstruction(request):
     # Start the Plasma store instances with a total of 1GB memory.
     plasma_store_memory = 10**9
     plasma_addresses = []
-    objstore_memory = plasma_store_memory // num_local_schedulers
+    object_store_memory = plasma_store_memory // num_local_schedulers
     for i in range(num_local_schedulers):
         store_stdout_file, store_stderr_file = (
             ray.tempfile_services.new_plasma_store_log_file(i, True))
@@ -178,7 +178,7 @@ def ray_start_reconstruction(request):
             ray.services.start_plasma_store(
                 node_ip_address,
                 redis_address,
-                objstore_memory=objstore_memory,
+                object_store_memory=object_store_memory,
                 store_stdout_file=store_stdout_file,
                 store_stderr_file=store_stderr_file))
 


### PR DESCRIPTION
This should allow Ray to work out of the box on kaggle or in docker containers by falling back to `/tmp` instead of `/dev/shm` when the shared memory file system is too small.

This also changes the default object store size on Mac (80% -> 40%) of total memory and Linux (45% -> 40%). Mostly because on MacOS things seem to get really slow when the object store fills up.

This is not without a cost, if we do end up defaulting to `/tmp` it can be much slower.

EDIT: For example, on a smallish machine, using `/dev/shm`, putting a 1GB object in the object store takes about 300ms. Using `/tmp` it sometimes takes 300ms, and sometimes takes up to 7s.