### PR TITLE
Fix logging when ray cluster utils is used

### DIFF
--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -94,7 +94,7 @@ class Cluster(object):
                 services.all_processes[key] = []
             node = Node(process_dict_copy)
             self.worker_nodes[node] = address_info
-        logging.info("Starting Node with raylet socket {}".format(
+        logger.info("Starting Node with raylet socket {}".format(
             address_info["raylet_socket_names"]))
 
         return node


### PR DESCRIPTION

## What do these changes do?

Before this change, all logger output from the application was blackholed. This seems to be because logging.info does some bad default setup that throws away the output :roll_eyes: 