### PR TITLE
Don't transfer objects whose data is not needed

### DIFF
--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -205,10 +205,12 @@ class NodeManager {
   /// \param client The client that is executing the blocked task.
   /// \param required_object_ids The IDs that the client is blocked waiting for.
   /// \param current_task_id The task that is blocked.
+  /// \param request_transfer Whether the client requests transfer of the
+  /// objects.
   /// \return Void.
   void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                          const std::vector<ObjectID> &required_object_ids,
-                         const TaskID &current_task_id);
+                         const TaskID &current_task_id, bool request_transfer);
 
   /// Handle a task that is unblocked. This could be a task assigned to a
   /// worker, an out-of-band task (e.g., a thread created by the application),

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -126,8 +126,8 @@ class TaskDependencyManager {
   /// A struct to represent the object dependencies of a task.
   struct TaskDependencies {
     /// The objects that the task is dependent on. These must be local before
-    /// the task is ready to execute. The bool is a flag of whether the task
-    /// requires the object to be local.
+    /// the task is ready to execute. For each object, we store a flag for
+    /// whether the task requires the object to be local.
     std::unordered_map<ObjectID, bool> object_dependencies;
     /// The number of object arguments that are not available locally. This
     /// must be zero before the task is ready to execute.
@@ -195,9 +195,9 @@ class TaskDependencyManager {
   std::unordered_map<ray::TaskID, std::unordered_map<ObjectID, ObjectDependencies>>
       required_tasks_;
   /// Objects that are required by a subscribed task, are not local, and are
-  /// not created by a pending task. For these objects, there are pending
-  /// operations to make the object available.
-  std::unordered_set<ray::ObjectID> required_objects_;
+  /// not created by a pending task. For each object, we store a flag for
+  /// whether at least one task requires the object to be local.
+  std::unordered_map<ray::ObjectID, bool> required_objects_;
   /// The set of locally available objects.
   std::unordered_set<ray::ObjectID> local_objects_;
   /// The set of tasks that are pending execution. Any objects created by these

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -114,7 +114,8 @@ TEST_F(TaskDependencyManagerTest, TestSimpleTask) {
     EXPECT_CALL(reconstruction_policy_mock_, ListenAndMaybeReconstruct(argument_id));
   }
   // Subscribe to the task's dependencies.
-  bool ready = task_dependency_manager_.SubscribeDependencies(task_id, arguments);
+  bool ready = task_dependency_manager_.SubscribeDependencies(task_id, arguments,
+                                                              /*request_transfer=*/true);
   ASSERT_FALSE(ready);
 
   // All arguments should be canceled as they become available locally.
@@ -150,7 +151,8 @@ TEST_F(TaskDependencyManagerTest, TestDuplicateSubscribe) {
     // requested from the node manager once.
     EXPECT_CALL(object_manager_mock_, Pull(argument_id));
     EXPECT_CALL(reconstruction_policy_mock_, ListenAndMaybeReconstruct(argument_id));
-    bool ready = task_dependency_manager_.SubscribeDependencies(task_id, arguments);
+    bool ready = task_dependency_manager_.SubscribeDependencies(
+        task_id, arguments, /*request_transfer=*/true);
     ASSERT_FALSE(ready);
   }
 
@@ -186,7 +188,8 @@ TEST_F(TaskDependencyManagerTest, TestMultipleTasks) {
     TaskID task_id = TaskID::from_random();
     dependent_tasks.push_back(task_id);
     // Subscribe to each of the task's dependencies.
-    bool ready = task_dependency_manager_.SubscribeDependencies(task_id, {argument_id});
+    bool ready = task_dependency_manager_.SubscribeDependencies(
+        task_id, {argument_id}, /*request_transfer=*/true);
     ASSERT_FALSE(ready);
   }
 
@@ -219,7 +222,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskChain) {
     // Subscribe to each of the tasks' arguments.
     const auto &arguments = task.GetDependencies();
     bool ready = task_dependency_manager_.SubscribeDependencies(
-        task.GetTaskSpecification().TaskId(), arguments);
+        task.GetTaskSpecification().TaskId(), arguments, /*request_transfer=*/true);
     if (i < num_ready_tasks) {
       // The first task should be ready to run since it has no arguments.
       ASSERT_TRUE(ready);
@@ -274,7 +277,7 @@ TEST_F(TaskDependencyManagerTest, TestDependentPut) {
   EXPECT_CALL(reconstruction_policy_mock_, ListenAndMaybeReconstruct(put_id));
   // Subscribe to the task's dependencies.
   bool ready = task_dependency_manager_.SubscribeDependencies(
-      task2.GetTaskSpecification().TaskId(), {put_id});
+      task2.GetTaskSpecification().TaskId(), {put_id}, /*request_transfer=*/true);
   ASSERT_FALSE(ready);
 
   // The put object should be considered local as soon as the task that creates
@@ -293,7 +296,7 @@ TEST_F(TaskDependencyManagerTest, TestTaskForwarding) {
     // Subscribe to each of the tasks' arguments.
     const auto &arguments = task.GetDependencies();
     static_cast<void>(task_dependency_manager_.SubscribeDependencies(
-        task.GetTaskSpecification().TaskId(), arguments));
+        task.GetTaskSpecification().TaskId(), arguments, /*request_transfer=*/true));
     EXPECT_CALL(gcs_mock_, Add(_, task.GetTaskSpecification().TaskId(), _, _));
     task_dependency_manager_.TaskPending(task);
   }
@@ -335,7 +338,8 @@ TEST_F(TaskDependencyManagerTest, TestEviction) {
     EXPECT_CALL(reconstruction_policy_mock_, ListenAndMaybeReconstruct(argument_id));
   }
   // Subscribe to the task's dependencies.
-  bool ready = task_dependency_manager_.SubscribeDependencies(task_id, arguments);
+  bool ready = task_dependency_manager_.SubscribeDependencies(task_id, arguments,
+                                                              /*request_transfer=*/true);
   ASSERT_FALSE(ready);
 
   // Tell the task dependency manager that each of the arguments is now

--- a/src/ray/raylet/task_spec.cc
+++ b/src/ray/raylet/task_spec.cc
@@ -44,6 +44,17 @@ void TaskSpecification::AssignSpecification(const uint8_t *spec, size_t spec_siz
   }
   required_resources_ = ResourceSet(required_resources);
   required_placement_resources_ = ResourceSet(required_placement_resources);
+
+  for (int i = 0; i < NumArgs(); ++i) {
+    int count = ArgIdCount(i);
+    for (int j = 0; j < count; j++) {
+      arguments_.push_back(ArgId(i, j));
+    }
+  }
+}
+
+const std::vector<ObjectID> &TaskSpecification::GetDependencies() const {
+  return arguments_;
 }
 
 TaskSpecification::TaskSpecification(const flatbuffers::String &string) {

--- a/src/ray/raylet/task_spec.h
+++ b/src/ray/raylet/task_spec.h
@@ -153,6 +153,11 @@ class TaskSpecification {
   flatbuffers::Offset<flatbuffers::String> ToFlatbuffer(
       flatbuffers::FlatBufferBuilder &fbb) const;
 
+  /// Get the task's object dependencies.
+  ///
+  /// \return The object dependencies. These are immutable.
+  const std::vector<ObjectID> &GetDependencies() const;
+
   // TODO(swang): Finalize and document these methods.
   TaskID TaskId() const;
   UniqueID DriverId() const;
@@ -204,12 +209,15 @@ class TaskSpecification {
   const uint8_t *data() const;
   /// Get the size in bytes of the task specification.
   size_t size() const;
+
+  /// The task specification data.
+  std::vector<uint8_t> spec_;
   /// Field storing required resources. Initalized in constructor.
   ResourceSet required_resources_;
   /// Field storing required placement resources. Initalized in constructor.
   ResourceSet required_placement_resources_;
-  /// The task specification data.
-  std::vector<uint8_t> spec_;
+  /// A cache of the task's object dependencies. Initialized in constructor.
+  std::vector<ObjectID> arguments_;
 };
 
 }  // namespace raylet


### PR DESCRIPTION
## What do these changes do?

The task dependency manager makes any needed object dependencies local, by pulling from a remote object manager if necessary. However, tasks that call `ray.wait` do not actually need the data transferred. Also, actor dummy objects have no data and therefore can never be pulled from a remote object manager. This PR prevents transfer of these objects by adding an extra `request_transfer` flag to the task dependency manager's methods.