### PR TITLE
[autoscaler] Fix Error Handling for botocore

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -273,8 +273,11 @@ def _get_role(role_name, config):
     try:
         role.load()
         return role
-    except botocore.errorfactory.NoSuchEntityException:
-        return None
+    except botocore.exceptions.ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "NoSuchEntity":
+            return None
+        else:
+            raise exc
 
 
 def _get_instance_profile(profile_name, config):
@@ -283,8 +286,11 @@ def _get_instance_profile(profile_name, config):
     try:
         profile.load()
         return profile
-    except botocore.errorfactory.NoSuchEntityException:
-        return None
+    except botocore.exceptions.ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "NoSuchEntity":
+            return None
+        else:
+            raise exc
 
 
 def _get_key(key_name, config):


### PR DESCRIPTION
Unfortunately Boto generates error classes dynamically, so this catches
the expected error and raises the error if it is the wrong class.

This would come up when generating a IamProfile. Is there a way to test this?

You can verify that this works by running 
```
aws iam delete-instance-profile --instance-profile-name ray-autoscaler-v1
ray up example-full.yaml
```

Closes #3533. 