### PR TITLE
Single sourcing the package version

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -61,8 +61,7 @@ import ray.internal  # noqa: E402
 import ray.actor  # noqa: F401
 from ray.actor import method  # noqa: E402
 
-# Ray version string. TODO(rkn): This is also defined separately in setup.py.
-# Fix this.
+# Ray version string.
 __version__ = "0.5.3"
 
 __all__ = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -118,10 +119,20 @@ class BinaryDistribution(Distribution):
         return True
 
 
+def find_version(*filepath):
+    # Extract version information from filepath
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, *filepath)) as fp:
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  fp.read(), re.M)
+        if version_match:
+            return version_match.group(1)
+        raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name="ray",
-    # The version string is also in __init__.py. TODO(pcm): Fix this.
-    version="0.5.3",
+    version=find_version("ray", "__init__.py"),
     description=("A system for parallel and distributed Python that unifies "
                  "the ML ecosystem."),
     long_description=open("../README.rst").read(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
Single sourcing the package version in setup.py and retrieve the version using package_resources in __init__.py.
Currently, package version strings are hard-coded in both setup.py and __init__.py. It leads to potential inconsistency. 

<!-- Related issue number -->

<!-- Are there any issues opened that will be resolved by merging this change? -->
