### PR TITLE
Fix pending callback not called when ServerConnection destructs

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -35,7 +35,7 @@ ServerConnection<T>::ServerConnection(boost::asio::basic_stream_socket<T> &&sock
 
 template <class T>
 ServerConnection<T>::~ServerConnection() {
-  // If there're any pending messages, invoke their callbacks with an IOError status.
+  // If there are any pending messages, invoke their callbacks with an IOError status.
   for (const auto &write_buffer : async_write_queue_) {
     write_buffer->handler(Status::IOError("Connection closed."));
   }

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -34,6 +34,14 @@ ServerConnection<T>::ServerConnection(boost::asio::basic_stream_socket<T> &&sock
       async_write_in_flight_(false) {}
 
 template <class T>
+ServerConnection<T>::~ServerConnection() {
+  // If there're any pending messages, invoke their callbacks with an IOError status.
+  for (const auto &write_buffer : async_write_queue_) {
+    write_buffer->handler(Status::IOError("Connection closed."));
+  }
+}
+
+template <class T>
 Status ServerConnection<T>::WriteBuffer(
     const std::vector<boost::asio::const_buffer> &buffer) {
   boost::system::error_code error;

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -29,7 +29,6 @@ ray::Status TcpConnect(boost::asio::ip::tcp::socket &socket,
 template <typename T>
 class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>> {
  public:
-
   /// ServerConnection destructor.
   virtual ~ServerConnection();
 

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -29,6 +29,10 @@ ray::Status TcpConnect(boost::asio::ip::tcp::socket &socket,
 template <typename T>
 class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>> {
  public:
+
+  /// ServerConnection destructor.
+  virtual ~ServerConnection();
+
   /// Allocate a new server connection.
   ///
   /// \param socket A reference to the server socket.


### PR DESCRIPTION
A task may get lost in the following case:
1) Node A forwards a task to Node B.
2) Node B dies, and Node A removes the connection from its local map.
3) The forward failure callback will never get called, and the task is lost.