### PR TITLE
Add option to evict keys LRU from the sharded redis tables

### DIFF
--- a/doc/source/redis-memory-management.rst
+++ b/doc/source/redis-memory-management.rst
@@ -7,92 +7,9 @@ servers, as described in `An Overview of the Internals
 task/object generation rate could risk high memory pressure, potentially leading
 to out-of-memory (OOM) errors.
 
-Here, we describe an experimental feature that transparently flushes metadata
-entries out of Redis memory.
+In Ray `0.6.1+` Redis shards can be configured to LRU evict task and object
+metadata by setting ``redis_max_memory`` when starting Ray. This supercedes the
+previously documented flushing functionality.
 
-Requirements
-------------
-
-As of early July 2018, the automatic memory management feature requires building
-Ray from source.  We are planning on eliminating this step in the near future by
-releasing official wheels.
-
-Building Ray
-~~~~~~~~~~~~
-
-First, follow `instructions to build Ray from source
-<installation.html#building-ray-from-source>`__ to install prerequisites.  After
-the prerequisites are installed, instead of doing the regular ``pip install`` as
-referenced in that document, pass an additional special flag,
-``RAY_USE_NEW_GCS=on``:
-
-.. code-block:: bash
-
-  git clone https://github.com/ray-project/ray.git
-  cd ray/python
-  RAY_USE_NEW_GCS=on pip install -e . --verbose  # Add --user if you see a permission denied error.
-
-Running Ray applications
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-At run time the environment variables ``RAY_USE_NEW_GCS=on`` and
-``RAY_USE_XRAY=1`` are required.
-
-.. code-block:: bash
-
-  export RAY_USE_NEW_GCS=on
-  export RAY_USE_XRAY=1
-  python my_ray_script.py  # Or launch python/ipython.
-
-Activate memory flushing
-------------------------
-
-After building Ray using the method above, simply add these two lines after
-``ray.init()`` to activate automatic memory flushing:
-
-.. code-block:: python
-
-   ray.init(...)
-
-   policy = ray.experimental.SimpleGcsFlushPolicy()
-   ray.experimental.set_flushing_policy(policy)
-
-   # My awesome Ray application logic follows.
-
-Paramaters of the flushing policy
----------------------------------
-
-There are three `user-configurable parameters
-<https://github.com/ray-project/ray/blob/8190ff1fd0c4b82f73e2c1c0f21de6bda494718c/python/ray/experimental/gcs_flush_policy.py#L31>`_
-of the ``SimpleGcsFlushPolicy``:
-
-* ``flush_when_at_least_bytes``: Wait until this many bytes of memory usage
-  accumulated in the redis server before flushing kicks in.
-* ``flush_period_secs``: Issue a flush to the Redis server every this many
-  seconds.
-* ``flush_num_entries_each_time``: A hint to the system on the number of entries
-  to flush on each request.
-
-The default values should serve to be non-invasive for lightweight Ray
-applications. ``flush_when_at_least_bytes`` is set to ``(1<<31)`` or 2GB,
-``flush_period_secs`` to 10, and ``flush_num_entries_each_time`` to 10000:
-
-.. code-block:: python
-
-    # Default parameters.
-    ray.experimental.SimpleGcsFlushPolicy(
-        flush_when_at_least_bytes=(1 << 31),
-        flush_period_secs=10,
-        flush_num_entries_each_time=10000)
-
-In particular, these default values imply that
-
-1. the Redis server would accumulate memory usage up to 2GB without any entries
-being flushed, then the flushing would kick in; and
-
-2. generally, "older" metadata entries would be flushed first, and the Redis
-server would always keep the most recent window of metadata of 2GB in size.
-
-**For advanced users.** Advanced users can tune the above parameters to their
-applications' needs; note that the desired flush rate is equal to (flush
-period) * (num entries each flush).
+Note that profiling is disabled when ``redis_max_memory`` is set. This is because
+profiling data cannot be LRU evicted.

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -37,7 +37,8 @@ class RayOutOfMemoryError(Exception):
                     round(psutil.virtual_memory().shared / 1e9, 2)) +
                 "currently being used by the Ray object store. You can set "
                 "the object store size with the `object_store_memory` "
-                "parameter when starting Ray.")
+                "parameter when starting Ray, and the max Redis size with "
+                "`redis_max_memory`.")
 
 
 class MemoryMonitor(object):

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -128,6 +128,19 @@ class Profiler(object):
             self.events.append(event)
 
 
+class NoopProfiler(object):
+    """A no-op profile used when collect_profile_data=False."""
+
+    def start_flush_thread(self):
+        pass
+
+    def flush_profile_data(self):
+        pass
+
+    def add_event(self, event):
+        pass
+
+
 class RayLogSpanRaylet(object):
     """An object used to enable logging a span of events with a with statement.
 

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -38,19 +38,18 @@ def create_parser(parser_creator=None):
         "--redis-address",
         default=None,
         type=str,
-        help="The Redis address of the cluster.")
+        help="Connect to an existing Ray cluster at this address instead "
+        "of starting a new one.")
     parser.add_argument(
         "--ray-num-cpus",
         default=None,
         type=int,
-        help="--num-cpus to pass to Ray."
-        " This only has an affect in local mode.")
+        help="--num-cpus to use if starting a new cluster.")
     parser.add_argument(
         "--ray-num-gpus",
         default=None,
         type=int,
-        help="--num-gpus to pass to Ray."
-        " This only has an affect in local mode.")
+        help="--num-gpus to use if starting a new cluster.")
     parser.add_argument(
         "--ray-num-local-schedulers",
         default=None,
@@ -60,14 +59,12 @@ def create_parser(parser_creator=None):
         "--ray-redis-max-memory",
         default=None,
         type=int,
-        help="--redis-max-memory to pass to Ray."
-        " This only has an affect in local mode.")
+        help="--redis-max-memory to use if starting a new cluster.")
     parser.add_argument(
         "--ray-object-store-memory",
         default=None,
         type=int,
-        help="--object-store-memory to pass to Ray."
-        " This only has an affect in local mode.")
+        help="--object-store-memory to use if starting a new cluster.")
     parser.add_argument(
         "--experiment-name",
         default="default",

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -57,6 +57,12 @@ def create_parser(parser_creator=None):
         type=int,
         help="Emulate multiple cluster nodes for debugging.")
     parser.add_argument(
+        "--ray-max-redis-memory",
+        default=None,
+        type=int,
+        help="--max-redis-memory to pass to Ray."
+        " This only has an affect in local mode.")
+    parser.add_argument(
         "--ray-object-store-memory",
         default=None,
         type=int,
@@ -122,12 +128,14 @@ def run(args, parser):
                     "num_cpus": args.ray_num_cpus or 1,
                     "num_gpus": args.ray_num_gpus or 0,
                 },
-                object_store_memory=args.ray_object_store_memory)
+                object_store_memory=args.ray_object_store_memory,
+                redis_max_memory=args.ray_redis_max_memory)
         ray.init(redis_address=cluster.redis_address)
     else:
         ray.init(
             redis_address=args.redis_address,
             object_store_memory=args.ray_object_store_memory,
+            redis_max_memory=args.ray_redis_max_memory,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     run_experiments(

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -57,10 +57,10 @@ def create_parser(parser_creator=None):
         type=int,
         help="Emulate multiple cluster nodes for debugging.")
     parser.add_argument(
-        "--ray-max-redis-memory",
+        "--ray-redis-max-memory",
         default=None,
         type=int,
-        help="--max-redis-memory to pass to Ray."
+        help="--redis-max-memory to pass to Ray."
         " This only has an affect in local mode.")
     parser.add_argument(
         "--ray-object-store-memory",

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -117,6 +117,23 @@ def cli(logging_level, logging_format):
     help="the maximum amount of memory (in bytes) to allow the "
     "object store to use")
 @click.option(
+    "--redis-max-memory",
+    required=False,
+    type=int,
+    help=(
+        "The max amount of memory (in bytes) to allow redis to use, or None "
+        "for no limit. Once the limit is exceeded, redis will start LRU "
+        "eviction of entries. This only applies to the sharded "
+        "redis tables (task and object tables)."))
+@click.option(
+    "--collect-profiling-data",
+    is_flag=True,
+    default=True,
+    help=("Whether to collect profiling data. Note that "
+          "profiling data cannot be LRU evicted, so if you set "
+          "redis_max_memory then profiling should also be disabled to prevent "
+          "it from consuming all available redis memory."))
+@click.option(
     "--num-workers",
     required=False,
     type=int,
@@ -202,7 +219,8 @@ def cli(logging_level, logging_format):
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
-          num_workers, num_cpus, num_gpus, resources, head, no_ui, block,
+          redis_max_memory, collect_profiling_data, num_workers, num_cpus,
+          num_gpus, resources, head, no_ui, block,
           plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
           plasma_store_socket_name, raylet_socket_name, temp_dir,
@@ -262,6 +280,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redis_port=redis_port,
             redis_shard_ports=redis_shard_ports,
             object_store_memory=object_store_memory,
+            redis_max_memory=redis_max_memory,
+            collect_profiling_data=collect_profiling_data,
             num_workers=num_workers,
             cleanup=False,
             redirect_worker_output=not no_redirect_worker_output,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -120,11 +120,10 @@ def cli(logging_level, logging_format):
     "--redis-max-memory",
     required=False,
     type=int,
-    help=(
-        "The max amount of memory (in bytes) to allow redis to use, or None "
-        "for no limit. Once the limit is exceeded, redis will start LRU "
-        "eviction of entries. This only applies to the sharded "
-        "redis tables (task and object tables)."))
+    help=("The max amount of memory (in bytes) to allow redis to use, or None "
+          "for no limit. Once the limit is exceeded, redis will start LRU "
+          "eviction of entries. This only applies to the sharded "
+          "redis tables (task and object tables)."))
 @click.option(
     "--collect-profiling-data",
     default=True,
@@ -220,11 +219,10 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
           redis_max_memory, collect_profiling_data, num_workers, num_cpus,
-          num_gpus, resources, head, no_ui, block,
-          plasma_directory, huge_pages, autoscaling_config,
-          no_redirect_worker_output, no_redirect_output,
-          plasma_store_socket_name, raylet_socket_name, temp_dir,
-          internal_config):
+          num_gpus, resources, head, no_ui, block, plasma_directory,
+          huge_pages, autoscaling_config, no_redirect_worker_output,
+          no_redirect_output, plasma_store_socket_name, raylet_socket_name,
+          temp_dir, internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -127,11 +127,11 @@ def cli(logging_level, logging_format):
         "redis tables (task and object tables)."))
 @click.option(
     "--collect-profiling-data",
-    is_flag=True,
     default=True,
+    type=bool,
     help=("Whether to collect profiling data. Note that "
           "profiling data cannot be LRU evicted, so if you set "
-          "redis_max_memory then profiling should also be disabled to prevent "
+          "redis_max_memory then profiling will also be disabled to prevent "
           "it from consuming all available redis memory."))
 @click.option(
     "--num-workers",

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -950,7 +950,8 @@ def start_raylet(redis_address,
                             "--temp-dir={}".format(
                                 sys.executable, worker_path, node_ip_address,
                                 plasma_store_name, raylet_name, redis_address,
-                                collect_profiling_data, get_temp_root()))
+                                "1" if collect_profiling_data else "0",
+                                get_temp_root()))
     if redis_password:
         start_worker_command += " --redis-password {}".format(redis_password)
 
@@ -1395,11 +1396,6 @@ def start_ray_processes(address_info=None,
         resources = {}
     if not isinstance(resources, list):
         resources = num_local_schedulers * [resources]
-
-    if redis_max_memory and collect_profiling_data:
-        logger.warn("Profiling data cannot be LRU evicted, so it is disabled "
-                    "when redis_max_memory is set.")
-        collect_profiling_data = False
 
     if num_workers is not None:
         raise Exception("The 'num_workers' argument is deprecated. Please use "

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1397,9 +1397,8 @@ def start_ray_processes(address_info=None,
         resources = num_local_schedulers * [resources]
 
     if redis_max_memory and collect_profiling_data:
-        logger.warn(
-            "Profiling data cannot be LRU evicted, so it is disabled "
-            "when redis_max_memory is set.")
+        logger.warn("Profiling data cannot be LRU evicted, so it is disabled "
+                    "when redis_max_memory is set.")
         collect_profiling_data = False
 
     if num_workers is not None:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1962,7 +1962,7 @@ def connect(info,
     # Enable nice stack traces on SIGSEGV etc.
     faulthandler.enable(all_threads=False)
 
-    if info["collect_profiling_data"]:
+    if info.get("collect_profiling_data"):
         worker.profiler = profiling.Profiler(worker)
     else:
         worker.profiler = profiling.NoopProfiler()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1574,7 +1574,6 @@ def _init(address_info=None,
             "redis_address": address_info["redis_address"],
             "store_socket_name": address_info["object_store_addresses"][0],
             "webui_url": address_info["webui_url"],
-            "collect_profiling_data": collect_profiling_data,
         }
         driver_address_info["raylet_socket_name"] = (
             address_info["raylet_socket_names"][0])
@@ -1587,7 +1586,8 @@ def _init(address_info=None,
         mode=driver_mode,
         worker=global_worker,
         driver_id=driver_id,
-        redis_password=redis_password)
+        redis_password=redis_password,
+        collect_profiling_data=collect_profiling_data)
     return address_info
 
 
@@ -1940,7 +1940,8 @@ def connect(info,
             mode=WORKER_MODE,
             worker=global_worker,
             driver_id=None,
-            redis_password=None):
+            redis_password=None,
+            collect_profiling_data=True):
     """Connect this worker to the local scheduler, to Plasma, and to Redis.
 
     Args:
@@ -1953,6 +1954,7 @@ def connect(info,
         driver_id: The ID of driver. If it's None, then we will generate one.
         redis_password (str): Prevents external clients without the password
             from connecting to Redis if provided.
+        collect_profiling_data: Whether to collect profiling data from workers.
     """
     # Do some basic checking to make sure we didn't call ray.init twice.
     error_message = "Perhaps you called ray.init twice by accident?"
@@ -1962,7 +1964,7 @@ def connect(info,
     # Enable nice stack traces on SIGSEGV etc.
     faulthandler.enable(all_threads=False)
 
-    if info.get("collect_profiling_data"):
+    if collect_profiling_data:
         worker.profiler = profiling.Profiler(worker)
     else:
         worker.profiler = profiling.NoopProfiler()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1342,6 +1342,8 @@ def _init(address_info=None,
           num_workers=None,
           num_local_schedulers=None,
           object_store_memory=None,
+          redis_max_memory=None,
+          collect_profiling_data=True,
           local_mode=False,
           driver_mode=None,
           redirect_worker_output=False,
@@ -1386,6 +1388,14 @@ def _init(address_info=None,
             This is only provided if start_ray_local is True.
         object_store_memory: The maximum amount of memory (in bytes) to
             allow the object store to use.
+        redis_max_memory: The max amount of memory (in bytes) to allow redis
+            to use, or None for no limit. Once the limit is exceeded, redis
+            will start LRU eviction of entries. This only applies to the
+            sharded redis tables (task and object tables).
+        collect_profiling_data: Whether to collect profiling data. Note that
+            profiling data cannot be LRU evicted, so if you set
+            redis_max_memory then profiling should also be disabled to prevent
+            it from consuming all available redis memory.
         local_mode (bool): True if the code should be executed serially
             without Ray. This is useful for debugging.
         redirect_worker_output: True if the stdout and stderr of worker
@@ -1479,6 +1489,8 @@ def _init(address_info=None,
             num_workers=num_workers,
             num_local_schedulers=num_local_schedulers,
             object_store_memory=object_store_memory,
+            redis_max_memory=redis_max_memory,
+            collect_profiling_data=collect_profiling_data,
             redirect_worker_output=redirect_worker_output,
             redirect_output=redirect_output,
             start_workers_from_local_scheduler=(
@@ -1519,6 +1531,9 @@ def _init(address_info=None,
         if object_store_memory is not None:
             raise Exception("When connecting to an existing cluster, "
                             "object_store_memory must not be provided.")
+        if redis_max_memory is not None:
+            raise Exception("When connecting to an existing cluster, "
+                            "redis_max_memory must not be provided.")
         if plasma_directory is not None:
             raise Exception("When connecting to an existing cluster, "
                             "plasma_directory must not be provided.")
@@ -1578,6 +1593,8 @@ def init(redis_address=None,
          num_gpus=None,
          resources=None,
          object_store_memory=None,
+         redis_max_memory=None,
+         collect_profiling_data=True,
          node_ip_address=None,
          object_id_seed=None,
          num_workers=None,
@@ -1634,6 +1651,14 @@ def init(redis_address=None,
             of that resource available.
         object_store_memory: The amount of memory (in bytes) to start the
             object store with.
+        redis_max_memory: The max amount of memory (in bytes) to allow redis
+            to use, or None for no limit. Once the limit is exceeded, redis
+            will start LRU eviction of entries. This only applies to the
+            sharded redis tables (task and object tables).
+        collect_profiling_data: Whether to collect profiling data. Note that
+            profiling data cannot be LRU evicted, so if you set
+            redis_max_memory then profiling should also be disabled to prevent
+            it from consuming all available redis memory.
         node_ip_address (str): The IP address of the node that we are on.
         object_id_seed (int): Used to seed the deterministic generation of
             object IDs. The same value can be used across multiple runs of the
@@ -1734,6 +1759,8 @@ def init(redis_address=None,
         huge_pages=huge_pages,
         include_webui=include_webui,
         object_store_memory=object_store_memory,
+        redis_max_memory=redis_max_memory,
+        collect_profiling_data=collect_profiling_data,
         driver_id=driver_id,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1392,10 +1392,7 @@ def _init(address_info=None,
             to use, or None for no limit. Once the limit is exceeded, redis
             will start LRU eviction of entries. This only applies to the
             sharded redis tables (task and object tables).
-        collect_profiling_data: Whether to collect profiling data. Note that
-            profiling data cannot be LRU evicted, so if you set
-            redis_max_memory then profiling should also be disabled to prevent
-            it from consuming all available redis memory.
+        collect_profiling_data: Whether to collect profiling data from workers.
         local_mode (bool): True if the code should be executed serially
             without Ray. This is useful for debugging.
         redirect_worker_output: True if the stdout and stderr of worker
@@ -1655,10 +1652,7 @@ def init(redis_address=None,
             to use, or None for no limit. Once the limit is exceeded, redis
             will start LRU eviction of entries. This only applies to the
             sharded redis tables (task and object tables).
-        collect_profiling_data: Whether to collect profiling data. Note that
-            profiling data cannot be LRU evicted, so if you set
-            redis_max_memory then profiling should also be disabled to prevent
-            it from consuming all available redis memory.
+        collect_profiling_data: Whether to collect profiling data from workers.
         node_ip_address (str): The IP address of the node that we are on.
         object_id_seed (int): Used to seed the deterministic generation of
             object IDs. The same value can be used across multiple runs of the

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -57,8 +57,8 @@ parser.add_argument(
     help=ray_constants.LOGGER_FORMAT_HELP)
 parser.add_argument(
     "--collect-profiling-data",
-    type=bool,
-    default=True,
+    type=int,  # but argparse can't handle bool values
+    default=1,
     help="Whether to collect profiling data from workers.")
 parser.add_argument(
     "--temp-dir",
@@ -76,8 +76,10 @@ if __name__ == "__main__":
         "redis_password": args.redis_password,
         "store_socket_name": args.object_store_name,
         "manager_socket_name": args.object_store_manager_name,
-        "raylet_socket_name": args.raylet_name
+        "raylet_socket_name": args.raylet_name,
+        "collect_profiling_data": args.collect_profiling_data,
     }
+    print(info)
 
     logging.basicConfig(
         level=logging.getLevelName(args.logging_level.upper()),

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -79,7 +79,6 @@ if __name__ == "__main__":
         "raylet_socket_name": args.raylet_name,
         "collect_profiling_data": args.collect_profiling_data,
     }
-    print(info)
 
     logging.basicConfig(
         level=logging.getLevelName(args.logging_level.upper()),

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -56,6 +56,11 @@ parser.add_argument(
     default=ray_constants.LOGGER_FORMAT,
     help=ray_constants.LOGGER_FORMAT_HELP)
 parser.add_argument(
+    "--collect-profiling-data",
+    type=bool,
+    default=True,
+    help="Whether to collect profiling data from workers.")
+parser.add_argument(
     "--temp-dir",
     required=False,
     type=str,

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -57,7 +57,7 @@ parser.add_argument(
     help=ray_constants.LOGGER_FORMAT_HELP)
 parser.add_argument(
     "--collect-profiling-data",
-    type=int,  # but argparse can't handle bool values
+    type=int,  # int since argparse can't handle bool values
     default=1,
     help="Whether to collect profiling data from workers.")
 parser.add_argument(

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         "store_socket_name": args.object_store_name,
         "manager_socket_name": args.object_store_manager_name,
         "raylet_socket_name": args.raylet_name,
-        "collect_profiling_data": args.collect_profiling_data,
     }
 
     logging.basicConfig(
@@ -88,7 +87,10 @@ if __name__ == "__main__":
     tempfile_services.set_temp_root(args.temp_dir)
 
     ray.worker.connect(
-        info, mode=ray.WORKER_MODE, redis_password=args.redis_password)
+        info,
+        mode=ray.WORKER_MODE,
+        redis_password=args.redis_password,
+        collect_profiling_data=args.collect_profiling_data)
 
     error_explanation = """
   This error is unexpected and should not have happened. Somehow a worker

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -199,8 +199,8 @@ class RayConfig {
   RayConfig()
       : ray_protocol_version_(0x0000000000000000),
         handler_warning_timeout_ms_(100),
-        heartbeat_timeout_milliseconds_(1000),
-        num_heartbeats_timeout_(30),
+        heartbeat_timeout_milliseconds_(100),
+        num_heartbeats_timeout_(300),
         num_heartbeats_warning_(5),
         debug_dump_period_milliseconds_(10000),
         initial_reconstruction_timeout_milliseconds_(10000),

--- a/src/ray/ray_config.h
+++ b/src/ray/ray_config.h
@@ -199,8 +199,8 @@ class RayConfig {
   RayConfig()
       : ray_protocol_version_(0x0000000000000000),
         handler_warning_timeout_ms_(100),
-        heartbeat_timeout_milliseconds_(100),
-        num_heartbeats_timeout_(100),
+        heartbeat_timeout_milliseconds_(1000),
+        num_heartbeats_timeout_(30),
         num_heartbeats_warning_(5),
         debug_dump_period_milliseconds_(10000),
         initial_reconstruction_timeout_milliseconds_(10000),

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1543,7 +1543,10 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
       [this](ray::gcs::AsyncGcsClient *client, const TaskID &task_id) {
         // The task was not in the GCS task table. It must therefore be in the
         // lineage cache.
-        RAY_CHECK(lineage_cache_.ContainsTask(task_id));
+        RAY_CHECK(lineage_cache_.ContainsTask(task_id)) <<
+            "Task metadata not found in either GCS or lineage cache. It may have been evicted " <<
+            "by the redis LRU configuration. Consider increasing the memory allocation via " <<
+            "ray.init(redis_max_memory=<max_memory_bytes>).";
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1543,10 +1543,12 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
       [this](ray::gcs::AsyncGcsClient *client, const TaskID &task_id) {
         // The task was not in the GCS task table. It must therefore be in the
         // lineage cache.
-        RAY_CHECK(lineage_cache_.ContainsTask(task_id)) <<
-            "Task metadata not found in either GCS or lineage cache. It may have been evicted " <<
-            "by the redis LRU configuration. Consider increasing the memory allocation via " <<
-            "ray.init(redis_max_memory=<max_memory_bytes>).";
+        RAY_CHECK(lineage_cache_.ContainsTask(task_id))
+            << "Task metadata not found in either GCS or lineage cache. It may have been "
+               "evicted "
+            << "by the redis LRU configuration. Consider increasing the memory "
+               "allocation via "
+            << "ray.init(redis_max_memory=<max_memory_bytes>).";
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -594,7 +594,7 @@ def test_warning_for_dead_node(ray_start_two_nodes):
     ray.services.all_processes[ray.services.PROCESS_TYPE_RAYLET][0].kill()
 
     # Check that we get warning messages for both raylets.
-    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 2, timeout=20)
+    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 2, timeout=40)
 
     # Extract the client IDs from the error messages. This will need to be
     # changed if the error message changes.

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import json
 import os
 import ray
 import sys
@@ -570,7 +571,13 @@ def test_warning_for_infeasible_zero_cpu_actor(shutdown_only):
 @pytest.fixture
 def ray_start_two_nodes():
     # Start the Ray processes.
-    ray.worker._init(start_ray_local=True, num_local_schedulers=2, num_cpus=0)
+    ray.worker._init(
+        start_ray_local=True,
+        num_local_schedulers=2,
+        num_cpus=0,
+        _internal_config=json.dumps({
+            "num_heartbeats_timeout": 40
+        }))
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This adds an experimental `redis_max_memory` flag that bounds the redis memory used per data shard. Note that this only applies to the non-primary shards which store the majority of the task and object metadata. Hence, stuff like client metadata is never evicted.

Since profiling data has a nested structure and cannot be LRU evicted, also make profiling controlled by `collect_profiling_data`, and disable it when `redis_max_memory` is set.

Analysis of redis's approximate LRU eviction algorithm: https://github.com/antirez/redis/blob/a2131f907a752e62c78ea6bb719daf9fe2f91402/src/evict.c#L118

We use `maxmemory_samples 10`. There is also a persisted eviction pool of 16 entries. This effectively gives us 26 tries per eviction to hit a old key (lower bound). Let's assume the most recent 30% of keys are required for stable operation, and we evict at 10000 QPS. Then:
 
```
>>> p_no_bad_eviction = 1 - 0.3**26
0.9999999999999746
>>> p_no_bad_eviction_year = p_not_bad_eviction**(10000*60*60*24*365)
0.9920143099318832
```

So a lower bound on reliability with approx LRU eviction is 99% per year. The actual reliability will be much higher of course since it's unlikely we need even 30% of the metadata, and also the eviction pool is persisted over time.

TODO:
- [x] stress test with long-running Ape-X cluster

## Related issue number

https://github.com/ray-project/ray/issues/3306
https://github.com/ray-project/ray/issues/954
https://github.com/ray-project/ray/issues/3452