### PR TITLE
[WIP] Use Ninja as the build system backend

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -19,7 +19,7 @@ fi
 
 if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
-  sudo apt-get install -y cmake pkg-config build-essential autoconf curl libtool python-dev python-numpy python-pip unzip
+  sudo apt-get install -y cmake pkg-config build-essential autoconf curl libtool python-dev python-numpy python-pip unzip ninja-build
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
@@ -28,7 +28,7 @@ if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
     feather-format lxml openpyxl xlrd py-spy setproctitle faulthandler
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
-  sudo apt-get install -y cmake pkg-config python-dev python-numpy build-essential autoconf curl libtool unzip
+  sudo apt-get install -y cmake pkg-config python-dev python-numpy build-essential autoconf curl libtool unzip ninja-build
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
@@ -71,7 +71,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
     feather-format lxml openpyxl xlrd py-spy setproctitle
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
-  sudo apt-get install -y cmake build-essential autoconf curl libtool unzip
+  sudo apt-get install -y cmake build-essential autoconf curl libtool unzip ninja-build
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -45,7 +45,7 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
     echo "Updating brew."
     brew update > /dev/null
   fi
-  brew install cmake pkg-config automake autoconf libtool openssl bison > /dev/null
+  brew install cmake pkg-config automake autoconf libtool openssl bison ninja > /dev/null
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda2-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
@@ -90,7 +90,7 @@ elif [[ "$MAC_WHEELS" == "1" ]]; then
     echo "Updating brew."
     brew update > /dev/null
   fi
-  brew install cmake pkg-config automake autoconf libtool openssl bison > /dev/null
+  brew install cmake pkg-config automake autoconf libtool openssl bison ninja > /dev/null
   # We use true to avoid exiting with an error code because the brew install can
   # fail if a package is already installed.
   true

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -62,7 +62,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
     echo "Updating brew."
     brew update > /dev/null
   fi
-  brew install cmake pkg-config automake autoconf libtool openssl bison > /dev/null
+  brew install cmake pkg-config automake autoconf libtool openssl bison ninja > /dev/null
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,11 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
 
   set(build_ray_file_list)
   foreach(file ${ray_file_list})
-    list(APPEND build_ray_file_list ${CMAKE_BINARY_DIR}/${file})
+    list(APPEND build_ray_file_list "${CMAKE_BINARY_DIR}/${file}")
   endforeach()
 
-  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
+  add_custom_target(copy_ray_files DEPENDS copy_redis ${build_ray_file_list} ray_redis_module)
+  add_dependencies(copy_ray_files copy_redis)
   add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,7 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     list(APPEND build_ray_file_list "${CMAKE_BINARY_DIR}/${file}")
   endforeach()
 
-  add_custom_target(copy_ray_files DEPENDS copy_redis ${build_ray_file_list} ray_redis_module)
-  add_dependencies(copy_ray_files copy_redis)
+  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
   add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,8 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     list(APPEND build_ray_file_list ${CMAKE_BINARY_DIR}/${file})
   endforeach()
 
-  ## add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
-  ## add_dependencies(copy_ray copy_ray_files)
+  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
+  add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.
   get_local_scheduler_library("python" LOCAL_SCHEDULER_LIBRARY_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,8 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     list(APPEND build_ray_file_list ${CMAKE_BINARY_DIR}/${file})
   endforeach()
 
-  add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
-  add_dependencies(copy_ray copy_ray_files)
+  ## add_custom_target(copy_ray_files DEPENDS ${build_ray_file_list} copy_redis ray_redis_module)
+  ## add_dependencies(copy_ray copy_ray_files)
 
   # Make sure that the Python extensions are built before copying the files.
   get_local_scheduler_library("python" LOCAL_SCHEDULER_LIBRARY_PYTHON)

--- a/build.sh
+++ b/build.sh
@@ -105,11 +105,12 @@ pushd "$BUILD_DIR"
 # and cmake will check some directories to determine whether some targets built
 make clean || true
 
-cmake -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
+cmake -GNinja \
+      -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \
       -DCMAKE_RAY_LANG_PYTHON=$RAY_BUILD_PYTHON \
       -DRAY_USE_NEW_GCS=$RAY_USE_NEW_GCS \
       -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON_EXECUTABLE $ROOT_DIR
 
-make -j${PARALLEL}
+ninja
 popd

--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,7 @@ cmake -GNinja \
       -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON_EXECUTABLE $ROOT_DIR
 
 ninja arrow_ep
+ninja copy_redis
 ninja
 
 popd

--- a/build.sh
+++ b/build.sh
@@ -101,10 +101,6 @@ fi
 
 pushd "$BUILD_DIR"
 
-# avoid the command failed and exits
-# and cmake will check some directories to determine whether some targets built
-make clean || true
-
 cmake -GNinja \
       -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \
@@ -112,5 +108,7 @@ cmake -GNinja \
       -DRAY_USE_NEW_GCS=$RAY_USE_NEW_GCS \
       -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON_EXECUTABLE $ROOT_DIR
 
+ninja arrow_ep
 ninja
+
 popd

--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -92,6 +92,7 @@ ExternalProject_Add(arrow_ep
   DEPENDS flatbuffers boost glog
   GIT_REPOSITORY ${arrow_URL}
   GIT_TAG ${arrow_TAG}
+  UPDATE_COMMAND ""
   ${ARROW_CONFIGURE}
   BUILD_BYPRODUCTS "${ARROW_SHARED_LIB}" "${ARROW_STATIC_LIB}")
 

--- a/cmake/Modules/ThirdpartyToolchain.cmake
+++ b/cmake/Modules/ThirdpartyToolchain.cmake
@@ -133,6 +133,7 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     ExternalProject_Add(pyarrow_ext
       PREFIX external/pyarrow
       DEPENDS arrow_ep
+      UPDATE_COMMAND ""
       DOWNLOAD_COMMAND ""
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND cd ${ARROW_SOURCE_DIR}/python && ${CMAKE_COMMAND} -E env ${pyarrow_ENV} ${PYTHON_EXECUTABLE} setup.py build

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -91,7 +91,7 @@ ADD_RAY_LIB(ray
 
 add_custom_target(copy_redis ALL)
 foreach(file "redis-cli" "redis-server")
-add_custom_command(TARGET copy_redis POST_BUILD
+add_custom_command(TARGET copy_redis
                    COMMAND ${CMAKE_COMMAND} -E
                       copy ${CMAKE_CURRENT_LIST_DIR}/../../thirdparty/pkg/redis/src/${file}
                            ${CMAKE_BINARY_DIR}/src/ray/thirdparty/redis/src/${file})


### PR DESCRIPTION
This should allow us to do fully incremental builds even of `pip install -e .`.

Ninja also has some nice features for visualizing and debugging build dependency problems: https://ninja-build.org/manual.html#_extra_tools

It is widely used and a well-supported CMake backend (used by most of the arrow CI and chrome uses it as the build system backend through gn for example).