### PR TITLE
[rllib]Fix outdated import get_agent_class in export model example

### DIFF
--- a/python/ray/rllib/examples/export/cartpole_dqn_export.py
+++ b/python/ray/rllib/examples/export/cartpole_dqn_export.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import ray
 import tensorflow as tf
 
-from ray.rllib.agents.agent import get_agent_class
+from ray.rllib.agents.registry import get_agent_class
 
 ray.init(num_cpus=10)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
A recent pull request [#3565](https://github.com/ray-project/ray/pull/3565) moved get_agent_class from agents/agent.py to agents/registry.py. 
This pull request fixes outdated import statement in cartpole_dqn_export.py.
<!-- Please give a short brief about these changes. -->

## Related issue number
None
<!-- Are there any issues opened that will be resolved by merging this change? -->
