### PR TITLE
gcp: allow manual network configuration

### DIFF
--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -267,6 +267,12 @@ def _configure_key_pair(config):
 def _configure_subnet(config):
     """Pick a reasonable subnet if not specified by the config."""
 
+    # Rationale: avoid subnet lookup if the network is already
+    # completely manually configured
+    if ("networkInterfaces" in config["head_node"]
+            and "networkInterfaces" in config["worker_nodes"]):
+        return config
+
     subnets = _list_subnets(config)
 
     if not subnets:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Prevent subnet lookup in the case the user already specified the network config.
The subnet lookup fails for complex networks (eg it takes the first one and cannot use shared subnets)

## Related issue number

No