### PR TITLE
Save initial config instead of initial resource config in the node manager.

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -55,7 +55,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       debug_dump_period_(config.debug_dump_period_ms),
       temp_dir_(config.temp_dir),
       object_manager_profile_timer_(io_service),
-      local_resources_(config.resource_config),
+      initial_config_(config),
       local_available_resources_(config.resource_config),
       worker_pool_(config.num_initial_workers, config.num_workers_per_process,
                    config.maximum_startup_concurrency, config.worker_commands),
@@ -332,7 +332,7 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   if (client_id == gcs_client_->client_table().GetLocalClientId()) {
     // We got a notification for ourselves, so we are connected to the GCS now.
     // Save this NodeManager's resource information in the cluster resource map.
-    cluster_resource_map_[client_id] = local_resources_;
+    cluster_resource_map_[client_id] = initial_config_.resource_config;
     return;
   }
 
@@ -1778,7 +1778,7 @@ std::string NodeManager::DebugString() const {
   std::stringstream result;
   uint64_t now_ms = current_time_ms();
   result << "NodeManager:";
-  result << "\nLocalResources: " << local_resources_.DebugString();
+  result << "\nInitialConfigResources: " << initial_config_.resource_config.ToString();
   result << "\nClusterResources:";
   for (auto &pair : cluster_resource_map_) {
     result << "\n" << pair.first.hex() << ": " << pair.second.DebugString();

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -389,8 +389,8 @@ class NodeManager {
   uint64_t last_heartbeat_at_ms_;
   /// The time that the last debug string was logged to the console.
   uint64_t last_debug_dump_at_ms_;
-  /// The resources local to this node.
-  const SchedulingResources local_resources_;
+  /// Initial node manager configuration.
+  const NodeManagerConfig initial_config_;
   /// The resources (and specific resource IDs) that are currently available.
   ResourceIdSet local_available_resources_;
   std::unordered_map<ClientID, SchedulingResources> cluster_resource_map_;


### PR DESCRIPTION
## What do these changes do?
minor code cleanup: the node manager needs to hold on to a copy of the initial resource config to initialize the main cluster resource map as soon as its client id is known (i.e., on client added handler). We saved this resource config in a const private variable just for that reason. This PR instead saves the full config (might be useful for debugging) instead and references its resource config field on client added callback. 

This removes confusion by reducing the set of data structures with resource state down to two. 

<!-- Please give a short brief about these changes. -->

## Related issue number

#3461 

<!-- Are there any issues opened that will be resolved by merging this change? -->
