### PR TITLE
Refine multi-threading support

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -39,7 +39,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
       path += ":";
     }
 
-    path += rayConfig.libraryPath.stream().collect(Collectors.joining(":"));
+    path += String.join(":", rayConfig.libraryPath);
 
     // This is a hack to reset library path at runtime,
     // see https://stackoverflow.com/questions/15409223/.
@@ -80,7 +80,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
         rayConfig.rayletSocketName,
         workerContext.getCurrentWorkerId(),
         rayConfig.workerMode == WorkerMode.WORKER,
-        workerContext.getCurrentTask().taskId
+        workerContext.getCurrentDriverId()
     );
 
     // register

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -43,8 +43,7 @@ public class Worker {
       RayFunction rayFunction = runtime.getFunctionManager()
           .getFunction(spec.driverId, spec.functionDescriptor);
       // Set context
-      runtime.getWorkerContext().setCurrentTask(spec);
-      runtime.getWorkerContext().setCurrentClassLoader(rayFunction.classLoader);
+      runtime.getWorkerContext().setCurrentTask(spec, rayFunction.classLoader);
       Thread.currentThread().setContextClassLoader(rayFunction.classLoader);
       // Get local actor object and arguments.
       Object actor = spec.isActorTask() ? runtime.localActors.get(spec.actorId) : null;
@@ -67,6 +66,7 @@ public class Worker {
       LOGGER.error("Error executing task " + spec, e);
       runtime.put(returnId, new RayException("Error executing task " + spec, e));
     } finally {
+      runtime.getWorkerContext().setCurrentTask(null, null);
       Thread.currentThread().setContextClassLoader(oldLoader);
     }
   }

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -1,9 +1,6 @@
 package org.ray.runtime;
 
 import com.google.common.base.Preconditions;
-import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.WorkerMode;
 import org.ray.runtime.task.TaskSpec;
@@ -11,123 +8,114 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WorkerContext {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkerContext.class);
 
-  /**
-   * Worker id.
-   */
   private UniqueId workerId;
 
-  /**
-   * Current task.
-   */
-  private TaskSpec currentTask;
+  private ThreadLocal<UniqueId> currentTaskId;
 
   /**
-   * Current class loader.
+   * Number of objects that have been put from current task.
    */
+  private ThreadLocal<Integer> putIndex;
+
+  /**
+   * Number of tasks that have been submitted from current task.
+   */
+  private ThreadLocal<Integer> taskIndex;
+
+  private UniqueId currentDriverId;
+
   private ClassLoader currentClassLoader;
-
-  /**
-   * How many puts have been done by current task.
-   */
-  private AtomicInteger currentTaskPutCount;
-
-  /**
-   * How many calls have been done by current task.
-   */
-  private AtomicInteger currentTaskCallCount;
 
   /**
    * The ID of main thread which created the worker context.
    */
   private long mainThreadId;
-  /**
-   * If the multi-threading warning message has been logged.
-   */
-  private AtomicBoolean multiThreadingWarned;
+
 
   public WorkerContext(WorkerMode workerMode, UniqueId driverId) {
-    workerId = workerMode == WorkerMode.DRIVER ? driverId : UniqueId.randomId();
-    currentTaskPutCount = new AtomicInteger(0);
-    currentTaskCallCount = new AtomicInteger(0);
-    currentClassLoader = null;
-    currentTask = createDummyTask(workerMode, driverId);
     mainThreadId = Thread.currentThread().getId();
-    multiThreadingWarned = new AtomicBoolean(false);
+    taskIndex = ThreadLocal.withInitial(() -> 0);
+    putIndex = ThreadLocal.withInitial(() -> 0);
+    currentTaskId = ThreadLocal.withInitial(UniqueId::randomId);
+    if (workerMode == WorkerMode.DRIVER) {
+      workerId = driverId;
+      currentTaskId.set(UniqueId.randomId());
+      currentDriverId = driverId;
+      currentClassLoader = null;
+    } else {
+      workerId = UniqueId.randomId();
+      setCurrentTask(null, null);
+    }
   }
 
   /**
-   * Get the current thread's task ID.
-   * This returns the assigned task ID if called on the main thread, else a
-   * random task ID.
+   * @return For the main thread, this method returns the ID of this worker's current running task;
+   *     for other threads, this method returns a random ID.
    */
-  public UniqueId getCurrentThreadTaskId() {
-    UniqueId taskId;
-    if (Thread.currentThread().getId() == mainThreadId) {
-      taskId = currentTask.taskId;
+  public UniqueId getCurrentTaskId() {
+    return currentTaskId.get();
+  }
+
+  /**
+   * Set the current task which is being executed by the current worker. Note, this method can only
+   * be called from the main thread.
+   */
+  public void setCurrentTask(TaskSpec task, ClassLoader classLoader) {
+    Preconditions.checkState(
+        Thread.currentThread().getId() == mainThreadId,
+        "This method should only be called from the main thread."
+    );
+    if (task != null) {
+      currentTaskId.set(task.taskId);
+      currentDriverId = task.driverId;
     } else {
-      taskId = UniqueId.randomId();
-      if (multiThreadingWarned.compareAndSet(false, true)) {
-        LOGGER.warn("Calling Ray.get or Ray.wait in a separate thread " +
-            "may lead to deadlock if the main thread blocks on this " +
-            "thread and there are not enough resources to execute " +
-            "more tasks");
-      }
+      currentTaskId.set(UniqueId.NIL);
+      currentDriverId = UniqueId.NIL;
     }
-
-    Preconditions.checkState(!taskId.isNil());
-    return taskId;
+    taskIndex.set(0);
+    putIndex.set(0);
+    currentClassLoader = classLoader;
   }
 
-  public void setWorkerId(UniqueId workerId) {
-    this.workerId = workerId;
-  }
-
-  public TaskSpec getCurrentTask() {
-    return currentTask;
-  }
-
+  /**
+   * Increment the put index and return the new value.
+   */
   public int nextPutIndex() {
-    return currentTaskPutCount.incrementAndGet();
+    putIndex.set(putIndex.get() + 1);
+    return putIndex.get();
   }
 
-  public int nextCallIndex() {
-    return currentTaskCallCount.incrementAndGet();
+  /**
+   * Increment the task index and return the new value.
+   */
+  public int nextTaskIndex() {
+    taskIndex.set(taskIndex.get() + 1);
+    return taskIndex.get();
   }
 
+  /**
+   * @return The ID of the current worker.
+   */
   public UniqueId getCurrentWorkerId() {
     return workerId;
   }
 
+  /**
+   * @return If this worker is a driver, this method returns the driver ID; Otherwise, it returns
+   *     the driver ID of the current running task.
+   */
+  public UniqueId getCurrentDriverId() {
+    return currentDriverId;
+  }
+
+  /**
+   * @return The class loader which is associated with the current driver.
+   */
   public ClassLoader getCurrentClassLoader() {
     return currentClassLoader;
   }
 
-  public void setCurrentTask(TaskSpec currentTask) {
-    this.currentTask = currentTask;
-    currentTaskCallCount.set(0);
-    currentTaskPutCount.set(0);
-  }
-
-  public void setCurrentClassLoader(ClassLoader currentClassLoader) {
-    this.currentClassLoader = currentClassLoader;
-  }
-
-  private TaskSpec createDummyTask(WorkerMode workerMode, UniqueId driverId) {
-    return new TaskSpec(
-        driverId,
-        workerMode == WorkerMode.DRIVER ? UniqueId.randomId() : UniqueId.NIL,
-        UniqueId.NIL,
-        0,
-        UniqueId.NIL,
-        0,
-        UniqueId.NIL,
-        UniqueId.NIL,
-        0,
-        null,
-        null,
-        new HashMap<>(),
-        null);
-  }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/objectstore/MockObjectStore.java
+++ b/java/runtime/src/main/java/org/ray/runtime/objectstore/MockObjectStore.java
@@ -95,7 +95,7 @@ public class MockObjectStore implements ObjectStoreLink {
   }
 
   private String logPrefix() {
-    return runtime.getWorkerContext().getCurrentTask().taskId + "-" + getUserTrace() + " -> ";
+    return runtime.getWorkerContext().getCurrentTaskId() + "-" + getUserTrace() + " -> ";
   }
 
   private String getUserTrace() {

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -79,6 +79,9 @@ public class RayletClientImpl implements RayletClient {
   @Override
   public void submitTask(TaskSpec spec) {
     LOGGER.debug("Submitting task: {}", spec);
+    Preconditions.checkState(!spec.parentTaskId.isNil());
+    Preconditions.checkState(!spec.driverId.isNil());
+
     ByteBuffer info = convertTaskSpecToFlatbuffer(spec);
     byte[] cursorId = null;
     if (!spec.getExecutionDependencies().isEmpty()) {

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import logging
 import sys
+import threading
 import traceback
 
 import ray.cloudpickle as pickle
@@ -225,8 +226,7 @@ class ActorMethod(object):
             self._method_name,
             args=args,
             kwargs=kwargs,
-            num_return_vals=num_return_vals,
-            dependency=self._actor._ray_actor_cursor)
+            num_return_vals=num_return_vals)
 
 
 class ActorClass(object):
@@ -525,13 +525,13 @@ class ActorHandle(object):
         self._ray_actor_method_cpus = actor_method_cpus
         self._ray_actor_driver_id = actor_driver_id
         self._ray_new_actor_handles = []
+        self._ray_actor_lock = threading.Lock()
 
     def _actor_method_call(self,
                            method_name,
                            args=None,
                            kwargs=None,
-                           num_return_vals=None,
-                           dependency=None):
+                           num_return_vals=None):
         """Method execution stub for an actor handle.
 
         This is the function that executes when
@@ -570,41 +570,33 @@ class ActorHandle(object):
             return getattr(worker.actors[self._ray_actor_id],
                            method_name)(*copy.deepcopy(args))
 
-        # Add the execution dependency.
-        if dependency is None:
-            execution_dependencies = []
-        else:
-            execution_dependencies = [dependency]
-
         is_actor_checkpoint_method = (method_name == "__ray_checkpoint__")
 
         function_descriptor = FunctionDescriptor(
             self._ray_module_name, method_name, self._ray_class_name)
-        object_ids = worker.submit_task(
-            function_descriptor,
-            args,
-            actor_id=self._ray_actor_id,
-            actor_handle_id=self._ray_actor_handle_id,
-            actor_counter=self._ray_actor_counter,
-            is_actor_checkpoint_method=is_actor_checkpoint_method,
-            actor_creation_dummy_object_id=(
-                self._ray_actor_creation_dummy_object_id),
-            execution_dependencies=execution_dependencies,
-            new_actor_handles=self._ray_new_actor_handles,
-            # We add one for the dummy return ID.
-            num_return_vals=num_return_vals + 1,
-            resources={"CPU": self._ray_actor_method_cpus},
-            placement_resources={},
-            driver_id=self._ray_actor_driver_id)
-        # Update the actor counter and cursor to reflect the most recent
-        # invocation.
-        self._ray_actor_counter += 1
-        # The last object returned is the dummy object that should be
-        # passed in to the next actor method. Do not return it to the user.
-        self._ray_actor_cursor = object_ids.pop()
-        # We have notified the backend of the new actor handles to expect since
-        # the last task was submitted, so clear the list.
-        self._ray_new_actor_handles = []
+        with self._ray_actor_lock:
+            object_ids = worker.submit_task(
+                function_descriptor,
+                args,
+                actor_id=self._ray_actor_id,
+                actor_handle_id=self._ray_actor_handle_id,
+                actor_counter=self._ray_actor_counter,
+                is_actor_checkpoint_method=is_actor_checkpoint_method,
+                actor_creation_dummy_object_id=(
+                    self._ray_actor_creation_dummy_object_id),
+                execution_dependencies=[self._ray_actor_cursor],
+                new_actor_handles=self._ray_new_actor_handles,
+                # We add one for the dummy return ID.
+                num_return_vals=num_return_vals + 1,
+                resources={"CPU": self._ray_actor_method_cpus},
+                placement_resources={},
+                driver_id=self._ray_actor_driver_id)
+            # Update the actor counter and cursor to reflect the most recent
+            # invocation.
+            self._ray_actor_counter += 1
+            # The last object returned is the dummy object that should be
+            # passed in to the next actor method. Do not return it to the user.
+            self._ray_actor_cursor = object_ids.pop()
 
         if len(object_ids) == 1:
             object_ids = object_ids[0]

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -590,7 +590,8 @@ class ActorHandle(object):
                 num_return_vals=num_return_vals + 1,
                 resources={"CPU": self._ray_actor_method_cpus},
                 placement_resources={},
-                driver_id=self._ray_actor_driver_id)
+                driver_id=self._ray_actor_driver_id,
+            )
             # Update the actor counter and cursor to reflect the most recent
             # invocation.
             self._ray_actor_counter += 1

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -486,7 +486,7 @@ class Worker(object):
                     ray.ObjectID(unready_id)
                     for unready_id in unready_ids.keys()
                 ]
-                fetch_request_size = (ray._config.worker_fetch_request_size())
+                fetch_request_size = ray._config.worker_fetch_request_size()
                 for i in range(0, len(object_ids_to_fetch),
                                fetch_request_size):
                     self.raylet_client.fetch_or_reconstruct(
@@ -498,8 +498,9 @@ class Worker(object):
                     object_ids_to_fetch,
                     max([
                         ray._config.get_timeout_milliseconds(),
-                        int(0.01 * len(unready_ids))
-                    ]))
+                        int(0.01 * len(unready_ids)),
+                    ]),
+                )
                 # Remove any entries for objects we received during this
                 # iteration so we don't retrieve the same object twice.
                 for i, val in enumerate(results):


### PR DESCRIPTION
## What do these changes do?

- Make `current_task_id`, `task_index`, and `put_index` thread local. 
- For main thread, `current_task_id` is the real task id, which gets set/reset before/after each task. For background threads, `current_task_id` is a fake random id that will be generated when it's used for the first time, and it will never change again. 
- `task_index` and `put_index` still increments monotonically each time when `submit_task` and `put` is called (so task id generation is still deterministic for the main thread).
- `state_lock` isn't needed anymore (could improve efficiency).
- `task_driver_id` is still shared among threads. But we don't reset it to NIL for actors.
- fix issue of calling an actor from multiple threads.

## Related issue number
#3651
