### PR TITLE
Fix test_multiple_actor_reconstruction failure

### DIFF
--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2249,6 +2249,10 @@ def test_actor_reconstruction_on_node_failure(head_node_cluster):
         ray.get(actor.increase.remote())
 
 
+# NOTE(hchen): we set initial_reconstruction_timeout_milliseconds to 1s for
+# this test. Because if this value is too small, suprious task reconstruction
+# may happen and cause the test fauilure. If the value is too large, this test
+# could be very slow. We can remove this once we support dynamic timeout.
 @pytest.mark.parametrize('head_node_cluster', [1000], indirect=True)
 def test_multiple_actor_reconstruction(head_node_cluster):
     # This test can be made more stressful by increasing the numbers below.

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -40,13 +40,14 @@ def shutdown_only():
 
 
 @pytest.fixture
-def head_node_cluster():
+def head_node_cluster(request):
+    timeout = getattr(request, 'param', 200)
     cluster = ray.test.cluster_utils.Cluster(
         initialize_head=True,
         connect=True,
         head_node_args={
             "_internal_config": json.dumps({
-                "initial_reconstruction_timeout_milliseconds": 200,
+                "initial_reconstruction_timeout_milliseconds": timeout,
                 "num_heartbeats_timeout": 10,
             })
         })
@@ -2248,6 +2249,7 @@ def test_actor_reconstruction_on_node_failure(head_node_cluster):
         ray.get(actor.increase.remote())
 
 
+@pytest.mark.parametrize('head_node_cluster', [1000], indirect=True)
 def test_multiple_actor_reconstruction(head_node_cluster):
     # This test can be made more stressful by increasing the numbers below.
     # The total number of actors created will be


### PR DESCRIPTION
`test_multiple_actor_reconstruction` sometimes fails in CI, because of spurious task reconstruction, in the following situation.
1) driver submits a task creation task, say A, to node X.
2) node X forwards A to node Y.
3) for some reason, forward doesn't finish in 200 ms. Then node X tries to resubmit A, and forwards A to another node Z.
4) Z receives A, and finishes executing it.
5) X removes A from linage cache.
6) the failure callback of forwarding A to Y gets invoked. X tries to resubmit A, but can't find it in lineage cache. Then raylet crashes.