### PR TITLE
Add test to test raylet client connection when raylet crashes.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,8 +103,8 @@ pushd "$BUILD_DIR"
 
 # avoid the command failed and exits
 # and cmake will check some directories to determine whether some targets built
-make clean || true
-rm -rf external/arrow-install
+#make clean || true
+#rm -rf external/arrow-install
 
 cmake -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \

--- a/build.sh
+++ b/build.sh
@@ -103,8 +103,8 @@ pushd "$BUILD_DIR"
 
 # avoid the command failed and exits
 # and cmake will check some directories to determine whether some targets built
-#make clean || true
-#rm -rf external/arrow-install
+make clean || true
+rm -rf external/arrow-install
 
 cmake -DCMAKE_BUILD_TYPE=$CBUILD_TYPE \
       -DCMAKE_RAY_LANG_JAVA=$RAY_BUILD_JAVA \

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/MockRayletClient.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
-import org.ray.api.exception.RayException;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.RayDevRuntime;
 import org.ray.runtime.objectstore.MockObjectStore;
@@ -68,7 +67,7 @@ public class MockRayletClient implements RayletClient {
 
   @Override
   public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly,
-      UniqueId currentTaskId) throws RayException {
+      UniqueId currentTaskId) {
 
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClient.java
@@ -3,7 +3,6 @@ package org.ray.runtime.raylet;
 import java.util.List;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
-import org.ray.api.exception.RayException;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.task.TaskSpec;
 
@@ -16,8 +15,7 @@ public interface RayletClient {
 
   TaskSpec getTask();
 
-  void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId)
-      throws RayException;
+  void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly, UniqueId currentTaskId);
 
   void notifyUnblocked(UniqueId currentTaskId);
 

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -90,7 +90,7 @@ public class RayletClientImpl implements RayletClient {
 
   @Override
   public void fetchOrReconstruct(List<UniqueId> objectIds, boolean fetchOnly,
-      UniqueId currentTaskId) throws RayException {
+      UniqueId currentTaskId) {
     if (RayLog.core.isDebugEnabled()) {
       RayLog.core.debug("Blocked on objects for task {}, object IDs are {}",
           UniqueIdUtil.computeTaskId(objectIds.get(0)), objectIds);

--- a/src/ray/raylet/lib/python/raylet_extension.cc
+++ b/src/ray/raylet/lib/python/raylet_extension.cc
@@ -98,7 +98,7 @@ static PyObject *PyRayletClient_FetchOrReconstruct(PyRayletClient *self, PyObjec
            << "raylet client may be closed, check raylet status. error message: "
            << status.ToString();
     PyErr_SetString(CommonError, stream.str().c_str());
-    Py_RETURN_NONE;
+    return NULL;
   }
 }
 

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -626,6 +626,6 @@ def test_raylet_crash_when_get(ray_start_regular):
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
     with pytest.raises(
-            Exception, match=r".*raylet connection may be closed.*"):
+            Exception, match=r".*raylet client may be closed.*"):
         ray.get(nonexistent_id)
     thread.join()

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -626,14 +626,7 @@ def test_raylet_crash_when_get(ray_start_regular):
 
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
-    try:
+    with pytest.raises(Exception,
+                       match=r".*raylet connection may be closed.*"):
         ray.get(nonexistent_id)
-        # The following assertion should not be reached.
-        assert False
-    except Exception:
-        stack_message = traceback.format_exc()
-        expected_message = (
-            "error: local_scheduler_fetch_or_reconstruct failed:"
-            " raylet connection may be closed, check raylet status")
-        assert expected_message in stack_message
     thread.join()

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -618,19 +618,22 @@ def test_warning_for_dead_node(ray_start_two_nodes):
 
 def test_raylet_crash_when_get(ray_start_regular):
     nonexistent_id = ray.ObjectID(_random_string())
+
     def sleep_to_kill_raylet():
         # Don't kill raylet before default workers get connected.
         time.sleep(2)
         ray.services.all_processes[ray.services.PROCESS_TYPE_RAYLET][0].kill()
+
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
     try:
-        obj = ray.get(nonexistent_id)
+        ray.get(nonexistent_id)
         # The following assertion should not be reached.
         assert False
     except SystemError as e:
         stack_message = traceback.format_exc()
-        expected_message = ("common.error: "
+        expected_message = (
+            "common.error: "
             "local_scheduler_fetch_or_reconstruct failed:"
             " raylet connection may be closed, check raylet status")
         assert expected_message in stack_message

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -625,7 +625,6 @@ def test_raylet_crash_when_get(ray_start_regular):
 
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
-    with pytest.raises(
-            Exception, match=r".*raylet client may be closed.*"):
+    with pytest.raises(Exception, match=r".*raylet client may be closed.*"):
         ray.get(nonexistent_id)
     thread.join()

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -617,7 +617,7 @@ def test_warning_for_dead_node(ray_start_two_nodes):
 
 
 def test_raylet_crash_when_get(ray_start_regular):
-    none_exist_id = ray.ObjectID(_random_string())
+    nonexistent_id = ray.ObjectID(_random_string())
     def sleep_to_kill_raylet():
         # Don't kill raylet before default workers get connected.
         time.sleep(2)
@@ -625,7 +625,7 @@ def test_raylet_crash_when_get(ray_start_regular):
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
     try:
-        obj = ray.get(none_exist_id)
+        obj = ray.get(nonexistent_id)
         # The following assertion should not be reached.
         assert False
     except SystemError as e:

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -630,11 +630,10 @@ def test_raylet_crash_when_get(ray_start_regular):
         ray.get(nonexistent_id)
         # The following assertion should not be reached.
         assert False
-    except SystemError as e:
+    except Exception:
         stack_message = traceback.format_exc()
         expected_message = (
-            "common.error: "
-            "local_scheduler_fetch_or_reconstruct failed:"
+            "error: local_scheduler_fetch_or_reconstruct failed:"
             " raylet connection may be closed, check raylet status")
         assert expected_message in stack_message
     thread.join()

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -626,7 +626,7 @@ def test_raylet_crash_when_get(ray_start_regular):
 
     thread = threading.Thread(target=sleep_to_kill_raylet)
     thread.start()
-    with pytest.raises(Exception,
-                       match=r".*raylet connection may be closed.*"):
+    with pytest.raises(
+            Exception, match=r".*raylet connection may be closed.*"):
         ray.get(nonexistent_id)
     thread.join()

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 import threading
 import time
-import traceback
 
 import ray.ray_constants as ray_constants
 from ray.utils import _random_string


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Add `test_raylet_crash_when_get` to test raylet connection when raylet crashes.
I have test that if [this PR](https://github.com/ray-project/ray/pull/3493) was not merged, this test would hang indefinitely.

<!-- Please give a short brief about these changes. -->

## Related issue number
https://github.com/ray-project/ray/pull/3493#issuecomment-446447519
<!-- Are there any issues opened that will be resolved by merging this change? -->
