### PR TITLE
Add missing lock in FreeObjects of object buffer pool

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -197,6 +197,7 @@ void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
 }
 
 std::string ObjectBufferPool::DebugString() const {
+  std::lock_guard<std::mutex> lock(pool_mutex_);
   std::stringstream result;
   result << "BufferPool:";
   result << "\n- get buffer state map size: " << get_buffer_state_.size();

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -192,6 +192,7 @@ void ObjectBufferPool::FreeObjects(const std::vector<ObjectID> &object_ids) {
   for (const auto &id : object_ids) {
     plasma_ids.push_back(id.to_plasma_id());
   }
+  std::lock_guard<std::mutex> lock(pool_mutex_);
   ARROW_CHECK_OK(store_client_.Delete(plasma_ids));
 }
 

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -182,7 +182,7 @@ class ObjectBufferPool {
 
   /// Mutex on public methods for thread-safe operations on
   /// get_buffer_state_, create_buffer_state_, and store_client_.
-  std::mutex pool_mutex_;
+  mutable std::mutex pool_mutex_;
   /// Determines the maximum chunk size to be transferred by a single thread.
   const uint64_t default_chunk_size_;
   /// The state of a buffer that's currently being used.


### PR DESCRIPTION
Object manager uses multi-threading for transferring objects between different nodes, the plasma client used in object_buffer_pool_ needs to be protected by lock. We have met crashes caused by missing lock in FreeObjects() interface, this PR fixes that issue.