### PR TITLE
Add the extra fallback for serialization

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -419,14 +419,14 @@ class Worker(object):
                 "The object with ID {} already exists in the object store."
                 .format(object_id))
         except (TypeError, Exception):
-            # It could because the __dict__ of an instance is not serializable
-            # for cloudpickle, typically some cython objects. But the instance
-            # itself could have an `__reduce__` method.
+            # This error can happen because one of the members of the object
+            # may not be serializable for cloudpickle. So we need these extra
+            # fallbacks here to start from the beginning. Hopefully the object
+            # could have a `__reduce__` method.
             register_custom_serializer(type(value), use_pickle=True)
-            warning_message = ("WARNING: Pickling the class {} "
-                               "failed, so we are using pickle "
-                               "and only registering the class "
-                               "locally.".format(type(value)))
+            warning_message = ("WARNING: Serializing the class {} failed, "
+                               "so are are falling back to cloudpickle."
+                               .format(type(value)))
             logger.warning(warning_message)
             self.store_and_register(object_id, value)
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -418,7 +418,7 @@ class Worker(object):
             logger.info(
                 "The object with ID {} already exists in the object store."
                 .format(object_id))
-        except (TypeError, Exception):
+        except TypeError:
             # This error can happen because one of the members of the object
             # may not be serializable for cloudpickle. So we need these extra
             # fallbacks here to start from the beginning. Hopefully the object

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -392,7 +392,7 @@ def test_serialization_final_fallback(ray_start):
 
     test_data = np.random.randint(0, 100, size=(50, 10))
     model = CatBoostClassifier(iterations=2, depth=2, learning_rate=1,
-                               loss_function='Logloss',
+                               loss_function="Logloss",
                                logging_level="Verbose")
     model = ray.get(fit.remote(model))
     preds_class = model.predict(test_data)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -379,7 +379,8 @@ def test_custom_serializers(shutdown_only):
 
 
 def test_serialization_final_fallback(ray_start):
-    pytest.importorskip('catboost')
+    pytest.importorskip("catboost")
+    # This test will only run when "catboost" is installed.
     from catboost import CatBoostClassifier
 
     @ray.remote

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -391,8 +391,8 @@ def test_serialization_final_fallback(ray_start):
         logging_level="Verbose")
 
     reconstructed_model = ray.get(ray.put(model))
-    assert (sorted(model.__reduce__()[-1].items()) ==
-            sorted(reconstructed_model.__reduce__()[-1].items()))
+    assert (sorted(model.__reduce__()[-1].items()) == sorted(
+        reconstructed_model.__reduce__()[-1].items()))
 
 
 def test_register_class(shutdown_only):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -393,7 +393,7 @@ def test_serialization_final_fallback(ray_start):
     test_data = np.random.randint(0, 100, size=(50, 10))
     model = CatBoostClassifier(iterations=2, depth=2, learning_rate=1,
                                loss_function='Logloss',
-                               logging_level='Verbose')
+                               logging_level="Verbose")
     model = ray.get(fit.remote(model))
     preds_class = model.predict(test_data)
     preds_proba = model.predict_proba(test_data)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -378,6 +378,28 @@ def test_custom_serializers(shutdown_only):
     assert ray.get(f.remote()) == ((3, "string1", Bar.__name__), "string2")
 
 
+def test_serialization_final_fallback(ray_start):
+    pytest.importorskip('catboost')
+    from catboost import CatBoostClassifier
+
+    @ray.remote
+    def fit(model):
+        train_data = np.random.randint(0, 100, size=(100, 10))
+        train_label = np.random.randint(0, 2, size=100)
+        model.fit(train_data, train_label, cat_features=[0, 2, 5])
+        return model
+
+    test_data = np.random.randint(0, 100, size=(50, 10))
+    model = CatBoostClassifier(iterations=2, depth=2, learning_rate=1,
+                               loss_function='Logloss',
+                               logging_level='Verbose')
+    model = ray.get(fit.remote(model))
+    preds_class = model.predict(test_data)
+    preds_proba = model.predict_proba(test_data)
+    assert len(preds_class) == 50
+    assert len(preds_proba) == 50
+
+
 def test_register_class(shutdown_only):
     ray.init(num_cpus=2)
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -391,9 +391,12 @@ def test_serialization_final_fallback(ray_start):
         return model
 
     test_data = np.random.randint(0, 100, size=(50, 10))
-    model = CatBoostClassifier(iterations=2, depth=2, learning_rate=1,
-                               loss_function="Logloss",
-                               logging_level="Verbose")
+    model = CatBoostClassifier(
+        iterations=2,
+        depth=2,
+        learning_rate=1,
+        loss_function="Logloss",
+        logging_level="Verbose")
     model = ray.get(fit.remote(model))
     preds_class = model.predict(test_data)
     preds_proba = model.predict_proba(test_data)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -391,8 +391,8 @@ def test_serialization_final_fallback(ray_start):
         logging_level="Verbose")
 
     reconstructed_model = ray.get(ray.put(model))
-    assert (sorted(model.__reduce__()[-1].items()) == sorted(
-        reconstructed_model.__reduce__()[-1].items()))
+    assert set(model.get_params().items()) == set(
+        reconstructed_model.get_params().items())
 
 
 def test_register_class(shutdown_only):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Our serialization prefers expanding an object's `__dict__` first if it is not serializable for plasma. It will fail if there are cython functions that cannot be serialized by cloudpickle in `__dict__`. In this case, we should try to use cloudpickle from the beginning.

## Related issue number

https://github.com/ray-project/ray/issues/3373