### PR TITLE
Raise exception if the node is nearly out of memory

### DIFF
--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import os
+import subprocess
+import sys
+import time
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+    
+logger = logging.getLogger(__name__)
+
+
+class RayOutOfMemoryError(Exception):
+    def __init__(self, msg):
+        Exception.__init__(self, msg)
+
+    @staticmethod
+    def get_message(used_gb, total_gb, threshold):
+        try:
+            ps_output = subprocess.check_output(
+                "ps -eo pid,user,%mem,args --sort -%mem | "
+                "head -n 6 | cut -c-200",
+                shell=True)
+            ps_output = ps_output.decode(sys.stdout.encoding).strip()
+        except Exception as e:
+            ps_output = str(e)
+        return (
+            "More than {}% of the memory on ".format(
+                int(100 * threshold)) +
+            "node {} is used ({} / {} GB). ".format(
+                os.uname()[1], round(used_gb, 1), round(total_gb, 1)) +
+            "The top 5 memory consumers are:\n\n{}".format(ps_output))
+
+
+class MemoryMonitor(object):
+    def __init__(self, error_threshold=0.95, check_interval=5):
+        self.error_threshold = error_threshold
+        self.last_checked = time.time()
+        self.check_interval = check_interval
+        if not psutil:
+            logger.warning(
+                "WARNING: Not monitoring node memory since `psutil` is not "
+                "installed. Install this with `pip install psutil` to enable "
+                "debugging of memory-related crashes.")
+            
+
+    def raise_if_low_memory(self):
+        if not psutil:
+            return
+        if time.time() - self.last_checked > self.check_interval:
+            self.last_checked = time.time()
+            total_gb = psutil.virtual_memory().total / 1e9
+            used_gb = total_gb - psutil.virtual_memory().available / 1e9
+            if used_gb > total_gb * self.error_threshold:
+                raise RayOutOfMemoryError(
+                    RayOutOfMemoryError.get_message(
+                        used_gb, total_gb, self.error_threshold))
+            else:
+                logger.debug(
+                    "Memory usage is {} / {}".format(used_gb, total_gb))

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -36,6 +36,12 @@ class RayOutOfMemoryError(Exception):
 
 
 class MemoryMonitor(object):
+    """Helper class for raising errors on low memory.
+
+    This presents a much cleaner error message to users than what would happen
+    if we actually ran out of memory.
+    """
+
     def __init__(self, error_threshold=0.95, check_interval=1):
         # Note: it takes ~50us to check the memory usage through psutil, so
         # throttle this check at most once a second or so.

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -32,7 +32,12 @@ class RayOutOfMemoryError(Exception):
         return ("More than {}% of the memory on ".format(int(
             100 * threshold)) + "node {} is used ({} / {} GB). ".format(
                 os.uname()[1], round(used_gb, 2), round(total_gb, 1)) +
-                "The top 5 memory consumers are:\n\n{}".format(proc_str))
+                "The top 5 memory consumers are:\n\n{}".format(proc_str) +
+                "\n\nIn addition, ~{} GB of shared memory is ".format(
+                    round(psutil.virtual_memory().shared / 1e9, 2)) +
+                "currently being used by the Ray object store. You can set "
+                "the object store size with the `object_store_memory` "
+                "parameter when starting Ray.")
 
 
 class MemoryMonitor(object):

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -55,7 +55,7 @@ class MemoryMonitor(object):
                 "debugging of memory-related crashes.")
 
     def raise_if_low_memory(self):
-        if not psutil:
+        if not psutil or os.environ["RAY_DEBUG_DISABLE_MEMORY_MONITOR"]:
             return
         if time.time() - self.last_checked > self.check_interval:
             self.last_checked = time.time()

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -28,10 +28,10 @@ class RayOutOfMemoryError(Exception):
         proc_str = "PID\tMEM\tCOMMAND"
         for rss, pid, cmdline in sorted(proc_stats, reverse=True)[:5]:
             proc_str += "\n{}\t{}GB\t{}".format(
-                pid, round(rss / 1e9, 1), " ".join(cmdline)[:100].strip())
+                pid, round(rss / 1e9, 2), " ".join(cmdline)[:100].strip())
         return ("More than {}% of the memory on ".format(int(
             100 * threshold)) + "node {} is used ({} / {} GB). ".format(
-                os.uname()[1], round(used_gb, 2), round(total_gb, 1)) +
+                os.uname()[1], round(used_gb, 2), round(total_gb, 2)) +
                 "The top 5 memory consumers are:\n\n{}".format(proc_str) +
                 "\n\nIn addition, ~{} GB of shared memory is ".format(
                     round(psutil.virtual_memory().shared / 1e9, 2)) +

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -55,8 +55,12 @@ class MemoryMonitor(object):
                 "debugging of memory-related crashes.")
 
     def raise_if_low_memory(self):
-        if not psutil or os.environ["RAY_DEBUG_DISABLE_MEMORY_MONITOR"]:
-            return
+        if not psutil:
+            return  # nothing we can do
+
+        if "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ:
+            return  # escape hatch, not intended for user use
+
         if time.time() - self.last_checked > self.check_interval:
             self.last_checked = time.time()
             total_gb = psutil.virtual_memory().total / 1e9

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -25,6 +25,7 @@ import pyarrow.plasma as plasma
 import ray.cloudpickle as pickle
 import ray.experimental.state as state
 import ray.gcs_utils
+import ray.memory_monitor as memory_monitor
 import ray.remote_function
 import ray.serialization as serialization
 import ray.services as services
@@ -213,6 +214,7 @@ class Worker(object):
         # CUDA_VISIBLE_DEVICES environment variable.
         self.original_gpu_ids = ray.utils.get_cuda_visible_devices()
         self.profiler = profiling.Profiler(self)
+        self.memory_monitor = memory_monitor.MemoryMonitor()
         self.state_lock = threading.Lock()
         # A dictionary that maps from driver id to SerializationContext
         # TODO: clean up the SerializationContext once the job finished.
@@ -821,6 +823,7 @@ class Worker(object):
         try:
             if function_name != "__ray_terminate__":
                 self.reraise_actor_init_error()
+            self.memory_monitor.raise_if_low_memory()
             with profiling.profile("task:deserialize_arguments", worker=self):
                 arguments = self._get_arguments_for_execution(
                     function_name, args)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Currently memory errors result in something opaque like ArrowIOError or nodes disappearing. Fast fail to raise a nicer application level error that includes a list of the top memory hogs.

You can test this with something like:
```
import numpy as np
import ray

@ray.remote
class X(object):
    def __init__(self):
        self.data = []

    def alloc(self, n):
        self.data.append(np.random.randn(n))
        ray.put(np.random.randn(n))

ray.init()
x = X.remote()

while True:
    ray.get(x.alloc.remote(1000000))
```

Which will cause:
```
Remote function alloc failed with:

Traceback (most recent call last):
  File "/home/eric/Desktop/ray-private/python/ray/worker.py", line 826, in _process_task
    self.memory_monitor.raise_if_low_memory()
  File "/home/eric/Desktop/ray-private/python/ray/memory_monitor.py", line 76, in
raise_if_low_memory
    self.error_threshold))
ray.memory_monitor.RayOutOfMemoryError: More than 95% of the memory on node
eric-ThinkPad is used (11.8 / 12.3 GB). The top 5 memory consumers are:

PID	MEM	COMMAND
28442	5.0GB	ray_X:alloc()
15294	0.4GB	/opt/google/chrome/chrome --type=renderer
11863	0.4GB	/opt/google/chrome/chrome --type=renderer
27098	0.3GB	/opt/google/chrome/chrome --type=renderer
26611	0.2GB	/usr/lib/x86_64-linux-gnu/zeitgeist-fts

In addition, ~4.12 GB of shared memory is currently being used by the Ray object
store. You can set the object store size with the `object_store_memory` parameter
when starting Ray.
```