### PR TITLE
Prevent overriding faulthandler settings

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1830,7 +1830,8 @@ def connect(ray_params,
     assert worker.cached_functions_to_run is not None, error_message
 
     # Enable nice stack traces on SIGSEGV etc.
-    faulthandler.enable(all_threads=False)
+    if not faulthandler.is_enabled():
+        faulthandler.enable(all_threads=False)
 
     if ray_params.collect_profiling_data:
         worker.profiler = profiling.Profiler(worker)


### PR DESCRIPTION
## What do these changes do?

This change ensures that Ray set up fault handlers only if it has not been enabled by other applications. Otherwise some applications could face strange issues when using Ray, and some unittests using xml runners will fail.

cc @mitar