### PR TITLE
[rllib] support running older version tensorflow(version < 1.5.0)

### DIFF
--- a/python/ray/rllib/agents/impala/vtrace_policy_graph.py
+++ b/python/ray/rllib/agents/impala/vtrace_policy_graph.py
@@ -168,7 +168,7 @@ class VTracePolicyGraph(LearningRateSchedule, TFPolicyGraph):
             mask = tf.sequence_mask(self.model.seq_lens, max_seq_len)
             mask = tf.reshape(mask, [-1])
         else:
-            mask = tf.ones_like(rewards)
+            mask = tf.ones_like(rewards, dtype=tf.bool)
 
         # Inputs are reshaped from [B * T] => [T - 1, B] for V-trace calc.
         self.loss = VTraceLoss(

--- a/python/ray/rllib/agents/ppo/ppo_policy_graph.py
+++ b/python/ray/rllib/agents/ppo/ppo_policy_graph.py
@@ -206,7 +206,7 @@ class PPOPolicyGraph(LearningRateSchedule, TFPolicyGraph):
             mask = tf.sequence_mask(self.model.seq_lens, max_seq_len)
             mask = tf.reshape(mask, [-1])
         else:
-            mask = tf.ones_like(adv_ph)
+            mask = tf.ones_like(adv_ph, dtype=tf.bool)
 
         self.loss_obj = PPOLoss(
             action_space,

--- a/python/ray/rllib/examples/multiagent_cartpole.py
+++ b/python/ray/rllib/examples/multiagent_cartpole.py
@@ -15,6 +15,7 @@ execution, set the TF_TIMELINE_DIR environment variable.
 import argparse
 import gym
 import random
+import distutils.version
 
 import tensorflow as tf
 import tensorflow.contrib.slim as slim
@@ -33,6 +34,8 @@ parser.add_argument("--num-agents", type=int, default=4)
 parser.add_argument("--num-policies", type=int, default=2)
 parser.add_argument("--num-iters", type=int, default=20)
 
+use_tf150_api = (distutils.version.LooseVersion(tf.VERSION) >=
+                 distutils.version.LooseVersion("1.5.0"))
 
 class CustomModel1(Model):
     def _build_layers_v2(self, input_dict, num_outputs, options):
@@ -41,12 +44,19 @@ class CustomModel1(Model):
         # by entering it explicitly with tf.AUTO_REUSE. This creates the
         # variables for the 'fc1' layer in a global scope called 'shared'
         # outside of the policy's normal variable scope.
-        with tf.variable_scope(
-                tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                reuse=tf.AUTO_REUSE,
-                auxiliary_name_scope=False):
-            last_layer = slim.fully_connected(
-                input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        if use_tf150_api:
+            with tf.variable_scope(
+                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                    reuse=tf.AUTO_REUSE,
+                    auxiliary_name_scope=False):
+                last_layer = slim.fully_connected(
+                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        else:
+            with tf.variable_scope(
+                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                    reuse=tf.AUTO_REUSE):
+                last_layer = slim.fully_connected(
+                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
         last_layer = slim.fully_connected(
             last_layer, 64, activation_fn=tf.nn.relu, scope="fc2")
         output = slim.fully_connected(
@@ -57,12 +67,19 @@ class CustomModel1(Model):
 class CustomModel2(Model):
     def _build_layers_v2(self, input_dict, num_outputs, options):
         # Weights shared with CustomModel1
-        with tf.variable_scope(
-                tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                reuse=tf.AUTO_REUSE,
-                auxiliary_name_scope=False):
-            last_layer = slim.fully_connected(
-                input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        if use_tf150_api:
+            with tf.variable_scope(
+                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                    reuse=tf.AUTO_REUSE,
+                    auxiliary_name_scope=False):
+                last_layer = slim.fully_connected(
+                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        else:
+            with tf.variable_scope(
+                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                    reuse=tf.AUTO_REUSE):
+                last_layer = slim.fully_connected(
+                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
         last_layer = slim.fully_connected(
             last_layer, 64, activation_fn=tf.nn.relu, scope="fc2")
         output = slim.fully_connected(

--- a/python/ray/rllib/examples/multiagent_cartpole.py
+++ b/python/ray/rllib/examples/multiagent_cartpole.py
@@ -33,6 +33,7 @@ parser.add_argument("--num-agents", type=int, default=4)
 parser.add_argument("--num-policies", type=int, default=2)
 parser.add_argument("--num-iters", type=int, default=20)
 
+
 class CustomModel1(Model):
     def _build_layers_v2(self, input_dict, num_outputs, options):
         # Example of (optional) weight sharing between two different policies.

--- a/python/ray/rllib/examples/multiagent_cartpole.py
+++ b/python/ray/rllib/examples/multiagent_cartpole.py
@@ -15,7 +15,6 @@ execution, set the TF_TIMELINE_DIR environment variable.
 import argparse
 import gym
 import random
-import distutils.version
 
 import tensorflow as tf
 import tensorflow.contrib.slim as slim
@@ -34,9 +33,6 @@ parser.add_argument("--num-agents", type=int, default=4)
 parser.add_argument("--num-policies", type=int, default=2)
 parser.add_argument("--num-iters", type=int, default=20)
 
-use_tf150_api = (distutils.version.LooseVersion(tf.VERSION) >=
-                 distutils.version.LooseVersion("1.5.0"))
-
 class CustomModel1(Model):
     def _build_layers_v2(self, input_dict, num_outputs, options):
         # Example of (optional) weight sharing between two different policies.
@@ -44,19 +40,12 @@ class CustomModel1(Model):
         # by entering it explicitly with tf.AUTO_REUSE. This creates the
         # variables for the 'fc1' layer in a global scope called 'shared'
         # outside of the policy's normal variable scope.
-        if use_tf150_api:
-            with tf.variable_scope(
-                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                    reuse=tf.AUTO_REUSE,
-                    auxiliary_name_scope=False):
-                last_layer = slim.fully_connected(
-                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
-        else:
-            with tf.variable_scope(
-                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                    reuse=tf.AUTO_REUSE):
-                last_layer = slim.fully_connected(
-                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        with tf.variable_scope(
+                tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                reuse=tf.AUTO_REUSE,
+                auxiliary_name_scope=False):
+            last_layer = slim.fully_connected(
+                input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
         last_layer = slim.fully_connected(
             last_layer, 64, activation_fn=tf.nn.relu, scope="fc2")
         output = slim.fully_connected(
@@ -67,19 +56,12 @@ class CustomModel1(Model):
 class CustomModel2(Model):
     def _build_layers_v2(self, input_dict, num_outputs, options):
         # Weights shared with CustomModel1
-        if use_tf150_api:
-            with tf.variable_scope(
-                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                    reuse=tf.AUTO_REUSE,
-                    auxiliary_name_scope=False):
-                last_layer = slim.fully_connected(
-                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
-        else:
-            with tf.variable_scope(
-                    tf.VariableScope(tf.AUTO_REUSE, "shared"),
-                    reuse=tf.AUTO_REUSE):
-                last_layer = slim.fully_connected(
-                    input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
+        with tf.variable_scope(
+                tf.VariableScope(tf.AUTO_REUSE, "shared"),
+                reuse=tf.AUTO_REUSE,
+                auxiliary_name_scope=False):
+            last_layer = slim.fully_connected(
+                input_dict["obs"], 64, activation_fn=tf.nn.relu, scope="fc1")
         last_layer = slim.fully_connected(
             last_layer, 64, activation_fn=tf.nn.relu, scope="fc2")
         output = slim.fully_connected(

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -23,7 +23,7 @@ try:
                      distutils.version.LooseVersion("1.5.0"))
 except ImportError:
     tf = None
-    use_tf150_api=True
+    use_tf150_api = True
     logger.warning("Couldn't import TensorFlow - "
                    "disabling TensorBoard logging.")
 

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -8,6 +8,7 @@ import logging
 import numpy as np
 import os
 import yaml
+import distutils.version
 
 import ray.cloudpickle as cloudpickle
 from ray.tune.log_sync import get_syncer
@@ -18,8 +19,11 @@ logger = logging.getLogger(__name__)
 
 try:
     import tensorflow as tf
+    use_tf150_api = (distutils.version.LooseVersion(tf.VERSION) >=
+                     distutils.version.LooseVersion("1.5.0"))
 except ImportError:
     tf = None
+    use_tf150_api=True
     logger.warning("Couldn't import TensorFlow - "
                    "disabling TensorBoard logging.")
 
@@ -155,7 +159,11 @@ def to_tf_values(result, path):
     values = []
     for attr, value in result.items():
         if value is not None:
-            if type(value) in [int, float, np.float32, np.float64, np.int32]:
+            if use_tf150_api:
+                type_list = [int, float, np.float32, np.float64, np.int32]
+            else:
+                type_list = [int, float]
+            if type(value) in type_list:
                 values.append(
                     tf.Summary.Value(
                         tag="/".join(path + [attr]), simple_value=value))


### PR DESCRIPTION
support run rllib's examples with older version tensorflow(version < 1.5.0)
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
support run the rllib's examples with tensorflow (version < 1.5.0)

- tf.boolean_mask only support tf.bool when tf version < 1.5.0

- tf.variable_scope support auxiliary_name_scope when tf version >= 1.5.0


<!-- Please give a short brief about these changes. -->

## Related issue number
#3570 
<!-- Are there any issues opened that will be resolved by merging this change? -->
