### PR TITLE
Fix some storage problems of RayLog

### DIFF
--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -169,10 +169,6 @@ def new_log_files(name, redirect_output):
     logs_dir = get_logs_dir_path()
     # Create another directory that will be used by some of the RL algorithms.
 
-    # TODO(suquark): This is done by the old code.
-    # We should be able to control its path later.
-    try_to_create_directory("/tmp/ray")
-
     log_stdout = make_inc_temp(
         suffix=".out", prefix=name, directory_name=logs_dir)
     log_stderr = make_inc_temp(

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -15,11 +15,6 @@ static std::vector<std::string> parse_worker_command(std::string worker_command)
 }
 
 int main(int argc, char *argv[]) {
-  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
-                                         ray::RayLog::ShutDownRayLog, argv[0],
-                                         ray::RayLogLevel::INFO,
-                                         /*log_dir=*/"");
-  ray::RayLog::InstallFailureSignalHandler();
   RAY_CHECK(argc >= 14 && argc <= 16);
 
   const std::string raylet_socket_name = std::string(argv[1]);
@@ -37,6 +32,12 @@ int main(int argc, char *argv[]) {
   const std::string java_worker_command = std::string(argv[13]);
   const std::string redis_password = (argc >= 15 ? std::string(argv[14]) : "");
   const std::string temp_dir = (argc >= 16 ? std::string(argv[15]) : "/tmp/ray");
+
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/temp_dir + "/logs");
+  ray::RayLog::InstallFailureSignalHandler();
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -15,6 +15,11 @@ static std::vector<std::string> parse_worker_command(std::string worker_command)
 }
 
 int main(int argc, char *argv[]) {
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog, argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"");
+  ray::RayLog::InstallFailureSignalHandler();
   RAY_CHECK(argc >= 14 && argc <= 16);
 
   const std::string raylet_socket_name = std::string(argv[1]);
@@ -32,12 +37,6 @@ int main(int argc, char *argv[]) {
   const std::string java_worker_command = std::string(argv[13]);
   const std::string redis_password = (argc >= 15 ? std::string(argv[14]) : "");
   const std::string temp_dir = (argc >= 16 ? std::string(argv[15]) : "/tmp/ray");
-
-  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
-                                         ray::RayLog::ShutDownRayLog, argv[0],
-                                         ray::RayLogLevel::INFO,
-                                         /*log_dir=*/temp_dir + "/logs");
-  ray::RayLog::InstallFailureSignalHandler();
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -67,7 +67,7 @@ typedef ray::CerrLog LoggingProvider;
 
 RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
 std::string RayLog::app_name_ = "";
-bool RayLog::is_stored_ = false;
+bool RayLog::log_dir_ = false;
 
 #ifdef RAY_USE_GLOG
 using namespace google;
@@ -123,7 +123,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
   google::SetStderrLogging(mapped_severity_threshold);
   // Enable log file if log_dir is not empty.
   if (!log_dir.empty()) {
-    is_stored_ = true;
+    log_dir_ = true;
     auto dir_ends_with_slash = log_dir;
     if (log_dir[log_dir.length() - 1] != '/') {
       dir_ends_with_slash += "/";
@@ -168,7 +168,7 @@ void RayLog::UninstallSignalAction() {
 void RayLog::ShutDownRayLog() {
 #ifdef RAY_USE_GLOG
   UninstallSignalAction();
-  if (is_stored_) {
+  if (log_dir_) {
     google::ShutdownGoogleLogging();
   }
 #endif

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -138,7 +138,11 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
       }
     }
     google::SetLogFilenameExtension(app_name_without_path.c_str());
-    google::SetLogDestination(mapped_severity_threshold, log_dir.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::DEBUG), dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::INFO), dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::WARNING), dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::ERROR), dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::FATAL), dir_ends_with_slash.c_str());
   }
 #endif
 }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -139,7 +139,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     google::InitGoogleLogging(app_name_.c_str());
     google::SetLogFilenameExtension(app_name_without_path.c_str());
     for (enum RayLogLevel level = severity_threshold_; level <= RayLogLevel::FATAL;
-         level = (enum RayLogLevel)((int)level+1)) {
+         level = (enum RayLogLevel)((int)level + 1)) {
       google::SetLogDestination(GetMappedSeverity(level), dir_ends_with_slash.c_str());
     }
   }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -67,7 +67,7 @@ typedef ray::CerrLog LoggingProvider;
 
 RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
 std::string RayLog::app_name_ = "";
-bool RayLog::log_dir_ = false;
+std::string RayLog::log_dir_ = "";
 
 #ifdef RAY_USE_GLOG
 using namespace google;
@@ -118,14 +118,14 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
   }
   severity_threshold_ = severity_threshold;
   app_name_ = app_name;
+  log_dir_ = log_dir;
 #ifdef RAY_USE_GLOG
   int mapped_severity_threshold = GetMappedSeverity(severity_threshold_);
   google::SetStderrLogging(mapped_severity_threshold);
-  // Enable log file if log_dir is not empty.
-  if (!log_dir.empty()) {
-    log_dir_ = true;
-    auto dir_ends_with_slash = log_dir;
-    if (log_dir[log_dir.length() - 1] != '/') {
+  // Enable log file if log_dir_ is not empty.
+  if (!log_dir_.empty()) {
+    auto dir_ends_with_slash = log_dir_;
+    if (log_dir_[log_dir_.length() - 1] != '/') {
       dir_ends_with_slash += "/";
     }
     auto app_name_without_path = app_name;
@@ -168,7 +168,7 @@ void RayLog::UninstallSignalAction() {
 void RayLog::ShutDownRayLog() {
 #ifdef RAY_USE_GLOG
   UninstallSignalAction();
-  if (log_dir_) {
+  if (!log_dir_.empty()) {
     google::ShutdownGoogleLogging();
   }
 #endif

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -119,7 +119,6 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
   app_name_ = app_name;
 #ifdef RAY_USE_GLOG
   int mapped_severity_threshold = GetMappedSeverity(severity_threshold_);
-  google::InitGoogleLogging(app_name_.c_str());
   google::SetStderrLogging(mapped_severity_threshold);
   // Enble log file if log_dir is not empty.
   if (!log_dir.empty()) {
@@ -137,17 +136,13 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
         app_name_without_path = app_name.substr(pos + 1);
       }
     }
+    google::InitGoogleLogging(app_name_.c_str());
     google::SetLogFilenameExtension(app_name_without_path.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::DEBUG),
-                              dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::INFO),
-                              dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::WARNING),
-                              dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::ERROR),
-                              dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::FATAL),
-                              dir_ends_with_slash.c_str());
+    for (enum RayLogLevel level = severity_threshold_; level <= RayLogLevel::FATAL;
+         level=(enum RayLogLevel)((int)level+1)) {
+      google::SetLogDestination(GetMappedSeverity(level),
+                                dir_ends_with_slash.c_str());
+    }
   }
 #endif
 }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -139,9 +139,8 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     google::InitGoogleLogging(app_name_.c_str());
     google::SetLogFilenameExtension(app_name_without_path.c_str());
     for (enum RayLogLevel level = severity_threshold_; level <= RayLogLevel::FATAL;
-         level=(enum RayLogLevel)((int)level+1)) {
-      google::SetLogDestination(GetMappedSeverity(level),
-                                dir_ends_with_slash.c_str());
+         level = (enum RayLogLevel)((int)level+1)) {
+      google::SetLogDestination(GetMappedSeverity(level), dir_ends_with_slash.c_str());
     }
   }
 #endif

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -138,11 +138,16 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
       }
     }
     google::SetLogFilenameExtension(app_name_without_path.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::DEBUG), dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::INFO), dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::WARNING), dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::ERROR), dir_ends_with_slash.c_str());
-    google::SetLogDestination(GetMappedSeverity(RayLogLevel::FATAL), dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::DEBUG),
+                              dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::INFO),
+                              dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::WARNING),
+                              dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::ERROR),
+                              dir_ends_with_slash.c_str());
+    google::SetLogDestination(GetMappedSeverity(RayLogLevel::FATAL),
+                              dir_ends_with_slash.c_str());
   }
 #endif
 }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -107,7 +107,8 @@ class RayLog : public RayLogBase {
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.
   static std::string app_name_;
-  /// The directory where the log files are stored. If this is empty, logs are printed to stdout.
+  /// The directory where the log files are stored. 
+  /// If this is empty, logs are printed to stdout.
   static std::string log_dir_;
 
  protected:

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -103,12 +103,12 @@ class RayLog : public RayLogBase {
   void *logging_provider_;
   /// True if log messages should be logged and false if they should be ignored.
   bool is_enabled_;
-  /// True if log messages should be stored in log file.
-  static bool log_dir_;
   static RayLogLevel severity_threshold_;
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.
   static std::string app_name_;
+  /// The directory where the log files are stored. If this is empty, logs are printed to stdout.
+  static std::string log_dir_;
 
  protected:
   virtual std::ostream &Stream();

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -104,7 +104,7 @@ class RayLog : public RayLogBase {
   /// True if log messages should be logged and false if they should be ignored.
   bool is_enabled_;
   /// True if log messages should be stored in log file.
-  static bool is_stored_;
+  static bool log_dir_;
   static RayLogLevel severity_threshold_;
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.
@@ -123,6 +123,8 @@ class Voidify {
   // higher than ?:
   void operator&(RayLogBase &) {}
 };
+
+
 
 }  // namespace ray
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -124,8 +124,6 @@ class Voidify {
   void operator&(RayLogBase &) {}
 };
 
-
-
 }  // namespace ray
 
 #endif  // RAY_UTIL_LOGGING_H

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -107,7 +107,7 @@ class RayLog : public RayLogBase {
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.
   static std::string app_name_;
-  /// The directory where the log files are stored. 
+  /// The directory where the log files are stored.
   /// If this is empty, logs are printed to stdout.
   static std::string log_dir_;
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -103,6 +103,8 @@ class RayLog : public RayLogBase {
   void *logging_provider_;
   /// True if log messages should be logged and false if they should be ignored.
   bool is_enabled_;
+  /// True if log messages should be stored in log file.
+  static bool is_stored_;
   static RayLogLevel severity_threshold_;
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.

--- a/src/ray/util/logging_test.cc
+++ b/src/ray/util/logging_test.cc
@@ -41,7 +41,7 @@ TEST(PrintLogTest, LogTestWithoutInit) {
 
 TEST(PrintLogTest, LogTestWithInit) {
   // Test empty app name.
-  RayLog::StartRayLog("", RayLogLevel::DEBUG);
+  RayLog::StartRayLog("", RayLogLevel::DEBUG, "/tmp/");
   PrintLog();
   RayLog::ShutDownRayLog();
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
RayLogs are saved to `/tmp` which is frequently cleaned out on reboot. And it makes error locating difficult if a long time running task failed with reboot. So save RayLog to `temp-dir` which is a configurable path maybe better.

Update:
1. Fix the problem of duplicated stored logs.
2. Save log whose level  is higher than severity_threshold, not only with severity_threshold.
3. Fix a `log_dir` bug: storing logs in a wrong path.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#3596 