### PR TITLE
[rllib] Raise worker TF intra_op threads to 2, lower driver intra_op threads to 8

### DIFF
--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -159,8 +159,8 @@ class Agent(Trainable):
             0,
             # important: allow local tf to use more CPUs for optimization
             merge_dicts(self.config, {
-                "tf_session_args":
-                self.config["local_evaluator_tf_session_args"]
+                "tf_session_args": self.
+                config["local_evaluator_tf_session_args"]
             }))
 
     def make_remote_evaluators(self, env_creator, policy_graph, count,

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -83,7 +83,7 @@ COMMON_CONFIG = {
     "synchronize_filters": True,
     # Configure TF for single-process operation by default
     "tf_session_args": {
-        # note: parallelism_threads is overriden by `driver_tf_session_args`
+        # note: overriden by `local_evaluator_tf_session_args`
         "intra_op_parallelism_threads": 2,
         "inter_op_parallelism_threads": 2,
         "gpu_options": {
@@ -95,8 +95,8 @@ COMMON_CONFIG = {
         },
         "allow_soft_placement": True,  # required by PPO multi-gpu
     },
-    # Override the following tf session args on the local driver
-    "driver_tf_session_args": {
+    # Override the following tf session args on the local evaluator
+    "local_evaluator_tf_session_args": {
         # Allow a higher level of parallelism by default, but not unlimited
         # since that can cause crashes with many concurrent drivers.
         "intra_op_parallelism_threads": 8,

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -159,9 +159,8 @@ class Agent(Trainable):
             0,
             # important: allow local tf to use more CPUs for optimization
             merge_dicts(
-                self.config, {
-                    "tf_session_args": self.config["driver_tf_session_args"]
-                }))
+                self.config,
+                {"tf_session_args": self.config["driver_tf_session_args"]}))
 
     def make_remote_evaluators(self, env_creator, policy_graph, count,
                                remote_args):
@@ -176,8 +175,8 @@ class Agent(Trainable):
     def _make_evaluator(self, cls, env_creator, policy_graph, worker_index,
                         config):
         def session_creator():
-            logger.debug(
-                "Creating TF session {}".format(config["tf_session_args"]))
+            logger.debug("Creating TF session {}".format(
+                config["tf_session_args"]))
             return tf.Session(
                 config=tf.ConfigProto(**config["tf_session_args"]))
 

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -83,7 +83,7 @@ COMMON_CONFIG = {
     "synchronize_filters": True,
     # Configure TF for single-process operation by default
     "tf_session_args": {
-        # note: parallelism_threads is overriden below for the driver
+        # note: parallelism_threads is overriden by `driver_tf_session_args`
         "intra_op_parallelism_threads": 2,
         "inter_op_parallelism_threads": 2,
         "gpu_options": {
@@ -98,7 +98,7 @@ COMMON_CONFIG = {
     # Override the following tf session args on the local driver
     "driver_tf_session_args": {
         # Allow a higher level of parallelism by default, but not unlimited
-        # since that can cause crashes.
+        # since that can cause crashes with many concurrent drivers.
         "intra_op_parallelism_threads": 8,
         "inter_op_parallelism_threads": 8,
     },

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -83,9 +83,9 @@ COMMON_CONFIG = {
     "synchronize_filters": True,
     # Configure TF for single-process operation by default
     "tf_session_args": {
-        # note: parallelism_threads is set to auto for the local evaluator
-        "intra_op_parallelism_threads": 1,
-        "inter_op_parallelism_threads": 1,
+        # note: parallelism_threads is overriden below for the driver
+        "intra_op_parallelism_threads": 2,
+        "inter_op_parallelism_threads": 2,
         "gpu_options": {
             "allow_growth": True,
         },
@@ -94,6 +94,13 @@ COMMON_CONFIG = {
             "CPU": 1
         },
         "allow_soft_placement": True,  # required by PPO multi-gpu
+    },
+    # Override the following tf session args on the local driver
+    "driver_tf_session_args": {
+        # Allow a higher level of parallelism by default, but not unlimited
+        # since that can cause crashes.
+        "intra_op_parallelism_threads": 8,
+        "inter_op_parallelism_threads": 8,
     },
     # Whether to LZ4 compress observations
     "compress_observations": False,
@@ -150,13 +157,10 @@ class Agent(Trainable):
             env_creator,
             policy_graph,
             0,
-            # important: allow local tf to use multiple CPUs for optimization
+            # important: allow local tf to use more CPUs for optimization
             merge_dicts(
                 self.config, {
-                    "tf_session_args": {
-                        "intra_op_parallelism_threads": None,
-                        "inter_op_parallelism_threads": None,
-                    }
+                    "tf_session_args": self.config["driver_tf_session_args"]
                 }))
 
     def make_remote_evaluators(self, env_creator, policy_graph, count,
@@ -172,6 +176,8 @@ class Agent(Trainable):
     def _make_evaluator(self, cls, env_creator, policy_graph, worker_index,
                         config):
         def session_creator():
+            logger.debug(
+                "Creating TF session {}".format(config["tf_session_args"]))
             return tf.Session(
                 config=tf.ConfigProto(**config["tf_session_args"]))
 

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -158,9 +158,10 @@ class Agent(Trainable):
             policy_graph,
             0,
             # important: allow local tf to use more CPUs for optimization
-            merge_dicts(
-                self.config,
-                {"tf_session_args": self.config["driver_tf_session_args"]}))
+            merge_dicts(self.config, {
+                "tf_session_args":
+                self.config["local_evaluator_tf_session_args"]
+            }))
 
     def make_remote_evaluators(self, env_creator, policy_graph, count,
                                remote_args):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -945,14 +945,12 @@ class Worker(object):
             }
             if task.actor_id().id() == NIL_ACTOR_ID:
                 title = "ray_worker:{}()".format(function_name)
-                next_title = "ray_worker"
             else:
                 actor = self.actors[task.actor_id().id()]
                 title = "ray_{}:{}()".format(actor.__class__.__name__,
                                              function_name)
-                next_title = "ray_{}".format(actor.__class__.__name__)
             with profiling.profile("task", extra_data=extra_data, worker=self):
-                with _changeproctitle(title, next_title):
+                with _changeproctitle(title):
                     self._process_task(task, execution_info)
                 # Reset the state fields so the next task can run.
                 with self.state_lock:
@@ -2165,10 +2163,11 @@ def disconnect(worker=global_worker):
 
 
 @contextmanager
-def _changeproctitle(title, next_title):
+def _changeproctitle(title):
+    old_title = setproctitle.getproctitle()
     setproctitle.setproctitle(title)
     yield
-    setproctitle.setproctitle(next_title)
+    setproctitle.setproctitle(old_title)
 
 
 def _try_to_compute_deterministic_class_id(cls, depth=5):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -945,12 +945,14 @@ class Worker(object):
             }
             if task.actor_id().id() == NIL_ACTOR_ID:
                 title = "ray_worker:{}()".format(function_name)
+                next_title = "ray_worker"
             else:
                 actor = self.actors[task.actor_id().id()]
                 title = "ray_{}:{}()".format(actor.__class__.__name__,
                                              function_name)
+                next_title = "ray_{}".format(actor.__class__.__name__)
             with profiling.profile("task", extra_data=extra_data, worker=self):
-                with _changeproctitle(title):
+                with _changeproctitle(title, next_title):
                     self._process_task(task, execution_info)
                 # Reset the state fields so the next task can run.
                 with self.state_lock:
@@ -2163,11 +2165,10 @@ def disconnect(worker=global_worker):
 
 
 @contextmanager
-def _changeproctitle(title):
-    old_title = setproctitle.getproctitle()
+def _changeproctitle(title, next_title):
     setproctitle.setproctitle(title)
     yield
-    setproctitle.setproctitle(old_title)
+    setproctitle.setproctitle(next_title)
 
 
 def _try_to_compute_deterministic_class_id(cls, depth=5):


### PR DESCRIPTION
## What do these changes do?

This should improve A3C performance and prevent resource exhaustion crashes. Some perf measurements:

```
Pong A3C (16 workers)
worker threads
1 -> 1932 steps/s
2 -> 2968 steps/s
4 -> 2680 steps/s

Pong APEX (16 workers)
driver threads, worker threads
8, 2 -> 
    sample_throughput: 4640.039
    train_throughput: 3393.857

8, 1 ->
    sample_throughput: 4613.557
    train_throughput: 3729.697

None, 2 ->
    sample_throughput: 4499.404
    train_throughput: 3314.669

1, 2 ->
    sample_throughput: 3993.63
    train_throughput: 3525.412
```
So (8, 2) seems to be a reasonable default config. Aside: we should probably investigate why the ape-x learner is so much slower now (maybe the default conv net is larger now).

## Related issue number

https://github.com/ray-project/ray/issues/3205