### PR TITLE
[minor] Change chunk already exists to DEBUG, add flags for rllib multi node testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ function usage()
 # Determine how many parallel jobs to use for make based on the number of cores
 unamestr="$(uname)"
 if [[ "$unamestr" == "Linux" ]]; then
-  PARALLEL=$(nproc)
+  PARALLEL=$(nproc --all)
 elif [[ "$unamestr" == "Darwin" ]]; then
   PARALLEL=$(sysctl -n hw.ncpu)
 else

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -119,8 +119,8 @@ def run(args, parser):
         for _ in range(args.ray_num_local_schedulers):
             cluster.add_node(
                 resources={
-                    "num_cpus": args.ray_num_cpus,
-                    "num_gpus": args.ray_num_gpus,
+                    "num_cpus": args.ray_num_cpus or 1,
+                    "num_gpus": args.ray_num_gpus or 0,
                 },
                 object_store_memory=args.ray_object_store_memory)
         ray.init(redis_address=cluster.redis_address)

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -117,13 +117,13 @@ def run(args, parser):
         ray.worker._init(
             start_ray_local=True,
             num_local_schedulers=args.ray_num_local_schedulers,
-            object_store_memory=object_store_memory,
+            object_store_memory=args.ray_object_store_memory,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     else:
         ray.init(
             redis_address=args.redis_address,
-            object_store_memory=object_store_memory,
+            object_store_memory=args.ray_object_store_memory,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     run_experiments(

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -56,6 +56,12 @@ def create_parser(parser_creator=None):
         type=int,
         help="Emulate multiple cluster nodes for debugging.")
     parser.add_argument(
+        "--ray-object-store-memory",
+        default=None,
+        type=int,
+        help="--object-store-memory to pass to Ray."
+        " This only has an affect in local mode.")
+    parser.add_argument(
         "--experiment-name",
         default="default",
         type=str,
@@ -111,11 +117,13 @@ def run(args, parser):
         ray.worker._init(
             start_ray_local=True,
             num_local_schedulers=args.ray_num_local_schedulers,
+            object_store_memory=object_store_memory,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     else:
         ray.init(
             redis_address=args.redis_address,
+            object_store_memory=object_store_memory,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     run_experiments(

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -762,7 +762,7 @@ void ObjectManager::ExecuteReceiveObject(const ClientID &client_id,
       // TODO(hme): This chunk failed, so create a pull request for this chunk.
     }
   } else {
-    RAY_LOG(ERROR) << "Create Chunk Failed index = " << chunk_index << ": "
+    RAY_LOG(DEBUG) << "Create Chunk Failed index = " << chunk_index << ": "
                    << chunk_status.second.message();
     // Read object into empty buffer.
     uint64_t buffer_length = buffer_pool_.GetBufferLength(chunk_index, data_size);


### PR DESCRIPTION
```
E1105 01:28:28.901176 70942 object_manager.cc:760] Create Chunk Failed index = 2: Chunk already referenced by another thread.
E1105 01:28:28.901196 70953 object_manager.cc:760] Create Chunk Failed index = 3: Chunk already referenced by another thread.
E1105 01:28:28.901216 70949 object_manager.cc:760] Create Chunk Failed index = 1: Chunk already referenced by another thread.
E1105 01:28:28.904553 70957 object_manager.cc:760] Create Chunk Failed index = 8: Chunk already referenced by another thread.
E1105 01:28:28.904507 70945 object_manager.cc:760] Create Chunk Failed index = 5: Chunk already referenced by another thread.
E1105 01:28:28.904534 70944 object_manager.cc:760] Create Chunk Failed index = 4: Chunk already referenced by another thread.
E1105 01:28:28.904618 70952 object_manager.cc:760] Create Chunk Failed index = 7: Chunk already referenced by another thread.
E1105 01:28:28.904345 70950 object_manager.cc:760] Create Chunk Failed index = 6: Chunk already referenced by another thread.
E1105 01:28:28.905189 70955 object_manager.cc:760] Create Chunk Failed index = 9: Chunk already referenced by another thread.
E1105 01:28:28.938772 70793 object_manager.cc:760] Create Chunk Failed index = 0: object already exists in the plasma store
E1105 01:28:28.989253 70792 object_manager.cc:760] Create Chunk Failed index = 0: object already exists in the plasma store
E1105 01:28:28.989260 70783 object_manager.cc:760] Create Chunk Failed index = 0: Chunk already referenced by another thread.
E1105 01:28:28.991091 71051 object_manager.cc:760] Create Chunk Failed index = 0: Chunk already referenced by another thread.
E1105 01:28:28.991886 71053 object_manager.cc:760] Create Chunk Failed index = 1: Chunk already referenced by another thread.
E1105 01:28:28.995105 71046 object_manager.cc:760] Create Chunk Failed index = 2: Chunk already referenced by another thread.
E1105 01:28:28.995266 71040 object_manager.cc:760] Create Chunk Failed index = 5: Chunk already referenced by another thread.
E1105 01:28:28.996075 71045 object_manager.cc:760] Create Chunk Failed index = 3: Chunk already referenced by another thread.
E1105 01:28:28.999382 71041 object_manager.cc:760] Create Chunk Failed index = 6: object already exists in the plasma store
```

When running Ape-X, you get these in the raylet logs.