### PR TITLE
Skip ready queue when no resources

### DIFF
--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -92,6 +92,7 @@ ExternalProject_Add(arrow_ep
   DEPENDS flatbuffers boost glog
   GIT_REPOSITORY ${arrow_URL}
   GIT_TAG ${arrow_TAG}
+  UPDATE_COMMAND ""
   ${ARROW_CONFIGURE}
   BUILD_BYPRODUCTS "${ARROW_SHARED_LIB}" "${ARROW_STATIC_LIB}")
 

--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -92,7 +92,6 @@ ExternalProject_Add(arrow_ep
   DEPENDS flatbuffers boost glog
   GIT_REPOSITORY ${arrow_URL}
   GIT_TAG ${arrow_TAG}
-  UPDATE_COMMAND ""
   ${ARROW_CONFIGURE}
   BUILD_BYPRODUCTS "${ARROW_SHARED_LIB}" "${ARROW_STATIC_LIB}")
 

--- a/src/ray/raylet/CMakeLists.txt
+++ b/src/ray/raylet/CMakeLists.txt
@@ -36,6 +36,7 @@ ADD_RAY_TEST(worker_pool_test STATIC_LINK_LIBS ray_static ${PLASMA_STATIC_LIB} $
 
 ADD_RAY_TEST(client_connection_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})
 ADD_RAY_TEST(task_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})
+ADD_RAY_TEST(resource_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})
 ADD_RAY_TEST(lineage_cache_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})
 ADD_RAY_TEST(task_dependency_manager_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})
 ADD_RAY_TEST(reconstruction_policy_test STATIC_LINK_LIBS ray_static gtest gtest_main gmock_main pthread ${Boost_SYSTEM_LIBRARY})

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -518,9 +518,11 @@ void NodeManager::DispatchTasks(const std::list<Task> &ready_tasks) {
   std::unordered_set<TaskID> removed_task_ids = {};
 
   for (const auto &task : ready_tasks) {
-    //if (!local_queues_.GetReadyQueue().CanScheduleMinTask(local_available_resources_)) {
-    //  break;
-    //}
+    if (!local_queues_.GetReadyQueue().CanScheduleMinTask(local_available_resources_)) {
+      // Local available resources cannot satisfy the requirements of any task
+      // still in the ready queue, so skip the remaining tasks.
+      break;
+    }
     const auto &task_resources = task.GetTaskSpecification().GetRequiredResources();
     if (!local_available_resources_.Contains(task_resources)) {
       // Not enough local resources for this task right now, skip this task.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -518,6 +518,9 @@ void NodeManager::DispatchTasks(const std::list<Task> &ready_tasks) {
   std::unordered_set<TaskID> removed_task_ids = {};
 
   for (const auto &task : ready_tasks) {
+    //if (!local_queues_.GetReadyQueue().CanScheduleMinTask(local_available_resources_)) {
+    //  break;
+    //}
     const auto &task_resources = task.GetTaskSpecification().GetRequiredResources();
     if (!local_available_resources_.Contains(task_resources)) {
       // Not enough local resources for this task right now, skip this task.

--- a/src/ray/raylet/resource_test.cc
+++ b/src/ray/raylet/resource_test.cc
@@ -34,25 +34,25 @@ TEST(ResourceTest, TestSchedulingQueue) {
   auto task = CreateTask(requirements);
   auto task_id = task.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task});
-  auto qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+  auto rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, rmq.GetMinTaskResources());
 
   auto task1 = CreateTask(requirements);
   auto task_id1 = task1.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task1});
-  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rmq.GetMinTaskResources());
 
   std::unordered_map<std::string, double> requirements2 = {{"CPU", 2}};
   auto rs2 = ResourceSet(requirements2);
   auto task2 = CreateTask(requirements2);
   const auto task_id2 = task2.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task2});
-  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
 
   std::unordered_map<std::string, double> available = {{"CPU", 2}, {"GPU", 1}};
   auto rs_available = ResourceSet(available);
@@ -62,9 +62,9 @@ TEST(ResourceTest, TestSchedulingQueue) {
   std::unordered_set<TaskID> removed_tasks = {};
   removed_tasks.insert(task_id2);
   queues.RemoveTasks(removed_tasks);
-  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rmq.GetMinTaskResources());
 
   schedule_flag = queues.GetReadyQueue().CanScheduleMinTask(rs_available);
   ASSERT_EQ(schedule_flag, false);
@@ -72,47 +72,47 @@ TEST(ResourceTest, TestSchedulingQueue) {
   removed_tasks = {};
   removed_tasks.insert(task_id);
   queues.RemoveTasks(removed_tasks);
-  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, rmq.GetMinTaskResources());
 
   removed_tasks = {};
   removed_tasks.insert(task_id1);
   queues.RemoveTasks(removed_tasks);
-  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
+  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
+  ASSERT_EQ(rmq.GetMinTaskCount(), 0);
 }
 
 
-TEST(ResourceTest, TestQueueReadyMetadata) {
-  QueueReadyMetadata qrm;
+TEST(ResourceTest, TestReadyQueueMetadata) {
+  ReadyQueueMetadata rmq;
 
   auto rs = ResourceSet({{"CPU", 2}, {"GPU", 2}});
-  qrm.UpdateMinOnAdd(rs);
+  rmq.UpdateMinOnAdd(rs);
 
-  qrm.UpdateMinOnAdd(rs);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+  rmq.UpdateMinOnAdd(rs);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rmq.GetMinTaskResources());
 
   auto rs1 = ResourceSet({{"CPU", 2}, {"GPU", 1}});
-  qrm.UpdateMinOnAdd(rs1);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs1, qrm.GetMinTaskResources());
+  rmq.UpdateMinOnAdd(rs1);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs1, rmq.GetMinTaskResources());
 
   auto rs2 = ResourceSet({{"CPU", 2}});
-  qrm.UpdateMinOnAdd(rs2);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+  rmq.UpdateMinOnAdd(rs2);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
 
-  qrm.UpdateMinOnRemove(rs);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+  rmq.UpdateMinOnRemove(rs);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
 
-  qrm.UpdateMinOnRemove(rs1);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  rmq.UpdateMinOnRemove(rs1);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
 
-  qrm.UpdateMinOnRemove(rs2);
-  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
+  rmq.UpdateMinOnRemove(rs2);
+  ASSERT_EQ(rmq.GetMinTaskCount(), 0);
 }
 
 

--- a/src/ray/raylet/resource_test.cc
+++ b/src/ray/raylet/resource_test.cc
@@ -34,25 +34,25 @@ TEST(ResourceTest, TestSchedulingQueue) {
   auto task = CreateTask(requirements);
   auto task_id = task.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task});
-  auto rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, rmq.GetMinTaskResources());
+  auto rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, rq.GetMinTaskResources());
 
   auto task1 = CreateTask(requirements);
   auto task_id1 = task1.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task1});
-  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, rmq.GetMinTaskResources());
+  rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rq.GetMinTaskResources());
 
   std::unordered_map<std::string, double> requirements2 = {{"CPU", 2}};
   auto rs2 = ResourceSet(requirements2);
   auto task2 = CreateTask(requirements2);
   const auto task_id2 = task2.GetTaskSpecification().TaskId();
   queues.QueueReadyTasks({task2});
-  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
+  rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rq.GetMinTaskResources());
 
   std::unordered_map<std::string, double> available = {{"CPU", 2}, {"GPU", 1}};
   auto rs_available = ResourceSet(available);
@@ -62,9 +62,9 @@ TEST(ResourceTest, TestSchedulingQueue) {
   std::unordered_set<TaskID> removed_tasks = {};
   removed_tasks.insert(task_id2);
   queues.RemoveTasks(removed_tasks);
-  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, rmq.GetMinTaskResources());
+  rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rq.GetMinTaskResources());
 
   schedule_flag = queues.GetReadyQueue().CanScheduleMinTask(rs_available);
   ASSERT_EQ(schedule_flag, false);
@@ -72,47 +72,47 @@ TEST(ResourceTest, TestSchedulingQueue) {
   removed_tasks = {};
   removed_tasks.insert(task_id);
   queues.RemoveTasks(removed_tasks);
-  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, rmq.GetMinTaskResources());
+  rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, rq.GetMinTaskResources());
 
   removed_tasks = {};
   removed_tasks.insert(task_id1);
   queues.RemoveTasks(removed_tasks);
-  rmq = queues.GetReadyQueue().GetReadyQueueMetadata();
-  ASSERT_EQ(rmq.GetMinTaskCount(), 0);
+  rq = queues.GetReadyQueue();
+  ASSERT_EQ(rq.GetMinTaskCount(), 0);
 }
 
 
 TEST(ResourceTest, TestReadyQueueMetadata) {
-  ReadyQueueMetadata rmq;
+  ReadyQueue rq;
 
   auto rs = ResourceSet({{"CPU", 2}, {"GPU", 2}});
-  rmq.UpdateMinOnAdd(rs);
+  rq.UpdateMinOnAdd(rs);
 
-  rmq.UpdateMinOnAdd(rs);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, rmq.GetMinTaskResources());
+  rq.UpdateMinOnAdd(rs);
+  ASSERT_EQ(rq.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, rq.GetMinTaskResources());
 
   auto rs1 = ResourceSet({{"CPU", 2}, {"GPU", 1}});
-  rmq.UpdateMinOnAdd(rs1);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs1, rmq.GetMinTaskResources());
+  rq.UpdateMinOnAdd(rs1);
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs1, rq.GetMinTaskResources());
 
   auto rs2 = ResourceSet({{"CPU", 2}});
-  rmq.UpdateMinOnAdd(rs2);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
+  rq.UpdateMinOnAdd(rs2);
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rq.GetMinTaskResources());
 
-  rmq.UpdateMinOnRemove(rs);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, rmq.GetMinTaskResources());
+  rq.UpdateMinOnRemove(rs);
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, rq.GetMinTaskResources());
 
-  rmq.UpdateMinOnRemove(rs1);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 1);
+  rq.UpdateMinOnRemove(rs1);
+  ASSERT_EQ(rq.GetMinTaskCount(), 1);
 
-  rmq.UpdateMinOnRemove(rs2);
-  ASSERT_EQ(rmq.GetMinTaskCount(), 0);
+  rq.UpdateMinOnRemove(rs2);
+  ASSERT_EQ(rq.GetMinTaskCount(), 0);
 }
 
 

--- a/src/ray/raylet/resource_test.cc
+++ b/src/ray/raylet/resource_test.cc
@@ -1,0 +1,190 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ray/raylet/format/node_manager_generated.h"
+#include "ray/raylet/lineage_cache.h"
+#include "ray/raylet/task.h"
+#include "ray/raylet/task_execution_spec.h"
+#include "ray/raylet/task_spec.h"
+#include "ray/raylet/scheduling_queue.h"
+
+
+namespace ray {
+
+namespace raylet {
+
+void TestTaskReturnId(const TaskID &task_id, int64_t return_index) {
+  // Round trip test for computing the object ID for a task's return value,
+  // then computing the task ID that created the object.
+  ObjectID return_id = ComputeReturnId(task_id, return_index);
+  ASSERT_EQ(ComputeTaskId(return_id), task_id);
+  ASSERT_EQ(ComputeObjectIndex(return_id), return_index);
+}
+
+void TestTaskPutId(const TaskID &task_id, int64_t put_index) {
+  // Round trip test for computing the object ID for a task's put value, then
+  // computing the task ID that created the object.
+  ObjectID put_id = ComputePutId(task_id, put_index);
+  ASSERT_EQ(ComputeTaskId(put_id), task_id);
+  ASSERT_EQ(ComputeObjectIndex(put_id), -1 * put_index);
+}
+
+
+Task CreateTask(std::unordered_map<std::string, double> required_resources) {
+  std::vector<std::shared_ptr<TaskArgument>> arguments;
+  std::vector<ObjectID> references = {};
+  arguments.emplace_back(std::make_shared<TaskArgumentByReference>(references));
+
+  auto spec = TaskSpecification(UniqueID::from_random(), TaskID::from_random(), 0,
+                                FunctionID::nil(), arguments, 0,
+                                required_resources, Language::PYTHON);
+  auto execution_spec = TaskExecutionSpecification(std::vector<ObjectID>());
+  Task task = Task(execution_spec, spec);
+  return task;
+}
+
+TEST(ResourceTest, TestSchedulingQueue) {
+  SchedulingQueue queues;
+
+  std::unordered_map<std::string, double> requirements = {{"CPU", 2}, {"GPU", 2}};
+  auto rs = ResourceSet(requirements);
+  auto task = CreateTask(requirements);
+  auto task_id = task.GetTaskSpecification().TaskId();
+  queues.QueueReadyTasks({task});
+  auto qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  auto task1 = CreateTask(requirements);
+  auto task_id1 = task1.GetTaskSpecification().TaskId();
+  queues.QueueReadyTasks({task1});
+  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  std::unordered_map<std::string, double> requirements2 = {{"CPU", 2}};
+  auto rs2 = ResourceSet(requirements2);
+  auto task2 = CreateTask(requirements2);
+  const auto task_id2 = task2.GetTaskSpecification().TaskId();
+  queues.QueueReadyTasks({task2});
+  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+
+  std::unordered_map<std::string, double> available = {{"CPU", 2}, {"GPU", 1}};
+  auto rs_available = ResourceSet(available);
+  auto schedule_flag = queues.GetReadyQueue().CanScheduleMinTask(rs_available);
+  ASSERT_EQ(schedule_flag, true);
+
+  std::unordered_set<TaskID> removed_tasks = {};
+  removed_tasks.insert(task_id2);
+  queues.RemoveTasks(removed_tasks);
+  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  schedule_flag = queues.GetReadyQueue().CanScheduleMinTask(rs_available);
+  ASSERT_EQ(schedule_flag, false);
+
+  removed_tasks = {};
+  removed_tasks.insert(task_id);
+  queues.RemoveTasks(removed_tasks);
+  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  removed_tasks = {};
+  removed_tasks.insert(task_id1);
+  queues.RemoveTasks(removed_tasks);
+  qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
+}
+
+TEST(ResourceTest, TestTaskQueue) {
+  SchedulingQueue::TaskQueue task_queue;
+
+  std::unordered_map<std::string, double> requirements = {{"CPU", 2}, {"GPU", 2}};
+  auto rs = ResourceSet(requirements);
+
+  auto task = CreateTask(requirements);
+  auto task_id = task.GetTaskSpecification().TaskId();
+  task_queue.AppendTask(task_id, task, true);
+  auto qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  auto task1 = CreateTask(requirements);
+  auto task_id1 = task1.GetTaskSpecification().TaskId();
+  task_queue.AppendTask(task_id1, task1, true);
+  qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  std::unordered_map<std::string, double> requirements2 = {{"CPU", 2}};
+  auto rs2 = ResourceSet(requirements2);
+  auto task2 = CreateTask(requirements2);
+  auto task_id2 = task2.GetTaskSpecification().TaskId();
+  task_queue.AppendTask(task_id2, task2, true);
+  qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+
+  std::vector<Task> removed_tasks;
+  bool flag = task_queue.RemoveTask(task_id2, &removed_tasks, true);
+  ASSERT_EQ(flag, true);
+  ASSERT_EQ(removed_tasks.size(), 1);
+  qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  task_queue.RemoveTask(task_id, &removed_tasks, true);
+  qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  task_queue.RemoveTask(task_id1, &removed_tasks, true);
+  qrm = task_queue.GetQueueReadyMetadata();
+  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
+}
+
+
+TEST(ResourceTest, TestQueueReadyMetadata) {
+  QueueReadyMetadata qrm;
+
+  auto rs = ResourceSet({{"CPU", 2}, {"GPU", 2}});
+  qrm.UpdateMinTaskOnAdd(rs);
+
+  qrm.UpdateMinTaskOnAdd(rs);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
+  ASSERT_EQ(rs, qrm.GetMinTaskResources());
+
+  auto rs1 = ResourceSet({{"CPU", 2}, {"GPU", 1}});
+  qrm.UpdateMinTaskOnAdd(rs1);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs1, qrm.GetMinTaskResources());
+
+  auto rs2 = ResourceSet({{"CPU", 2}});
+  qrm.UpdateMinTaskOnAdd(rs2);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+
+  qrm.UpdateMinTaskOnRemove(rs);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
+
+  qrm.UpdateMinTaskOnRemove(rs1);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
+
+  qrm.UpdateMinTaskOnRemove(rs2);
+  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
+}
+
+
+}  // namespace raylet
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/raylet/resource_test.cc
+++ b/src/ray/raylet/resource_test.cc
@@ -13,23 +13,6 @@ namespace ray {
 
 namespace raylet {
 
-void TestTaskReturnId(const TaskID &task_id, int64_t return_index) {
-  // Round trip test for computing the object ID for a task's return value,
-  // then computing the task ID that created the object.
-  ObjectID return_id = ComputeReturnId(task_id, return_index);
-  ASSERT_EQ(ComputeTaskId(return_id), task_id);
-  ASSERT_EQ(ComputeObjectIndex(return_id), return_index);
-}
-
-void TestTaskPutId(const TaskID &task_id, int64_t put_index) {
-  // Round trip test for computing the object ID for a task's put value, then
-  // computing the task ID that created the object.
-  ObjectID put_id = ComputePutId(task_id, put_index);
-  ASSERT_EQ(ComputeTaskId(put_id), task_id);
-  ASSERT_EQ(ComputeObjectIndex(put_id), -1 * put_index);
-}
-
-
 Task CreateTask(std::unordered_map<std::string, double> required_resources) {
   std::vector<std::shared_ptr<TaskArgument>> arguments;
   std::vector<ObjectID> references = {};
@@ -97,53 +80,6 @@ TEST(ResourceTest, TestSchedulingQueue) {
   removed_tasks.insert(task_id1);
   queues.RemoveTasks(removed_tasks);
   qrm = queues.GetReadyQueue().GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 0);
-}
-
-TEST(ResourceTest, TestTaskQueue) {
-  SchedulingQueue::TaskQueue task_queue;
-
-  std::unordered_map<std::string, double> requirements = {{"CPU", 2}, {"GPU", 2}};
-  auto rs = ResourceSet(requirements);
-
-  auto task = CreateTask(requirements);
-  auto task_id = task.GetTaskSpecification().TaskId();
-  task_queue.AppendTask(task_id, task, true);
-  auto qrm = task_queue.GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
-
-  auto task1 = CreateTask(requirements);
-  auto task_id1 = task1.GetTaskSpecification().TaskId();
-  task_queue.AppendTask(task_id1, task1, true);
-  qrm = task_queue.GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
-
-  std::unordered_map<std::string, double> requirements2 = {{"CPU", 2}};
-  auto rs2 = ResourceSet(requirements2);
-  auto task2 = CreateTask(requirements2);
-  auto task_id2 = task2.GetTaskSpecification().TaskId();
-  task_queue.AppendTask(task_id2, task2, true);
-  qrm = task_queue.GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs2, qrm.GetMinTaskResources());
-
-  std::vector<Task> removed_tasks;
-  bool flag = task_queue.RemoveTask(task_id2, &removed_tasks, true);
-  ASSERT_EQ(flag, true);
-  ASSERT_EQ(removed_tasks.size(), 1);
-  qrm = task_queue.GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 2);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
-
-  task_queue.RemoveTask(task_id, &removed_tasks, true);
-  qrm = task_queue.GetQueueReadyMetadata();
-  ASSERT_EQ(qrm.GetMinTaskCount(), 1);
-  ASSERT_EQ(rs, qrm.GetMinTaskResources());
-
-  task_queue.RemoveTask(task_id1, &removed_tasks, true);
-  qrm = task_queue.GetQueueReadyMetadata();
   ASSERT_EQ(qrm.GetMinTaskCount(), 0);
 }
 

--- a/src/ray/raylet/resource_test.cc
+++ b/src/ray/raylet/resource_test.cc
@@ -152,30 +152,30 @@ TEST(ResourceTest, TestQueueReadyMetadata) {
   QueueReadyMetadata qrm;
 
   auto rs = ResourceSet({{"CPU", 2}, {"GPU", 2}});
-  qrm.UpdateMinTaskOnAdd(rs);
+  qrm.UpdateMinOnAdd(rs);
 
-  qrm.UpdateMinTaskOnAdd(rs);
+  qrm.UpdateMinOnAdd(rs);
   ASSERT_EQ(qrm.GetMinTaskCount(), 2);
   ASSERT_EQ(rs, qrm.GetMinTaskResources());
 
   auto rs1 = ResourceSet({{"CPU", 2}, {"GPU", 1}});
-  qrm.UpdateMinTaskOnAdd(rs1);
+  qrm.UpdateMinOnAdd(rs1);
   ASSERT_EQ(qrm.GetMinTaskCount(), 1);
   ASSERT_EQ(rs1, qrm.GetMinTaskResources());
 
   auto rs2 = ResourceSet({{"CPU", 2}});
-  qrm.UpdateMinTaskOnAdd(rs2);
+  qrm.UpdateMinOnAdd(rs2);
   ASSERT_EQ(qrm.GetMinTaskCount(), 1);
   ASSERT_EQ(rs2, qrm.GetMinTaskResources());
 
-  qrm.UpdateMinTaskOnRemove(rs);
+  qrm.UpdateMinOnRemove(rs);
   ASSERT_EQ(qrm.GetMinTaskCount(), 1);
   ASSERT_EQ(rs2, qrm.GetMinTaskResources());
 
-  qrm.UpdateMinTaskOnRemove(rs1);
+  qrm.UpdateMinOnRemove(rs1);
   ASSERT_EQ(qrm.GetMinTaskCount(), 1);
 
-  qrm.UpdateMinTaskOnRemove(rs2);
+  qrm.UpdateMinOnRemove(rs2);
   ASSERT_EQ(qrm.GetMinTaskCount(), 0);
 }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -109,10 +109,6 @@ bool TaskQueue::HasTask(const TaskID &task_id) const {
   return task_map_.find(task_id) != task_map_.end();
 }
 
-// const ResourceSet &TaskQueue::GetCurrentResourceLoad() const {
-//   return ready_tasks_metadata_.GetCurrentResourceLoad();
-// }
-
 const std::list<Task> &TaskQueue::GetTasks() const { return task_list_; }
 
 bool ReadyQueue::AppendTask(const TaskID &task_id, const Task &task) {
@@ -264,8 +260,7 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   std::vector<Task> removed_tasks;
 
   // Try to find the tasks to remove from the queues.
-  RemoveTasksFromQueue(methods_waiting_for_actor_creation_, task_ids,
-                       removed_tasks);
+  RemoveTasksFromQueue(methods_waiting_for_actor_creation_, task_ids, removed_tasks);
   RemoveTasksFromQueue(waiting_tasks_, task_ids, removed_tasks);
   RemoveTasksFromQueue(placeable_tasks_, task_ids, removed_tasks);
   RemoveTasksFromQueue(ready_tasks_, task_ids, removed_tasks);

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -93,7 +93,7 @@ void QueueReadyMetadata::UpdateMinTaskOnAdd(const ResourceSet &resources) {
   }
   if (resources.IsSubset(min_task_resources_)) {
     if (min_task_resources_.IsSubset(resources)) {
-      // resources == min_task_resources_
+      // In this case, resources == min_task_resources._
       min_task_count_++;
     } else {
       min_task_resources_ = resources;

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -73,19 +73,19 @@ namespace ray {
 
 namespace raylet {
 
-void QueueReadyMetadata::UpdateSumOnAdd(const ResourceSet &resources) {
+void ReadyQueueMetadata::UpdateSumOnAdd(const ResourceSet &resources) {
   current_resource_load_.AddResources(resources);
 }
 
-void QueueReadyMetadata::UpdateSumOnRemove(const ResourceSet &resources) {
+void ReadyQueueMetadata::UpdateSumOnRemove(const ResourceSet &resources) {
   current_resource_load_.SubtractResourcesStrict(resources);
 }
 
-const ResourceSet &QueueReadyMetadata::GetCurrentResourceLoad() const {
+const ResourceSet &ReadyQueueMetadata::GetCurrentResourceLoad() const {
   return current_resource_load_;
 }
 
-void QueueReadyMetadata::UpdateMinOnAdd(const ResourceSet &resources) {
+void ReadyQueueMetadata::UpdateMinOnAdd(const ResourceSet &resources) {
   if (min_task_count_ <= 0) {
     min_task_resources_ = resources;
     min_task_count_= 1;
@@ -102,7 +102,7 @@ void QueueReadyMetadata::UpdateMinOnAdd(const ResourceSet &resources) {
   }
 };
 
-void QueueReadyMetadata::UpdateMinOnRemove(const ResourceSet &resources) {
+void ReadyQueueMetadata::UpdateMinOnRemove(const ResourceSet &resources) {
   if (min_task_resources_ == resources) {
     min_task_count_--;
   }

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -93,7 +93,7 @@ void QueueReadyMetadata::UpdateMinOnAdd(const ResourceSet &resources) {
   }
   if (resources.IsSubset(min_task_resources_)) {
     if (min_task_resources_.IsSubset(resources)) {
-      // In this case, resources == min_task_resources._
+      // In this case, resources == min_task_resources_.
       min_task_count_++;
     } else {
       min_task_resources_ = resources;

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -113,9 +113,10 @@ const std::list<Task> &TaskQueue::GetTasks() const { return task_list_; }
 
 bool ReadyQueue::AppendTask(const TaskID &task_id, const Task &task) {
   bool result = TaskQueue::AppendTask(task_id, task);
-  // Resource bookkeeping
   const auto &task_resources = task.GetTaskSpecification().GetRequiredResources();
+  // Update sum resources.
   current_resource_load_.AddResources(task_resources);
+  // Update min resources.
   UpdateMinOnAdd(task_resources);
   return result;
 }

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -82,7 +82,7 @@ TaskQueue::~TaskQueue() {
 }
 
 bool TaskQueue::AppendTask(const TaskID &task_id,
-                                            const Task &task) {
+                           const Task &task) {
   RAY_CHECK(task_map_.find(task_id) == task_map_.end());
   auto list_iterator = task_list_.insert(task_list_.end(), task);
   task_map_[task_id] = list_iterator;
@@ -90,7 +90,7 @@ bool TaskQueue::AppendTask(const TaskID &task_id,
 }
 
 bool TaskQueue::RemoveTask(const TaskID &task_id,
-                          std::vector<Task> *removed_tasks) {
+                           std::vector<Task> *removed_tasks) {
   auto task_found_iterator = task_map_.find(task_id);
   if (task_found_iterator == task_map_.end()) {
     return false;

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -50,14 +50,14 @@ public:
   ///
   /// \param resources: The resource set to add.
   /// \return Void.
-  void AddResources(const ResourceSet &resources);
+  void UpdateSumOnAdd(const ResourceSet &resources);
 
   /// \brief Subtract a set of resources from the current set of resources, only if
   /// resource labels match.
   ///
   /// \param resources: The resource set to subtract from the current resource set.
   /// \return Void.
-  void RemoveResources(const ResourceSet &resources);
+  void UpdateSumOnRemove(const ResourceSet &resources);
 
   /// \brief Get the total resources required by the tasks in the queue.
   ///
@@ -68,13 +68,13 @@ public:
   //  when a new task is added to the queue.
   ///
   /// \param resources: Resource requirements of the new task being added.
-  void UpdateMinTaskOnAdd(const ResourceSet &resources);
+  void UpdateMinOnAdd(const ResourceSet &resources);
 
   /// \brief Update the min resources required by a task in the ready queue,
   //  when a task is removed from the queue.
   ///
   /// \param resources: Resource requirements of the new task being removed.
-  void UpdateMinTaskOnRemove(const ResourceSet &resources);
+  void UpdateMinOnRemove(const ResourceSet &resources);
 
   /// \brief Get resources of the task with the minimum resource requirements
   /// in the ready queue.

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -85,8 +85,20 @@ protected:
 
 class ReadyQueue : public TaskQueue {
 public:
+  /// \brief Append a task to the ready queue.
+  ///
+  /// \param task_id The task ID for the task to append.
+  /// \param task The task to append to the queue.
+  /// \return Whether the append operation succeeds.
   bool AppendTask(const TaskID &task_id, const Task &task);
 
+  /// \brief Remove a task from the ready queue.
+  ///
+  /// \param task_id The task ID for the task to remove from the queue.
+  /// \param removed_tasks If the task specified by task_id is successfully
+  ///  removed from the queue, the task data is appended to the vector. Can
+  ///  be a nullptr, in which case nothing is appended.
+  /// \return Whether the removal succeeds.
   bool RemoveTask(const TaskID &task_id,
                   std::vector<Task> *removed_tasks = nullptr);
 

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -37,13 +37,13 @@ enum class TaskState {
   INFEASIBLE
 };
 
-class QueueReadyMetadata {
+class ReadyQueueMetadata {
 public:
   /// Create metadata for ready queue.
-  QueueReadyMetadata() {}
+  ReadyQueueMetadata() {}
 
   /// Destructor for metadata of ready queue.
-  virtual ~QueueReadyMetadata() {}
+  virtual ~ReadyQueueMetadata() {}
 
   /// \brief Aggregate resources from the other set into this set, adding any missing
   /// resource labels to this set.
@@ -343,7 +343,7 @@ class SchedulingQueue {
     /// \brief Return metadata associated with the ready queue.
     ///
     /// \return Metadata associated with the ready queue.
-    const QueueReadyMetadata &GetQueueReadyMetadata() const {
+    const ReadyQueueMetadata &GetReadyQueueMetadata() const {
       return ready_tasks_metadata_;
     }
 
@@ -353,7 +353,7 @@ class SchedulingQueue {
     /// A hash to speed up looking up a task.
     std::unordered_map<TaskID, std::list<Task>::iterator> task_map_;
     /// Metadata associated to ready queue.
-    QueueReadyMetadata ready_tasks_metadata_;
+    ReadyQueueMetadata ready_tasks_metadata_;
   };
 
   /// \brief Get the ready queue.

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -352,11 +352,11 @@ class SchedulingQueue {
     std::list<Task> task_list_;
     /// A hash to speed up looking up a task.
     std::unordered_map<TaskID, std::list<Task>::iterator> task_map_;
-    /// Metadata associated to readsy queue.
+    /// Metadata associated to ready queue.
     QueueReadyMetadata ready_tasks_metadata_;
   };
 
-  /// \brief Het ready queue.
+  /// \brief Get the ready queue.
   ///
   /// \return Ready queue.
   const TaskQueue &GetReadyQueue() const { return ready_tasks_; };

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -51,35 +51,49 @@ public:
   /// \param resources: The resource set to add.
   /// \return Void.
   void AddResources(const ResourceSet &resources);
+
   /// \brief Subtract a set of resources from the current set of resources, only if
   /// resource labels match.
   ///
   /// \param resources: The resource set to subtract from the current resource set.
   /// \return Void.
   void RemoveResources(const ResourceSet &resources);
+
   /// \brief Get the total resources required by the tasks in the queue.
   ///
   /// \return Total resources required by the tasks in the queue.
   const ResourceSet &GetCurrentResourceLoad() const;
-  /// \brief Add task resource info to metadata.
-  ///
-  /// \param Resource set to be added.
-  void AddTask(const ResourceSet &resources);
-  /// \brief Remove resource info from metadata.
-  ///
-  /// \param Resource set to be removed.
-  void RemoveTask(const ResourceSet &resources);
 
-  const ResourceSet &GetMinTaskResources() { return min_task_resources_;};
+  /// \brief Update the min  resources required by a task in the ready queue,
+  //  when a new task is added to the queue.
+  ///
+  /// \param resources: Resource requirements of the new task being added.
+  void UpdateMinTaskOnAdd(const ResourceSet &resources);
 
-  const int &GetMinTaskCount() { return min_task_count_;};
+  /// \brief Update the min resources required by a task in the ready queue,
+  //  when a task is removed from the queue.
+  ///
+  /// \param resources: Resource requirements of the new task being removed.
+  void UpdateMinTaskOnRemove(const ResourceSet &resources);
+
+  /// \brief Get resources of the task with the minimum resource requirements
+  /// in the ready queue.
+  ///
+  /// \return: Minimum resources required by any task in the ready queue.
+  const ResourceSet &GetMinTaskResources() const { return min_task_resources_;};
+
+  /// \brief Get number of tasks with minimum resource requirements in the
+  /// ready queue.
+  ///
+  /// \return Number of tasks with minimum resource requirements.
+  const int &GetMinTaskCount() const { return min_task_count_;};
 
 private:
   /// Aggregate resources of all the tasks in this queue.
   ResourceSet current_resource_load_;
-  /// Minimum resources requested by a task in tyhe ready queue.
+  /// Minimum resources requested by any task in tyhe ready queue.
   ResourceSet min_task_resources_;
-  /// Count of tasks which requests the lowest quantity of resources.
+  /// Count of tasks which the minimum resource requirements in the ready queue.
   int min_task_count_ = 0;
 };
 
@@ -315,10 +329,20 @@ class SchedulingQueue {
     /// \return Total resources required by the tasks in the queue.
     const ResourceSet &GetCurrentResourceLoad() const;
 
+    /// \brief Recompute the resources of the tasks with minimum requirements
+    /// in the ready queue.
     void RecomputeMinResources();
 
-    bool CanScheduleMinTask(const ResourceIdSet &local_available_resources);
+    /// \brief Check whether any of the tasks in the ready queue can be scheduled.
+    ///
+    /// \param local_available_resources: resources available on local node.
+    /// \return True if there is at least a task that can be scheduled, i.e.
+    /// whose requirements can be satisfied by the local node; false otherwise.
+    const bool CanScheduleMinTask(const ResourceIdSet &local_available_resources) const;
 
+    /// \brief Return metadata associated with the ready queue.
+    ///
+    /// \return Metadata associated with the ready queue.
     const QueueReadyMetadata &GetQueueReadyMetadata() const {
       return ready_tasks_metadata_;
     }
@@ -332,8 +356,10 @@ class SchedulingQueue {
     QueueReadyMetadata ready_tasks_metadata_;
   };
 
- /// XXX
- const TaskQueue &GetReadyQueue() const { return ready_tasks_; };
+  /// \brief Het ready queue.
+  ///
+  /// \return Ready queue.
+  const TaskQueue &GetReadyQueue() const { return ready_tasks_; };
 
  private:
   /// Tasks that are destined for actors that have not yet been created.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR improves the performance of selecting a task from ready queue to schedule when the resource availability change or a new worker becomes available. It is doing so by maintaining (1) the minimum resource quantities required by any task in the ready queue, and (2) and the number of such tasks. If (1) is larger than the available resources at the node, there is no need to walk through the ready queue, as we know that no tasks can be scheduled. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> Resolves the issue https://github.com/ray-project/ray/issues/3194.
