### PR TITLE
Note requirement cython==0.29.0 in installation instructions

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -76,7 +76,7 @@ For Ubuntu, run the following commands:
   # If you are on Ubuntu 14.04, you need the following.
   pip install cmake
 
-  pip install cython==0.27.3
+  pip install cython==0.29.0
 
 For MacOS, run the following commands:
 
@@ -85,7 +85,7 @@ For MacOS, run the following commands:
   brew update
   brew install cmake pkg-config automake autoconf libtool openssl bison wget
 
-  pip install cython==0.27.3
+  pip install cython==0.29.0
 
 
 If you are using Anaconda, you may also need to run the following.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Note requirement cython==0.29.0 in installation instructions.
A recent pull request [PR#3545](https://github.com/ray-project/ray/pull/3545) upgraded arrow and the required cython minimum version became 0.29.0.
With cython == 0.27.3, when compiling using setup.py, the compiler complains "Coercion from Python not allowed without the GIL".

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
None.