### PR TITLE
Fix 2 small bugs

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -108,6 +108,7 @@ class RayTaskError(Exception):
         self.host = os.uname()[1]
         self.function_name = function_name
         self.traceback_str = traceback_str
+        assert traceback_str is not None
 
     def __str__(self):
         """Format a RayTaskError as a string."""
@@ -794,8 +795,9 @@ class Worker(object):
                 arguments = self._get_arguments_for_execution(
                     function_name, args)
         except RayTaskError as e:
-            self._handle_process_task_failure(function_id, function_name,
-                                              return_object_ids, e, None)
+            self._handle_process_task_failure(
+                function_id, function_name, return_object_ids, e,
+                ray.utils.format_error_message(traceback.format_exc()))
             return
         except Exception as e:
             self._handle_process_task_failure(

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -29,7 +29,8 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
       const ObjectID object_id = callback.first;
       auto it = locations_.find(object_id);
       if (it == locations_.end()) {
-        callback.second(object_id, {}, /*created=*/false);
+        callback.second(object_id, std::unordered_set<ray::ClientID>(),
+                        /*created=*/false);
       } else {
         callback.second(object_id, it->second, /*created=*/true);
       }
@@ -254,7 +255,8 @@ TEST_F(ReconstructionPolicyTest, TestReconstructionEvicted) {
   ASSERT_EQ(reconstructed_tasks_[task_id], 0);
 
   // Simulate evicting one of the objects.
-  mock_object_directory_->SetObjectLocations(object_id, {});
+  mock_object_directory_->SetObjectLocations(object_id,
+                                             std::unordered_set<ray::ClientID>());
   // Run the test again.
   Run(reconstruction_timeout_ms_ * 1.1);
   // Check that reconstruction was triggered, since one of the objects was

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -412,7 +412,7 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "use_pytorch": true, "sample_async": false}'
 
-docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA python -m pytest /ray/test/object_manager_test.py
+docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA python -m pytest -v /ray/test/object_manager_test.py
 
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
1. Fix compiling error of reconstruction_policy_test.cc. I have a machine installed with old CentOS with GCC 4.9.2. It has following compiling error:
```
/home/admin/yuhong/ray/src/ray/raylet/reconstruction_policy_test.cc: In member function ‘void ray::raylet::MockObjectDirectory::FlushCallbacks()’:
/home/admin/yuhong/ray/src/ray/raylet/reconstruction_policy_test.cc:32:57: error: converting to ‘const std::unordered_set<ray::UniqueID>’ from initializer list would use explicit constructor ‘std::unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(std::unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Value = ray::UniqueID; _Hash = std::hash<ray::UniqueID>; _Pred = std::equal_to<ray::UniqueID>; _Alloc = std::allocator<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::hasher = std::hash<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<ray::UniqueID>]’
         callback.second(object_id, {}, /*created=*/false);
                                                         ^
/home/admin/yuhong/ray/src/ray/raylet/reconstruction_policy_test.cc: In member function ‘virtual void ray::raylet::ReconstructionPolicyTest_TestReconstructionEvicted_Test::TestBody()’:
/home/admin/yuhong/ray/src/ray/raylet/reconstruction_policy_test.cc:257:59: error: converting to ‘const std::unordered_set<ray::UniqueID>’ from initializer list would use explicit constructor ‘std::unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(std::unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type, const hasher&, const key_equal&, const allocator_type&) [with _Value = ray::UniqueID; _Hash = std::hash<ray::UniqueID>; _Pred = std::equal_to<ray::UniqueID>; _Alloc = std::allocator<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type = long unsigned int; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::hasher = std::hash<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::key_equal = std::equal_to<ray::UniqueID>; std::unordered_set<_Value, _Hash, _Pred, _Alloc>::allocator_type = std::allocator<ray::UniqueID>]’
   mock_object_directory_->SetObjectLocations(object_id, {});
```
2. Fix the crash of ` RayTaskError.__str__` when `traceback_str` is None. 
https://travis-ci.com/ray-project/ray/jobs/165797279
```

Traceback (most recent call last):
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/workers/default_worker.py", line 107, in <module>
    ray.worker.global_worker.main_loop()
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/worker.py", line 960, in main_loop
    self._wait_for_and_process_task(task)
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/worker.py", line 917, in _wait_for_and_process_task
    self._process_task(task, execution_info)
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/worker.py", line 798, in _process_task
    return_object_ids, e, None)
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/worker.py", line 857, in _handle_process_task_failure
    str(failure_object),
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.6.0-py3.6-linux-x86_64.egg/ray/worker.py", line 113, in __str__
    lines = self.traceback_str.split("\n")
AttributeError: 'NoneType' object has no attribute 'split'
```
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
