### PR TITLE
Enable timeline visualizations of object transfers.

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -233,12 +233,12 @@ void ClientConnection<T>::ProcessMessage(const boost::system::error_code &error)
     read_type_ = static_cast<int64_t>(protocol::MessageType::DisconnectClient);
   }
 
-  uint64_t start_ms = current_time_ms();
+  int64_t start_ms = current_time_ms();
   message_handler_(shared_ClientConnection_from_this(), read_type_, read_message_.data());
-  uint64_t interval = current_time_ms() - start_ms;
+  int64_t interval = current_time_ms() - start_ms;
   if (interval > RayConfig::instance().handler_warning_timeout_ms()) {
     RAY_LOG(WARNING) << "[" << debug_label_ << "]ProcessMessage with type " << read_type_
-                     << " took " << interval << " ms ";
+                     << " took " << interval << " ms.";
   }
 }
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -315,10 +315,8 @@ void ObjectManager::HandlePushTaskTimeout(const ObjectID &object_id,
 }
 
 void ObjectManager::HandleSendFinished(const ObjectID &object_id,
-                                       const ClientID &client_id,
-                                       uint64_t chunk_index,
-                                       double start_time,
-                                       double end_time,
+                                       const ClientID &client_id, uint64_t chunk_index,
+                                       double start_time, double end_time,
                                        ray::Status status) {
   if (!status.ok()) {
     // TODO(rkn): What do we want to do if the send failed?
@@ -330,17 +328,15 @@ void ObjectManager::HandleSendFinished(const ObjectID &object_id,
   profile_event.end_time = end_time;
   // Encode the object ID, client ID, chunk index, and status as a json list,
   // which will be parsed by the reader of the profile table.
-  profile_event.extra_data = "[\"" + object_id.hex() + "\",\"" + client_id.hex() +
-                             "\"," + std::to_string(chunk_index) + ",\"" +
-                             status.ToString() + "\"]";
+  profile_event.extra_data = "[\"" + object_id.hex() + "\",\"" + client_id.hex() + "\"," +
+                             std::to_string(chunk_index) + ",\"" + status.ToString() +
+                             "\"]";
   profile_events_.push_back(profile_event);
 }
 
 void ObjectManager::HandleReceiveFinished(const ObjectID &object_id,
-                                          const ClientID &client_id,
-                                          uint64_t chunk_index,
-                                          double start_time,
-                                          double end_time,
+                                          const ClientID &client_id, uint64_t chunk_index,
+                                          double start_time, double end_time,
                                           ray::Status status) {
   if (!status.ok()) {
     // TODO(rkn): What do we want to do if the send failed?
@@ -352,9 +348,9 @@ void ObjectManager::HandleReceiveFinished(const ObjectID &object_id,
   profile_event.end_time = end_time;
   // Encode the object ID, client ID, chunk index, and status as a json list,
   // which will be parsed by the reader of the profile table.
-  profile_event.extra_data = "[\"" + object_id.hex() + "\",\"" + client_id.hex() +
-                             "\"," + std::to_string(chunk_index) + ",\"" +
-                             status.ToString() + "\"]";
+  profile_event.extra_data = "[\"" + object_id.hex() + "\",\"" + client_id.hex() + "\"," +
+                             std::to_string(chunk_index) + ",\"" + status.ToString() +
+                             "\"]";
   profile_events_.push_back(profile_event);
 }
 
@@ -407,17 +403,16 @@ void ObjectManager::Push(const ObjectID &object_id, const ClientID &client_id) {
         // will have already been evicted. It's also possible that the
         // object could be in the process of being transferred to this
         // object manager from another object manager.
-        ray::Status status = ExecuteSendObject(client_id, object_id, data_size,
-                                               metadata_size, chunk_index,
-                                               connection_info);
+        ray::Status status = ExecuteSendObject(
+            client_id, object_id, data_size, metadata_size, chunk_index, connection_info);
 
         // Notify the main thread that we have finished sending the chunk.
-        main_service_->post([this, object_id, client_id, chunk_index, start_time,
-                             status]() {
-          double end_time = current_sys_time_seconds();
-          HandleSendFinished(object_id, client_id, chunk_index, start_time, end_time,
-                             status);
-        });
+        main_service_->post(
+            [this, object_id, client_id, chunk_index, start_time, status]() {
+              double end_time = current_sys_time_seconds();
+              HandleSendFinished(object_id, client_id, chunk_index, start_time, end_time,
+                                 status);
+            });
       });
     }
   } else {
@@ -801,7 +796,6 @@ void ObjectManager::ReceivePushRequest(std::shared_ptr<TcpClientConnection> &con
     });
 
   });
-
 }
 
 ray::Status ObjectManager::ExecuteReceiveObject(

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -12,7 +12,7 @@ class RayConfig {
 
   int64_t ray_protocol_version() const { return ray_protocol_version_; }
 
-  uint64_t handler_warning_timeout_ms() const { return handler_warning_timeout_ms_; }
+  int64_t handler_warning_timeout_ms() const { return handler_warning_timeout_ms_; }
 
   int64_t heartbeat_timeout_milliseconds() const {
     return heartbeat_timeout_milliseconds_;
@@ -147,7 +147,7 @@ class RayConfig {
 
   /// The duration that a single handler on the event loop can take before a
   /// warning is logged that the handler is taking too long.
-  uint64_t handler_warning_timeout_ms_;
+  int64_t handler_warning_timeout_ms_;
 
   /// The duration between heartbeats. These are sent by the plasma manager and
   /// local scheduler.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -104,8 +104,15 @@ class NodeManager {
   /// \param client_data Data associated with the removed client.
   /// \return Void.
   void ClientRemoved(const ClientTableDataT &client_data);
+
   /// Send heartbeats to the GCS.
   void Heartbeat();
+
+  /// Get profiling information from the object manager and push it to the GCS.
+  ///
+  /// \return Void.
+  void GetObjectManagerProfileInfo();
+
   /// Handler for a heartbeat notification from the GCS.
   ///
   /// \param client The GCS client.
@@ -339,6 +346,9 @@ class NodeManager {
   boost::asio::steady_timer heartbeat_timer_;
   /// The period used for the heartbeat timer.
   std::chrono::milliseconds heartbeat_period_;
+  /// The timer used to get profiling information from the object manager and
+  /// push it to the GCS.
+  boost::asio::steady_timer object_manager_profile_timer_;
   /// The time that the last heartbeat was sent at. Used to make sure we are
   /// keeping up with heartbeats.
   uint64_t last_heartbeat_at_ms_;

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -29,6 +29,18 @@ inline int64_t current_sys_time_ms() {
   return ms_since_epoch.count();
 }
 
+inline int64_t current_sys_time_us() {
+  std::chrono::microseconds mu_since_epoch =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::system_clock::now().time_since_epoch());
+  return mu_since_epoch.count();
+}
+
+inline double current_sys_time_seconds() {
+  int64_t microseconds_in_seconds = 1000000;
+  return static_cast<double>(current_sys_time_us()) / microseconds_in_seconds;
+}
+
 inline ray::Status boost_to_ray_status(const boost::system::error_code &error) {
   switch (error.value()) {
   case boost::system::errc::success:

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import os
 import re
 import setproctitle
@@ -17,6 +18,7 @@ import pytest
 
 import ray
 import ray.ray_constants as ray_constants
+import ray.test.cluster_utils
 import ray.test.test_utils
 
 
@@ -1035,6 +1037,58 @@ def test_profiling_api(shutdown_only):
         if all(expected_type in event_types
                for expected_type in expected_types):
             break
+
+
+@pytest.fixture()
+def ray_start_cluster():
+    cluster = ray.test.cluster_utils.Cluster()
+    yield cluster
+
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    cluster.shutdown()
+
+
+def test_object_transfer_dump(ray_start_cluster):
+    cluster = ray_start_cluster
+
+    num_nodes = 3
+    for i in range(num_nodes):
+        cluster.add_node(resources={str(i): 1}, object_store_memory=10**9)
+
+    ray.init(redis_address=cluster.redis_address)
+
+    @ray.remote
+    def f(x):
+        return
+
+    # These objects will live on different nodes.
+    object_ids = [
+        f._submit(args=[1], resources={str(i): 1}) for i in range(num_nodes)
+    ]
+
+    # Broadcast each object from each machine to each other machine.
+    for object_id in object_ids:
+        ray.get([
+            f._submit(args=[object_id], resources={str(i): 1})
+            for i in range(num_nodes)
+        ])
+
+    # The profiling information only flushes once every second.
+    time.sleep(1.1)
+
+    transfer_dump = ray.global_state.chrome_tracing_object_transfer_dump()
+    # Make sure the transfer dump can be serialized with JSON.
+    json.loads(json.dumps(transfer_dump))
+    assert len(transfer_dump) >= num_nodes**2
+    assert len({
+        event["pid"]
+        for event in transfer_dump if event["name"] == "transfer_receive"
+    }) == num_nodes
+    assert len({
+        event["pid"]
+        for event in transfer_dump if event["name"] == "transfer_send"
+    }) == num_nodes
 
 
 def test_identical_function_names(shutdown_only):


### PR DESCRIPTION
It looks something like this. Each "process" refers to an object manager. Black boxes refer to **sends** and gray boxes refer to **receives**. Each object has its own color.

In this workload, the bottom node broadcasts 4 objects to 3 other nodes.

All of the little pieces are due to object chunking.

<img width="1388" alt="screen shot 2018-11-06 at 2 55 59 pm" src="https://user-images.githubusercontent.com/249517/48099335-1cf5fe80-e1d4-11e8-8696-be70a6aea6a2.png">
