### PR TITLE
Release sender connections as soon as WriteMessageAsync completes

### DIFF
--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -57,6 +57,11 @@ class ConnectionPool {
   void RegisterSender(ConnectionType type, const ClientID &client_id,
                       std::shared_ptr<SenderConnection> &conn);
 
+  /// Remove a sender connection.
+  ///
+  /// \param conn The actual connection.
+  void RemoveSender(const std::shared_ptr<SenderConnection> &conn);
+
   /// Get a sender connection from the connection pool.
   /// The connection must be released or removed when the operation for which the
   /// connection was obtained is completed. If the connection pool is empty, the
@@ -107,6 +112,9 @@ class ConnectionPool {
   /// Removes the given receiver for ClientID from the given map.
   void Remove(ReceiverMapType &conn_map, const ClientID &client_id,
               std::shared_ptr<TcpClientConnection> &conn);
+
+  void Remove(SenderMapType &conn_map, const ClientID &client_id,
+              const std::shared_ptr<SenderConnection> &conn);
 
   /// Returns the count of sender connections to ClientID.
   uint64_t Count(SenderMapType &conn_map, const ClientID &client_id);

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -113,6 +113,7 @@ class ConnectionPool {
   void Remove(ReceiverMapType &conn_map, const ClientID &client_id,
               std::shared_ptr<TcpClientConnection> &conn);
 
+  /// Removes the given sender for ClientID from the given map.
   void Remove(SenderMapType &conn_map, const ClientID &client_id,
               const std::shared_ptr<SenderConnection> &conn);
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -6,15 +6,6 @@ namespace asio = boost::asio;
 
 namespace object_manager_protocol = ray::object_manager::protocol;
 
-namespace {
-
-void CheckIOError(ray::Status &status, const std::string &operation) {
-  RAY_CHECK(status.IsIOError());
-  RAY_LOG(ERROR) << "Failed to contact remote object manager during " << operation;
-}
-
-}  // namespace
-
 namespace ray {
 
 ObjectManager::ObjectManager(asio::io_service &main_service,
@@ -295,7 +286,8 @@ void ObjectManager::PullSendRequest(const ObjectID &object_id,
       static_cast<int64_t>(object_manager_protocol::MessageType::PullRequest),
       fbb.GetSize(), fbb.GetBufferPointer(), [this, conn](ray::Status status) {
         if (!status.ok()) {
-          CheckIOError(status, "Pull");
+          RAY_CHECK(status.IsIOError())
+              << "Failed to contact remote object manager during Pull";
           connection_pool_.RemoveSender(conn);
         }
       });
@@ -439,7 +431,9 @@ ray::Status ObjectManager::ExecuteSendObject(
   if (conn != nullptr) {
     status = SendObjectHeaders(object_id, data_size, metadata_size, chunk_index, conn);
     if (!status.ok()) {
-      CheckIOError(status, "Push");
+      RAY_CHECK(status.IsIOError())
+          << "Failed to contact remote object manager during Push";
+      connection_pool_.RemoveSender(conn);
     }
   }
   return status;
@@ -882,7 +876,8 @@ void ObjectManager::SpreadFreeObjectRequest(const std::vector<ObjectID> &object_
           static_cast<int64_t>(object_manager_protocol::MessageType::FreeRequest),
           fbb.GetSize(), fbb.GetBufferPointer(), [this, conn](ray::Status status) {
             if (!status.ok()) {
-              CheckIOError(status, "Free");
+              RAY_CHECK(status.IsIOError())
+                  << "Failed to contact remote object manager during Free";
               connection_pool_.RemoveSender(conn);
             }
           });


### PR DESCRIPTION
## What do these changes do?

Now that we use asynchronous messaging for the object manager, the messages for a given remote object manager will be buffered inside of the connection. Therefore, we can release the connection as soon as the message is queued, instead of waiting for the message to get sent completely. Since all messages that do not involve data transfer are sent on the object manager's main event loop, this also limits the number of outgoing connections per remote object manager to 1.

## Related issue number

Fixes #2941.
