### PR TITLE
Upgrade Arrow to include Plasma TensorFlow Op release fix

### DIFF
--- a/cmake/Modules/ArrowExternalProject.cmake
+++ b/cmake/Modules/ArrowExternalProject.cmake
@@ -15,10 +15,10 @@
 #  - PLASMA_SHARED_LIB
 
 set(arrow_URL https://github.com/apache/arrow.git)
-# The PR for this commit is https://github.com/apache/arrow/pull/2826. We
+# The PR for this commit is https://github.com/apache/arrow/pull/3061. We
 # include the link here to make it easier to find the right commit because
 # Arrow often rewrites git history and invalidates certain commits.
-set(arrow_TAG b4f7ed6d6ed5cdb6dd136bac3181a438f35c8ea0)
+set(arrow_TAG a667fca3b71772886bb2595986266d2039823dcc)
 
 set(ARROW_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/arrow-install)
 set(ARROW_HOME ${ARROW_INSTALL_PREFIX})


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This includes a fix so the TensorFlow op releases memory properly (https://github.com/apache/arrow/pull/3061) and the possibility to store arrow datastructures in plasma (https://github.com/apache/arrow/pull/2832).

## Related issue number

https://github.com/ray-project/ray/issues/3404
