### PR TITLE
Click 0.7 changes the naming convention for commands; fix this

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -674,16 +674,15 @@ done
 
 cli.add_command(start)
 cli.add_command(stop)
-cli.add_command(create_or_update)
 cli.add_command(create_or_update, name="up")
 cli.add_command(attach)
 cli.add_command(exec_cmd, name="exec")
-cli.add_command(rsync_down)
-cli.add_command(rsync_up)
+cli.add_command(rsync_down, name="rsync_down")
+cli.add_command(rsync_up, name="rsync_up")
 cli.add_command(submit)
 cli.add_command(teardown)
 cli.add_command(teardown, name="down")
-cli.add_command(get_head_ip)
+cli.add_command(get_head_ip, name="get_head_ip")
 cli.add_command(stack)
 
 


### PR DESCRIPTION
Closes: https://github.com/ray-project/ray/issues/3419