### PR TITLE
Allow manually writing to return ObjectIDs from tasks/actor methods

### DIFF
--- a/python/ray/experimental/no_return.py
+++ b/python/ray/experimental/no_return.py
@@ -1,0 +1,11 @@
+class NoReturn(object):
+    """Do not store the return value in the object store.
+
+    If a task returns this object, then Ray will not store this object in the
+    object store. Calling `ray.get` on the task's return ObjectIDs may block
+    indefinitely unless the task manually stores a objects corresponding to the
+    ObjectIds.
+    """
+
+    def __init__(self):
+        raise TypeError("The `NoReturn` object should not be instantiated")

--- a/python/ray/experimental/no_return.py
+++ b/python/ray/experimental/no_return.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
 class NoReturn(object):
     """Do not store the return value in the object store.
 

--- a/python/ray/experimental/no_return.py
+++ b/python/ray/experimental/no_return.py
@@ -8,8 +8,8 @@ class NoReturn(object):
 
     If a task returns this object, then Ray will not store this object in the
     object store. Calling `ray.get` on the task's return ObjectIDs may block
-    indefinitely unless the task manually stores a objects corresponding to the
-    ObjectIds.
+    indefinitely unless the task manually stores an object for the
+    corresponding ObjectID.
     """
 
     def __init__(self):

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -49,6 +49,22 @@ def test_set_multiple_outputs(ray_start, set_out0, set_out1, set_out2):
     assert ray.get(result_object_ids) == [set_out0, set_out1, set_out2]
 
 
+def test_set_actor_method(ray_start):
+    @ray.remote
+    class Actor(object):
+        def __init__(self):
+            pass
+
+        def ping(self):
+            return_object_ids = ray.worker.global_worker._current_task.returns(
+            )
+            ray.worker.global_worker.put_object(return_object_ids[0], 123)
+            return ray.experimental.no_return.NoReturn
+
+    actor = Actor.remote()
+    assert ray.get(actor.ping.remote()) == 123
+
+
 def test_exception(ray_start):
     @ray.remote(num_return_vals=2)
     def f():

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -31,7 +31,7 @@ def test_set_single_output(ray_start):
 
 def test_set_multiple_outputs(ray_start):
     @ray.remote(num_return_vals=3)
-    def f(set_out0, set_out1, set_out3):
+    def f(set_out0, set_out1, set_out2):
         returns = []
         return_object_ids = ray.worker.global_worker._current_task.returns()
         for i, set_out in enumerate([set_out0, set_out1, set_out2]):
@@ -90,4 +90,5 @@ def test_no_set_and_no_return(ray_start):
         return ray.experimental.no_return.NoReturn
 
     object_id = f.remote()
-    assert ray.get(object_id) is ray.experimental.no_return.NoReturn
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.get(object_id)

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -90,5 +90,6 @@ def test_no_set_and_no_return(ray_start):
         return ray.experimental.no_return.NoReturn
 
     object_id = f.remote()
-    with pytest.raises(ray.exceptions.RayTaskError):
+    with pytest.raises(ray.exceptions.RayTaskError) as e:
         ray.get(object_id)
+    assert "Attempting to return 'ray.experimental.NoReturn'" in str(e.value)

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -3,10 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-try:
-    import pytest_timeout
-except ImportError:
-    pytest_timeout = None
 
 import ray
 import ray.exceptions
@@ -86,10 +82,6 @@ def test_exception(ray_start):
         ray.get(exception_id)
 
 
-@pytest.mark.skipif(
-    pytest_timeout is None,
-    reason="Timeout package not installed; skipping test that may hang.")
-@pytest.mark.timeout(5)
 def test_no_set_and_no_return(ray_start):
     @ray.remote
     def f():

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import pytest
 try:
     import pytest_timeout

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -29,10 +29,7 @@ def test_set_single_output(ray_start):
     assert ray.get(f.remote()) == 123
 
 
-@pytest.mark.parametrize("set_out0", [True, False])
-@pytest.mark.parametrize("set_out1", [True, False])
-@pytest.mark.parametrize("set_out2", [True, False])
-def test_set_multiple_outputs(ray_start, set_out0, set_out1, set_out2):
+def test_set_multiple_outputs(ray_start):
     @ray.remote(num_return_vals=3)
     def f(set_out0, set_out1, set_out3):
         returns = []
@@ -45,8 +42,13 @@ def test_set_multiple_outputs(ray_start, set_out0, set_out1, set_out2):
                 returns.append(False)
         return tuple(returns)
 
-    result_object_ids = f.remote(set_out0, set_out1, set_out2)
-    assert ray.get(result_object_ids) == [set_out0, set_out1, set_out2]
+    for set_out0 in [True, False]:
+        for set_out1 in [True, False]:
+            for set_out2 in [True, False]:
+                result_object_ids = f.remote(set_out0, set_out1, set_out2)
+                assert ray.get(result_object_ids) == [
+                    set_out0, set_out1, set_out2
+                ]
 
 
 def test_set_actor_method(ray_start):
@@ -71,7 +73,7 @@ def test_exception(ray_start):
         return_object_ids = ray.worker.global_worker._current_task.returns()
         # The first return value is successfully stored in the object store
         ray.worker.global_worker.put_object(return_object_ids[0], 123)
-        raise Exception
+        raise Exception("Error")
         # The exception is stored at the second return objcet ID.
         return ray.experimental.no_return.NoReturn, 456
 

--- a/python/ray/tests/test_set_task_returns.py
+++ b/python/ray/tests/test_set_task_returns.py
@@ -1,0 +1,79 @@
+import pytest
+try:
+    import pytest_timeout
+except ImportError:
+    pytest_timeout = None
+
+import ray
+import ray.exceptions
+import ray.experimental.no_return
+import ray.worker
+
+
+@pytest.fixture
+def ray_start():
+    # Start the Ray processes.
+    ray.init(num_cpus=1)
+    yield None
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+def test_set_single_output(ray_start):
+    @ray.remote
+    def f():
+        return_object_ids = ray.worker.global_worker._current_task.returns()
+        ray.worker.global_worker.put_object(return_object_ids[0], 123)
+        return ray.experimental.no_return.NoReturn
+
+    assert ray.get(f.remote()) == 123
+
+
+@pytest.mark.parametrize("set_out0", [True, False])
+@pytest.mark.parametrize("set_out1", [True, False])
+@pytest.mark.parametrize("set_out2", [True, False])
+def test_set_multiple_outputs(ray_start, set_out0, set_out1, set_out2):
+    @ray.remote(num_return_vals=3)
+    def f(set_out0, set_out1, set_out3):
+        returns = []
+        return_object_ids = ray.worker.global_worker._current_task.returns()
+        for i, set_out in enumerate([set_out0, set_out1, set_out2]):
+            if set_out:
+                ray.worker.global_worker.put_object(return_object_ids[i], True)
+                returns.append(ray.experimental.no_return.NoReturn)
+            else:
+                returns.append(False)
+        return tuple(returns)
+
+    result_object_ids = f.remote(set_out0, set_out1, set_out2)
+    assert ray.get(result_object_ids) == [set_out0, set_out1, set_out2]
+
+
+def test_exception(ray_start):
+    @ray.remote(num_return_vals=2)
+    def f():
+        return_object_ids = ray.worker.global_worker._current_task.returns()
+        # The first return value is successfully stored in the object store
+        ray.worker.global_worker.put_object(return_object_ids[0], 123)
+        raise Exception
+        # The exception is stored at the second return objcet ID.
+        return ray.experimental.no_return.NoReturn, 456
+
+    object_id, exception_id = f.remote()
+
+    assert ray.get(object_id) == 123
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.get(exception_id)
+
+
+@pytest.mark.skipif(
+    pytest_timeout is None,
+    reason="Timeout package not installed; skipping test that may hang.")
+@pytest.mark.timeout(5)
+def test_no_set_and_no_return(ray_start):
+    @ray.remote
+    def f():
+        return ray.experimental.no_return.NoReturn
+
+    object_id = f.remote()
+    assert ray.get(object_id) is ray.experimental.no_return.NoReturn

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -164,6 +164,7 @@ class Worker(object):
         # Index of the current session. This number will
         # increment every time when `ray.shutdown` is called.
         self._session_index = 0
+        self._return_object_ids = []
 
     @property
     def task_context(self):
@@ -206,6 +207,10 @@ class Worker(object):
     @property
     def current_task_id(self):
         return self.task_context.current_task_id
+
+    @property
+    def return_object_ids(self):
+        return list(self._return_object_ids)
 
     def mark_actor_init_failed(self, error):
         """Called to mark this actor as failed during initialization."""
@@ -825,6 +830,7 @@ class Worker(object):
             task.function_descriptor_list())
         args = task.arguments()
         return_object_ids = task.returns()
+        self._return_object_ids = return_object_ids
         if (not task.actor_id().is_nil()
                 or not task.actor_creation_id().is_nil()):
             dummy_return_id = return_object_ids.pop()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -830,7 +830,6 @@ class Worker(object):
             task.function_descriptor_list())
         args = task.arguments()
         return_object_ids = task.returns()
-        self._return_object_ids = return_object_ids
         if (not task.actor_id().is_nil()
                 or not task.actor_creation_id().is_nil()):
             dummy_return_id = return_object_ids.pop()
@@ -853,6 +852,7 @@ class Worker(object):
 
         # Execute the task.
         try:
+            self._return_object_ids = return_object_ids
             with profiling.profile("task:execute"):
                 if (task.actor_id().is_nil()
                         and task.actor_creation_id().is_nil()):
@@ -873,6 +873,8 @@ class Worker(object):
             self._handle_process_task_failure(
                 function_descriptor, return_object_ids, e, traceback_str)
             return
+        finally:
+            self._return_object_ids = []
 
         # Store the outputs in the local object store.
         try:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -795,7 +795,7 @@ class Worker(object):
             if outputs[i] is ray.experimental.no_return.NoReturn:
                 if not self.plasma_client.contains(
                         pyarrow.plasma.ObjectID(object_ids[i].binary())):
-                    raise ValueError(
+                    raise RuntimeError(
                         "Attempting to return `ray.experimental.NoReturn` "
                         "from a remote function, but the corresponding "
                         "ObjectID does not exist in the local object store.")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -894,7 +894,7 @@ class Worker(object):
                     # If this is an actor task, then the last object ID returned by
                     # the task is a dummy output, not returned by the function
                     # itself. Decrement to get the correct number of return values.
-                    num_returns = len(return_object_ids)
+                   num_returns = len(return_object_ids)
                     if num_returns == 1:
                         outputs = (outputs, )
                     self._store_outputs_in_object_store(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -796,7 +796,7 @@ class Worker(object):
                 if not self.plasma_client.contains(
                         pyarrow.plasma.ObjectID(object_ids[i].binary())):
                     raise RuntimeError(
-                        "Attempting to return `ray.experimental.NoReturn` "
+                        "Attempting to return 'ray.experimental.NoReturn' "
                         "from a remote function, but the corresponding "
                         "ObjectID does not exist in the local object store.")
             else:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Allows manually writing to return ObjectIDs from tasks and actor methods.

Implements the `ray.worker.Worker.return_object_ids` property which provides the list of ObjectIDs returned by the current task/actor method.

Also adds the `ray.worker.RayNoReturn` class which when returned signals not to store the return value in the object store .

This works for tasks:
```python
In [3]: @ray.remote
   ...: def f():
   ...:     oid = ray.worker.global_worker.return_object_ids[0]
   ...:     ray.worker.global_worker.put_object(oid, 123)
   ...:     return ray.worker.RayNoReturn()
   ...: 
   ...: 

In [4]: ray.get(f.remote())
Out[4]: 123
```
As well as actors:
```python
In [3]: @ray.remote
   ...: class Foo:
   ...:     def bar(self):
   ...:         oid = ray.worker.global_worker.return_object_ids[0]
   ...:         ray.worker.global_worker.put_object(oid, 123)
   ...:         return ray.worker.RayNoReturn
   ...: 

In [4]: f = Foo.remote()

In [5]: ray.get(f.bar.remote())
Out[5]: 123
```