### PR TITLE
change order of allocation for io_service and gcs client in raylet

### DIFF
--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -118,14 +118,14 @@ int main(int argc, char *argv[]) {
                  << "max_receives = " << object_manager_config.max_receives << "\n"
                  << "object_chunk_size = " << object_manager_config.object_chunk_size;
 
+  // Initialize the node manager.
+  boost::asio::io_service main_service;
+
   //  initialize mock gcs & object directory
   auto gcs_client = std::make_shared<ray::gcs::AsyncGcsClient>(redis_address, redis_port,
                                                                redis_password);
   RAY_LOG(DEBUG) << "Initializing GCS client "
                  << gcs_client->client_table().GetLocalClientId();
-
-  // Initialize the node manager.
-  boost::asio::io_service main_service;
 
   ray::raylet::Raylet server(main_service, raylet_socket_name, node_ip_address,
                              redis_address, redis_port, redis_password,


### PR DESCRIPTION
## What do these changes do?

Change the order of allocation for boost asio io_service and async gcs client in raylet main.
Reason: need to make sure that the async gcs client dtor gets called before io_service dtor, as the order in which these dtors are called is the opposite of object allocation.

*before*: 24 valgrind errors for this unit test:
`python python/ray/tune/test/dependency_test.py`

*after*: zero valgrind errors.
```
==2534== LEAK SUMMARY:
==2534==    definitely lost: 0 bytes in 0 blocks
==2534==    indirectly lost: 0 bytes in 0 blocks
==2534==      possibly lost: 0 bytes in 0 blocks
==2534==    still reachable: 72,704 bytes in 1 blocks
==2534==         suppressed: 0 bytes in 0 blocks
==2534==
==2534== For counts of detected and suppressed errors, rerun with: -v
==2534== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Related issue number
Stability for 0.6.1