### PR TITLE
Allowing multiple users to access the /tmp/ray file at the same time

### DIFF
--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -64,7 +64,10 @@ def try_to_create_directory(directory_path):
                 "exists.".format(directory_path))
         # Change the log directory permissions so others can use it. This is
         # important when multiple people are using the same machine.
-    os.chmod(directory_path, 0o0777)
+    try:
+        os.chmod(directory_path, 0o0777)
+    except PermissionError:
+        pass
 
 
 def get_temp_root():

--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -64,7 +64,7 @@ def try_to_create_directory(directory_path):
                 "exists.".format(directory_path))
         # Change the log directory permissions so others can use it. This is
         # important when multiple people are using the same machine.
-        os.chmod(directory_path, 0o0777)
+    os.chmod(directory_path, 0o0777)
 
 
 def get_temp_root():


### PR DESCRIPTION
Previous sequence that caused this issue:
* User A starts ray with `ray.init` when /tmp/ray does not exist
* User B starts ray with `ray.init` and /tmp/ray now exists

User B will get a permissions error
Checking the permissions, /tmp/ray is 700

I have identified a race condition in `try_to_create_directory`
* Multiple processes try to create /tmp/ray at the same time
* chmod is either silently erroring or working properly within the race condition

Resolution: Move chmod outside of the check for whether the directory exists or not.

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
