### PR TITLE
Update redis version in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -151,7 +151,7 @@ setup(
         "colorama",
         "pytest",
         "pyyaml",
-        "redis",
+        "redis~=2.10.6",
         "faulthandler;python_version<'3'",
         "setproctitle",
         # The six module is required by pyarrow.


### PR DESCRIPTION
* `redis` has released a new version (https://github.com/andymccurdy/redis-py/releases/tag/3.0.0)
* `ray` is not compatible with this version
* This PR adds the "compatible release" operator for `redis` version 2.10.6.