### PR TITLE
Add units to argument names in ray.init and ray.wait.

### DIFF
--- a/doc/source/redis-memory-management.rst
+++ b/doc/source/redis-memory-management.rst
@@ -8,8 +8,8 @@ task/object generation rate could risk high memory pressure, potentially leading
 to out-of-memory (OOM) errors.
 
 In Ray `0.6.1+` Redis shards can be configured to LRU evict task and object
-metadata by setting ``redis_max_memory`` when starting Ray. This supercedes the
-previously documented flushing functionality.
+metadata by setting ``redis_max_memory_bytes`` when starting Ray. This
+supercedes the previously documented flushing functionality.
 
-Note that profiling is disabled when ``redis_max_memory`` is set. This is because
-profiling data cannot be LRU evicted.
+Note that profiling is disabled when ``redis_max_memory_bytes`` is set. This is
+because profiling data cannot be LRU evicted.

--- a/doc/source/redis-memory-management.rst
+++ b/doc/source/redis-memory-management.rst
@@ -8,8 +8,8 @@ task/object generation rate could risk high memory pressure, potentially leading
 to out-of-memory (OOM) errors.
 
 In Ray `0.6.1+` Redis shards can be configured to LRU evict task and object
-metadata by setting ``redis_max_memory_bytes`` when starting Ray. This
+metadata by setting ``redis_max_memory_mb`` when starting Ray. This
 supercedes the previously documented flushing functionality.
 
-Note that profiling is disabled when ``redis_max_memory_bytes`` is set. This is
+Note that profiling is disabled when ``redis_max_memory_mb`` is set. This is
 because profiling data cannot be LRU evicted.

--- a/python/ray/experimental/api.py
+++ b/python/ray/experimental/api.py
@@ -61,6 +61,14 @@ def wait(object_ids, num_returns=1, timeout_seconds=None, worker=None):
     """
     worker = ray.worker.global_worker if worker is None else worker
     if isinstance(object_ids, (tuple, np.ndarray)):
-        return ray.wait(list(object_ids), num_returns, timeout_seconds, worker)
+        return ray.wait(
+            list(object_ids),
+            num_returns=num_returns,
+            timeout_seconds=timeout_seconds,
+            worker=worker)
 
-    return ray.wait(object_ids, num_returns, timeout_seconds, worker)
+    return ray.wait(
+        object_ids,
+        num_returns=num_returns,
+        timeout_seconds=timeout_seconds,
+        worker=worker)

--- a/python/ray/experimental/api.py
+++ b/python/ray/experimental/api.py
@@ -41,7 +41,7 @@ def get(object_ids, worker=None):
         return ray.get(object_ids, worker)
 
 
-def wait(object_ids, num_returns=1, timeout=None, worker=None):
+def wait(object_ids, num_returns=1, timeout_seconds=None, worker=None):
     """Return a list of IDs that are ready and a list of IDs that are not.
 
     This method is identical to `ray.wait` except it adds support for tuples
@@ -52,7 +52,7 @@ def wait(object_ids, num_returns=1, timeout=None, worker=None):
             List like of object IDs for objects that may or may not be ready.
             Note that these IDs must be unique.
         num_returns (int): The number of object IDs that should be returned.
-        timeout (int): The maximum amount of time in milliseconds to wait
+        timeout_seconds (int): The maximum amount of time in seconds to wait
             before returning.
 
     Returns:
@@ -61,6 +61,6 @@ def wait(object_ids, num_returns=1, timeout=None, worker=None):
     """
     worker = ray.worker.global_worker if worker is None else worker
     if isinstance(object_ids, (tuple, np.ndarray)):
-        return ray.wait(list(object_ids), num_returns, timeout, worker)
+        return ray.wait(list(object_ids), num_returns, timeout_seconds, worker)
 
-    return ray.wait(object_ids, num_returns, timeout, worker)
+    return ray.wait(object_ids, num_returns, timeout_seconds, worker)

--- a/python/ray/experimental/async_plasma.py
+++ b/python/ray/experimental/async_plasma.py
@@ -219,7 +219,7 @@ class PlasmaEventHandler:
         fut = PlasmaObjectFuture(loop=self._loop, object_id=plain_object_id)
 
         if check_ready:
-            ready, _ = ray.wait([object_id], timeout=0)
+            ready, _ = ray.wait([object_id], timeout_seconds=0)
             if ready:
                 if self._loop.get_debug():
                     logger.debug("%s has been ready.", plain_object_id)

--- a/python/ray/experimental/sgd/test_sgd.py
+++ b/python/ray/experimental/sgd/test_sgd.py
@@ -20,7 +20,7 @@ parser.add_argument("--grad-shard-bytes", default=10000000, type=int)
 parser.add_argument("--devices-per-worker", default=2, type=int)
 parser.add_argument("--stats-interval", default=10, type=int)
 parser.add_argument("--all-reduce-alg", default="simple", type=str)
-parser.add_argument("--object-store-memory-bytes", default=None, type=int)
+parser.add_argument("--object-store-memory-mb", default=None, type=int)
 parser.add_argument(
     "--warmup", action="store_true", help="Warm up object store before start.")
 parser.add_argument(
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     args, _ = parser.parse_known_args()
     ray.init(
         redis_address=args.redis_address,
-        object_store_memory_bytes=args.object_store_memory_bytes)
+        object_store_memory_mb=args.object_store_memory_mb)
 
     model_creator = (
         lambda worker_idx, device_idx: TFBenchModel(

--- a/python/ray/experimental/sgd/test_sgd.py
+++ b/python/ray/experimental/sgd/test_sgd.py
@@ -20,7 +20,7 @@ parser.add_argument("--grad-shard-bytes", default=10000000, type=int)
 parser.add_argument("--devices-per-worker", default=2, type=int)
 parser.add_argument("--stats-interval", default=10, type=int)
 parser.add_argument("--all-reduce-alg", default="simple", type=str)
-parser.add_argument("--object-store-memory", default=None, type=int)
+parser.add_argument("--object-store-memory-bytes", default=None, type=int)
 parser.add_argument(
     "--warmup", action="store_true", help="Warm up object store before start.")
 parser.add_argument(
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     args, _ = parser.parse_known_args()
     ray.init(
         redis_address=args.redis_address,
-        object_store_memory=args.object_store_memory)
+        object_store_memory_bytes=args.object_store_memory_bytes)
 
     model_creator = (
         lambda worker_idx, device_idx: TFBenchModel(

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -36,9 +36,9 @@ class RayOutOfMemoryError(Exception):
                 "\n\nIn addition, ~{} GB of shared memory is ".format(
                     round(psutil.virtual_memory().shared / 1e9, 2)) +
                 "currently being used by the Ray object store. You can set "
-                "the object store size with the `object_store_memory` "
+                "the object store size with the `object_store_memory_bytes` "
                 "parameter when starting Ray, and the max Redis size with "
-                "`redis_max_memory`.")
+                "`redis_max_memory_bytes`.")
 
 
 class MemoryMonitor(object):

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -36,9 +36,9 @@ class RayOutOfMemoryError(Exception):
                 "\n\nIn addition, ~{} GB of shared memory is ".format(
                     round(psutil.virtual_memory().shared / 1e9, 2)) +
                 "currently being used by the Ray object store. You can set "
-                "the object store size with the `object_store_memory_bytes` "
+                "the object store size with the `object_store_memory_mb` "
                 "parameter when starting Ray, and the max Redis size with "
-                "`redis_max_memory_bytes`.")
+                "`redis_max_memory_mb`.")
 
 
 class MemoryMonitor(object):

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -40,9 +40,9 @@ class RayParams(object):
             This is only provided if start_ray_local is True.
         resources: A dictionary mapping the name of a resource to the quantity
             of that resource available.
-        object_store_memory_bytes: The amount of memory (in bytes) to start the
+        object_store_memory_mb: The amount of memory (in bytes) to start the
             object store with.
-        redis_max_memory_bytes: The max amount of memory (in bytes) to allow
+        redis_max_memory_mb: The max amount of memory (in bytes) to allow
             redis to use, or None for no limit. Once the limit is exceeded,
             redis will start LRU eviction of entries. This only applies to the
             sharded redis tables (task and object tables).
@@ -100,8 +100,8 @@ class RayParams(object):
                  num_gpus=None,
                  num_local_schedulers=None,
                  resources=None,
-                 object_store_memory_bytes=None,
-                 redis_max_memory_bytes=None,
+                 object_store_memory_mb=None,
+                 redis_max_memory_mb=None,
                  redis_port=None,
                  redis_shard_ports=None,
                  object_manager_ports=None,
@@ -137,8 +137,8 @@ class RayParams(object):
         self.num_gpus = num_gpus
         self.num_local_schedulers = num_local_schedulers
         self.resources = resources
-        self.object_store_memory_bytes = object_store_memory_bytes
-        self.redis_max_memory_bytes = redis_max_memory_bytes
+        self.object_store_memory_mb = object_store_memory_mb
+        self.redis_max_memory_mb = redis_max_memory_mb
         self.redis_port = redis_port
         self.redis_shard_ports = redis_shard_ports
         self.object_manager_ports = object_manager_ports

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -40,11 +40,11 @@ class RayParams(object):
             This is only provided if start_ray_local is True.
         resources: A dictionary mapping the name of a resource to the quantity
             of that resource available.
-        object_store_memory: The amount of memory (in bytes) to start the
+        object_store_memory_bytes: The amount of memory (in bytes) to start the
             object store with.
-        redis_max_memory: The max amount of memory (in bytes) to allow redis
-            to use, or None for no limit. Once the limit is exceeded, redis
-            will start LRU eviction of entries. This only applies to the
+        redis_max_memory_bytes: The max amount of memory (in bytes) to allow
+            redis to use, or None for no limit. Once the limit is exceeded,
+            redis will start LRU eviction of entries. This only applies to the
             sharded redis tables (task and object tables).
         object_manager_ports (list): A list of the ports to use for the object
             managers. There should be one per object manager being started on
@@ -100,8 +100,8 @@ class RayParams(object):
                  num_gpus=None,
                  num_local_schedulers=None,
                  resources=None,
-                 object_store_memory=None,
-                 redis_max_memory=None,
+                 object_store_memory_bytes=None,
+                 redis_max_memory_bytes=None,
                  redis_port=None,
                  redis_shard_ports=None,
                  object_manager_ports=None,
@@ -137,8 +137,8 @@ class RayParams(object):
         self.num_gpus = num_gpus
         self.num_local_schedulers = num_local_schedulers
         self.resources = resources
-        self.object_store_memory = object_store_memory
-        self.redis_max_memory = redis_max_memory
+        self.object_store_memory_bytes = object_store_memory_bytes
+        self.redis_max_memory_bytes = redis_max_memory_bytes
         self.redis_port = redis_port
         self.redis_shard_ports = redis_shard_ports
         self.object_manager_ports = object_manager_ports

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -40,8 +40,8 @@ class RayParams(object):
             This is only provided if start_ray_local is True.
         resources: A dictionary mapping the name of a resource to the quantity
             of that resource available.
-        object_store_memory_mb: The amount of memory (in bytes) to start the
-            object store with.
+        object_store_memory_mb: The amount of memory (in megabytes) to start
+            the object store with.
         redis_max_memory_mb: The max amount of memory (in bytes) to allow
             redis to use, or None for no limit. Once the limit is exceeded,
             redis will start LRU eviction of entries. This only applies to the

--- a/python/ray/plasma/plasma.py
+++ b/python/ray/plasma/plasma.py
@@ -11,8 +11,6 @@ from ray.tempfile_services import get_object_store_socket_name
 
 __all__ = ["start_plasma_store", "DEFAULT_PLASMA_STORE_MEMORY"]
 
-PLASMA_WAIT_TIMEOUT = 2**30
-
 DEFAULT_PLASMA_STORE_MEMORY = 10**9
 
 

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -82,3 +82,6 @@ LOGGER_LEVEL_HELP = ("The logging level threshold, choices=['debug', 'info',"
 NO_RECONSTRUCTION = 0
 # A constant indicating that an actor should be reconstructed infinite times.
 INFINITE_RECONSTRUCTION = 2**30
+
+# Max bytes to allocate to plasma unless overriden by the user
+DEFAULT_MAX_MEMORY_MB = 20 * 1000

--- a/python/ray/rllib/evaluation/metrics.py
+++ b/python/ray/rllib/evaluation/metrics.py
@@ -32,7 +32,7 @@ def collect_episodes(local_evaluator,
         for a in remote_evaluators
     ]
     collected, _ = ray.wait(
-        pending, num_returns=len(pending), timeout=timeout_seconds * 1000)
+        pending, num_returns=len(pending), timeout_seconds=timeout_seconds)
     num_metric_batches_dropped = len(pending) - len(collected)
 
     metric_lists = ray.get(collected)

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -57,15 +57,15 @@ def create_parser(parser_creator=None):
         type=int,
         help="Emulate multiple cluster nodes for debugging.")
     parser.add_argument(
-        "--ray-redis-max-memory",
+        "--ray-redis-max-memory-bytes",
         default=None,
         type=int,
-        help="--redis-max-memory to use if starting a new cluster.")
+        help="--redis-max-memory-bytes to use if starting a new cluster.")
     parser.add_argument(
-        "--ray-object-store-memory",
+        "--ray-object-store-memory-bytes",
         default=None,
         type=int,
-        help="--object-store-memory to use if starting a new cluster.")
+        help="--object-store-memory-bytes to use if starting a new cluster.")
     parser.add_argument(
         "--experiment-name",
         default="default",
@@ -130,14 +130,14 @@ def run(args, parser):
                     "num_cpus": args.ray_num_cpus or 1,
                     "num_gpus": args.ray_num_gpus or 0,
                 },
-                object_store_memory=args.ray_object_store_memory,
-                redis_max_memory=args.ray_redis_max_memory)
+                object_store_memory_bytes=args.ray_object_store_memory_bytes,
+                redis_max_memory_bytes=args.ray_redis_max_memory_bytes)
         ray.init(redis_address=cluster.redis_address)
     else:
         ray.init(
             redis_address=args.redis_address,
-            object_store_memory=args.ray_object_store_memory,
-            redis_max_memory=args.ray_redis_max_memory,
+            object_store_memory_bytes=args.ray_object_store_memory_bytes,
+            redis_max_memory_bytes=args.ray_redis_max_memory_bytes,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     run_experiments(

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -57,15 +57,15 @@ def create_parser(parser_creator=None):
         type=int,
         help="Emulate multiple cluster nodes for debugging.")
     parser.add_argument(
-        "--ray-redis-max-memory-bytes",
+        "--ray-redis-max-memory-mb",
         default=None,
         type=int,
-        help="--redis-max-memory-bytes to use if starting a new cluster.")
+        help="--redis-max-memory-mb to use if starting a new cluster.")
     parser.add_argument(
-        "--ray-object-store-memory-bytes",
+        "--ray-object-store-memory-mb",
         default=None,
         type=int,
-        help="--object-store-memory-bytes to use if starting a new cluster.")
+        help="--object-store-memory-mb to use if starting a new cluster.")
     parser.add_argument(
         "--experiment-name",
         default="default",
@@ -130,14 +130,14 @@ def run(args, parser):
                     "num_cpus": args.ray_num_cpus or 1,
                     "num_gpus": args.ray_num_gpus or 0,
                 },
-                object_store_memory_bytes=args.ray_object_store_memory_bytes,
-                redis_max_memory_bytes=args.ray_redis_max_memory_bytes)
+                object_store_memory_mb=args.ray_object_store_memory_mb,
+                redis_max_memory_mb=args.ray_redis_max_memory_mb)
         ray.init(redis_address=cluster.redis_address)
     else:
         ray.init(
             redis_address=args.redis_address,
-            object_store_memory_bytes=args.ray_object_store_memory_bytes,
-            redis_max_memory_bytes=args.ray_redis_max_memory_bytes,
+            object_store_memory_mb=args.ray_object_store_memory_mb,
+            redis_max_memory_mb=args.ray_redis_max_memory_mb,
             num_cpus=args.ray_num_cpus,
             num_gpus=args.ray_num_gpus)
     run_experiments(

--- a/python/ray/rllib/utils/actors.py
+++ b/python/ray/rllib/utils/actors.py
@@ -28,7 +28,8 @@ class TaskPool(object):
     def completed(self):
         pending = list(self._tasks)
         if pending:
-            ready, _ = ray.wait(pending, num_returns=len(pending), timeout=10)
+            ready, _ = ray.wait(
+                pending, num_returns=len(pending), timeout_seconds=0.01)
             for obj_id in ready:
                 yield (self._tasks.pop(obj_id), self._objects.pop(obj_id))
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -113,7 +113,7 @@ def cli(logging_level, logging_format):
     type=int,
     help="the port to use for starting the node manager")
 @click.option(
-    "--object-store-memory-bytes",
+    "--object-store-memory-mb",
     required=False,
     type=int,
     help="the maximum amount of memory (in bytes) to allow the "
@@ -123,9 +123,9 @@ def cli(logging_level, logging_format):
     required=False,
     type=int,
     help="--object-store-memory is deprecated, please use "
-    "--object-store-memory-bytes ")
+    "--object-store-memory-mb ")
 @click.option(
-    "--redis-max-memory-bytes",
+    "--redis-max-memory-mb",
     required=False,
     type=int,
     help=("The max amount of memory (in bytes) to allow redis to use, or None "
@@ -137,13 +137,13 @@ def cli(logging_level, logging_format):
     required=False,
     type=int,
     help="--redis-max-memory is deprecated, please use "
-    "--redis-max-memory-bytes")
+    "--redis-max-memory-mb")
 @click.option(
     "--collect-profiling-data",
     default=True,
     type=bool,
     help="Whether to collect profiling data. Note that profiling data cannot "
-    "be LRU evicted, so if you set redis_max_memory_bytes then profiling will "
+    "be LRU evicted, so if you set redis_max_memory_mb then profiling will "
     "also be disabled to prevent it from consuming all available redis "
     "memory.")
 @click.option(
@@ -231,8 +231,8 @@ def cli(logging_level, logging_format):
     help="Do NOT use this. This is for debugging/development purposes ONLY.")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
-          object_manager_port, node_manager_port, object_store_memory_bytes,
-          object_store_memory, redis_max_memory_bytes, redis_max_memory,
+          object_manager_port, node_manager_port, object_store_memory_mb,
+          object_store_memory, redis_max_memory_mb, redis_max_memory,
           collect_profiling_data, num_workers, num_cpus, num_gpus, resources,
           head, no_ui, block, plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
@@ -240,13 +240,13 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           internal_config):
     if object_store_memory is not None:
         logger.warning("WARNING: The --object-store-memory argument has been "
-                       "deprecated. Please use --object-store-memory-bytes.")
-        object_store_memory_bytes = object_store_memory
+                       "deprecated. Please use --object-store-memory-mb.")
+        object_store_memory_mb = object_store_memory
 
     if redis_max_memory is not None:
         logger.warning("WARNING: The --redis-max-memory argument has been "
-                       "deprecated. Please use --redis-max-memory-bytes.")
-        redis_max_memory_bytes = redis_max_memory
+                       "deprecated. Please use --redis-max-memory-mb.")
+        redis_max_memory_mb = redis_max_memory
 
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
@@ -273,7 +273,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
         object_manager_ports=[object_manager_port],
         node_manager_ports=[node_manager_port],
         num_workers=num_workers,
-        object_store_memory_bytes=object_store_memory_bytes,
+        object_store_memory_mb=object_store_memory_mb,
         redis_password=redis_password,
         redirect_worker_output=not no_redirect_worker_output,
         redirect_output=not no_redirect_output,
@@ -314,7 +314,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
         ray_params.update_if_absent(
             redis_port=redis_port,
             redis_shard_ports=redis_shard_ports,
-            redis_max_memory_bytes=redis_max_memory_bytes,
+            redis_max_memory_mb=redis_max_memory_mb,
             collect_profiling_data=collect_profiling_data,
             num_redis_shards=num_redis_shards,
             redis_max_clients=redis_max_clients,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -113,13 +113,19 @@ def cli(logging_level, logging_format):
     type=int,
     help="the port to use for starting the node manager")
 @click.option(
-    "--object-store-memory",
+    "--object-store-memory-bytes",
     required=False,
     type=int,
     help="the maximum amount of memory (in bytes) to allow the "
     "object store to use")
 @click.option(
-    "--redis-max-memory",
+    "--object-store-memory",
+    required=False,
+    type=int,
+    help="--object-store-memory is deprecated, please use "
+    "--object-store-memory-bytes ")
+@click.option(
+    "--redis-max-memory-bytes",
     required=False,
     type=int,
     help=("The max amount of memory (in bytes) to allow redis to use, or None "
@@ -127,13 +133,19 @@ def cli(logging_level, logging_format):
           "eviction of entries. This only applies to the sharded "
           "redis tables (task and object tables)."))
 @click.option(
+    "--redis-max-memory",
+    required=False,
+    type=int,
+    help="--redis-max-memory is deprecated, please use "
+    "--redis-max-memory-bytes")
+@click.option(
     "--collect-profiling-data",
     default=True,
     type=bool,
-    help=("Whether to collect profiling data. Note that "
-          "profiling data cannot be LRU evicted, so if you set "
-          "redis_max_memory then profiling will also be disabled to prevent "
-          "it from consuming all available redis memory."))
+    help="Whether to collect profiling data. Note that profiling data cannot "
+    "be LRU evicted, so if you set redis_max_memory_bytes then profiling will "
+    "also be disabled to prevent it from consuming all available redis "
+    "memory.")
 @click.option(
     "--num-workers",
     required=False,
@@ -219,12 +231,23 @@ def cli(logging_level, logging_format):
     help="Do NOT use this. This is for debugging/development purposes ONLY.")
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
-          object_manager_port, node_manager_port, object_store_memory,
-          redis_max_memory, collect_profiling_data, num_workers, num_cpus,
-          num_gpus, resources, head, no_ui, block, plasma_directory,
-          huge_pages, autoscaling_config, no_redirect_worker_output,
-          no_redirect_output, plasma_store_socket_name, raylet_socket_name,
-          temp_dir, internal_config):
+          object_manager_port, node_manager_port, object_store_memory_bytes,
+          object_store_memory, redis_max_memory_bytes, redis_max_memory,
+          collect_profiling_data, num_workers, num_cpus, num_gpus, resources,
+          head, no_ui, block, plasma_directory, huge_pages, autoscaling_config,
+          no_redirect_worker_output, no_redirect_output,
+          plasma_store_socket_name, raylet_socket_name, temp_dir,
+          internal_config):
+    if object_store_memory is not None:
+        logger.warning("WARNING: The --object-store-memory argument has been "
+                       "deprecated. Please use --object-store-memory-bytes.")
+        object_store_memory_bytes = object_store_memory
+
+    if redis_max_memory is not None:
+        logger.warning("WARNING: The --redis-max-memory argument has been "
+                       "deprecated. Please use --redis-max-memory-bytes.")
+        redis_max_memory_bytes = redis_max_memory
+
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -250,7 +273,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
         object_manager_ports=[object_manager_port],
         node_manager_ports=[node_manager_port],
         num_workers=num_workers,
-        object_store_memory=object_store_memory,
+        object_store_memory_bytes=object_store_memory_bytes,
         redis_password=redis_password,
         redirect_worker_output=not no_redirect_worker_output,
         redirect_output=not no_redirect_output,
@@ -291,7 +314,7 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
         ray_params.update_if_absent(
             redis_port=redis_port,
             redis_shard_ports=redis_shard_ports,
-            redis_max_memory=redis_max_memory,
+            redis_max_memory_bytes=redis_max_memory_bytes,
             collect_profiling_data=collect_profiling_data,
             num_redis_shards=num_redis_shards,
             redis_max_clients=redis_max_clients,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -239,14 +239,15 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           plasma_store_socket_name, raylet_socket_name, temp_dir,
           internal_config):
     if object_store_memory is not None:
-        logger.warning("WARNING: The --object-store-memory argument has been "
-                       "deprecated. Please use --object-store-memory-mb.")
-        object_store_memory_mb = object_store_memory
+        logger.warning("WARNING: The '--object-store-memory' argument has "
+                       "been deprecated. Please use "
+                       "'--object-store-memory-mb'.")
+        object_store_memory_mb = object_store_memory / 10**6
 
     if redis_max_memory is not None:
-        logger.warning("WARNING: The --redis-max-memory argument has been "
-                       "deprecated. Please use --redis-max-memory-mb.")
-        redis_max_memory_mb = redis_max_memory
+        logger.warning("WARNING: The '--redis-max-memory' argument has been "
+                       "deprecated. Please use '--redis-max-memory-mb'.")
+        redis_max_memory_mb = redis_max_memory / 10**6
 
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1027,7 +1027,7 @@ def determine_plasma_store_config(object_store_memory_mb=None,
             use. If either of these values is specified by the user, then that
             value will be preserved.
     """
-    system_memory_mb = ray.utils.get_system_memory() / 1e6
+    system_memory_mb = ray.utils.get_system_memory_bytes() / 1e6
 
     # Choose a default object store size.
     if object_store_memory_mb is None:
@@ -1047,22 +1047,22 @@ def determine_plasma_store_config(object_store_memory_mb=None,
     # in which case we default to /tmp on Linux.
     if plasma_directory is None:
         if sys.platform == "linux" or sys.platform == "linux2":
-            shm_avail = ray.utils.get_shared_memory_bytes()
+            shm_avail_mb = ray.utils.get_shared_memory_bytes() / 1e6
             # Compare the requested memory size to the memory available in
             # /dev/shm.
-            if shm_avail > object_store_memory_mb:
+            if shm_avail_mb > object_store_memory_mb:
                 plasma_directory = "/dev/shm"
             else:
                 plasma_directory = "/tmp"
                 logger.warning(
                     "WARNING: The object store is using /tmp instead of "
-                    "/dev/shm because /dev/shm has only {} bytes available. "
+                    "/dev/shm because /dev/shm has only {}MB available. "
                     "This may slow down performance! You may be able to free "
                     "up space by deleting files in /dev/shm or terminating "
                     "any running plasma_store_server processes. If you are "
                     "inside a Docker container, you may need to pass an "
                     "argument with the flag '--shm-size' to 'docker run'."
-                    .format(shm_avail))
+                    .format(shm_avail_mb))
         else:
             plasma_directory = "/tmp"
 

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1129,7 +1129,7 @@ def start_plasma_store(node_ip_address,
                 "using {}.".format(object_store_memory_str, plasma_directory))
     # Start the Plasma store.
     plasma_store_name, p1 = ray.plasma.start_plasma_store(
-        plasma_store_memory=object_store_memory_mb * 10**6,
+        plasma_store_memory=int(object_store_memory_mb * 10**6),
         use_profiler=RUN_PLASMA_STORE_PROFILER,
         stdout_file=store_stdout_file,
         stderr_file=store_stderr_file,

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -64,7 +64,7 @@ class Cluster(object):
         All nodes are by default started with the following settings:
             cleanup=True,
             resources={"CPU": 1},
-            object_store_memory_bytes=100 * (2**20) # 100 MB
+            object_store_memory_mb=100  # 100 MB
 
         Args:
             override_kwargs: Keyword arguments used in `start_ray_head`
@@ -77,7 +77,7 @@ class Cluster(object):
             "resources": {
                 "CPU": 1
             },
-            "object_store_memory_bytes": 100 * (2**20)  # 100 MB
+            "object_store_memory_mb": 100 * (2**20)  # 100 MB
         }
         node_kwargs.update(override_kwargs)
         ray_params = RayParams(

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -77,7 +77,7 @@ class Cluster(object):
             "resources": {
                 "CPU": 1
             },
-            "object_store_memory_mb": 100 * (2**20)  # 100 MB
+            "object_store_memory_mb": 100  # 100 MB
         }
         node_kwargs.update(override_kwargs)
         ray_params = RayParams(

--- a/python/ray/test/cluster_utils.py
+++ b/python/ray/test/cluster_utils.py
@@ -64,7 +64,7 @@ class Cluster(object):
         All nodes are by default started with the following settings:
             cleanup=True,
             resources={"CPU": 1},
-            object_store_memory=100 * (2**20) # 100 MB
+            object_store_memory_bytes=100 * (2**20) # 100 MB
 
         Args:
             override_kwargs: Keyword arguments used in `start_ray_head`
@@ -77,7 +77,7 @@ class Cluster(object):
             "resources": {
                 "CPU": 1
             },
-            "object_store_memory": 100 * (2**20)  # 100 MB
+            "object_store_memory_bytes": 100 * (2**20)  # 100 MB
         }
         node_kwargs.update(override_kwargs)
         ray_params = RayParams(

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -105,7 +105,7 @@ class RayTrialExecutor(TrialExecutor):
                 stop_tasks.append(trial.runner.__ray_terminate__.remote())
                 # TODO(ekl)  seems like wait hangs when killing actors
                 _, unfinished = ray.wait(
-                    stop_tasks, num_returns=2, timeout=250)
+                    stop_tasks, num_returns=2, timeout_seconds=0.25)
         except Exception:
             logger.exception("Error stopping runner.")
             self.set_status(trial, Trial.ERROR)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -322,7 +322,7 @@ class TrialRunner(object):
                         "unexpected crashes. Consider "
                         "reducing the memory used by your application "
                         "or reducing the Ray object store size by setting "
-                        "`object_store_memory_bytes` when calling `ray.init`.")
+                        "`object_store_memory_mb` when calling `ray.init`.")
             else:
                 warn = ""
             return "Memory usage on this node: {}/{} GB{}".format(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -322,7 +322,7 @@ class TrialRunner(object):
                         "unexpected crashes. Consider "
                         "reducing the memory used by your application "
                         "or reducing the Ray object store size by setting "
-                        "`object_store_memory` when calling `ray.init`.")
+                        "`object_store_memory_bytes` when calling `ray.init`.")
             else:
                 warn = ""
             return "Memory usage on this node: {}/{} GB{}".format(

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -316,7 +316,7 @@ def sysctl(command):
         return result
 
 
-def get_system_memory():
+def get_system_memory_bytes():
     """Return the total amount of system memory in bytes.
 
     Returns:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2353,6 +2353,10 @@ def wait(object_ids,
                        "Please use timeout_seconds.")
         timeout_seconds = timeout / 1000
 
+    if timeout_seconds is not None and timeout_seconds < 0:
+        raise ValueError("The timeout_seconds argument cannot be negative. "
+                         "Received {}.".format(timeout_seconds))
+
     if isinstance(object_ids, ray.ObjectID):
         raise TypeError(
             "wait() expected a list of ObjectID, got a single ObjectID")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1281,8 +1281,8 @@ def _init(ray_params, driver_id=None):
         ray_params (ray.params.RayParams): The RayParams instance. The
             following parameters could be checked: address_info,
             start_ray_local, object_id_seed, num_workers,
-            num_local_schedulers, object_store_memory_bytes,
-            redis_max_memory_bytes, collect_profiling_data, local_mode,
+            num_local_schedulers, object_store_memory_mb,
+            redis_max_memory_mb, collect_profiling_data, local_mode,
             redirect_worker_output, driver_mode, redirect_output,
             start_workers_from_local_scheduler, num_cpus, num_gpus, resources,
             num_redis_shards, redis_max_clients, redis_password,
@@ -1306,10 +1306,10 @@ def _init(ray_params, driver_id=None):
     else:
         ray_params.driver_mode = SCRIPT_MODE
 
-    if ray_params.redis_max_memory_bytes and ray_params.collect_profiling_data:
+    if ray_params.redis_max_memory_mb and ray_params.collect_profiling_data:
         logger.warning(
             "Profiling data cannot be LRU evicted, so it is disabled "
-            "when redis_max_memory_bytes is set.")
+            "when redis_max_memory_mb is set.")
         ray_params.collect_profiling_data = False
 
     # Get addresses of existing services.
@@ -1368,12 +1368,12 @@ def _init(ray_params, driver_id=None):
         if ray_params.redis_max_clients is not None:
             raise Exception("When connecting to an existing cluster, "
                             "redis_max_clients must not be provided.")
-        if ray_params.object_store_memory_bytes is not None:
+        if ray_params.object_store_memory_mb is not None:
             raise Exception("When connecting to an existing cluster, "
-                            "object_store_memory_bytes must not be provided.")
-        if ray_params.redis_max_memory_bytes is not None:
+                            "object_store_memory_mb must not be provided.")
+        if ray_params.redis_max_memory_mb is not None:
             raise Exception("When connecting to an existing cluster, "
-                            "redis_max_memory_bytes must not be provided.")
+                            "redis_max_memory_mb must not be provided.")
         if ray_params.plasma_directory is not None:
             raise Exception("When connecting to an existing cluster, "
                             "plasma_directory must not be provided.")
@@ -1435,8 +1435,8 @@ def init(redis_address=None,
          num_cpus=None,
          num_gpus=None,
          resources=None,
-         object_store_memory_bytes=None,
-         redis_max_memory_bytes=None,
+         object_store_memory_mb=None,
+         redis_max_memory_mb=None,
          collect_profiling_data=True,
          node_ip_address=None,
          object_id_seed=None,
@@ -1492,9 +1492,9 @@ def init(redis_address=None,
             be configured with.
         resources: A dictionary mapping the name of a resource to the quantity
             of that resource available.
-        object_store_memory_bytes: The amount of memory (in bytes) to start the
+        object_store_memory_mb: The amount of memory (in bytes) to start the
             object store with.
-        redis_max_memory_bytes: The max amount of memory (in bytes) to allow
+        redis_max_memory_mb: The max amount of memory (in bytes) to allow
             redis to use, or None for no limit. Once the limit is exceeded,
             redis will start LRU eviction of entries. This only applies to the
             sharded redis tables (task and object tables).
@@ -1598,8 +1598,8 @@ def init(redis_address=None,
         plasma_directory=plasma_directory,
         huge_pages=huge_pages,
         include_webui=include_webui,
-        object_store_memory_bytes=object_store_memory_bytes,
-        redis_max_memory_bytes=redis_max_memory_bytes,
+        object_store_memory_mb=object_store_memory_mb,
+        redis_max_memory_mb=redis_max_memory_mb,
         collect_profiling_data=collect_profiling_data,
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1435,7 +1435,9 @@ def init(redis_address=None,
          num_cpus=None,
          num_gpus=None,
          resources=None,
+         object_store_memory=None,
          object_store_memory_mb=None,
+         redis_max_memory=None,
          redis_max_memory_mb=None,
          collect_profiling_data=True,
          node_ip_address=None,
@@ -1558,6 +1560,16 @@ def init(redis_address=None,
         else:
             raise DeprecationWarning("The use_raylet argument is deprecated. "
                                      "Please remove it.")
+
+    if object_store_memory is not None:
+        logger.warning("WARNING: The 'object_store_memory' argument has been "
+                       "deprecated. Please use 'object_store_memory_mb'.")
+        object_store_memory_mb = object_store_memory / 10**6
+
+    if redis_max_memory is not None:
+        logger.warning("WARNING: The 'redis_max_memory' argument has been "
+                       "deprecated. Please use 'redis_max_memory_mb'.")
+        redis_max_memory_mb = redis_max_memory / 10**6
 
     if setproctitle is None:
         logger.warning(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1683,7 +1683,7 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
                "evicted "
             << "by the redis LRU configuration. Consider increasing the memory "
                "allocation via "
-            << "ray.init(redis_max_memory_bytes=<max_memory_bytes>).";
+            << "ray.init(redis_max_memory_mb=<max_memory_bytes>).";
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1683,7 +1683,7 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
                "evicted "
             << "by the redis LRU configuration. Consider increasing the memory "
                "allocation via "
-            << "ray.init(redis_max_memory_mb=<max_memory_bytes>).";
+            << "ray.init(redis_max_memory_mb=<max_memory_megabytes>).";
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1683,7 +1683,7 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
                "evicted "
             << "by the redis LRU configuration. Consider increasing the memory "
                "allocation via "
-            << "ray.init(redis_max_memory=<max_memory_bytes>).";
+            << "ray.init(redis_max_memory_bytes=<max_memory_bytes>).";
         // Use a copy of the cached task spec to re-execute the task.
         const Task task = lineage_cache_.GetTask(task_id);
         ResubmitTask(task);

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2137,7 +2137,8 @@ def test_actor_eviction(shutdown_only):
     objects = []
     num_objects = 20
     for _ in range(num_objects):
-        obj = a.create_object.remote(object_store_memory_mb // num_objects)
+        obj = a.create_object.remote(
+            10**6 * object_store_memory_mb // num_objects)
         objects.append(obj)
         # Get each object once to make sure each object gets created.
         ray.get(obj)

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2124,9 +2124,9 @@ def test_actor_eviction(shutdown_only):
         def create_object(self, size):
             return np.random.rand(size)
 
-    object_store_memory_bytes = 10**8
+    object_store_memory_mb = 10**8
     ray.init(
-        object_store_memory_bytes=object_store_memory_bytes,
+        object_store_memory_mb=object_store_memory_mb,
         _internal_config=json.dumps({
             "initial_reconstruction_timeout_milliseconds": 200
         }))
@@ -2137,7 +2137,7 @@ def test_actor_eviction(shutdown_only):
     objects = []
     num_objects = 20
     for _ in range(num_objects):
-        obj = a.create_object.remote(object_store_memory_bytes // num_objects)
+        obj = a.create_object.remote(object_store_memory_mb // num_objects)
         objects.append(obj)
         # Get each object once to make sure each object gets created.
         ray.get(obj)

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2138,7 +2138,7 @@ def test_actor_eviction(shutdown_only):
     num_objects = 20
     for _ in range(num_objects):
         obj = a.create_object.remote(
-            10**6 * object_store_memory_mb // num_objects)
+            (10**6 * object_store_memory_mb) // num_objects)
         objects.append(obj)
         # Get each object once to make sure each object gets created.
         ray.get(obj)

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2124,7 +2124,7 @@ def test_actor_eviction(shutdown_only):
         def create_object(self, size):
             return np.random.rand(size)
 
-    object_store_memory_mb = 10**8
+    object_store_memory_mb = 100
     ray.init(
         object_store_memory_mb=object_store_memory_mb,
         _internal_config=json.dumps({

--- a/test/component_failures_test.py
+++ b/test/component_failures_test.py
@@ -86,7 +86,7 @@ def test_dying_worker_get(shutdown_only):
     time.sleep(1)
 
     # Make sure the task hasn't finished.
-    ready_ids, _ = ray.wait([result_id], timeout=0)
+    ready_ids, _ = ray.wait([result_id], timeout_seconds=0)
     assert len(ready_ids) == 0
 
     # Kill the worker.
@@ -94,7 +94,7 @@ def test_dying_worker_get(shutdown_only):
     time.sleep(0.1)
 
     # Make sure the sleep task hasn't finished.
-    ready_ids, _ = ray.wait([x_id], timeout=0)
+    ready_ids, _ = ray.wait([x_id], timeout_seconds=0)
     assert len(ready_ids) == 0
     # Seal the object so the store attempts to notify the worker that the
     # get has been fulfilled.
@@ -137,7 +137,7 @@ ray.get(ray.ObjectID(ray.utils.hex_to_binary("{}")))
     time.sleep(0.1)
 
     # Make sure the original task hasn't finished.
-    ready_ids, _ = ray.wait([x_id], timeout=0)
+    ready_ids, _ = ray.wait([x_id], timeout_seconds=0)
     assert len(ready_ids) == 0
     # Seal the object so the store attempts to notify the worker that the
     # get has been fulfilled.
@@ -222,7 +222,7 @@ ray.wait([ray.ObjectID(ray.utils.hex_to_binary("{}"))])
     time.sleep(0.1)
 
     # Make sure the original task hasn't finished.
-    ready_ids, _ = ray.wait([x_id], timeout=0)
+    ready_ids, _ = ray.wait([x_id], timeout_seconds=0)
     assert len(ready_ids) == 0
     # Seal the object so the store attempts to notify the worker that the
     # wait can return.
@@ -401,7 +401,7 @@ def test_actor_creation_node_failure(ray_start_cluster):
             ready, _ = ray.wait(
                 children_out,
                 num_returns=len(children_out),
-                timeout=5 * 60 * 1000)
+                timeout_seconds=5 * 60)
             assert len(ready) == len(children_out)
 
             # Replace any actors that died.

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -389,17 +389,17 @@ def test_actor_scope_or_intentionally_killed_message(ray_start_regular):
 
 
 @pytest.fixture
-def ray_start_object_store_memory_bytes():
+def ray_start_object_store_memory_mb():
     # Start the Ray processes.
     store_size = 10**6
-    ray.init(num_cpus=1, object_store_memory_bytes=store_size)
+    ray.init(num_cpus=1, object_store_memory_mb=store_size)
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
 
 @pytest.mark.skip("This test does not work yet.")
-def test_put_error1(ray_start_object_store_memory_bytes):
+def test_put_error1(ray_start_object_store_memory_mb):
     num_objects = 3
     object_size = 4 * 10**5
 
@@ -441,7 +441,7 @@ def test_put_error1(ray_start_object_store_memory_bytes):
 
 
 @pytest.mark.skip("This test does not work yet.")
-def test_put_error2(ray_start_object_store_memory_bytes):
+def test_put_error2(ray_start_object_store_memory_mb):
     # This is the same as the previous test, but it calls ray.put directly.
     num_objects = 3
     object_size = 4 * 10**5

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -330,7 +330,7 @@ def test_actor_worker_dying(ray_start_regular):
         pass
 
     a = Actor.remote()
-    [obj], _ = ray.wait([a.kill.remote()], timeout=5000)
+    [obj], _ = ray.wait([a.kill.remote()], timeout_seconds=5)
     with pytest.raises(Exception):
         ray.get(obj)
     with pytest.raises(Exception):
@@ -389,17 +389,17 @@ def test_actor_scope_or_intentionally_killed_message(ray_start_regular):
 
 
 @pytest.fixture
-def ray_start_object_store_memory():
+def ray_start_object_store_memory_bytes():
     # Start the Ray processes.
     store_size = 10**6
-    ray.init(num_cpus=1, object_store_memory=store_size)
+    ray.init(num_cpus=1, object_store_memory_bytes=store_size)
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
 
 @pytest.mark.skip("This test does not work yet.")
-def test_put_error1(ray_start_object_store_memory):
+def test_put_error1(ray_start_object_store_memory_bytes):
     num_objects = 3
     object_size = 4 * 10**5
 
@@ -441,7 +441,7 @@ def test_put_error1(ray_start_object_store_memory):
 
 
 @pytest.mark.skip("This test does not work yet.")
-def test_put_error2(ray_start_object_store_memory):
+def test_put_error2(ray_start_object_store_memory_bytes):
     # This is the same as the previous test, but it calls ray.put directly.
     num_objects = 3
     object_size = 4 * 10**5

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -21,7 +21,8 @@ if (multiprocessing.cpu_count() < 40
 def create_cluster(num_nodes):
     cluster = Cluster()
     for i in range(num_nodes):
-        cluster.add_node(resources={str(i): 100}, object_store_memory=10**9)
+        cluster.add_node(
+            resources={str(i): 100}, object_store_memory_bytes=10**9)
 
     ray.init(redis_address=cluster.redis_address)
     return cluster

--- a/test/object_manager_test.py
+++ b/test/object_manager_test.py
@@ -21,8 +21,7 @@ if (multiprocessing.cpu_count() < 40
 def create_cluster(num_nodes):
     cluster = Cluster()
     for i in range(num_nodes):
-        cluster.add_node(
-            resources={str(i): 100}, object_store_memory_bytes=10**9)
+        cluster.add_node(resources={str(i): 100}, object_store_memory_mb=1000)
 
     ray.init(redis_address=cluster.redis_address)
     return cluster

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -770,7 +770,8 @@ def test_defining_remote_functions(shutdown_only):
                 args=[], num_cpus=1, num_gpus=1,
                 resources={"Custom": 1})) == [0]
         infeasible_id = g._remote(args=[], resources={"NonexistentCustom": 1})
-        ready_ids, remaining_ids = ray.wait([infeasible_id], timeout=50)
+        ready_ids, remaining_ids = ray.wait(
+            [infeasible_id], timeout_seconds=0.05)
         assert len(ready_ids) == 0
         assert len(remaining_ids) == 1
 
@@ -845,14 +846,15 @@ def test_wait(shutdown_only):
 
     objectids = [f.remote(0.5), f.remote(0.5), f.remote(0.5), f.remote(0.5)]
     start_time = time.time()
-    ready_ids, remaining_ids = ray.wait(objectids, timeout=1750, num_returns=4)
+    ready_ids, remaining_ids = ray.wait(
+        objectids, timeout_seconds=1.75, num_returns=4)
     assert time.time() - start_time < 2
     assert len(ready_ids) == 3
     assert len(remaining_ids) == 1
     ray.wait(objectids)
     objectids = [f.remote(1.0), f.remote(0.5), f.remote(0.5), f.remote(0.5)]
     start_time = time.time()
-    ready_ids, remaining_ids = ray.wait(objectids, timeout=5000)
+    ready_ids, remaining_ids = ray.wait(objectids, timeout_seconds=5)
     assert time.time() - start_time < 5
     assert len(ready_ids) == 1
     assert len(remaining_ids) == 3
@@ -1073,7 +1075,8 @@ def test_object_transfer_dump(ray_start_cluster):
 
     num_nodes = 3
     for i in range(num_nodes):
-        cluster.add_node(resources={str(i): 1}, object_store_memory=10**9)
+        cluster.add_node(
+            resources={str(i): 1}, object_store_memory_bytes=10**9)
 
     ray.init(redis_address=cluster.redis_address)
 
@@ -1326,13 +1329,13 @@ def test_free_objects_multi_node(shutdown_only):
     ]
     # Case 1: run this local_only=False. All 3 objects will be deleted.
     (a, b, c) = run_one_test(actors, False)
-    (l1, l2) = ray.wait([a, b, c], timeout=10, num_returns=1)
+    (l1, l2) = ray.wait([a, b, c], timeout_seconds=0.01, num_returns=1)
     # All the objects are deleted.
     assert len(l1) == 0
     assert len(l2) == 3
     # Case 2: run this local_only=True. Only 1 object will be deleted.
     (a, b, c) = run_one_test(actors, True)
-    (l1, l2) = ray.wait([a, b, c], timeout=10, num_returns=3)
+    (l1, l2) = ray.wait([a, b, c], timeout_seconds=0.01, num_returns=3)
     # One object is deleted and 2 objects are not.
     assert len(l1) == 2
     assert len(l2) == 1
@@ -1381,7 +1384,7 @@ def test_local_mode(shutdown_only):
     num_returns = 5
     object_ids = [ray.put(i) for i in range(20)]
     ready, remaining = ray.wait(
-        object_ids, num_returns=num_returns, timeout=None)
+        object_ids, num_returns=num_returns, timeout_seconds=None)
     assert_equal(ready, object_ids[:num_returns])
     assert_equal(remaining, object_ids[num_returns:])
 
@@ -1763,7 +1766,7 @@ def test_fractional_resources(shutdown_only):
     # custom resource. TODO(rkn): Re-enable this once ray.wait is
     # implemented.
     f2 = Foo2._remote([], {}, resources={"Custom": 0.7})
-    ready, _ = ray.wait([f2.method.remote()], timeout=500)
+    ready, _ = ray.wait([f2.method.remote()], timeout_seconds=0.5)
     assert len(ready) == 0
     # Make sure we can start an actor that requries only 0.3 of the custom
     # resource.
@@ -1992,7 +1995,8 @@ def test_two_custom_resources(shutdown_only):
 
     # Make sure that tasks with unsatisfied custom resource requirements do
     # not get scheduled.
-    ready_ids, remaining_ids = ray.wait([j.remote(), k.remote()], timeout=500)
+    ready_ids, remaining_ids = ray.wait(
+        [j.remote(), k.remote()], timeout_seconds=0.5)
     assert ready_ids == []
 
 
@@ -2413,7 +2417,7 @@ def test_initialized_local_mode(shutdown_only_with_initialization_check):
 
 
 def test_wait_reconstruction(shutdown_only):
-    ray.init(num_cpus=1, object_store_memory=10**8)
+    ray.init(num_cpus=1, object_store_memory_bytes=10**8)
 
     @ray.remote
     def f():

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1075,8 +1075,7 @@ def test_object_transfer_dump(ray_start_cluster):
 
     num_nodes = 3
     for i in range(num_nodes):
-        cluster.add_node(
-            resources={str(i): 1}, object_store_memory_bytes=10**9)
+        cluster.add_node(resources={str(i): 1}, object_store_memory_mb=1000)
 
     ray.init(redis_address=cluster.redis_address)
 
@@ -2417,7 +2416,7 @@ def test_initialized_local_mode(shutdown_only_with_initialization_check):
 
 
 def test_wait_reconstruction(shutdown_only):
-    ray.init(num_cpus=1, object_store_memory_bytes=10**8)
+    ray.init(num_cpus=1, object_store_memory_mb=100)
 
     @ray.remote
     def f():

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -196,7 +196,7 @@ def ray_start_reconstruction(request):
     # Start the Plasma store instances with a total of 1GB memory.
     plasma_store_memory = 10**9
     plasma_addresses = []
-    object_store_memory_mb = plasma_store_memory // num_local_schedulers
+    object_store_memory_mb = plasma_store_memory / 1e6 // num_local_schedulers
     for i in range(num_local_schedulers):
         store_stdout_file, store_stderr_file = (
             ray.tempfile_services.new_plasma_store_log_file(i, True))
@@ -500,7 +500,7 @@ def test_nondeterministic_task(ray_start_reconstruction):
 def ray_start_driver_put_errors():
     plasma_store_memory = 10**9
     # Start the Ray processes.
-    ray.init(num_cpus=1, object_store_memory_mb=plasma_store_memory)
+    ray.init(num_cpus=1, object_store_memory_mb=plasma_store_memory / 10**6)
     yield plasma_store_memory
     # The code after the yield will run as teardown code.
     ray.shutdown()

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -196,7 +196,7 @@ def ray_start_reconstruction(request):
     # Start the Plasma store instances with a total of 1GB memory.
     plasma_store_memory = 10**9
     plasma_addresses = []
-    object_store_memory_bytes = plasma_store_memory // num_local_schedulers
+    object_store_memory_mb = plasma_store_memory // num_local_schedulers
     for i in range(num_local_schedulers):
         store_stdout_file, store_stderr_file = (
             ray.tempfile_services.new_plasma_store_log_file(i, True))
@@ -204,7 +204,7 @@ def ray_start_reconstruction(request):
             ray.services.start_plasma_store(
                 node_ip_address,
                 redis_address,
-                object_store_memory_bytes=object_store_memory_bytes,
+                object_store_memory_mb=object_store_memory_mb,
                 store_stdout_file=store_stdout_file,
                 store_stderr_file=store_stderr_file))
 
@@ -500,7 +500,7 @@ def test_nondeterministic_task(ray_start_reconstruction):
 def ray_start_driver_put_errors():
     plasma_store_memory = 10**9
     # Start the Ray processes.
-    ray.init(num_cpus=1, object_store_memory_bytes=plasma_store_memory)
+    ray.init(num_cpus=1, object_store_memory_mb=plasma_store_memory)
     yield plasma_store_memory
     # The code after the yield will run as teardown code.
     ray.shutdown()

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -196,7 +196,7 @@ def ray_start_reconstruction(request):
     # Start the Plasma store instances with a total of 1GB memory.
     plasma_store_memory = 10**9
     plasma_addresses = []
-    object_store_memory = plasma_store_memory // num_local_schedulers
+    object_store_memory_bytes = plasma_store_memory // num_local_schedulers
     for i in range(num_local_schedulers):
         store_stdout_file, store_stderr_file = (
             ray.tempfile_services.new_plasma_store_log_file(i, True))
@@ -204,7 +204,7 @@ def ray_start_reconstruction(request):
             ray.services.start_plasma_store(
                 node_ip_address,
                 redis_address,
-                object_store_memory=object_store_memory,
+                object_store_memory_bytes=object_store_memory_bytes,
                 store_stdout_file=store_stdout_file,
                 store_stderr_file=store_stderr_file))
 
@@ -500,7 +500,7 @@ def test_nondeterministic_task(ray_start_reconstruction):
 def ray_start_driver_put_errors():
     plasma_store_memory = 10**9
     # Start the Ray processes.
-    ray.init(num_cpus=1, object_store_memory=plasma_store_memory)
+    ray.init(num_cpus=1, object_store_memory_bytes=plasma_store_memory)
     yield plasma_store_memory
     # The code after the yield will run as teardown code.
     ray.shutdown()


### PR DESCRIPTION
This replaces #3629.

This makes the following changes:
- `object_store_memory` -> `object_store_memory_bytes`
- `redis_max_memory` -> `redis_max_memory_bytes`
- `timeout` -> `timeout_milliseconds`

Addresses #3411.