### PR TITLE
Fix the issue when waiting an empty list or a null pointer

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -47,6 +47,10 @@ public class RayletClientImpl implements RayletClient {
   @Override
   public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
       timeoutMs, UniqueId currentTaskId) {
+    if (waitFor == null || waitFor.isEmpty()) {
+      return null;
+    }
+
     List<UniqueId> ids = new ArrayList<>();
     for (RayObject<T> element : waitFor) {
       ids.add(element.getId());

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -47,9 +47,7 @@ public class RayletClientImpl implements RayletClient {
   @Override
   public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
       timeoutMs, UniqueId currentTaskId) {
-    if (waitFor == null) {
-      throw new NullPointerException();
-    }
+    Preconditions.checkNotNull(waitFor);
     if (waitFor.isEmpty()) {
       return new WaitResult<>(new ArrayList<>(), new ArrayList<>());
     }

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -47,8 +47,11 @@ public class RayletClientImpl implements RayletClient {
   @Override
   public <T> WaitResult<T> wait(List<RayObject<T>> waitFor, int numReturns, int
       timeoutMs, UniqueId currentTaskId) {
-    if (waitFor == null || waitFor.isEmpty()) {
-      return null;
+    if (waitFor == null) {
+      throw new NullPointerException();
+    }
+    if (waitFor.isEmpty()) {
+      return new WaitResult<>(new ArrayList<>(), new ArrayList<>());
     }
 
     List<UniqueId> ids = new ArrayList<>();

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -1,6 +1,8 @@
 package org.ray.api.test;
 
 import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,5 +59,10 @@ public class WaitTest {
   public void testWaitInWorker() {
     RayObject<Object> res = Ray.call(WaitTest::waitInWorker);
     res.get();
+  }
+
+  @Test
+  public void testWaitForEmpty() {
+    Assert.assertNull(Ray.wait(new ArrayList<>()));
   }
 }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -63,6 +63,15 @@ public class WaitTest {
 
   @Test
   public void testWaitForEmpty() {
-    Assert.assertNull(Ray.wait(new ArrayList<>()));
+    WaitResult<String> result = Ray.wait(new ArrayList<>());
+    Assert.assertTrue(result.getReady().isEmpty());
+    Assert.assertTrue(result.getUnready().isEmpty());
+
+    try {
+      Ray.wait(null);
+      Assert.fail();
+    } catch (NullPointerException e) {
+      Assert.assertTrue(true);
+    }
   }
 }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -1,7 +1,6 @@
 package org.ray.api.test;
 
 import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Before this change, if we wait an empty list or a null pointer, the raylet will crash because of a failure of `check(list.size() is not 0)`.



<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
