### PR TITLE
Add ordered_set container.

### DIFF
--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -16,7 +16,7 @@ class ordered_set {
  public:
   using elements_type = std::list<T>;
   using positions_type = std::unordered_map<T, typename elements_type::iterator>;
-  using iterator_type = typename elements_type::iterator;
+  using iterator = typename elements_type::iterator;
 
   ordered_set() {}
 
@@ -48,14 +48,14 @@ class ordered_set {
     return positions_.erase(k);
   }
 
-  iterator_type erase(const iterator_type position) {
+  iterator erase(const iterator position) {
     positions_.erase(*position);
     return elements_.erase(position);
   }
 
-  iterator_type begin() noexcept { return elements_.begin(); }
+  iterator begin() noexcept { return elements_.begin(); }
 
-  iterator_type end() noexcept { return elements_.end(); }
+  iterator end() noexcept { return elements_.end(); }
 
  private:
   elements_type elements_;

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -7,7 +7,11 @@
 template <typename T>
 class ordered_set {
  public:
-  explicit ordered_set() {}
+  ordered_set() {}
+
+  ordered_set(const ordered_set &other) = delete;
+
+  ordered_set &operator=(const ordered_set &other) = delete;
 
   void push_back(const T &value) {
     RAY_CHECK(iterators_.find(value) == iterators_.end());

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -34,7 +34,7 @@ class ordered_set {
     auto it = iterators_.find(k);
     RAY_CHECK(it != iterators_.end());
     elements_.erase(it->second);
-    return iterators_.erase(it);
+    return iterators_.erase(k);
   }
 
  private:

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -14,6 +14,10 @@
 template <typename T>
 class ordered_set {
  public:
+  using elements_type = std::list<T>;
+  using positions_type = std::unordered_map<T, typename elements_type::iterator>;
+  using iterator_type = typename elements_type::iterator;
+
   ordered_set() {}
 
   ordered_set(const ordered_set &other) = delete;
@@ -21,32 +25,41 @@ class ordered_set {
   ordered_set &operator=(const ordered_set &other) = delete;
 
   void push_back(const T &value) {
-    RAY_CHECK(iterators_.find(value) == iterators_.end());
+    RAY_CHECK(positions_.find(value) == positions_.end());
     auto list_iterator = elements_.insert(elements_.end(), value);
-    iterators_[value] = list_iterator;
+    positions_[value] = list_iterator;
   }
 
-  size_t count(const T &k) const { return iterators_.count(k); }
+  size_t count(const T &k) const { return positions_.count(k); }
 
   void pop_front() {
-    iterators_.erase(elements_.front());
+    positions_.erase(elements_.front());
     elements_.pop_front();
   }
 
   const T &front() const { return elements_.front(); }
 
-  size_t size() const noexcept { return iterators_.size(); }
+  size_t size() const noexcept { return positions_.size(); }
 
   size_t erase(const T &k) {
-    auto it = iterators_.find(k);
-    RAY_CHECK(it != iterators_.end());
+    auto it = positions_.find(k);
+    RAY_CHECK(it != positions_.end());
     elements_.erase(it->second);
-    return iterators_.erase(k);
+    return positions_.erase(k);
   }
 
+  iterator_type erase(const iterator_type position) {
+    positions_.erase(*position);
+    return elements_.erase(position);
+  }
+
+  iterator_type begin() noexcept { return elements_.begin(); }
+
+  iterator_type end() noexcept { return elements_.end(); }
+
  private:
-  std::list<T> elements_;
-  std::unordered_map<T, typename std::list<T>::iterator> iterators_;
+  elements_type elements_;
+  positions_type positions_;
 };
 
 #endif  // RAY_UTIL_ORDERED_SET_H

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -4,6 +4,13 @@
 #include <list>
 #include <unordered_map>
 
+/// \class ordered_set
+///
+/// This container has properties of both a deque and a set. It is like a deque
+/// in the sense that it maintains the insertion order and allows you to
+/// push_back elements and pop_front elements. It is like a set in the sense
+/// that it does not allow duplicate entries. Looking up and erasing elements is
+/// quick.
 template <typename T>
 class ordered_set {
  public:

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -17,6 +17,7 @@ class ordered_set {
   using elements_type = std::list<T>;
   using positions_type = std::unordered_map<T, typename elements_type::iterator>;
   using iterator = typename elements_type::iterator;
+  using const_iterator = typename elements_type::const_iterator;
 
  public:
   ordered_set() {}
@@ -56,7 +57,11 @@ class ordered_set {
 
   iterator begin() noexcept { return elements_.begin(); }
 
+  const_iterator begin() const noexcept { return elements_.begin(); }
+
   iterator end() noexcept { return elements_.end(); }
+
+  const_iterator end() const noexcept { return elements_.end(); }
 
  private:
   elements_type elements_;

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -28,10 +28,7 @@ class ordered_set {
 
   const T &front() const { return elements_.front(); }
 
-  size_t size() const noexcept {
-    RAY_CHECK(elements_.size() == iterators_.size());
-    return elements_.size();
-  }
+  size_t size() const noexcept { return iterators_.size(); }
 
   size_t erase(const T &k) {
     auto it = iterators_.find(k);

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -15,18 +15,14 @@ class ordered_set {
     iterators_[value] = list_iterator;
   }
 
-  size_t count(const T &k) const {
-    return iterators_.count(k);
-  }
+  size_t count(const T &k) const { return iterators_.count(k); }
 
   void pop_front() {
     iterators_.erase(elements_.front());
     elements_.pop_front();
   }
 
-  const T &front() const {
-    return elements_.front();
-  }
+  const T &front() const { return elements_.front(); }
 
   size_t size() const noexcept {
     RAY_CHECK(elements_.size() == iterators_.size());

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -1,0 +1,48 @@
+#ifndef RAY_UTIL_ORDERED_SET_H
+#define RAY_UTIL_ORDERED_SET_H
+
+#include <list>
+#include <unordered_map>
+
+template <typename T>
+class ordered_set {
+ public:
+  explicit ordered_set() {}
+
+  void push_back(const T &value) {
+    RAY_CHECK(iterators_.find(value) == iterators_.end());
+    auto list_iterator = elements_.insert(elements_.end(), value);
+    iterators_[value] = list_iterator;
+  }
+
+  size_t count(const T &k) const {
+    return iterators_.count(k);
+  }
+
+  void pop_front() {
+    iterators_.erase(elements_.front());
+    elements_.pop_front();
+  }
+
+  const T &front() const {
+    return elements_.front();
+  }
+
+  size_t size() const noexcept {
+    RAY_CHECK(elements_.size() == iterators_.size());
+    return elements_.size();
+  }
+
+  size_t erase(const T &k) {
+    auto it = iterators_.find(k);
+    RAY_CHECK(it != iterators_.end());
+    elements_.erase(it->second);
+    iterators_.erase(it);
+  }
+
+ private:
+  std::list<T> elements_;
+  std::unordered_map<T, typename std::list<T>::iterator> iterators_;
+};
+
+#endif  // RAY_UTIL_ORDERED_SET_H

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -13,11 +13,12 @@
 /// quick.
 template <typename T>
 class ordered_set {
- public:
+ private:
   using elements_type = std::list<T>;
   using positions_type = std::unordered_map<T, typename elements_type::iterator>;
   using iterator = typename elements_type::iterator;
 
+ public:
   ordered_set() {}
 
   ordered_set(const ordered_set &other) = delete;

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -37,7 +37,7 @@ class ordered_set {
     auto it = iterators_.find(k);
     RAY_CHECK(it != iterators_.end());
     elements_.erase(it->second);
-    iterators_.erase(it);
+    return iterators_.erase(it);
   }
 
  private:


### PR DESCRIPTION
This adds a header only ordered_set implementation, which has come up several times (e.g., task queues, queues for pushing objects from object managers).

It can be used with

```cpp
#include "ray/util/ordered_set.h"

ordered_set<size_t> stuff;
stuff.push_back(stuff.size());
```

See some related discussion in https://github.com/ray-project/ray/pull/3351.