### PR TITLE
Fix compilation error on ARM.

### DIFF
--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -68,8 +68,7 @@ TEST(SignalTest, SIGILL_Test) {
   pid = fork();
   ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
-    // This code will cause SIGILL sent.
-    asm("ud2");
+    std::raise(SIGILL);
   } else {
     Sleep();
     RAY_LOG(ERROR) << "SIGILL_Test: kill pid " << pid

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -1,7 +1,6 @@
 #include <signal.h>
 #include <cstdlib>
 #include <iostream>
-#include <csignal>
 
 #include "gtest/gtest.h"
 #include "ray/util/logging.h"
@@ -69,7 +68,7 @@ TEST(SignalTest, SIGILL_Test) {
   pid = fork();
   ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
-    std::raise(SIGILL);
+    raise(SIGILL);
   } else {
     Sleep();
     RAY_LOG(ERROR) << "SIGILL_Test: kill pid " << pid

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -1,6 +1,7 @@
 #include <signal.h>
 #include <cstdlib>
 #include <iostream>
+#include <csignal>
 
 #include "gtest/gtest.h"
 #include "ray/util/logging.h"


### PR DESCRIPTION
This removes an x86 assembler instruction that prevented compilation on aarch64.

According to https://github.com/ray-project/ray/issues/3767 this allows ray to be compiled on the NVIDIA Jetson Xavier board.