### PR TITLE
When getting a role/profile, catch only exception that indicates the …

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -10,6 +10,7 @@ import time
 
 import boto3
 from botocore.config import Config
+import botocore
 
 from ray.ray_constants import BOTO_MAX_RETRIES
 
@@ -272,7 +273,7 @@ def _get_role(role_name, config):
     try:
         role.load()
         return role
-    except Exception:
+    except botocore.errorfactory.NoSuchEntityException:
         return None
 
 
@@ -282,7 +283,7 @@ def _get_instance_profile(profile_name, config):
     try:
         profile.load()
         return profile
-    except Exception:
+    except botocore.errorfactory.NoSuchEntityException:
         return None
 
 


### PR DESCRIPTION
## What do these changes do?

When using AWS autoscaler, we need to check if the role/profile already exists, in order to know whether to create a new one or not. Previously, the indicator for this was catching ANY exception on attempting to get the role/profile. This resulted in catching other exceptions too, and interpreting them as "role/profile exists". The fix is to catch only the appropriate exception, and allow the others to be raised. 

## Related issue number

Closes [issue #3380](https://github.com/ray-project/ray/issues/3380)