### PR TITLE
Average aggregated gradients before put in plasma store

### DIFF
--- a/python/ray/experimental/sgd/param_server.py
+++ b/python/ray/experimental/sgd/param_server.py
@@ -67,6 +67,7 @@ class ParameterServer(object):
         client = ray.worker.global_worker.plasma_client
         assert self.acc_counter == self.num_sgd_workers, self.acc_counter
         oid = ray.pyarrow.plasma.ObjectID(object_id)
+        self.accumulated /= self.acc_counter
         client.put(self.accumulated.flatten(), object_id=oid)
         self.accumulated = np.zeros_like(self.accumulated)
         self.acc_counter = 0


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As we have discussed@ericl, it's better to average the accumulated gradients before sending them back to work actors. This will better fit the lr by keeping the scale of gradients not changed.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
