### PR TITLE
Allow object managers to cancel unnecessary object pull requests.

### DIFF
--- a/src/ray/object_manager/format/object_manager.fbs
+++ b/src/ray/object_manager/format/object_manager.fbs
@@ -29,7 +29,8 @@ enum MessageType:int {
   ConnectClient = 1,
   PushRequest,
   PullRequest,
-  FreeRequest
+  CancelPullRequest,
+  FreeRequest,
 }
 
 table PushRequestMessage {
@@ -44,6 +45,13 @@ table PushRequestMessage {
 }
 
 table PullRequestMessage {
+  // ID of the requesting client.
+  client_id: string;
+  // Requested ObjectID.
+  object_id: string;
+}
+
+table CancelPullRequestMessage {
   // ID of the requesting client.
   client_id: string;
   // Requested ObjectID.

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -109,7 +109,7 @@ void ObjectDirectory::LookupRemoteConnectionInfo(
     RemoteConnectionInfo &connection_info) const {
   ClientTableDataT client_data;
   gcs_client_->client_table().GetClient(connection_info.client_id, client_data);
-  ClientID result_client_id = ClientID::from_binary(client_data.client_id);
+  const ClientID result_client_id = ClientID::from_binary(client_data.client_id);
   if (!result_client_id.is_nil()) {
     RAY_CHECK(result_client_id == connection_info.client_id);
     if (client_data.is_insertion) {

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -222,8 +222,8 @@ void ObjectManager::TryPull(const ObjectID &object_id) {
   ClientID client_id_to_cancel;
   if (static_cast<int64_t>(it->second.clients_requested.size()) >=
       RayConfig::instance().object_manager_max_outstanding_pulls()) {
-    std::uniform_int_distribution<int>
-        cancel_distribution(0, it->second.clients_requested.size() - 1);
+    std::uniform_int_distribution<int> cancel_distribution(
+        0, it->second.clients_requested.size() - 1);
     int client_to_cancel_index = cancel_distribution(gen_);
     auto client_it = it->second.clients_requested.begin();
     for (int i = 0; i < client_to_cancel_index; ++i) {
@@ -922,7 +922,7 @@ void ObjectManager::ReceivePullRequest(std::shared_ptr<TcpClientConnection> &con
 void ObjectManager::ReceiveCancelPullRequest(std::shared_ptr<TcpClientConnection> &conn,
                                              const uint8_t *message) {
   auto cancellation_message =
-    flatbuffers::GetRoot<object_manager_protocol::CancelPullRequestMessage>(message);
+      flatbuffers::GetRoot<object_manager_protocol::CancelPullRequestMessage>(message);
   const ObjectID object_id =
       ObjectID::from_binary(cancellation_message->object_id()->str());
   const ClientID client_id =
@@ -969,8 +969,8 @@ void ObjectManager::ReceivePushRequest(std::shared_ptr<TcpClientConnection> &con
         // Notify the main thread that we have finished receiving the object.
         main_service_->post(
             [this, object_id, client_id, chunk_index, start_time, end_time, status]() {
-              HandleReceiveFinished(object_id, client_id, chunk_index, start_time, end_time,
-                                    status);
+              HandleReceiveFinished(object_id, client_id, chunk_index, start_time,
+                                    end_time, status);
             });
 
       });
@@ -1102,7 +1102,6 @@ std::string ObjectManager::DebugString() const {
   result << "\n" << connection_pool_.DebugString();
 
   return result.str();
-
 }
 
 }  // namespace ray

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -40,7 +40,8 @@ struct hash<std::pair<::ray::UniqueID, ::ray::UniqueID>> {
 
 template <>
 struct hash<std::tuple<::ray::UniqueID, ::ray::UniqueID, uint64_t>> {
-  size_t operator()(const std::tuple<::ray::UniqueID, ::ray::UniqueID, uint64_t> &ids) const {
+  size_t operator()(
+      const std::tuple<::ray::UniqueID, ::ray::UniqueID, uint64_t> &ids) const {
     return std::get<0>(ids).hash() + std::get<1>(ids).hash() + std::get<2>(ids);
   }
 };

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -227,7 +227,7 @@ class ObjectManager : public ObjectManagerInterface {
     std::vector<ClientID> client_locations;
     /// The IDs of the remote object managers that we have already requested the
     /// object from. If we cancel a request, then we will remove that client
-    /// from this vector.
+    /// from this set.
     std::unordered_set<ClientID> clients_requested;
   };
 
@@ -294,7 +294,7 @@ class ObjectManager : public ObjectManagerInterface {
   /// Part of an asynchronous sequence of Pull methods.
   /// Uses an existing connection or creates a connection to ClientID.
   /// Executes on main_service_ thread.
-  void PullEstablishConnection(const ObjectID &object_id, const ClientID &client_id);
+  void SendPullRequest(const ObjectID &object_id, const ClientID &client_id);
 
   /// Asynchronously send a pull request via remote object manager connection.
   /// Executes on main_service_ thread.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -336,7 +336,7 @@ class ObjectManager : public ObjectManagerInterface {
   /// Push more objects if there are pending pushes and there are available
   /// resources to push.
   ///
-  /// \return Void
+  /// \return Void.
   void DispatchPushes();
 
   /// This is used to notify the main thread that the receiving of a chunk has

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -100,6 +100,10 @@ class RayConfig {
 
   int object_manager_pull_timeout_ms() const { return object_manager_pull_timeout_ms_; }
 
+  int object_manager_max_outstanding_pulls() const {
+    return object_manager_max_outstanding_pulls_;
+  }
+
   int object_manager_push_timeout_ms() const { return object_manager_push_timeout_ms_; }
 
   int object_manager_repeated_push_delay_ms() const {
@@ -182,6 +186,8 @@ class RayConfig {
         node_manager_forward_task_retry_timeout_milliseconds_ = pair.second;
       } else if (pair.first == "object_manager_pull_timeout_ms") {
         object_manager_pull_timeout_ms_ = pair.second;
+      } else if (pair.first == "object_manager_max_outstanding_pulls") {
+        object_manager_max_outstanding_pulls_ = pair.second;
       } else if (pair.first == "object_manager_push_timeout_ms") {
         object_manager_push_timeout_ms_ = pair.second;
       } else if (pair.first == "object_manager_default_chunk_size") {
@@ -230,6 +236,7 @@ class RayConfig {
         actor_creation_num_spillbacks_warning_(100),
         node_manager_forward_task_retry_timeout_milliseconds_(1000),
         object_manager_pull_timeout_ms_(10000),
+        object_manager_max_outstanding_pulls_(3),
         object_manager_push_timeout_ms_(10000),
         object_manager_repeated_push_delay_ms_(60000),
         object_manager_default_chunk_size_(1000000),
@@ -347,6 +354,10 @@ class RayConfig {
   /// Timeout, in milliseconds, to wait before retrying a failed pull in the
   /// ObjectManager.
   int object_manager_pull_timeout_ms_;
+
+  /// The maximum number of remote object managers that a given object manager
+  /// should be simultaneously requesting an object from.
+  int object_manager_max_outstanding_pulls_;
 
   /// Timeout, in milliseconds, to wait until the Push request fails.
   /// Special value:

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -16,10 +16,11 @@ class ordered_set {
  private:
   using elements_type = std::list<T>;
   using positions_type = std::unordered_map<T, typename elements_type::iterator>;
+
+ public:
   using iterator = typename elements_type::iterator;
   using const_iterator = typename elements_type::const_iterator;
 
- public:
   ordered_set() {}
 
   ordered_set(const ordered_set &other) = delete;
@@ -53,6 +54,14 @@ class ordered_set {
   iterator erase(const iterator position) {
     positions_.erase(*position);
     return elements_.erase(position);
+  }
+
+  iterator find(const T &k) {
+    auto it = positions_.find(k);
+    if (it == positions_.end()) {
+      return elements_.end();
+    }
+    return it->second;
   }
 
   iterator begin() noexcept { return elements_.begin(); }

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -359,7 +359,7 @@ docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "use_pytorch": true, "sample_async": false}'
 
-docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA python -m pytest /ray/test/object_manager_test.py
+docker run --rm --shm-size=10G --memory=10G $DOCKER_SHA python -m pytest -v /ray/test/object_manager_test.py
 
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \


### PR DESCRIPTION
This is very much a work in progress, but I'm opening it now to try to get some earlier feedback on the best design here.

Note that some related work was recently done in https://github.com/ray-project/ray/pull/3276, which did some deduplication on the "sender" side. That is, no object manager will send the same object multiple times to the same remote object manager within a certain window of time.

This PR should address the **N^2** broadcast issue in #2945. Ideally, when broadcasting an object to N other nodes, the object would be transmitted exactly N times. This PR doesn't quite achieve that, e.g., I still see it transmitted around **2N** times.

__In this PR:__
- When an object manager is trying to fetch an object, it may request it from multiple (potentially all) other remote object managers that have the object.
- As soon as the object manager begins receiving an object from a remote object manager, it will send messages to all other object managers that it has requested the object from (except for the one that is currently transmitting the object) and cancel those requests.
- Object managers maintain a queue of "pending object pushes". These are pushes that have not been posted to one of the "asio send services". If an object manager receives a cancellation message, it will look in the queue.
- When one of the send service threads finishes sending an object, we see if we can dispatch more sends.

__Some notes/questions:__
- **Chunks versus objects.** We queue "object transfers" in the `pending_pushes_` queue. But when we actually decide to push an object, we break it into chunks and post the sends of the individual chunks to the send service threads. So objects are queued in the object manager queue and chunks are queued in the asio queue. It may be advantageous to queue chunks in the object manager queue because that way we could cancel an object transfer even after we've sent some of its chunks. The eventual solution should ideally allow for an object manager to receive different chunks from different object managers, though that will probably require more thought.
- **Data structures.** Currently I'm using something very naive, for `pending_pushes_` (a deque). The operations that we need are to be able to pop off the front, append to the back, and remove from anywhere. So basically an "ordered map" or something like that.

@guoyuhong @stephanie-wang @elibol @ujvl @ericl 