### PR TITLE
Re-enable incremental builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,6 +104,7 @@ pushd "$BUILD_DIR"
 # avoid the command failed and exits
 # and cmake will check some directories to determine whether some targets built
 make clean || true
+rm -rf external/arrow-install
 
 cmake -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \

--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -92,6 +92,7 @@ ExternalProject_Add(arrow_ep
   DEPENDS flatbuffers boost glog
   GIT_REPOSITORY ${arrow_URL}
   GIT_TAG ${arrow_TAG}
+  UPDATE_COMMAND ""
   ${ARROW_CONFIGURE}
   BUILD_BYPRODUCTS "${ARROW_SHARED_LIB}" "${ARROW_STATIC_LIB}")
 


### PR DESCRIPTION
This is a little bit hacky, it instructs CMake to not update arrow_ep (via UPDATE_COMMAND "") unless it has to be rebuilt. We force a rebuilt in setup.py by deleting the installed files after "make clean".

See also https://github.com/ray-project/ray/issues/3089