### PR TITLE
[tune] Tweak/allow nested pbt mutations

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -49,9 +49,8 @@ def explore(config, mutations, resample_probability, custom_explore_fn):
     for key, distribution in mutations.items():
         if isinstance(distribution, dict):
             new_config.update({
-                key: explore(
-                    config[key], mutations[key],
-                    resample_probability, custom_explore_fn)
+                key: explore(config[key], mutations[key], resample_probability,
+                             None)
             })
         elif isinstance(distribution, list):
             if random.random() < resample_probability or \

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -213,8 +213,8 @@ class PopulationBasedTraining(FIFOScheduler):
         trial_state = self._trial_state[trial]
         new_state = self._trial_state[trial_to_clone]
         if not new_state.last_checkpoint:
-            logger.warning("[pbt]: no checkpoint for trial"
-                           "skip exploit for Trial {}".format(trial))
+            logger.warning("[pbt]: no checkpoint for trial."
+                           " Skip exploit for Trial {}".format(trial))
             return
         new_config = explore(trial_to_clone.config, self._hyperparam_mutations,
                              self._resample_probability,

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -47,7 +47,13 @@ def explore(config, mutations, resample_probability, custom_explore_fn):
     """
     new_config = copy.deepcopy(config)
     for key, distribution in mutations.items():
-        if isinstance(distribution, list):
+        if isinstance(distribution, dict):
+            new_config.update({
+                key: explore(
+                    config[key], mutations[key],
+                    resample_probability, custom_explore_fn)
+            })
+        elif isinstance(distribution, list):
             if random.random() < resample_probability or \
                     config[key] not in distribution:
                 new_config[key] = random.choice(distribution)

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import random
 import unittest
 import numpy as np
-
+import sys
 import ray
 from ray.tune.schedulers import (HyperBandScheduler, AsyncHyperBandScheduler,
                                  PopulationBasedTraining, MedianStoppingRule,
@@ -16,6 +16,11 @@ from ray.tune.trial_executor import TrialExecutor
 
 from ray.rllib import _register_all
 _register_all()
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import MagicMock
+else:
+    from mock import MagicMock
 
 
 def result(t, rew):
@@ -804,7 +809,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                 },
             })
 
-        custom_explore_fn = unittest.mock.MagicMock(side_effect=lambda x: x)
+        custom_explore_fn = MagicMock(side_effect=lambda x: x)
 
         # Nested mutation and spec
         assertNestedProduces(

--- a/python/ray/tune/test/trial_scheduler_test.py
+++ b/python/ray/tune/test/trial_scheduler_test.py
@@ -804,6 +804,47 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                 },
             })
 
+        custom_explore_fn = unittest.mock.MagicMock(side_effect=lambda x: x)
+
+        # Nested mutation and spec
+        assertNestedProduces(
+            lambda: explore(
+                {
+                    "a": {
+                        "b": 4
+                    },
+                    "1": {
+                        "2": {
+                            "3": 100
+                        }
+                    },
+                },
+                {
+                    "a": {
+                        "b": [3, 4, 8, 10]
+                    },
+                    "1": {
+                        "2": {
+                            "3": lambda: random.choice([10, 100])
+                        }
+                    },
+                },
+                0.0,
+                custom_explore_fn),
+            {
+                "a": {
+                    "b": {3, 8}
+                },
+                "1": {
+                    "2": {
+                        "3": {80, 120}
+                    }
+                },
+            })
+
+        # Expect call count to be 100 because we call explore 100 times
+        self.assertEqual(custom_explore_fn.call_count, 100)
+
     def testYieldsTimeToOtherTrials(self):
         pbt, runner = self.basicSetup()
         trials = runner.get_trials()


### PR DESCRIPTION
## What do these changes do?
Changes the population-based training exploration to allow nested mutations

## Related issue number
Closes #3412