### PR TITLE
Fix client table for removed clients.

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -328,7 +328,7 @@ class GlobalState(object):
         # Handle the case where no clients are returned. This should only
         # occur potentially immediately after the cluster is started.
         if message is None:
-            return []
+            return [], []
 
         gcs_entry = ray.gcs_utils.GcsTableEntry.GetRootAsGcsTableEntry(
             message, 0)

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -316,7 +316,9 @@ class GlobalState(object):
         """Fetch and parse the Redis DB client table.
 
         Returns:
-            Information about the Ray clients in the cluster.
+            A tuple of two lists. The first list contains information about the
+                live clients in the cluster, and the second list contains
+                information about the clients that have been removed.
         """
         self._check_connected()
 

--- a/python/ray/gcs_utils.py
+++ b/python/ray/gcs_utils.py
@@ -28,6 +28,9 @@ __all__ = [
 
 FUNCTION_PREFIX = "RemoteFunction:"
 
+# Client table updates.
+CLIENT_CHANNEL = str(TablePubsub.CLIENT).encode("ascii")
+
 # xray heartbeats
 XRAY_HEARTBEAT_CHANNEL = str(TablePubsub.HEARTBEAT).encode("ascii")
 XRAY_HEARTBEAT_BATCH_CHANNEL = str(TablePubsub.HEARTBEAT_BATCH).encode("ascii")

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -246,11 +246,12 @@ class Monitor(object):
                 message_handler(channel, data)
 
     def update_local_scheduler_map(self):
-        local_schedulers = self.state.client_table()
+        live_clients, dead_clients = self.state.client_table()
+        local_schedulers = live_clients + dead_clients
         self.local_scheduler_id_to_ip_map = {}
         for local_scheduler_info in local_schedulers:
-            client_id = local_scheduler_info.get("DBClientID") or \
-                local_scheduler_info["ClientID"]
+            client_id = (local_scheduler_info.get("DBClientID")
+                         or local_scheduler_info["ClientID"])
             ip_address = (
                 local_scheduler_info.get("AuxAddress")
                 or local_scheduler_info["NodeManagerAddress"]).split(":")[0]

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -138,10 +138,7 @@ class Cluster(object):
         return False
 
     def _check_registered_nodes(self):
-        registered = len([
-            client for client in ray.global_state.client_table()
-            if client["IsInsertion"]
-        ])
+        registered = len(ray.global_state.client_table()[0])
         expected = len(self.list_all_nodes())
         if registered == expected:
             logger.info("All nodes registered as expected.")

--- a/python/ray/test/test_utils.py
+++ b/python/ray/test/test_utils.py
@@ -32,8 +32,8 @@ def _wait_for_nodes_to_join(num_nodes, timeout=20):
     """
     start_time = time.time()
     while time.time() - start_time < timeout:
-        client_table = ray.global_state.client_table()
-        num_ready_nodes = len(client_table)
+        live_clients, dead_clients = ray.global_state.client_table()
+        num_ready_nodes = len(live_clients) + len(dead_clients)
         if num_ready_nodes == num_nodes:
             # Check that for each node, a local scheduler and a plasma manager
             # are present.

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -587,10 +587,11 @@ def ray_start_two_nodes():
 # the monitor to detect enough missed heartbeats.
 def test_warning_for_dead_node(ray_start_two_nodes):
     # Wait for the raylet to appear in the client table.
-    while len(ray.global_state.client_table()) < 2:
+    while len(ray.global_state.client_table()[0]) < 2:
         time.sleep(0.1)
 
-    client_ids = {item["ClientID"] for item in ray.global_state.client_table()}
+    live_clients, dead_clients = ray.global_state.client_table()
+    client_ids = {item["ClientID"] for item in live_clients + dead_clients}
 
     # Try to make sure that the monitor has received at least one heartbeat
     # from the node.

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2249,11 +2249,12 @@ def test_global_state_api(shutdown_only):
     assert task_spec["FunctionID"] == ray_constants.ID_SIZE * "ff"
     assert task_spec["ReturnObjectIDs"] == []
 
-    client_table = ray.global_state.client_table()
+    live_clients, dead_clients = ray.global_state.client_table()
     node_ip_address = ray.worker.global_worker.node_ip_address
 
-    assert len(client_table) == 1
-    assert client_table[0]["NodeManagerAddress"] == node_ip_address
+    assert len(live_clients) == 1
+    assert live_clients[0]["NodeManagerAddress"] == node_ip_address
+    assert len(dead_clients) == 0
 
     @ray.remote
     def f(*xs):

--- a/test/stress_tests/test_many_tasks_and_transfers.py
+++ b/test/stress_tests/test_many_tasks_and_transfers.py
@@ -21,7 +21,7 @@ num_remote_cpus = num_remote_nodes * head_node_cpus
 
 # Wait until the expected number of nodes have joined the cluster.
 while True:
-    if len(ray.global_state.client_table()) >= num_remote_nodes + 1:
+    if len(ray.global_state.client_table()[0]) >= num_remote_nodes + 1:
         break
 logger.info("Nodes have all joined. There are {} resources."
             .format(ray.global_state.cluster_resources()))


### PR DESCRIPTION
Clients that have been removed have two entries in the client table: one for the insertion, which has all of the information, and one for the deletion, which has no information. This changes the client table to display the insertion information instead of the deletion information.