### PR TITLE
Add Perf Counter

### DIFF
--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -27,6 +27,7 @@ set(RAY_SRCS
   util/logging.cc
   metrics/tag/tags.cc
   metrics/registry/metrics_registry_interface.cc
+  metrics/perf_counter.cc
   common/client_connection.cc
   common/common_protocol.cc
   object_manager/object_manager_client_connection.cc

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -25,6 +25,8 @@ set(RAY_SRCS
   gcs/redis_context.cc
   gcs/asio.cc
   util/logging.cc
+  metrics/tag/tags.cc
+  metrics/registry/metrics_registry_interface.cc
   common/client_connection.cc
   common/common_protocol.cc
   object_manager/object_manager_client_connection.cc
@@ -94,6 +96,7 @@ ADD_RAY_LIB(ray
 set(RAY_TEST_LIBS ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} gtest gtest_main gmock_main ${RAY_SYSTEM_LIBS})
 
 add_subdirectory(util)
+add_subdirectory(metrics)
 add_subdirectory(gcs)
 add_subdirectory(object_manager)
 add_subdirectory(raylet)

--- a/src/ray/metrics/CMakeLists.txt
+++ b/src/ray/metrics/CMakeLists.txt
@@ -1,0 +1,5 @@
+ADD_RAY_TEST(registry/any_ptr_test STATIC_LINK_LIBS gtest gtest_main pthread)
+
+install(FILES
+        metrics
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ray/metrics")

--- a/src/ray/metrics/metrics_conf.h
+++ b/src/ray/metrics/metrics_conf.h
@@ -1,0 +1,62 @@
+#ifndef RAY_METRICS_METRICS_CONF_H
+#define RAY_METRICS_METRICS_CONF_H
+
+#include "ray/metrics/registry/metrics_registry_interface.h"
+#include "ray/metrics/reporter/metrics_reporter_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+/// \class MetricsConf
+///
+/// The configuration of metrics.
+class MetricsConf {
+ public:
+  /// Create a configuration from the given config string.
+  ///
+  /// \param conf_str The string of configuration. The items of
+  /// it should be joined with comma like "k1,v1,k2,v2[,...]".
+  explicit MetricsConf(const std::string &conf_str = "");
+
+  virtual ~MetricsConf() = default;
+
+  /// Get the options of registry.
+  ///
+  /// \return The options of registry.
+  const RegistryOption &GetRegistryOption() const;
+
+  /// Get the options of reporter.
+  ///
+  /// \return The options of reporter.
+  const ReporterOption &GetReporterOption() const;
+
+  /// Get the name of registry implementation.
+  ///
+  /// \return The name of registry implementation.
+  const std::string &GetRegistryName() const;
+
+  /// Get the name of reporter implementation.
+  ///
+  /// \return The name of reporter implementation.
+  const std::string &GetReporterName() const;
+
+ protected:
+  /// Initialize the configuration from the given config string.
+  ///
+  /// \param conf_str The string of configuration.
+  void Init(const std::string &conf_str);
+
+ protected:
+  std::string registry_name_;
+  RegistryOption registry_options_;
+
+  std::string reporter_name_;
+  ReporterOption reporter_options_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_METRICS_CONF_H

--- a/src/ray/metrics/perf_counter.cc
+++ b/src/ray/metrics/perf_counter.cc
@@ -1,0 +1,54 @@
+#include "perf_counter.h"
+
+#include <memory>
+#include <mutex>
+
+#include "ray/metrics/metrics_conf.h"
+#include "ray/metrics/registry/metrics_registry_interface.h"
+#include "ray/metrics/reporter/metrics_reporter_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class PerfCounter::Impl {
+ public:
+  Impl() = default;
+  virtual ~Impl() = default;
+
+  // noncopyable
+  Impl(const Impl &) = delete;
+  Impl &operator=(const Impl &) = delete;
+
+  bool Start(const MetricsConf &conf);
+
+  void Shutdown();
+
+  // If not found, we should insert one.
+  void UpdateCounter(const std::string &metrics_name,
+                     double value,
+                     const Tags *tags);
+
+  void UpdateGauge(const std::string &metrics_name,
+                   double value,
+                   const Tags *tags);
+
+  void UpdateHistogram(const std::string &metrics_name,
+                       double value,
+                       double min_value,
+                       double max_value,
+                       const Tags *tags);
+
+  MetricsRegistryInterface *GetRegistry();
+
+ protected:
+  void Clear();
+
+ protected:
+  MetricsRegistryInterface *registry_{nullptr};
+  MetricsReporterInterface *reporter_{nullptr};
+};
+
+} // namespace metrics
+
+} // namespace ray

--- a/src/ray/metrics/perf_counter.cc
+++ b/src/ray/metrics/perf_counter.cc
@@ -25,19 +25,12 @@ class PerfCounter::Impl {
   void Shutdown();
 
   // If not found, we should insert one.
-  void UpdateCounter(const std::string &metrics_name,
-                     double value,
-                     const Tags *tags);
+  void UpdateCounter(const std::string &metrics_name, double value, const Tags *tags);
 
-  void UpdateGauge(const std::string &metrics_name,
-                   double value,
-                   const Tags *tags);
+  void UpdateGauge(const std::string &metrics_name, double value, const Tags *tags);
 
-  void UpdateHistogram(const std::string &metrics_name,
-                       double value,
-                       double min_value,
-                       double max_value,
-                       const Tags *tags);
+  void UpdateHistogram(const std::string &metrics_name, double value, double min_value,
+                       double max_value, const Tags *tags);
 
   MetricsRegistryInterface *GetRegistry();
 
@@ -49,6 +42,6 @@ class PerfCounter::Impl {
   MetricsReporterInterface *reporter_{nullptr};
 };
 
-} // namespace metrics
+}  // namespace metrics
 
-} // namespace ray
+}  // namespace ray

--- a/src/ray/metrics/perf_counter.h
+++ b/src/ray/metrics/perf_counter.h
@@ -1,0 +1,101 @@
+#ifndef RAY_METRICS_PERF_COUNTER_H
+#define RAY_METRICS_PERF_COUNTER_H
+
+#include <boost/asio.hpp>
+
+#include "ray/metrics/metrics_conf.h"
+
+
+namespace ray {
+
+#define METRICS_UPDATE_COUNTER(metrics_name, value) \
+  metrics::PerfCounter::GetInstance()->UpdateCounter(metrics_name, value)
+
+#define METRICS_UPDATE_COUNTER_WITH_TAGS(metrics_name, value, tags) \
+  metrics::PerfCounter::GetInstance()->UpdateCounter(metrics_name, value, tags)
+
+#define METRICS_RESET_GAUGE(metrics_name, value) \
+  metrics::PerfCounter::GetInstance()->UpdateGauge(metrics_name, value)
+
+#define METRICS_RESET_GAUGE_WITH_TAGS(metrics_name, value, tags) \
+  metrics::PerfCounter::GetInstance()->UpdateGauge(metrics_name, value, tags)
+
+#define METRICS_UPDATE_HISTOGRAM( \
+  metrics_name, value, min_value, max_value) \
+  metrics::PerfCounter::GetInstance()->UpdateHistogram( \
+  metrics_name, value, min_value, max_value)
+
+#define METRICS_UPDATE_HISTOGRAM_WITH_TAGS( \
+  metrics_name, value, min_value, max_value, tags) \
+  metrics::PerfCounter::GetInstance()->UpdateHistogram( \
+  metrics_name, value, min_value, max_value, tags)
+
+namespace metrics {
+
+class PerfCounter final {
+ public:
+  static PerfCounter *GetInstance();
+
+  // Deleted methods to avoid creating instance with out `GetInstance()`.
+  PerfCounter(const PerfCounter &) = delete;
+
+  PerfCounter &operator=(const PerfCounter &) = delete;
+
+  /// Initialize the PerfCounter functions.
+  ///
+  /// \param conf The configuration of metrics.
+  /// \return True for success, and false for failure.
+  bool Start(const MetricsConf &conf);
+
+  /// Shutdown the PerfCounter.
+  void Shutdown();
+
+  /// Update counter metric.
+  ///
+  /// \param metrics_name The name of the metric that we want to update.
+  /// \param value The value that we want to update to.
+  /// \param tags The tags that we want to attach to.
+  void UpdateCounter(const std::string &metrics_name,
+                     double value,
+                     const Tags &tags = Tags{});
+
+  /// Update gauge metric.
+  ///
+  /// \param metrics_name The name of the metric that we want to update.
+  /// \param value The value that we want to update to.
+  /// \param tags The tags that we want to attach to.
+  void UpdateGauge(const std::string &metrics_name,
+                   double value,
+                   const Tags &tags = Tags{});
+
+  /// Update histogram metric.
+  /// The reasonable range of fluctuation is[min_value, max_value].
+  /// Exceeding the range can still be counted, but the accuracy is lower.
+  ///
+  /// \param metrics_name The name of the metric that we want to update.
+  /// \param value The value that we want to update to.
+  /// \param min_value The minimum value that we can specified.
+  /// \param max_value The maximum value that we can specified.
+  /// \param tags The tags that we want to attach to.
+  void UpdateHistogram(const std::string &metrics_name,
+                       double value,
+                       double min_value,
+                       double max_value,
+                       const Tags &tags = Tags{});
+
+  MetricsRegistryInterface *GetRegistry();
+
+ private:
+  PerfCounter() = default;
+  ~PerfCounter() = default;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_ptr_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_PERF_COUNTER_H

--- a/src/ray/metrics/perf_counter.h
+++ b/src/ray/metrics/perf_counter.h
@@ -5,7 +5,6 @@
 
 #include "ray/metrics/metrics_conf.h"
 
-
 namespace ray {
 
 #define METRICS_UPDATE_COUNTER(metrics_name, value) \
@@ -20,15 +19,14 @@ namespace ray {
 #define METRICS_RESET_GAUGE_WITH_TAGS(metrics_name, value, tags) \
   metrics::PerfCounter::GetInstance()->UpdateGauge(metrics_name, value, tags)
 
-#define METRICS_UPDATE_HISTOGRAM( \
-  metrics_name, value, min_value, max_value) \
-  metrics::PerfCounter::GetInstance()->UpdateHistogram( \
-  metrics_name, value, min_value, max_value)
+#define METRICS_UPDATE_HISTOGRAM(metrics_name, value, min_value, max_value)            \
+  metrics::PerfCounter::GetInstance()->UpdateHistogram(metrics_name, value, min_value, \
+                                                       max_value)
 
-#define METRICS_UPDATE_HISTOGRAM_WITH_TAGS( \
-  metrics_name, value, min_value, max_value, tags) \
-  metrics::PerfCounter::GetInstance()->UpdateHistogram( \
-  metrics_name, value, min_value, max_value, tags)
+#define METRICS_UPDATE_HISTOGRAM_WITH_TAGS(metrics_name, value, min_value, max_value,  \
+                                           tags)                                       \
+  metrics::PerfCounter::GetInstance()->UpdateHistogram(metrics_name, value, min_value, \
+                                                       max_value, tags)
 
 namespace metrics {
 
@@ -36,7 +34,7 @@ class PerfCounter final {
  public:
   static PerfCounter *GetInstance();
 
-  // Deleted methods to avoid creating instance with out `GetInstance()`.
+  // Deleted methods to avoid creating instance without `GetInstance()`.
   PerfCounter(const PerfCounter &) = delete;
 
   PerfCounter &operator=(const PerfCounter &) = delete;
@@ -55,8 +53,7 @@ class PerfCounter final {
   /// \param metrics_name The name of the metric that we want to update.
   /// \param value The value that we want to update to.
   /// \param tags The tags that we want to attach to.
-  void UpdateCounter(const std::string &metrics_name,
-                     double value,
+  void UpdateCounter(const std::string &metrics_name, double value,
                      const Tags &tags = Tags{});
 
   /// Update gauge metric.
@@ -64,8 +61,7 @@ class PerfCounter final {
   /// \param metrics_name The name of the metric that we want to update.
   /// \param value The value that we want to update to.
   /// \param tags The tags that we want to attach to.
-  void UpdateGauge(const std::string &metrics_name,
-                   double value,
+  void UpdateGauge(const std::string &metrics_name, double value,
                    const Tags &tags = Tags{});
 
   /// Update histogram metric.
@@ -77,11 +73,8 @@ class PerfCounter final {
   /// \param min_value The minimum value that we can specified.
   /// \param max_value The maximum value that we can specified.
   /// \param tags The tags that we want to attach to.
-  void UpdateHistogram(const std::string &metrics_name,
-                       double value,
-                       double min_value,
-                       double max_value,
-                       const Tags &tags = Tags{});
+  void UpdateHistogram(const std::string &metrics_name, double value, double min_value,
+                       double max_value, const Tags &tags = Tags{});
 
   MetricsRegistryInterface *GetRegistry();
 

--- a/src/ray/metrics/registry/any_ptr.h
+++ b/src/ray/metrics/registry/any_ptr.h
@@ -1,0 +1,75 @@
+#ifndef RAY_METRICS_REGISTRY_ANY_PTR_H
+#define RAY_METRICS_REGISTRY_ANY_PTR_H
+
+#include <typeinfo>
+
+namespace ray {
+
+namespace metrics {
+
+/// A container of any type of heap object, manage the life cycle of the object.
+/// TODO(micafan) public function Swap
+class AnyPtr {
+ public:
+  AnyPtr()
+      : object_ptr_(nullptr),
+        type_info_(&typeid(void*)),
+        deleter_(nullptr) {}
+
+  ~AnyPtr() {
+    Destroy();
+  }
+
+  // noncopyable
+  AnyPtr(const AnyPtr &) = delete;
+  AnyPtr &operator=(const AnyPtr &) = delete;
+
+  /// Assign a heap object of type T.
+  template <typename T>
+  AnyPtr &operator=(T *object_ptr) {
+    // Destroy old object before set new object.
+    Destroy();
+
+    object_ptr_ = object_ptr;
+    type_info_ = &typeid(T *);
+    deleter_ = &AnyPtr::Deleter<T>;
+    return *this;
+  }
+
+  /// Cast object to T.
+  template <typename T>
+  T *CastTo() const {
+    if (*type_info_ == typeid(T *) && object_ptr_ != nullptr) {
+      return reinterpret_cast<T *>(object_ptr_);
+    }
+
+    return nullptr;
+  }
+
+ private:
+  void Destroy() {
+    if (object_ptr_ != nullptr && deleter_ !=nullptr) {
+      deleter_(object_ptr_);
+
+      object_ptr_ = nullptr;
+      deleter_ = nullptr;
+      type_info_ = &typeid(void*);
+    }
+  }
+
+  template <typename T>
+  static void Deleter(void *ptr) {
+    delete static_cast<T *>(ptr);
+  }
+
+ private:
+  void *object_ptr_;
+  const std::type_info *type_info_;
+  void (*deleter_)(void *);
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REGISTRY_ANY_PTR_H

--- a/src/ray/metrics/registry/any_ptr.h
+++ b/src/ray/metrics/registry/any_ptr.h
@@ -11,14 +11,9 @@ namespace metrics {
 /// TODO(micafan) public function Swap
 class AnyPtr {
  public:
-  AnyPtr()
-      : object_ptr_(nullptr),
-        type_info_(&typeid(void*)),
-        deleter_(nullptr) {}
+  AnyPtr() : object_ptr_(nullptr), type_info_(&typeid(void *)), deleter_(nullptr) {}
 
-  ~AnyPtr() {
-    Destroy();
-  }
+  ~AnyPtr() { Destroy(); }
 
   // noncopyable
   AnyPtr(const AnyPtr &) = delete;
@@ -48,12 +43,12 @@ class AnyPtr {
 
  private:
   void Destroy() {
-    if (object_ptr_ != nullptr && deleter_ !=nullptr) {
+    if (object_ptr_ != nullptr && deleter_ != nullptr) {
       deleter_(object_ptr_);
 
       object_ptr_ = nullptr;
       deleter_ = nullptr;
-      type_info_ = &typeid(void*);
+      type_info_ = &typeid(void *);
     }
   }
 

--- a/src/ray/metrics/registry/any_ptr_test.cc
+++ b/src/ray/metrics/registry/any_ptr_test.cc
@@ -1,0 +1,27 @@
+#include <vector>
+#include "gtest/gtest.h"
+#include "ray/metrics/registry/any_ptr.h"
+
+namespace ray {
+
+namespace metrics {
+
+TEST(AnyPtrTest, CastToTest) {
+  AnyPtr any_ptr;
+  auto *vec = new std::vector<std::string>();
+  any_ptr = vec;
+  auto *vec_cast = any_ptr.CastTo<std::vector<std::string>>();
+  ASSERT_EQ(vec_cast, vec);
+
+  auto *bad_type = any_ptr.CastTo<std::vector<int>>();
+  ASSERT_EQ(bad_type, nullptr);
+}
+
+}  // namespace metrics
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/metrics/registry/any_ptr_test.cc
+++ b/src/ray/metrics/registry/any_ptr_test.cc
@@ -1,6 +1,6 @@
+#include "ray/metrics/registry/any_ptr.h"
 #include <vector>
 #include "gtest/gtest.h"
-#include "ray/metrics/registry/any_ptr.h"
 
 namespace ray {
 

--- a/src/ray/metrics/registry/empty_metrics_registry.h
+++ b/src/ray/metrics/registry/empty_metrics_registry.h
@@ -1,0 +1,42 @@
+#ifndef RAY_METRICS_REGISTRY_EMPTY_METRICS_REGISTRY_H
+#define RAY_METRICS_REGISTRY_EMPTY_METRICS_REGISTRY_H
+
+#include "ray/metrics/registry/metrics_registry_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class EmptyMetricsRegistry : public MetricsRegistryInterface {
+ public:
+  explicit EmptyMetricsRegistry(const RegistryOption &options)
+      : MetricsRegistryInterface(options) {}
+
+  virtual ~EmptyMetricsRegistry() {}
+
+  void ExportMetrics(const std::string &regex_filter,
+                     AnyPtr *any_ptr) override {}
+
+ protected:
+  void DoRegisterCounter(
+    const std::string &metric_name, const Tags *tags) override {}
+
+  void DoRegisterGauge(
+    const std::string &metric_name, const Tags *tags) override {}
+
+
+  void DoRegisterHistogram(const std::string &metric_name,
+                           double min_value,
+                           double max_value,
+                           const Tags *tags) override {}
+
+  void DoUpdateValue(const std::string &metric_name,
+                     double value,
+                     const Tags *tags) override {}
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REGISTRY_EMPTY_METRICS_REGISTRY_H

--- a/src/ray/metrics/registry/empty_metrics_registry.h
+++ b/src/ray/metrics/registry/empty_metrics_registry.h
@@ -14,24 +14,17 @@ class EmptyMetricsRegistry : public MetricsRegistryInterface {
 
   virtual ~EmptyMetricsRegistry() {}
 
-  void ExportMetrics(const std::string &regex_filter,
-                     AnyPtr *any_ptr) override {}
+  void ExportMetrics(const std::string &regex_filter, AnyPtr *any_ptr) override {}
 
  protected:
-  void DoRegisterCounter(
-    const std::string &metric_name, const Tags *tags) override {}
+  void DoRegisterCounter(const std::string &metric_name, const Tags *tags) override {}
 
-  void DoRegisterGauge(
-    const std::string &metric_name, const Tags *tags) override {}
+  void DoRegisterGauge(const std::string &metric_name, const Tags *tags) override {}
 
+  void DoRegisterHistogram(const std::string &metric_name, double min_value,
+                           double max_value, const Tags *tags) override {}
 
-  void DoRegisterHistogram(const std::string &metric_name,
-                           double min_value,
-                           double max_value,
-                           const Tags *tags) override {}
-
-  void DoUpdateValue(const std::string &metric_name,
-                     double value,
+  void DoUpdateValue(const std::string &metric_name, double value,
                      const Tags *tags) override {}
 };
 

--- a/src/ray/metrics/registry/metrics_registry_interface.cc
+++ b/src/ray/metrics/registry/metrics_registry_interface.cc
@@ -1,0 +1,37 @@
+#include "metrics_registry_interface.h"
+
+#include <math.h>
+
+namespace ray {
+
+namespace metrics {
+
+std::vector<double> MetricsRegistryInterface::GenBucketBoundaries(
+  double min_value,
+  double max_value,
+  size_t bucket_count) const {
+  std::vector<double> boundaries;
+  // min_value should be always less or equal than max_value
+  if (min_value >= max_value) {
+    boundaries.emplace_back(min_value);
+    return boundaries;
+  }
+
+  if (bucket_count == 0) {
+    bucket_count = 2;
+  }
+
+  double diff = max_value - min_value;
+  double bucket_range = diff / bucket_count;
+  double cur_boundary = min_value;
+  while (cur_boundary < max_value) {
+    boundaries.emplace_back(cur_boundary);
+    cur_boundary += bucket_range;
+  }
+  boundaries.emplace_back(max_value);
+  return boundaries;
+}
+
+}  // namespace metrics
+
+}  // namespace ray

--- a/src/ray/metrics/registry/metrics_registry_interface.cc
+++ b/src/ray/metrics/registry/metrics_registry_interface.cc
@@ -7,9 +7,7 @@ namespace ray {
 namespace metrics {
 
 std::vector<double> MetricsRegistryInterface::GenBucketBoundaries(
-  double min_value,
-  double max_value,
-  size_t bucket_count) const {
+    double min_value, double max_value, size_t bucket_count) const {
   std::vector<double> boundaries;
   // min_value should be always less or equal than max_value
   if (min_value >= max_value) {

--- a/src/ray/metrics/registry/metrics_registry_interface.h
+++ b/src/ray/metrics/registry/metrics_registry_interface.h
@@ -1,0 +1,137 @@
+#ifndef RAY_METRICS_REGISTRY_METRICS_REGISTRY_INTERFACE_H
+#define RAY_METRICS_REGISTRY_METRICS_REGISTRY_INTERFACE_H
+
+#include <map>
+#include <regex>
+#include <string>
+#include <unordered_set>
+
+#include "ray/metrics/tag/tags.h"
+#include "ray/metrics/registry/any_ptr.h"
+
+namespace ray {
+
+namespace metrics {
+
+enum class MetricType : int8_t {
+  kCounter,
+  kGauge,
+  kHistogram,
+};
+
+class RegistryOption {
+ public:
+  RegistryOption() = default;
+
+  // Global tags as the default tags for all metrics of the registry.
+  std::map<std::string, std::string> default_tag_map_{};
+
+  // Percentiles for each histogram metric.
+  std::unordered_set<double> default_percentiles_{0.01, 1, 60, 90, 99, 99.99};
+  // Bucket count for each histogram metric.
+  // The more the number of buckets, the more accurate, but the greater the overhead.
+  size_t bucket_count_{100};
+};
+
+class MetricsRegistryInterface {
+ public:
+  virtual ~MetricsRegistryInterface() = default;
+
+  // noncopyable
+  MetricsRegistryInterface(const MetricsRegistryInterface &) = delete;
+  MetricsRegistryInterface &operator=(const MetricsRegistryInterface &) = delete;
+
+  /// Register a counter metric.
+  ///
+  /// \param metrics_name The name of the metric that we want to register.
+  /// \param tags The tags that we want to attach to this metric.
+  void RegisterCounter(const std::string &metric_name,
+                       const Tags *tags = nullptr) {
+    DoRegisterCounter(metric_name, tags);
+  }
+
+  /// Register a gauge metric.
+  ///
+  /// \param metrics_name The name of the metric that we want to register.
+  /// \param tags The tags that we want to attach to this metric.
+  void RegisterGauge(const std::string &metric_name,
+                     const Tags *tags = nullptr) {
+    DoRegisterGauge(metric_name, tags);
+  }
+
+  /// Register a histogram metric.
+  /// The reasonable range of fluctuation is[min_value, max_value].
+  /// Exceeding the range can still be counted, but the accuracy is lower.
+  ///
+  /// \param metrics_name The name of the metric that we want to register.
+  /// \param min_value The minimum value that the metric could be.
+  /// \param max_value The maximum value that the metric could be.
+  /// \param tags The tags that we want to attach to this metric.
+  void RegisterHistogram(const std::string &metric_name,
+                         double min_value,
+                         double max_value,
+                         const Tags *tags = nullptr) {
+    DoRegisterHistogram(metric_name, min_value, max_value, tags);
+  }
+
+  /// Update the value of metric.
+  /// If metric registered as counter: increase value.
+  /// If metric registered as gauge: reset to the input value.
+  /// If metric registered as historgram: add a new sample which value is the input value.
+  ///
+  /// \param metrics_name The name of the metric that we want to update.
+  /// \param value The value that we want to update.
+  /// \param tags The tags that attached to this value.
+  void UpdateValue(const std::string &metric_name,
+                   double value,
+                   const Tags *tags = nullptr) {
+    DoUpdateValue(metric_name, value, tags);
+  }
+
+  /// Export all registered metrics which match the filter.
+  ///
+  /// \param regex_filter Regex expression to filter the metrics.
+  /// As we all known regex ".*" match all values.
+  /// \param any_ptr Result after filter.
+  virtual void ExportMetrics(const std::string &regex_filter,
+                             AnyPtr *any_ptr) = 0;
+
+  /// Get global tags.
+  virtual const Tags &GetDefaultTags() {
+    return default_tags_;
+  }
+
+ protected:
+  explicit MetricsRegistryInterface(const RegistryOption &options)
+      : default_tags_(options.default_tag_map_),
+        options_(options) {}
+
+  virtual void DoRegisterCounter(const std::string &metric_name,
+                                 const Tags *tags) = 0;
+
+  virtual void DoRegisterGauge(const std::string &metric_name,
+                               const Tags *tags) = 0;
+
+  virtual void DoRegisterHistogram(const std::string &metric_name,
+                                   double min_value,
+                                   double max_value,
+                                   const Tags *tags) = 0;
+
+  virtual void DoUpdateValue(const std::string &metric_name,
+                             double value,
+                             const Tags *tags) = 0;
+
+  /// Divided range[min_value, max_value] into multiple buckets for histogram statistics.
+  std::vector<double> GenBucketBoundaries(double min_value,
+                                          double max_value,
+                                          size_t bucket_count) const;
+
+  Tags default_tags_;
+  RegistryOption options_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REGISTRY_METRICS_REGISTRY_INTERFACE_H

--- a/src/ray/metrics/registry/metrics_registry_interface.h
+++ b/src/ray/metrics/registry/metrics_registry_interface.h
@@ -45,8 +45,7 @@ class MetricsRegistryInterface {
   ///
   /// \param metrics_name The name of the metric that we want to register.
   /// \param tags The tags that we want to attach to this metric.
-  void RegisterCounter(const std::string &metric_name,
-                       const Tags *tags = nullptr) {
+  void RegisterCounter(const std::string &metric_name, const Tags *tags = nullptr) {
     DoRegisterCounter(metric_name, tags);
   }
 
@@ -54,8 +53,7 @@ class MetricsRegistryInterface {
   ///
   /// \param metrics_name The name of the metric that we want to register.
   /// \param tags The tags that we want to attach to this metric.
-  void RegisterGauge(const std::string &metric_name,
-                     const Tags *tags = nullptr) {
+  void RegisterGauge(const std::string &metric_name, const Tags *tags = nullptr) {
     DoRegisterGauge(metric_name, tags);
   }
 
@@ -67,10 +65,8 @@ class MetricsRegistryInterface {
   /// \param min_value The minimum value that the metric could be.
   /// \param max_value The maximum value that the metric could be.
   /// \param tags The tags that we want to attach to this metric.
-  void RegisterHistogram(const std::string &metric_name,
-                         double min_value,
-                         double max_value,
-                         const Tags *tags = nullptr) {
+  void RegisterHistogram(const std::string &metric_name, double min_value,
+                         double max_value, const Tags *tags = nullptr) {
     DoRegisterHistogram(metric_name, min_value, max_value, tags);
   }
 
@@ -82,8 +78,7 @@ class MetricsRegistryInterface {
   /// \param metrics_name The name of the metric that we want to update.
   /// \param value The value that we want to update.
   /// \param tags The tags that attached to this value.
-  void UpdateValue(const std::string &metric_name,
-                   double value,
+  void UpdateValue(const std::string &metric_name, double value,
                    const Tags *tags = nullptr) {
     DoUpdateValue(metric_name, value, tags);
   }
@@ -93,37 +88,27 @@ class MetricsRegistryInterface {
   /// \param regex_filter Regex expression to filter the metrics.
   /// As we all known regex ".*" match all values.
   /// \param any_ptr Result after filter.
-  virtual void ExportMetrics(const std::string &regex_filter,
-                             AnyPtr *any_ptr) = 0;
+  virtual void ExportMetrics(const std::string &regex_filter, AnyPtr *any_ptr) = 0;
 
   /// Get global tags.
-  virtual const Tags &GetDefaultTags() {
-    return default_tags_;
-  }
+  virtual const Tags &GetDefaultTags() { return default_tags_; }
 
  protected:
   explicit MetricsRegistryInterface(const RegistryOption &options)
-      : default_tags_(options.default_tag_map_),
-        options_(options) {}
+      : default_tags_(options.default_tag_map_), options_(options) {}
 
-  virtual void DoRegisterCounter(const std::string &metric_name,
-                                 const Tags *tags) = 0;
+  virtual void DoRegisterCounter(const std::string &metric_name, const Tags *tags) = 0;
 
-  virtual void DoRegisterGauge(const std::string &metric_name,
-                               const Tags *tags) = 0;
+  virtual void DoRegisterGauge(const std::string &metric_name, const Tags *tags) = 0;
 
-  virtual void DoRegisterHistogram(const std::string &metric_name,
-                                   double min_value,
-                                   double max_value,
-                                   const Tags *tags) = 0;
+  virtual void DoRegisterHistogram(const std::string &metric_name, double min_value,
+                                   double max_value, const Tags *tags) = 0;
 
-  virtual void DoUpdateValue(const std::string &metric_name,
-                             double value,
+  virtual void DoUpdateValue(const std::string &metric_name, double value,
                              const Tags *tags) = 0;
 
   /// Divided range[min_value, max_value] into multiple buckets for histogram statistics.
-  std::vector<double> GenBucketBoundaries(double min_value,
-                                          double max_value,
+  std::vector<double> GenBucketBoundaries(double min_value, double max_value,
                                           size_t bucket_count) const;
 
   Tags default_tags_;

--- a/src/ray/metrics/registry/prometheus_metrics_registry.cc
+++ b/src/ray/metrics/registry/prometheus_metrics_registry.cc
@@ -1,0 +1,213 @@
+#include "prometheus_metrics_registry.h"
+
+#include "ray/util/logging.h"
+
+namespace ray {
+
+namespace metrics {
+
+thread_local std::unordered_map<std::string, std::shared_ptr<MetricFamily>>
+    PrometheusMetricsRegistry::metric_map_;
+
+MetricFamily::MetricFamily(MetricType type, const std::string &metric_name,
+                           prometheus::Registry *registry, const Tags *tags,
+                           std::vector<double> bucket_boundaries)
+    : type_(type), bucket_boundaries_(std::move(bucket_boundaries)) {
+  switch (type_) {
+  case MetricType::kCounter:
+    if (tags != nullptr) {
+      counter_family_ = &prometheus::BuildCounter()
+                             .Name(metric_name)
+                             .Labels(tags->GetTags())
+                             .Register(*registry);
+    } else {
+      counter_family_ = &prometheus::BuildCounter().Name(metric_name).Register(*registry);
+    }
+    break;
+  case MetricType::kGauge:
+    if (tags != nullptr) {
+      gauge_family_ = &prometheus::BuildGauge()
+                           .Name(metric_name)
+                           .Labels(tags->GetTags())
+                           .Register(*registry);
+    } else {
+      gauge_family_ = &prometheus::BuildGauge().Name(metric_name).Register(*registry);
+    }
+    break;
+  case MetricType::kHistogram:
+    if (tags != nullptr) {
+      histogram_family_ = &prometheus::BuildHistogram()
+                               .Name(metric_name)
+                               .Labels(tags->GetTags())
+                               .Register(*registry);
+    } else {
+      histogram_family_ =
+          &prometheus::BuildHistogram().Name(metric_name).Register(*registry);
+    }
+    break;
+  default:
+    RAY_DCHECK(0);
+    return;
+  }
+}
+
+void MetricFamily::UpdateValue(double value, const Tags *tags) {
+  switch (type_) {
+  case MetricType::kCounter: {
+    prometheus::Counter &counter = GetCounter(tags);
+    counter.Increment(value);
+  } break;
+  case MetricType::kGauge: {
+    prometheus::Gauge &gauge = GetGauge(tags);
+    gauge.Set(value);
+  } break;
+  case MetricType::kHistogram: {
+    prometheus::Histogram &histogram = GetHistogram(tags);
+    histogram.Observe(value);
+  } break;
+  default:
+    RAY_DCHECK(0);
+    return;
+  }
+}
+
+prometheus::Counter &MetricFamily::GetCounter(const Tags *tags) {
+  if (tags == nullptr) {
+    std::map<std::string, std::string> labels;
+    return counter_family_->Add(labels);
+  }
+
+  auto it = tag_to_counter_map_.find(tags->GetID());
+  if (it != tag_to_counter_map_.end()) {
+    return it->second;
+  }
+  prometheus::Counter &counter = counter_family_->Add(tags->GetTags());
+  tag_to_counter_map_.emplace(tags->GetID(), counter);
+  return counter;
+}
+
+prometheus::Gauge &MetricFamily::GetGauge(const Tags *tags) {
+  if (tags == nullptr) {
+    std::map<std::string, std::string> labels;
+    return gauge_family_->Add(labels);
+  }
+
+  auto it = tag_to_gauge_map_.find(tags->GetID());
+  if (it != tag_to_gauge_map_.end()) {
+    return it->second;
+  }
+  prometheus::Gauge &gauge = gauge_family_->Add(tags->GetTags());
+  tag_to_gauge_map_.emplace(tags->GetID(), gauge);
+  return gauge;
+}
+
+prometheus::Histogram &MetricFamily::GetHistogram(const Tags *tags) {
+  if (tags == nullptr) {
+    std::map<std::string, std::string> labels;
+    return histogram_family_->Add(labels, bucket_boundaries_);
+  }
+
+  auto it = tag_to_histogram_map_.find(tags->GetID());
+  if (it != tag_to_histogram_map_.end()) {
+    return it->second;
+  }
+  prometheus::Histogram &histogram =
+      histogram_family_->Add(tags->GetTags(), bucket_boundaries_);
+  tag_to_histogram_map_.emplace(tags->GetID(), histogram);
+  return histogram;
+}
+
+PrometheusMetricsRegistry::PrometheusMetricsRegistry(const RegistryOption &options)
+    : MetricsRegistryInterface(options) {}
+
+void PrometheusMetricsRegistry::ExportMetrics(const std::string &regex_filter,
+                                              AnyPtr *any_ptr) {
+  RAY_CHECK(any_ptr != nullptr);
+
+  std::vector<prometheus::MetricFamily> *dest_metrics =
+      new std::vector<prometheus::MetricFamily>;
+  *any_ptr = dest_metrics;
+
+  auto source_metrics = registry_.Collect();
+  if (regex_filter == ".*") {
+    dest_metrics->insert(dest_metrics->end(), source_metrics.begin(),
+                         source_metrics.end());
+    return;
+  }
+
+  std::regex filter(regex_filter.c_str());
+  for (auto &metric : source_metrics) {
+    bool match = std::regex_match(metric.name, filter);
+    if (match) {
+      dest_metrics->emplace_back(std::move(metric));
+    }
+  }
+}
+
+void PrometheusMetricsRegistry::DoRegisterCounter(const std::string &metric_name,
+                                                  const Tags *tags) {
+  auto it = metric_map_.find(metric_name);
+  if (it != metric_map_.end()) {
+    return;
+  }
+
+  DoRegister(MetricType::kCounter, metric_name, &default_tags_);
+}
+
+void PrometheusMetricsRegistry::DoRegisterGauge(const std::string &metric_name,
+                                                const Tags *tags) {
+  auto it = metric_map_.find(metric_name);
+  if (it != metric_map_.end()) {
+    return;
+  }
+
+  DoRegister(MetricType::kGauge, metric_name, &default_tags_);
+}
+
+void PrometheusMetricsRegistry::DoRegisterHistogram(const std::string &metric_name,
+                                                    double min_value, double max_value,
+                                                    const Tags *tags) {
+  std::vector<double> bucket_boundaries =
+      GenBucketBoundaries(min_value, max_value, options_.bucket_count_);
+
+  auto it = metric_map_.find(metric_name);
+  if (it != metric_map_.end()) {
+    return;
+  }
+
+  DoRegister(MetricType::kHistogram, metric_name, &default_tags_,
+             std::move(bucket_boundaries));
+}
+
+void PrometheusMetricsRegistry::DoUpdateValue(const std::string &metric_name,
+                                              double value, const Tags *tags) {
+  std::shared_ptr<MetricFamily> metric;
+
+  auto it = metric_map_.find(metric_name);
+  if (it != metric_map_.end()) {
+    metric = it->second;
+  }
+
+  if (metric == nullptr) {
+    metric = DoRegister(MetricType::kCounter, metric_name, &default_tags_);
+  }
+
+  metric->UpdateValue(value, tags);
+}
+
+std::shared_ptr<MetricFamily> PrometheusMetricsRegistry::DoRegister(
+    MetricType type, const std::string &metric_name, const Tags *tags,
+    std::vector<double> bucket_boundaries) {
+  auto it = metric_map_.find(metric_name);
+  if (it != metric_map_.end()) {
+    return it->second;
+  }
+  auto metric = std::make_shared<MetricFamily>(type, metric_name, &registry_, tags,
+                                               std::move(bucket_boundaries));
+  metric_map_.emplace(metric_name, metric);
+  return metric;
+}
+
+}  // namespace metrics
+
+}  // namespace ray

--- a/src/ray/metrics/registry/prometheus_metrics_registry.h
+++ b/src/ray/metrics/registry/prometheus_metrics_registry.h
@@ -1,0 +1,86 @@
+#ifndef RAY_METRICS_REGISTRY_PROMETHEUS_METRICS_REGISTRY_H
+#define RAY_METRICS_REGISTRY_PROMETHEUS_METRICS_REGISTRY_H
+
+#include <unordered_map>
+
+#include "prometheus/registry.h"
+#include "ray/metrics/registry/metrics_registry_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class MetricFamily {
+ public:
+  MetricFamily(MetricType type, const std::string &metric_name,
+               prometheus::Registry *registry, const Tags *tags = nullptr,
+               std::vector<double> bucket_boundaries = {});
+
+  ~MetricFamily() = default;
+
+  /// Update value with tags
+  void UpdateValue(double value, const Tags *tags = nullptr);
+
+ private:
+  /// Get counter by tags
+  prometheus::Counter &GetCounter(const Tags *tags);
+  /// Get gauge by tags
+  prometheus::Gauge &GetGauge(const Tags *tags);
+  /// Get histogram by tags
+  prometheus::Histogram &GetHistogram(const Tags *tags);
+
+  MetricType type_;
+  /// Container of all counters
+  prometheus::Family<prometheus::Counter> *counter_family_{nullptr};
+  /// The counter object corresponding to each tags
+  std::unordered_map<size_t, prometheus::Counter &> tag_to_counter_map_;
+  /// Container of all gauges
+  prometheus::Family<prometheus::Gauge> *gauge_family_{nullptr};
+  /// The gauge object corresponding to each tags
+  std::unordered_map<size_t, prometheus::Gauge &> tag_to_gauge_map_;
+  /// Container of all histogram
+  prometheus::Family<prometheus::Histogram> *histogram_family_{nullptr};
+  /// The histogram object corresponding to each tags
+  std::unordered_map<size_t, prometheus::Histogram &> tag_to_histogram_map_;
+  /// Boundary of histogram bucket
+  std::vector<double> bucket_boundaries_;
+};
+
+class PrometheusMetricsRegistry : public MetricsRegistryInterface {
+ public:
+  explicit PrometheusMetricsRegistry(const RegistryOption &options);
+
+  virtual ~PrometheusMetricsRegistry() = default;
+
+  void ExportMetrics(const std::string &regex_filter, AnyPtr *any_ptr) override;
+
+ protected:
+  void DoRegisterCounter(const std::string &metric_name, const Tags *tags) override;
+
+  void DoRegisterGauge(const std::string &metric_name, const Tags *tags) override;
+
+  void DoRegisterHistogram(const std::string &metric_name, double min_value,
+                           double max_value, const Tags *tags) override;
+
+  void DoUpdateValue(const std::string &metric_name, double value,
+                     const Tags *tags) override;
+
+ private:
+  std::shared_ptr<MetricFamily> DoRegister(MetricType type,
+                                           const std::string &metric_name,
+                                           const Tags *tags,
+                                           std::vector<double> bucket_boundaries = {});
+
+ private:
+  /// Prometheus registry
+  prometheus::Registry registry_;
+  /// Thread local metrics
+  static thread_local std::unordered_map<std::string, std::shared_ptr<MetricFamily>>
+      metric_map_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REGISTRY_PROMETHEUS_METRICS_REGISTRY_H

--- a/src/ray/metrics/reporter/empty_metrics_reporter.h
+++ b/src/ray/metrics/reporter/empty_metrics_reporter.h
@@ -10,20 +10,15 @@ namespace metrics {
 class EmptyMetricsReporter : public MetricsReporterInterface {
  public:
   explicit EmptyMetricsReporter(const ReporterOption &options)
-  : MetricsReporterInterface(options) {}
+      : MetricsReporterInterface(options) {}
 
   virtual ~EmptyMetricsReporter() = default;
 
-  bool Start() override {
-    return true;
-  }
+  bool Start() override { return true; }
 
-  bool Stop() override {
-    return true;
-  }
+  bool Stop() override { return true; }
 
   void RegisterRegistry(MetricsRegistryInterface *registry) override {}
-
 };
 
 }  // namespace metrics

--- a/src/ray/metrics/reporter/empty_metrics_reporter.h
+++ b/src/ray/metrics/reporter/empty_metrics_reporter.h
@@ -1,0 +1,33 @@
+#ifndef RAY_METRICS_REPORTER_EMPTY_METRICS_REPORTER_H
+#define RAY_METRICS_REPORTER_EMPTY_METRICS_REPORTER_H
+
+#include "ray/metrics/reporter/metrics_reporter_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class EmptyMetricsReporter : public MetricsReporterInterface {
+ public:
+  explicit EmptyMetricsReporter(const ReporterOption &options)
+  : MetricsReporterInterface(options) {}
+
+  virtual ~EmptyMetricsReporter() = default;
+
+  bool Start() override {
+    return true;
+  }
+
+  bool Stop() override {
+    return true;
+  }
+
+  void RegisterRegistry(MetricsRegistryInterface *registry) override {}
+
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REPORTER_EMPTY_METRICS_REPORTER_H

--- a/src/ray/metrics/reporter/metrics_reporter_interface.h
+++ b/src/ray/metrics/reporter/metrics_reporter_interface.h
@@ -50,8 +50,7 @@ class MetricsReporterInterface {
   virtual bool Stop() = 0;
 
  protected:
-  explicit MetricsReporterInterface(const ReporterOption &options)
-      : options_(options) {}
+  explicit MetricsReporterInterface(const ReporterOption &options) : options_(options) {}
 
   ReporterOption options_;
 };

--- a/src/ray/metrics/reporter/metrics_reporter_interface.h
+++ b/src/ray/metrics/reporter/metrics_reporter_interface.h
@@ -1,0 +1,63 @@
+#ifndef RAY_METRICS_REPORTER_METRICS_REPORTER_INTERFACE_H
+#define RAY_METRICS_REPORTER_METRICS_REPORTER_INTERFACE_H
+
+#include <chrono>
+#include <regex>
+#include <string>
+
+#include "ray/metrics/registry/metrics_registry_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class ReporterOption {
+ public:
+  ReporterOption() = default;
+
+  // User name.
+  std::string user_name_;
+  // Password.
+  std::string password_;
+  // Job name.
+  std::string job_name_;
+
+  // Required field.
+  // Address of service. e.g.: Address of gateway.
+  std::string service_addr_;
+
+  // Report interval.
+  std::chrono::seconds report_interval_{10};
+
+  // Regex filter. Used to filter metrics of registry.
+  std::string regex_filter_{".*"};
+
+  // Max retry times when report failed.
+  int64_t max_retry_times_{2};
+};
+
+class MetricsReporterInterface {
+ public:
+  virtual ~MetricsReporterInterface() = default;
+
+  /// Register registry to Reporter.
+  virtual void RegisterRegistry(MetricsRegistryInterface *registry) = 0;
+
+  /// Start reporter.
+  virtual bool Start() = 0;
+
+  /// Stop reporter.
+  virtual bool Stop() = 0;
+
+ protected:
+  explicit MetricsReporterInterface(const ReporterOption &options)
+      : options_(options) {}
+
+  ReporterOption options_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REPORTER_METRICS_REPORTER_INTERFACE_H

--- a/src/ray/metrics/reporter/prometheus_push_reporter.cc
+++ b/src/ray/metrics/reporter/prometheus_push_reporter.cc
@@ -1,0 +1,102 @@
+#include "prometheus_push_reporter.h"
+
+#include "ray/util/logging.h"
+
+namespace ray {
+
+namespace metrics {
+
+RegistryExportHandler::RegistryExportHandler(const std::string &regex_filter,
+                                             MetricsRegistryInterface *registry)
+    : regex_filter_(regex_filter), registry_(registry) {}
+
+std::vector<prometheus::MetricFamily> RegistryExportHandler::Collect() {
+  AnyPtr any_ptr;
+  registry_->ExportMetrics(regex_filter_, &any_ptr);
+  auto *src_metrics = any_ptr.CastTo<std::vector<prometheus::MetricFamily>>();
+
+  std::vector<prometheus::MetricFamily> dest_metrics;
+  if (src_metrics != nullptr) {
+    dest_metrics.swap(*src_metrics);
+  } else {
+    RAY_LOG(DEBUG) << "Registry not match PrometheusPushReporter.";
+  }
+  return dest_metrics;
+}
+
+PrometheusPushReporter::PrometheusPushReporter(const ReporterOption &options)
+    : MetricsReporterInterface(options) {
+  gate_way_.reset(new prometheus::Gateway(options_.service_addr_, options_.job_name_, {},
+                                          options_.user_name_, options_.password_));
+}
+
+PrometheusPushReporter::~PrometheusPushReporter() {}
+
+void PrometheusPushReporter::RegisterRegistry(MetricsRegistryInterface *registry) {
+  if (registry != nullptr) {
+    std::shared_ptr<RegistryExportHandler> export_handler =
+        std::make_shared<RegistryExportHandler>(options_.regex_filter_, registry);
+    std::map<std::string, std::string> tag_map = registry->GetDefaultTags().GetTags();
+    tag_map.emplace("step", std::to_string(options_.report_interval_.count()));
+    gate_way_->RegisterCollectable(export_handler, &tag_map);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      exporter_handler_.emplace(registry, export_handler);
+    }
+  }
+}
+
+bool PrometheusPushReporter::Start() {
+  if (options_.service_addr_.empty() || options_.job_name_.empty()) {
+    RAY_LOG(WARNING) << "Prometheus Init failed, invalid service addr or job name, "
+                     << " address=" << options_.service_addr_
+                     << " job_name=" << options_.job_name_;
+    return false;
+  }
+
+  report_thread_.reset(
+      new std::thread(std::bind(&PrometheusPushReporter::ThreadReportAction, this)));
+  return true;
+}
+
+void PrometheusPushReporter::ThreadReportAction() {
+  while (!is_stopped.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(options_.report_interval_);
+    // TODO(micafan) AsyncPush
+    int ret_code = gate_way_->Push();
+    int64_t left_retry_times = options_.max_retry_times_;
+    // Retry
+    if (ret_code == 200) {
+      RAY_LOG(DEBUG) << "Prometheus report ret_code=" << ret_code
+                     << " address=" << options_.service_addr_
+                     << " job_name=" << options_.job_name_;
+    } else {
+      RAY_LOG(WARNING) << "Prometheus report failed, ret_code=" << ret_code
+                       << " address=" << options_.service_addr_
+                       << " job_name=" << options_.job_name_
+                       << " left_retry_times=" << left_retry_times;
+    }
+    while (ret_code != 200 && (left_retry_times-- > 0)) {
+      std::chrono::milliseconds wait_time(100);
+      std::this_thread::sleep_for(wait_time);
+      ret_code = gate_way_->Push();
+    }
+  }
+}
+
+bool PrometheusPushReporter::Stop() {
+  bool expected = false;
+  if (!std::atomic_compare_exchange_strong(&is_stopped, &expected, true)) {
+    return false;
+  }
+
+  if (report_thread_ != nullptr) {
+    report_thread_->join();
+  }
+
+  return true;
+}
+
+}  // namespace metrics
+
+}  // namespace ray

--- a/src/ray/metrics/reporter/prometheus_push_reporter.h
+++ b/src/ray/metrics/reporter/prometheus_push_reporter.h
@@ -1,0 +1,63 @@
+#ifndef RAY_METRICS_REPORTER_PROMETHEUS_PUSH_REPORTER_H
+#define RAY_METRICS_REPORTER_PROMETHEUS_PUSH_REPORTER_H
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "prometheus/collectable.h"
+#include "prometheus/gateway.h"
+#include "ray/metrics/registry/metrics_registry_interface.h"
+#include "ray/metrics/reporter/metrics_reporter_interface.h"
+
+namespace ray {
+
+namespace metrics {
+
+class RegistryExportHandler : public prometheus::Collectable {
+ public:
+  RegistryExportHandler(const std::string &regex_filter,
+                        MetricsRegistryInterface *registry);
+
+  std::vector<prometheus::MetricFamily> Collect() override;
+
+ private:
+  const std::string &regex_filter_;
+  MetricsRegistryInterface *registry_;
+};
+
+class PrometheusPushReporter : public MetricsReporterInterface {
+ public:
+  explicit PrometheusPushReporter(const ReporterOption &options);
+
+  virtual ~PrometheusPushReporter();
+
+  void RegisterRegistry(MetricsRegistryInterface *registry) override;
+
+  bool Start() override;
+
+  bool Stop() override;
+
+ private:
+  void ThreadReportAction();
+
+  std::mutex mutex_;
+  /// Registry handler map
+  std::unordered_map<MetricsRegistryInterface *, std::shared_ptr<RegistryExportHandler>>
+      exporter_handler_;
+  /// Prometheus gateway
+  std::unique_ptr<prometheus::Gateway> gate_way_;
+  /// Whether the reporter stopped
+  std::atomic<bool> is_stopped{false};
+  /// A thread that reporting (synchronous mode)
+  /// every ReporterOption.report_interval_ seconds.
+  std::unique_ptr<std::thread> report_thread_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_REPORTER_PROMETHEUS_PUSH_REPORTER_H

--- a/src/ray/metrics/tag/tags.cc
+++ b/src/ray/metrics/tag/tags.cc
@@ -1,0 +1,55 @@
+#include "tags.h"
+
+#include <numeric>
+#include <unordered_map>
+#include <string>
+#include <set>
+
+namespace ray {
+
+namespace metrics {
+
+TagKeys::TagKeys(const std::set<std::string> &keys)
+    : keys_(keys) {
+  DoHash();
+}
+
+void TagKeys::DoHash() {
+  size_t final_code = 1;
+  for (const auto &key : keys_) {
+    size_t key_code = std::hash<std::string>{} (key);
+    final_code = 31 * final_code + key_code;
+  }
+
+  id_ = final_code;
+}
+
+Tags::Tags(const std::map<std::string, std::string> &tag_map)
+    : tag_map_(tag_map) {
+  DoHash();
+
+  std::set<std::string> keys;
+  for (const auto &tag : tag_map_) {
+    keys.insert(tag.first);
+  }
+
+  keys_ = TagKeys(keys);
+}
+
+//TODO(qwang): Should we implement this with SHA like UniqueID?
+void Tags::DoHash() {
+  size_t final_code = 1;
+  for (const auto &tag : tag_map_) {
+    size_t key_code = std::hash<std::string>{}(tag.first);
+    final_code = 31 * final_code + key_code;
+
+    size_t value_code = std::hash<std::string>{}(tag.second);
+    final_code = 31 * final_code + value_code;
+  }
+
+  id_ = final_code;
+}
+
+}  // namespace metrics
+
+}  // namespace ray

--- a/src/ray/metrics/tag/tags.cc
+++ b/src/ray/metrics/tag/tags.cc
@@ -1,31 +1,27 @@
 #include "tags.h"
 
 #include <numeric>
-#include <unordered_map>
-#include <string>
 #include <set>
+#include <string>
+#include <unordered_map>
 
 namespace ray {
 
 namespace metrics {
 
-TagKeys::TagKeys(const std::set<std::string> &keys)
-    : keys_(keys) {
-  DoHash();
-}
+TagKeys::TagKeys(const std::set<std::string> &keys) : keys_(keys) { DoHash(); }
 
 void TagKeys::DoHash() {
   size_t final_code = 1;
   for (const auto &key : keys_) {
-    size_t key_code = std::hash<std::string>{} (key);
+    size_t key_code = std::hash<std::string>{}(key);
     final_code = 31 * final_code + key_code;
   }
 
   id_ = final_code;
 }
 
-Tags::Tags(const std::map<std::string, std::string> &tag_map)
-    : tag_map_(tag_map) {
+Tags::Tags(const std::map<std::string, std::string> &tag_map) : tag_map_(tag_map) {
   DoHash();
 
   std::set<std::string> keys;
@@ -36,7 +32,6 @@ Tags::Tags(const std::map<std::string, std::string> &tag_map)
   keys_ = TagKeys(keys);
 }
 
-//TODO(qwang): Should we implement this with SHA like UniqueID?
 void Tags::DoHash() {
   size_t final_code = 1;
   for (const auto &tag : tag_map_) {

--- a/src/ray/metrics/tag/tags.h
+++ b/src/ray/metrics/tag/tags.h
@@ -1,0 +1,95 @@
+#ifndef RAY_METRICS_TAG_TAGS_H
+#define RAY_METRICS_TAG_TAGS_H
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace ray {
+
+namespace metrics {
+
+/// \class TagKeys
+///
+/// The immutable class that represents all of the keys in tag.
+/// All of the members cannot be changed after creating.
+class TagKeys {
+ public:
+  /// Create a TagKeys object from a set of strings.
+  ///
+  /// \param keys A set of tag keys.
+  TagKeys(const std::set<std::string> &keys = {});
+
+  ~TagKeys() = default;
+
+  /// Get the set of tag keys.
+  ///
+  /// \return The set of tag keys.
+  const std::set<std::string> &GetTagKeys() const {
+    return keys_;
+  }
+
+  /// Get the id of this TagKeys object.
+  ///
+  /// \return The id of this TagKeys.
+  size_t GetID() const {
+    return id_;
+  }
+
+ private:
+  void DoHash();
+
+ private:
+  std::set<std::string> keys_;
+  size_t id_{0};
+};
+
+/// \class Tags
+///
+/// The immutable class that represents a set of tags.
+/// All of the members cannot be changed after creating.
+class Tags {
+ public:
+
+  /// Create a Tags object from the given map.
+  ///
+  /// \param tag_map The map of k-v tags.
+  explicit Tags(const std::map<std::string, std::string> &tag_map = {});
+
+  ~Tags() = default;
+
+  /// Get the tags with a map.
+  ///
+  /// \return The map that contains k-v tags.
+  const std::map<std::string, std::string> &GetTags() const {
+    return tag_map_;
+  }
+
+  /// get the keys of this Tags object.
+  ///
+  /// \return The TagKeys object that contains all of the keys of this Tags object.
+  const TagKeys &GetTagKeys() const {
+    return keys_;
+  }
+
+  /// Get the id of this Tags object.
+  ///
+  /// \return The id of this Tags object.
+  size_t GetID() const {
+    return id_;
+  }
+
+ private:
+  void DoHash();
+
+  std::map<std::string, std::string> tag_map_;
+  size_t id_{0};
+
+  TagKeys keys_;
+};
+
+}  // namespace metrics
+
+}  // namespace ray
+
+#endif  // RAY_METRICS_TAG_TAGS_H

--- a/src/ray/metrics/tag/tags.h
+++ b/src/ray/metrics/tag/tags.h
@@ -25,16 +25,12 @@ class TagKeys {
   /// Get the set of tag keys.
   ///
   /// \return The set of tag keys.
-  const std::set<std::string> &GetTagKeys() const {
-    return keys_;
-  }
+  const std::set<std::string> &GetTagKeys() const { return keys_; }
 
   /// Get the id of this TagKeys object.
   ///
   /// \return The id of this TagKeys.
-  size_t GetID() const {
-    return id_;
-  }
+  size_t GetID() const { return id_; }
 
  private:
   void DoHash();
@@ -50,7 +46,6 @@ class TagKeys {
 /// All of the members cannot be changed after creating.
 class Tags {
  public:
-
   /// Create a Tags object from the given map.
   ///
   /// \param tag_map The map of k-v tags.
@@ -61,23 +56,17 @@ class Tags {
   /// Get the tags with a map.
   ///
   /// \return The map that contains k-v tags.
-  const std::map<std::string, std::string> &GetTags() const {
-    return tag_map_;
-  }
+  const std::map<std::string, std::string> &GetTags() const { return tag_map_; }
 
   /// get the keys of this Tags object.
   ///
   /// \return The TagKeys object that contains all of the keys of this Tags object.
-  const TagKeys &GetTagKeys() const {
-    return keys_;
-  }
+  const TagKeys &GetTagKeys() const { return keys_; }
 
   /// Get the id of this Tags object.
   ///
   /// \return The id of this Tags object.
-  size_t GetID() const {
-    return id_;
-  }
+  size_t GetID() const { return id_; }
 
  private:
   void DoHash();


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

With performance counter, we can easy to view service running status and abnormal conditions. This PR is to support perf counter.

I will submit code in several stages. And now is the first stage, submit the base interface class of performance counter.

Introduction:
MetricsRegistryInterface is the base registry class. Registry is used to register and update metrics.
MetricsReporterInterface is the base reporter class. Reporter is used to reporter metrics to any monitor service.



## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
