### PR TITLE
Fix get null current driver id in actor in subthread

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -1,5 +1,6 @@
 package org.ray.runtime;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -215,6 +216,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, Object[] args, CallOptions options) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(func, RayActorImpl.NIL, args, false, options);
     rayletClient.submitTask(spec);
     return new RayObjectImpl(spec.returnIds[0]);
@@ -222,6 +224,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, RayActor actor, Object[] args) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     if (!(actor instanceof RayActorImpl)) {
       throw new IllegalArgumentException("Unsupported actor type: " + actor.getClass().getName());
     }
@@ -240,6 +243,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   @SuppressWarnings("unchecked")
   public <T> RayActor<T> createActor(RayFunc actorFactoryFunc,
       Object[] args, ActorCreationOptions options) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(actorFactoryFunc, RayActorImpl.NIL,
         args, true, options);
     RayActorImpl<?> actor = new RayActorImpl(spec.returnIds[0]);

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -95,7 +95,12 @@ public class Worker {
         currentActorId = returnId;
       }
     } finally {
-      runtime.getWorkerContext().setCurrentTask(null, null);
+      // Don't need to reset current driver id if the worker is an actor.
+      // Because the following tasks should all have the same driver id.
+      if (!spec.isActorTask() && !spec.isActorCreationTask()) {
+        runtime.getWorkerContext().setCurrentTask(null, null);
+      }
+
       Thread.currentThread().setContextClassLoader(oldLoader);
     }
   }

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -620,6 +620,9 @@ class Worker(object):
             self.task_context.task_index += 1
             # The parent task must be set for the submitted task.
             assert not self.current_task_id.is_nil()
+            # Current driver id must not be nil when submitting a task.
+            # Because every task must belong to a driver.
+            assert not self.task_driver_id.is_nil()
             # Submit the task to local scheduler.
             function_descriptor_list = (
                 function_descriptor.get_function_descriptor_list())


### PR DESCRIPTION
## What do these changes do?
There are 2 changes in this PR:
1 .[Java] 
For actor task , we should not set current task , current driver id to null, otherwise it will be crashed when a worker sub thread submitting task because of null current task id etc.

2. [Java & Python]
Add `assert current driver id is not nil` when submitting task. 

## Related issue number
N/A