### PR TITLE
increase docker container memory for jenkins multinode test

### DIFF
--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -409,9 +409,9 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     python /ray/python/ray/experimental/sgd/mnist_example.py --num-iters=1 \
         --num-workers=1 --devices-per-worker=1 --strategy=ps
 
-docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
-    python /ray/python/ray/experimental/sgd/mnist_example.py --num-iters=1 \
-        --num-workers=1 --devices-per-worker=1 --strategy=ps --tune
+#docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
+#    python /ray/python/ray/experimental/sgd/mnist_example.py --num-iters=1 \
+#        --num-workers=1 --devices-per-worker=1 --strategy=ps --tune
 
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
@@ -432,6 +432,8 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA pytho
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \
+    --mem-size=20G \
+    --shm-size=20G \
     --num-redis-shards=10 \
     --test-script=/ray/test/jenkins_tests/multi_node_tests/test_0.py
 

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -14,6 +14,38 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 DOCKER_SHA=$($ROOT_DIR/../../build-docker.sh --output-sha --no-cache)
 echo "Using Docker image" $DOCKER_SHA
 
+python3 $ROOT_DIR/multi_node_docker_test.py \
+    --docker-image=$DOCKER_SHA \
+    --num-nodes=5 \
+    --num-redis-shards=10 \
+    --test-script=/ray/test/jenkins_tests/multi_node_tests/test_0.py
+
+python3 $ROOT_DIR/multi_node_docker_test.py \
+    --docker-image=$DOCKER_SHA \
+    --num-nodes=5 \
+    --num-redis-shards=5 \
+    --num-gpus=0,1,2,3,4 \
+    --num-drivers=7 \
+    --driver-locations=0,1,0,1,2,3,4 \
+    --test-script=/ray/test/jenkins_tests/multi_node_tests/remove_driver_test.py
+
+python3 $ROOT_DIR/multi_node_docker_test.py \
+    --docker-image=$DOCKER_SHA \
+    --num-nodes=5 \
+    --num-redis-shards=2 \
+    --num-gpus=0,0,5,6,50 \
+    --num-drivers=100 \
+    --test-script=/ray/test/jenkins_tests/multi_node_tests/many_drivers_test.py
+
+python3 $ROOT_DIR/multi_node_docker_test.py \
+    --docker-image=$DOCKER_SHA \
+    --num-nodes=1 \
+    --mem-size=60G \
+    --shm-size=60G \
+    --test-script=/ray/test/jenkins_tests/multi_node_tests/large_memory_test.py
+
+docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA python -m pytest -v /ray/test/object_manager_test.py
+
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     python /ray/python/ray/rllib/train.py \
     --env PongDeterministic-v0 \
@@ -427,40 +459,3 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     --stop '{"training_iteration": 2}' \
     --config '{"num_workers": 2, "use_pytorch": true, "sample_async": false}'
 
-docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA python -m pytest -v /ray/test/object_manager_test.py
-
-python3 $ROOT_DIR/multi_node_docker_test.py \
-    --docker-image=$DOCKER_SHA \
-    --num-nodes=5 \
-    --mem-size=20G \
-    --shm-size=20G \
-    --num-redis-shards=10 \
-    --test-script=/ray/test/jenkins_tests/multi_node_tests/test_0.py
-
-python3 $ROOT_DIR/multi_node_docker_test.py \
-    --docker-image=$DOCKER_SHA \
-    --num-nodes=5 \
-    --mem-size=20G \
-    --shm-size=20G \
-    --num-redis-shards=5 \
-    --num-gpus=0,1,2,3,4 \
-    --num-drivers=7 \
-    --driver-locations=0,1,0,1,2,3,4 \
-    --test-script=/ray/test/jenkins_tests/multi_node_tests/remove_driver_test.py
-
-python3 $ROOT_DIR/multi_node_docker_test.py \
-    --docker-image=$DOCKER_SHA \
-    --num-nodes=5 \
-    --mem-size=20G \
-    --shm-size=20G \
-    --num-redis-shards=2 \
-    --num-gpus=0,0,5,6,50 \
-    --num-drivers=100 \
-    --test-script=/ray/test/jenkins_tests/multi_node_tests/many_drivers_test.py
-
-python3 $ROOT_DIR/multi_node_docker_test.py \
-    --docker-image=$DOCKER_SHA \
-    --num-nodes=1 \
-    --mem-size=60G \
-    --shm-size=60G \
-    --test-script=/ray/test/jenkins_tests/multi_node_tests/large_memory_test.py

--- a/test/jenkins_tests/run_multi_node_tests.sh
+++ b/test/jenkins_tests/run_multi_node_tests.sh
@@ -438,6 +438,8 @@ python3 $ROOT_DIR/multi_node_docker_test.py \
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \
+    --mem-size=20G \
+    --shm-size=20G \
     --num-redis-shards=5 \
     --num-gpus=0,1,2,3,4 \
     --num-drivers=7 \
@@ -447,6 +449,8 @@ python3 $ROOT_DIR/multi_node_docker_test.py \
 python3 $ROOT_DIR/multi_node_docker_test.py \
     --docker-image=$DOCKER_SHA \
     --num-nodes=5 \
+    --mem-size=20G \
+    --shm-size=20G \
     --num-redis-shards=2 \
     --num-gpus=0,0,5,6,50 \
     --num-drivers=100 \


### PR DESCRIPTION
## What do these changes do?
Jenkins tests are failing on the multinode test. The multinode test is starting docker containers with only 1G of memory and shm_size. This PR increases this to 20GB, since the object store inside each docker container will be started with 20GB.

```
+ python3 /home/jenkins/workspace/Ray/test/jenkins_tests/multi_node_docker_test.py --docker-image=35b9dbf667827000ca86c8fab5899f5ca155e1d72aa80d00421122d0348204d1 --num-nodes=5 --num-redis-shards=5 --num-gpus=0,1,2,3,4 --num-drivers=7 --driver-locations=0,1,0,1,2,3,4 --test-script=/ray/test/jenkins_tests/multi_node_tests/remove_driver_test.py
Starting head node with command:['docker', 'run', '-d', '--shm-size=1G', '35b9dbf667827000ca86c8fab5899f5ca155e1d72aa80d00421122d0348204d1', 'ray', 'start', '--head', '--block', '--redis-port=6379', '--num-redis-shards=5', '--num-cpus=10', '--num-gpus=0', '--no-ui']
Starting worker node with command:['docker', 'run', '-d', '--shm-size=1G', '--shm-size=1G', 
```

This results in dead workers:
```
STDERR:
WARNING: Not updating worker name since `setproctitle` is not installed. Install this with `pip install setproctitle` (or ray[debug]) to enable monitoring of worker processes.
Traceback (most recent call last):
  File "/ray/python/ray/workers/default_worker.py", line 107, in <module>
    ray.worker.global_worker.main_loop()
  File "/ray/python/ray/worker.py", line 962, in main_loop
    self._wait_for_and_process_task(task)
  File "/ray/python/ray/worker.py", line 890, in _wait_for_and_process_task
    driver_id, function_descriptor)
  File "/ray/python/ray/function_manager.py", line 447, in get_execution_info
    return self._function_execution_info[driver_id][function_id]
KeyError: 'C\x81\xa4`|\xc0>\x93\x8cd3\x96iPo\xf0\x9d3\xb6-'
```

## Related issue number
#3476 

