### PR TITLE
Initialize client_id_ in ObjectManager constructor

### DIFF
--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -192,6 +192,10 @@ ray::Status ObjectDirectory::LookupLocations(const ObjectID &object_id,
   return status;
 }
 
+ray::ClientID ObjectDirectory::GetLocalClientID() {
+  return gcs_client_->client_table().GetLocalClientId();
+}
+
 std::string ObjectDirectory::DebugString() const {
   std::stringstream result;
   result << "ObjectDirectory:";

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -104,6 +104,11 @@ class ObjectDirectoryInterface {
   virtual ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                           const ClientID &client_id) = 0;
 
+  /// Get local client id
+  ///
+  /// \return ClientID
+  virtual ray::ClientID GetLocalClientID() = 0;
+
   /// Returns debug string for class.
   ///
   /// \return string.
@@ -144,6 +149,8 @@ class ObjectDirectory : public ObjectDirectoryInterface {
       const object_manager::protocol::ObjectInfoT &object_info) override;
   ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                   const ClientID &client_id) override;
+
+  ray::ClientID GetLocalClientID() override;
 
   std::string DebugString() const override;
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -52,7 +52,7 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {
   RAY_CHECK(config_.max_sends > 0);
   RAY_CHECK(config_.max_receives > 0);
-  // TODO(hme) Client ID is never set with this constructor.
+  client_id_ = object_directory_->GetLocalClientID();
   main_service_ = &main_service;
   store_notification_.SubscribeObjAdded(
       [this](const object_manager::protocol::ObjectInfoT &object_info) {

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -39,6 +39,7 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
   std::string DebugString() const { return ""; }
 
   MOCK_METHOD0(RegisterBackend, void(void));
+  MOCK_METHOD0(GetLocalClientID, ray::ClientID());
   MOCK_CONST_METHOD1(LookupRemoteConnectionInfo, void(RemoteConnectionInfo &));
   MOCK_CONST_METHOD0(LookupAllRemoteConnections, std::vector<RemoteConnectionInfo>());
   MOCK_METHOD3(SubscribeObjectLocations,


### PR DESCRIPTION
Initialize client_id_ in ObjectManager constructor that takes user-defined ObjectDirectory.

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In the ObjectManager constructor that takes user-defined ObjectDirectoryInterface implementation, 
client_id_ is not initialized. But several member functions rely on client_id_, such as [NotifyDirectoryObjectDeleted](https://github.com/ray-project/ray/blob/master/src/ray/object_manager/object_manager.cc#L127) and [HandleObjectAdded](https://github.com/ray-project/ray/blob/master/src/ray/object_manager/object_manager.cc#L101).

This pull request initializes client_id_ by invoking GetLocalClientID of ObjectDirectoryInterface, which retrieves local client id through gcs_client.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
No