### PR TITLE
Convert UniqueID::nil() to a constructor

### DIFF
--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -121,7 +121,7 @@ Status Log<ID, Data>::Subscribe(const JobID &job_id, const ClientID &client_id,
       if (subscribe != nullptr) {
         // Parse the notification.
         auto root = flatbuffers::GetRoot<GcsTableEntry>(data.data());
-        ID id = UniqueID::nil();
+        ID id;
         if (root->id()->size() > 0) {
           id = from_flatbuf(*root->id());
         }

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -552,7 +552,7 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
       : Log(contexts, client),
         // We set the client log's key equal to nil so that all instances of
         // ClientTable have the same key.
-        client_log_key_(UniqueID::nil()),
+        client_log_key_(),
         disconnected_(false),
         client_id_(client_id),
         local_client_() {
@@ -621,8 +621,6 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   bool IsRemoved(const ClientID &client_id) const;
 
   /// Get the information of all clients.
-  ///
-  /// Note: The return value contains ClientID::nil() which should be filtered.
   ///
   /// \return The client ID to client information map.
   const std::unordered_map<ClientID, ClientTableDataT> &GetAllClients() const;

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -55,11 +55,9 @@ UniqueID UniqueID::from_binary(const std::string &binary) {
   return id;
 }
 
-const UniqueID UniqueID::nil() {
-  UniqueID result;
-  uint8_t *data = result.mutable_data();
-  std::fill_n(data, kUniqueIDSize, 255);
-  return result;
+const UniqueID &UniqueID::nil() {
+  static const UniqueID nil_id;
+  return nil_id;
 }
 
 bool UniqueID::is_nil() const {

--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -24,6 +24,11 @@ std::mt19937 RandomlySeededMersenneTwister() {
   return seeded_engine;
 }
 
+UniqueID::UniqueID() {
+  // Set the ID to nil.
+  std::fill_n(id_, kUniqueIDSize, 255);
+}
+
 UniqueID::UniqueID(const plasma::UniqueID &from) {
   std::memcpy(&id_, from.data(), kUniqueIDSize);
 }
@@ -67,17 +72,11 @@ bool UniqueID::is_nil() const {
   return true;
 }
 
-const uint8_t *UniqueID::data() const {
-  return id_;
-}
+const uint8_t *UniqueID::data() const { return id_; }
 
-uint8_t *UniqueID::mutable_data() {
-  return id_;
-}
+uint8_t *UniqueID::mutable_data() { return id_; }
 
-size_t UniqueID::size() const {
-  return kUniqueIDSize;
-}
+size_t UniqueID::size() const { return kUniqueIDSize; }
 
 std::string UniqueID::binary() const {
   return std::string(reinterpret_cast<const char *>(id_), kUniqueIDSize);

--- a/src/ray/id.h
+++ b/src/ray/id.h
@@ -14,7 +14,7 @@ namespace ray {
 
 class RAY_EXPORT UniqueID {
  public:
-  UniqueID() {}
+  UniqueID();
   UniqueID(const plasma::UniqueID &from);
   static UniqueID from_random();
   static UniqueID from_binary(const std::string &binary);
@@ -34,8 +34,7 @@ class RAY_EXPORT UniqueID {
   uint8_t id_[kUniqueIDSize];
 };
 
-static_assert(std::is_standard_layout<UniqueID>::value,
-              "UniqueID must be standard");
+static_assert(std::is_standard_layout<UniqueID>::value, "UniqueID must be standard");
 
 std::ostream &operator<<(std::ostream &os, const UniqueID &id);
 

--- a/src/ray/id.h
+++ b/src/ray/id.h
@@ -18,7 +18,7 @@ class RAY_EXPORT UniqueID {
   UniqueID(const plasma::UniqueID &from);
   static UniqueID from_random();
   static UniqueID from_binary(const std::string &binary);
-  static const UniqueID nil();
+  static const UniqueID &nil();
   size_t hash() const;
   bool is_nil() const;
   bool operator==(const UniqueID &rhs) const;

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -451,7 +451,7 @@ class TestObjectManager : public TestObjectManagerBase {
                    << "\n";
     ClientTableDataT data;
     gcs_client_1->client_table().GetClient(client_id_1, data);
-    RAY_LOG(DEBUG) << (ClientID::from_binary(data.client_id) == ClientID::nil());
+    RAY_LOG(DEBUG) << (ClientID::from_binary(data.client_id).is_nil());
     RAY_LOG(DEBUG) << "Server 1 ClientID=" << ClientID::from_binary(data.client_id);
     RAY_LOG(DEBUG) << "Server 1 ClientIp=" << data.node_manager_address;
     RAY_LOG(DEBUG) << "Server 1 ClientPort=" << data.node_manager_port;

--- a/src/ray/raylet/actor_registration.cc
+++ b/src/ray/raylet/actor_registration.cc
@@ -9,9 +9,7 @@ namespace ray {
 namespace raylet {
 
 ActorRegistration::ActorRegistration(const ActorTableDataT &actor_table_data)
-    : actor_table_data_(actor_table_data),
-      execution_dependency_(ObjectID::nil()),
-      frontier_() {}
+    : actor_table_data_(actor_table_data) {}
 
 const ClientID ActorRegistration::GetNodeManagerId() const {
   return ClientID::from_binary(actor_table_data_.node_manager_id);

--- a/src/ray/raylet/lib/python/common_extension.cc
+++ b/src/ray/raylet/lib/python/common_extension.cc
@@ -358,9 +358,9 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   // ID of the driver that this task originates from.
   UniqueID driver_id;
   // ID of the actor this task should run on.
-  UniqueID actor_id = ActorID::nil();
+  UniqueID actor_id;
   // ID of the actor handle used to submit this task.
-  UniqueID actor_handle_id = ActorHandleID::nil();
+  UniqueID actor_handle_id;
   // How many tasks have been launched on the actor so far?
   int actor_counter = 0;
   // ID of the function this task executes.
@@ -374,9 +374,9 @@ static int PyTask_init(PyTask *self, PyObject *args, PyObject *kwds) {
   // The number of tasks that the parent task has called prior to this one.
   int parent_counter;
   // The actor creation ID.
-  ActorID actor_creation_id = ActorID::nil();
+  ActorID actor_creation_id;
   // The dummy object for the actor creation task (if this is an actor method).
-  ObjectID actor_creation_dummy_object_id = ObjectID::nil();
+  ObjectID actor_creation_dummy_object_id;
   // Max number of times to reconstruct this actor (only used for actor creation
   // task).
   int32_t max_actor_reconstructions;

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -206,7 +206,7 @@ class TestObjectManagerIntegration : public TestObjectManagerBase {
                   << "\n";
     ClientTableDataT data;
     gcs_client_2->client_table().GetClient(client_id_1, data);
-    RAY_LOG(INFO) << (ClientID::from_binary(data.client_id) == ClientID::nil());
+    RAY_LOG(INFO) << (ClientID::from_binary(data.client_id).is_nil());
     RAY_LOG(INFO) << "ClientID=" << ClientID::from_binary(data.client_id);
     RAY_LOG(INFO) << "ClientIp=" << data.node_manager_address;
     RAY_LOG(INFO) << "ClientPort=" << data.node_manager_port;

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -15,8 +15,6 @@ Worker::Worker(pid_t pid, const Language &language,
     : pid_(pid),
       language_(language),
       connection_(connection),
-      assigned_task_id_(TaskID::nil()),
-      actor_id_(ActorID::nil()),
       dead_(false),
       blocked_(false) {}
 


### PR DESCRIPTION
## What do these changes do?

The default `UniqueID()` does not initialize the ID data, which can make statements like `ObjectID object_id;` error-prone. This merges the `UniqueID::nil()` static method into the default constructor.