### PR TITLE
Better errors on process deaths

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -25,7 +25,7 @@ if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q cython==0.27.3 cmake tensorflow gym opencv-python pyyaml pandas==0.22 requests \
-    feather-format lxml openpyxl xlrd py-spy
+    feather-format lxml openpyxl xlrd py-spy faulthandler
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y cmake pkg-config python-dev python-numpy build-essential autoconf curl libtool unzip
@@ -51,7 +51,7 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q cython==0.27.3 cmake tensorflow gym opencv-python pyyaml pandas==0.22 requests \
-    feather-format lxml openpyxl xlrd py-spy
+    feather-format lxml openpyxl xlrd py-spy faulthandler
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew

--- a/python/setup.py
+++ b/python/setup.py
@@ -151,6 +151,7 @@ setup(
         "pytest",
         "pyyaml",
         "redis",
+        "faulthandler;python_version<'3'",
         # The six module is required by pyarrow.
         "six >= 1.0.0",
         "flatbuffers"

--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -47,7 +47,8 @@ void ObjectStoreNotificationManager::ProcessStoreLength(
 void ObjectStoreNotificationManager::ProcessStoreNotification(
     const boost::system::error_code &error) {
   if (error.value() != boost::system::errc::success) {
-    RAY_LOG(FATAL) << boost_to_ray_status(error).ToString();
+    RAY_LOG(FATAL) << "Problem communicating with the object store from raylet, check logs or "
+        << "dmesg for previous errors: " << boost_to_ray_status(error).ToString();
   }
 
   const auto &object_info =

--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -47,7 +47,8 @@ void ObjectStoreNotificationManager::ProcessStoreLength(
 void ObjectStoreNotificationManager::ProcessStoreNotification(
     const boost::system::error_code &error) {
   if (error.value() != boost::system::errc::success) {
-    RAY_LOG(FATAL) << "Problem communicating with the object store from raylet, check logs or "
+    RAY_LOG(FATAL)
+        << "Problem communicating with the object store from raylet, check logs or "
         << "dmesg for previous errors: " << boost_to_ray_status(error).ToString();
   }
 

--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -259,8 +259,8 @@ ray::raylet::TaskSpecification *local_scheduler_get_task_raylet(
     exit(1);
   }
   if (type != static_cast<int64_t>(MessageType::ExecuteTask)) {
-    RAY_LOG(FATAL) <<
-        "Problem communicating with raylet from worker: check logs or dmesg for previous errors.";
+    RAY_LOG(FATAL) << "Problem communicating with raylet from worker: check logs or "
+                      "dmesg for previous errors.";
   }
 
   // Parse the flatbuffer object.
@@ -341,9 +341,10 @@ std::pair<std::vector<ObjectID>, std::vector<ObjectID>> local_scheduler_wait(
     // Read result.
     read_message(conn->conn, &type, &reply_size, &reply);
   }
-  if (static_cast<ray::protocol::MessageType>(type) != ray::protocol::MessageType::WaitReply) {
-    RAY_LOG(FATAL) <<
-        "Problem communicating with raylet from worker: check logs or dmesg for previous errors.";
+  if (static_cast<ray::protocol::MessageType>(type) !=
+      ray::protocol::MessageType::WaitReply) {
+    RAY_LOG(FATAL) << "Problem communicating with raylet from worker: check logs or "
+                      "dmesg for previous errors.";
   }
   auto reply_message = flatbuffers::GetRoot<ray::protocol::WaitReply>(reply);
   // Convert result.

--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -258,7 +258,10 @@ ray::raylet::TaskSpecification *local_scheduler_get_task_raylet(
     RAY_LOG(DEBUG) << "Exiting because local scheduler closed connection.";
     exit(1);
   }
-  RAY_CHECK(type == static_cast<int64_t>(MessageType::ExecuteTask));
+  if (type != static_cast<int64_t>(MessageType::ExecuteTask)) {
+    RAY_LOG(FATAL) <<
+        "Problem communicating with raylet from worker: check logs or dmesg for previous errors.";
+  }
 
   // Parse the flatbuffer object.
   auto reply_message = flatbuffers::GetRoot<ray::protocol::GetTaskReply>(reply);
@@ -338,8 +341,10 @@ std::pair<std::vector<ObjectID>, std::vector<ObjectID>> local_scheduler_wait(
     // Read result.
     read_message(conn->conn, &type, &reply_size, &reply);
   }
-  RAY_CHECK(static_cast<ray::protocol::MessageType>(type) ==
-            ray::protocol::MessageType::WaitReply);
+  if (static_cast<ray::protocol::MessageType>(type) != ray::protocol::MessageType::WaitReply) {
+    RAY_LOG(FATAL) <<
+        "Problem communicating with raylet from worker: check logs or dmesg for previous errors.";
+  }
   auto reply_message = flatbuffers::GetRoot<ray::protocol::WaitReply>(reply);
   // Convert result.
   std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add more informative C++ errors on process deaths, and also enable faulthandler in Python (requires package for Python 2.7).

Before:
```
F1106 13:22:42.457109 19724 object_store_notification_manager.cc:50] IOError: No such file or directory
*** Check failure stack trace: ***
    @           0x57b79c  google::LogMessage::Fail()
    @           0x57b6e0  google::LogMessage::SendToLog()
    @           0x57b022  google::LogMessage::Flush()
    @           0x57ae1d  google::LogMessage::~LogMessage()
    @           0x4d33b0  ray::RayLog::~RayLog()
    @           0x534c62  ray::ObjectStoreNotificationManager::ProcessStoreNotification()
    @           0x5353ae  boost::asio::detail::reactive_socket_recv_op<>::do_complete()
    @           0x489708  boost::asio::detail::task_io_service::run()
    @           0x47f4a0  main
    @     0x7f3130f1e830  __libc_start_main
    @           0x483799  _start
    @              (nil)  (unknown)
WARNING: Logging before InitGoogleLogging() is written to STDERR
F1106 13:22:42.467880 19679 local_scheduler_client.cc:342]  Check failed: static_cast<ray::protocol::MessageType>(type) == ray::protocol::MessageType::WaitReply 
*** Check failure stack trace: ***
zsh: abort (core dumped)  ./train.py --run=PG --env=CartPole-v0 --config='{"num_workers": 2}'

```

After:
```
F1106 13:26:12.847466 21487 object_store_notification_manager.cc:50] Problem communicating with the object store from raylet, check logs or dmesg for previous errors: IOError: No such file or directory
*** Check failure stack trace: ***
    @           0x57b80c  google::LogMessage::Fail()
    @           0x57b750  google::LogMessage::SendToLog()
    @           0x57b092  google::LogMessage::Flush()
    @           0x57ae8d  google::LogMessage::~LogMessage()
    @           0x4d33b0  ray::RayLog::~RayLog()
    @           0x534c82  ray::ObjectStoreNotificationManager::ProcessStoreNotification()
    @           0x53541e  boost::asio::detail::reactive_socket_recv_op<>::do_complete()
    @           0x489708  boost::asio::detail::task_io_service::run()
    @           0x47f4a0  main
    @     0x7f240f4ce830  __libc_start_main
    @           0x483799  _start
    @              (nil)  (unknown)
WARNING: Logging before InitGoogleLogging() is written to STDERR
F1106 13:26:12.853338 21409 local_scheduler_client.cc:345] Problem communicating with raylet from worker: check logs or dmesg for previous errors.
*** Check failure stack trace: ***
Fatal Python error: Aborted

Stack (most recent call first):
  File "/home/eric/Desktop/ray-private/python/ray/worker.py", line 2403 in wait
  File "/home/eric/Desktop/ray-private/python/ray/tune/ray_trial_executor.py", line 188 in get_next_available_trial
  File "/home/eric/Desktop/ray-private/python/ray/tune/trial_runner.py", line 241 in _process_events
  File "/home/eric/Desktop/ray-private/python/ray/tune/trial_runner.py", line 116 in step
  File "/home/eric/Desktop/ray-private/python/ray/tune/tune.py", line 108 in run_experiments
  File "./train.py", line 132 in run
  File "./train.py", line 138 in <module>
zsh: abort      ./train.py --run=PG --env=CartPole-v0 --config='{"num_workers": 2}'

```
