### PR TITLE
[DO NOT MERGE] Bump version from 0.5.3 to 0.6.0a0.

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -62,7 +62,7 @@ import ray.actor  # noqa: F401
 from ray.actor import method  # noqa: E402
 
 # Ray version string.
-__version__ = "0.5.3"
+__version__ = "0.6.0a0"
 
 __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",


### PR DESCRIPTION
Opening this in case we want to upload an alpha release to PyPI (which could be installed with `pip install ray --pre` I think).