### PR TITLE
Move actor table to primary redis context

### DIFF
--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -106,13 +106,13 @@ AsyncGcsClient::AsyncGcsClient(const std::string &address, int port,
                                              /*password=*/password));
   }
 
+  actor_table_.reset(new ActorTable({primary_context_}, this));
   client_table_.reset(new ClientTable({primary_context_}, this, client_id));
   error_table_.reset(new ErrorTable({primary_context_}, this));
   driver_table_.reset(new DriverTable({primary_context_}, this));
   heartbeat_batch_table_.reset(new HeartbeatBatchTable({primary_context_}, this));
   // Tables below would be sharded.
   object_table_.reset(new ObjectTable(shard_contexts_, this, command_type));
-  actor_table_.reset(new ActorTable(shard_contexts_, this));
   raylet_task_table_.reset(new raylet::TaskTable(shard_contexts_, this, command_type));
   task_reconstruction_log_.reset(new TaskReconstructionLog(shard_contexts_, this));
   task_lease_table_.reset(new TaskLeaseTable(shard_contexts_, this));


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Moves the actor table to the primary redis context, which is not subject to LRU eviction. The actor table does not get a lot of updates since it is only updated on actor creation and destruction.

## Related issue number

Closes https://github.com/ray-project/ray/issues/3519