### PR TITLE
Improve backend log: env variable setting and format refine.

### DIFF
--- a/src/ray/id.cc
+++ b/src/ray/id.cc
@@ -155,7 +155,11 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
 size_t UniqueID::hash() const { return MurmurHash64A(&id_[0], kUniqueIDSize, 0); }
 
 std::ostream &operator<<(std::ostream &os, const UniqueID &id) {
-  os << id.hex();
+  if (id.is_nil()) {
+    os << "NIL_ID";
+  } else {
+    os << id.hex();
+  }
   return os;
 }
 

--- a/src/ray/raylet/task_spec.cc
+++ b/src/ray/raylet/task_spec.cc
@@ -1,4 +1,5 @@
 #include "task_spec.h"
+#include <sstream>
 
 #include "ray/common/common_protocol.h"
 #include "ray/gcs/format/gcs_generated.h"
@@ -137,6 +138,21 @@ int64_t TaskSpecification::ParentCounter() const {
 std::vector<std::string> TaskSpecification::FunctionDescriptor() const {
   auto message = flatbuffers::GetRoot<TaskInfo>(spec_.data());
   return string_vec_from_flatbuf(*message->function_descriptor());
+}
+
+std::string TaskSpecification::FunctionDescriptorString() const {
+  auto message = flatbuffers::GetRoot<TaskInfo>(spec_.data());
+  auto list = string_vec_from_flatbuf(*message->function_descriptor());
+  std::ostringstream stream;
+  // The 4th is the code hash which is binary bits. No need to output it.
+  int size = std::min(static_cast<size_t>(3), list.size());
+  for (int i = 0; i < size; ++i) {
+    if (i != 0) {
+      stream << ",";
+    }
+    stream << list[i];
+  }
+  return stream.str();
 }
 
 int64_t TaskSpecification::NumArgs() const {

--- a/src/ray/raylet/task_spec.cc
+++ b/src/ray/raylet/task_spec.cc
@@ -1,4 +1,5 @@
 #include "task_spec.h"
+
 #include <sstream>
 
 #include "ray/common/common_protocol.h"

--- a/src/ray/raylet/task_spec.h
+++ b/src/ray/raylet/task_spec.h
@@ -160,6 +160,8 @@ class TaskSpecification {
   TaskID ParentTaskId() const;
   int64_t ParentCounter() const;
   std::vector<std::string> FunctionDescriptor() const;
+  // Output the function descriptor as a string for log purpose.
+  std::string FunctionDescriptorString() const;
   int64_t NumArgs() const;
   int64_t NumReturns() const;
   bool ArgByRef(int64_t arg_index) const;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -110,7 +110,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     } else if (data == "fatal") {
       severity_threshold = RayLogLevel::FATAL;
     } else {
-      RAY_LOG(INFO) << "Unrecognized setting of RAY_BACKEND_LOG_LEVEL=" << var_value;
+      RAY_LOG(WARNING) << "Unrecognized setting of RAY_BACKEND_LOG_LEVEL=" << var_value;
     }
     RAY_LOG(INFO) << "Set ray log level from environment variable RAY_BACKEND_LOG_LEVEL"
                   << " to " << static_cast<int>(severity_threshold);
@@ -144,7 +144,8 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
 }
 
 void RayLog::UninstallSignalAction() {
-  RAY_LOG(INFO) << "Uninstall signal handlers.";
+#ifdef RAY_USE_GLOG
+  RAY_LOG(DEBUG) << "Uninstall signal handlers.";
   // This signal list comes from glog's signalhandler.cc.
   // https://github.com/google/glog/blob/master/src/signalhandler.cc#L58-L70
   static std::vector<int> installed_signals({SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM});
@@ -155,6 +156,7 @@ void RayLog::UninstallSignalAction() {
   for (int signal_num : installed_signals) {
     sigaction(signal_num, &sig_action, NULL);
   }
+#endif
 }
 
 void RayLog::ShutDownRayLog() {

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -113,7 +113,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
       RAY_LOG(INFO) << "Unrecognized setting of RAY_BACKEND_LOG_LEVEL=" << var_value;
     }
     RAY_LOG(INFO) << "Set ray log level from environment variable RAY_BACKEND_LOG_LEVEL"
-                  << " to " << static_cast<int>(severity_threshold_);
+                  << " to " << static_cast<int>(severity_threshold);
   }
   severity_threshold_ = severity_threshold;
   app_name_ = app_name;
@@ -143,8 +143,10 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
 #endif
 }
 
-void RayLog::UnInstallSignalAction() {
+void RayLog::UninstallSignalAction() {
   RAY_LOG(INFO) << "Uninstall signal handlers.";
+  // This signal list comes from glog's signalhandler.cc.
+  // https://github.com/google/glog/blob/master/src/signalhandler.cc#L58-L70
   static std::vector<int> installed_signals({SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM});
   struct sigaction sig_action;
   memset(&sig_action, 0, sizeof(sig_action));
@@ -157,7 +159,7 @@ void RayLog::UnInstallSignalAction() {
 
 void RayLog::ShutDownRayLog() {
 #ifdef RAY_USE_GLOG
-  UnInstallSignalAction();
+  UninstallSignalAction();
   google::ShutdownGoogleLogging();
 #endif
 }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -83,7 +83,7 @@ class RayLog : public RayLogBase {
   static void ShutDownRayLog();
 
   /// Uninstall the signal actions installed by InstallFailureSignalHandler.
-  static void UnInstallSignalAction();
+  static void UninstallSignalAction();
 
   /// Return whether or not the log level is enabled in current setting.
   ///

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -82,6 +82,9 @@ class RayLog : public RayLogBase {
   /// The shutdown function of ray log which should be used with StartRayLog as a pair.
   static void ShutDownRayLog();
 
+  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
+  static void UnInstallSignalAction();
+
   /// Return whether or not the log level is enabled in current setting.
   ///
   /// \param log_level The input log level to test.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
1. Enable setting raylet logging level from env variable `RAY_BACKEND_LOG_LEVEL` instead of recompiling raylet. This is a good feature when we want to debug raylet.
2. In change the printed NIL ID from `ffffffffffffffffffffffffffffffffffffffff` to `NIL_ID`. This will make debug log a bit smaller.
3. Change the some enum number in the log to enum name. This helps us when the enums is very big. For example, origin log shows `Message of type 11`. We need to count the 11th entry in node_manager.fbs. Now the log changes to `Message of NotifyUnblocked(11)`.
4. In some rare cases, when raylet is exiting in abnormal cases `glog` seems to fall into a dead-lock of the output log file. In this PR,  `UninstallSignalAction` is added at exiting time.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
