### PR TITLE
Raylet events subscription support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,18 @@ matrix:
     - os: linux
       dist: trusty
       env: PYTHON=2.7 PYTHONWARNINGS=ignore
+      before_install:
+        # `libtcmalloc-minimal4` is for this TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/6968.
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libtcmalloc-minimal4
 
     - os: linux
       dist: trusty
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
+      before_install:
+        # `libtcmalloc-minimal4` is for this TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/6968.
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libtcmalloc-minimal4
 
     - os: osx
       osx_image: xcode7
@@ -105,6 +113,10 @@ matrix:
         - PYTHON=3.5
         - RAY_USE_NEW_GCS=on
         - PYTHONWARNINGS=ignore
+      before_install:
+        # `libtcmalloc-minimal4` is for this TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/6968.
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libtcmalloc-minimal4
 
 
 install:
@@ -135,6 +147,8 @@ script:
   # with pytest have the same name as the test file -- and this
   # module is only found if the test directory is in the PYTHONPATH.
   - export PYTHONPATH="$PYTHONPATH:./test/"
+  # It is for this TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/6968.
+  - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4:$LD_PRELOAD"
 
   # ray tune tests
   - python python/ray/tune/test/dependency_test.py

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,8 @@ MOCK_MODULES = [
     "ray.core.generated.ProfileTableData",
     "ray.core.generated.ObjectTableData",
     "ray.core.generated.ray.protocol.Task",
+    "ray.core.generated.ray.protocol.MessageType",
+    "ray.core.generated.ray.protocol.ObjectLocalEvent",
     "ray.core.generated.TablePrefix",
     "ray.core.generated.TablePubsub",
     "ray.core.generated.Language",

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -78,6 +78,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
 
     rayletClient = new RayletClientImpl(
         rayConfig.rayletSocketName,
+        rayConfig.rayletEventSocketName,
         workerContext.getCurrentWorkerId(),
         rayConfig.workerMode == WorkerMode.WORKER,
         workerContext.getCurrentTask().taskId

--- a/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
+++ b/java/runtime/src/main/java/org/ray/runtime/config/RayConfig.java
@@ -50,6 +50,7 @@ public class RayConfig {
   public final Long objectStoreSize;
 
   public final String rayletSocketName;
+  public final String rayletEventSocketName;
 
   public final String redisServerExecutablePath;
   public final String redisModulePath;
@@ -161,6 +162,12 @@ public class RayConfig {
 
     // raylet socket name
     rayletSocketName = config.getString("ray.raylet.socket-name");
+    // Ensure compatibility with previous versions.
+    if (config.hasPath("ray.raylet.event-socket-name")) {
+      rayletEventSocketName = config.getString("ray.raylet.event-socket-name");
+    } else {
+      rayletEventSocketName = rayletSocketName + "_events";
+    }
 
     // library path
     this.libraryPath = new ImmutableList.Builder<String>().add(
@@ -230,6 +237,7 @@ public class RayConfig {
         + ", objectStoreSocketName='" + objectStoreSocketName + '\''
         + ", objectStoreSize=" + objectStoreSize
         + ", rayletSocketName='" + rayletSocketName + '\''
+        + ", rayletEventSocketName='" + rayletEventSocketName + '\''
         + ", redisServerExecutablePath='" + redisServerExecutablePath + '\''
         + ", plasmaStoreExecutablePath='" + plasmaStoreExecutablePath + '\''
         + ", rayletExecutablePath='" + rayletExecutablePath + '\''

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -41,9 +41,9 @@ public class RayletClientImpl implements RayletClient {
    */
   private long client = 0;
 
-  public RayletClientImpl(String schedulerSockName, UniqueId clientId,
+  public RayletClientImpl(String schedulerSockName, String eventSockName, UniqueId clientId,
       boolean isWorker, UniqueId driverId) {
-    client = nativeInit(schedulerSockName, clientId.getBytes(),
+    client = nativeInit(schedulerSockName, eventSockName, clientId.getBytes(),
         isWorker, driverId.getBytes());
   }
 
@@ -287,8 +287,8 @@ public class RayletClientImpl implements RayletClient {
   /// 5) vim $Dir/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
   /// 6) popd
 
-  private static native long nativeInit(String localSchedulerSocket, byte[] workerId,
-      boolean isWorker, byte[] driverTaskId);
+  private static native long nativeInit(String localSchedulerSocket, String rayletEventSocket,
+      byte[] workerId, boolean isWorker, byte[] driverTaskId);
 
   private static native void nativeSubmitTask(long client, byte[] cursorId, ByteBuffer taskBuff,
       int pos, int taskSize);

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -196,6 +196,7 @@ public class RunManager {
     List<String> command = ImmutableList.of(
         rayConfig.rayletExecutablePath,
         rayConfig.rayletSocketName,
+        rayConfig.rayletEventSocketName,
         rayConfig.objectStoreSocketName,
         "0",  // The object manager port.
         "0",  // The node manager port.

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -85,6 +85,7 @@ ray {
   raylet {
     // RPC socket name of Raylet
     socket-name: /tmp/ray/sockets/raylet
+    event-socket-name: /tmp/ray/sockets/raylet_events
   }
 
 }

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -70,6 +70,8 @@ def parse_client_table(redis_client):
                 client.ObjectStoreSocketName(), allow_none=True),
             "RayletSocketName": decode(
                 client.RayletSocketName(), allow_none=True),
+            "RayletEventSocketName": decode(
+                client.RayletEventSocketName(), allow_none=True),
             "Resources": resources
         }
     return list(node_info.values())

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -73,6 +73,8 @@ class RayParams(object):
             name used by the plasma store.
         raylet_socket_name (str): If provided, it will specify the socket path
             used by the raylet process.
+        raylet_event_socket_name (str) : If provided, it will specify the
+            event socket used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
         include_log_monitor (bool): If True, then start a log monitor to
@@ -114,6 +116,7 @@ class RayParams(object):
                  logging_format=ray_constants.LOGGER_FORMAT,
                  plasma_store_socket_name=None,
                  raylet_socket_name=None,
+                 raylet_event_socket_name=None,
                  temp_dir=None,
                  include_log_monitor=None,
                  autoscaling_config=None,
@@ -146,6 +149,7 @@ class RayParams(object):
         self.include_webui = include_webui
         self.plasma_store_socket_name = plasma_store_socket_name
         self.raylet_socket_name = raylet_socket_name
+        self.raylet_event_socket_name = raylet_event_socket_name
         self.temp_dir = temp_dir
         self.include_log_monitor = include_log_monitor
         self.autoscaling_config = autoscaling_config

--- a/python/ray/raylet/__init__.py
+++ b/python/ray/raylet/__init__.py
@@ -4,10 +4,10 @@ from __future__ import print_function
 
 from ray.core.src.ray.raylet.libraylet_library_python import (
     Task, RayletClient, ObjectID, check_simple_value, compute_task_id,
-    task_from_string, task_to_string, _config, common_error)
+    task_from_string, task_to_string, _config, common_error, random_id)
 
 __all__ = [
     "Task", "RayletClient", "ObjectID", "check_simple_value",
     "compute_task_id", "task_from_string", "task_to_string",
-    "start_local_scheduler", "_config", "common_error"
+    "start_local_scheduler", "_config", "common_error", "random_id"
 ]

--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -124,6 +124,15 @@ def get_raylet_socket_name(suffix=""):
     return raylet_socket_name
 
 
+def get_raylet_event_socket_name(suffix=""):
+    """Get a socket name for raylet."""
+    sockets_dir = get_sockets_dir_path()
+
+    raylet_socket_name = make_inc_temp(
+        prefix="raylet_events", directory_name=sockets_dir, suffix=suffix)
+    return raylet_socket_name
+
+
 def get_object_store_socket_name():
     """Get a socket name for plasma object store."""
     sockets_dir = get_sockets_dir_path()

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -39,6 +39,11 @@ parser.add_argument(
 parser.add_argument(
     "--raylet-name", required=False, type=str, help="the raylet's name")
 parser.add_argument(
+    "--raylet-event-socket-name",
+    required=False,
+    type=str,
+    help="the raylet event socket name")
+parser.add_argument(
     "--logging-level",
     required=False,
     type=str,
@@ -67,6 +72,7 @@ if __name__ == "__main__":
         "redis_password": args.redis_password,
         "store_socket_name": args.object_store_name,
         "raylet_socket_name": args.raylet_name,
+        "raylet_event_socket_name": args.raylet_event_socket_name,
     }
 
     logging.basicConfig(

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -33,6 +33,7 @@ set(RAY_SRCS
   object_manager/object_store_notification_manager.cc
   object_manager/object_directory.cc
   object_manager/object_manager.cc
+  raylet/event/raylet_events.cc
   raylet/monitor.cc
   raylet/mock_gcs_client.cc
   raylet/task.cc

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -252,6 +252,8 @@ table ClientTableData {
   node_manager_address: string;
   // The IPC socket name of the client's raylet.
   raylet_socket_name: string;
+  // The event IPC socket name of the client's raylet.
+  raylet_event_socket_name: string;
   // The IPC socket name of the client's plasma store.
   object_store_socket_name: string;
   // The port at which the client's node manager is listening for TCP

--- a/src/ray/id.h
+++ b/src/ray/id.h
@@ -49,6 +49,7 @@ typedef UniqueID WorkerID;
 typedef UniqueID DriverID;
 typedef UniqueID ConfigID;
 typedef UniqueID ClientID;
+typedef UniqueID SubscriptionID;
 
 // TODO(swang): ObjectID and TaskID should derive from UniqueID. Then, we
 // can make these methods of the derived classes.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -817,8 +817,8 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(chunk_info.data, chunk_info.buffer_length));
     boost::system::error_code ec;
-    conn.ReadBuffer(buffer, ec);
-    if (ec.value() == boost::system::errc::success) {
+    auto status = conn.ReadBuffer(buffer);
+    if (status.ok()) {
       buffer_pool_.SealChunk(object_id, chunk_index);
     } else {
       buffer_pool_.AbortCreateChunk(object_id, chunk_index);
@@ -834,10 +834,8 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(mutable_vec, buffer_length));
     boost::system::error_code ec;
-    conn.ReadBuffer(buffer, ec);
-    if (ec.value() != boost::system::errc::success) {
-      RAY_LOG(ERROR) << boost_to_ray_status(ec).ToString();
-    }
+    auto status = conn.ReadBuffer(buffer);
+    if (!status.ok()) RAY_LOG(ERROR) << status.ToString();
     // TODO(hme): If the object isn't local, create a pull request for this chunk.
   }
   conn.ProcessMessages();

--- a/src/ray/object_manager/object_manager_client_connection.h
+++ b/src/ray/object_manager/object_manager_client_connection.h
@@ -59,7 +59,7 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   /// Write a buffer to this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
+  /// \return ray::Status
   Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer) {
     return conn_->WriteBuffer(buffer);
   }
@@ -67,10 +67,9 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   /// Read a buffer from this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
-  void ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer,
-                  boost::system::error_code &ec) {
-    return conn_->ReadBuffer(buffer, ec);
+  /// \return ray::Status
+  Status ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer) {
+    return conn_->ReadBuffer(buffer);
   }
 
   /// \return The ClientID of this connection.

--- a/src/ray/raylet/event/events.h
+++ b/src/ray/raylet/event/events.h
@@ -1,0 +1,300 @@
+#ifndef RAY_EVENT_EVENTS_H
+#define RAY_EVENT_EVENTS_H
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "ray/id.h"
+
+namespace ray {
+
+namespace events {
+
+/// The enum of event status.
+enum class EventStatus { pending, cancelled, finished };
+
+struct EventEdge;
+template <typename TEvent>
+class EventsManager;
+
+class IEventNode {
+ public:
+  /// Finish an input edge of the node.
+  ///
+  /// \param in_edge The input edge.
+  /// \return Void.
+  virtual void FinishInEdge(std::shared_ptr<EventEdge> &in_edge) = 0;
+  virtual void FinishInEdge(std::shared_ptr<EventEdge> &&in_edge) = 0;
+
+  /// Finish the output edge of the node.
+  ///
+  /// \param out_edge The output edge.
+  /// \return Void.
+  virtual void FinishOutEdge(std::shared_ptr<EventEdge> &out_edge) = 0;
+  virtual void FinishOutEdge(std::shared_ptr<EventEdge> &&out_edge) = 0;
+
+  /// Cancel an input edge of the node.
+  ///
+  /// \param in_edge The input edge.
+  /// \return Void.
+  virtual void CancelInEdge(std::shared_ptr<EventEdge> &in_edge) = 0;
+  virtual void CancelInEdge(std::shared_ptr<EventEdge> &&in_edge) = 0;
+
+  /// Cancel the output edge of the node.
+  ///
+  /// \param out_edge The output edge.
+  /// \return Void.
+  virtual void CancelOutEdge(std::shared_ptr<EventEdge> &out_edge) = 0;
+  virtual void CancelOutEdge(std::shared_ptr<EventEdge> &&out_edge) = 0;
+
+  /// Finish the node.
+  ///
+  /// \return Void.
+  virtual void Finish() = 0;
+
+  /// Cancel the node.
+  ///
+  /// \return Void.
+  virtual void Cancel() = 0;
+};
+
+struct EventEdge : std::enable_shared_from_this<EventEdge> {
+  /// Cancel the edge.
+  ///
+  /// \return Void.
+  virtual void Cancel() {
+    if (status == EventStatus::pending) {
+      status = EventStatus::cancelled;
+      if (in_event_node) in_event_node->CancelOutEdge(shared_from_this());
+      if (out_event_node) out_event_node->CancelInEdge(shared_from_this());
+    }
+  }
+
+  /// Finish the edge.
+  ///
+  /// \return Void.
+  virtual void Finish() {
+    if (status == EventStatus::pending) {
+      status = EventStatus::finished;
+      if (in_event_node) in_event_node->FinishOutEdge(shared_from_this());
+      if (out_event_node) out_event_node->FinishInEdge(shared_from_this());
+    }
+  }
+  virtual ~EventEdge(){};
+  /// Current status of the edge.
+  EventStatus status = EventStatus::pending;
+  /// The upstrean node. This edge serves as one of its output edges.
+  std::shared_ptr<IEventNode> in_event_node;
+  /// The downstrean node. This edge serves as one of its input edges.
+  std::shared_ptr<IEventNode> out_event_node;
+};
+
+template <typename TEvent>
+class EventNode : public IEventNode {
+ public:
+  /// Create an event node.
+  ///
+  /// \param event The event this node represents.
+  /// \param manager The event manager this node belongs to.
+  EventNode(const TEvent &event, EventsManager<TEvent> &manager)
+      : event_(event), manager_(manager) {}
+  virtual ~EventNode() {}
+
+  void InsertOutEdge(std::shared_ptr<EventEdge> &out_node) {
+    out_edges_.insert(out_node);
+  }
+
+  virtual void FinishInEdge(std::shared_ptr<EventEdge> &in_edge) override {
+    auto extracted_in_edge = ExtractInEdge(in_edge);
+    if (extracted_in_edge) extracted_in_edge->Finish();
+    if (in_edges_.empty()) Finish();
+  }
+
+  virtual void FinishInEdge(std::shared_ptr<EventEdge> &&in_edge) override {
+    FinishInEdge(in_edge);
+  }
+
+  virtual void FinishOutEdge(std::shared_ptr<EventEdge> &out_edge) override {
+    auto extracted_out_edge = ExtractOutEdge(out_edge);
+    if (extracted_out_edge) extracted_out_edge->Finish();
+    if (out_edges_.empty()) Cancel();
+  }
+
+  virtual void FinishOutEdge(std::shared_ptr<EventEdge> &&out_edge) override {
+    FinishOutEdge(out_edge);
+  }
+
+  virtual void CancelInEdge(std::shared_ptr<EventEdge> &in_edge) override {
+    auto extracted_in_edge = ExtractInEdge(in_edge);
+    if (extracted_in_edge) extracted_in_edge->Cancel();
+    if (in_edges_.empty()) Finish();
+  }
+
+  virtual void CancelInEdge(std::shared_ptr<EventEdge> &&in_edge) override {
+    CancelInEdge(in_edge);
+  }
+
+  virtual void CancelOutEdge(std::shared_ptr<EventEdge> &out_edge) override {
+    auto extracted_out_edge = ExtractOutEdge(out_edge);
+    if (extracted_out_edge) extracted_out_edge->Cancel();
+    if (out_edges_.empty()) Cancel();
+  }
+
+  virtual void CancelOutEdge(std::shared_ptr<EventEdge> &&out_edge) override {
+    CancelOutEdge(out_edge);
+  }
+
+  virtual void Cancel() override {
+    if (status_ != EventStatus::pending) return;
+    status_ = EventStatus::cancelled;
+    if (!in_edges_.empty()) {
+      std::vector<std::shared_ptr<EventEdge>> in_edges_copy(in_edges_.begin(),
+                                                            in_edges_.end());
+      // Cancel unfinished dependencies.
+      for (auto &in_edge : in_edges_copy) CancelInEdge(in_edge);
+    }
+    if (!out_edges_.empty()) {
+      std::vector<std::shared_ptr<EventEdge>> out_edges_copy(out_edges_.begin(),
+                                                             out_edges_.end());
+      // Cancel unfinished dependencies.
+      for (auto &out_edge : out_edges_copy) CancelOutEdge(out_edge);
+    }
+    manager_.CancelEvent(event_);
+  }
+
+  virtual void Finish() override {
+    if (status_ != EventStatus::pending) return;
+    status_ = EventStatus::finished;
+    if (!in_edges_.empty()) {
+      std::vector<std::shared_ptr<EventEdge>> in_edges_copy(in_edges_.begin(),
+                                                            in_edges_.end());
+      // Cancel unfinished dependencies.
+      for (auto &in_edge : in_edges_copy) CancelInEdge(in_edge);
+    }
+    std::vector<std::shared_ptr<EventEdge>> out_edges_copy(out_edges_.begin(),
+                                                           out_edges_.end());
+    for (auto &out_edge : out_edges_copy) FinishOutEdge(out_edge);
+    manager_.FinishEvent(event_);
+  }
+
+ private:
+  /// Remove and return an input edge if it exists; otherwise return nullptr.
+  ///
+  /// \param in_edge The input edge.
+  /// \return The input edge.
+  std::shared_ptr<EventEdge> ExtractInEdge(std::shared_ptr<EventEdge> &in_edge) {
+    // We can use `extract` since C++14.
+    auto search = in_edges_.find(in_edge);
+    if (search != in_edges_.end()) {
+      in_edges_.erase(in_edge);
+      in_edge->out_event_node.reset();
+      return in_edge;
+    } else {
+      return nullptr;
+    }
+  }
+
+  /// Remove and return an output edge if it exists; otherwise return nullptr.
+  ///
+  /// \param out_edge The output edge.
+  /// \return The output edge.
+  std::shared_ptr<EventEdge> ExtractOutEdge(std::shared_ptr<EventEdge> &out_edge) {
+    // We can use `extract` since C++14.
+    auto search = out_edges_.find(out_edge);
+    if (search != out_edges_.end()) {
+      out_edges_.erase(out_edge);
+      out_edge->in_event_node.reset();
+      return out_edge;
+    } else {
+      return nullptr;
+    }
+  }
+
+  /// The event this event node represents.
+  const TEvent event_;
+  /// The event manager of the event node.
+  EventsManager<TEvent> &manager_;
+  /// Current status of the event node.
+  EventStatus status_ = EventStatus::pending;
+  /// `in_edges_` are dependencies of some upstream events.
+  std::unordered_set<std::shared_ptr<EventEdge>> in_edges_;
+  /// `out_edges_` are dependencies of some downstream events.
+  std::unordered_set<std::shared_ptr<EventEdge>> out_edges_;
+};
+
+/// An events manager maintains its event nodes.
+template <typename TEvent>
+class EventsManager {
+ public:
+  /// Subscribe an event. If the corresponding node does not exists, it will create one.
+  ///
+  /// \param event The event to subscribe.
+  /// \param edge The output edge of the corresponding event node.
+  /// \return Void
+  void SubscribeEvent(const TEvent &event, std::shared_ptr<EventEdge> &edge) {
+    auto event_node = CreateEventNode(event);
+    event_node->InsertOutEdge(edge);
+  }
+
+  /// Cancel an event. If the event does not exists, it will be ignored.
+  /// The corresponding node will be cancelled and erased from the event manager.
+  ///
+  /// \param event The event to cancel.
+  /// \return Void
+  void CancelEvent(const TEvent &event) {
+    auto search = events_.find(event);
+    if (search != events_.end()) {
+      search->second->Cancel();
+      events_.erase(event);
+    }
+  }
+
+  /// Finish an event. If the event does not exists, it will be ignored.
+  /// The corresponding node will be finished and erased from the event manager.
+  ///
+  /// \param event The event to finish.
+  /// \return Void
+  void FinishEvent(const TEvent &event) {
+    auto search = events_.find(event);
+    if (search != events_.end()) {
+      search->second->Finish();
+      events_.erase(event);
+    }
+  }
+
+  virtual ~EventsManager() {}
+
+ private:
+  /// Try to create an event node with the given event.
+  /// Return the existing one if the event node already exists.
+  ///
+  /// \param event The event for the event node.
+  /// \return The corresponding event node.
+  std::shared_ptr<EventNode<TEvent>> CreateEventNode(const TEvent &event) {
+    auto search = events_.find(event);
+    std::shared_ptr<EventNode<TEvent>> event_node;
+    if (search == events_.end()) {
+      event_node = std::make_shared<EventNode<TEvent>>(event, *this);
+      InitializeEventNode(event_node);
+      events_[event] = event_node;
+    } else {
+      event_node = search->second;
+    }
+    return event_node;
+  }
+
+  /// Initializer for a new event node.
+  ///
+  /// \param event_node The event node to be initialized.
+  /// \return Void
+  virtual void InitializeEventNode(std::shared_ptr<EventNode<TEvent>> &event_node) = 0;
+  /// A mapping between events and event nodes.
+  std::unordered_map<TEvent, std::shared_ptr<EventNode<TEvent>>> events_;
+};
+
+};  // namespace events
+};  // namespace ray
+
+#endif  // RAY_EVENT_EVENTS_H

--- a/src/ray/raylet/event/raylet_events.cc
+++ b/src/ray/raylet/event/raylet_events.cc
@@ -1,0 +1,89 @@
+#include "ray/raylet/event/raylet_events.h"
+
+namespace ray {
+
+namespace events {
+
+void EventEdgeEndpoint::Finish() {
+  EventEdge::Finish();
+  raylet_events_.Unsubscribe(subscription_id_);
+}
+
+void ObjectLocalEndpoint::Finish() {
+  EventEdgeEndpoint::Finish();
+  // Write the data.
+  flatbuffers::FlatBufferBuilder fbb;
+  auto object_ready_event = protocol::CreateObjectLocalEvent(
+      fbb, to_flatbuf(fbb, subscription_id_), to_flatbuf(fbb, object_id_));
+  fbb.Finish(object_ready_event);
+
+  event_client_->WriteMessageAsync(
+      static_cast<int64_t>(MessageType::ObjectLocalEvent), fbb.GetSize(),
+      fbb.GetBufferPointer(), [this](const ray::Status &status) {
+        // The null ID means the client has been deactivated,
+        // so we just ignore errors here.
+        if (!status.ok() && !event_client_->GetClientId().is_nil()) {
+          RAY_LOG(ERROR) << status.ToString()
+                         << ". Failed to send ObjectLocalEvent to client.";
+        }
+      });
+}
+
+RayletEvents::RayletEvents(ObjectManager &object_manager)
+    : object_manager_(object_manager) {
+  objectlocal_events_manager_.reset(new ObjectLocalEventsManager());
+  RAY_CHECK_OK(object_manager_.SubscribeObjAdded(
+      [this](const object_manager::protocol::ObjectInfoT &object_info) {
+        ObjectID object_id = ObjectID::from_binary(object_info.object_id);
+        HandleObjectLocal(object_id);
+      }));
+
+  RAY_CHECK_OK(object_manager_.SubscribeObjDeleted(
+      [this](const ObjectID &object_id) { HandleObjectMissing(object_id); }));
+}
+
+void RayletEvents::Unsubscribe(const SubscriptionID &subscription_id) {
+  auto search = endpoints_.find(subscription_id);
+  if (search != endpoints_.end()) {
+    endpoints_.erase(subscription_id);
+    // Only pending tasks will be cancelled.
+    search->second->Cancel();
+  }
+}
+
+ray::Status RayletEvents::SubscribeObjectLocalEvent(
+    const SubscriptionID &subscription_id,
+    const std::shared_ptr<LocalClientConnection> &client, const ObjectLocalEvent &event) {
+  auto events_client = GetEventConnection(client);
+  if (!events_client)
+    return ray::Status::KeyError("The events client has not been activated.");
+
+  auto objectlocal_endpoint = std::make_shared<ObjectLocalEndpoint>(
+      *this, subscription_id, client, events_client, event);
+
+  if (local_objects_.find(event) == local_objects_.end()) {
+    auto event_edge =
+        std::static_pointer_cast<EventEdge, ObjectLocalEndpoint>(objectlocal_endpoint);
+    objectlocal_events_manager_->SubscribeEvent(event, event_edge);
+  } else {
+    // The object ID has been local.
+    objectlocal_endpoint->Finish();
+  }
+  return ray::Status::OK();
+}
+
+std::shared_ptr<LocalClientConnection> RayletEvents::GetEventConnection(
+    const std::shared_ptr<LocalClientConnection> &client) {
+  const auto &client_id = client->GetClientId();
+  auto search = event_socket_connections_.find(client_id);
+  if (search != event_socket_connections_.end()) {
+    auto events_client = search->second;
+    RAY_CHECK(client_id == events_client->GetClientId());
+    return events_client;
+  } else {
+    return nullptr;
+  }
+}
+
+};  // namespace events
+};  // namespace ray

--- a/src/ray/raylet/event/raylet_events.h
+++ b/src/ray/raylet/event/raylet_events.h
@@ -147,11 +147,30 @@ class RayletEvents {
     }
   }
 
+  /// Deactivate event socket connection.
+  ///
+  /// \param events_client The event socket connection to be deactivated.
+  /// \return Void
+  void DeactivateEventConnection(
+      const std::shared_ptr<LocalClientConnection> &events_client) {
+    DeactivateEventConnection(events_client->GetClientId());
+  }
+
   /// Cancel a subscription.
   ///
   /// \param subscription_id The subscription ID to cancel.
   /// \return Void
   void Unsubscribe(const SubscriptionID &subscription_id);
+
+  /// Push events to client.
+  ///
+  /// \param client_id The ID of the client we want to push events to.
+  /// \param type The type of the event message.
+  /// \param fbb The builder for the event message.
+  /// \param callback The callback for the event push result.
+  void PushEvent(const ClientID &client_id, MessageType type,
+      flatbuffers::FlatBufferBuilder &fbb,
+      std::function<void(const ray::Status &)> callback);
 
   /// Subscribe the ObjectLocal event.
   ///

--- a/src/ray/raylet/event/raylet_events.h
+++ b/src/ray/raylet/event/raylet_events.h
@@ -1,0 +1,190 @@
+#ifndef RAY_EVENT_RAYLET_EVENTS_H
+#define RAY_EVENT_RAYLET_EVENTS_H
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "ray/common/client_connection.h"
+#include "ray/common/common_protocol.h"
+
+#include "ray/id.h"
+#include "ray/object_manager/object_manager.h"
+#include "ray/raylet/event/events.h"
+#include "ray/raylet/format/node_manager_generated.h"
+
+namespace ray {
+
+namespace events {
+
+typedef ObjectID ObjectLocalEvent;
+using ray::protocol::MessageType;
+
+/// This event manager controls ObjectID ready events coming from the plasma store.
+class ObjectLocalEventsManager : public EventsManager<ObjectLocalEvent> {
+ private:
+  /// It is a nop function here.
+  virtual void InitializeEventNode(
+      std::shared_ptr<EventNode<ObjectLocalEvent>> &event_edge) override {}
+};
+
+class RayletEvents;
+
+/// The endpoint is a special event edge that keeps a subscription ID
+/// and interacts with the client. They are leaves in the event-driven DAG.
+class EventEdgeEndpoint : public EventEdge {
+ public:
+  /// Create an event edge endpoint.
+  ///
+  /// \param raylet_events The raylet events main controller.
+  /// \param subscription_id The subscription ID this endpoint holds.
+  /// \param client The connection to the client through raylet socket.
+  /// \param events_client The connection to the client through raylet events socket.
+  EventEdgeEndpoint(RayletEvents &raylet_events, const SubscriptionID &subscription_id,
+                    const std::shared_ptr<LocalClientConnection> &client,
+                    const std::shared_ptr<LocalClientConnection> &events_client)
+      : raylet_events_(raylet_events),
+        subscription_id_(subscription_id),
+        client_(client),
+        event_client_(events_client) {}
+
+  virtual void Finish() override;
+
+ protected:
+  /// The raylet events main controller it belongs to.
+  RayletEvents &raylet_events_;
+  /// The subscription ID this endpoint holds.
+  const SubscriptionID subscription_id_;
+  /// The connection to the client through raylet socket.
+  std::shared_ptr<LocalClientConnection> client_;
+  /// The connection to the client through raylet events socket.
+  std::shared_ptr<LocalClientConnection> event_client_;
+};
+
+/// This class represents the endpoint for the ObjectLocal event.
+class ObjectLocalEndpoint : public EventEdgeEndpoint {
+ public:
+  /// Create an ObjectLocal event edge endpoint.
+  ///
+  /// \param raylet_events The raylet events main controller.
+  /// \param subscription_id The subscription ID this endpoint holds.
+  /// \param client The connection to the client through raylet socket.
+  /// \param events_client The connection to the client through raylet events socket.
+  /// \param object_id The object ID this endpoint deals with.
+  ObjectLocalEndpoint(RayletEvents &raylet_events, const SubscriptionID &subscription_id,
+                      const std::shared_ptr<LocalClientConnection> &client,
+                      const std::shared_ptr<LocalClientConnection> &events_client,
+                      const ray::ObjectID &object_id)
+      : EventEdgeEndpoint(raylet_events, subscription_id, client, events_client),
+        object_id_(object_id) {}
+
+  virtual void Finish() override;
+
+ private:
+  /// The ObjectID this endpoint holds.
+  const ray::ObjectID object_id_;
+};
+
+/// This class is the main controller of raylet events.
+class RayletEvents {
+ public:
+  /// Create an instance of this class.
+  /// \param object_manager The object manager instance.
+  RayletEvents(ObjectManager &object_manager);
+
+  /// The handler of the ObjectLocal event.
+  ///
+  /// \param object_id The object ID of the ObjectLocal event.
+  /// \return Void
+  void HandleObjectLocal(const ObjectID &object_id) {
+    // Add the object to the table of locally available objects.
+    auto inserted = local_objects_.insert(object_id);
+    RAY_CHECK(inserted.second);
+    ProcessObjectLocalEvent(object_id);
+  }
+
+  /// The handler of the ObjectMissing event.
+  ///
+  /// \param object_id The object ID of the ObjectMissing event.
+  /// \return Void
+  void HandleObjectMissing(const ObjectID &object_id) {
+    // Remove the object from the table of locally available objects.
+    auto erased = local_objects_.erase(object_id);
+    RAY_CHECK(erased == 1);
+  }
+
+  /// Process the ObjectLocal event.
+  ///
+  /// \param event The ObjectLocal event.
+  /// \return Void
+  void ProcessObjectLocalEvent(const ObjectLocalEvent &event) {
+    objectlocal_events_manager_->FinishEvent(event);
+  }
+
+  /// Activate event socket connection.
+  ///
+  /// \param events_client The event socket connection to be activated.
+  /// \param client_id The ID to be assigned to the event socket connection.
+  /// \return Void
+  void ActivateEventConnection(
+      const std::shared_ptr<LocalClientConnection> &events_client,
+      const ClientID &client_id) {
+    events_client->SetClientID(client_id);
+    event_socket_connections_[client_id] = events_client;
+  }
+
+  /// Deactivate event socket connection.
+  ///
+  /// \param client_id The ID of the event socket connection.
+  /// \return Void
+  void DeactivateEventConnection(const ClientID &client_id) {
+    auto search = event_socket_connections_.find(client_id);
+    if (search != event_socket_connections_.end()) {
+      auto events_client = search->second;
+      // Replace with a null ID.
+      events_client->SetClientID(UniqueID::nil());
+      event_socket_connections_.erase(client_id);
+    }
+  }
+
+  /// Cancel a subscription.
+  ///
+  /// \param subscription_id The subscription ID to cancel.
+  /// \return Void
+  void Unsubscribe(const SubscriptionID &subscription_id);
+
+  /// Subscribe the ObjectLocal event.
+  ///
+  /// \param subscription_id The subscription ID.
+  /// \param client The connection to the client through raylet socket.
+  /// \param event The event to subscribe.
+  ray::Status SubscribeObjectLocalEvent(
+      const SubscriptionID &subscription_id,
+      const std::shared_ptr<LocalClientConnection> &client,
+      const ObjectLocalEvent &event);
+
+ private:
+  /// Get the connection to the raylet event socket through the default connection.
+  ///
+  /// \param client The default connection.
+  /// \return The connection to the raylet event socket.
+  std::shared_ptr<LocalClientConnection> GetEventConnection(
+      const std::shared_ptr<LocalClientConnection> &client);
+
+  /// The set of locally available objects.
+  std::unordered_set<ray::ObjectID> local_objects_;
+  /// The object manager instance.
+  ObjectManager &object_manager_;
+  /// A mapping between subscription ID and event edge endpoints.
+  std::unordered_map<SubscriptionID, std::shared_ptr<EventEdge>> endpoints_;
+  /// The ObjectLocal event manager.
+  std::unique_ptr<ObjectLocalEventsManager> objectlocal_events_manager_;
+  /// A mapping from client ID to clients connection through the events socket.
+  std::unordered_map<ClientID, std::shared_ptr<LocalClientConnection>>
+      event_socket_connections_;
+};
+
+};  // namespace events
+};  // namespace ray
+
+#endif  // RAY_EVENT_RAYLET_EVENTS_H

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -71,6 +71,16 @@ enum MessageType:int {
   PushProfileEventsRequest,
   // Free the objects in objects store.
   FreeObjectsInObjectStoreRequest,
+  // Activate the event socket connection.
+  ActivateEventSocketRequest,
+  // Reply to the activation of the event socket connection.
+  ActivateEventSocketReply,
+  // Subscribe Object Ready
+  SubscribeObjectLocalEvent,
+  // Unsubscribe request
+  UnsubscribeRequest,
+  // Object ready event
+  ObjectLocalEvent,
 }
 
 table TaskExecutionSpecification {
@@ -133,8 +143,6 @@ table RegisterClientRequest {
 }
 
 table RegisterClientReply {
-  // The IDs of the GPUs that are reserved for this worker.
-  gpu_ids: [int];
 }
 
 table RegisterNodeManagerRequest {
@@ -203,4 +211,30 @@ table FreeObjectsRequest {
   local_only: bool;
   // List of object ids we'll delete from object store.
   object_ids: [string];
+}
+
+table ActivateEventSocketRequest {
+  // The ID of the client.
+  client_id: string;
+}
+
+table ActivateEventSocketReply {
+  activated: bool;
+}
+
+table UnsubscribeRequest {
+  // The subscription ID.
+  subscription_id: string;
+}
+
+table ObjectLocalRequest {
+  // The subscription ID.
+  subscription_id: string;
+  // The ID of the Object.
+  object_id: string;
+}
+
+table ObjectLocalEvent {
+  subscription_id: string;
+  object_id: string;
 }

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -34,17 +34,19 @@ class UniqueIdFromJByteArray {
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
  * Method:    nativeInit
- * Signature: (Ljava/lang/String;[BZ[B)J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;[BZ[B)J
  */
 JNIEXPORT jlong JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeInit(
-    JNIEnv *env, jclass, jstring sockName, jbyteArray workerId, jboolean isWorker,
-    jbyteArray driverId) {
+    JNIEnv *env, jclass, jstring sockName, jstring eventSockName, jbyteArray workerId,
+    jboolean isWorker, jbyteArray driverId) {
   UniqueIdFromJByteArray worker_id(env, workerId);
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
-  auto raylet_client = new RayletClient(nativeString, *worker_id.PID, isWorker,
-                                        *driver_id.PID, Language::JAVA);
+  const char *nativeEventSockName = env->GetStringUTFChars(eventSockName, JNI_FALSE);
+  auto raylet_client = new RayletClient(nativeString, nativeEventSockName, *worker_id.PID,
+                                        isWorker, *driver_id.PID, Language::JAVA);
   env->ReleaseStringUTFChars(sockName, nativeString);
+  env->ReleaseStringUTFChars(eventSockName, nativeEventSockName);
   return reinterpret_cast<jlong>(raylet_client);
 }
 

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl
  * Method:    nativeInit
- * Signature: (Ljava/lang/String;[BZ[B)J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;[BZ[B)J
  */
 JNIEXPORT jlong JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeInit(
-    JNIEnv *, jclass, jstring, jbyteArray, jboolean, jbyteArray);
+    JNIEnv *, jclass, jstring, jstring, jbyteArray, jboolean, jbyteArray);
 
 /*
  * Class:     org_ray_runtime_raylet_RayletClientImpl

--- a/src/ray/raylet/lib/python/common_extension.cc
+++ b/src/ray/raylet/lib/python/common_extension.cc
@@ -820,3 +820,7 @@ PyObject *compute_task_id(PyObject *self, PyObject *args) {
   TaskID task_id = ray::ComputeTaskId(object_id);
   return PyObjectID_make(task_id);
 }
+
+PyObject *random_id(PyObject *self, PyObject *args) {
+  return PyObjectID_make(ObjectID::from_random());
+}

--- a/src/ray/raylet/lib/python/common_extension.h
+++ b/src/ray/raylet/lib/python/common_extension.h
@@ -57,4 +57,6 @@ PyObject *PyTask_from_string(PyObject *, PyObject *args);
 
 PyObject *PyTask_make(ray::raylet::TaskSpecification *task_spec);
 
+PyObject *random_id(PyObject *self, PyObject *args);
+
 #endif /* COMMON_EXTENSION_H */

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -29,6 +29,7 @@ class TestObjectManagerBase : public ::testing::Test {
   }
 
   NodeManagerConfig GetNodeManagerConfig(std::string raylet_socket_name,
+                                         std::string raylet_event_socket_name,
                                          std::string store_socket_name) {
     // Configuration for the node manager.
     ray::raylet::NodeManagerConfig node_manager_config;
@@ -43,6 +44,7 @@ class TestObjectManagerBase : public ::testing::Test {
     py_worker_command.push_back("python");
     py_worker_command.push_back("../python/ray/workers/default_worker.py");
     py_worker_command.push_back(raylet_socket_name.c_str());
+    py_worker_command.push_back(raylet_event_socket_name.c_str());
     py_worker_command.push_back(store_socket_name.c_str());
     node_manager_config.worker_commands[Language::PYTHON] = py_worker_command;
     return node_manager_config;
@@ -60,8 +62,9 @@ class TestObjectManagerBase : public ::testing::Test {
     om_config_1.store_socket_name = store_sock_1;
     om_config_1.push_timeout_ms = 10000;
     server1.reset(new ray::raylet::Raylet(
-        main_service, "raylet_1", "0.0.0.0", "127.0.0.1", 6379, "",
-        GetNodeManagerConfig("raylet_1", store_sock_1), om_config_1, gcs_client_1));
+        main_service, "raylet_1", "raylet_events", "0.0.0.0", "127.0.0.1", 6379, "",
+        GetNodeManagerConfig("raylet_1", "raylet_events", store_sock_1), om_config_1,
+        gcs_client_1));
 
     // start second server
     gcs_client_2 = std::shared_ptr<gcs::AsyncGcsClient>(
@@ -70,8 +73,9 @@ class TestObjectManagerBase : public ::testing::Test {
     om_config_2.store_socket_name = store_sock_2;
     om_config_2.push_timeout_ms = 10000;
     server2.reset(new ray::raylet::Raylet(
-        main_service, "raylet_2", "0.0.0.0", "127.0.0.1", 6379, "",
-        GetNodeManagerConfig("raylet_2", store_sock_2), om_config_2, gcs_client_2));
+        main_service, "raylet_2", "raylet_events", "0.0.0.0", "127.0.0.1", 6379, "",
+        GetNodeManagerConfig("raylet_2", "raylet_events", store_sock_2), om_config_2,
+        gcs_client_2));
 
     // connect to stores.
     ARROW_CHECK_OK(client1.Connect(store_sock_1));

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -145,7 +145,6 @@ void Raylet::DoAccept() {
 
 void Raylet::HandleAccept(const boost::system::error_code &error) {
   if (!error) {
-    // TODO: typedef these handlers.
     ClientHandler<boost::asio::local::stream_protocol> client_handler =
         [this](LocalClientConnection &client) { node_manager_.ProcessNewClient(client); };
     MessageHandler<boost::asio::local::stream_protocol> message_handler = [this](
@@ -170,7 +169,6 @@ void Raylet::DoAcceptEventSocket() {
 
 void Raylet::HandleAcceptEventSocket(const boost::system::error_code &error) {
   if (!error) {
-    // TODO: typedef these handlers.
     ClientHandler<boost::asio::local::stream_protocol> client_handler =
         [this](LocalClientConnection &client) { node_manager_.ProcessNewClient(client); };
     MessageHandler<boost::asio::local::stream_protocol> message_handler = [this](

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -36,9 +36,9 @@ class Raylet {
   /// manager.
   /// \param gcs_client A client connection to the GCS.
   Raylet(boost::asio::io_service &main_service, const std::string &socket_name,
-         const std::string &node_ip_address, const std::string &redis_address,
-         int redis_port, const std::string &redis_password,
-         const NodeManagerConfig &node_manager_config,
+         const std::string &event_socket_name, const std::string &node_ip_address,
+         const std::string &redis_address, int redis_port,
+         const std::string &redis_password, const NodeManagerConfig &node_manager_config,
          const ObjectManagerConfig &object_manager_config,
          std::shared_ptr<gcs::AsyncGcsClient> gcs_client);
 
@@ -49,6 +49,7 @@ class Raylet {
   /// Register GCS client.
   ray::Status RegisterGcs(const std::string &node_ip_address,
                           const std::string &raylet_socket_name,
+                          const std::string &raylet_event_socket_name,
                           const std::string &object_store_socket_name,
                           const std::string &redis_address, int redis_port,
                           const std::string &redis_password,
@@ -59,6 +60,9 @@ class Raylet {
   void DoAccept();
   /// Handle an accepted client connection.
   void HandleAccept(const boost::system::error_code &error);
+  // Accept a client connection
+  void DoAcceptEventSocket();
+  void HandleAcceptEventSocket(const boost::system::error_code &error);
   /// Accept a tcp client connection.
   void DoAcceptObjectManager();
   /// Handle an accepted tcp client connection.
@@ -79,9 +83,13 @@ class Raylet {
   NodeManager node_manager_;
   /// The name of the socket this raylet listens on.
   std::string socket_name_;
+  /// The name of the socket this raylet pushes events to.
+  std::string events_socket_name_;
 
   /// An acceptor for new clients.
   boost::asio::local::stream_protocol::acceptor acceptor_;
+  /// An acceptor for new clients (event socket).
+  boost::asio::local::stream_protocol::acceptor event_socket_acceptor_;
   /// The socket to listen on for new clients.
   boost::asio::local::stream_protocol::socket socket_;
   /// An acceptor for new object manager tcp clients.

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -35,10 +35,11 @@ class RayletConnection {
   /// \param client_id A unique ID to represent the client.
   /// \param raylet_socket The name of the socket for raylet connection.
   /// \param num_retries The maximum num of retries to connect to the raylet socket.
-  /// \param timeout The timeout used to reconnect to the raylet socket.
+  /// \param timeout_milliseconds The timeout (in millisecond)
+  /// used to reconnect to the raylet socket.
   /// \return The connection information.
   RayletConnection(const ClientID &client_id, const std::string &raylet_socket,
-                   int num_retries, int64_t timeout);
+                   int num_retries, int64_t timeout_milliseconds);
 
   ~RayletConnection() { close(conn_); }
 

--- a/test/tempfile_test.py
+++ b/test/tempfile_test.py
@@ -76,7 +76,7 @@ def test_raylet_tempfiles():
         "redis.err"
     }  # without raylet logs
     socket_files = set(os.listdir(tempfile_services.get_sockets_dir_path()))
-    assert socket_files == {"plasma_store", "raylet"}
+    assert socket_files == {"plasma_store", "raylet", "raylet_events"}
     ray.shutdown()
 
     ray.init(redirect_worker_output=True, num_cpus=0)
@@ -90,7 +90,7 @@ def test_raylet_tempfiles():
         "redis.err", "raylet.out", "raylet.err"
     }  # with raylet logs
     socket_files = set(os.listdir(tempfile_services.get_sockets_dir_path()))
-    assert socket_files == {"plasma_store", "raylet"}
+    assert socket_files == {"plasma_store", "raylet", "raylet_events"}
     ray.shutdown()
 
     ray.init(redirect_worker_output=True, num_cpus=2)
@@ -110,5 +110,5 @@ def test_raylet_tempfiles():
         1 for filename in log_files if filename.startswith("worker")) == 4
 
     socket_files = set(os.listdir(tempfile_services.get_sockets_dir_path()))
-    assert socket_files == {"plasma_store", "raylet"}
+    assert socket_files == {"plasma_store", "raylet", "raylet_events"}
     ray.shutdown()


### PR DESCRIPTION
## Related issue number

https://github.com/ray-project/ray/issues/3524

Changes include:

* Implement raylet events subscription. (https://docs.google.com/document/d/11WJ6eQs_IC_Ne1VUjf7Tx8KQaPbD4aR7ewom6XiTdRA/edit?usp=sharing)
* Introduce a new socket called `raylet_events`.
* Implemented `SimpleConnection` for raylet client. We can replace the legacy `io.h` methods with this.
* Reuse `RegisterClientReply` to sync `RegisterClientRequest`. `RegisterClientReply` was slightly modified to remove the legacy `gpu_ids`.
* Implemented `RayletEventTransport`. Now async_api can be initialized synchronously.
* Use new `RayletEventProtocol` to replace the old `PlasmaProtocol`. Improve performance using `bytearray`.