### PR TITLE
Enable Twin Delayed DDPG for RLlib DDPG agent

### DIFF
--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -84,7 +84,7 @@ DEFAULT_CONFIG = with_common_config({
 
     # === Optimization ===
     # Learning rate for adam optimizer.
-    # Instead of using two optimizers respectively, we use a common learning rate to minimize loss = actor_loss_coeff * actor_loss + critic_loss_coeff * critic_loss
+    # Instead of using two optimizers, we use two different loss coefficients
     "lr": 1e-3,
     "actor_loss_coeff": 0.1,
     "critic_loss_coeff": 1.0,

--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -17,15 +17,19 @@ OPTIMIZER_SHARED_CONFIGS = [
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
     # === Twin Delayed DDPG (TD3) and Soft Actor-Critic (SAC) tricks ===
+    # TD3: https://spinningup.openai.com/en/latest/algorithms/td3.html
     # twin Q-net
     "twin_q": False,
     # delayed policy update
     "policy_delay": 1,
     # target policy smoothing
-    "use_gaussian_noise": False,
-    # target noise stddev
+    # this also forces the use of gaussian instead of OU noise for exploration
+    "smooth_target_policy": False,
+    # gaussian stddev of act noise
+    "act_noise": 0.1,
+    # gaussian stddev of target noise
     "target_noise": 0.2,
-    # action noise limit (bound)
+    # target noise limit (bound)
     "noise_clip": 0.5,
 
     # === Model ===

--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -83,9 +83,11 @@ DEFAULT_CONFIG = with_common_config({
     "compress_observations": False,
 
     # === Optimization ===
-    # Learning rate for adam optimizer
-    "actor_lr": 1e-4,
-    "critic_lr": 1e-3,
+    # Learning rate for adam optimizer.
+    # Instead of using two optimizers respectively, we use a common learning rate to minimize loss = actor_loss_coeff * actor_loss + critic_loss_coeff * critic_loss
+    "lr": 1e-3,
+    "actor_loss_coeff": 0.1,
+    "critic_loss_coeff": 1.0,
     # If True, use huber loss instead of squared loss for critic network
     # Conventionally, no need to clip gradients if using a huber loss
     "use_huber": False,

--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -16,6 +16,18 @@ OPTIMIZER_SHARED_CONFIGS = [
 # yapf: disable
 # __sphinx_doc_begin__
 DEFAULT_CONFIG = with_common_config({
+    # === Twin Delayed DDPG (TD3) and Soft Actor-Critic (SAC) tricks ===
+    # twin Q-net
+    "twin_q": False,
+    # delayed policy update
+    "policy_delay": 1,
+    # target policy smoothing
+    "use_gaussian_noise": False,
+    # target noise stddev
+    "target_noise": 0.2,
+    # action noise limit (bound)
+    "noise_clip": 0.5,
+
     # === Model ===
     # Hidden layer sizes of the policy network
     "actor_hiddens": [64, 64],

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -348,7 +348,8 @@ class DDPGPolicyGraph(TFPolicyGraph):
     def _build_action_network(self, p_values, stochastic, eps, target_smoothing=False):
         return ActionNetwork(p_values, self.low_action, self.high_action,
                              stochastic, eps, self.config["use_gaussian_noise"],
-                             self.config["exploration_theta"], target_smoothing,
+                             self.config["exploration_theta"],
+                             self.config["exploration_sigma"], target_smoothing,
                              self.config["target_noise"], self.config["noise_clip"]).actions
 
     def _build_actor_critic_loss(self, q_t, q_tp1, q_tp0, twin_q_t=None, twin_q_tp1=None):

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -165,13 +165,13 @@ class ActorCriticLoss(object):
         self.critic_loss = critic_loss_coeff * tf.reduce_mean(
             importance_weights * errors)
 
-        # for policy gradient
-        # update policy net one time v.s. update critic net `policy_delay` time(s)
+        # for policy gradient, update policy net one time v.s.
+        # update critic net `policy_delay` time(s)
         global_step = tf.train.get_or_create_global_step()
         policy_delay_mask = tf.to_float(
             tf.equal(tf.mod(global_step, policy_delay), 0))
-        self.actor_loss = -1.0 * actor_loss_coeff * policy_delay_mask * tf.reduce_mean(
-            q_tp0)
+        self.actor_loss = (-1.0 * actor_loss_coeff * policy_delay_mask *
+                           tf.reduce_mean(q_tp0))
 
         self.total_loss = self.actor_loss + self.critic_loss
 

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -155,8 +155,8 @@ class ActorCriticLoss(object):
                 errors = 0.5 * tf.square(td_error) + 0.5 * tf.square(
                     twin_td_error)
         else:
-            self.td_error = q_t_selected - tf.stop_gradient(
-                q_t_selected_target)
+            self.td_error = (
+                q_t_selected - tf.stop_gradient(q_t_selected_target))
             if use_huber:
                 errors = _huber_loss(self.td_error, huber_threshold)
             else:

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -165,7 +165,8 @@ class ActorCriticLoss(object):
         self.actor_loss = -1.0 * tf.reduce_mean(q_tp0)
 
         # update policy net one time v.s. update critic net `policy_delay` time(s)
-        actor_loss_coeff = tf.to_float(tf.equal(tf.mod(global_step, policy_delay), 0))
+        actor_loss_coeff = tf.to_float(
+            tf.equal(tf.mod(global_step, policy_delay), 0))
         self.total_loss = actor_loss_coeff * self.actor_loss + self.critic_loss
 
 
@@ -244,8 +245,10 @@ class DDPGPolicyGraph(TFPolicyGraph):
                 self.p_t, deterministic_flag, zero_eps)
             output_actions_estimated = self._build_action_network(
                 p_tp1,
-                tf.constant(value=False, dtype=tf.bool) if self.config["smooth_target_policy"] else deterministic_flag,
-                zero_eps, is_target=True)
+                tf.constant(value=False, dtype=tf.bool)
+                if self.config["smooth_target_policy"] else deterministic_flag,
+                zero_eps,
+                is_target=True)
 
         # q network evaluation
         with tf.variable_scope(Q_SCOPE) as scope:
@@ -364,16 +367,14 @@ class DDPGPolicyGraph(TFPolicyGraph):
             self.config["actor_hiddens"],
             self.config["actor_hidden_activation"]).action_scores
 
-    def _build_action_network(self,
-                              p_values,
-                              stochastic,
-                              eps,
+    def _build_action_network(self, p_values, stochastic, eps,
                               is_target=False):
         return ActionNetwork(
             p_values, self.low_action, self.high_action, stochastic, eps,
             self.config["exploration_theta"], self.config["exploration_sigma"],
             self.config["smooth_target_policy"], self.config["act_noise"],
-            is_target, self.config["target_noise"], self.config["noise_clip"]).actions
+            is_target, self.config["target_noise"],
+            self.config["noise_clip"]).actions
 
     def _build_actor_critic_loss(self,
                                  q_t,
@@ -412,7 +413,7 @@ class DDPGPolicyGraph(TFPolicyGraph):
                                 if g is not None]
         critic_grads_and_vars = [(g, v) for (g, v) in critic_grads_and_vars
                                  if g is not None]
-        return critic_grads_and_vars+actor_grads_and_vars
+        return critic_grads_and_vars + actor_grads_and_vars
 
     def extra_compute_action_feed_dict(self):
         return {

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -162,14 +162,16 @@ class ActorCriticLoss(object):
             else:
                 errors = 0.5 * tf.square(self.td_error)
 
-        self.critic_loss = critic_loss_coeff * tf.reduce_mean(importance_weights * errors)
+        self.critic_loss = critic_loss_coeff * tf.reduce_mean(
+            importance_weights * errors)
 
         # for policy gradient
         # update policy net one time v.s. update critic net `policy_delay` time(s)
         global_step = tf.train.get_or_create_global_step()
         policy_delay_mask = tf.to_float(
             tf.equal(tf.mod(global_step, policy_delay), 0))
-        self.actor_loss = -1.0 * actor_loss_coeff * policy_delay_mask * tf.reduce_mean(q_tp0)
+        self.actor_loss = -1.0 * actor_loss_coeff * policy_delay_mask * tf.reduce_mean(
+            q_tp0)
 
         self.total_loss = self.actor_loss + self.critic_loss
 
@@ -242,12 +244,15 @@ class DDPGPolicyGraph(TFPolicyGraph):
         # Action outputs
         with tf.variable_scope(A_SCOPE, reuse=True):
             output_actions = self._build_action_network(
-                self.p_t, stochastic=tf.constant(value=False, dtype=tf.bool),
+                self.p_t,
+                stochastic=tf.constant(value=False, dtype=tf.bool),
                 eps=.0)
             output_actions_estimated = self._build_action_network(
                 p_tp1,
-                stochastic=tf.constant(value=self.config["smooth_target_policy"], dtype=tf.bool),
-                eps=.0, is_target=True)
+                stochastic=tf.constant(
+                    value=self.config["smooth_target_policy"], dtype=tf.bool),
+                eps=.0,
+                is_target=True)
 
         # q network evaluation
         with tf.variable_scope(Q_SCOPE) as scope:

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -104,11 +104,14 @@ class TFPolicyGraph(PolicyGraph):
         self._batch_divisibility_req = batch_divisibility_req
 
         self._optimizer = self.optimizer()
-        self._grads_and_vars = [(g, v) for (g, v) in self.gradients(self._optimizer) if g is not None]
+        self._grads_and_vars = [(g, v)
+                                for (g, v) in self.gradients(self._optimizer)
+                                if g is not None]
         self._grads = [g for (g, v) in self._grads_and_vars]
         self._apply_op = self._optimizer.apply_gradients(
             self._grads_and_vars,
-            global_step=self.global_step if hasattr(self, "global_step") else None)
+            global_step=self.global_step
+            if hasattr(self, "global_step") else None)
 
         self._variables = ray.experimental.TensorFlowVariables(
             self._loss, self._sess)

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -106,16 +106,24 @@ class TFPolicyGraph(PolicyGraph):
         self._optimizer = self.optimizer()
         if isinstance(self._optimizer, tuple):
             # more than one optimizers, e.g., DDPG
-            self._grads_and_vars = [[(g, v) for (g, v) in grad_var_list if g is not None] for grad_var_list in self.gradients(self._optimizer)]
-            self._grads = [[g for (g, v) in grad_var_list] for grad_var_list in self._grads_and_vars]
-            self._apply_ops = [opt.apply_gradients(grad_var_list) for opt, grad_var_list in zip(self._optimizer, self._grads_and_vars)]
+            self._grads_and_vars = [[
+                (g, v) for (g, v) in grad_var_list if g is not None
+            ] for grad_var_list in self.gradients(self._optimizer)]
+            self._grads = [[g for (g, v) in grad_var_list]
+                           for grad_var_list in self._grads_and_vars]
+            self._apply_ops = [
+                opt.apply_gradients(grad_var_list) for opt, grad_var_list in
+                zip(self._optimizer, self._grads_and_vars)
+            ]
             self._apply_op = tf.group(*(self._apply_ops))
         else:
             self._grads_and_vars = [(g, v)
-                                    for (g, v) in self.gradients(self._optimizer)
+                                    for (g,
+                                         v) in self.gradients(self._optimizer)
                                     if g is not None]
             self._grads = [g for (g, v) in self._grads_and_vars]
-            self._apply_op = self._optimizer.apply_gradients(self._grads_and_vars)
+            self._apply_op = self._optimizer.apply_gradients(
+                self._grads_and_vars)
 
         self._variables = ray.experimental.TensorFlowVariables(
             self._loss, self._sess)

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -108,7 +108,7 @@ class TFPolicyGraph(PolicyGraph):
                                 for (g, v) in self.gradients(self._optimizer)
                                 if g is not None]
         self._grads = [g for (g, v) in self._grads_and_vars]
-        # specify global_step for TD3 which needs to count the number of updating
+        # specify global_step for TD3 which needs to count the num updates
         self._apply_op = self._optimizer.apply_gradients(
             self._grads_and_vars,
             global_step=tf.train.get_or_create_global_step())

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -108,10 +108,10 @@ class TFPolicyGraph(PolicyGraph):
                                 for (g, v) in self.gradients(self._optimizer)
                                 if g is not None]
         self._grads = [g for (g, v) in self._grads_and_vars]
+        # specify global_step for TD3 which needs to count the number of updating
         self._apply_op = self._optimizer.apply_gradients(
             self._grads_and_vars,
-            global_step=self.global_step
-            if hasattr(self, "global_step") else None)
+            global_step=tf.train.get_or_create_global_step())
 
         self._variables = ray.experimental.TensorFlowVariables(
             self._loss, self._sess)

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -104,26 +104,11 @@ class TFPolicyGraph(PolicyGraph):
         self._batch_divisibility_req = batch_divisibility_req
 
         self._optimizer = self.optimizer()
-        if isinstance(self._optimizer, tuple):
-            # more than one optimizers, e.g., DDPG
-            self._grads_and_vars = [[
-                (g, v) for (g, v) in grad_var_list if g is not None
-            ] for grad_var_list in self.gradients(self._optimizer)]
-            self._grads = [[g for (g, v) in grad_var_list]
-                           for grad_var_list in self._grads_and_vars]
-            self._apply_ops = [
-                opt.apply_gradients(grad_var_list) for opt, grad_var_list in
-                zip(self._optimizer, self._grads_and_vars)
-            ]
-            self._apply_op = tf.group(*(self._apply_ops))
-        else:
-            self._grads_and_vars = [(g, v)
-                                    for (g,
-                                         v) in self.gradients(self._optimizer)
-                                    if g is not None]
-            self._grads = [g for (g, v) in self._grads_and_vars]
-            self._apply_op = self._optimizer.apply_gradients(
-                self._grads_and_vars)
+        self._grads_and_vars = [(g, v) for (g, v) in self.gradients(self._optimizer) if g is not None]
+        self._grads = [g for (g, v) in self._grads_and_vars]
+        self._apply_op = self._optimizer.apply_gradients(
+            self._grads_and_vars,
+            global_step=self.global_step if hasattr(self, "global_step") else None)
 
         self._variables = ray.experimental.TensorFlowVariables(
             self._loss, self._sess)

--- a/python/ray/rllib/tuned_examples/mountaincarcontinuous-ddpg.yaml
+++ b/python/ray/rllib/tuned_examples/mountaincarcontinuous-ddpg.yaml
@@ -34,8 +34,9 @@ mountaincarcontinuous-ddpg:
         clip_rewards: False
 
         # === Optimization ===
-        actor_lr: 0.0001
-        critic_lr: 0.001
+        lr: 0.001
+        actor_loss_coeff: 0.1
+        critic_loss_coeff: 1.0
         use_huber: False
         huber_threshold: 1.0
         l2_reg: 0.00001

--- a/python/ray/rllib/tuned_examples/pendulum-ddpg.yaml
+++ b/python/ray/rllib/tuned_examples/pendulum-ddpg.yaml
@@ -34,8 +34,9 @@ pendulum-ddpg:
         clip_rewards: False
 
         # === Optimization ===
-        actor_lr: 0.0001
-        critic_lr: 0.001
+        lr: 0.001
+        actor_loss_coeff: 0.1
+        critic_loss_coeff: 1.0
         use_huber: True
         huber_threshold: 1.0
         l2_reg: 0.000001

--- a/python/ray/rllib/tuned_examples/pendulum-td3.yaml
+++ b/python/ray/rllib/tuned_examples/pendulum-td3.yaml
@@ -9,7 +9,8 @@ pendulum-ddpg:
         # === Tricks ===
         twin_q: True
         policy_delay: 2
-        use_gaussian_noise: True
+        smooth_target_policy: True
+        act_noise: 0.1
         target_noise: 0.2
         noise_clip: 0.5
 

--- a/python/ray/rllib/tuned_examples/pendulum-td3.yaml
+++ b/python/ray/rllib/tuned_examples/pendulum-td3.yaml
@@ -42,8 +42,9 @@ pendulum-ddpg:
         clip_rewards: False
 
         # === Optimization ===
-        actor_lr: 0.0001
-        critic_lr: 0.001
+        lr: 0.001
+        actor_loss_coeff: 0.1
+        critic_loss_coeff: 1.0
         use_huber: True
         huber_threshold: 1.0
         l2_reg: 0.000001

--- a/python/ray/rllib/tuned_examples/pendulum-td3.yaml
+++ b/python/ray/rllib/tuned_examples/pendulum-td3.yaml
@@ -1,0 +1,58 @@
+# This configuration can expect to reach -160 reward in 10k-20k timesteps
+pendulum-ddpg:
+    env: Pendulum-v0
+    run: DDPG
+    stop:
+        episode_reward_mean: -160
+        time_total_s: 600 # 10 minutes
+    config:
+        # === Tricks ===
+        twin_q: True
+        policy_delay: 2
+        use_gaussian_noise: True
+        target_noise: 0.2
+        noise_clip: 0.5
+
+        # === Model ===
+        actor_hiddens: [64, 64]
+        critic_hiddens: [64, 64]
+        n_step: 1
+        model: {}
+        gamma: 0.99
+        env_config: {}
+
+        # === Exploration ===
+        schedule_max_timesteps: 100000
+        timesteps_per_iteration: 600
+        exploration_fraction: 0.1
+        exploration_final_eps: 0.02
+        noise_scale: 0.1
+        exploration_theta: 0.15
+        exploration_sigma: 0.2
+        target_network_update_freq: 0
+        tau: 0.001
+
+        # === Replay buffer ===
+        buffer_size: 10000
+        prioritized_replay: True
+        prioritized_replay_alpha: 0.6
+        prioritized_replay_beta: 0.4
+        prioritized_replay_eps: 0.000001
+        clip_rewards: False
+
+        # === Optimization ===
+        actor_lr: 0.0001
+        critic_lr: 0.001
+        use_huber: True
+        huber_threshold: 1.0
+        l2_reg: 0.000001
+        learning_starts: 500
+        sample_batch_size: 1
+        train_batch_size: 64
+
+        # === Parallelism ===
+        num_workers: 0
+        num_gpus_per_worker: 0
+        optimizer_class: "SyncReplayOptimizer"
+        per_worker_exploration: False
+        worker_side_prioritization: False


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- fix DDPG optimizers
- add Twin Delayed DDPG (TD3)

The original implementation compute gradients with actor optimizer and critic optimizer respectively but apply gradients with the fake optimizer defined by base class tf policy graph. Actually, TensorFlow optimizers compute the gradients in the same way, while the momentum adjustments function in applying the gradients. Thus, the original implementation failed to use the two optimizers created by the DDPG agent itself.

[TD3](https://spinningup.openai.com/en/latest/algorithms/td3.html) mainly add 3 tricks to DDPG and this pr tries to add TD3 upon DDPG. The comparison is showed as follow: 

![ddpg_improvements](https://user-images.githubusercontent.com/6416895/48715844-e945ba80-ec50-11e8-938c-4c0eba9f32a6.png)

TD3 seems more stable w.r.t. DDPG and solves the Pendulum-v0 quickly in the sense of sample efficiency.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
