### PR TITLE
[tune] Remove Pausing Queue

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -63,7 +63,7 @@ class RayTrialExecutor(TrialExecutor):
         # because there may have been in-flight result that was not processed.
         if (prior_status == Trial.PAUSED and trial.next_result is not None):
             # If Trial was in flight when paused, we restore result.
-            self._running[ray.put(trial.next_result)] = trial
+            self._running[trial.next_result] = trial
             trial.next_result = None
         else:
             self._train(trial)
@@ -159,7 +159,7 @@ class RayTrialExecutor(TrialExecutor):
 
         trial_future = self._find_item(self._running, trial)
         if trial_future:
-            trial.next_result = ray.get(trial_future)
+            trial.next_result = trial_future
         super(RayTrialExecutor, self).pause_trial(trial)
 
     def reset_trial(self, trial, new_config, new_experiment_tag):

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -149,9 +149,10 @@ class Trial(object):
         self.max_failures = max_failures
 
         # Local trial state that is updated during the run
+
+        # The last result processed for this trial.
         self.last_result = None
-        # Saves an in-flight result that hasn't been processed.
-        # Used in pausing and unpausing of trials.
+        # An un-processed in-flight result used in pausing/unpausing of trials.
         self.next_result = None
         self.checkpoint_freq = checkpoint_freq
         self.checkpoint_at_end = checkpoint_at_end

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -150,6 +150,9 @@ class Trial(object):
 
         # Local trial state that is updated during the run
         self.last_result = None
+        # Saves an in-flight result that hasn't been processed.
+        # Used in pausing and unpausing of trials.
+        self.next_result = None
         self.checkpoint_freq = checkpoint_freq
         self.checkpoint_at_end = checkpoint_at_end
         self._checkpoint = Checkpoint(

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -85,7 +85,7 @@ class TrialExecutor(object):
         pass
 
     def pause_trial(self, trial):
-        """Pauses the trial.
+        """Pauses the trial by checkpointing and then stopping the actor.
 
         We want to release resources (specifically GPUs) when pausing an
         experiment. This results in PAUSED state that similar to TERMINATED.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

Removes some state from the trial executor. In-flight results are saved
in `trial` rather than in a queue of the executor.

This shouldn't affect performance much because pausing is only executed
_after_ the current training iteration anyways.

TODO:
- [ ] In xray, `ray_terminate` returns now (!); so we can actually guarantee actor kill.