### PR TITLE
[rllib] fix for rollout of lstm policies

### DIFF
--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -97,21 +97,18 @@ def run(args, parser):
     agent = cls(env=args.env, config=config)
     agent.restore(args.checkpoint)
     num_steps = int(args.steps)
-    rollout(agent, args.env, num_steps, config, args.out, args.no_render)
+    rollout(agent, args.env, num_steps, args.out, args.no_render)
 
 
-def rollout(agent, env_name, num_steps, config, out=None, no_render=True):
+def rollout(agent, env_name, num_steps, out=None, no_render=True):
     if hasattr(agent, "local_evaluator"):
         env = agent.local_evaluator.env
     else:
         env = gym.make(env_name)
 
-    if config['model']['use_lstm']:
+    state_init = agent.local_evaluator.policy_map["default"].get_initial_state()
+    if state_init:
         use_lstm = True
-        state_init = [
-            np.zeros(config['model']['lstm_cell_size'], np.float32),
-            np.zeros(config['model']['lstm_cell_size'], np.float32)
-        ]
     else:
         use_lstm = False
 

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -107,7 +107,8 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         env = gym.make(env_name)
 
     if hasattr(agent, "local_evaluator"):
-        state_init = agent.local_evaluator.policy_map["default"].get_initial_state()
+        state_init = agent.local_evaluator.policy_map[
+            "default"].get_initial_state()
     else:
         state_init = []
     if state_init:

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import os
 import pickle
+import numpy as np
 
 import gym
 import ray
@@ -96,14 +97,24 @@ def run(args, parser):
     agent = cls(env=args.env, config=config)
     agent.restore(args.checkpoint)
     num_steps = int(args.steps)
-    rollout(agent, args.env, num_steps, args.out, args.no_render)
+    rollout(agent, args.env, num_steps, config, args.out, args.no_render)
 
 
-def rollout(agent, env_name, num_steps, out=None, no_render=True):
+def rollout(agent, env_name, num_steps, config, out=None, no_render=True):
     if hasattr(agent, "local_evaluator"):
         env = agent.local_evaluator.env
     else:
         env = gym.make(env_name)
+
+    if config['model']['use_lstm']:
+        use_lstm = True
+        state_init = [
+            np.zeros(config['model']['lstm_cell_size'], np.float32),
+            np.zeros(config['model']['lstm_cell_size'], np.float32)
+        ]
+    else:
+        use_lstm = False
+
     if out is not None:
         rollouts = []
     steps = 0
@@ -114,7 +125,11 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         done = False
         reward_total = 0.0
         while not done and steps < (num_steps or steps + 1):
-            action = agent.compute_action(state)
+            if use_lstm:
+                action, state_init, logits = agent.compute_action(
+                    state, state=state_init)
+            else:
+                action = agent.compute_action(state)
             next_state, reward, done, _ = env.step(action)
             reward_total += reward
             if not no_render:

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -106,7 +106,10 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
     else:
         env = gym.make(env_name)
 
-    state_init = agent.local_evaluator.policy_map["default"].get_initial_state()
+    if hasattr(agent, "local_evaluator"):
+        state_init = agent.local_evaluator.policy_map["default"].get_initial_state()
+    else:
+        state_init = []
     if state_init:
         use_lstm = True
     else:

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -8,7 +8,6 @@ import argparse
 import json
 import os
 import pickle
-import numpy as np
 
 import gym
 import ray


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fix for using rollout.py if the policies are lstms; the call to compute an action for lstm policies is different.  

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes https://github.com/ray-project/ray/issues/2704