### PR TITLE
[autoscaler] External node provider import fix

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -66,6 +66,8 @@ CLUSTER_CONFIG_SCHEMA = {
             "availability_zone": (str, OPTIONAL),  # e.g. us-east-1a
             "module": (str,
                        OPTIONAL),  # module, if using external node provider
+            "module_path": (str,
+                            OPTIONAL),  # module_path, if using external node provider
             "project_id": (None, OPTIONAL),  # gcp project id, if using gcp
             "head_ip": (str, OPTIONAL),  # local cluster head node
             "worker_ips": (list, OPTIONAL),  # local cluster worker nodes

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import importlib
+import imp
 import os
 import yaml
 
@@ -70,25 +70,27 @@ DEFAULT_CONFIGS = {
 }
 
 
-def load_class(path):
+def load_class(module_name, module_path):
     """
     Load a class at runtime given a full path.
 
     Example of the path: mypkg.mysubpkg.myclass
     """
-    class_data = path.split(".")
+    class_data = module_name.split(".")
     if len(class_data) < 2:
         raise ValueError(
             "You need to pass a valid path like mymodule.provider_class")
-    module_path = ".".join(class_data[:-1])
+    module_str = ".".join(class_data[:-1])
     class_str = class_data[-1]
-    module = importlib.import_module(module_path)
+
+    module = imp.load_source(module_str, module_path)
     return getattr(module, class_str)
 
 
 def get_node_provider(provider_config, cluster_name):
     if provider_config["type"] == "external":
-        provider_cls = load_class(path=provider_config["module"])
+        provider_cls = load_class(module_name=provider_config["module"],
+                                  module_path=provider_config["module_path"])
         return provider_cls(provider_config, cluster_name)
 
     importer = NODE_PROVIDERS.get(provider_config["type"])


### PR DESCRIPTION
## What do these changes do?

Since the external module usually won't be added into the sys path, and it won't be passed into the head node's environment when creating a worker node by the head.

By introducing a `module_path` into the cluster config to let the external module import working smoothly.
