### PR TITLE
Remove redundant error message

### DIFF
--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -6,7 +6,6 @@ import binascii
 import functools
 import hashlib
 import inspect
-import logging
 import numpy as np
 import os
 import subprocess
@@ -18,8 +17,6 @@ import uuid
 import ray.gcs_utils
 import ray.raylet
 import ray.ray_constants as ray_constants
-
-logger = logging.getLogger(__name__)
 
 
 def _random_string():
@@ -72,8 +69,6 @@ def push_error_to_driver(worker,
     if driver_id is None:
         driver_id = ray_constants.NIL_JOB_ID.id()
     data = {} if data is None else data
-    logging.error("Pushing error to dirver, type: %s, message: %s.",
-                  error_type, message)
     worker.raylet_client.push_error(
         ray.ObjectID(driver_id), error_type, message, time.time())
 


### PR DESCRIPTION


## What do these changes do?

If you run
```
import ray

@ray.remote
class A():
    def __init__(self):
        pass

    def f(self):
        raise Exception("uh oh")


ray.init()
a = A.remote()
a.f.remote()
import time
time.sleep(10)
```

You get
```
Pushing error to dirver, type: task, message: ray_A:f() (pid=18009, host=eric-ThinkPad)
  File "err.py", line 9, in f
    raise Exception("uh oh")
Exception: uh oh
.
Possible unhandled error from worker: ray_A:f() (pid=18009, host=eric-ThinkPad)
  File "err.py", line 9, in f
    raise Exception("uh oh")
Exception: uh oh

```

Also note that dirver is misspelled.