### PR TITLE
Revert "[autoscaler] Also grant roles to worker nodes"

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -101,7 +101,6 @@ def _configure_iam_role(config):
     logger.info("Role not specified for head node, using {}".format(
         profile.arn))
     config["head_node"]["IamInstanceProfile"] = {"Arn": profile.arn}
-    config["worker_nodes"]["IamInstanceProfile"] = {"Arn": profile.arn}
 
     return config
 

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -168,16 +168,12 @@ def _configure_iam_role(config):
 
     _add_iam_policy_binding(service_account, DEFAULT_SERVICE_ACCOUNT_ROLES)
 
-    # NOTE: The amount of access is determined by the scope + IAM
-    # role of the service account. Even if the cloud-platform scope
-    # gives (scope) access to the whole cloud-platform, the service
-    # account is limited by the IAM rights specified below.
     config["head_node"]["serviceAccounts"] = [{
         "email": service_account["email"],
-        "scopes": ["https://www.googleapis.com/auth/cloud-platform"]
-    }]
-    config["worker_nodes"]["serviceAccounts"] = [{
-        "email": service_account["email"],
+        # NOTE: The amount of access is determined by the scope + IAM
+        # role of the service account. Even if the cloud-platform scope
+        # gives (scope) access to the whole cloud-platform, the service
+        # account is limited by the IAM rights specified below.
         "scopes": ["https://www.googleapis.com/auth/cloud-platform"]
     }]
 


### PR DESCRIPTION
This reverts commit 55d161b49f4ab2803463c3b003bc392a49e7faa6.

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The head node does not have sufficient privileges to start workers with the same role as it does. Presumably this is possible with more IAM tweaks, but reverting it for now.

## Related issue number

https://github.com/ray-project/ray/issues/3190