### PR TITLE
Make stress test time shorter.

### DIFF
--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -294,6 +294,12 @@ def test_simple(ray_start_reconstruction):
         del values
 
 
+def sorted_random_indexes(total, output_num):
+    random_indexes = [np.random.randint(total) for _ in range(output_num)]
+    random_indexes.sort()
+    return random_indexes
+
+
 @pytest.mark.skipif(
     os.environ.get("RAY_USE_NEW_GCS") == "on",
     reason="Failing with new GCS API on Linux.")
@@ -338,8 +344,8 @@ def test_recursive(ray_start_reconstruction):
         value = ray.get(args[i])
         assert value[0] == i
     # Get 10 values randomly.
-    for _ in range(10):
-        i = np.random.randint(num_objects)
+    random_indexes = sorted_random_indexes(num_objects, 10)
+    for i in random_indexes:
         value = ray.get(args[i])
         assert value[0] == i
     # Get values sequentially, in chunks.
@@ -398,8 +404,8 @@ def test_multiple_recursive(ray_start_reconstruction):
         value = ray.get(args[i])
         assert value[0] == i
     # Get 10 values randomly.
-    for _ in range(10):
-        i = np.random.randint(num_objects)
+    random_indexes = sorted_random_indexes(num_objects, 10)
+    for i in random_indexes:
         value = ray.get(args[i])
         assert value[0] == i
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
I found the 10-random-index test is the most expensive test and the test time has a very big range. In my Mac, the test time for the 10-random-index test ranges from 100 seconds to 380 seconds. I think the reason is that the plasma cannot keep all the result in it and if the random index has a distribution like [big, small, big, ...], it will need to reconstruct the objects from the beginning when the index goes from big to small. 

In this PR, I sort the random indexes to keep an increasing order, which makes the previous results reusable by the latter test. Finally, there are less reconstructions. Maybe the stress is not enough, but I think done is better than perfect.

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
