### PR TITLE
Fix socket retry message

### DIFF
--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -67,8 +67,10 @@ int connect_ipc_sock_retry(const char *socket_pathname, int num_retries,
     if (fd >= 0) {
       break;
     }
-    if (num_attempts == 0) {
-      RAY_LOG(ERROR) << "Connection to socket failed for pathname " << socket_pathname;
+    if (num_attempts > 0) {
+      RAY_LOG(ERROR) << "Retrying to connect to socket for pathname "
+                     << socket_pathname << " (num_attempts = " << num_attempts
+                     << ", num_retries = " << num_retries << ")";
     }
     /* Sleep for timeout milliseconds. */
     usleep(timeout * 1000);

--- a/src/ray/raylet/local_scheduler_client.cc
+++ b/src/ray/raylet/local_scheduler_client.cc
@@ -68,8 +68,8 @@ int connect_ipc_sock_retry(const char *socket_pathname, int num_retries,
       break;
     }
     if (num_attempts > 0) {
-      RAY_LOG(ERROR) << "Retrying to connect to socket for pathname "
-                     << socket_pathname << " (num_attempts = " << num_attempts
+      RAY_LOG(ERROR) << "Retrying to connect to socket for pathname " << socket_pathname
+                     << " (num_attempts = " << num_attempts
                      << ", num_retries = " << num_retries << ")";
     }
     /* Sleep for timeout milliseconds. */


### PR DESCRIPTION
Sometimes the retry message is shown even if nothing goes wrong (since processes might be slow to start up). This changes things so the message is only shown after the first retry and also so it looks less like a failure.