### PR TITLE
Resolve no handlers could be found for logger 'ray.worker' 

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -76,10 +76,6 @@ try:
     import setproctitle
 except ImportError:
     setproctitle = None
-    logger.warning(
-        "WARNING: Not updating worker name since `setproctitle` is not "
-        "installed. Install this with `pip install setproctitle` "
-        "(or ray[debug]) to enable monitoring of worker processes.")
 
 
 class RayTaskError(Exception):
@@ -1685,6 +1681,10 @@ def init(redis_address=None,
         Exception: An exception is raised if an inappropriate combination of
             arguments is passed in.
     """
+
+    if configure_logging:
+        logging.basicConfig(level=logging_level, format=logging_format)
+
     # Add the use_raylet option for backwards compatibility.
     if use_raylet is not None:
         if use_raylet:
@@ -1694,8 +1694,11 @@ def init(redis_address=None,
             raise DeprecationWarning("The use_raylet argument is deprecated. "
                                      "Please remove it.")
 
-    if configure_logging:
-        logging.basicConfig(level=logging_level, format=logging_format)
+    if setproctitle is None:
+        logger.warning(
+            "WARNING: Not updating worker name since `setproctitle` is not "
+            "installed. Install this with `pip install setproctitle` "
+            "(or ray[debug]) to enable monitoring of worker processes.")
 
     if global_worker.connected:
         if ignore_reinit_error:


### PR DESCRIPTION


<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Resolve no handlers could be found for logger 'ray.worker'  when importing ray

<!-- Please give a short brief about these changes. -->
Move any logger.warn calls after calling logging.basicConfig

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
[#3482](https://github.com/ray-project/ray/issues/3482) 