### PR TITLE
[Raylet]remove RAY_CHECK around wait_state.remaining.erase

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -609,7 +609,7 @@ void ObjectManager::SubscribeRemainingWaitObjects(const UniqueID &wait_id) {
                 return;
               }
               auto &wait_state = object_id_wait_state->second;
-              RAY_CHECK(wait_state.remaining.erase(subscribe_object_id));
+              wait_state.remaining.erase(subscribe_object_id);
               wait_state.found.insert(subscribe_object_id);
               wait_state.requested_objects.erase(subscribe_object_id);
               RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
As described in [issue#3741](https://github.com/ray-project/ray/issues/3741), object manager would core dumped if an object id was erased more than one time.

According to the debug logs, SubscribeObjectLocations could be invoked more than once for a specific object id, thus an object id could be erased more than one time.

## Related issue number
[issue#3741](https://github.com/ray-project/ray/issues/3741)
<!-- Are there any issues opened that will be resolved by merging this change? -->
