### PR TITLE
Clean up Ray processes after cluster util exits

### DIFF
--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import atexit
 import logging
 import time
 
@@ -41,6 +42,7 @@ class Cluster(object):
                 ray.init(
                     redis_address=self.redis_address,
                     redis_password=redis_password)
+        atexit.register(self.shutdown)
 
     def add_node(self, **override_kwargs):
         """Adds a node to the local Ray Cluster.

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -16,7 +16,8 @@ class Cluster(object):
     def __init__(self,
                  initialize_head=False,
                  connect=False,
-                 head_node_args=None):
+                 head_node_args=None,
+                 shutdown_at_exit=True):
         """Initializes the cluster.
 
         Args:
@@ -25,8 +26,10 @@ class Cluster(object):
             connect (bool): If `initialize_head=True` and `connect=True`,
                 ray.init will be called with the redis address of this cluster
                 passed in.
-            head_node_args (kwargs): Arguments to be passed into
+            head_node_args (dict): Arguments to be passed into
                 `start_ray_head` via `self.add_node`.
+            shutdown_at_exit (bool): If True, registers an exit hook
+                for shutting down all started processes.
         """
         self.head_node = None
         self.worker_nodes = {}
@@ -42,7 +45,8 @@ class Cluster(object):
                 ray.init(
                     redis_address=self.redis_address,
                     redis_password=redis_password)
-        atexit.register(self.shutdown)
+        if shutdown_at_exit:
+            atexit.register(self.shutdown)
 
     def add_node(self, **override_kwargs):
         """Adds a node to the local Ray Cluster.
@@ -155,12 +159,16 @@ class Cluster(object):
         return nodes
 
     def shutdown(self):
+        """Removes all nodes."""
+
         # We create a list here as a copy because `remove_node`
         # modifies `self.worker_nodes`.
         all_nodes = list(self.worker_nodes)
         for node in all_nodes:
             self.remove_node(node)
-        self.remove_node(self.head_node)
+
+        if self.head_node is not None:
+            self.remove_node(self.head_node)
 
 
 class Node(object):

--- a/test/multi_node_test_2.py
+++ b/test/multi_node_test_2.py
@@ -57,7 +57,15 @@ def test_cluster():
     assert node2.all_processes_alive()
     g.remove_node(node2)
     g.remove_node(node)
-    assert not any(node.any_processes_alive() for node in g.list_all_nodes())
+    assert not any(n.any_processes_alive() for n in [node, node2])
+
+
+def test_shutdown():
+    g = Cluster(initialize_head=False)
+    node = g.add_node()
+    node2 = g.add_node()
+    g.shutdown()
+    assert not any(n.any_processes_alive() for n in [node, node2])
 
 
 def test_internal_config(start_connected_longer_cluster):

--- a/test/multi_node_test_2.py
+++ b/test/multi_node_test_2.py
@@ -46,6 +46,7 @@ def start_connected_longer_cluster():
     yield g
     # The code after the yield will run as teardown code.
     ray.shutdown()
+    g.shutdown()
 
 
 def test_cluster():

--- a/test/multi_node_test_2.py
+++ b/test/multi_node_test_2.py
@@ -19,7 +19,6 @@ def start_connected_cluster():
     yield g
     # The code after the yield will run as teardown code.
     ray.shutdown()
-    g.shutdown()
 
 
 def test_cluster():

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1046,7 +1046,6 @@ def ray_start_cluster():
 
     # The code after the yield will run as teardown code.
     ray.shutdown()
-    cluster.shutdown()
 
 
 def test_object_transfer_dump(ray_start_cluster):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1046,6 +1046,7 @@ def ray_start_cluster():
 
     # The code after the yield will run as teardown code.
     ray.shutdown()
+    cluster.shutdown()
 
 
 def test_object_transfer_dump(ray_start_cluster):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

Adds `atexit` hook to Cluster instantiation.


Closes #3277.
<!-- Are there any issues opened that will be resolved by merging this change? -->