### PR TITLE
[tune/rllib] Use cloudpickle to dump config

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -106,9 +106,7 @@ class _JsonLogger(Logger):
                 cls=_SafeFallbackEncoder)
         config_pkl = os.path.join(self.logdir, "params.pkl")
         with open(config_pkl, "wb") as f:
-            cloudpickle.dump(
-                self.config,
-                f)
+            cloudpickle.dump(self.config, f)
         local_file = os.path.join(self.logdir, "result.json")
         self.local_out = open(local_file, "w")
 

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -3,13 +3,13 @@ from __future__ import division
 from __future__ import print_function
 
 import csv
-import dill
 import json
 import logging
 import numpy as np
 import os
 import yaml
 
+from ray.cloudpickle import cloudpickle
 from ray.tune.log_sync import get_syncer
 from ray.tune.result import NODE_IP, TRAINING_ITERATION, TIME_TOTAL_S, \
     TIMESTEPS_TOTAL
@@ -106,7 +106,7 @@ class _JsonLogger(Logger):
                 cls=_SafeFallbackEncoder)
         config_pkl = os.path.join(self.logdir, "params.pkl")
         with open(config_pkl, "wb") as f:
-            dill.dump(
+            cloudpickle.dump(
                 self.config,
                 f)
         local_file = os.path.join(self.logdir, "result.json")

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -9,7 +9,7 @@ import numpy as np
 import os
 import yaml
 
-from ray.cloudpickle import cloudpickle
+import ray.cloudpickle as cloudpickle
 from ray.tune.log_sync import get_syncer
 from ray.tune.result import NODE_IP, TRAINING_ITERATION, TIME_TOTAL_S, \
     TIMESTEPS_TOTAL

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import csv
+import dill
 import json
 import logging
 import numpy as np
@@ -103,6 +104,11 @@ class _JsonLogger(Logger):
                 indent=2,
                 sort_keys=True,
                 cls=_SafeFallbackEncoder)
+        config_pkl = os.path.join(self.logdir, "params.pkl")
+        with open(config_pkl, "wb") as f:
+            dill.dump(
+                self.config,
+                f)
         local_file = os.path.join(self.logdir, "result.json")
         self.local_out = open(local_file, "w")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

JSON Logger now uses cloudpickle to dump the configs as welll, which pkls the functions needed for multi-agent replay.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
