### PR TITLE
[Java] Support calling Ray APIs from multiple threads

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -108,8 +108,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   @Override
   public <T> List<T> get(List<UniqueId> objectIds) {
     boolean wasBlocked = false;
-    // TODO(swang): If we are not on the main thread, then we should generate a
-    // random task ID to pass to the backend.
     UniqueId taskId = workerContext.getCurrentThreadTaskId();
 
     try {

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -345,4 +345,8 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   public FunctionManager getFunctionManager() {
     return functionManager;
   }
+
+  public RayConfig getRayConfig() {
+    return rayConfig;
+  }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -237,9 +237,12 @@ public abstract class AbstractRayRuntime implements RayRuntime {
       throw new IllegalArgumentException("Unsupported actor type: " + actor.getClass().getName());
     }
     RayActorImpl actorImpl = (RayActorImpl)actor;
-    TaskSpec spec = createTaskSpec(func, actorImpl, args, false, null);
-    spec.getExecutionDependencies().add(((RayActorImpl) actor).getTaskCursor());
-    actorImpl.setTaskCursor(spec.returnIds[1]);
+    TaskSpec spec;
+    synchronized (actor) {
+      spec = createTaskSpec(func, actorImpl, args, false, null);
+      spec.getExecutionDependencies().add(((RayActorImpl) actor).getTaskCursor());
+      actorImpl.setTaskCursor(spec.returnIds[1]);
+    }
     rayletClient.submitTask(spec);
     return new RayObjectImpl(spec.returnIds[0]);
   }

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -223,7 +223,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   }
 
   @Override
-  public synchronized RayObject call(RayFunc func, Object[] args, CallOptions options) {
+  public RayObject call(RayFunc func, Object[] args, CallOptions options) {
     TaskSpec spec = createTaskSpec(func, RayActorImpl.NIL, args, false, options);
     rayletClient.submitTask(spec);
     return new RayObjectImpl(spec.returnIds[0]);

--- a/java/runtime/src/main/java/org/ray/runtime/RayDevRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayDevRuntime.java
@@ -11,15 +11,21 @@ public class RayDevRuntime extends AbstractRayRuntime {
     super(rayConfig);
   }
 
+  private MockObjectStore store;
+
   @Override
   public void start() {
-    MockObjectStore store = new MockObjectStore(this);
-    objectStoreProxy = new ObjectStoreProxy(this, store);
+    store = new MockObjectStore(this);
+    objectStoreProxy = new ObjectStoreProxy(this, null);
     rayletClient = new MockRayletClient(this, store);
   }
 
   @Override
   public void shutdown() {
     // nothing to do
+  }
+
+  public MockObjectStore getObjectStore() {
+    return store;
   }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -74,8 +74,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
     }
     kvStore = new RedisClient(rayConfig.getRedisAddress());
 
-    ObjectStoreLink store = new PlasmaClient(rayConfig.objectStoreSocketName, "", 0);
-    objectStoreProxy = new ObjectStoreProxy(this, store);
+    objectStoreProxy = new ObjectStoreProxy(this, rayConfig.objectStoreSocketName);
 
     rayletClient = new RayletClientImpl(
         rayConfig.rayletSocketName,

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -106,6 +106,8 @@ public class WorkerContext {
 
   public void setCurrentTask(TaskSpec currentTask) {
     this.currentTask = currentTask;
+    currentTaskCallCount.set(0);
+    currentTaskCallCount.set(0);
   }
 
   public void setCurrentClassLoader(ClassLoader currentClassLoader) {

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -1,9 +1,9 @@
 package org.ray.runtime;
 
+import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import com.google.common.base.Preconditions;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.WorkerMode;
 import org.ray.runtime.task.TaskSpec;
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WorkerContext {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerContext.class);
 
   /**
    * Worker id.
@@ -45,8 +46,6 @@ public class WorkerContext {
    * If the multi-threading warning message has been logged.
    */
   private AtomicBoolean multiThreadingWarned;
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerContext.class);
 
   public WorkerContext(WorkerMode workerMode, UniqueId driverId) {
     workerId = workerMode == WorkerMode.DRIVER ? driverId : UniqueId.randomId();

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -54,7 +54,7 @@ public class WorkerContext {
     currentClassLoader = null;
     currentTask = createDummyTask(workerMode, driverId);
     mainThreadId = Thread.currentThread().getId();
-    multiThreadingWarned = new AtomicBoolean();
+    multiThreadingWarned = new AtomicBoolean(false);
   }
 
   /**

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -1,11 +1,14 @@
 package org.ray.runtime;
 
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import com.google.common.base.Preconditions;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.WorkerMode;
 import org.ray.runtime.task.TaskSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WorkerContext {
 
@@ -34,12 +37,48 @@ public class WorkerContext {
    */
   private AtomicInteger currentTaskCallCount;
 
+  /**
+   * The ID of main thread which created the worker context.
+   */
+  private long mainThreadId;
+  /**
+   * If the multi-threading warning message has been logged.
+   */
+  private AtomicBoolean multiThreadingWarned;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerContext.class);
+
   public WorkerContext(WorkerMode workerMode, UniqueId driverId) {
     workerId = workerMode == WorkerMode.DRIVER ? driverId : UniqueId.randomId();
     currentTaskPutCount = new AtomicInteger(0);
     currentTaskCallCount = new AtomicInteger(0);
     currentClassLoader = null;
     currentTask = createDummyTask(workerMode, driverId);
+    mainThreadId = Thread.currentThread().getId();
+    multiThreadingWarned = new AtomicBoolean();
+  }
+
+  /**
+   * Get the current thread's task ID.
+   * This returns the assigned task ID if called on the main thread, else a
+   * random task ID.
+   */
+  public UniqueId getCurrentThreadTaskId() {
+    UniqueId taskId;
+    if (Thread.currentThread().getId() == mainThreadId) {
+      taskId = currentTask.taskId;
+    } else {
+      taskId = UniqueId.randomId();
+      if (multiThreadingWarned.compareAndSet(false, true)) {
+        LOGGER.warn("Calling Ray.get or Ray.wait in a separate thread " +
+            "may lead to deadlock if the main thread blocks on this " +
+            "thread and there are not enough resources to execute " +
+            "more tasks");
+      }
+    }
+
+    Preconditions.checkState(!taskId.isNil());
+    return taskId;
   }
 
   public void setWorkerId(UniqueId workerId) {

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -1,6 +1,8 @@
 package org.ray.runtime;
 
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.WorkerMode;
 import org.ray.runtime.task.TaskSpec;
@@ -25,17 +27,17 @@ public class WorkerContext {
   /**
    * How many puts have been done by current task.
    */
-  private int currentTaskPutCount;
+  private AtomicInteger currentTaskPutCount;
 
   /**
    * How many calls have been done by current task.
    */
-  private int currentTaskCallCount;
+  private AtomicInteger currentTaskCallCount;
 
   public WorkerContext(WorkerMode workerMode, UniqueId driverId) {
     workerId = workerMode == WorkerMode.DRIVER ? driverId : UniqueId.randomId();
-    currentTaskPutCount = 0;
-    currentTaskCallCount = 0;
+    currentTaskPutCount = new AtomicInteger(0);
+    currentTaskCallCount = new AtomicInteger(0);
     currentClassLoader = null;
     currentTask = createDummyTask(workerMode, driverId);
   }
@@ -49,11 +51,11 @@ public class WorkerContext {
   }
 
   public int nextPutIndex() {
-    return ++currentTaskPutCount;
+    return currentTaskPutCount.incrementAndGet();
   }
 
   public int nextCallIndex() {
-    return ++currentTaskCallCount;
+    return currentTaskCallCount.incrementAndGet();
   }
 
   public UniqueId getCurrentWorkerId() {

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -107,7 +107,7 @@ public class WorkerContext {
   public void setCurrentTask(TaskSpec currentTask) {
     this.currentTask = currentTask;
     currentTaskCallCount.set(0);
-    currentTaskCallCount.set(0);
+    currentTaskPutCount.set(0);
   }
 
   public void setCurrentClassLoader(ClassLoader currentClassLoader) {

--- a/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
+++ b/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
@@ -1,0 +1,100 @@
+package org.ray.api.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ray.api.Ray;
+import org.ray.api.RayActor;
+import org.ray.api.RayObject;
+import org.ray.api.annotation.RayRemote;
+
+
+public class MultiThreadingTest extends BaseTest {
+
+  private static final int LOOP_COUNTER = 1000;
+  private static final int NUM_THREADS = 20;
+
+  @RayRemote
+  public static Integer echo(int num) {
+    return num;
+  }
+
+  @RayRemote
+  public static class Echo {
+
+    @RayRemote
+    public Integer echo(int num) {
+      return num;
+    }
+  }
+
+  public static String testMultiThreading() {
+    Random random = new Random();
+    // Test calling normal functions.
+    runTestCaseInMultipleThreads(() -> {
+      int arg = random.nextInt();
+      RayObject<Integer> obj = Ray.call(MultiThreadingTest::echo, arg);
+      Assert.assertEquals(arg, (int) obj.get());
+    });
+    // Test calling actors.
+    RayActor<Echo> echoActor = Ray.createActor(Echo::new);
+    runTestCaseInMultipleThreads(() -> {
+      int arg = random.nextInt();
+      RayObject<Integer> obj = Ray.call(Echo::echo, echoActor, arg);
+      Assert.assertEquals(arg, (int) obj.get());
+    });
+    // Test put and get.
+    runTestCaseInMultipleThreads(() -> {
+      int arg = random.nextInt();
+      RayObject<Integer> obj = Ray.put(arg);
+      Assert.assertEquals(arg, (int) Ray.get(obj.getId()));
+    });
+    return "ok";
+  }
+
+  @Test
+  public void testInDriver() {
+    testMultiThreading();
+  }
+
+  @Test
+  public void testInWorker() {
+    RayObject<String> obj = Ray.call(MultiThreadingTest::testMultiThreading);
+    Assert.assertEquals("ok", obj.get());
+  }
+
+  private static void runTestCaseInMultipleThreads(Runnable testCase) {
+    ExecutorService service = Executors.newFixedThreadPool(NUM_THREADS);
+
+    try {
+      List<Future<String>> futures = new ArrayList<>();
+      for (int i = 0; i < NUM_THREADS; i++) {
+        Callable<String> task = () -> {
+          for (int j = 0; j < LOOP_COUNTER; j++) {
+            TimeUnit.MILLISECONDS.sleep(1);
+            testCase.run();
+          }
+          return "ok";
+        };
+        futures.add(service.submit(task));
+      }
+      for (Future<String> future : futures) {
+        try {
+          Assert.assertEquals(future.get(), "ok");
+        } catch (Exception e) {
+          throw new RuntimeException("Test case failed.", e);
+        }
+      }
+    } finally {
+      service.shutdown();
+    }
+  }
+
+}


### PR DESCRIPTION
## What do these changes do?
We do these things for supporting this: 
1. Lock the actor when call on an actor.
2. Make `currentTaskPutCount` and `currentTaskCallCount` as atomic variables.
3. Make `objectStore` as thread local.
4. Use different `currentThreadTaskId`s in different threads.

Btw, the implementation of `getCurrentThreadTaskId()` is quoted from @kfstorm, thanks.

## Related issue number
N/A