### PR TITLE
Fix multi-thread problem of function manager and Jenkins test

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -515,10 +515,8 @@ class FunctionActorManager(object):
     def export_actor_class(self, Class, actor_method_names,
                            checkpoint_interval):
         function_descriptor = FunctionDescriptor.from_class(Class)
-        if (self._worker.task_driver_id.is_nil()):
-            logger.warning("export_actor_class with NIL task_driver_id, this "
-                           "may happen when export_actor_class runs not in "
-                           "the main thread. Will wait for the driver id.")
+        # When a worker becomes an actor, task_driver_id will be fixed without
+        # changing. Therefore, self._worker.task_driver_id should not be NIL.
         assert not self._worker.task_driver_id.is_nil()
         driver_id = self._worker.task_driver_id
         key = (b"ActorClass:" + driver_id.id() + b":" +

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -519,8 +519,7 @@ class FunctionActorManager(object):
             logger.warning("export_actor_class with NIL task_driver_id, this "
                            "may happen when export_actor_class runs not in "
                            "the main thread. Will wait for the driver id.")
-        while (self._worker.task_driver_id.is_nil()):
-            time.sleep(0.01)
+        assert not self._worker.task_driver_id.is_nil()
         driver_id = self._worker.task_driver_id
         key = (b"ActorClass:" + driver_id.id() + b":" +
                function_descriptor.function_id.id())

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -72,8 +72,8 @@ def push_error_to_driver(worker,
     if driver_id is None:
         driver_id = ray_constants.NIL_JOB_ID.id()
     data = {} if data is None else data
-    logging.error("push_error_to_driver with type={} and message: {}".format(
-        error_type, message))
+    logging.error("Pushing error to dirver, type: %s, message: %s.",
+                  error_type, message)
     worker.raylet_client.push_error(
         ray.ObjectID(driver_id), error_type, message, time.time())
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -72,7 +72,8 @@ def push_error_to_driver(worker,
     if driver_id is None:
         driver_id = ray_constants.NIL_JOB_ID.id()
     data = {} if data is None else data
-    logging.error("push_error_to_driver with message: %s" % message)
+    logging.error("push_error_to_driver with type={} and message: {}".format(
+        error_type, message))
     worker.raylet_client.push_error(
         ray.ObjectID(driver_id), error_type, message, time.time())
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -6,6 +6,7 @@ import binascii
 import functools
 import hashlib
 import inspect
+import logging
 import numpy as np
 import os
 import subprocess
@@ -17,6 +18,8 @@ import uuid
 import ray.gcs_utils
 import ray.raylet
 import ray.ray_constants as ray_constants
+
+logger = logging.getLogger(__name__)
 
 
 def _random_string():
@@ -69,6 +72,7 @@ def push_error_to_driver(worker,
     if driver_id is None:
         driver_id = ray_constants.NIL_JOB_ID.id()
     data = {} if data is None else data
+    logging.error("push_error_to_driver with message: %s" % message)
     worker.raylet_client.push_error(
         ray.ObjectID(driver_id), error_type, message, time.time())
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -770,16 +770,17 @@ class Worker(object):
             assert self.current_task_id.is_nil()
             assert self.task_index == 0
             assert self.put_index == 1
-            # self.actor_id is set before hand, so here we use task.actor_id.
             if task.actor_id().is_nil():
-                # This worker is not an actor, task_driver_id has been reset.
+                # If this worker is not an actor, check that `task_driver_id`
+                # was reset when the worker finished the previous task.
                 assert self.task_driver_id.is_nil()
-                # The ID of the driver that this task belongs to. This is
+                # Set the driver ID of the current running task. This is
                 # needed so that if the task throws an exception, we propagate
                 # the error message to the correct driver.
                 self.task_driver_id = task.driver_id()
             else:
-                # This worker is an actor, we will not change task_driver_id.
+                # If this worker is an actor, task_driver_id wasn't reset.
+                # Check that current task's driver ID equals the previous one.
                 assert self.task_driver_id == task.driver_id()
 
             self.current_task_id = task.task_id()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -618,7 +618,8 @@ class Worker(object):
                 task_index = self.task_index
                 self.task_index += 1
                 # The parent task must be set for the submitted task.
-                assert not self.current_task_id.is_nil()
+                if self.actor_id == NIL_ACTOR_ID:
+                    assert not self.current_task_id.is_nil()
             # Submit the task to local scheduler.
             function_descriptor_list = (
                 function_descriptor.get_function_descriptor_list())
@@ -766,23 +767,29 @@ class Worker(object):
         use the outputs of this task).
         """
         with self.state_lock:
-            assert self.task_driver_id.is_nil()
             assert self.current_task_id.is_nil()
             assert self.task_index == 0
             assert self.put_index == 1
+            # self.actor_id is set before hand, so here we use task.actor_id.
+            if task.actor_id().is_nil():
+                # This worker is not an actor, task_driver_id has been reset.
+                assert self.task_driver_id.is_nil()
+                # The ID of the driver that this task belongs to. This is
+                # needed so that if the task throws an exception, we propagate
+                # the error message to the correct driver.
+                self.task_driver_id = task.driver_id()
+            else:
+                # This worker is an actor, we will not change task_driver_id.
+                assert self.task_driver_id == task.driver_id()
 
-            # The ID of the driver that this task belongs to. This is needed so
-            # that if the task throws an exception, we propagate the error
-            # message to the correct driver.
-            self.task_driver_id = task.driver_id()
             self.current_task_id = task.task_id()
 
         function_descriptor = FunctionDescriptor.from_bytes_list(
             task.function_descriptor_list())
         args = task.arguments()
         return_object_ids = task.returns()
-        if (task.actor_id().id() != NIL_ACTOR_ID
-                or task.actor_creation_id().id() != NIL_ACTOR_ID):
+        if (not task.actor_id().is_nil()
+                or not task.actor_creation_id().is_nil()):
             dummy_return_id = return_object_ids.pop()
         function_executor = function_execution_info.function
         function_name = function_execution_info.function_name
@@ -809,11 +816,11 @@ class Worker(object):
         # Execute the task.
         try:
             with profiling.profile("task:execute", worker=self):
-                if (task.actor_id().id() == NIL_ACTOR_ID
-                        and task.actor_creation_id().id() == NIL_ACTOR_ID):
+                if (task.actor_id().is_nil()
+                        and task.actor_creation_id().is_nil()):
                     outputs = function_executor(*arguments)
                 else:
-                    if task.actor_id().id() != NIL_ACTOR_ID:
+                    if not task.actor_id().is_nil():
                         key = task.actor_id().id()
                     else:
                         key = task.actor_creation_id().id()
@@ -822,7 +829,7 @@ class Worker(object):
         except Exception as e:
             # Determine whether the exception occured during a task, not an
             # actor method.
-            task_exception = task.actor_id().id() == NIL_ACTOR_ID
+            task_exception = task.actor_id().is_nil()
             traceback_str = ray.utils.format_error_message(
                 traceback.format_exc(), task_exception=task_exception)
             self._handle_process_task_failure(
@@ -881,7 +888,7 @@ class Worker(object):
 
         # TODO(rkn): It would be preferable for actor creation tasks to share
         # more of the code path with regular task execution.
-        if (task.actor_creation_id() != ray.ObjectID(NIL_ACTOR_ID)):
+        if not task.actor_creation_id().is_nil():
             assert self.actor_id == NIL_ACTOR_ID
             self.actor_id = task.actor_creation_id().id()
             self.function_actor_manager.load_actor(driver_id,
@@ -901,8 +908,8 @@ class Worker(object):
                 "name": function_name,
                 "task_id": task.task_id().hex()
             }
-            if task.actor_id().id() == NIL_ACTOR_ID:
-                if (task.actor_creation_id() == ray.ObjectID(NIL_ACTOR_ID)):
+            if task.actor_id().is_nil():
+                if task.actor_creation_id().is_nil():
                     title = "ray_worker:{}()".format(function_name)
                     next_title = "ray_worker"
                 else:
@@ -920,7 +927,9 @@ class Worker(object):
                     self._process_task(task, execution_info)
                 # Reset the state fields so the next task can run.
                 with self.state_lock:
-                    self.task_driver_id = ray.ObjectID(NIL_ID)
+                    if self.actor_id == NIL_ACTOR_ID:
+                        # We will keep task_driver_id unchanged for actor.
+                        self.task_driver_id = ray.ObjectID(NIL_ID)
                     self.current_task_id = ray.ObjectID(NIL_ID)
                     self.task_index = 0
                     self.put_index = 1


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
The Jenkins test `mnist_example.py` uses multi-thread in actor and we found frequent Jenkins test failures recently. 

1. Pattern 1
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10425/console
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10423/console
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10422/console
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10416/console
2. Pattern 2
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10428/console 
  - https://amplab.cs.berkeley.edu/jenkins/job/Ray-PRB/10404/console

Pattern 1 is caused by NIL driver ID in multi-thread actor exporting. In this case, exporting is called before `worker.task_driver_id` is set in main thread. Finally, `load_actor` won't get the right actor key from GCS.
```
File "/usr/local/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
File "/home/admin/yuhong/ray/python/ray/tune/function_runner.py", line 80, in run
    self._entrypoint(*self._entrypoint_args)
File "python/ray/experimental/sgd/mnist_example.py", line 112, in train_mnist
    strategy=args.strategy)
File "/home/admin/yuhong/ray/python/ray/experimental/sgd/sgd.py", line 106, in __init__
    all_reduce_alg=all_reduce_alg))
File "/home/admin/yuhong/ray/python/ray/actor.py", line 329, in remote
    return self._remote(args=args, kwargs=kwargs)
File "/home/admin/yuhong/ray/python/ray/actor.py", line 392, in _remote
    self._checkpoint_interval)
File "/home/admin/yuhong/ray/python/ray/function_manager.py", line 520, in export_actor_class
    for line in traceback.format_stack():
 export_actor_class: FunctionDescriptor:ray.experimental.sgd.sgd_worker.SGDWorker.__init__., driver id: ObjectID(fffffffffffffffffffffffffffffffffffffff)
```
Pattern 2 is because that `worker.task_driver_id` becomes NIL in `_publish_actor_class_to_key`. The actor key is right, but `driver_id` information is not correct. Actually, in this case, worker continues with following failures, but `push_error_to_driver` suppresses this error message and the task is reconstructed indefinitely. 
```
Traceback (most recent call last):
  File "/home/admin/yuhong/ray/python/ray/workers/default_worker.py", line 106, in <module>
    ray.worker.global_worker.main_loop()
  File "/home/admin/yuhong/ray/python/ray/worker.py", line 963, in main_loop
    self._wait_for_and_process_task(task)
  File "/home/admin/yuhong/ray/python/ray/worker.py", line 891, in _wait_for_and_process_task
    driver_id, function_descriptor)
  File "/home/admin/yuhong/ray/python/ray/function_manager.py", line 453, in get_execution_info
    raise KeyError(message)
KeyError: "Error occurs in get_execution_info: driver_id: 44b1341be3f9ee0bdfb8d249f82eaa4e9cab6930, function_descriptor: FunctionDescriptor:ray.experimental.sgd.sgd_worker.SGDWorker.__init__.. Message: b'j\\xceZ\\xbd\\xba\\x98\\xf0\\x91\\xc6\\xa7m\\x80|\\xfd\\x16m$\\x94\\xf6\\xac'"
```

In this PR, the following changes are included,
1. The function manager will wait the driver ID and driver ID will be kept as soon as it is not NIL. 
2. `actor_class_info` will has the `driver_id` item at the beginning. Otherwise, if `actor_class_info` is put to `_actors_to_export` the `driver_id` infor will be missing.
3. Add error log to `push_error_to_driver`.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
