### PR TITLE
Fix memory leak in lineage cache

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -99,7 +99,7 @@ bool Lineage::SetEntry(const Task &task, GcsStatus status) {
       // The task's spec may have changed, so remove its old dependencies.
       // TODO(swang): This could be inefficient for tasks that have lots of
       // dependencies and/or large specs. A flag could be passed in for tasks
-      // wohse data has not changed.
+      // whose data has not changed.
       for (const auto &parent_id : it->second.GetParentTaskIds()) {
         RAY_CHECK(children_[parent_id].erase(task_id) == 1);
       }

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -176,9 +176,23 @@ class Lineage {
   flatbuffers::Offset<protocol::ForwardTaskRequest> ToFlatbuffer(
       flatbuffers::FlatBufferBuilder &fbb, const TaskID &entry_id) const;
 
+  /// Return the IDs of tasks in the lineage that are dependent on the given
+  /// task.
+  ///
+  /// \param The ID of the task whose children to get.
+  /// \return The list of IDs for tasks that are in the lineage and dependent
+  /// on the given task.
+  const std::unordered_set<TaskID> &GetChildren(const TaskID &task_id) const;
+
+  /// Return the size of the children_ map. This is used for debugging purposes
+  /// only.
+  size_t GetChildrenSize() const { return children_.size(); }
+
  private:
   /// The lineage entries.
   std::unordered_map<const TaskID, LineageEntry> entries_;
+  /// A mapping from each task in the lineage to its children.
+  std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
 };
 
 /// \class LineageCache
@@ -305,8 +319,6 @@ class LineageCache {
   gcs::PubsubInterface<TaskID> &task_pubsub_;
   /// The set of tasks that have been committed but not evicted.
   std::unordered_set<TaskID> committed_tasks_;
-  /// A mapping from each task in the lineage cache to its children.
-  std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
   /// All tasks and objects that we are responsible for writing back to the
   /// GCS, and the tasks and objects in their lineage.
   Lineage lineage_;

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -1,6 +1,7 @@
 #ifndef RAY_RAYLET_LINEAGE_CACHE_H
 #define RAY_RAYLET_LINEAGE_CACHE_H
 
+#include <gtest/gtest_prod.h>
 #include <boost/optional.hpp>
 
 // clang-format off
@@ -193,6 +194,11 @@ class Lineage {
   std::unordered_map<const TaskID, LineageEntry> entries_;
   /// A mapping from each task in the lineage to its children.
   std::unordered_map<TaskID, std::unordered_set<TaskID>> children_;
+
+  /// Record the fact that the child task depends on the parent task.
+  void AddChild(const TaskID &parent_id, const TaskID &child_id);
+  /// Erase the fact that the child task depends on the parent task.
+  void RemoveChild(const TaskID &parent_id, const TaskID &child_id);
 };
 
 /// \class LineageCache
@@ -281,10 +287,10 @@ class LineageCache {
   /// \return Whether the task is in the lineage cache.
   bool ContainsTask(const TaskID &task_id) const;
 
-  /// Get the number of entries in the lineage cache.
+  /// Get all lineage in the lineage cache.
   ///
-  /// \return The number of entries in the lineage cache.
-  size_t NumEntries() const;
+  /// \return A const reference to the lineage.
+  const Lineage &GetLineage() const;
 
   /// Returns debug string for class.
   ///
@@ -292,6 +298,7 @@ class LineageCache {
   std::string DebugString() const;
 
  private:
+  FRIEND_TEST(LineageCacheTest, BarReturnsZeroOnNull);
   /// Flush a task that is in UNCOMMITTED_READY state.
   void FlushTask(const TaskID &task_id);
   /// Evict a single task. This should only be called if we are sure that the

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -563,20 +563,6 @@ TEST_F(LineageCacheTest, TestEvictionUncommittedChildren) {
     num_tasks_flushed++;
   }
 
-  // Simulate executing the last task on a remote node and adding it to the
-  // GCS.
-  // auto task_data = std::make_shared<protocol::TaskT>();
-  // auto it = tasks.rbegin();
-  // RAY_CHECK_OK(mock_gcs_.RemoteAdd(it->GetTaskSpecification().TaskId(), task_data));
-  //// We expect the task that was added remotely to be flushed.
-  // num_tasks_flushed++;
-  //// Check that once the last task in the forwarded chain is flushed, all local
-  //// tasks are flushed, since all of their dependencies have been evicted and
-  //// are therefore committed in the GCS.
-  // mock_gcs_.Flush();
-  // ASSERT_EQ(mock_gcs_.TaskTable().size(), num_tasks_flushed);
-  // ASSERT_EQ(lineage_cache_.GetLineage().GetEntries().size(), lineage_size * 2);
-
   // Simulate executing the tasks on the remote node in reverse order and
   // adding them to the GCS. Lineage at the local node should not get evicted
   // until after the final remote task is executed, since a task can only be

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -1866,7 +1866,6 @@ def setup_queue_actor():
     ray.shutdown()
 
 
-@pytest.mark.skip("This test does not work yet.")
 def test_fork(setup_queue_actor):
     queue = setup_queue_actor
 
@@ -1883,7 +1882,6 @@ def test_fork(setup_queue_actor):
         assert filtered_items == list(range(1))
 
 
-@pytest.mark.skip("This test does not work yet.")
 def test_fork_consistency(setup_queue_actor):
     queue = setup_queue_actor
 


### PR DESCRIPTION
## What do these changes do?

The lineage cache has to keep track of dependencies between tasks in the cache, but this map was not getting cleaned up before. This refactors the lineage cache to make sure that the dependencies are cleaned up properly when tasks are removed from the lineage cache.

## Related issue number

Closes #3360.
