### PR TITLE
minor fix for string formatting

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -449,7 +449,7 @@ class FunctionActorManager(object):
         except KeyError as e:
             message = ("Error occurs in get_execution_info: "
                        "driver_id: %s, function_descriptor: %s. Message: %s" %
-                       driver_id, function_descriptor, e)
+                       (driver_id, function_descriptor, e))
             raise KeyError(message)
         return info
 


### PR DESCRIPTION
## What do these changes do?

The bracket is lost in the expression, so there is not enough arguments for format string.