### PR TITLE
object store notification mgr: fix using uninitialized variables

### DIFF
--- a/src/ray/object_manager/object_store_notification_manager.h
+++ b/src/ray/object_manager/object_store_notification_manager.h
@@ -67,9 +67,9 @@ class ObjectStoreNotificationManager {
 
   plasma::PlasmaClient store_client_;
   int c_socket_;
-  int64_t length_;
-  int64_t num_adds_processed_;
-  int64_t num_removes_processed_;
+  int64_t length_ = 0;
+  int64_t num_adds_processed_ = 0;
+  int64_t num_removes_processed_ = 0;
   std::vector<uint8_t> notification_;
   boost::asio::local::stream_protocol::socket socket_;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Initialize private class variables to avoid valgrind errors. They are used before initialization:
```
==18922== Conditional jump or move depends on uninitialised value(s)
==18922==    at 0x5159CAE: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x5159EDC: std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::do_put(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x51663F9: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x551744: operator<< (ostream:167)
==18922==    by 0x551744: ray::ObjectStoreNotificationManager::DebugString() const (object_store_notification_manager.cc:95)
==18922==    by 0x4FE7DC: ray::ObjectManager::DebugString() const (object_manager.cc:924)
==18922==    by 0x51F612: ray::raylet::NodeManager::DebugString() const (node_manager.cc:1916)
==18922==    by 0x51FF35: ray::raylet::NodeManager::DumpDebugState() (node_manager.cc:1903)
==18922==    by 0x521AD9: ray::raylet::NodeManager::Heartbeat() (node_manager.cc:295)
==18922==    by 0x521E34: operator() (node_manager.cc:303)
==18922==    by 0x521E34: operator() (bind_handler.hpp:47)
==18922==    by 0x521E34: asio_handler_invoke<boost::asio::detail::binder1<ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)>, boost::system::error_code> > (handler_invoke_hook.hpp:69)
==18922==    by 0x521E34: invoke<boost::asio::detail::binder1<ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)>, boost::system::error_code>, ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)> > (handler_invoke_helpers.hpp:37)
==18922==    by 0x521E34: boost::asio::detail::wait_handler<ray::raylet::NodeManager::Heartbeat()::{lambda(boost::system::error_code const&)#2}>::do_complete(boost::asio::detail::task_io_service*, boost::asio::detail::task_io_service_operation*, boost::system::error_code const&, unsigned long) (wait_handler.hpp:70)
==18922==    by 0x4924E7: complete (task_io_service_operation.hpp:38)
==18922==    by 0x4924E7: do_run_one (task_io_service.ipp:372)
==18922==    by 0x4924E7: boost::asio::detail::task_io_service::run(boost::system::error_code&) (task_io_service.ipp:149)
==18922==    by 0x4892AD: run (io_service.ipp:59)
==18922==    by 0x4892AD: main (main.cc:146)
==18922==  Uninitialised value was created by a stack allocation
==18922==    at 0x487DBA: main (main.cc:17)
```
```
==18922== Conditional jump or move depends on uninitialised value(s)
==18922==    at 0x5159CAE: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x5159EDC: std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::do_put(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x51663F9: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==18922==    by 0x551769: operator<< (ostream:167)
==18922==    by 0x551769: ray::ObjectStoreNotificationManager::DebugString() const (object_store_notification_manager.cc:96)
==18922==    by 0x4FE7DC: ray::ObjectManager::DebugString() const (object_manager.cc:924)
==18922==    by 0x51F612: ray::raylet::NodeManager::DebugString() const (node_manager.cc:1916)
==18922==    by 0x51FF35: ray::raylet::NodeManager::DumpDebugState() (node_manager.cc:1903)
==18922==    by 0x521AD9: ray::raylet::NodeManager::Heartbeat() (node_manager.cc:295)
==18922==    by 0x521E34: operator() (node_manager.cc:303)
==18922==    by 0x521E34: operator() (bind_handler.hpp:47)
==18922==    by 0x521E34: asio_handler_invoke<boost::asio::detail::binder1<ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)>, boost::system::error_code> > (handler_invoke_hook.hpp:69)
==18922==    by 0x521E34: invoke<boost::asio::detail::binder1<ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)>, boost::system::error_code>, ray::raylet::NodeManager::Heartbeat()::<lambda(const boost::system::error_code&)> > (handler_invoke_helpers.hpp:37)
==18922==    by 0x521E34: boost::asio::detail::wait_handler<ray::raylet::NodeManager::Heartbeat()::{lambda(boost::system::error_code const&)#2}>::do_complete(boost::asio::detail::task_io_service*, boost::asio::detail::task_io_service_operation*, boost::system::error_code const&, unsigned long) (wait_handler.hpp:70)
==18922==    by 0x4924E7: complete (task_io_service_operation.hpp:38)
==18922==    by 0x4924E7: do_run_one (task_io_service.ipp:372)
==18922==    by 0x4924E7: boost::asio::detail::task_io_service::run(boost::system::error_code&) (task_io_service.ipp:149)
==18922==    by 0x4892AD: run (io_service.ipp:59)
==18922==    by 0x4892AD: main (main.cc:146)
==18922==  Uninitialised value was created by a stack allocation
==18922==    at 0x487DBA: main (main.cc:17)
```

## Related issue number
