### PR TITLE
[WIP] Remove RayGetError and stop throwing from tasks

### DIFF
--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -66,6 +66,7 @@ def push_error_to_driver(worker,
         data: This should be a dictionary mapping strings to strings. It
             will be serialized with json and stored in Redis.
     """
+    return
     if driver_id is None:
         driver_id = ray_constants.NIL_JOB_ID.id()
     data = {} if data is None else data

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -92,11 +92,7 @@ class RayTaskError(Exception):
     def __init__(self, function_name, exception, traceback_str):
         """Initialize a RayTaskError."""
         self.function_name = function_name
-        if (isinstance(exception, RayGetError)
-                or isinstance(exception, RayGetArgumentError)):
-            self.exception = exception
-        else:
-            self.exception = None
+        self.exception = exception
         self.traceback_str = traceback_str
 
     def __str__(self):
@@ -2277,7 +2273,7 @@ def get(object_ids, worker=global_worker):
             values = worker.get_object(object_ids)
             for i, value in enumerate(values):
                 if isinstance(value, RayTaskError):
-                    raise RayGetError(object_ids[i], value)
+                    raise value.exception
             return values
         else:
             value = worker.get_object([object_ids])[0]
@@ -2285,7 +2281,7 @@ def get(object_ids, worker=global_worker):
                 # If the result is a RayTaskError, then the task that created
                 # this object failed, and we should propagate the error message
                 # here.
-                raise RayGetError(object_ids, value)
+                raise value.exception
             return value
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

It is hard to catch `RayGetError` and handle different errors differently. This just throws the error that was thrown in the task. This is a bit more comprehensive than #3208.
<!-- Please give a short brief about these changes. -->

## Related issue number
#1885
<!-- Are there any issues opened that will be resolved by merging this change? -->
