### PR TITLE
Suppress duplicate pre-emptive object pushes.

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -189,7 +189,7 @@ ClientConnection<T>::ClientConnection(MessageHandler<T> &message_handler,
       debug_label_(debug_label) {}
 
 template <class T>
-const ClientID &ClientConnection<T>::GetClientID() {
+const ClientID &ClientConnection<T>::GetClientId() {
   return client_id_;
 }
 

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -152,7 +152,7 @@ class ClientConnection : public ServerConnection<T> {
   }
 
   /// \return The ClientID of the remote client.
-  const ClientID &GetClientID();
+  const ClientID &GetClientId();
 
   /// \param client_id The ClientID of the remote client.
   void SetClientID(const ClientID &client_id);

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -40,7 +40,7 @@ void ConnectionPool::RegisterSender(ConnectionType type, const ClientID &client_
 
 void ConnectionPool::RemoveSender(const std::shared_ptr<SenderConnection> &conn) {
   std::unique_lock<std::mutex> guard(connection_mutex);
-  ClientID client_id = conn->GetClientID();
+  const ClientID client_id = conn->GetClientId();
   if (message_send_connections_.count(client_id) != 0) {
     Remove(message_send_connections_, client_id, conn);
   }

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -19,7 +19,7 @@ void ConnectionPool::RegisterReceiver(ConnectionType type, const ClientID &clien
 
 void ConnectionPool::RemoveReceiver(std::shared_ptr<TcpClientConnection> conn) {
   std::unique_lock<std::mutex> guard(connection_mutex);
-  ClientID client_id = conn->GetClientID();
+  const ClientID client_id = conn->GetClientId();
   if (message_receive_connections_.count(client_id) != 0) {
     Remove(message_receive_connections_, client_id, conn);
   }
@@ -68,7 +68,7 @@ void ConnectionPool::ReleaseSender(ConnectionType type,
   SenderMapType &conn_map = (type == ConnectionType::MESSAGE)
                                 ? available_message_send_connections_
                                 : available_transfer_send_connections_;
-  Return(conn_map, conn->GetClientID(), conn);
+  Return(conn_map, conn->GetClientId(), conn);
 }
 
 void ConnectionPool::Add(ReceiverMapType &conn_map, const ClientID &client_id,

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -387,19 +387,18 @@ void ObjectManager::Push(const ObjectID &object_id, const ClientID &client_id) {
     return;
   }
 
-  // If we've pushed this same object to this same object manager recently, then
-  // don't do it again. Otherwise do it.
+  // If we haven't pushed this object to this same object manager yet, then push
+  // it. If we have, but it was a long time ago, then push it. If we have and it
+  // was recent, then don't do it again.
   auto &recent_pushes = local_objects_[object_id].recent_pushes;
   auto it = recent_pushes.find(client_id);
   if (it == recent_pushes.end()) {
     // We haven't pushed this specific object to this specific object manager
     // yet (or if we have then the object must have been evicted and recreated
     // locally).
-    recent_pushes[client_id] = current_time_ms();
+    recent_pushes[client_id] = current_sys_time_ms();
   } else {
-    // We've already pushed this object to this object manager, but if that
-    // happened long ago, push it again.
-    int64_t current_time = current_time_ms();
+    int64_t current_time = current_sys_time_ms();
     if (current_time - it->second <=
         RayConfig::instance().object_manager_repeated_push_delay_ms()) {
       // We pushed this object to the object manager recently, so don't do it

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -176,18 +176,10 @@ ray::Status ObjectManager::Pull(const ObjectID &object_id) {
             it->second.timer_set = false;
           }
         } else {
-          // New object locations were found.
-          if (!it->second.timer_set) {
-            // The timer was not set, which means that we weren't trying any
-            // clients. We now have some clients to try, so begin trying to
-            // Pull from one.  If we fail to receive an object within the pull
-            // timeout, then this will try the rest of the clients in the list
-            // in succession.
-            TryPull(object_id);
-          } else {
-            // TODO(rkn): We may want to immediately start trying to pull from
-            // another client here.
-          }
+          // New object locations were found, so begin trying to pull from a
+          // client. This will be called every time a new client location
+          // appears.
+          TryPull(object_id);
         }
       });
 }

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <random>
 #include <thread>
 
 #include <boost/asio.hpp>
@@ -418,6 +419,9 @@ class ObjectManager : public ObjectManagerInterface {
   /// Profiling events that are to be batched together and added to the profile
   /// table in the GCS.
   std::vector<ProfileEventT> profile_events_;
+
+  /// Internally maintained random number generator.
+  std::mt19937_64 gen_;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -335,13 +335,6 @@ class ObjectManager : public ObjectManagerInterface {
                              const ObjectBufferPool::ChunkInfo &chunk_info,
                              std::shared_ptr<SenderConnection> &conn);
 
-  /// Remove some elements from the list of recently pushed objects. This allows
-  /// the object manager to forget about objects it pushed so that it can push
-  /// them again. This is executed on the main service on a timer.
-  ///
-  /// \return Void.
-  void ForgetRecentPushes();
-
   /// Invoked when a remote object manager pushes an object to this object manager.
   /// This will invoke the object receive on the receive_service_ thread pool.
   void ReceivePushRequest(std::shared_ptr<TcpClientConnection> &conn,

--- a/src/ray/object_manager/object_manager_client_connection.h
+++ b/src/ray/object_manager/object_manager_client_connection.h
@@ -74,7 +74,7 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   }
 
   /// \return The ClientID of this connection.
-  const ClientID &GetClientID() { return client_id_; }
+  const ClientID &GetClientId() { return client_id_; }
 
  private:
   bool operator==(const SenderConnection &rhs) const {

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -120,7 +120,7 @@ class TestObjectManagerBase : public ::testing::Test {
     store_id_1 = StartStore(UniqueID::from_random().hex());
     store_id_2 = StartStore(UniqueID::from_random().hex());
 
-    uint pull_timeout_ms = 1;
+    uint pull_timeout_ms = 100;
     int max_sends_a = 2;
     int max_receives_a = 2;
     int max_sends_b = 3;

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -120,7 +120,7 @@ class TestObjectManagerBase : public ::testing::Test {
     store_id_1 = StartStore(UniqueID::from_random().hex());
     store_id_2 = StartStore(UniqueID::from_random().hex());
 
-    uint pull_timeout_ms = 100;
+    uint pull_timeout_ms = 1000;
     int max_sends_a = 2;
     int max_receives_a = 2;
     int max_sends_b = 3;

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -229,7 +229,7 @@ class RayConfig {
         max_tasks_to_spillback_(10),
         actor_creation_num_spillbacks_warning_(100),
         node_manager_forward_task_retry_timeout_milliseconds_(1000),
-        object_manager_pull_timeout_ms_(100),
+        object_manager_pull_timeout_ms_(10000),
         object_manager_push_timeout_ms_(10000),
         object_manager_repeated_push_delay_ms_(60000),
         object_manager_default_chunk_size_(1000000),

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -102,6 +102,14 @@ class RayConfig {
 
   int object_manager_push_timeout_ms() const { return object_manager_push_timeout_ms_; }
 
+  int object_manager_num_recent_pushes() const {
+    return object_manager_num_recent_pushes_;
+  }
+
+  int object_manager_recent_pushes_timer_period_ms() const {
+    return object_manager_recent_pushes_timer_period_ms_;
+  }
+
   uint64_t object_manager_default_chunk_size() const {
     return object_manager_default_chunk_size_;
   }
@@ -226,6 +234,8 @@ class RayConfig {
         node_manager_forward_task_retry_timeout_milliseconds_(1000),
         object_manager_pull_timeout_ms_(100),
         object_manager_push_timeout_ms_(10000),
+        object_manager_num_recent_pushes_(20),
+        object_manager_recent_pushes_timer_period_ms_(3000),
         object_manager_default_chunk_size_(1000000),
         num_workers_per_process_(1),
         initialized_(false) {}
@@ -347,6 +357,15 @@ class RayConfig {
   /// Negative: waiting infinitely.
   /// 0: giving up retrying immediately.
   int object_manager_push_timeout_ms_;
+
+  /// This is the maximum number of objects that each object manager will
+  /// remember pushing to each other object manager in order to suppress
+  /// duplicate pushes.
+  int object_manager_num_recent_pushes_;
+
+  /// The period of the timer that will be used to make the object manager
+  /// forget about objects that it has recently pushed to other object managers.
+  int object_manager_recent_pushes_timer_period_ms_;
 
   /// Default chunk size for multi-chunk transfers to use in the object manager.
   /// In the object manager, no single thread is permitted to transfer more

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -102,14 +102,9 @@ class RayConfig {
 
   int object_manager_push_timeout_ms() const { return object_manager_push_timeout_ms_; }
 
-  int object_manager_num_recent_pushes() const {
-    return object_manager_num_recent_pushes_;
+  int object_manager_repeated_push_delay_ms() const {
+    return object_manager_repeated_push_delay_ms_;
   }
-
-  int object_manager_recent_pushes_timer_period_ms() const {
-    return object_manager_recent_pushes_timer_period_ms_;
-  }
-
   uint64_t object_manager_default_chunk_size() const {
     return object_manager_default_chunk_size_;
   }
@@ -191,6 +186,8 @@ class RayConfig {
         object_manager_push_timeout_ms_ = pair.second;
       } else if (pair.first == "object_manager_default_chunk_size") {
         object_manager_default_chunk_size_ = pair.second;
+      } else if (pair.first == "object_manager_repeated_push_delay_ms") {
+        object_manager_repeated_push_delay_ms_ = pair.second;
       } else {
         RAY_LOG(FATAL) << "Received unexpected config parameter " << pair.first;
       }
@@ -234,8 +231,7 @@ class RayConfig {
         node_manager_forward_task_retry_timeout_milliseconds_(1000),
         object_manager_pull_timeout_ms_(100),
         object_manager_push_timeout_ms_(10000),
-        object_manager_num_recent_pushes_(20),
-        object_manager_recent_pushes_timer_period_ms_(3000),
+        object_manager_repeated_push_delay_ms_(60000),
         object_manager_default_chunk_size_(1000000),
         num_workers_per_process_(1),
         initialized_(false) {}
@@ -358,14 +354,9 @@ class RayConfig {
   /// 0: giving up retrying immediately.
   int object_manager_push_timeout_ms_;
 
-  /// This is the maximum number of objects that each object manager will
-  /// remember pushing to each other object manager in order to suppress
-  /// duplicate pushes.
-  int object_manager_num_recent_pushes_;
-
-  /// The period of the timer that will be used to make the object manager
-  /// forget about objects that it has recently pushed to other object managers.
-  int object_manager_recent_pushes_timer_period_ms_;
+  /// The period of time that an object manager will wait before pushing the
+  /// same object again to a specific object manager.
+  int object_manager_repeated_push_delay_ms_;
 
   /// Default chunk size for multi-chunk transfers to use in the object manager.
   /// In the object manager, no single thread is permitted to transfer more

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -763,7 +763,7 @@ void NodeManager::ProcessDisconnectClientMessage(
     DispatchTasks(local_queues_.GetReadyTasks());
   } else if (is_driver) {
     // The client is a driver.
-    RAY_CHECK_OK(gcs_client_->driver_table().AppendDriverData(client->GetClientID(),
+    RAY_CHECK_OK(gcs_client_->driver_table().AppendDriverData(client->GetClientId(),
                                                               /*is_dead=*/true));
     auto driver_id = worker->GetAssignedTaskId();
     RAY_CHECK(!driver_id.is_nil());

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -359,6 +359,8 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "use_pytorch": true, "sample_async": false}'
 
+docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA python -m pytest /ray/test/stress_tests_2.py
+
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -359,7 +359,7 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "use_pytorch": true, "sample_async": false}'
 
-docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA python -m pytest /ray/test/stress_tests_2.py
+docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA python -m pytest /ray/test/object_manager_test.py
 
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -70,7 +70,7 @@ def test_object_broadcast(ray_start_cluster):
         x_id = ray.put(x)
         object_ids.append(x_id)
         ray.get([
-            f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+            f._remote(args=[x_id], resources={str(i % num_nodes): 1})
             for i in range(10 * num_nodes)
         ])
 
@@ -79,7 +79,7 @@ def test_object_broadcast(ray_start_cluster):
         x_id = create_object.remote()
         object_ids.append(x_id)
         ray.get([
-            f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+            f._remote(args=[x_id], resources={str(i % num_nodes): 1})
             for i in range(10 * num_nodes)
         ])
 
@@ -144,7 +144,7 @@ def test_actor_broadcast(ray_start_cluster):
             pass
 
     actors = [
-        Actor._submit(args=[], kwargs={}, resources={str(i % num_nodes): 1})
+        Actor._remote(args=[], kwargs={}, resources={str(i % num_nodes): 1})
         for i in range(100)
     ]
 
@@ -286,7 +286,7 @@ def test_many_small_transfers(ray_start_cluster):
         id_lists = []
         for i in range(num_nodes):
             id_lists.append([
-                f._submit(args=[], kwargs={}, resources={str(i): 1})
+                f._remote(args=[], kwargs={}, resources={str(i): 1})
                 for _ in range(1000)
             ])
         ids = []
@@ -295,7 +295,7 @@ def test_many_small_transfers(ray_start_cluster):
                 if i == j:
                     continue
                 ids.append(
-                    f._submit(
+                    f._remote(
                         args=id_lists[j], kwargs={}, resources={str(i): 1}))
 
         # Wait for all of the transfers to finish.

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -23,9 +23,10 @@ def create_cluster(num_nodes):
     for i in range(num_nodes):
         cluster.add_node(resources={str(i): 100}, object_store_memory=10**9)
 
-    # TODO(rkn): Remove this wait. It is only a workaround for
+    # TODO(rkn): Remove this wait and sleep. It is only a workaround for
     # https://github.com/ray-project/ray/issues/3275.
     cluster.wait_for_nodes()
+    time.sleep(1)
 
     ray.init(redis_address=cluster.redis_address)
     return cluster

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -23,11 +23,6 @@ def create_cluster(num_nodes):
     for i in range(num_nodes):
         cluster.add_node(resources={str(i): 100}, object_store_memory=10**9)
 
-    # TODO(rkn): Remove this wait and sleep. It is only a workaround for
-    # https://github.com/ray-project/ray/issues/3275.
-    cluster.wait_for_nodes()
-    time.sleep(1)
-
     ray.init(redis_address=cluster.redis_address)
     return cluster
 

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -251,9 +251,9 @@ def test_object_transfer_retry(ray_start_empty_cluster):
 
     # Make sure that the object was retransferred before the object manager
     # repeated push delay expired.
-    assert end_time - start_time <= repeated_push_delay, (
-        "This test didn't really fail, but the timing is such that it is not "
-        "testing the thing it should be testing.")
+    if end_time - start_time <= repeated_push_delay:
+        warnings.warn("This test didn't really fail, but the timing is such "
+                      "that it is not testing the thing it should be testing.")
     # We should have had to wait for the repeated push delay.
     assert end_transfer_time - start_time >= repeated_push_delay
 

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -23,6 +23,10 @@ def create_cluster(num_nodes):
     for i in range(num_nodes):
         cluster.add_node(resources={str(i): 100}, object_store_memory=10**9)
 
+    # TODO(rkn): Remove this wait. It is only a workaround for
+    # https://github.com/ray-project/ray/issues/3275.
+    cluster.wait_for_nodes()
+
     ray.init(redis_address=cluster.redis_address)
     return cluster
 

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -212,8 +212,9 @@ def test_object_transfer_retry(ray_start_empty_cluster):
 
     repeated_push_delay = 4
 
-    config = json.dumps(
-        {"object_manager_repeated_push_delay_ms": repeated_push_delay * 1000})
+    config = json.dumps({
+        "object_manager_repeated_push_delay_ms": repeated_push_delay * 1000
+    })
     cluster.add_node(_internal_config=config)
     cluster.add_node(resources={"GPU": 1}, _internal_config=config)
     ray.init(redis_address=cluster.redis_address)
@@ -223,9 +224,9 @@ def test_object_transfer_retry(ray_start_empty_cluster):
         return np.zeros(size, dtype=np.uint8)
 
     x_ids = [f.remote(10**i) for i in [1, 2, 3, 4, 5, 6, 7]]
-    assert not any([ray.worker.global_worker.plasma_client.contains(
-                        ray.pyarrow.plasma.ObjectID(x_id.id()))
-                    for x_id in x_ids])
+    assert not any(
+        ray.worker.global_worker.plasma_client.contains(
+            ray.pyarrow.plasma.ObjectID(x_id.id())) for x_id in x_ids)
 
     start_time = time.time()
 
@@ -237,9 +238,9 @@ def test_object_transfer_retry(ray_start_empty_cluster):
     x = np.zeros(10**7, dtype=np.uint8)
     for _ in range(10):
         ray.put(x)
-    assert not any([ray.worker.global_worker.plasma_client.contains(
-                        ray.pyarrow.plasma.ObjectID(x_id.id()))
-                    for x_id in x_ids])
+    assert not any(
+        ray.worker.global_worker.plasma_client.contains(
+            ray.pyarrow.plasma.ObjectID(x_id.id())) for x_id in x_ids)
 
     end_time = time.time()
 
@@ -261,9 +262,9 @@ def test_object_transfer_retry(ray_start_empty_cluster):
     del xs
     for _ in range(10):
         ray.put(x)
-    assert not any([ray.worker.global_worker.plasma_client.contains(
-                        ray.pyarrow.plasma.ObjectID(x_id.id()))
-                    for x_id in x_ids])
+    assert not any(
+        ray.worker.global_worker.plasma_client.contains(
+            ray.pyarrow.plasma.ObjectID(x_id.id())) for x_id in x_ids)
 
     time.sleep(repeated_push_delay)
-    xs = ray.get(x_ids)
+    ray.get(x_ids)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1231,6 +1231,7 @@ def test_multithreading(shutdown_only):
 
 
 def test_free_objects_multi_node(shutdown_only):
+    config = json.dumps({"object_manager_repeated_push_delay_ms": 1000})
     ray.worker._init(
         start_ray_local=True,
         num_local_schedulers=3,
@@ -1241,7 +1242,8 @@ def test_free_objects_multi_node(shutdown_only):
             "Custom1": 1
         }, {
             "Custom2": 1
-        }])
+        }],
+        _internal_config=config)
 
     @ray.remote(resources={"Custom0": 1})
     def run_on_0():

--- a/test/stress_tests_2.py
+++ b/test/stress_tests_2.py
@@ -1,0 +1,149 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import multiprocessing
+import numpy as np
+import pytest
+import time
+import warnings
+
+import ray
+from ray.test.cluster_utils import Cluster
+
+
+if (multiprocessing.cpu_count() < 40 or
+        ray.utils.get_system_memory() < 50 * 10**9):
+    warnings.warn("This test must be run on large machines.")
+
+
+def create_cluster(num_nodes):
+    cluster = Cluster()
+    for i in range(num_nodes):
+        cluster.add_node(resources={str(i): 100}, object_store_memory=10**9)
+
+    ray.init(redis_address=cluster.redis_address)
+    return cluster
+
+
+@pytest.fixture()
+def ray_start_cluster():
+    num_nodes = 5
+    cluster = create_cluster(num_nodes)
+    yield cluster, num_nodes
+
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    cluster.shutdown()
+
+
+# This test is here to make sure that when we broadcast an object to a bunch of
+# machines, we don't have too many excess object transfers.
+@pytest.mark.skip("This test does not work yet.")
+def test_object_broadcast(ray_start_cluster):
+    cluster, num_nodes = ray_start_cluster
+
+    @ray.remote
+    def f(x):
+        return
+
+    x = np.zeros(10**8, dtype=np.uint8)
+
+    @ray.remote
+    def create_object():
+        return np.zeros(10**8, dtype=np.uint8)
+
+    object_ids = []
+
+    for _ in range(3):
+        # Broadcast an object to all machines.
+        x_id = ray.put(x)
+        object_ids.append(x_id)
+        ray.get([f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+                 for i in range(10 * num_nodes)])
+
+    for _ in range(3):
+        # Broadcast an object to all machines.
+        x_id = create_object.remote()
+        object_ids.append(x_id)
+        ray.get([f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+                 for i in range(10 * num_nodes)])
+
+    # Wait for profiling information to be pushed to the profile table.
+    time.sleep(1)
+    transfer_events = ray.global_state.chrome_tracing_object_transfer_dump()
+
+    # Make sure that each object was transferred a reasonable number of times.
+    for x_id in object_ids:
+        relevant_events = [
+            event for event in transfer_events
+            if event["cat"] == "transfer_send"
+            and event["args"][0] == x_id.hex() and event["args"][2] == 1
+        ]
+        # Each object must have been broadcast to each remote machine.
+        assert len(relevant_events) >= num_nodes - 1
+        # If more object transfers than necessary have been done, print a
+        # warning.
+        if len(relevant_events) > num_nodes - 1:
+            warnings.warn("This object was trasnferred {} times, when only {} "
+                          "transfers were required."
+                          .format(len(relevant_events), num_nodes - 1))
+        # Each object should not have been broadcast more than once from every
+        # machine to every other machine.
+        assert len(relevant_events) <= (num_nodes - 1) * num_nodes / 2
+
+
+# When submitting an actor method, we try to pre-emptively push its arguments
+# to the actor's object manager. However, in the past we did not deduplicate
+# the pushes and so the same object could get shipped to the same object
+# manager many times. This test checks that that isn't happening.
+def test_actor_broadcast(ray_start_cluster):
+    cluster, num_nodes = ray_start_cluster
+
+    @ray.remote
+    class Actor(object):
+        def ready(self):
+            pass
+
+        def set_weights(self, x):
+            pass
+
+    actors = [Actor._submit(
+                  args=[], kwargs={},
+                  resources={str(i % num_nodes): 1})
+              for i in range(100)]
+
+    # Wait for the actors to start up.
+    ray.get([a.ready.remote() for a in actors])
+
+    object_ids = []
+
+    # Broadcast a large object to all actors.
+    for _ in range(10):
+        x_id = ray.put(np.zeros(10**7, dtype=np.uint8))
+        object_ids.append(x_id)
+        # Pass the object into a method for every actor.
+        ray.get([a.set_weights.remote(x_id) for a in actors])
+
+    # Wait for profiling information to be pushed to the profile table.
+    time.sleep(1)
+    transfer_events = ray.global_state.chrome_tracing_object_transfer_dump()
+
+    # Make sure that each object was transferred a reasonable number of times.
+    for x_id in object_ids:
+        relevant_events = [
+            event for event in transfer_events
+            if event["cat"] == "transfer_send"
+            and event["args"][0] == x_id.hex() and event["args"][2] == 1
+        ]
+        # Each object must have been broadcast to each remote machine.
+        assert len(relevant_events) >= num_nodes - 1
+        # If more object transfers than necessary have been done, print a
+        # warning.
+        if len(relevant_events) > num_nodes - 1:
+            warnings.warn("This object was trasnferred {} times, when only {} "
+                          "transfers were required."
+                          .format(len(relevant_events), num_nodes - 1))
+        # Each object should not have been broadcast more than once from every
+        # machine to every other machine.
+        assert len(relevant_events) <= (num_nodes - 1) * num_nodes / 2

--- a/test/stress_tests_2.py
+++ b/test/stress_tests_2.py
@@ -11,9 +11,8 @@ import warnings
 import ray
 from ray.test.cluster_utils import Cluster
 
-
-if (multiprocessing.cpu_count() < 40 or
-        ray.utils.get_system_memory() < 50 * 10**9):
+if (multiprocessing.cpu_count() < 40
+        or ray.utils.get_system_memory() < 50 * 10**9):
     warnings.warn("This test must be run on large machines.")
 
 
@@ -59,15 +58,19 @@ def test_object_broadcast(ray_start_cluster):
         # Broadcast an object to all machines.
         x_id = ray.put(x)
         object_ids.append(x_id)
-        ray.get([f._submit(args=[x_id], resources={str(i % num_nodes): 1})
-                 for i in range(10 * num_nodes)])
+        ray.get([
+            f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+            for i in range(10 * num_nodes)
+        ])
 
     for _ in range(3):
         # Broadcast an object to all machines.
         x_id = create_object.remote()
         object_ids.append(x_id)
-        ray.get([f._submit(args=[x_id], resources={str(i % num_nodes): 1})
-                 for i in range(10 * num_nodes)])
+        ray.get([
+            f._submit(args=[x_id], resources={str(i % num_nodes): 1})
+            for i in range(10 * num_nodes)
+        ])
 
     # Wait for profiling information to be pushed to the profile table.
     time.sleep(1)
@@ -86,8 +89,8 @@ def test_object_broadcast(ray_start_cluster):
         # warning.
         if len(relevant_events) > num_nodes - 1:
             warnings.warn("This object was trasnferred {} times, when only {} "
-                          "transfers were required."
-                          .format(len(relevant_events), num_nodes - 1))
+                          "transfers were required.".format(
+                              len(relevant_events), num_nodes - 1))
         # Each object should not have been broadcast more than once from every
         # machine to every other machine.
         assert len(relevant_events) <= (num_nodes - 1) * num_nodes / 2
@@ -108,10 +111,10 @@ def test_actor_broadcast(ray_start_cluster):
         def set_weights(self, x):
             pass
 
-    actors = [Actor._submit(
-                  args=[], kwargs={},
-                  resources={str(i % num_nodes): 1})
-              for i in range(100)]
+    actors = [
+        Actor._submit(args=[], kwargs={}, resources={str(i % num_nodes): 1})
+        for i in range(100)
+    ]
 
     # Wait for the actors to start up.
     ray.get([a.ready.remote() for a in actors])
@@ -142,8 +145,8 @@ def test_actor_broadcast(ray_start_cluster):
         # warning.
         if len(relevant_events) > num_nodes - 1:
             warnings.warn("This object was trasnferred {} times, when only {} "
-                          "transfers were required."
-                          .format(len(relevant_events), num_nodes - 1))
+                          "transfers were required.".format(
+                              len(relevant_events), num_nodes - 1))
         # Each object should not have been broadcast more than once from every
         # machine to every other machine.
         assert len(relevant_events) <= (num_nodes - 1) * num_nodes / 2

--- a/test/stress_tests_2.py
+++ b/test/stress_tests_2.py
@@ -114,7 +114,7 @@ def test_object_broadcast(ray_start_cluster):
             # The pid identifies the sender and the tid identifies the
             # receiver.
             send_counts[(event["pid"], event["tid"])] += 1
-        assert all([value == 1 for value in send_counts.values()])
+        assert all(value == 1 for value in send_counts.values())
 
 
 # When submitting an actor method, we try to pre-emptively push its arguments
@@ -191,4 +191,4 @@ def test_actor_broadcast(ray_start_cluster):
             # The pid identifies the sender and the tid identifies the
             # receiver.
             send_counts[(event["pid"], event["tid"])] += 1
-        assert all([value == 1 for value in send_counts.values()])
+        assert all(value == 1 for value in send_counts.values())


### PR DESCRIPTION
For some tasks (like actor tasks), we know exactly where they are going to be scheduled, so we try to pre-emptively push the object dependencies to the right location. However, if multiple actor methods depend on the same object, we don't deduplicate the pushes. This should fix #3273.

This let's each object manager remember the most recent objects that it pushed to each other manager, and it slowly forgets objects via a timer.