### PR TITLE
[Java] Fix package jaxb not exist when JDK11

### DIFF
--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -14,6 +14,10 @@
   <description>java api for ray</description>
 
   <packaging>jar</packaging>
+  
+  <properties>
+    <jaxbVersion>2.3.0</jaxbVersion>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -23,17 +27,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
+      <version>${jaxbVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>2.3.0</version>
+      <version>${jaxbVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.3.0</version>
+      <version>${jaxbVersion}</version>
     </dependency>
   </dependencies>
 </project>

--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -20,5 +20,20 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -14,10 +14,6 @@
   <description>java api for ray</description>
 
   <packaging>jar</packaging>
-  
-  <properties>
-    <jaxbVersion>2.3.0</jaxbVersion>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/java/api/pom.xml
+++ b/java/api/pom.xml
@@ -23,17 +23,14 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>${jaxbVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>${jaxbVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>${jaxbVersion}</version>
     </dependency>
   </dependencies>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,6 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <projetct.version>0.1-SNAPSHOT</projetct.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <jaxbVersion>2.3.0</jaxbVersion>
   </properties>
 
   <dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -116,6 +116,21 @@
         <artifactId>junit</artifactId>
         <version>4.11</version>
       </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxbVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>${jaxbVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${jaxbVersion}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <projetct.version>0.1-SNAPSHOT</projetct.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <jaxbVersion>2.3.0</jaxbVersion>
+    <jaxb.version>2.3.0</jaxb.version>
   </properties>
 
   <dependencyManagement>
@@ -119,17 +119,17 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>${jaxbVersion}</version>
+        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-core</artifactId>
-        <version>${jaxbVersion}</version>
+        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>${jaxbVersion}</version>
+        <version>${jaxb.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Adding jaxb dependencies explicitely in the java API to awork with jdk 9 and later

## Related issue number

#3737 
