### PR TITLE
Replace junit with testNG

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -111,9 +111,9 @@
         <version>1.10.19</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>6.9.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -72,8 +72,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
+++ b/java/runtime/src/test/java/org/ray/runtime/functionmanager/FunctionManagerTest.java
@@ -7,15 +7,14 @@ import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.ray.api.annotation.RayRemote;
 import org.ray.api.function.RayFunc0;
 import org.ray.api.function.RayFunc1;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.functionmanager.FunctionManager.DriverFunctionTable;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests for {@link FunctionManager}

--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -30,8 +30,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
     </dependency>
 
     <dependency>

--- a/java/test/src/main/java/org/ray/api/benchmark/ActorPressTest.java
+++ b/java/test/src/main/java/org/ray/api/benchmark/ActorPressTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.benchmark;
 
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
+import org.testng.annotations.Test;
 
 public class ActorPressTest extends RayBenchmarkTest {
 

--- a/java/test/src/main/java/org/ray/api/benchmark/MaxPressureTest.java
+++ b/java/test/src/main/java/org/ray/api/benchmark/MaxPressureTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.benchmark;
 
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
+import org.testng.annotations.Test;
 
 public class MaxPressureTest extends RayBenchmarkTest {
 

--- a/java/test/src/main/java/org/ray/api/benchmark/RateLimiterPressureTest.java
+++ b/java/test/src/main/java/org/ray/api/benchmark/RateLimiterPressureTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.benchmark;
 
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
+import org.testng.annotations.Test;
 
 public class RateLimiterPressureTest extends RayBenchmarkTest {
 

--- a/java/test/src/main/java/org/ray/api/benchmark/RayBenchmarkTest.java
+++ b/java/test/src/main/java/org/ray/api/benchmark/RayBenchmarkTest.java
@@ -6,7 +6,6 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Assert;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
@@ -14,6 +13,7 @@ import org.ray.api.annotation.RayRemote;
 import org.ray.api.test.BaseTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 
 public abstract class RayBenchmarkTest<T> extends BaseTest implements Serializable {
 

--- a/java/test/src/main/java/org/ray/api/benchmark/SingleLatencyTest.java
+++ b/java/test/src/main/java/org/ray/api/benchmark/SingleLatencyTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.benchmark;
 
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
+import org.testng.annotations.Test;
 
 public class SingleLatencyTest extends RayBenchmarkTest {
 

--- a/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
@@ -5,12 +5,12 @@ import static org.ray.runtime.util.SystemUtil.pid;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.annotation.RayRemote;
 import org.ray.api.options.ActorCreationOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class ActorReconstructionTest extends BaseTest {
 

--- a/java/test/src/main/java/org/ray/api/test/ActorTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorTest.java
@@ -1,7 +1,5 @@
 package org.ray.api.test;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
@@ -9,6 +7,8 @@ import org.ray.api.annotation.RayRemote;
 import org.ray.api.function.RayFunc2;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.RayActorImpl;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class ActorTest extends BaseTest {
 

--- a/java/test/src/main/java/org/ray/api/test/BaseTest.java
+++ b/java/test/src/main/java/org/ray/api/test/BaseTest.java
@@ -1,26 +1,29 @@
 package org.ray.api.test;
 
 import java.io.File;
-import org.junit.After;
-import org.junit.Before;
 import org.ray.api.Ray;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 
 public class BaseTest {
 
-  @Before
+  @BeforeMethod
   public void setUp() {
+    System.out.println("setUp");
     System.setProperty("ray.home", "../..");
     System.setProperty("ray.resources", "CPU:4,RES-A:4");
     Ray.init();
   }
 
-  @After
+  @AfterMethod
   public void tearDown() {
     // TODO(qwang): This is double check to check that the socket file is removed actually.
     // We could not enable this until `systemInfo` enabled.
     //File rayletSocketFIle = new File(Ray.systemInfo().rayletSocketName());
     Ray.shutdown();
-
+    System.out.println("tearDown");
     //remove raylet socket file
     //rayletSocketFIle.delete();
 

--- a/java/test/src/main/java/org/ray/api/test/BaseTest.java
+++ b/java/test/src/main/java/org/ray/api/test/BaseTest.java
@@ -11,7 +11,6 @@ public class BaseTest {
 
   @BeforeMethod
   public void setUp() {
-    System.out.println("setUp");
     System.setProperty("ray.home", "../..");
     System.setProperty("ray.resources", "CPU:4,RES-A:4");
     Ray.init();
@@ -23,7 +22,7 @@ public class BaseTest {
     // We could not enable this until `systemInfo` enabled.
     //File rayletSocketFIle = new File(Ray.systemInfo().rayletSocketName());
     Ray.shutdown();
-    System.out.println("tearDown");
+
     //remove raylet socket file
     //rayletSocketFIle.delete();
 

--- a/java/test/src/main/java/org/ray/api/test/FailureTest.java
+++ b/java/test/src/main/java/org/ray/api/test/FailureTest.java
@@ -1,11 +1,11 @@
 package org.ray.api.test;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.exception.RayException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class FailureTest extends BaseTest {
 

--- a/java/test/src/main/java/org/ray/api/test/HelloWorldTest.java
+++ b/java/test/src/main/java/org/ray/api/test/HelloWorldTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.test;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Hello world.

--- a/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
+++ b/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
@@ -9,13 +9,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
 import org.ray.api.annotation.RayRemote;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class MultiThreadingTest extends BaseTest {

--- a/java/test/src/main/java/org/ray/api/test/ObjectStoreTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ObjectStoreTest.java
@@ -3,12 +3,11 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.id.UniqueId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Test putting and getting objects.

--- a/java/test/src/main/java/org/ray/api/test/PlasmaFreeTest.java
+++ b/java/test/src/main/java/org/ray/api/test/PlasmaFreeTest.java
@@ -3,14 +3,13 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
 import org.ray.api.annotation.RayRemote;
 import org.ray.api.id.UniqueId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class PlasmaFreeTest extends BaseTest {

--- a/java/test/src/main/java/org/ray/api/test/RayCallTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayCallTest.java
@@ -2,15 +2,13 @@ package org.ray.api.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.ray.api.Ray;
 import org.ray.api.annotation.RayRemote;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Test Ray.call API
@@ -87,7 +85,7 @@ public class RayCallTest extends BaseTest {
     Assert.assertEquals(1, (long) Ray.call(RayCallTest::testLong, 1L).get());
     Assert.assertEquals(1.0, Ray.call(RayCallTest::testDouble, 1.0).get(), 0.0);
     Assert.assertEquals(1.0f, Ray.call(RayCallTest::testFloat, 1.0f).get(), 0.0);
-    Assert.assertEquals(true, Ray.call(RayCallTest::testBool, true).get());
+    // Assert.assertEquals(true, Ray.call(RayCallTest::testBool, true).get());
     Assert.assertEquals("foo", Ray.call(RayCallTest::testString, "foo").get());
     List<Integer> list = ImmutableList.of(1, 2, 3);
     Assert.assertEquals(list, Ray.call(RayCallTest::testList, list).get());

--- a/java/test/src/main/java/org/ray/api/test/RayCallTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayCallTest.java
@@ -85,7 +85,7 @@ public class RayCallTest extends BaseTest {
     Assert.assertEquals(1, (long) Ray.call(RayCallTest::testLong, 1L).get());
     Assert.assertEquals(1.0, Ray.call(RayCallTest::testDouble, 1.0).get(), 0.0);
     Assert.assertEquals(1.0f, Ray.call(RayCallTest::testFloat, 1.0f).get(), 0.0);
-    // Assert.assertEquals(true, Ray.call(RayCallTest::testBool, true).get());
+    Assert.assertTrue(Ray.call(RayCallTest::testBool, true).get());
     Assert.assertEquals("foo", Ray.call(RayCallTest::testString, "foo").get());
     List<Integer> list = ImmutableList.of(1, 2, 3);
     Assert.assertEquals(list, Ray.call(RayCallTest::testList, list).get());

--- a/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
@@ -1,10 +1,10 @@
 package org.ray.api.test;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.runtime.config.RayConfig;
 import org.ray.runtime.config.RunMode;
 import org.ray.runtime.config.WorkerMode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class RayConfigTest {
 

--- a/java/test/src/main/java/org/ray/api/test/RayMethodsTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayMethodsTest.java
@@ -3,11 +3,11 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Integration test for Ray.*

--- a/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ResourcesManagementTest.java
@@ -2,8 +2,6 @@ package org.ray.api.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
@@ -11,6 +9,8 @@ import org.ray.api.WaitResult;
 import org.ray.api.annotation.RayRemote;
 import org.ray.api.options.ActorCreationOptions;
 import org.ray.api.options.CallOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Resources Management Test.

--- a/java/test/src/main/java/org/ray/api/test/StressTest.java
+++ b/java/test/src/main/java/org/ray/api/test/StressTest.java
@@ -3,12 +3,12 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
 import org.ray.api.id.UniqueId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class StressTest extends BaseTest {
 

--- a/java/test/src/main/java/org/ray/api/test/UniqueIdTest.java
+++ b/java/test/src/main/java/org/ray/api/test/UniqueIdTest.java
@@ -2,12 +2,11 @@ package org.ray.api.test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.List;
 import javax.xml.bind.DatatypeConverter;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.util.UniqueIdUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class UniqueIdTest {
 

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -3,12 +3,12 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.WaitResult;
 import org.ray.api.annotation.RayRemote;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class WaitTest extends BaseTest {
 

--- a/java/test/src/main/java/org/ray/api/test/WordCountTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WordCountTest.java
@@ -3,11 +3,12 @@ package org.ray.api.test;
 import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assert;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.annotation.RayRemote;
 import org.ray.runtime.util.FileUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * given a directory of document files on each "machine", we would like to count the appearance of


### PR DESCRIPTION
## What do these changes do?
`testNG` is a better modern test framework than `junit`. some advantages are:
1. `testNG` have clearer annotations than `junit`, like `BeforeMethod` and `BeforeSuite` vs `Before`.
2. `testNG` have richer annotations: http://www.mkyong.com/unittest/junit-4-vs-testng-comparison/

etc.

in short, it's time to use `testNG` instead of `junit`.


## Related issue number
N/A