### PR TITLE
bump version from 0.6.0 to 0.6.1

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -65,7 +65,7 @@ import ray.actor  # noqa: F401
 from ray.actor import method  # noqa: E402
 
 # Ray version string.
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",


### PR DESCRIPTION
As far as I know, there are no more release blocking issues. This should be merged as soon as we're ready to build wheels.
