### PR TITLE
Allow multiple threads to call ray.get and ray.wait

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -189,7 +189,8 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   public <T> WaitResult<T> wait(List<RayObject<T>> waitList, int numReturns, int timeoutMs) {
     // TODO(swang): If we are not on the main thread, then we should generate a
     // random task ID to pass to the backend.
-    return rayletClient.wait(waitList, numReturns, timeoutMs, workerContext.getCurrentTask().taskId);
+    return rayletClient.wait(waitList, numReturns, timeoutMs,
+        workerContext.getCurrentTask().taskId);
   }
 
   @Override

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -88,6 +88,8 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   @Override
   public <T> List<T> get(List<UniqueId> objectIds) {
     boolean wasBlocked = false;
+    // TODO(swang): If we are not on the main thread, then we should generate a
+    // random task ID to pass to the backend.
     UniqueId taskId = workerContext.getCurrentTask().taskId;
 
     try {
@@ -97,7 +99,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
       List<List<UniqueId>> fetchBatches =
           splitIntoBatches(objectIds, FETCH_BATCH_SIZE);
       for (List<UniqueId> batch : fetchBatches) {
-        rayletClient.reconstructObjects(batch, true);
+        rayletClient.notifyBlocked(batch, true, taskId);
       }
 
       // Get the objects. We initially try to get the objects immediately.
@@ -122,7 +124,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
             splitIntoBatches(unreadyList, FETCH_BATCH_SIZE);
 
         for (List<UniqueId> batch : reconstructBatches) {
-          rayletClient.reconstructObjects(batch, false);
+          rayletClient.notifyBlocked(batch, false, taskId);
         }
 
         List<Pair<T, GetStatus>> results = objectStoreProxy
@@ -157,7 +159,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
       // If there were objects that we weren't able to get locally, let the local
       // scheduler know that we're now unblocked.
       if (wasBlocked) {
-        rayletClient.notifyUnblocked();
+        rayletClient.notifyUnblocked(taskId);
       }
     }
   }
@@ -185,7 +187,9 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public <T> WaitResult<T> wait(List<RayObject<T>> waitList, int numReturns, int timeoutMs) {
-    return rayletClient.wait(waitList, numReturns, timeoutMs);
+    // TODO(swang): If we are not on the main thread, then we should generate a
+    // random task ID to pass to the backend.
+    return rayletClient.wait(waitList, numReturns, timeoutMs, workerContext.getCurrentTask().taskId);
   }
 
   @Override

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -99,7 +99,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
       List<List<UniqueId>> fetchBatches =
           splitIntoBatches(objectIds, FETCH_BATCH_SIZE);
       for (List<UniqueId> batch : fetchBatches) {
-        rayletClient.notifyBlocked(batch, true, taskId);
+        rayletClient.fetchOrReconstruct(batch, true, taskId);
       }
 
       // Get the objects. We initially try to get the objects immediately.
@@ -124,7 +124,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
             splitIntoBatches(unreadyList, FETCH_BATCH_SIZE);
 
         for (List<UniqueId> batch : reconstructBatches) {
-          rayletClient.notifyBlocked(batch, false, taskId);
+          rayletClient.fetchOrReconstruct(batch, false, taskId);
         }
 
         List<Pair<T, GetStatus>> results = objectStoreProxy

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
@@ -66,7 +66,8 @@ public class MockRayletClient implements RayletClient {
   }
 
   @Override
-  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
+  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly,
+      UniqueId currentTaskId) {
 
   }
 
@@ -81,7 +82,8 @@ public class MockRayletClient implements RayletClient {
   }
 
   @Override
-  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs, UniqueId currentTaskId) {
+  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
+      timeoutMs, UniqueId currentTaskId) {
     return new WaitResult<T>(
         waitFor,
         ImmutableList.of()

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
@@ -66,7 +66,7 @@ public class MockRayletClient implements RayletClient {
   }
 
   @Override
-  public void notifyBlocked(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
+  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
 
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
@@ -66,12 +66,12 @@ public class MockRayletClient implements RayletClient {
   }
 
   @Override
-  public void reconstructObjects(List<UniqueId> objectIds, boolean fetchOnly) {
+  public void notifyBlocked(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
 
   }
 
   @Override
-  public void notifyUnblocked() {
+  public void notifyUnblocked(UniqueId currentTaskId) {
 
   }
 
@@ -81,7 +81,7 @@ public class MockRayletClient implements RayletClient {
   }
 
   @Override
-  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs) {
+  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs, UniqueId currentTaskId) {
     return new WaitResult<T>(
         waitFor,
         ImmutableList.of()

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
@@ -15,13 +15,13 @@ public interface RayletClient {
 
   TaskSpec getTask();
 
-  void reconstructObjects(List<UniqueId> objectIds, boolean fetchOnly);
+  void notifyBlocked(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId);
 
-  void notifyUnblocked();
+  void notifyUnblocked(UniqueId currentTaskId);
 
   UniqueId generateTaskId(UniqueId driverId, UniqueId parentTaskId, int taskIndex);
 
-  <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs);
+  <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs, UniqueId currentTaskId);
 
   void freePlasmaObjects(List<UniqueId> objectIds, boolean localOnly);
 }

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
@@ -15,7 +15,7 @@ public interface RayletClient {
 
   TaskSpec getTask();
 
-  void notifyBlocked(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId);
+  void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId);
 
   void notifyUnblocked(UniqueId currentTaskId);
 

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
@@ -21,7 +21,8 @@ public interface RayletClient {
 
   UniqueId generateTaskId(UniqueId driverId, UniqueId parentTaskId, int taskIndex);
 
-  <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs, UniqueId currentTaskId);
+  <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
+      timeoutMs, UniqueId currentTaskId);
 
   void freePlasmaObjects(List<UniqueId> objectIds, boolean localOnly);
 }

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -87,12 +87,12 @@ public class RayletClientImpl implements RayletClient {
   }
 
   @Override
-  public void notifyBlocked(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
+  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
     if (RayLog.core.isInfoEnabled()) {
       RayLog.core.info("Blocked on objects for task {}, object IDs are {}",
           UniqueIdUtil.computeTaskId(objectIds.get(0)), objectIds);
     }
-    nativeNotifyBlocked(client, UniqueIdUtil.getIdBytes(objectIds), fetchOnly, currentTaskId);
+    nativeFetchOrReconstruct(client, UniqueIdUtil.getIdBytes(objectIds), fetchOnly, currentTaskId);
   }
 
   @Override
@@ -271,7 +271,7 @@ public class RayletClientImpl implements RayletClient {
 
   private static native void nativeDestroy(long client);
 
-  private static native void nativeNotifyBlocked(long client, byte[][] objectIds,
+  private static native void nativeFetchOrReconstruct(long client, byte[][] objectIds,
       boolean fetchOnly, UniqueId currentTaskId);
 
   private static native void nativeNotifyUnblocked(long client, UniqueId currentTaskId);

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -52,7 +52,7 @@ public class RayletClientImpl implements RayletClient {
     }
 
     boolean[] ready = nativeWaitObject(client, UniqueIdUtil.getIdBytes(ids),
-        numReturns, timeoutMs, false, currentTaskId);
+        numReturns, timeoutMs, false, currentTaskId.getBytes());
     List<RayObject<T>> readyList = new ArrayList<>();
     List<RayObject<T>> unreadyList = new ArrayList<>();
 
@@ -94,7 +94,8 @@ public class RayletClientImpl implements RayletClient {
       RayLog.core.info("Blocked on objects for task {}, object IDs are {}",
           UniqueIdUtil.computeTaskId(objectIds.get(0)), objectIds);
     }
-    nativeFetchOrReconstruct(client, UniqueIdUtil.getIdBytes(objectIds), fetchOnly, currentTaskId);
+    nativeFetchOrReconstruct(client, UniqueIdUtil.getIdBytes(objectIds),
+        fetchOnly, currentTaskId.getBytes());
   }
 
   @Override
@@ -105,7 +106,7 @@ public class RayletClientImpl implements RayletClient {
 
   @Override
   public void notifyUnblocked(UniqueId currentTaskId) {
-    nativeNotifyUnblocked(client, currentTaskId);
+    nativeNotifyUnblocked(client, currentTaskId.getBytes());
   }
 
   @Override
@@ -274,14 +275,14 @@ public class RayletClientImpl implements RayletClient {
   private static native void nativeDestroy(long client);
 
   private static native void nativeFetchOrReconstruct(long client, byte[][] objectIds,
-      boolean fetchOnly, UniqueId currentTaskId);
+      boolean fetchOnly, byte[] currentTaskId);
 
-  private static native void nativeNotifyUnblocked(long client, UniqueId currentTaskId);
+  private static native void nativeNotifyUnblocked(long client, byte[] currentTaskId);
 
   private static native void nativePutObject(long client, byte[] taskId, byte[] objectId);
 
   private static native boolean[] nativeWaitObject(long conn, byte[][] objectIds,
-      int numReturns, int timeout, boolean waitLocal, UniqueId currentTaskId);
+      int numReturns, int timeout, boolean waitLocal, byte[] currentTaskId);
 
   private static native byte[] nativeGenerateTaskId(byte[] driverId, byte[] parentTaskId,
       int taskIndex);

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -44,7 +44,8 @@ public class RayletClientImpl implements RayletClient {
   }
 
   @Override
-  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int timeoutMs, UniqueId currentTaskId) {
+  public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
+      timeoutMs, UniqueId currentTaskId) {
     List<UniqueId> ids = new ArrayList<>();
     for (RayObject<T> element : waitFor) {
       ids.add(element.getId());
@@ -87,7 +88,8 @@ public class RayletClientImpl implements RayletClient {
   }
 
   @Override
-  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId) {
+  public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly,
+      UniqueId currentTaskId) {
     if (RayLog.core.isInfoEnabled()) {
       RayLog.core.info("Blocked on objects for task {}, object IDs are {}",
           UniqueIdUtil.computeTaskId(objectIds.get(0)), objectIds);

--- a/python/ray/experimental/sgd/util.py
+++ b/python/ray/experimental/sgd/util.py
@@ -36,7 +36,7 @@ def fetch(oids):
     local_sched_client = ray.worker.global_worker.local_scheduler_client
     for o in oids:
         ray_obj_id = ray.ObjectID(o)
-        local_sched_client.reconstruct_objects([ray_obj_id], True)
+        local_sched_client.fetch_or_reconstruct([ray_obj_id], True)
 
 
 def run_timeline(sess, ops, feed_dict=None, write_timeline=False, name=""):

--- a/python/ray/rllib/utils/actors.py
+++ b/python/ray/rllib/utils/actors.py
@@ -40,7 +40,7 @@ class TaskPool(object):
         for worker, obj_id in self.completed():
             plasma_id = ray.pyarrow.plasma.ObjectID(obj_id.id())
             (ray.worker.global_worker.local_scheduler_client.
-             reconstruct_objects([obj_id], True))
+             fetch_or_reconstruct([obj_id], True))
             self._fetching.append((worker, obj_id))
 
         remaining = []

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -423,3 +423,6 @@ def thread_safe_client(client, lock=None):
     if lock is None:
         lock = threading.Lock()
     return _ThreadSafeProxy(client, lock)
+
+def is_main_thread():
+    return threading.current_thread().getName() == "MainThread"

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -424,5 +424,6 @@ def thread_safe_client(client, lock=None):
         lock = threading.Lock()
     return _ThreadSafeProxy(client, lock)
 
+
 def is_main_thread():
     return threading.current_thread().getName() == "MainThread"

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -235,7 +235,9 @@ class Worker(object):
             if not self.multithreading_warned:
                 logger.warning(
                     "Calling ray.get or ray.wait in a separate thread "
-                    "may lead to deadlock")
+                    "may lead to deadlock if the main thread blocks on this "
+                    "thread and there are not enough resources to execute "
+                    "more tasks")
                 self.multithreading_warned = True
         assert not current_task_id.is_nil()
         return current_task_id

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -865,13 +865,6 @@ class Worker(object):
                 function_id, function_name, return_object_ids, e,
                 ray.utils.format_error_message(traceback.format_exc()))
 
-        # Reset the state fields so the next task can run.
-        with self.state_lock:
-            self.task_driver_id = ray.ObjectID(NIL_ID)
-            self.current_task_id = ray.ObjectID(NIL_ID)
-            self.task_index = 0
-            self.put_index = 1
-
     def _handle_process_task_failure(self, function_id, function_name,
                                      return_object_ids, error, backtrace):
         failure_object = RayTaskError(function_name, error, backtrace)
@@ -948,6 +941,12 @@ class Worker(object):
             }
             with profiling.profile("task", extra_data=extra_data, worker=self):
                 self._process_task(task, execution_info)
+            # Reset the state fields so the next task can run.
+            with self.state_lock:
+                self.task_driver_id = ray.ObjectID(NIL_ID)
+                self.current_task_id = ray.ObjectID(NIL_ID)
+                self.task_index = 0
+                self.put_index = 1
 
         # Increase the task execution counter.
         self.function_actor_manager.increase_task_counter(

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -37,7 +37,7 @@ enum MessageType:int {
   ExecuteTask,
   // Reconstruct or fetch possibly lost objects. This is sent from a worker to
   // a local scheduler.
-  NotifyBlocked,
+  FetchOrReconstruct,
   // For a worker that was blocked on some object(s), tell the local scheduler
   // that the worker is now unblocked. This is sent from a worker to a local
   // scheduler.
@@ -150,7 +150,7 @@ table ForwardTaskRequest {
   uncommitted_tasks: [Task];
 }
 
-table NotifyBlocked {
+table FetchOrReconstruct {
   // List of object IDs of the objects that we want to reconstruct or fetch.
   object_ids: [string];
   // Do we only want to fetch the objects or also reconstruct them?

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -37,7 +37,7 @@ enum MessageType:int {
   ExecuteTask,
   // Reconstruct or fetch possibly lost objects. This is sent from a worker to
   // a local scheduler.
-  ReconstructObjects,
+  NotifyBlocked,
   // For a worker that was blocked on some object(s), tell the local scheduler
   // that the worker is now unblocked. This is sent from a worker to a local
   // scheduler.
@@ -150,11 +150,18 @@ table ForwardTaskRequest {
   uncommitted_tasks: [Task];
 }
 
-table ReconstructObjects {
+table NotifyBlocked {
   // List of object IDs of the objects that we want to reconstruct or fetch.
   object_ids: [string];
   // Do we only want to fetch the objects or also reconstruct them?
   fetch_only: bool;
+  // The current task ID. If fetch_only is false, then this task is blocked.
+  task_id: string;
+}
+
+table NotifyUnblocked {
+  // The current task ID. This task is no longer blocked.
+  task_id: string;
 }
 
 table WaitRequest {

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -173,6 +173,9 @@ table WaitRequest {
   timeout: long;
   // Whether to wait until objects appear locally.
   wait_local: bool;
+  // The current task ID. If there are less than num_ready_objects local, then
+  // this task is blocked.
+  task_id: string;
 }
 
 table WaitReply {

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -118,11 +118,11 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeDestro
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
- * Method:    nativeNotifyBlocked
+ * Method:    nativeFetchOrReconstruct
  * Signature: (J[[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyBlocked(
+Java_org_ray_runtime_raylet_RayletClientImpl_nativeFetchOrReconstruct(
     JNIEnv *env, jclass, jlong client, jobjectArray objectIds, jboolean fetchOnly,
     jbyteArray currentTaskId) {
   std::vector<ObjectID> object_ids;
@@ -136,7 +136,7 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyBlocked(
   }
   UniqueIdFromJByteArray current_task_id(env, currentTaskId);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  local_scheduler_notify_blocked(conn, object_ids, fetchOnly, *current_task_id.PID);
+  local_scheduler_fetch_or_reconstruct(conn, object_ids, fetchOnly, *current_task_id.PID);
 }
 
 /*

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -174,9 +174,9 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeWaitObject(
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
 
   // Invoke wait.
-  std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result = local_scheduler_wait(
-      conn, object_ids, numReturns, timeoutMillis, static_cast<bool>(isWaitLocal),
-      *current_task_id.PID);
+  std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result =
+      local_scheduler_wait(conn, object_ids, numReturns, timeoutMillis,
+                           static_cast<bool>(isWaitLocal), *current_task_id.PID);
 
   // Convert result to java object.
   jboolean put_value = true;

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -118,12 +118,13 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeDestro
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
- * Method:    nativeReconstructObjects
+ * Method:    nativeNotifyBlocked
  * Signature: (J[[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_runtime_raylet_RayletClientImpl_nativeReconstructObjects(
-    JNIEnv *env, jclass, jlong client, jobjectArray objectIds, jboolean fetchOnly) {
+Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyBlocked(
+    JNIEnv *env, jclass, jlong client, jobjectArray objectIds, jboolean fetchOnly,
+    jbyteArray currentTaskId) {
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
@@ -133,8 +134,9 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeReconstructObjects(
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
   }
+  UniqueIdFromJByteArray current_task_id(env, currentTaskId);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  local_scheduler_reconstruct_objects(conn, object_ids, fetchOnly);
+  local_scheduler_notify_blocked(conn, object_ids, fetchOnly, *current_task_id.PID);
 }
 
 /*
@@ -143,9 +145,10 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeReconstructObjects(
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyUnblocked(
-    JNIEnv *, jclass, jlong client) {
+    JNIEnv *env, jclass, jlong client, jbyteArray currentTaskId) {
+  UniqueIdFromJByteArray current_task_id(env, currentTaskId);
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
-  local_scheduler_notify_unblocked(conn);
+  local_scheduler_notify_unblocked(conn, *current_task_id.PID);
 }
 
 /*
@@ -156,7 +159,7 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotify
 JNIEXPORT jbooleanArray JNICALL
 Java_org_ray_runtime_raylet_RayletClientImpl_nativeWaitObject(
     JNIEnv *env, jclass, jlong client, jobjectArray objectIds, jint numReturns,
-    jint timeoutMillis, jboolean isWaitLocal) {
+    jint timeoutMillis, jboolean isWaitLocal, jbyteArray currentTaskId) {
   std::vector<ObjectID> object_ids;
   auto len = env->GetArrayLength(objectIds);
   for (int i = 0; i < len; i++) {
@@ -166,12 +169,14 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeWaitObject(
     object_ids.push_back(*object_id.PID);
     env->DeleteLocalRef(object_id_bytes);
   }
+  UniqueIdFromJByteArray current_task_id(env, currentTaskId);
 
   auto conn = reinterpret_cast<LocalSchedulerConnection *>(client);
 
   // Invoke wait.
   std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result = local_scheduler_wait(
-      conn, object_ids, numReturns, timeoutMillis, static_cast<bool>(isWaitLocal));
+      conn, object_ids, numReturns, timeoutMillis, static_cast<bool>(isWaitLocal),
+      *current_task_id.PID);
 
   // Convert result to java object.
   jboolean put_value = true;

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
@@ -41,13 +41,14 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeDestroy(JNIEnv *, jclass, jlo
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
- * Method:    nativeReconstructObjects
+ * Method:    nativeNotifyBlocked
  * Signature: (J[[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_runtime_raylet_RayletClientImpl_nativeReconstructObjects(JNIEnv *, jclass,
-                                                                      jlong, jobjectArray,
-                                                                      jboolean);
+Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyBlocked(JNIEnv *, jclass,
+                                                                 jlong, jobjectArray,
+                                                                 jboolean,
+                                                                 jbyteArray);
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
@@ -55,7 +56,7 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeReconstructObjects(JNIEnv *, 
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyUnblocked(
-    JNIEnv *, jclass, jlong);
+    JNIEnv *, jclass, jlong, jbyteArray);
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
@@ -65,7 +66,7 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotify
 JNIEXPORT jbooleanArray JNICALL
 Java_org_ray_runtime_raylet_RayletClientImpl_nativeWaitObject(JNIEnv *, jclass, jlong,
                                                               jobjectArray, jint, jint,
-                                                              jboolean);
+                                                              jboolean, jbyteArray);
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
@@ -41,14 +41,14 @@ Java_org_ray_runtime_raylet_RayletClientImpl_nativeDestroy(JNIEnv *, jclass, jlo
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
- * Method:    nativeNotifyBlocked
+ * Method:    nativeFetchOrReconstruct
  * Signature: (J[[BZ)V
  */
 JNIEXPORT void JNICALL
-Java_org_ray_runtime_raylet_RayletClientImpl_nativeNotifyBlocked(JNIEnv *, jclass,
-                                                                 jlong, jobjectArray,
-                                                                 jboolean,
-                                                                 jbyteArray);
+Java_org_ray_runtime_raylet_RayletClientImpl_nativeFetchOrReconstruct(JNIEnv *, jclass,
+                                                                      jlong, jobjectArray,
+                                                                      jboolean,
+                                                                      jbyteArray);
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl

--- a/src/ray/raylet/lib/python/common_extension.cc
+++ b/src/ray/raylet/lib/python/common_extension.cc
@@ -176,6 +176,16 @@ static PyObject *PyObjectID_hex(PyObject *self) {
   return result;
 }
 
+static PyObject *PyObjectID_is_nil(PyObject *self) {
+  ObjectID object_id;
+  PyObjectToUniqueID(self, &object_id);
+  if (object_id.is_nil()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 static PyObject *PyObjectID_richcompare(PyObjectID *self, PyObject *other, int op) {
   PyObject *result = NULL;
   if (Py_TYPE(self)->tp_richcompare != Py_TYPE(other)->tp_richcompare) {
@@ -245,6 +255,8 @@ static PyMethodDef PyObjectID_methods[] = {
      "Return the redis shard that this ObjectID is associated with"},
     {"hex", (PyCFunction)PyObjectID_hex, METH_NOARGS,
      "Return the object ID as a string in hex."},
+    {"is_nil", (PyCFunction)PyObjectID_is_nil, METH_NOARGS,
+     "Return whether the ObjectID is nil"},
     {"__reduce__", (PyCFunction)PyObjectID___reduce__, METH_NOARGS,
      "Say how to pickle this ObjectID. This raises an exception to prevent"
      "object IDs from being serialized."},

--- a/src/ray/raylet/lib/python/local_scheduler_extension.cc
+++ b/src/ray/raylet/lib/python/local_scheduler_extension.cc
@@ -165,9 +165,10 @@ static PyObject *PyLocalSchedulerClient_wait(PyObject *self, PyObject *args) {
   int num_returns;
   int64_t timeout_ms;
   PyObject *py_wait_local;
+  TaskID current_task_id;
 
-  if (!PyArg_ParseTuple(args, "OilO", &py_object_ids, &num_returns, &timeout_ms,
-                        &py_wait_local)) {
+  if (!PyArg_ParseTuple(args, "OilOO&", &py_object_ids, &num_returns, &timeout_ms,
+                        &py_wait_local, &PyObjectToUniqueID, &current_task_id)) {
     return NULL;
   }
 
@@ -195,7 +196,7 @@ static PyObject *PyLocalSchedulerClient_wait(PyObject *self, PyObject *args) {
   // Invoke wait.
   std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result = local_scheduler_wait(
       reinterpret_cast<PyLocalSchedulerClient *>(self)->local_scheduler_connection,
-      object_ids, num_returns, timeout_ms, static_cast<bool>(wait_local));
+      object_ids, num_returns, timeout_ms, wait_local, current_task_id);
 
   // Convert result to py object.
   PyObject *py_found = PyList_New(static_cast<Py_ssize_t>(result.first.size()));

--- a/src/ray/raylet/lib/python/local_scheduler_extension.cc
+++ b/src/ray/raylet/lib/python/local_scheduler_extension.cc
@@ -72,7 +72,8 @@ static PyObject *PyLocalSchedulerClient_get_task(PyObject *self) {
 }
 // clang-format on
 
-static PyObject *PyLocalSchedulerClient_notify_blocked(PyObject *self, PyObject *args) {
+static PyObject *PyLocalSchedulerClient_fetch_or_reconstruct(PyObject *self,
+                                                             PyObject *args) {
   PyObject *py_object_ids;
   PyObject *py_fetch_only;
   std::vector<ObjectID> object_ids;
@@ -91,7 +92,7 @@ static PyObject *PyLocalSchedulerClient_notify_blocked(PyObject *self, PyObject 
     }
     object_ids.push_back(object_id);
   }
-  local_scheduler_notify_blocked(
+  local_scheduler_fetch_or_reconstruct(
       reinterpret_cast<PyLocalSchedulerClient *>(self)->local_scheduler_connection,
       object_ids, fetch_only, current_task_id);
   Py_RETURN_NONE;
@@ -370,8 +371,8 @@ static PyMethodDef PyLocalSchedulerClient_methods[] = {
      "Submit a task to the local scheduler."},
     {"get_task", (PyCFunction)PyLocalSchedulerClient_get_task, METH_NOARGS,
      "Get a task from the local scheduler."},
-    {"notify_blocked", (PyCFunction)PyLocalSchedulerClient_notify_blocked, METH_VARARGS,
-     "Ask the local scheduler to reconstruct an object."},
+    {"fetch_or_reconstruct", (PyCFunction)PyLocalSchedulerClient_fetch_or_reconstruct,
+     METH_VARARGS, "Ask the local scheduler to reconstruct an object."},
     {"notify_unblocked", (PyCFunction)PyLocalSchedulerClient_notify_unblocked,
      METH_VARARGS, "Notify the local scheduler that we are unblocked."},
     {"compute_put_id", (PyCFunction)PyLocalSchedulerClient_compute_put_id, METH_VARARGS,

--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -301,15 +301,16 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn) {
                 &conn->write_mutex);
 }
 
-void local_scheduler_notify_blocked(LocalSchedulerConnection *conn,
-                                    const std::vector<ObjectID> &object_ids,
-                                    bool fetch_only, const TaskID &current_task_id) {
+void local_scheduler_fetch_or_reconstruct(LocalSchedulerConnection *conn,
+                                          const std::vector<ObjectID> &object_ids,
+                                          bool fetch_only,
+                                          const TaskID &current_task_id) {
   flatbuffers::FlatBufferBuilder fbb;
   auto object_ids_message = to_flatbuf(fbb, object_ids);
-  auto message = ray::protocol::CreateNotifyBlocked(fbb, object_ids_message, fetch_only,
-                                                    to_flatbuf(fbb, current_task_id));
+  auto message = ray::protocol::CreateFetchOrReconstruct(
+      fbb, object_ids_message, fetch_only, to_flatbuf(fbb, current_task_id));
   fbb.Finish(message);
-  write_message(conn->conn, static_cast<int64_t>(MessageType::NotifyBlocked),
+  write_message(conn->conn, static_cast<int64_t>(MessageType::FetchOrReconstruct),
                 fbb.GetSize(), fbb.GetBufferPointer(), &conn->write_mutex);
   /* TODO(swang): Propagate the error. */
 }

--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -326,11 +326,13 @@ void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn,
 
 std::pair<std::vector<ObjectID>, std::vector<ObjectID>> local_scheduler_wait(
     LocalSchedulerConnection *conn, const std::vector<ObjectID> &object_ids,
-    int num_returns, int64_t timeout_milliseconds, bool wait_local) {
+    int num_returns, int64_t timeout_milliseconds, bool wait_local,
+    const TaskID &current_task_id) {
   // Write request.
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateWaitRequest(
-      fbb, to_flatbuf(fbb, object_ids), num_returns, timeout_milliseconds, wait_local);
+      fbb, to_flatbuf(fbb, object_ids), num_returns, timeout_milliseconds, wait_local,
+      to_flatbuf(fbb, current_task_id));
   fbb.Finish(message);
   int64_t type;
   int64_t reply_size;

--- a/src/ray/raylet/local_scheduler_client.h
+++ b/src/ray/raylet/local_scheduler_client.h
@@ -96,6 +96,7 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn);
  * @param conn The connection information.
  * @param object_ids The IDs of the objects to reconstruct.
  * @param fetch_only Only fetch objects, do not reconstruct them.
+ * @param current_task_id The task that needs the objects.
  * @return Void.
  */
 void local_scheduler_notify_blocked(LocalSchedulerConnection *conn,
@@ -106,6 +107,7 @@ void local_scheduler_notify_blocked(LocalSchedulerConnection *conn,
  * Notify the local scheduler that this client (worker) is no longer blocked.
  *
  * @param conn The connection information.
+ * @param current_task_id The task that is no longer blocked.
  * @return Void.
  */
 void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn,
@@ -141,11 +143,13 @@ void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn,
 /// \param timeout_milliseconds Duration, in milliseconds, to wait before
 /// returning.
 /// \param wait_local Whether to wait for objects to appear on this node.
+/// \param current_task_id The task that called wait.
 /// \return A pair with the first element containing the object ids that were
 /// found, and the second element the objects that were not found.
 std::pair<std::vector<ObjectID>, std::vector<ObjectID>> local_scheduler_wait(
     LocalSchedulerConnection *conn, const std::vector<ObjectID> &object_ids,
-    int num_returns, int64_t timeout_milliseconds, bool wait_local);
+    int num_returns, int64_t timeout_milliseconds, bool wait_local,
+    const TaskID &current_task_id);
 
 /// Push an error to the relevant driver.
 ///

--- a/src/ray/raylet/local_scheduler_client.h
+++ b/src/ray/raylet/local_scheduler_client.h
@@ -98,9 +98,9 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn);
  * @param fetch_only Only fetch objects, do not reconstruct them.
  * @return Void.
  */
-void local_scheduler_reconstruct_objects(LocalSchedulerConnection *conn,
-                                         const std::vector<ObjectID> &object_ids,
-                                         bool fetch_only = false);
+void local_scheduler_notify_blocked(LocalSchedulerConnection *conn,
+                                    const std::vector<ObjectID> &object_ids,
+                                    bool fetch_only, const TaskID &current_task_id);
 
 /**
  * Notify the local scheduler that this client (worker) is no longer blocked.
@@ -108,7 +108,8 @@ void local_scheduler_reconstruct_objects(LocalSchedulerConnection *conn,
  * @param conn The connection information.
  * @return Void.
  */
-void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn);
+void local_scheduler_notify_unblocked(LocalSchedulerConnection *conn,
+                                      const TaskID &current_task_id);
 
 // /**
 //  * Get an actor's current task frontier.

--- a/src/ray/raylet/local_scheduler_client.h
+++ b/src/ray/raylet/local_scheduler_client.h
@@ -99,9 +99,9 @@ void local_scheduler_task_done(LocalSchedulerConnection *conn);
  * @param current_task_id The task that needs the objects.
  * @return Void.
  */
-void local_scheduler_notify_blocked(LocalSchedulerConnection *conn,
-                                    const std::vector<ObjectID> &object_ids,
-                                    bool fetch_only, const TaskID &current_task_id);
+void local_scheduler_fetch_or_reconstruct(LocalSchedulerConnection *conn,
+                                          const std::vector<ObjectID> &object_ids,
+                                          bool fetch_only, const TaskID &current_task_id);
 
 /**
  * Notify the local scheduler that this client (worker) is no longer blocked.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -541,8 +541,8 @@ void NodeManager::ProcessClientMessage(
   case protocol::MessageType::SubmitTask: {
     ProcessSubmitTaskMessage(message_data);
   } break;
-  case protocol::MessageType::NotifyBlocked: {
-    ProcessNotifyBlockedMessage(client, message_data);
+  case protocol::MessageType::FetchOrReconstruct: {
+    ProcessFetchOrReconstructMessage(client, message_data);
   } break;
   case protocol::MessageType::NotifyUnblocked: {
     auto message = flatbuffers::GetRoot<protocol::NotifyUnblocked>(message_data);
@@ -735,9 +735,9 @@ void NodeManager::ProcessSubmitTaskMessage(const uint8_t *message_data) {
   SubmitTask(task, Lineage());
 }
 
-void NodeManager::ProcessNotifyBlockedMessage(
+void NodeManager::ProcessFetchOrReconstructMessage(
     const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data) {
-  auto message = flatbuffers::GetRoot<protocol::NotifyBlocked>(message_data);
+  auto message = flatbuffers::GetRoot<protocol::FetchOrReconstruct>(message_data);
   std::vector<ObjectID> required_object_ids;
   for (size_t i = 0; i < message->object_ids()->size(); ++i) {
     ObjectID object_id = from_flatbuf(*message->object_ids()->Get(i));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -636,7 +636,10 @@ void NodeManager::ProcessDisconnectClientMessage(
   // particular, we are no longer waiting for their dependencies.
   if (worker) {
     while (!worker->GetBlockedTaskIds().empty()) {
-      HandleTaskUnblocked(client, *worker->GetBlockedTaskIds().begin());
+      // NOTE(swang): HandleTaskUnblocked will modify the worker, so it is
+      // not safe to pass in the iterator directly.
+      const TaskID task_id = *worker->GetBlockedTaskIds().begin();
+      HandleTaskUnblocked(client, task_id);
     }
   }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -206,9 +206,8 @@ class NodeManager {
   /// Handle a task that is unblocked. This could be a task assigned to a
   /// worker, an out-of-band task (e.g., a thread created by the application),
   /// or a driver task. This can be triggered when a client finishes a get call
-  /// or a wait call. It is ok to call this even if the task is not actually
-  /// blocked.
-  ///
+  /// or a wait call. The given task must be blocked, via a previous call to
+  /// HandleTaskBlocked.
   ///
   /// \param client The client that is executing the unblocked task.
   /// \param current_task_id The task that is unblocked.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -304,13 +304,13 @@ class NodeManager {
   /// \return Void.
   void ProcessSubmitTaskMessage(const uint8_t *message_data);
 
-  /// Process client message of NotifyBlocked
+  /// Process client message of FetchOrReconstruct
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessNotifyBlockedMessage(const std::shared_ptr<LocalClientConnection> &client,
-                                   const uint8_t *message_data);
+  void ProcessFetchOrReconstructMessage(
+      const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
 
   /// Process client message of WaitRequest
   ///

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -189,33 +189,32 @@ class NodeManager {
   /// Dispatch locally scheduled tasks. This attempts the transition from "scheduled" to
   /// "running" task state.
   void DispatchTasks();
-  /// Handle a worker becoming blocked in a `ray.get`.
-  ///
-  /// \param worker The worker that is blocked.
-  /// \return Void.
-  void HandleWorkerBlocked(std::shared_ptr<Worker> worker);
-  /// Handle a worker exiting a `ray.get`.
-  ///
-  /// \param worker The worker that is unblocked.
-  /// \return Void.
-  void HandleWorkerUnblocked(std::shared_ptr<Worker> worker);
 
-  /// Handle a client that is blocked. This could be a worker or a driver. This
-  /// can be triggered when a client starts a get call or a wait call.
+  /// Handle a task that is blocked. This could be a task assigned to a worker,
+  /// an out-of-band task (e.g., a thread created by the application), or a
+  /// driver task. This can be triggered when a client starts a get call or a
+  /// wait call.
   ///
-  /// \param client The client that is blocked.
+  /// \param client The client that is executing the blocked task.
   /// \param required_object_ids The IDs that the client is blocked waiting for.
+  /// \param current_task_id The task that is blocked.
   /// \return Void.
-  void HandleClientBlocked(const std::shared_ptr<LocalClientConnection> &client,
-                           const std::vector<ObjectID> &required_object_ids);
+  void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
+                         const std::vector<ObjectID> &required_object_ids,
+                         const TaskID &current_task_id);
 
-  /// Handle a client that is unblocked. This could be a worker or a driver.
-  /// This can be triggered when a client is finished with a get call or a wait
-  /// call. It is ok to call this even if the client is not actually blocked.
+  /// Handle a task that is unblocked. This could be a task assigned to a
+  /// worker, an out-of-band task (e.g., a thread created by the application),
+  /// or a driver task. This can be triggered when a client finishes a get call
+  /// or a wait call. It is ok to call this even if the task is not actually
+  /// blocked.
   ///
-  /// \param client The client that is unblocked.
+  ///
+  /// \param client The client that is executing the unblocked task.
+  /// \param current_task_id The task that is unblocked.
   /// \return Void.
-  void HandleClientUnblocked(const std::shared_ptr<LocalClientConnection> &client);
+  void HandleTaskUnblocked(const std::shared_ptr<LocalClientConnection> &client,
+                           const TaskID &current_task_id);
 
   /// Kill a worker.
   ///
@@ -305,13 +304,13 @@ class NodeManager {
   /// \return Void.
   void ProcessSubmitTaskMessage(const uint8_t *message_data);
 
-  /// Process client message of ReconstructObjects
+  /// Process client message of NotifyBlocked
   ///
   /// \param client The client that sent the message.
   /// \param message_data A pointer to the message data.
   /// \return Void.
-  void ProcessReconstructObjectsMessage(
-      const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data);
+  void ProcessNotifyBlockedMessage(const std::shared_ptr<LocalClientConnection> &client,
+                                   const uint8_t *message_data);
 
   /// Process client message of WaitRequest
   ///

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -14,12 +14,26 @@ namespace raylet {
 
 enum class TaskState {
   INIT,
+  // The task may be placed on a node.
   PLACEABLE,
+  // The task has been placed on a node and is waiting for some object
+  // dependencies to become local.
   WAITING,
+  // The task has been placed on a node, all dependencies are satisfied, and is
+  // waiting for resources to run.
   READY,
+  // The task is running on a worker. The task may also be blocked in a ray.get
+  // or ray.wait call, in which case it also has state BLOCKED.
   RUNNING,
+  // The task is running but blocked in a ray.get or ray.wait call. Tasks that
+  // were explicitly assigned by us may be both BLOCKED and RUNNING, while
+  // tasks that were created out-of-band (e.g., the application created
+  // multiple threads) are only BLOCKED.
   BLOCKED,
+  // The task is a driver task.
   DRIVER,
+  // The task has resources that cannot be satisfied by any node, as far as we
+  // know.
   INFEASIBLE
 };
 
@@ -86,10 +100,12 @@ class SchedulingQueue {
 
   /// Get the tasks in the blocked state.
   ///
-  /// \return A const reference to the queue of tasks that have been dispatched
-  /// to a worker but are blocked on a data dependency discovered to be missing
-  /// at runtime.
-  const std::list<Task> &GetBlockedTasks() const;
+  /// \return A const reference to the tasks that are are blocked on a data
+  /// dependency discovered to be missing at runtime. These include RUNNING
+  /// tasks that were explicitly assigned to a worker by us, as well as tasks
+  /// that were created out-of-band (e.g., the application created
+  // multiple threads) are only BLOCKED.
+  const std::unordered_set<TaskID> &GetBlockedTaskIds() const;
 
   /// Get the set of driver task IDs.
   ///
@@ -143,12 +159,19 @@ class SchedulingQueue {
   /// \param tasks The tasks to queue.
   void QueueRunningTasks(const std::vector<Task> &tasks);
 
-  /// Queue tasks in the blocked state. These are tasks that have been
+  /// Add a task ID in the blocked state. These are tasks that have been
   /// dispatched to a worker but are blocked on a data dependency that was
   /// discovered to be missing at runtime.
   ///
-  /// \param tasks The tasks to queue.
-  void QueueBlockedTasks(const std::vector<Task> &tasks);
+  /// \param task_id The task to mark as blocked.
+  void AddBlockedTaskId(const TaskID &task_id);
+
+  /// Remove a task ID in the blocked state. These are tasks that have been
+  /// dispatched to a worker but were blocked on a data dependency that was
+  /// discovered to be missing at runtime.
+  ///
+  /// \param task_id The task to mark as unblocked.
+  void RemoveBlockedTaskId(const TaskID &task_id);
 
   /// Add a driver task ID. This is an empty task used to represent a driver.
   ///
@@ -258,7 +281,7 @@ class SchedulingQueue {
   TaskQueue running_tasks_;
   /// Tasks that were dispatched to a worker but are blocked on a data
   /// dependency that was missing at runtime.
-  TaskQueue blocked_tasks_;
+  std::unordered_set<TaskID> blocked_task_ids_;
   /// Tasks that require resources that are not available on any of the nodes
   /// in the cluster.
   TaskQueue infeasible_tasks_;

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -38,6 +38,20 @@ void Worker::AssignTaskId(const TaskID &task_id) { assigned_task_id_ = task_id; 
 
 const TaskID &Worker::GetAssignedTaskId() const { return assigned_task_id_; }
 
+bool Worker::AddBlockedTaskId(const TaskID &task_id) {
+  auto inserted = blocked_task_ids_.insert(task_id);
+  return inserted.second;
+}
+
+bool Worker::RemoveBlockedTaskId(const TaskID &task_id) {
+  auto erased = blocked_task_ids_.erase(task_id);
+  return erased == 1;
+}
+
+const std::unordered_set<TaskID> &Worker::GetBlockedTaskIds() const {
+  return blocked_task_ids_;
+}
+
 void Worker::AssignDriverId(const DriverID &driver_id) {
   assigned_driver_id_ = driver_id;
 }

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -31,6 +31,9 @@ class Worker {
   Language GetLanguage() const;
   void AssignTaskId(const TaskID &task_id);
   const TaskID &GetAssignedTaskId() const;
+  bool AddBlockedTaskId(const TaskID &task_id);
+  bool RemoveBlockedTaskId(const TaskID &task_id);
+  const std::unordered_set<TaskID> &GetBlockedTaskIds() const;
   void AssignDriverId(const DriverID &driver_id);
   const DriverID &GetAssignedDriverId() const;
   void AssignActorId(const ActorID &actor_id);
@@ -72,6 +75,7 @@ class Worker {
   /// The specific resource IDs that this worker currently owns for the duration
   // of a task.
   ResourceIdSet task_resource_ids_;
+  std::unordered_set<TaskID> blocked_task_ids_;
 };
 
 }  // namespace raylet

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1118,7 +1118,7 @@ def test_illegal_api_calls(shutdown_only):
 def test_multithreading(shutdown_only):
     # This test requires at least 2 CPUs to finish since the worker does not
     # relase resources when joining the threads.
-    ray.init(num_cpus=10)
+    ray.init(num_cpus=2)
 
     @ray.remote
     def f():

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1168,7 +1168,7 @@ def test_multithreading(shutdown_only):
 
     # test multi-threading in the actor
     a = MultithreadedActor.remote()
-    ray.get(a.test_multi_threading.remote())
+    ray.get(a.spawn.remote())
     ray.get(a.join.remote())
 
 

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -507,7 +507,7 @@ def test_driver_put_errors(ray_start_driver_put_errors):
     # were evicted and whose originating tasks are still running, this
     # for-loop should hang on its first iteration and push an error to the
     # driver.
-    ray.worker.global_worker.local_scheduler_client.reconstruct_objects(
+    ray.worker.global_worker.local_scheduler_client.fetch_or_reconstruct(
         [args[0]], False)
 
     def error_check(errors):


### PR DESCRIPTION
## What do these changes do?

The backend expects that each `ray.get` or `ray.wait` call is made by a specific task, but this is not true when the application has multithreading. This PR modifies the Python and Java frontends to pass in the current task ID when calling `ray.get` or `ray.wait` and to generate a fake task ID if the call is not from the main thread. The backend is also modified to keep track of all blocked task IDs, including the tasks that are only generated to represent application threads. Resources are only reclaimed from a worker if the blocked task is the one that was explicitly assigned to the worker.

## Related issue number

None, but @ericl reported that some tune apps were crashing because of this.