### PR TITLE
Python 3 wheels have a requirement for faulthandler module

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -131,6 +131,23 @@ def find_version(*filepath):
         raise RuntimeError("Unable to find version string.")
 
 
+requires = [
+    "numpy",
+    "funcsigs",
+    "click",
+    "colorama",
+    "pytest",
+    "pyyaml",
+    "redis~=2.10.6",
+    "setproctitle",
+    # The six module is required by pyarrow.
+    "six >= 1.0.0",
+    "flatbuffers",
+]
+
+if sys.version_info < (3, 0):
+    requires.append("faulthandler")
+
 setup(
     name="ray",
     version=find_version("ray", "__init__.py"),
@@ -144,20 +161,7 @@ setup(
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
-    install_requires=[
-        "numpy",
-        "funcsigs",
-        "click",
-        "colorama",
-        "pytest",
-        "pyyaml",
-        "redis~=2.10.6",
-        "faulthandler;python_version<'3'",
-        "setproctitle",
-        # The six module is required by pyarrow.
-        "six >= 1.0.0",
-        "flatbuffers"
-    ],
+    install_requires=requires,
     setup_requires=["cython >= 0.27, < 0.28"],
     extras_require=extras,
     entry_points={


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Seems like the faulthandler <3 check does not work for making wheels.

## Related issue number

Closes https://github.com/ray-project/ray/issues/3372