### PR TITLE
[Java] Fix `setCurrentTask()` in multi threading

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -216,7 +216,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, Object[] args, CallOptions options) {
-    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(func, RayActorImpl.NIL, args, false, options);
     rayletClient.submitTask(spec);
     return new RayObjectImpl(spec.returnIds[0]);
@@ -224,7 +223,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, RayActor actor, Object[] args) {
-    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     if (!(actor instanceof RayActorImpl)) {
       throw new IllegalArgumentException("Unsupported actor type: " + actor.getClass().getName());
     }
@@ -243,7 +241,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   @SuppressWarnings("unchecked")
   public <T> RayActor<T> createActor(RayFunc actorFactoryFunc,
       Object[] args, ActorCreationOptions options) {
-    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(actorFactoryFunc, RayActorImpl.NIL,
         args, true, options);
     RayActorImpl<?> actor = new RayActorImpl(spec.returnIds[0]);

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -1,6 +1,5 @@
 package org.ray.runtime;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -1,5 +1,6 @@
 package org.ray.runtime;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -215,6 +216,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, Object[] args, CallOptions options) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(func, RayActorImpl.NIL, args, false, options);
     rayletClient.submitTask(spec);
     return new RayObjectImpl(spec.returnIds[0]);
@@ -222,6 +224,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   @Override
   public RayObject call(RayFunc func, RayActor actor, Object[] args) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     if (!(actor instanceof RayActorImpl)) {
       throw new IllegalArgumentException("Unsupported actor type: " + actor.getClass().getName());
     }
@@ -240,6 +243,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   @SuppressWarnings("unchecked")
   public <T> RayActor<T> createActor(RayFunc actorFactoryFunc,
       Object[] args, ActorCreationOptions options) {
+    Preconditions.checkState(!workerContext.getCurrentDriverId().isNil());
     TaskSpec spec = createTaskSpec(actorFactoryFunc, RayActorImpl.NIL,
         args, true, options);
     RayActorImpl<?> actor = new RayActorImpl(spec.returnIds[0]);

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -59,8 +59,7 @@ public class Worker {
       RayFunction rayFunction = runtime.getFunctionManager()
           .getFunction(spec.driverId, spec.functionDescriptor);
       // Set context
-      runtime.getWorkerContext().setCurrentTask(
-          spec.taskId, spec.driverId, rayFunction.classLoader);
+      runtime.getWorkerContext().setCurrentTask(spec, rayFunction.classLoader);
       Thread.currentThread().setContextClassLoader(rayFunction.classLoader);
       // Get local actor object and arguments.
       Object actor = null;
@@ -96,15 +95,6 @@ public class Worker {
         currentActorId = returnId;
       }
     } finally {
-      if (spec.isActorTask() || spec.isActorCreationTask()) {
-        // Don't need to reset current driver id if the worker is an actor.
-        // Because the following tasks should all have the same driver id.
-        runtime.getWorkerContext().setCurrentTask(null, spec.driverId, null);
-      } else {
-        // For normal task, we should set current task id to null as well.
-        runtime.getWorkerContext().setCurrentTask(null, null, null);
-      }
-
       Thread.currentThread().setContextClassLoader(oldLoader);
     }
   }

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -95,7 +95,12 @@ public class Worker {
         currentActorId = returnId;
       }
     } finally {
-      runtime.getWorkerContext().setCurrentTask(null, null);
+      // Don't need to reset current driver id if the worker is an actor.
+      // Because the following tasks should all have the same driver id.
+      if (!spec.isActorTask() && !spec.isActorCreationTask()) {
+        runtime.getWorkerContext().setCurrentTask(null, null);
+      }
+
       Thread.currentThread().setContextClassLoader(oldLoader);
     }
   }

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -60,7 +60,7 @@ public class Worker {
           .getFunction(spec.driverId, spec.functionDescriptor);
       // Set context
       runtime.getWorkerContext().setCurrentTask(
-        spec.taskId, spec.driverId, rayFunction.classLoader);
+          spec.taskId, spec.driverId, rayFunction.classLoader);
       Thread.currentThread().setContextClassLoader(rayFunction.classLoader);
       // Get local actor object and arguments.
       Object actor = null;

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -47,7 +47,7 @@ public class WorkerContext {
       currentClassLoader = null;
     } else {
       workerId = UniqueId.randomId();
-      setCurrentTask(null, null);
+      setCurrentTask(null, null, null);
     }
   }
 
@@ -63,18 +63,15 @@ public class WorkerContext {
    * Set the current task which is being executed by the current worker. Note, this method can only
    * be called from the main thread.
    */
-  public void setCurrentTask(TaskSpec task, ClassLoader classLoader) {
+  public void setCurrentTask(UniqueId currentTaskId,
+      UniqueId currentDriverId, ClassLoader classLoader) {
     Preconditions.checkState(
         Thread.currentThread().getId() == mainThreadId,
         "This method should only be called from the main thread."
     );
-    if (task != null) {
-      currentTaskId.set(task.taskId);
-      currentDriverId = task.driverId;
-    } else {
-      currentTaskId.set(UniqueId.NIL);
-      currentDriverId = UniqueId.NIL;
-    }
+
+    this.currentTaskId.set(currentTaskId);
+    this.currentDriverId = currentDriverId;
     taskIndex.set(0);
     putIndex.set(0);
     currentClassLoader = classLoader;

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -40,14 +40,15 @@ public class WorkerContext {
     taskIndex = ThreadLocal.withInitial(() -> 0);
     putIndex = ThreadLocal.withInitial(() -> 0);
     currentTaskId = ThreadLocal.withInitial(UniqueId::randomId);
+    currentClassLoader = null;
     if (workerMode == WorkerMode.DRIVER) {
       workerId = driverId;
       currentTaskId.set(UniqueId.randomId());
       currentDriverId = driverId;
-      currentClassLoader = null;
     } else {
       workerId = UniqueId.randomId();
-      setCurrentTask(null, null, null);
+      this.currentTaskId.set(UniqueId.NIL);
+      this.currentDriverId = UniqueId.NIL;
     }
   }
 
@@ -63,15 +64,15 @@ public class WorkerContext {
    * Set the current task which is being executed by the current worker. Note, this method can only
    * be called from the main thread.
    */
-  public void setCurrentTask(UniqueId currentTaskId,
-      UniqueId currentDriverId, ClassLoader classLoader) {
+  public void setCurrentTask(TaskSpec task, ClassLoader classLoader) {
     Preconditions.checkState(
         Thread.currentThread().getId() == mainThreadId,
         "This method should only be called from the main thread."
     );
 
-    this.currentTaskId.set(currentTaskId);
-    this.currentDriverId = currentDriverId;
+    Preconditions.checkNotNull(task);
+    this.currentTaskId.set(task.taskId);
+    this.currentDriverId = task.driverId;
     taskIndex.set(0);
     putIndex.set(0);
     currentClassLoader = classLoader;

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -620,6 +620,9 @@ class Worker(object):
             self.task_context.task_index += 1
             # The parent task must be set for the submitted task.
             assert not self.current_task_id.is_nil()
+            # Current driver id must not be nil when submitting a task.
+            # Because every task must belong to a driver.
+            assert not self.task_driver_id.is_nil()
             # Submit the task to local scheduler.
             function_descriptor_list = (
                 function_descriptor.get_function_descriptor_list())


### PR DESCRIPTION
## What do these changes do?
For actor tasks , we should not set current driver id to null.

## Related issue number
N/A