### PR TITLE
Split profile table among many keys in the GCS.

### DIFF
--- a/doc/source/redis-memory-management.rst
+++ b/doc/source/redis-memory-management.rst
@@ -10,6 +10,3 @@ to out-of-memory (OOM) errors.
 In Ray `0.6.1+` Redis shards can be configured to LRU evict task and object
 metadata by setting ``redis_max_memory`` when starting Ray. This supercedes the
 previously documented flushing functionality.
-
-Note that profiling is disabled when ``redis_max_memory`` is set. This is because
-profiling data cannot be LRU evicted.

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -466,8 +466,12 @@ class GlobalState(object):
 
         result = defaultdict(list)
         for batch_id in batch_identifiers_binary:
-            result[binary_to_hex(batch_id)].extend(
-                self._profile_table(binary_to_object_id(batch_id)))
+            profile_data = self._profile_table(binary_to_object_id(batch_id))
+            # Note that if keys are being evicted from Redis, then it is
+            # possible that the batch will be evicted before we get it.
+            if len(profile_data) > 0:
+                component_id = profile_data[0]["component_id"]
+                result[component_id].extend(profile_data)
 
         return dict(result)
 

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -52,7 +52,6 @@ class RayParams(object):
         node_manager_ports (list): A list of the ports to use for the node
             managers. There should be one per node manager being started on
             this node (typically just one).
-        collect_profiling_data: Whether to collect profiling data from workers.
         node_ip_address (str): The IP address of the node that we are on.
         object_id_seed (int): Used to seed the deterministic generation of
             object IDs. The same value can be used across multiple runs of the
@@ -106,7 +105,6 @@ class RayParams(object):
                  redis_shard_ports=None,
                  object_manager_ports=None,
                  node_manager_ports=None,
-                 collect_profiling_data=True,
                  node_ip_address=None,
                  object_id_seed=None,
                  num_workers=None,
@@ -143,7 +141,6 @@ class RayParams(object):
         self.redis_shard_ports = redis_shard_ports
         self.object_manager_ports = object_manager_ports
         self.node_manager_ports = node_manager_ports
-        self.collect_profiling_data = collect_profiling_data
         self.node_ip_address = node_ip_address
         self.num_workers = num_workers
         self.local_mode = local_mode

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -128,19 +128,6 @@ class Profiler(object):
             self.events.append(event)
 
 
-class NoopProfiler(object):
-    """A no-op profile used when collect_profile_data=False."""
-
-    def start_flush_thread(self):
-        pass
-
-    def flush_profile_data(self):
-        pass
-
-    def add_event(self, event):
-        pass
-
-
 class RayLogSpanRaylet(object):
     """An object used to enable logging a span of events with a with statement.
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -127,14 +127,6 @@ def cli(logging_level, logging_format):
           "eviction of entries. This only applies to the sharded "
           "redis tables (task and object tables)."))
 @click.option(
-    "--collect-profiling-data",
-    default=True,
-    type=bool,
-    help=("Whether to collect profiling data. Note that "
-          "profiling data cannot be LRU evicted, so if you set "
-          "redis_max_memory then profiling will also be disabled to prevent "
-          "it from consuming all available redis memory."))
-@click.option(
     "--num-workers",
     required=False,
     type=int,
@@ -220,11 +212,11 @@ def cli(logging_level, logging_format):
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
-          redis_max_memory, collect_profiling_data, num_workers, num_cpus,
-          num_gpus, resources, head, no_ui, block, plasma_directory,
-          huge_pages, autoscaling_config, no_redirect_worker_output,
-          no_redirect_output, plasma_store_socket_name, raylet_socket_name,
-          temp_dir, internal_config):
+          redis_max_memory, num_workers, num_cpus, num_gpus, resources, head,
+          no_ui, block, plasma_directory, huge_pages, autoscaling_config,
+          no_redirect_worker_output, no_redirect_output,
+          plasma_store_socket_name, raylet_socket_name, temp_dir,
+          internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -292,7 +284,6 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
             redis_port=redis_port,
             redis_shard_ports=redis_shard_ports,
             redis_max_memory=redis_max_memory,
-            collect_profiling_data=collect_profiling_data,
             num_redis_shards=num_redis_shards,
             redis_max_clients=redis_max_clients,
             include_webui=(not no_ui),

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -934,12 +934,10 @@ def start_raylet(ray_params,
                             "--object-store-name={} "
                             "--raylet-name={} "
                             "--redis-address={} "
-                            "--collect-profiling-data={} "
                             "--temp-dir={}".format(
                                 sys.executable, ray_params.worker_path,
                                 ray_params.node_ip_address, plasma_store_name,
-                                raylet_name, ray_params.redis_address, "1"
-                                if ray_params.collect_profiling_data else "0",
+                                raylet_name, ray_params.redis_address,
                                 get_temp_root()))
     if ray_params.redis_password:
         start_worker_command += " --redis-password {}".format(
@@ -1498,8 +1496,8 @@ def start_ray_head(ray_params, cleanup=True):
             following parameters could be checked: address_info,
             object_manager_ports, node_manager_ports, node_ip_address,
             redis_port, redis_shard_ports, num_workers, num_local_schedulers,
-            object_store_memory, redis_max_memory, collect_profiling_data,
-            worker_path, cleanup, redirect_worker_output, redirect_output,
+            object_store_memory, redis_max_memory, worker_path, cleanup,
+            redirect_worker_output, redirect_output,
             start_workers_from_local_scheduler, resources, num_redis_shards,
             redis_max_clients, redis_password, include_webui, huge_pages,
             plasma_directory, autoscaling_config, plasma_store_socket_name,

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -52,11 +52,6 @@ parser.add_argument(
     default=ray_constants.LOGGER_FORMAT,
     help=ray_constants.LOGGER_FORMAT_HELP)
 parser.add_argument(
-    "--collect-profiling-data",
-    type=int,  # int since argparse can't handle bool values
-    default=1,
-    help="Whether to collect profiling data from workers.")
-parser.add_argument(
     "--temp-dir",
     required=False,
     type=str,

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -501,23 +501,6 @@ class ProfileTable : private Log<UniqueID, ProfileTableData> {
     prefix_ = TablePrefix::PROFILE;
   };
 
-  /// Add a single profile event to the profile table.
-  ///
-  /// \param event_type The type of the event.
-  /// \param component_type The type of the component that the event came from.
-  /// \param component_id An identifier for the component that generated the event.
-  /// \param node_ip_address The IP address of the node that generated the event.
-  /// \param start_time The timestamp of the event start, this should be in seconds since
-  /// the Unix epoch.
-  /// \param end_time The timestamp of the event end, this should be in seconds since
-  /// the Unix epoch. If the event is a point event, this should be equal to start_time.
-  /// \param extra_data Additional data to associate with the event.
-  /// \return Status.
-  Status AddProfileEvent(const std::string &event_type, const std::string &component_type,
-                         const UniqueID &component_id, const std::string &node_ip_address,
-                         double start_time, double end_time,
-                         const std::string &extra_data);
-
   /// Add a batch of profiling events to the profile table.
   ///
   /// \param profile_events The profile events to record.


### PR DESCRIPTION
This fixes #3306 by sharding the profile table over a number of keys in the GCS.
- Each key now corresponds to one batch of profiling info (e.g., one second of data) as opposed to all events from a given process.
- I removed `--collect-profiling-data`.
- I verified that the profile table gets flushed via GCS LRU eviction.
- I checked that the timeline visualization works properly (including when GCS eviction is happening).