### PR TITLE
Update RayTaskError to save the exception thrown by the worker

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -92,11 +92,8 @@ class RayTaskError(Exception):
     def __init__(self, function_name, exception, traceback_str):
         """Initialize a RayTaskError."""
         self.function_name = function_name
-        if (isinstance(exception, RayGetError)
-                or isinstance(exception, RayGetArgumentError)):
+        if isinstance(exception, Exception):
             self.exception = exception
-        elif isinstance(exception, Exception):
-            self.exception = type(exception)
         else:
             self.exception = None
         self.traceback_str = traceback_str

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -95,6 +95,8 @@ class RayTaskError(Exception):
         if (isinstance(exception, RayGetError)
                 or isinstance(exception, RayGetArgumentError)):
             self.exception = exception
+        elif isinstance(exception, Exception):
+            self.exception = type(exception)
         else:
             self.exception = None
         self.traceback_str = traceback_str


### PR DESCRIPTION
## What do these changes do?

Saves the exceptions of all `Exceptions` instead of only `RayGetErrors` and `RayArgumentErrors`. This change allows users to be able to determine the error that was thrown by the worker without having to parse the traceback string.

With this change, users will be able to catch the workers error as follows
```
try:
    ray.get(error_task.remote())
except RayGetError as e:
    throw e.task_error.exception
```

## Related issue number

#1885 
