### PR TITLE
Refactor ObjectDirectory to reduce and fix callback usage

### DIFF
--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -648,7 +648,8 @@ void ClientTableNotification(gcs::AsyncGcsClient *client, const ClientID &client
   ASSERT_EQ(ClientID::from_binary(data.client_id), added_id);
   ASSERT_EQ(data.is_insertion, is_insertion);
 
-  auto cached_client = client->client_table().GetClient(added_id);
+  ClientTableDataT cached_client;
+  client->client_table().GetClient(added_id, cached_client);
   ASSERT_EQ(ClientID::from_binary(cached_client.client_id), added_id);
   ASSERT_EQ(cached_client.is_insertion, is_insertion);
 }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -421,15 +421,14 @@ ray::Status ClientTable::MarkDisconnected(const ClientID &dead_client_id) {
   return Append(JobID::nil(), client_log_key_, data, nullptr);
 }
 
-const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) const {
+void ClientTable::GetClient(const ClientID &client_id,
+                            ClientTableDataT &client_info) const {
   RAY_CHECK(!client_id.is_nil());
   auto entry = client_cache_.find(client_id);
   if (entry != client_cache_.end()) {
-    return entry->second;
+    client_info = entry->second;
   } else {
-    // If the requested client was not found, return a reference to the nil
-    // client entry.
-    return client_cache_.at(ClientID::nil());
+    client_info.client_id = ClientID::nil().binary();
   }
 }
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -517,12 +517,6 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
 
     // Set the local client's ID.
     local_client_.client_id = client_id.binary();
-
-    // Add a nil client to the cache so that we can serve requests for clients
-    // that we have not heard about.
-    ClientTableDataT nil_client;
-    nil_client.client_id = ClientID::nil().binary();
-    client_cache_[ClientID::nil()] = nil_client;
   };
 
   /// Connect as a client to the GCS. This registers us in the client table
@@ -560,9 +554,11 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   /// information for clients that we've heard a notification for.
   ///
   /// \param client The client to get information about.
-  /// \return A reference to the requested client. If the client is not in the
-  /// cache, then an entry with a nil ClientID will be returned.
-  const ClientTableDataT &GetClient(const ClientID &client) const;
+  /// \param A reference to the client information. If we have information
+  /// about the client in the cache, then the reference will be modified to
+  /// contain that information. Else, the reference will be updated to contain
+  /// a nil client ID.
+  void GetClient(const ClientID &client, ClientTableDataT &client_info) const;
 
   /// Get the local client's ID.
   ///

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -153,7 +153,7 @@ ray::Status ObjectDirectory::SubscribeObjectLocations(const UniqueID &callback_i
   // have been evicted from all nodes.
   std::vector<ClientID> client_id_vec(listener_state.current_object_locations.begin(),
                                       listener_state.current_object_locations.end());
-  io_service_.post([this, callback, client_id_vec, object_id]() {
+  io_service_.post([callback, client_id_vec, object_id]() {
     callback(client_id_vec, object_id);
   });
   return status;

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -107,12 +107,15 @@ ray::Status ObjectDirectory::ReportObjectRemoved(const ObjectID &object_id,
 
 void ObjectDirectory::LookupRemoteConnectionInfo(
     RemoteConnectionInfo &connection_info) const {
-  const ClientTableDataT &data =
-      gcs_client_->client_table().GetClient(connection_info.client_id);
-  ClientID result_client_id = ClientID::from_binary(data.client_id);
-  if (result_client_id != ClientID::nil() && data.is_insertion) {
-    connection_info.ip = data.node_manager_address;
-    connection_info.port = static_cast<uint16_t>(data.object_manager_port);
+  ClientTableDataT client_data;
+  gcs_client_->client_table().GetClient(connection_info.client_id, client_data);
+  ClientID result_client_id = ClientID::from_binary(client_data.client_id);
+  if (!result_client_id.is_nil()) {
+    RAY_CHECK(result_client_id == connection_info.client_id);
+    if (client_data.is_insertion) {
+      connection_info.ip = client_data.node_manager_address;
+      connection_info.port = static_cast<uint16_t>(client_data.object_manager_port);
+    }
   }
 }
 

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -2,8 +2,9 @@
 
 namespace ray {
 
-ObjectDirectory::ObjectDirectory(std::shared_ptr<gcs::AsyncGcsClient> &gcs_client)
-    : gcs_client_(gcs_client) {}
+ObjectDirectory::ObjectDirectory(boost::asio::io_service &io_service,
+                                 std::shared_ptr<gcs::AsyncGcsClient> &gcs_client)
+    : io_service_(io_service), gcs_client_(gcs_client) {}
 
 namespace {
 

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -153,9 +153,8 @@ ray::Status ObjectDirectory::SubscribeObjectLocations(const UniqueID &callback_i
   // have been evicted from all nodes.
   std::vector<ClientID> client_id_vec(listener_state.current_object_locations.begin(),
                                       listener_state.current_object_locations.end());
-  io_service_.post([callback, client_id_vec, object_id]() {
-    callback(client_id_vec, object_id);
-  });
+  io_service_.post(
+      [callback, client_id_vec, object_id]() { callback(client_id_vec, object_id); });
   return status;
 }
 

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -27,7 +27,6 @@ struct RemoteConnectionInfo {
 
 class ObjectDirectoryInterface {
  public:
-  ObjectDirectoryInterface() = default;
   virtual ~ObjectDirectoryInterface() = default;
 
   /// Callbacks for GetInformation.
@@ -114,8 +113,15 @@ class ObjectDirectoryInterface {
 /// Ray ObjectDirectory declaration.
 class ObjectDirectory : public ObjectDirectoryInterface {
  public:
-  ObjectDirectory() = default;
-  ~ObjectDirectory() override = default;
+  /// Create an object directory.
+  ///
+  /// \param io_service The event loop to dispatch callbacks to.
+  /// \param gcs_client A Ray GCS client to request object and client
+  /// information from.
+  ObjectDirectory(boost::asio::io_service &io_service,
+                  std::shared_ptr<gcs::AsyncGcsClient> &gcs_client);
+
+  virtual ~ObjectDirectory(){};
 
   void RegisterBackend() override;
 
@@ -139,8 +145,6 @@ class ObjectDirectory : public ObjectDirectoryInterface {
       const object_manager::protocol::ObjectInfoT &object_info) override;
   ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                   const ClientID &client_id) override;
-  /// Ray only (not part of the OD interface).
-  ObjectDirectory(std::shared_ptr<gcs::AsyncGcsClient> &gcs_client);
 
   /// ObjectDirectory should not be copied.
   RAY_DISALLOW_COPY_AND_ASSIGN(ObjectDirectory);
@@ -154,6 +158,8 @@ class ObjectDirectory : public ObjectDirectoryInterface {
     std::unordered_set<ClientID> current_object_locations;
   };
 
+  /// Reference to the event loop.
+  boost::asio::io_service &io_service_;
   /// Reference to the gcs client.
   std::shared_ptr<gcs::AsyncGcsClient> gcs_client_;
   /// Info about subscribers to object locations.

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -115,7 +115,8 @@ class ObjectDirectory : public ObjectDirectoryInterface {
  public:
   /// Create an object directory.
   ///
-  /// \param io_service The event loop to dispatch callbacks to.
+  /// \param io_service The event loop to dispatch callbacks to. This should
+  /// usually be the same event loop that the given gcs_client runs on.
   /// \param gcs_client A Ray GCS client to request object and client
   /// information from.
   ObjectDirectory(boost::asio::io_service &io_service,

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -31,9 +31,6 @@ class ObjectDirectoryInterface {
  public:
   virtual ~ObjectDirectoryInterface() {}
 
-  /// Callbacks for LookupRemoteConnectionInfo.
-  using InfoSuccessCallback = std::function<void(const ray::RemoteConnectionInfo &info)>;
-
   virtual void RegisterBackend() = 0;
 
   /// Lookup how to connect to a remote object manager.
@@ -42,7 +39,13 @@ class ObjectDirectoryInterface {
   /// should be pre-populated with the requested client ID. If the directory
   /// has information about the requested client, then the rest of the fields
   /// in this struct will be populated accordingly.
-  virtual void LookupRemoteConnectionInfo(RemoteConnectionInfo &connection_info) = 0;
+  virtual void LookupRemoteConnectionInfo(
+      RemoteConnectionInfo &connection_info) const = 0;
+
+  /// Get information for all connected remote object managers.
+  ///
+  /// \return A vector of information for all connected remote object managers.
+  virtual std::vector<RemoteConnectionInfo> LookupAllRemoteConnections() const = 0;
 
   /// Callback for object location notifications.
   using OnLocationsFound = std::function<void(const std::vector<ray::ClientID> &,
@@ -100,13 +103,6 @@ class ObjectDirectoryInterface {
   /// \return Status of whether this method succeeded.
   virtual ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                           const ClientID &client_id) = 0;
-
-  /// Go through all the client information.
-  ///
-  /// \param success_cb A callback which handles the success of this method.
-  /// This function will be called multiple times.
-  /// \return Void.
-  virtual void RunFunctionForEachClient(const InfoSuccessCallback &client_function) = 0;
 };
 
 /// Ray ObjectDirectory declaration.
@@ -125,9 +121,9 @@ class ObjectDirectory : public ObjectDirectoryInterface {
 
   void RegisterBackend() override;
 
-  void LookupRemoteConnectionInfo(RemoteConnectionInfo &connection_info) override;
+  void LookupRemoteConnectionInfo(RemoteConnectionInfo &connection_info) const override;
 
-  void RunFunctionForEachClient(const InfoSuccessCallback &client_function) override;
+  std::vector<RemoteConnectionInfo> LookupAllRemoteConnections() const override;
 
   ray::Status LookupLocations(const ObjectID &object_id,
                               const OnLocationsFound &callback) override;

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -23,7 +23,7 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
     // TODO(hme): Eliminate knowledge of GCS.
     : client_id_(gcs_client->client_table().GetLocalClientId()),
       config_(config),
-      object_directory_(new ObjectDirectory(gcs_client)),
+      object_directory_(new ObjectDirectory(main_service, gcs_client)),
       store_notification_(main_service, config_.store_socket_name),
       // release_delay of 2 * config_.max_sends is to ensure the pool does not release
       // an object prematurely whenever we reach the maximum number of sends.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -643,7 +643,7 @@ std::shared_ptr<SenderConnection> ObjectManager::CreateSenderConnection(
     flatbuffers::FlatBufferBuilder fbb;
     bool is_transfer = (type == ConnectionPool::ConnectionType::TRANSFER);
     auto message = object_manager_protocol::CreateConnectClientMessage(
-        fbb, fbb.CreateString(client_id_.binary()), is_transfer);
+        fbb, to_flatbuf(fbb, client_id_), is_transfer);
     fbb.Finish(message);
     // Send synchronously.
     // TODO(swang): Make this a WriteMessageAsync.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -646,6 +646,7 @@ std::shared_ptr<SenderConnection> ObjectManager::CreateSenderConnection(
         fbb, fbb.CreateString(client_id_.binary()), is_transfer);
     fbb.Finish(message);
     // Send synchronously.
+    // TODO(swang): Make this a WriteMessageAsync.
     RAY_CHECK_OK(conn->WriteMessage(
         static_cast<int64_t>(object_manager_protocol::MessageType::ConnectClient),
         fbb.GetSize(), fbb.GetBufferPointer()));
@@ -814,6 +815,7 @@ void ObjectManager::SpreadFreeObjectRequest(const std::vector<ObjectID> &object_
     }
 
     if (conn != nullptr) {
+      // TODO(swang): Make this a WriteMessageAsync.
       ray::Status status = conn->WriteMessage(
           static_cast<int64_t>(object_manager_protocol::MessageType::FreeRequest),
           fbb.GetSize(), fbb.GetBufferPointer());

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -433,11 +433,13 @@ class StressTestObjectManager : public TestObjectManagerBase {
     RAY_LOG(DEBUG) << "\n"
                    << "All connected clients:"
                    << "\n";
-    const ClientTableDataT &data = gcs_client_1->client_table().GetClient(client_id_1);
+    ClientTableDataT data;
+    gcs_client_1->client_table().GetClient(client_id_1, data);
     RAY_LOG(DEBUG) << "ClientID=" << ClientID::from_binary(data.client_id) << "\n"
                    << "ClientIp=" << data.node_manager_address << "\n"
                    << "ClientPort=" << data.node_manager_port;
-    const ClientTableDataT &data2 = gcs_client_1->client_table().GetClient(client_id_2);
+    ClientTableDataT data2;
+    gcs_client_1->client_table().GetClient(client_id_2, data2);
     RAY_LOG(DEBUG) << "ClientID=" << ClientID::from_binary(data2.client_id) << "\n"
                    << "ClientIp=" << data2.node_manager_address << "\n"
                    << "ClientPort=" << data2.node_manager_port;

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -447,13 +447,15 @@ class TestObjectManager : public TestObjectManagerBase {
     RAY_LOG(DEBUG) << "\n"
                    << "Server client ids:"
                    << "\n";
-    const ClientTableDataT &data = gcs_client_1->client_table().GetClient(client_id_1);
+    ClientTableDataT data;
+    gcs_client_1->client_table().GetClient(client_id_1, data);
     RAY_LOG(DEBUG) << (ClientID::from_binary(data.client_id) == ClientID::nil());
     RAY_LOG(DEBUG) << "Server 1 ClientID=" << ClientID::from_binary(data.client_id);
     RAY_LOG(DEBUG) << "Server 1 ClientIp=" << data.node_manager_address;
     RAY_LOG(DEBUG) << "Server 1 ClientPort=" << data.node_manager_port;
     ASSERT_EQ(client_id_1, ClientID::from_binary(data.client_id));
-    const ClientTableDataT &data2 = gcs_client_1->client_table().GetClient(client_id_2);
+    ClientTableDataT data2;
+    gcs_client_1->client_table().GetClient(client_id_2, data2);
     RAY_LOG(DEBUG) << "Server 2 ClientID=" << ClientID::from_binary(data2.client_id);
     RAY_LOG(DEBUG) << "Server 2 ClientIp=" << data2.node_manager_address;
     RAY_LOG(DEBUG) << "Server 2 ClientPort=" << data2.node_manager_port;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -304,14 +304,13 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   }
 
   // Establish a new NodeManager connection to this GCS client.
-  auto client_info = gcs_client_->client_table().GetClient(client_id);
   RAY_LOG(DEBUG) << "[ClientAdded] Trying to connect to client " << client_id << " at "
-                 << client_info.node_manager_address << ":"
-                 << client_info.node_manager_port;
+                 << client_data.node_manager_address << ":"
+                 << client_data.node_manager_port;
 
   boost::asio::ip::tcp::socket socket(io_service_);
   auto status =
-      TcpConnect(socket, client_info.node_manager_address, client_info.node_manager_port);
+      TcpConnect(socket, client_data.node_manager_address, client_data.node_manager_port);
   // A disconnected client has 2 entries in the client table (one for being
   // inserted and one for being removed). When a new raylet starts, ClientAdded
   // will be called with the disconnected client's first entry, which will cause
@@ -1555,8 +1554,6 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
 
   RAY_LOG(DEBUG) << "Forwarding task " << task_id << " to " << node_id << " spillback="
                  << lineage_cache_entry_task.GetTaskExecutionSpec().NumForwards();
-
-  auto client_info = gcs_client_->client_table().GetClient(node_id);
 
   // Lookup remote server connection for this node_id and use it to send the request.
   auto it = remote_server_connections_.find(node_id);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -61,7 +61,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
           [this](const TaskID &task_id) { HandleTaskReconstruction(task_id); },
           RayConfig::instance().initial_reconstruction_timeout_milliseconds(),
           gcs_client_->client_table().GetLocalClientId(), gcs_client->task_lease_table(),
-          std::make_shared<ObjectDirectory>(gcs_client),
+          std::make_shared<ObjectDirectory>(io_service, gcs_client),
           gcs_client_->task_reconstruction_log()),
       task_dependency_manager_(
           object_manager, reconstruction_policy_, io_service,

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -204,12 +204,14 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
     RAY_LOG(INFO) << "\n"
                   << "All connected clients:"
                   << "\n";
-    const ClientTableDataT &data = gcs_client_2->client_table().GetClient(client_id_1);
+    ClientTableDataT data;
+    gcs_client_2->client_table().GetClient(client_id_1, data);
     RAY_LOG(INFO) << (ClientID::from_binary(data.client_id) == ClientID::nil());
     RAY_LOG(INFO) << "ClientID=" << ClientID::from_binary(data.client_id);
     RAY_LOG(INFO) << "ClientIp=" << data.node_manager_address;
     RAY_LOG(INFO) << "ClientPort=" << data.node_manager_port;
-    const ClientTableDataT &data2 = gcs_client_1->client_table().GetClient(client_id_2);
+    ClientTableDataT data2;
+    gcs_client_1->client_table().GetClient(client_id_2, data2);
     RAY_LOG(INFO) << "ClientID=" << ClientID::from_binary(data2.client_id);
     RAY_LOG(INFO) << "ClientIp=" << data2.node_manager_address;
     RAY_LOG(INFO) << "ClientPort=" << data2.node_manager_port;

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -37,7 +37,8 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   }
 
   MOCK_METHOD0(RegisterBackend, void(void));
-  MOCK_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo &));
+  MOCK_CONST_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo &));
+  MOCK_CONST_METHOD0(LookupAllRemoteConnections, std::vector<RemoteConnectionInfo>());
   MOCK_METHOD3(SubscribeObjectLocations,
                ray::Status(const ray::UniqueID &, const ObjectID &,
                            const OnLocationsFound &));
@@ -47,7 +48,6 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
                ray::Status(const ObjectID &, const ClientID &,
                            const object_manager::protocol::ObjectInfoT &));
   MOCK_METHOD2(ReportObjectRemoved, ray::Status(const ObjectID &, const ClientID &));
-  MOCK_METHOD1(RunFunctionForEachClient, void(const InfoSuccessCallback &success_cb));
 
  private:
   std::vector<std::pair<ObjectID, OnLocationsFound>> callbacks_;

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -37,8 +37,7 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   }
 
   MOCK_METHOD0(RegisterBackend, void(void));
-  MOCK_METHOD3(GetInformation, ray::Status(const ClientID &, const InfoSuccessCallback &,
-                                           const InfoFailureCallback &));
+  MOCK_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo &));
   MOCK_METHOD3(SubscribeObjectLocations,
                ray::Status(const ray::UniqueID &, const ObjectID &,
                            const OnLocationsFound &));


### PR DESCRIPTION
## What do these changes do?

This refactors the `ObjectDirectory` to only use callbacks where necessary and to post callbacks on an event loop instead of calling the callbacks in the same stack.

## Related issue number
#2959