### PR TITLE
[rllib] Agent: Allow unknown subkeys for custom_resources_per_worker

### DIFF
--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -201,7 +201,7 @@ class Agent(Trainable):
 
     _allow_unknown_configs = False
     _allow_unknown_subkeys = [
-        "tf_session_args", "env_config", "model", "optimizer", "multiagent"
+        "tf_session_args", "env_config", "model", "optimizer", "multiagent", "custom_resources_per_worker"
     ]
 
     def __init__(self, config=None, env=None, logger_creator=None):

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -201,7 +201,8 @@ class Agent(Trainable):
 
     _allow_unknown_configs = False
     _allow_unknown_subkeys = [
-        "tf_session_args", "env_config", "model", "optimizer", "multiagent", "custom_resources_per_worker"
+        "tf_session_args", "env_config", "model", "optimizer", "multiagent",
+        "custom_resources_per_worker"
     ]
 
     def __init__(self, config=None, env=None, logger_creator=None):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Allows specifying custom resources in the custom_resources_per_worker configuration to the agent. Without this change, specifying any custom resource causes the config dict merge to fail.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
