### PR TITLE
Remove deprecation warnings when running actor tests

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -228,7 +228,7 @@ class ActorMethod(object):
         return self._remote(args, kwargs)
 
     def _submit(self, args, kwargs, num_return_vals=None):
-        logger.warn(
+        logger.warning(
             "WARNING: _submit() is being deprecated. Please use _remote().")
         return self._remote(
             args=args, kwargs=kwargs, num_return_vals=num_return_vals)
@@ -338,7 +338,7 @@ class ActorClass(object):
                 num_cpus=None,
                 num_gpus=None,
                 resources=None):
-        logger.warn(
+        logger.warning(
             "WARNING: _submit() is being deprecated. Please use _remote().")
         return self._remote(
             args=args,
@@ -676,7 +676,7 @@ class ActorHandle(object):
             # If the worker is a driver and driver id has changed because
             # Ray was shut down re-initialized, the actor is already cleaned up
             # and we don't need to send `__ray_terminate__` again.
-            logger.warn(
+            logger.warning(
                 "Actor is garbage collected in the wrong driver." +
                 " Actor id = %s, class name = %s.", self._ray_actor_id,
                 self._ray_class_name)

--- a/python/ray/experimental/sgd/sgd.py
+++ b/python/ray/experimental/sgd/sgd.py
@@ -69,7 +69,7 @@ class DistributedSGD(object):
                  all_reduce_alg="simple"):
 
         if num_workers == 1 and strategy == "ps":
-            logger.warn(
+            logger.warning(
                 "The parameter server strategy does not make sense for single "
                 "worker operation, falling back to simple mode.")
             strategy = "simple"

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -109,7 +109,7 @@ class RemoteFunction(object):
                 num_cpus=None,
                 num_gpus=None,
                 resources=None):
-        logger.warn(
+        logger.warning(
             "WARNING: _submit() is being deprecated. Please use _remote().")
         return self._remote(
             args=args,

--- a/python/ray/rllib/agents/ppo/ppo.py
+++ b/python/ray/rllib/agents/ppo/ppo.py
@@ -118,7 +118,7 @@ class PPOAgent(Agent):
             if waste_ratio > 1.5:
                 raise ValueError(msg)
             else:
-                logger.warn(msg)
+                logger.warning(msg)
         if self.config["sgd_minibatch_size"] > self.config["train_batch_size"]:
             raise ValueError(
                 "Minibatch size {} must be <= train batch size {}.".format(
@@ -136,6 +136,6 @@ class PPOAgent(Agent):
                 "simple_optimizer=True if this doesn't work for you.")
         if self.config["observation_filter"] != "NoFilter":
             # TODO(ekl): consider setting the default to be NoFilter
-            logger.warn(
+            logger.warning(
                 "By default, observations will be normalized with {}".format(
                     self.config["observation_filter"]))

--- a/python/ray/rllib/evaluation/metrics.py
+++ b/python/ray/rllib/evaluation/metrics.py
@@ -53,7 +53,7 @@ def summarize_episodes(episodes, new_episodes, num_dropped):
     """
 
     if num_dropped > 0:
-        logger.warn("WARNING: {} workers have NOT returned metrics".format(
+        logger.warning("WARNING: {} workers have NOT returned metrics".format(
             num_dropped))
 
     episode_rewards = []

--- a/python/ray/rllib/evaluation/policy_evaluator.py
+++ b/python/ray/rllib/evaluation/policy_evaluator.py
@@ -300,7 +300,7 @@ class PolicyEvaluator(EvaluatorInterface):
                 self.batch_mode))
 
         if input_evaluation_method == "simulation":
-            logger.warn(
+            logger.warning(
                 "Requested 'simulation' input evaluation method: "
                 "will discard all sampler outputs and keep only metrics.")
             sample_async = True

--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -323,7 +323,7 @@ def _process_observations(async_vector_env, policies, batch_builder_pool,
         if (not _large_batch_warned and
                 episode.batch_builder.total() > max(1000, unroll_length * 10)):
             _large_batch_warned = True
-            logger.warn(
+            logger.warning(
                 "More than {} observations for {} env steps ".format(
                     episode.batch_builder.total(),
                     episode.batch_builder.count) + "are buffered in "

--- a/python/ray/rllib/offline/json_reader.py
+++ b/python/ray/rllib/offline/json_reader.py
@@ -42,7 +42,7 @@ class JsonReader(InputReader):
         if isinstance(inputs, six.string_types):
             if os.path.isdir(inputs):
                 inputs = os.path.join(inputs, "*.json")
-                logger.warn(
+                logger.warning(
                     "Treating input directory as glob pattern: {}".format(
                         inputs))
             if urlparse(inputs).scheme:

--- a/python/ray/rllib/utils/compression.py
+++ b/python/ray/rllib/utils/compression.py
@@ -16,8 +16,8 @@ try:
     LZ4_ENABLED = True
 except ImportError:
     logger.warning("lz4 not available, disabling sample compression. "
-                "This will significantly impact RLlib performance. "
-                "To install lz4, run `pip install lz4`.")
+                   "This will significantly impact RLlib performance. "
+                   "To install lz4, run `pip install lz4`.")
     LZ4_ENABLED = False
 
 

--- a/python/ray/rllib/utils/compression.py
+++ b/python/ray/rllib/utils/compression.py
@@ -15,7 +15,7 @@ try:
     import lz4.frame
     LZ4_ENABLED = True
 except ImportError:
-    logger.warn("lz4 not available, disabling sample compression. "
+    logger.warning("lz4 not available, disabling sample compression. "
                 "This will significantly impact RLlib performance. "
                 "To install lz4, run `pip install lz4`.")
     LZ4_ENABLED = False

--- a/python/ray/rllib/utils/policy_client.py
+++ b/python/ray/rllib/utils/policy_client.py
@@ -11,8 +11,9 @@ try:
     import requests  # `requests` is not part of stdlib.
 except ImportError:
     requests = None
-    logger.warning("Couldn't import `requests` library. Be sure to install it on"
-                " the client side.")
+    logger.warning(
+        "Couldn't import `requests` library. Be sure to install it on"
+        " the client side.")
 
 
 class PolicyClient(object):

--- a/python/ray/rllib/utils/policy_client.py
+++ b/python/ray/rllib/utils/policy_client.py
@@ -11,7 +11,7 @@ try:
     import requests  # `requests` is not part of stdlib.
 except ImportError:
     requests = None
-    logger.warn("Couldn't import `requests` library. Be sure to install it on"
+    logger.warning("Couldn't import `requests` library. Be sure to install it on"
                 " the client side.")
 
 

--- a/python/ray/tune/suggest/variant_generator.py
+++ b/python/ray/tune/suggest/variant_generator.py
@@ -227,7 +227,7 @@ def _is_resolved(v):
 
 def _try_resolve(v):
     if isinstance(v, types.FunctionType):
-        logger.warn(
+        logger.warning(
             "Deprecation warning: Function values are ambiguous in Tune "
             "configuations. Either wrap the function with "
             "`tune.function(func)` to specify a function literal, or "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1387,7 +1387,7 @@ def _init(address_info=None,
         driver_mode = SCRIPT_MODE
 
     if redis_max_memory and collect_profiling_data:
-        logger.warn("Profiling data cannot be LRU evicted, so it is disabled "
+        logger.warning("Profiling data cannot be LRU evicted, so it is disabled "
                     "when redis_max_memory is set.")
         collect_profiling_data = False
 
@@ -1652,7 +1652,7 @@ def init(redis_address=None,
     # Add the use_raylet option for backwards compatibility.
     if use_raylet is not None:
         if use_raylet:
-            logger.warn("WARNING: The use_raylet argument has been "
+            logger.warning("WARNING: The use_raylet argument has been "
                         "deprecated. Please remove it.")
         else:
             raise DeprecationWarning("The use_raylet argument is deprecated. "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1387,8 +1387,9 @@ def _init(address_info=None,
         driver_mode = SCRIPT_MODE
 
     if redis_max_memory and collect_profiling_data:
-        logger.warning("Profiling data cannot be LRU evicted, so it is disabled "
-                    "when redis_max_memory is set.")
+        logger.warning(
+            "Profiling data cannot be LRU evicted, so it is disabled "
+            "when redis_max_memory is set.")
         collect_profiling_data = False
 
     # Get addresses of existing services.
@@ -1653,7 +1654,7 @@ def init(redis_address=None,
     if use_raylet is not None:
         if use_raylet:
             logger.warning("WARNING: The use_raylet argument has been "
-                        "deprecated. Please remove it.")
+                           "deprecated. Please remove it.")
         else:
             raise DeprecationWarning("The use_raylet argument is deprecated. "
                                      "Please remove it.")


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR removes deprecation warnings when running actor tests on macosx py36. On master, running `python -m pytest  test/actor_test.py` I see these deprecation warnings:
```
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)

test/actor_test.py::test_pickled_actor_handle_call_in_method_twice
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)

test/actor_test.py::test_creating_more_actors_than_resources
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)

test/actor_test.py::test_actor_reconstruction
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)

test/actor_test.py::test_actor_reconstruction_on_node_failure
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)

test/actor_test.py::test_multiple_actor_reconstruction
  /Users/atumanov/devrepo/github/ray-mydev/python/ray/actor.py:682: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._ray_class_name)
```

## Related issue number
No issue filed, minor.
