### PR TITLE
 Fix: do not treat actor task as failed if the actor will be reconstructed

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -842,7 +842,8 @@ void NodeManager::ProcessDisconnectClientMessage(
     // If the worker was running a task, clean up the task and push an error to
     // the driver, unless the worker is already dead.
     if (!task_id.is_nil() && !worker->IsDead()) {
-      // If the worker was an actor, the task was already cleaned up.
+      // If the worker was an actor, the task was already cleaned up in
+      // `HandleDisconnectedActor`.
       if (actor_id.is_nil()) {
         const Task &task = local_queues_.RemoveTask(task_id);
         TreatTaskAsFailed(task);

--- a/test/actor_test.py
+++ b/test/actor_test.py
@@ -2229,9 +2229,9 @@ def test_actor_reconstruction(ray_start_regular):
     for _ in range(3):
         ray.get(actor.increase.remote())
     # Call increase again with some delay.
-    result = actor.increase.remote(delay=1.0)
+    result = actor.increase.remote(delay=0.5)
     # Sleep some time to wait for the above task to start execution.
-    time.sleep(0.1)
+    time.sleep(0.2)
     # Kill actor process, while the above task is still being executed.
     os.kill(pid, signal.SIGKILL)
     # Check that the above task didn't fail and the actor is reconstructed.

--- a/test/multi_node_test.py
+++ b/test/multi_node_test.py
@@ -416,3 +416,41 @@ print("success")
     for i in range(2):
         out = run_string_as_driver(driver_script)
         assert "success" in out
+
+
+def test_driver_exiting_when_worker_blocked(ray_start_head):
+    # This test will create some drivers that submit some tasks and then
+    # exit without waiting for the tasks to complete.
+    redis_address = ray_start_head
+
+    ray.init(redis_address=redis_address)
+
+    # Define a driver that creates an actor and exits.
+    driver_script = """
+import time
+import ray
+ray.init(redis_address="{}")
+@ray.remote
+def f():
+    time.sleep(10**6)
+@ray.remote
+def g():
+    ray.get(f.remote())
+g.remote()
+time.sleep(1)
+print("success")
+""".format(redis_address)
+
+    # Create some drivers and let them exit and make sure everything is
+    # still alive.
+    for _ in range(3):
+        out = run_string_as_driver(driver_script)
+        # Make sure the first driver ran to completion.
+        assert "success" in out
+
+    @ray.remote
+    def f():
+        return 1
+
+    # Make sure we can still talk with the raylet.
+    ray.get(f.remote())


### PR DESCRIPTION
- Fix: do not treat actor task as failed if the actor will be reconstructed.
- Fix raylet crash caused by killing a blocked worker when driver exits.