### PR TITLE
[hot-fix] Fix error when calling Ray.init() twice.

### DIFF
--- a/java/api/src/main/java/org/ray/api/Ray.java
+++ b/java/api/src/main/java/org/ray/api/Ray.java
@@ -41,8 +41,10 @@ public final class Ray extends RayCall {
    * Shutdown Ray runtime.
    */
   public static void shutdown() {
-    runtime.shutdown();
-    runtime = null;
+    if (runtime != null) {
+      runtime.shutdown();
+      runtime = null;
+    }
   }
 
   /**

--- a/java/api/src/main/java/org/ray/api/Ray.java
+++ b/java/api/src/main/java/org/ray/api/Ray.java
@@ -42,6 +42,7 @@ public final class Ray extends RayCall {
    */
   public static void shutdown() {
     runtime.shutdown();
+    runtime = null;
   }
 
   /**


### PR DESCRIPTION
```java
Ray.init();
Ray.shutdown();
Ray.init();
```

This change will fix the code snippet.