### PR TITLE
Expose internal config parameters for starting Ray

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -187,6 +187,7 @@ public class RunManager {
         "0", // number of initial workers
         String.valueOf(maximumStartupConcurrency),
         ResourceUtil.getResourcesStringFromMap(rayConfig.resources),
+        "",  // The internal config list.
         buildPythonWorkerCommand(), // python worker command
         buildWorkerCommandRaylet() // java worker command
     );

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -204,8 +204,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
           plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
-          plasma_store_socket_name, raylet_socket_name,
-          temp_dir, internal_config):
+          plasma_store_socket_name, raylet_socket_name, temp_dir,
+          internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -197,14 +197,15 @@ def cli(logging_level, logging_format):
     "--internal-config",
     default=None,
     type=str,
-    help="Do NOT use this. This is for debugging and development purposes ONLY.")
+    help="Do NOT use this. This is for debugging/development purposes ONLY.")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
           num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
           plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
-          plasma_store_socket_name, raylet_socket_name, temp_dir, internal_config):
+          plasma_store_socket_name, raylet_socket_name,
+          temp_dir, internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -275,7 +276,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            internal_config=internal_config)
+            _internal_config=internal_config)
         logger.info(address_info)
         logger.info(
             "\nStarted Ray on this node. You can add additional nodes to "
@@ -355,7 +356,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            internal_config=internal_config)
+            _internal_config=internal_config)
         logger.info(address_info)
         logger.info("\nStarted Ray on this node. If you wish to terminate the "
                     "processes that have been started, run\n\n"

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -194,18 +194,17 @@ def cli(logging_level, logging_format):
     default=None,
     help="manually specify the root temporary dir of the Ray process")
 @click.option(
-    "-f",
-    "--config-file",
+    "--internal-config",
     default=None,
     type=str,
-    help="If specified, use config options from this file. ")
+    help="Do NOT use this. This is for debugging and development purposes ONLY.")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
           num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
           plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
-          plasma_store_socket_name, raylet_socket_name, temp_dir, config_file):
+          plasma_store_socket_name, raylet_socket_name, temp_dir, internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -276,7 +275,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            config_file=config_file)
+            internal_config=internal_config)
         logger.info(address_info)
         logger.info(
             "\nStarted Ray on this node. You can add additional nodes to "
@@ -356,7 +355,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            config_file=config_file)
+            internal_config=internal_config)
         logger.info(address_info)
         logger.info("\nStarted Ray on this node. If you wish to terminate the "
                     "processes that have been started, run\n\n"

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -193,13 +193,19 @@ def cli(logging_level, logging_format):
     "--temp-dir",
     default=None,
     help="manually specify the root temporary dir of the Ray process")
+@click.option(
+    "-f",
+    "--config-file",
+    default=None,
+    type=str,
+    help="If specified, use config options from this file. ")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
           num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
           plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
-          plasma_store_socket_name, raylet_socket_name, temp_dir):
+          plasma_store_socket_name, raylet_socket_name, temp_dir, config_file):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -269,7 +275,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             autoscaling_config=autoscaling_config,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
-            temp_dir=temp_dir)
+            temp_dir=temp_dir,
+            config_file=config_file)
         logger.info(address_info)
         logger.info(
             "\nStarted Ray on this node. You can add additional nodes to "
@@ -348,7 +355,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             huge_pages=huge_pages,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
-            temp_dir=temp_dir)
+            temp_dir=temp_dir,
+            config_file=config_file)
         logger.info(address_info)
         logger.info("\nStarted Ray on this node. If you wish to terminate the "
                     "processes that have been started, run\n\n"

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1269,7 +1269,7 @@ def start_ray_processes(address_info=None,
                         plasma_store_socket_name=None,
                         raylet_socket_name=None,
                         temp_dir=None,
-                        internal_config=None):
+                        _internal_config=None):
     """Helper method to start Ray processes.
 
     Args:
@@ -1334,7 +1334,7 @@ def start_ray_processes(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:
@@ -1347,7 +1347,7 @@ def start_ray_processes(address_info=None,
     logger.info("Process STDOUT and STDERR is being redirected to {}.".format(
         get_logs_dir_path()))
 
-    config = json.loads(internal_config) if internal_config else None
+    config = json.loads(_internal_config) if _internal_config else None
 
     if resources is None:
         resources = {}
@@ -1523,7 +1523,7 @@ def start_ray_node(node_ip_address,
                    plasma_store_socket_name=None,
                    raylet_socket_name=None,
                    temp_dir=None,
-                   internal_config=None):
+                   _internal_config=None):
     """Start the Ray processes for a single node.
 
     This assumes that the Ray processes on some master node have already been
@@ -1567,7 +1567,7 @@ def start_ray_node(node_ip_address,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:
@@ -1597,7 +1597,7 @@ def start_ray_node(node_ip_address,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        internal_config=internal_config)
+        _internal_config=_internal_config)
 
 
 def start_ray_head(address_info=None,
@@ -1625,7 +1625,7 @@ def start_ray_head(address_info=None,
                    plasma_store_socket_name=None,
                    raylet_socket_name=None,
                    temp_dir=None,
-                   internal_config=None):
+                   _internal_config=None):
     """Start Ray in local mode.
 
     Args:
@@ -1686,7 +1686,7 @@ def start_ray_head(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:
@@ -1721,4 +1721,4 @@ def start_ray_head(address_info=None,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        internal_config=internal_config)
+        _internal_config=_internal_config)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -888,6 +888,8 @@ def start_raylet(redis_address,
         cleanup (bool): True if using Ray in local mode. If cleanup is true,
             then this process will be killed by serices.cleanup() when the
             Python process that imported services exits.
+        config (dict|None): Optional Raylet configuration that will
+            override defaults in RayConfig.
         redis_password (str): The password of the redis server.
 
     Returns:
@@ -1215,6 +1217,8 @@ def start_raylet_monitor(redis_address,
             Python process that imported services exits. This is True by
             default.
         redis_password (str): The password of the redis server.
+        config (dict|None): Optional configuration that will
+            override defaults in RayConfig.
     """
     gcs_ip_address, gcs_port = redis_address.split(":")
     redis_password = redis_password or ""

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import threading
 import time
+import yaml
 from collections import OrderedDict
 import redis
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 import threading
 import time
-import yaml
 from collections import OrderedDict
 import redis
 
@@ -1253,7 +1252,7 @@ def start_ray_processes(address_info=None,
                         plasma_store_socket_name=None,
                         raylet_socket_name=None,
                         temp_dir=None,
-                        config_file=None):
+                        internal_config=None):
     """Helper method to start Ray processes.
 
     Args:
@@ -1318,6 +1317,8 @@ def start_ray_processes(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        internal_config (str): JSON configuration for overriding
+            RayConfig defaults. For testing purposes ONLY.
 
     Returns:
         A dictionary of the address information for the processes that were
@@ -1329,10 +1330,7 @@ def start_ray_processes(address_info=None,
     logger.info("Process STDOUT and STDERR is being redirected to {}.".format(
         get_logs_dir_path()))
 
-    config = None
-    if config_file:
-        with open(config_file) as f:
-            config = yaml.load(f)
+    config = json.loads(internal_config) if internal_config else None
 
     if resources is None:
         resources = {}
@@ -1508,7 +1506,7 @@ def start_ray_node(node_ip_address,
                    plasma_store_socket_name=None,
                    raylet_socket_name=None,
                    temp_dir=None,
-                   config_file=None):
+                   internal_config=None):
     """Start the Ray processes for a single node.
 
     This assumes that the Ray processes on some master node have already been
@@ -1552,6 +1550,8 @@ def start_ray_node(node_ip_address,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        internal_config (str): JSON configuration for overriding
+            RayConfig defaults. For testing purposes ONLY.
 
     Returns:
         A dictionary of the address information for the processes that were
@@ -1580,7 +1580,7 @@ def start_ray_node(node_ip_address,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        config_file=config_file)
+        internal_config=internal_config)
 
 
 def start_ray_head(address_info=None,
@@ -1608,7 +1608,7 @@ def start_ray_head(address_info=None,
                    plasma_store_socket_name=None,
                    raylet_socket_name=None,
                    temp_dir=None,
-                   config_file=None):
+                   internal_config=None):
     """Start Ray in local mode.
 
     Args:
@@ -1669,6 +1669,8 @@ def start_ray_head(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        internal_config (str): JSON configuration for overriding
+            RayConfig defaults. For testing purposes ONLY.
 
     Returns:
         A dictionary of the address information for the processes that were
@@ -1702,4 +1704,4 @@ def start_ray_head(address_info=None,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        config_file=config_file)
+        internal_config=internal_config)

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -108,15 +108,17 @@ class Cluster(object):
         assert not node.any_processes_alive(), (
             "There are zombie processes left over after killing.")
 
-    def wait_for_nodes(self, retries=20):
+    def wait_for_nodes(self, retries=30):
         """Waits for all nodes to be registered with global state.
+
+        By default, waits for 3 seconds.
 
         Args:
             retries (int): Number of times to retry checking client table.
         """
         for i in range(retries):
             if not ray.is_initialized() or not self._check_registered_nodes():
-                time.sleep(0.3)
+                time.sleep(0.1)
             else:
                 break
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1667,7 +1667,7 @@ def init(redis_address=None,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        internal_config=internal_config)
+        _internal_config=_internal_config)
     for hook in _post_init_hooks:
         hook()
     return ret

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1282,7 +1282,8 @@ def _init(address_info=None,
           driver_id=None,
           plasma_store_socket_name=None,
           raylet_socket_name=None,
-          temp_dir=None):
+          temp_dir=None,
+          config_file=None):
     """Helper method to connect to an existing Ray cluster or start a new one.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1416,7 +1417,8 @@ def _init(address_info=None,
             include_webui=include_webui,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
-            temp_dir=temp_dir)
+            temp_dir=temp_dir,
+            config_file=config_file)
     else:
         if redis_address is None:
             raise Exception("When connecting to an existing cluster, "
@@ -1519,6 +1521,7 @@ def init(redis_address=None,
          plasma_store_socket_name=None,
          raylet_socket_name=None,
          temp_dir=None,
+         config_file=None,
          use_raylet=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
@@ -1647,7 +1650,8 @@ def init(redis_address=None,
         driver_id=driver_id,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
-        temp_dir=temp_dir)
+        temp_dir=temp_dir,
+        config_file=config_file)
     for hook in _post_init_hooks:
         hook()
     return ret

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1292,7 +1292,7 @@ def _init(address_info=None,
           plasma_store_socket_name=None,
           raylet_socket_name=None,
           temp_dir=None,
-          config_file=None):
+          internal_config=None):
     """Helper method to connect to an existing Ray cluster or start a new one.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1354,6 +1354,8 @@ def _init(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        internal_config (str): JSON configuration for overriding
+            RayConfig defaults. For testing purposes ONLY.
 
     Returns:
         Address information about the started processes.
@@ -1427,7 +1429,7 @@ def _init(address_info=None,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            config_file=config_file)
+            internal_config=internal_config)
     else:
         if redis_address is None:
             raise Exception("When connecting to an existing cluster, "
@@ -1530,7 +1532,7 @@ def init(redis_address=None,
          plasma_store_socket_name=None,
          raylet_socket_name=None,
          temp_dir=None,
-         config_file=None,
+         internal_config=None,
          use_raylet=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
@@ -1602,6 +1604,8 @@ def init(redis_address=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        internal_config (str): JSON configuration for overriding
+            RayConfig defaults. For testing purposes ONLY.
 
     Returns:
         Address information about the started processes.
@@ -1660,7 +1664,7 @@ def init(redis_address=None,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        config_file=config_file)
+        internal_config=internal_config)
     for hook in _post_init_hooks:
         hook()
     return ret

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1292,7 +1292,7 @@ def _init(address_info=None,
           plasma_store_socket_name=None,
           raylet_socket_name=None,
           temp_dir=None,
-          internal_config=None):
+          _internal_config=None):
     """Helper method to connect to an existing Ray cluster or start a new one.
 
     This method handles two cases. Either a Ray cluster already exists and we
@@ -1354,7 +1354,7 @@ def _init(address_info=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:
@@ -1429,7 +1429,7 @@ def _init(address_info=None,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            internal_config=internal_config)
+            internal_config=_internal_config)
     else:
         if redis_address is None:
             raise Exception("When connecting to an existing cluster, "
@@ -1470,6 +1470,9 @@ def _init(address_info=None,
         if raylet_socket_name is not None:
             raise Exception("When connecting to an existing cluster, "
                             "raylet_socket_name must not be provided.")
+        if _internal_config is not None:
+            raise Exception("When connecting to an existing cluster, "
+                            "_internal_config must not be provided.")
 
         # Get the node IP address if one is not provided.
         if node_ip_address is None:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1429,7 +1429,7 @@ def _init(address_info=None,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
-            internal_config=_internal_config)
+            _internal_config=_internal_config)
     else:
         if redis_address is None:
             raise Exception("When connecting to an existing cluster, "
@@ -1535,7 +1535,7 @@ def init(redis_address=None,
          plasma_store_socket_name=None,
          raylet_socket_name=None,
          temp_dir=None,
-         internal_config=None,
+         _internal_config=None,
          use_raylet=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
@@ -1607,7 +1607,7 @@ def init(redis_address=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:
@@ -1667,7 +1667,7 @@ def init(redis_address=None,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
-        internal_config=internal_config)
+        _internal_config=_internal_config)
     for hook in _post_init_hooks:
         hook()
     return ret

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1607,7 +1607,7 @@ def init(redis_address=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
-        internal_config (str): JSON configuration for overriding
+        _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
     Returns:

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -1,7 +1,9 @@
 #ifndef RAY_CONFIG_H
 #define RAY_CONFIG_H
 
-#include <stdint.h>
+#include <unordered_map>
+
+#include "ray/util/logging.h"
 
 class RayConfig {
  public:
@@ -105,14 +107,11 @@ class RayConfig {
   void initialize(const std::unordered_map<std::string, int> &config_map) {
     RAY_CHECK(!initialized_);
     for (auto const &pair : config_map) {
-      switch (pair.first):
-      case "handler_warning_timeout_ms": {
+      if (pair.first == "handler_warning_timeout_ms") {
         handler_warning_timeout_ms_ = pair.second;
-      } break;
-      case "num_heartbeats_timeout": {
+      } else if (pair.first == "num_heartbeats_timeout") {
         num_heartbeats_timeout_ = pair.second;
-      } break;
-      default:
+      } else {
         RAY_LOG(FATAL) << "Invalid config key: " << pair.first;
       }
     }

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -102,6 +102,23 @@ class RayConfig {
 
   int num_workers_per_process() const { return num_workers_per_process_; }
 
+  void initialize(const std::unordered_map<std::string, int> &config_map) {
+    RAY_CHECK(!initialized_);
+    for (auto const &pair : config_map) {
+      switch (pair.first):
+      case "handler_warning_timeout_ms": {
+        handler_warning_timeout_ms_ = pair.second;
+      } break;
+      case "num_heartbeats_timeout": {
+        num_heartbeats_timeout_ = pair.second;
+      } break;
+      default:
+        RAY_LOG(FATAL) << "Invalid config key: " << pair.first;
+      }
+    }
+    initialized_ = true;
+  }
+
  private:
   RayConfig()
       : ray_protocol_version_(0x0000000000000000),
@@ -138,7 +155,8 @@ class RayConfig {
         object_manager_pull_timeout_ms_(100),
         object_manager_push_timeout_ms_(10000),
         object_manager_default_chunk_size_(1000000),
-        num_workers_per_process_(1) {}
+        num_workers_per_process_(1),
+        initialized_(false) {}
 
   ~RayConfig() {}
 
@@ -263,6 +281,10 @@ class RayConfig {
 
   /// Number of workers per process
   int num_workers_per_process_;
+
+  /// Whether the initialization of the instance has been called before.
+  /// The RayConfig instance can only (and must) be initialized once.
+  bool initialized_;
 };
 
 #endif  // RAY_CONFIG_H

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -107,12 +107,78 @@ class RayConfig {
   void initialize(const std::unordered_map<std::string, int> &config_map) {
     RAY_CHECK(!initialized_);
     for (auto const &pair : config_map) {
-      if (pair.first == "handler_warning_timeout_ms") {
+      // We use a big chain of if else statements because C++ doesn't allow
+      // switch statements on strings.
+      if (pair.first == "ray_protocol_version") {
+        ray_protocol_version_ = pair.second;
+      } else if (pair.first == "handler_warning_timeout_ms") {
         handler_warning_timeout_ms_ = pair.second;
+      } else if (pair.first == "heartbeat_timeout_milliseconds") {
+        heartbeat_timeout_milliseconds_ = pair.second;
       } else if (pair.first == "num_heartbeats_timeout") {
         num_heartbeats_timeout_ = pair.second;
+      } else if (pair.first == "num_heartbeats_warning") {
+        num_heartbeats_warning_ = pair.second;
+      } else if (pair.first == "initial_reconstruction_timeout_milliseconds") {
+        initial_reconstruction_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "get_timeout_milliseconds") {
+        get_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "worker_get_request_size") {
+        worker_get_request_size_ = pair.second;
+      } else if (pair.first == "worker_fetch_request_size") {
+        worker_fetch_request_size_ = pair.second;
+      } else if (pair.first == "max_lineage_size") {
+        max_lineage_size_ = pair.second;
+      } else if (pair.first == "actor_max_dummy_objects") {
+        actor_max_dummy_objects_ = pair.second;
+      } else if (pair.first == "num_connect_attempts") {
+        num_connect_attempts_ = pair.second;
+      } else if (pair.first == "connect_timeout_milliseconds") {
+        connect_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "local_scheduler_fetch_timeout_milliseconds") {
+        local_scheduler_fetch_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "local_scheduler_reconstruction_timeout_milliseconds") {
+        local_scheduler_reconstruction_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "max_num_to_reconstruct") {
+        max_num_to_reconstruct_ = pair.second;
+      } else if (pair.first == "local_scheduler_fetch_request_size") {
+        local_scheduler_fetch_request_size_ = pair.second;
+      } else if (pair.first == "kill_worker_timeout_milliseconds") {
+        kill_worker_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "manager_timeout_milliseconds") {
+        manager_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "buf_size") {
+        buf_size_ = pair.second;
+      } else if (pair.first == "max_time_for_handler_milliseconds") {
+        max_time_for_handler_milliseconds_ = pair.second;
+      } else if (pair.first == "size_limit") {
+        size_limit_ = pair.second;
+      } else if (pair.first == "num_elements_limit") {
+        num_elements_limit_ = pair.second;
+      } else if (pair.first == "max_time_for_loop") {
+        max_time_for_loop_ = pair.second;
+      } else if (pair.first == "redis_db_connect_retries") {
+        redis_db_connect_retries_ = pair.second;
+      } else if (pair.first == "redis_db_connect_wait_milliseconds") {
+        redis_db_connect_wait_milliseconds_ = pair.second;
+      } else if (pair.first == "plasma_default_release_delay") {
+        plasma_default_release_delay_ = pair.second;
+      } else if (pair.first == "L3_cache_size_bytes") {
+        L3_cache_size_bytes_ = pair.second;
+      } else if (pair.first == "max_tasks_to_spillback") {
+        max_tasks_to_spillback_ = pair.second;
+      } else if (pair.first == "actor_creation_num_spillbacks_warning") {
+        actor_creation_num_spillbacks_warning_ = pair.second;
+      } else if (pair.first == "node_manager_forward_task_retry_timeout_milliseconds") {
+        node_manager_forward_task_retry_timeout_milliseconds_ = pair.second;
+      } else if (pair.first == "object_manager_pull_timeout_ms") {
+        object_manager_pull_timeout_ms_ = pair.second;
+      } else if (pair.first == "object_manager_push_timeout_ms") {
+        object_manager_push_timeout_ms_ = pair.second;
+      } else if (pair.first == "object_manager_default_chunk_size") {
+        object_manager_default_chunk_size_ = pair.second;
       } else {
-        RAY_LOG(FATAL) << "Invalid config key: " << pair.first;
+        RAY_LOG(FATAL) << "Received unexpected config parameter " << pair.first;
       }
     }
     initialized_ = true;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
                                          ray::RayLogLevel::INFO,
                                          /*log_dir=*/"");
   ray::RayLog::InstallFailureSignalHandler();
-  RAY_CHECK(argc == 13 || argc == 14);
+  RAY_CHECK(argc == 14 || argc == 15);
 
   const std::string raylet_socket_name = std::string(argv[1]);
   const std::string store_socket_name = std::string(argv[2]);
@@ -32,13 +32,27 @@ int main(int argc, char *argv[]) {
   int num_initial_workers = std::stoi(argv[8]);
   int maximum_startup_concurrency = std::stoi(argv[9]);
   const std::string static_resource_list = std::string(argv[10]);
-  const std::string python_worker_command = std::string(argv[11]);
-  const std::string java_worker_command = std::string(argv[12]);
-  const std::string redis_password = (argc == 14 ? std::string(argv[13]) : "");
+  const std::string config_list = std::string(argv[11]);
+  const std::string python_worker_command = std::string(argv[12]);
+  const std::string java_worker_command = std::string(argv[13]);
+  const std::string redis_password = (argc == 15 ? std::string(argv[14]) : "");
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
   std::unordered_map<std::string, double> static_resource_conf;
+  std::unordered_map<std::string, int> raylet_config;
+
+  // Parse the configuration list.
+  std::istringstream config_string(config_list);
+  std::string config_name;
+  std::string config_value;
+
+  while (std::getline(config_string, config_name, ',')) {
+    RAY_CHECK(std::getline(config_string, config_value, ','));
+    // TODO(rkn): The line below could throw an exception. What should we do about this?
+    raylet_config[config_name] = std::stoi(config_value);
+  }
+
   // Parse the resource list.
   std::istringstream resource_string(static_resource_list);
   std::string resource_name;
@@ -49,6 +63,7 @@ int main(int argc, char *argv[]) {
     // TODO(rkn): The line below could throw an exception. What should we do about this?
     static_resource_conf[resource_name] = std::stod(resource_quantity);
   }
+
   node_manager_config.resource_config =
       ray::raylet::ResourceSet(std::move(static_resource_conf));
   RAY_LOG(DEBUG) << "Starting raylet with static resource configuration: "

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -53,6 +53,8 @@ int main(int argc, char *argv[]) {
     raylet_config[config_name] = std::stoi(config_value);
   }
 
+  RayConfig::instance().initialize(raylet_config);
+
   // Parse the resource list.
   std::istringstream resource_string(static_resource_list);
   std::string resource_name;

--- a/src/ray/raylet/monitor_main.cc
+++ b/src/ray/raylet/monitor_main.cc
@@ -8,11 +8,12 @@ int main(int argc, char *argv[]) {
                                          ray::RayLog::ShutDownRayLog, argv[0],
                                          ray::RayLogLevel::INFO, /*log_dir=*/"");
   ray::RayLog::InstallFailureSignalHandler();
-  RAY_CHECK(argc == 3 || argc == 4);
+  RAY_CHECK(argc == 4 || argc == 5);
 
   const std::string redis_address = std::string(argv[1]);
   int redis_port = std::stoi(argv[2]);
-  const std::string redis_password = (argc == 4 ? std::string(argv[3]) : "");
+  const std::string config_list = std::string(argv[3]);
+  const std::string redis_password = (argc == 5 ? std::string(argv[4]) : "");
 
   // Initialize the monitor.
   boost::asio::io_service io_service;

--- a/src/ray/raylet/monitor_main.cc
+++ b/src/ray/raylet/monitor_main.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "ray/ray_config.h"
 #include "ray/raylet/monitor.h"
 #include "ray/util/util.h"
 
@@ -14,6 +15,21 @@ int main(int argc, char *argv[]) {
   int redis_port = std::stoi(argv[2]);
   const std::string config_list = std::string(argv[3]);
   const std::string redis_password = (argc == 5 ? std::string(argv[4]) : "");
+
+  std::unordered_map<std::string, int> raylet_config;
+
+  // Parse the configuration list.
+  std::istringstream config_string(config_list);
+  std::string config_name;
+  std::string config_value;
+
+  while (std::getline(config_string, config_name, ',')) {
+    RAY_CHECK(std::getline(config_string, config_value, ','));
+    // TODO(rkn): The line below could throw an exception. What should we do about this?
+    raylet_config[config_name] = std::stoi(config_value);
+  }
+
+  RayConfig::instance().initialize(raylet_config);
 
   // Initialize the monitor.
   boost::asio::io_service io_service;

--- a/test/multi_node_test_2.py
+++ b/test/multi_node_test_2.py
@@ -21,7 +21,7 @@ def start_connected_cluster():
         connect=True,
         head_node_args={
             "resources": dict(CPU=1),
-            "internal_config": json.dumps({
+            "_internal_config": json.dumps({
                 "num_heartbeats_timeout": 10
             })
         })
@@ -49,7 +49,7 @@ def test_internal_config():
         connect=True,
         head_node_args={
             "resources": dict(CPU=1),
-            "internal_config": json.dumps({
+            "_internal_config": json.dumps({
                 "num_heartbeats_timeout": 20
             })
         })

--- a/test/multi_node_test_2.py
+++ b/test/multi_node_test_2.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import logging
 import pytest
-import json
 
 import ray
 import ray.services as services
@@ -31,6 +31,24 @@ def start_connected_cluster():
     g.shutdown()
 
 
+@pytest.fixture
+def start_connected_longer_cluster():
+    """Creates a cluster with a longer timeout."""
+    g = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "resources": dict(CPU=1),
+            "_internal_config": json.dumps({
+                "num_heartbeats_timeout": 20
+            })
+        })
+    yield g
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    g.shutdown()
+
+
 def test_cluster():
     """Basic test for adding and removing nodes in cluster."""
     g = Cluster(initialize_head=False)
@@ -43,16 +61,15 @@ def test_cluster():
     assert not any(node.any_processes_alive() for node in g.list_all_nodes())
 
 
-def test_internal_config():
-    cluster = Cluster(
-        initialize_head=True,
-        connect=True,
-        head_node_args={
-            "resources": dict(CPU=1),
-            "_internal_config": json.dumps({
-                "num_heartbeats_timeout": 20
-            })
-        })
+def test_internal_config(start_connected_longer_cluster):
+    """Checks that the internal configuration setting works.
+
+    We set the cluster to timeout nodes after 2 seconds of no timeouts. We
+    then remove a node, wait for 1 second to check that the cluster is out
+    of sync, then wait another 2 seconds (giving 1 second of leeway) to check
+    that the client has timed out.
+    """
+    cluster = start_connected_longer_cluster
     worker = cluster.add_node()
     cluster.wait_for_nodes()
 
@@ -62,9 +79,6 @@ def test_internal_config():
 
     cluster.wait_for_nodes(retries=20)
     assert ray.global_state.cluster_resources()["CPU"] == 1
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-    cluster.shutdown()
 
 
 def test_wait_for_nodes(start_connected_cluster):

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import numpy as np
 import os
 import pytest
@@ -216,7 +217,10 @@ def ray_start_reconstruction(request):
         start_ray_local=True,
         num_local_schedulers=num_local_schedulers,
         num_cpus=[1] * num_local_schedulers,
-        redirect_output=True)
+        redirect_output=True,
+        _internal_config=json.dumps({
+            "initial_reconstruction_timeout_milliseconds": 200
+        }))
 
     yield (redis_ip_address, redis_port, plasma_store_memory,
            num_local_schedulers)
@@ -249,7 +253,6 @@ def ray_start_reconstruction(request):
     ray.shutdown()
 
 
-@pytest.mark.skip("Add this test back once reconstruction is faster.")
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_NEW_GCS") == "on",
     reason="Failing with new GCS API on Linux.")
@@ -291,7 +294,6 @@ def test_simple(ray_start_reconstruction):
         del values
 
 
-@pytest.mark.skip("Add this test back once reconstruction is faster.")
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_NEW_GCS") == "on",
     reason="Failing with new GCS API on Linux.")
@@ -348,7 +350,6 @@ def test_recursive(ray_start_reconstruction):
         del values
 
 
-@pytest.mark.skip("Add this test back once reconstruction is faster.")
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_NEW_GCS") == "on",
     reason="Failing with new GCS API on Linux.")


### PR DESCRIPTION
## What do these changes do?

This PR exposes the CL option for using a config file. This is important for certain tests (i.e., FT tests that removing nodes) to run quickly.

Note that this is bad practice and should be replaced with GFLAGS or some equivalent as soon as possible.

#3239 depends on this.

TODO:
 - [x] Add documentation to method arguments before merging.
 - [x] Add test to verify this works?

## Related issue number

