### PR TITLE
[autoscaler] Allow more than 5s from node creation to first heartbeat

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -493,7 +493,7 @@ class StandardAutoscaler(object):
             return
         key = self.provider.internal_ip(node_id)
         if key not in self.load_metrics.last_heartbeat_time_by_ip:
-            self.load_metrics.last_heartbeat_by_ip = time.time()
+            self.load_metrics.last_heartbeat_by_ip[key] = time.time()
         last_heartbeat_time = self.load_metrics.last_heartbeat_time_by_ip[key]
         delta = time.time() - last_heartbeat_time
         if delta < AUTOSCALER_HEARTBEAT_TIMEOUT_S:

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -493,7 +493,7 @@ class StandardAutoscaler(object):
             return
         key = self.provider.internal_ip(node_id)
         if key not in self.load_metrics.last_heartbeat_time_by_ip:
-            self.load_metrics.last_heartbeat_by_ip[key] = time.time()
+            self.load_metrics.last_heartbeat_time_by_ip[key] = time.time()
         last_heartbeat_time = self.load_metrics.last_heartbeat_time_by_ip[key]
         delta = time.time() - last_heartbeat_time
         if delta < AUTOSCALER_HEARTBEAT_TIMEOUT_S:

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -491,8 +491,10 @@ class StandardAutoscaler(object):
     def recover_if_needed(self, node_id):
         if not self.can_update(node_id):
             return
-        last_heartbeat_time = self.load_metrics.last_heartbeat_time_by_ip.get(
-            self.provider.internal_ip(node_id), 0)
+        key = self.provider.internal_ip(node_id)
+        if key not in self.load_metrics.last_heartbeat_time_by_ip:
+            self.load_metrics.last_heartbeat_by_ip = time.time()
+        last_heartbeat_time = self.load_metrics.last_heartbeat_time_by_ip[key]
         delta = time.time() - last_heartbeat_time
         if delta < AUTOSCALER_HEARTBEAT_TIMEOUT_S:
             return


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

I think this is due to a race condition between when we first mark a node as active and check for restarts. It's possible a node state changes in the background between these two checks, which would result in a spurious restart.

## Related issue number

Closes https://github.com/ray-project/ray/issues/3361