### PR TITLE
Add warning about using latest wheels

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -10,7 +10,7 @@ You can install the latest stable version of Ray as follows.
 
 .. code-block:: bash
 
-  pip install ray
+  pip install -U ray
 
 Trying snapshots from master
 ----------------------------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -19,7 +19,7 @@ Here are links to the latest wheels (which are built off of master). To install 
 
 .. danger::
 
-    These versions will have newer features but are subject to more bugs. If you encounter crashes or other instability, please revert to the latest stable version.
+    These versions will have newer features but are subject to more bugs. If you encounter crashes or other instabilities, please revert to the latest stable version.
 
 .. code-block:: bash
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,17 +3,23 @@ Installing Ray
 
 Ray should work with Python 2 and Python 3. We have tested Ray on Ubuntu 14.04, Ubuntu 16.04, OS X 10.11 and 10.12.
 
-You can install Ray as follows.
+Latest stable version
+---------------------
+
+You can install the latest stable version of Ray as follows.
 
 .. code-block:: bash
 
   pip install ray
 
-Trying the latest version of Ray
---------------------------------
+Trying snapshots from master
+----------------------------
 
-Here are links to the latest wheels (which are built off of master). These versions will have newer
-features but may be subject to more bugs. To install these wheels, run the following command:
+Here are links to the latest wheels (which are built off of master). To install these wheels, run the following command:
+
+.. danger::
+
+    These versions will have newer features but are subject to more bugs. If you encounter crashes or other instability, please revert to the latest stable version.
 
 .. code-block:: bash
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

The ray backend is currently in a particularly experimental state in master right now, so add an extra warning to discourage use at the moment.

## Related issue number

https://github.com/ray-project/ray/issues/3201
https://github.com/ray-project/ray/issues/3170