### PR TITLE
Create a PullManager class in the object manager.

### DIFF
--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -33,6 +33,7 @@ set(RAY_SRCS
   object_manager/object_store_notification_manager.cc
   object_manager/object_directory.cc
   object_manager/object_manager.cc
+  object_manager/pull_manager.cc
   raylet/monitor.cc
   raylet/mock_gcs_client.cc
   raylet/task.cc

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -122,6 +122,10 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
       create_buffer_state_[object_id].chunk_info[chunk_index], ray::Status::OK());
 }
 
+// TODO(rkn): There's something weird about the abort logic here. It only aborts if all chunks are
+// in the available state, but maybe it should abort if all chunks are either available or sealed.
+// Also, if we abort a chunk, then a subsequent create might just recreate the object and leave it
+// only partially filled.
 void ObjectBufferPool::AbortCreateChunk(const ObjectID &object_id,
                                         const uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -122,10 +122,11 @@ std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> ObjectBufferPool::Cr
       create_buffer_state_[object_id].chunk_info[chunk_index], ray::Status::OK());
 }
 
-// TODO(rkn): There's something weird about the abort logic here. It only aborts if all chunks are
-// in the available state, but maybe it should abort if all chunks are either available or sealed.
-// Also, if we abort a chunk, then a subsequent create might just recreate the object and leave it
-// only partially filled.
+// TODO(rkn): There's something weird about the abort logic here. It only aborts
+// if all chunks are in the available state, but maybe it should abort if all
+// chunks are either available or sealed. Also, if we abort a chunk, then a
+// subsequent create might just recreate the object and leave it only partially
+// filled.
 void ObjectBufferPool::AbortCreateChunk(const ObjectID &object_id,
                                         const uint64_t chunk_index) {
   std::lock_guard<std::mutex> lock(pool_mutex_);

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -78,7 +78,7 @@ class ObjectDirectoryInterface {
   /// \param callback_id The id associated with the specified callback. This is
   /// needed when UnsubscribeObjectLocations is called.
   /// \param object_id The required object's ObjectID.
-  /// \param success_cb Invoked with non-empty list of client ids and object_id.
+  /// \param callback Invoked with non-empty list of client ids and object_id.
   /// \return Status of whether subscription succeeded.
   virtual ray::Status SubscribeObjectLocations(const UniqueID &callback_id,
                                                const ObjectID &object_id,

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -21,11 +21,12 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
       send_work_(send_service_),
       receive_work_(receive_service_),
       connection_pool_(),
-      pull_manager_(*main_service_, client_id_, [this](
-          const std::vector<ray::ClientID> &clients_to_request,
-          const std::vector<ray::ClientID> &clients_to_cancel, bool abort_object) {
-              HandleObjectRequestCancelAbort(clients_to_request, clients_to_cancel,
-                                             abort_object);
+      pull_manager_(
+          *main_service_, client_id_,
+          [this](const std::vector<ray::ClientID> &clients_to_request,
+                 const std::vector<ray::ClientID> &clients_to_cancel, bool abort_object) {
+            HandleObjectRequestCancelAbort(clients_to_request, clients_to_cancel,
+                                           abort_object);
           }),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {
   RAY_CHECK(config_.max_sends > 0);

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -9,9 +9,9 @@ namespace object_manager_protocol = ray::object_manager::protocol;
 
 namespace ray {
 
-void HandleObjectRequestCancelAbort(
-    const std::vector<ray::ClientID> &clients_to_request,
-    const std::vector<ray::ClientID> &clients_to_cancel, bool abort_object) {
+void HandleObjectRequestCancelAbort(const std::vector<ray::ClientID> &clients_to_request,
+                                    const std::vector<ray::ClientID> &clients_to_cancel,
+                                    bool abort_object) {
 }
 
 ObjectManager::ObjectManager(asio::io_service &main_service,
@@ -829,7 +829,8 @@ void ObjectManager::ReceivePushRequest(std::shared_ptr<TcpClientConnection> &con
   int64_t num_chunks = buffer_pool_.GetNumChunks(data_size + metadata_size);
   pull_manager_.ReceivePushRequest(object_id, client_id, chunk_index, num_chunks);
 
-  receive_service_.post([this, object_id, client_id, data_size, metadata_size, chunk_index, conn]() {
+  receive_service_.post([this, object_id, client_id, data_size, metadata_size,
+                         chunk_index, conn]() {
     double start_time = current_sys_time_seconds();
 
     auto status = ExecuteReceiveObject(client_id, object_id, data_size, metadata_size,

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -25,6 +25,7 @@
 #include "ray/object_manager/object_directory.h"
 #include "ray/object_manager/object_manager_client_connection.h"
 #include "ray/object_manager/object_store_notification_manager.h"
+#include "ray/object_manager/pull_manager.h"
 
 namespace ray {
 
@@ -80,7 +81,7 @@ class ObjectManager : public ObjectManagerInterface {
                          const ObjectManagerConfig &config,
                          std::shared_ptr<ObjectDirectoryInterface> object_directory);
 
-  ~ObjectManager();
+  virtual ~ObjectManager();
 
   /// Register GCS-related functionality.
   void RegisterGcs();
@@ -405,6 +406,8 @@ class ObjectManager : public ObjectManagerInterface {
   /// The objects that this object manager is currently trying to fetch from
   /// remote object managers.
   std::unordered_map<ObjectID, PullRequest> pull_requests_;
+
+  PullManager pull_manager_;
 
   /// Profiling events that are to be batched together and added to the profile
   /// table in the GCS.

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -258,6 +258,18 @@ class ObjectManager : public ObjectManagerInterface {
   /// Register object remove with directory.
   void NotifyDirectoryObjectDeleted(const ObjectID &object_id);
 
+  /// This callback is responsible for issuing the object requests and object
+  /// cancellation requests decided on by the pull manager.
+  ///
+  /// \param clients_to_request The object managers to issue object requests to.
+  /// \param clients_to_cancel The object managers to issue cancellation
+  /// requests to.
+  /// \param abort_object True if the object creation should be aborted.
+  /// \return Void.
+  void HandleObjectRequestCancelAbort(
+      const std::vector<ray::ClientID> &clients_to_request,
+      const std::vector<ray::ClientID> &clients_to_cancel, bool abort_object);
+
   /// Part of an asynchronous sequence of Pull methods.
   /// Uses an existing connection or creates a connection to ClientID.
   /// Executes on main_service_ thread.

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -6,16 +6,10 @@
 
 namespace ray {
 
-PullInfo::PullInfo(bool required, const ObjectID &object_id,
-                   boost::asio::io_service &main_service,
-                   const std::function<void()> &timer_callback)
+PullInfo::PullInfo(bool required, const ObjectID &object_id)
     : required(required),
       total_num_chunks(-1),
-      num_in_progress_chunk_ids(0),
-      retry_timer(main_service),
-      timer_callback(timer_callback) {
-  RestartTimer(main_service);
-}
+      num_in_progress_chunk_ids(0) {}
 
 void PullInfo::InitializeChunksIfNecessary(int64_t num_chunks) {
   if (total_num_chunks == -1) {
@@ -32,56 +26,37 @@ bool PullInfo::LifetimeEnded() {
   return !required && client_receiving_from.is_nil() && num_in_progress_chunk_ids == 0;
 }
 
-void PullInfo::RestartTimer(boost::asio::io_service &main_service) {
-  // Create a new timer. This will cancel the old timer.
-  retry_timer = boost::asio::deadline_timer(main_service);
-  boost::posix_time::milliseconds retry_timeout(
-      RayConfig::instance().object_manager_pull_timeout_ms());
-  retry_timer.expires_from_now(retry_timeout);
-  // Pass a copy of the callback into the timer.
-  auto &timer_callback_copy = timer_callback;
-  retry_timer.async_wait([timer_callback_copy](const boost::system::error_code &error) {
-    if (!error) {
-      timer_callback_copy();
-    } else {
-      // Check that the error was due to the timer being canceled.
-      RAY_CHECK(error == boost::asio::error::operation_aborted);
-    }
-  });
-}
-
-PullManager::PullManager(boost::asio::io_service &main_service, const ClientID &client_id,
-                         const ObjectRequestManagementCallback &callback)
+PullManager::PullManager(const ClientID &client_id)
     : total_pull_calls_(0),
       total_cancel_calls_(0),
       total_successful_chunk_reads_(0),
       total_failed_chunk_reads_(0),
-      main_service_(main_service),
       client_id_(client_id),
-      callback_(callback),
       gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
 
 void PullManager::ReceivePushRequest(const ObjectID &object_id, const ClientID &client_id,
-                                     int64_t chunk_index, int64_t num_chunks) {
+                                     int64_t chunk_index, int64_t num_chunks,
+                                     std::vector<ClientID> *clients_to_cancel,
+                                     bool *start_timer) {
+  *start_timer = false;
   RAY_CHECK(client_id != client_id_);
-  std::vector<ClientID> clients_to_cancel;
+  *clients_to_cancel = std::vector<ClientID>();
 
   auto it = pulls_.find(object_id);
   if (it == pulls_.end()) {
+    *start_timer = true;
     auto insertion_it = pulls_.insert(std::make_pair(
-        object_id, std::unique_ptr<PullInfo>(
-                       new PullInfo(false, object_id, main_service_,
-                                    [this, object_id]() { TimerExpires(object_id); }))));
+        object_id, PullInfo(false, object_id)));
 
     RAY_CHECK(insertion_it.second);
     it = insertion_it.first;
 
-    auto &pull_info = *it->second;
+    auto &pull_info = it->second;
     RAY_CHECK(!pull_info.required);
     pull_info.client_receiving_from = client_id;
     pull_info.InitializeChunksIfNecessary(num_chunks);
   } else {
-    auto &pull_info = *it->second;
+    auto &pull_info = it->second;
     if (pull_info.client_receiving_from.is_nil()) {
       pull_info.InitializeChunksIfNecessary(num_chunks);
       pull_info.client_receiving_from = client_id;
@@ -89,7 +64,7 @@ void PullManager::ReceivePushRequest(const ObjectID &object_id, const ClientID &
       // except for this one.
       for (auto const &client_requested_from : pull_info.clients_requested_from) {
         if (client_requested_from != client_id) {
-          clients_to_cancel.push_back(client_requested_from);
+          clients_to_cancel->push_back(client_requested_from);
         }
       }
       pull_info.clients_requested_from.clear();
@@ -100,25 +75,26 @@ void PullManager::ReceivePushRequest(const ObjectID &object_id, const ClientID &
     }
   }
 
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
   RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
   pull_info.num_in_progress_chunk_ids++;
-
-  // Cancel the request from everyone else.
-  callback_(std::vector<ClientID>(), clients_to_cancel, /* abort */ false);
 }
 
 // If the object is required and if we are not already receiving the object from
 // some object manager, request the object from any object managers that we have
 // not already requested the object from.
 void PullManager::NewObjectLocations(
-    const ObjectID &object_id, const std::unordered_set<ClientID> &clients_with_object) {
+    const ObjectID &object_id, const std::unordered_set<ClientID> &clients_with_object,
+    std::vector<ClientID> *clients_to_request, bool *restart_timer) {
+  *clients_to_request = std::vector<ClientID>();
+  *restart_timer = false;
+
   auto it = pulls_.find(object_id);
   if (it == pulls_.end()) {
     return;
   }
 
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
   pull_info.clients_with_object = clients_with_object;
 
   if (!pull_info.required) {
@@ -131,51 +107,58 @@ void PullManager::NewObjectLocations(
     return;
   }
 
-  std::vector<ClientID> clients_to_request;
   for (auto const &client_id : pull_info.clients_with_object) {
     if (pull_info.clients_requested_from.count(client_id) == 0) {
-      clients_to_request.push_back(client_id);
+      clients_to_request->push_back(client_id);
       pull_info.clients_requested_from.insert(client_id);
     }
   }
 
-  if (!clients_to_request.empty()) {
-    pull_info.RestartTimer(main_service_);
+  if (!clients_to_request->empty()) {
+    *restart_timer = true;
   }
-  callback_(clients_to_request, std::vector<ClientID>(), /* abort */ false);
 }
 
-void PullManager::PullObject(const ObjectID &object_id) {
+void PullManager::PullObject(const ObjectID &object_id, bool *subscribe_to_locations,
+                             bool *start_timer) {
   ++total_pull_calls_;
+  // The subscribe_to_locations variable should be set to true precisely when
+  // the object becomes "required" for the first time.
+  *subscribe_to_locations = true;
+  *start_timer = false;
   auto it = pulls_.find(object_id);
 
   if (it == pulls_.end()) {
+    *start_timer = true;
     auto insertion_it = pulls_.insert(std::make_pair(
-        object_id, std::unique_ptr<PullInfo>(
-                       new PullInfo(true, object_id, main_service_,
-                                    [this, object_id]() { TimerExpires(object_id); }))));
+        object_id, PullInfo(true, object_id)));
     it = insertion_it.first;
-    auto &pull_info = *it->second;
+    auto &pull_info = it->second;
     RAY_CHECK(pull_info.required);
     RAY_CHECK(pull_info.client_receiving_from.is_nil());
   } else {
-    auto &pull_info = *it->second;
+    auto &pull_info = it->second;
 
     if (!pull_info.required) {
       // In this case, we are already receiving the object, but it was not
       // required before.
-      auto &pull_info = *it->second;
+      auto &pull_info = it->second;
       RAY_CHECK(!pull_info.client_receiving_from.is_nil());
       pull_info.required = true;
     } else {
       // In this case, we are already pulling the object, so there is nothing new
       // to do.
+      *subscribe_to_locations = false;
     }
   }
 }
 
-void PullManager::CancelPullObject(const ObjectID &object_id) {
+void PullManager::CancelPullObject(const ObjectID &object_id,
+                                   std::vector<ClientID> *clients_to_cancel,
+                                   bool *unsubscribe_from_locations) {
   ++total_cancel_calls_;
+  *clients_to_cancel = std::vector<ClientID>();
+  *unsubscribe_from_locations = false;
 
   auto it = pulls_.find(object_id);
 
@@ -185,21 +168,21 @@ void PullManager::CancelPullObject(const ObjectID &object_id) {
     return;
   }
 
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
   if (!pull_info.required) {
     // This object already was not required, so this cancel message contains no
     // new information.
     return;
   }
 
+  *unsubscribe_from_locations = true;
   pull_info.required = false;
 
-  std::vector<ClientID> clients_to_cancel;
   for (auto const &client_id : pull_info.clients_requested_from) {
-    clients_to_cancel.push_back(client_id);
+    clients_to_cancel->push_back(client_id);
   }
   if (!pull_info.client_receiving_from.is_nil()) {
-    clients_to_cancel.push_back(pull_info.client_receiving_from);
+    clients_to_cancel->push_back(pull_info.client_receiving_from);
   }
   pull_info.client_receiving_from = ClientID::nil();
 
@@ -208,16 +191,17 @@ void PullManager::CancelPullObject(const ObjectID &object_id) {
     pulls_.erase(object_id);
     abort_creation = true;
   }
-  callback_(std::vector<ClientID>(), clients_to_cancel, abort_creation);
 }
 
-/// We finished reading a chunk.
+// We finished reading a chunk.
 void PullManager::ChunkReadSucceeded(const ObjectID &object_id, const ClientID &client_id,
-                                     int64_t chunk_index) {
+                                int64_t chunk_index, bool *abort_creation,
+                                bool *restart_timer) {
+  *restart_timer = false;
   ++total_successful_chunk_reads_;
   auto it = pulls_.find(object_id);
   RAY_CHECK(it != pulls_.end());
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
 
   pull_info.num_in_progress_chunk_ids--;
   RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
@@ -225,51 +209,52 @@ void PullManager::ChunkReadSucceeded(const ObjectID &object_id, const ClientID &
   RAY_CHECK(pull_info.received_chunk_ids.insert(chunk_index).second);
 
   if (client_id == pull_info.client_receiving_from) {
-    pull_info.RestartTimer(main_service_);
+    *restart_timer = true;
   }
 
-  bool abort_creation = false;
+  *abort_creation = false;
   if (pull_info.LifetimeEnded()) {
     pulls_.erase(object_id);
-    abort_creation = true;
+    *abort_creation = true;
   }
-  callback_(std::vector<ClientID>(), std::vector<ClientID>(), abort_creation);
 }
 
-void PullManager::ChunkReadFailed(const ObjectID &object_id, const ClientID &client_id,
-                                  int64_t chunk_index) {
+void PullManager::ChunkReadFailed(
+    const ObjectID &object_id, const ClientID &client_id, int64_t chunk_index,
+    std::vector<ClientID> *clients_to_cancel, bool *abort_creation) {
   ++total_failed_chunk_reads_;
   auto it = pulls_.find(object_id);
   RAY_CHECK(it != pulls_.end());
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
 
   pull_info.num_in_progress_chunk_ids--;
   RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
 
-  std::vector<ClientID> clients_to_cancel;
+  *clients_to_cancel = std::vector<ClientID>();
   if (client_id == pull_info.client_receiving_from &&
       pull_info.received_chunk_ids.count(chunk_index) == 0) {
     pull_info.client_receiving_from = ClientID::nil();
-    clients_to_cancel.push_back(pull_info.client_receiving_from);
+    clients_to_cancel->push_back(pull_info.client_receiving_from);
   }
 
-  bool abort_creation = false;
+  *abort_creation = false;
   if (pull_info.LifetimeEnded()) {
     pulls_.erase(object_id);
-    abort_creation = true;
+    *abort_creation = true;
   }
-  callback_(std::vector<ClientID>(), clients_to_cancel, abort_creation);
 }
 
 // The timer for this pull request expired. If the object is required, then we
 // need to reissue some new requests. If it is not required, then we may need to
 // end the pull lifetime.
-void PullManager::TimerExpires(const ObjectID &object_id) {
+void PullManager::TimerExpired(const ObjectID &object_id,
+                               std::vector<ClientID> *clients_to_request,
+                               bool *abort_creation, bool *restart_timer) {
   auto it = pulls_.find(object_id);
   RAY_CHECK(it != pulls_.end());
-  auto &pull_info = *it->second;
+  auto &pull_info = it->second;
 
-  std::vector<ClientID> clients_to_request;
+  *clients_to_request = std::vector<ClientID>();
   if (!pull_info.client_receiving_from.is_nil()) {
     // We could optionally send a cancellation message to this remote object
     // manager.
@@ -284,20 +269,20 @@ void PullManager::TimerExpires(const ObjectID &object_id) {
                          << "according to the object table.";
         continue;
       }
-      clients_to_request.push_back(client_id);
+      clients_to_request->push_back(client_id);
     }
   }
 
   if (pull_info.required) {
-    pull_info.RestartTimer(main_service_);
+    *restart_timer = true;
   }
 
-  bool abort_creation = false;
   if (pull_info.LifetimeEnded()) {
     pulls_.erase(object_id);
-    abort_creation = true;
+    *abort_creation = true;
+  } else {
+    *abort_creation = false;
   }
-  callback_(clients_to_request, std::vector<ClientID>(), abort_creation);
 }
 
 std::string PullManager::DebugString() const {

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -1,0 +1,370 @@
+#include "pull_manager.h"
+
+#include <chrono>
+
+namespace ray {
+
+PullInfo::PullInfo(bool required, const ObjectID &object_id,
+                                boost::asio::io_service &main_service,
+                                const std::function<void()> &timer_callback)
+    : required(required),
+      total_num_chunks(-1),
+      num_in_progress_chunk_ids(0),
+      // pull_manager(pull_manager),
+      // object_id(object_id),
+      // retry_timer(new boost::asio::deadline_timer(main_service)),
+      timer_callback(timer_callback) {
+  RestartTimer(main_service);
+}
+
+// PullInfo::~PullInfo() {
+//   retry_timer->cancel();
+// }
+
+void PullInfo::InitializeChunksIfNecessary(int64_t num_chunks) {
+  if (total_num_chunks == -1) {
+    total_num_chunks = num_chunks;
+    RAY_CHECK(received_chunk_ids_.size() == 0);
+    RAY_CHECK(num_in_progress_chunk_ids == 0);
+    for (int64_t i = 0; i < total_num_chunks; ++i) {
+      remaining_chunk_ids_.insert(i);
+    }
+  }
+}
+
+bool PullInfo::LifetimeEnded() {
+  return !required && client_receiving_from_.is_nil() && num_in_progress_chunk_ids == 0;
+}
+
+void PullInfo::RestartTimer(boost::asio::io_service &main_service) {
+  if (retry_timer != nullptr) {
+    retry_timer->cancel();
+  }
+  retry_timer.reset(new boost::asio::deadline_timer(main_service));
+  boost::posix_time::milliseconds retry_timeout(1000);  // FIX THIS CONSTANT!!!!!!!!!!!!!!!!!!!!!
+  retry_timer->expires_from_now(retry_timeout);
+  retry_timer->async_wait(
+      [this](const boost::system::error_code &error) {
+      // [](const boost::system::error_code &error) {
+        if (!error) {
+          timer_callback();
+
+          // pull_manager->TimerExpires(object_id);
+
+        } else {
+          // Check that the error was due to the timer being canceled.
+          RAY_CHECK(error == boost::asio::error::operation_aborted);
+        }
+      });
+}
+
+// void PullInfo::StartTimer() {
+//   // ExtendTimer();
+//   //
+//   // retry_timer->async_wait(
+//   //     [this](const boost::system::error_code &error) {
+//   //     // [](const boost::system::error_code &error) {
+//   //       RAY_LOG(INFO) << "111";
+//   //       if (!error) {
+//   //         RAY_LOG(INFO) << "222";
+//   //         timer_callback();
+//   //       } else {
+//   //         RAY_LOG(INFO) << "333";
+//   //         // Check that the error was due to the timer being canceled.
+//   //         RAY_CHECK(error == boost::asio::error::operation_aborted);
+//   //       }
+//   //       RAY_LOG(INFO) << "444";
+//   //     });
+//   RestartTimer();
+// }
+//
+// void PullInfo::ExtendTimer() {
+//   // // TODO(rkn): Is this the right way to reset a timer?
+//   // boost::posix_time::milliseconds retry_timeout(1000);  // FIX THIS CONSTANT!!!!!!!!!!!!!!!!!!!!!
+//   // retry_timer->expires_from_now(retry_timeout);
+//   RestartTimer();
+// }
+
+PullManager::PullManager(boost::asio::io_service &main_service, const ClientID &client_id,
+                         const ObjectRequestManagementCallback &callback)
+    : total_pull_calls_(0),
+      total_cancel_calls_(0),
+      total_successful_chunk_reads_(0),
+      total_failed_chunk_reads_(0),
+      main_service_(main_service),
+      client_id_(client_id),
+      callback_(callback),
+      gen_(std::chrono::high_resolution_clock::now().time_since_epoch().count()) {}
+
+void PullManager::ReceivePushRequest(const ObjectID &object_id, const ClientID &client_id,
+                                     int64_t chunk_index, int64_t num_chunks) {
+  RAY_CHECK(client_id != client_id_);
+  std::vector<ClientID> clients_to_cancel;
+
+  auto it = pulls_.find(object_id);
+  if (it == pulls_.end()) {
+    // auto insertion_it = pulls_.emplace(std::piecewise_construct,
+    //   std::forward_as_tuple(object_id),
+    //   std::forward_as_tuple(false, object_id, main_service_,
+    //                       [this, object_id]() { TimerExpires(object_id); }));
+
+    auto insertion_it = pulls_.insert(std::make_pair(
+        object_id, PullInfo(false, object_id, main_service_,
+                            [this, object_id]() { TimerExpires(object_id); })));
+    // auto insertion_it = pulls_.emplace(
+    //     object_id, PullInfo(false, object_id, main_service_,
+    //                         [this, object_id]() { TimerExpires(object_id); }));
+        // object_id, PullInfo(false, object_id, main_service_,
+        //                     []() {}));
+
+    RAY_CHECK(insertion_it.second);
+    it = insertion_it.first;
+
+    auto &pull_info = it->second;
+    RAY_CHECK(!pull_info.required);
+    pull_info.client_receiving_from_ = client_id;
+    pull_info.InitializeChunksIfNecessary(num_chunks);
+  } else {
+    auto &pull_info = it->second;
+    if (pull_info.client_receiving_from_.is_nil()) {
+      pull_info.InitializeChunksIfNecessary(num_chunks);
+      pull_info.client_receiving_from_ = client_id;
+      // Cancel it from all remote object managers that we've requested it from
+      // except for this one.
+      for (auto const &client_requested_from : pull_info.clients_requested_from_) {
+        if (client_requested_from != client_id) {
+          clients_to_cancel.push_back(client_requested_from);
+        }
+      }
+      pull_info.clients_requested_from_.clear();
+    } else {
+      // We are already receiving the object from some other remote object
+      // manager.
+      RAY_CHECK(pull_info.clients_requested_from_.empty());
+    }
+  }
+
+  auto &pull_info = it->second;
+  RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
+  pull_info.num_in_progress_chunk_ids++;
+
+  // Cancel the request from everyone else.
+  callback_(std::vector<ClientID>(), clients_to_cancel, /* abort */ false);
+}
+
+// If the object is required and if we are not already receiving the object from
+// some object manager, request the object from any object managers that we have
+// not already requested the object from.
+void PullManager::NewObjectLocations(
+    const ObjectID &object_id, const std::unordered_set<ClientID> &clients_with_object) {
+  auto it = pulls_.find(object_id);
+  if (it == pulls_.end()) {
+    return;
+  }
+
+  auto &pull_info = it->second;
+  pull_info.clients_with_object_ = clients_with_object;
+
+  if (!pull_info.required) {
+    return;
+  }
+
+  // If we are already receiving the object, don't request it from any more
+  // object managers.
+  if (!pull_info.client_receiving_from_.is_nil()) {
+    return;
+  }
+
+  std::vector<ClientID> clients_to_request;
+  for (auto const &client_id : pull_info.clients_with_object_) {
+    if (pull_info.clients_requested_from_.count(client_id) == 0){
+      clients_to_request.push_back(client_id);
+      pull_info.clients_requested_from_.insert(client_id);
+    }
+  }
+
+  if (!clients_to_request.empty()) {
+    pull_info.RestartTimer(main_service_);
+  }
+  callback_(clients_to_request, std::vector<ClientID>(), /* abort */ false);
+}
+
+void PullManager::PullObject(const ObjectID &object_id) {
+  ++total_pull_calls_;
+  auto it = pulls_.find(object_id);
+
+  if (it == pulls_.end()) {
+    // auto insertion_it = pulls_.emplace(std::piecewise_construct,
+    //   std::forward_as_tuple(object_id),
+    //   std::forward_as_tuple(true, object_id, main_service_,
+    //                       [this, object_id]() { TimerExpires(object_id); }));
+
+    auto insertion_it = pulls_.insert(std::make_pair(
+        object_id, PullInfo(true, object_id, main_service_,
+                            [this, object_id]() { TimerExpires(object_id); })));
+    // auto insertion_it = pulls_.emplace(
+    //     object_id, PullInfo(true, object_id, main_service_,
+    //                         [this, object_id]() { TimerExpires(object_id); }));
+        // object_id, PullInfo(true, object_id, main_service_,
+        //                     []() {}));
+    it = insertion_it.first;
+    auto &pull_info = it->second;
+    RAY_CHECK(pull_info.required);
+    RAY_CHECK(pull_info.client_receiving_from_.is_nil());
+  } else {
+    auto &pull_info = it->second;
+
+    if (!pull_info.required) {
+      // In this case, we are already receiving the object, but it was not
+      // required before.
+      auto &pull_info = it->second;
+      RAY_CHECK(!pull_info.client_receiving_from_.is_nil());
+      pull_info.required = true;
+    } else {
+      // In this case, we are already pulling the object, so there is nothing new
+      // to do.
+    }
+  }
+}
+
+void PullManager::CancelPullObject(const ObjectID &object_id) {
+  ++total_cancel_calls_;
+
+  auto it = pulls_.find(object_id);
+
+  // If we currently are not trying to pull this object, then there is nothing
+  // to do.
+  if (it == pulls_.end()) {
+    return;
+  }
+
+  auto &pull_info = it->second;
+  if (!pull_info.required) {
+    // This object already was not required, so this cancel message contains no
+    // new information.
+    return;
+  }
+
+  pull_info.required = false;
+
+  std::vector<ClientID> clients_to_cancel;
+  for (auto const &client_id : pull_info.clients_requested_from_) {
+    clients_to_cancel.push_back(client_id);
+  }
+  if (!pull_info.client_receiving_from_.is_nil()) {
+    clients_to_cancel.push_back(pull_info.client_receiving_from_);
+  }
+  pull_info.client_receiving_from_ = ClientID::nil();
+
+  bool abort_creation = false;
+  if (pull_info.LifetimeEnded()) {
+    pulls_.erase(object_id);
+    abort_creation = true;
+  }
+  callback_(std::vector<ClientID>(), clients_to_cancel, abort_creation);
+}
+
+/// We finished reading a chunk.
+void PullManager::ChunkReadSucceeded(const ObjectID &object_id, const ClientID &client_id,
+                                     int64_t chunk_index) {
+  ++total_successful_chunk_reads_;
+  auto it = pulls_.find(object_id);
+  RAY_CHECK(it != pulls_.end());
+  auto &pull_info = it->second;
+
+  // RAY_CHECK(pull_info.client_receiving_from_.is_nil() ||
+    //           client_id == pull_info.client_receiving_from_);
+
+  pull_info.num_in_progress_chunk_ids--;
+  RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
+  RAY_CHECK(pull_info.remaining_chunk_ids_.erase(chunk_index) == 1);
+  RAY_CHECK(pull_info.received_chunk_ids_.insert(chunk_index).second);
+
+  if (client_id == pull_info.client_receiving_from_) {
+    pull_info.RestartTimer(main_service_);
+  }
+
+  bool abort_creation = false;
+  if (pull_info.LifetimeEnded()) {
+    pulls_.erase(object_id);
+    abort_creation = true;
+  }
+  callback_(std::vector<ClientID>(), std::vector<ClientID>(), abort_creation);
+}
+
+void PullManager::ChunkReadFailed(const ObjectID &object_id, const ClientID &client_id,
+                                  int64_t chunk_index) {
+  ++total_failed_chunk_reads_;
+  auto it = pulls_.find(object_id);
+  RAY_CHECK(it != pulls_.end());
+  auto &pull_info = it->second;
+
+  pull_info.num_in_progress_chunk_ids--;
+  RAY_CHECK(pull_info.num_in_progress_chunk_ids >= 0);
+
+  std::vector<ClientID> clients_to_cancel;
+  if (client_id == pull_info.client_receiving_from_ &&
+      pull_info.received_chunk_ids_.count(chunk_index) == 0) {
+    pull_info.client_receiving_from_ = ClientID::nil();
+    clients_to_cancel.push_back(pull_info.client_receiving_from_);
+  }
+
+  bool abort_creation = false;
+  if (pull_info.LifetimeEnded()) {
+    pulls_.erase(object_id);
+    abort_creation = true;
+  }
+  callback_(std::vector<ClientID>(), clients_to_cancel, abort_creation);
+}
+
+// The timer for this pull request expired. If the object is required, then we
+// need to reissue some new requests. If it is not required, then we may need to
+// end the pull lifetime.
+void PullManager::TimerExpires(const ObjectID &object_id) {
+  auto it = pulls_.find(object_id);
+  RAY_CHECK(it != pulls_.end());
+  auto &pull_info = it->second;
+
+  std::vector<ClientID> clients_to_request;
+  if (!pull_info.client_receiving_from_.is_nil()) {
+    // We could optionally send a cancellation message to this remote object
+    // manager.
+    pull_info.client_receiving_from_ = ClientID::nil();
+  }
+
+  if (pull_info.required && !pull_info.clients_with_object_.empty()) {
+    // Issue a new request for the object.
+    for (auto const &client_id : pull_info.clients_with_object_) {
+      if (client_id == client_id_) {
+        RAY_LOG(WARNING) << "This object manager already has the object "
+                         << "according to the object table.";
+        continue;
+      }
+      clients_to_request.push_back(client_id);
+    }
+  }
+
+  if (pull_info.required) {
+    pull_info.RestartTimer(main_service_);
+  }
+
+  bool abort_creation = false;
+  if (pull_info.LifetimeEnded()) {
+    pulls_.erase(object_id);
+    abort_creation = true;
+  }
+  callback_(clients_to_request, std::vector<ClientID>(), abort_creation);
+}
+
+std::string PullManager::DebugString() const {
+  std::stringstream result;
+  result << "PullManager:";
+  result << "\n- num pulls: " << pulls_.size();
+  result << "\n- total pull calls " << total_pull_calls_;
+  result << "\n- total cancel calls: " << total_cancel_calls_;
+  result << "\n- total successful chunk reads: " << total_successful_chunk_reads_;
+  result << "\n- total failed chunk reads: " << total_failed_chunk_reads_;
+  return result.str();
+}
+
+}  // namespace ray

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -1,0 +1,235 @@
+#ifndef RAY_OBJECT_MANAGER_PULL_MANAGER_H
+#define RAY_OBJECT_MANAGER_PULL_MANAGER_H
+
+#include <random>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+
+#include "ray/id.h"
+#include "ray/status.h"
+
+namespace ray {
+
+class PullManager;
+
+struct PullInfo {
+  PullInfo(bool required, const ObjectID &object_id, boost::asio::io_service &main_service,
+           const std::function<void()> &timer_callback);
+  // ~PullInfo();
+
+  // PullInfo(const PullInfo &other) = delete;
+  //
+  // PullInfo &operator=(const PullInfo &other) = delete;
+
+  void InitializeChunksIfNecessary(int64_t num_chunks);
+  bool LifetimeEnded();
+  void RestartTimer(boost::asio::io_service &main_service);
+  // void StartTimer();
+  // void ExtendTimer();
+  /// True if we must pull this object. False if we are simply receiving the
+  /// object but do not need to pull the object (meaning we do not have to
+  /// guarantee that the object appears locally).
+  bool required;
+  /// Our most recent estimate of which object managers have the object.
+  std::unordered_set<ClientID> clients_with_object_;
+  /// The IDs of the remote object managers that we have already requested
+  /// the object from. If we cancel a request, then we will remove that
+  /// client from this set.
+  std::unordered_set<ClientID> clients_requested_from_;
+  /// If this object manager is currently receiving the object from a remote
+  /// object manager, this will be the client ID of the remote object
+  /// manager. Otherwise, it will be nil.
+  ClientID client_receiving_from_;
+  /// The total number of chunks that the object is divided into. If this is
+  /// -1, then the number is not known.
+  int64_t total_num_chunks;
+  /// The chunk IDs that have successfully been received.
+  std::unordered_set<int> received_chunk_ids_;
+  /// The chunks that have not yet been received. This is the complement of
+  /// the values in received_chunk_ids_.
+  std::unordered_set<int> remaining_chunk_ids_;
+  // /// A mapping from chunk index to the number of outstanding receive tasks
+  // /// that are about to read that chunk (for chunks where that number is
+  // /// non-zero). Note that some of these chunks may have already been read.
+  // std::unordered_map<int, int> in_progress_chunk_ids_;
+  int64_t num_in_progress_chunk_ids;
+  /// This timer is used for two purposes: 1) If we are receiving the
+  /// object from some remote object manager but one of the reads fails,
+  /// then this timer will be used to issue new requests. If we have requested
+  ///
+  std::unique_ptr<boost::asio::deadline_timer> retry_timer;
+
+  std::function<void()> timer_callback;
+};
+
+using ObjectRequestManagementCallback = std::function<void(
+    const std::vector<ray::ClientID> &clients_to_request,
+    const std::vector<ray::ClientID> &clients_to_cancel, bool abort_object)>;
+
+/// This class is responsible for ensuring that objects that this object
+/// manager is attempting to pull eventually show up. It is responsible for
+/// deciding when to issue requests to and cancel requests from remote object
+/// managers as well as when to abort an object creation.
+///
+/// We say that we are "receiving" an object from another object manager if we
+/// received a ReceivePushRequest from it while we were not receiving the
+/// object from any other object managers, no reads from that object manager
+/// have subsequently failed, and not more than a certain amount of time has
+/// passed since the last chunk was received.
+///
+/// The lifetime of a "pull" begins when either PullObject is called or when
+/// ReceivePushRequest is called (whichever comes first). The lifetime ends as
+/// soon as three conditions are met:
+/// 1. The pull is no longer required because CancelPullObject has been called
+///    or it was never required in the first place because PullObject was
+///    never called.
+/// 2. There are no in progress chunks as represented by
+///    num_in_progress_chunk_ids.
+/// 3. We are currently not receiving the object from any object manager. This
+///    means that if we started receiving it from some object manager earlier,
+///    then we one of the chunks from that object manager failed to be read or
+///    we have not received any chunks from that object manager in a while.
+///
+/// A given object is considered to be "being received" from a remote object
+/// manager if the following conditions are met:
+/// 1. While we were in the state of not receiving the object, we received a
+///    ReceivePushRequest message.
+/// 2. Since the ReceivePushRequest message, none of the chunks failed to be
+///    read and the timer has not expired.
+///
+/// Each pull has a timer, which operates as follows:
+/// 1. The timer begins as soon as the pull object is created.
+/// 2. Whenever we request the object from a new object manager, the timer is
+///    reset.
+/// 3. Whenever we receive a chunk from the object manager that we are
+///    receiving the object from, the timer is reset.
+/// 4. The timer is canceled when the object has been fully received
+///    successfully.
+/// 5. The timer is canceled when the pull lifetime ends.
+/// 6. When the timer expires, we do the following:
+///    - If no remote object managers have the object, we reset the timer.
+///    - If other remote object managers have the object and have not started
+///    - receiving the object, we issue some new requests for the object and
+///      possibly cancel some requests.
+///    - If we are in the process of receiving the object, we cancel the
+///      request and issue at least one new request for the object.
+///    - If the object is required, reset the timer.
+///
+/// When we are pulling an object, we only will read chunks from the first
+/// object manager that sends us a push request. Chunks from other object
+/// managers will be ignored. If we fail to read a chunk from the object
+/// manager that we are not ignoring, then we consider ourselves to be no
+/// longer reading from that object manager.
+///
+/// When do we abort an object creation? We only ever abort a creation for
+/// objects that we are not required to pull (e.g., those that were being
+/// pushed to us or whose pulls were canceled). There is the danger that we
+/// abort an object creation only to have a subsequent read try to recreate
+/// it. To deal with this, we have the main thread abort object creations only
+/// when the lifetime of a pull ends.
+class PullManager {
+ public:
+  /// Construct a PullManager.
+  ///
+  /// \param main_service The service to use for running timer callbacks.
+  /// \param client_id The ID of this object manager.
+  /// \param callback The callback that the pull manager can use to request
+  /// objects, cancel requests, and abort object creations.
+  PullManager(boost::asio::io_service &main_service, const ClientID &client_id,
+               const ObjectRequestManagementCallback &callback);
+
+  PullManager(const PullManager &other) = delete;
+
+  PullManager &operator=(const PullManager &other) = delete;
+
+  /// Pull an object. This will guarantee that the object is pulled. That is,
+  /// it will keep trying to request the object until CancelPullObject is
+  /// called. CancelPullObject is also called when the object appears locally.
+  ///
+  /// \param object_id The ID of the object to pull.
+  /// \return Void.
+  void PullObject(const ObjectID &object_id);
+
+  /// Notify the PullManager that a certain object is no longer required. This
+  /// is also called when an object appears locally.
+  ///
+  /// \param object_id The ID of the object whose to pull.
+  /// \return Void.
+  void CancelPullObject(const ObjectID &object_id);
+
+  /// Notify the PullManager that a remote object manager wishes to push an
+  /// object chunk to this object manager. Note that this will happen once per
+  /// chunk, not once per object.
+  ///
+  /// \param object_id The ID of the object that is being pushed.
+  /// \param client_id The ID of the remote object manager that is pushing the
+  /// object.
+  /// \param chunk_index The index of the chunk that is being pushed.
+  /// \param num_chunks The total number of chunks that the object is divided
+  /// into.
+  /// \return Void.
+  /// TODO(rkn): Should we actually return a bool saying whether to read or ignore the object?
+  void ReceivePushRequest(const ObjectID &object_id, const ClientID &client_id,
+                          int64_t chunk_index, int64_t num_chunks);
+
+  /// Notify the PullManager that the locations of the object in the object
+  /// table have changed.
+  ///
+  /// \param object_id The ID of the object whose locations have changed.
+  /// \param clients_with_object The IDs of the object managers that have the
+  /// object.
+  /// \return Void.
+  void NewObjectLocations(const ObjectID &object_id,
+                          const std::unordered_set<ClientID> &clients_with_object);
+
+  /// Notify the PullManager that a chunk was read successfully.
+  ///
+  /// \param object_id The ID of the object that was read.
+  /// \param client_id The ID of the remote object manager that the object was
+  /// read from.
+  /// \param chunk_index The index of the chunk.
+  /// \return Void.
+  void ChunkReadSucceeded(const ObjectID &object_id, const ClientID &client_id,
+                          int64_t chunk_index);
+
+  /// Notify the PullManager that a chunk was not successfully read. This could
+  /// happen because the chunk was intentionally ignored, because the object
+  /// already existed in the store, because the remote object manager died, or
+  /// because the object store was full or the object was already present in the
+  /// object store when we tried to create a chunk.
+  ///
+  /// \param object_id The ID of the object that was read.
+  /// \param client_id The ID of the remote object manager that the object was
+  /// read from.
+  /// \param chunk_index The index of the chunk.
+  /// \return Void.
+  void ChunkReadFailed(const ObjectID &object_id, const ClientID &client_id,
+                       int64_t chunk_index);
+
+  std::string DebugString() const;
+
+ private:
+   /// Handle the fact that the timer for a pull has expired.
+   ///
+   /// \param object_id The ID of the object that the pull is for.
+   /// \return Void.
+   void TimerExpires(const ObjectID &object_id);
+
+  int64_t total_pull_calls_;
+  int64_t total_cancel_calls_;
+  int64_t total_successful_chunk_reads_;
+  int64_t total_failed_chunk_reads_;
+  boost::asio::io_service &main_service_;
+  ClientID client_id_;
+  const ObjectRequestManagementCallback callback_;
+  std::unordered_map<ObjectID, PullInfo> pulls_;
+  std::mt19937_64 gen_;
+};
+
+}  // namespace ray
+
+#endif  // RAY_OBJECT_MANAGER_PULL_MANAGER_H

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -17,7 +17,8 @@ namespace ray {
 class PullManager;
 
 struct PullInfo {
-  PullInfo(bool required, const ObjectID &object_id, boost::asio::io_service &main_service,
+  PullInfo(bool required, const ObjectID &object_id,
+           boost::asio::io_service &main_service,
            const std::function<void()> &timer_callback);
 
   void InitializeChunksIfNecessary(int64_t num_chunks);
@@ -135,7 +136,7 @@ class PullManager {
   /// \param callback The callback that the pull manager can use to request
   /// objects, cancel requests, and abort object creations.
   PullManager(boost::asio::io_service &main_service, const ClientID &client_id,
-               const ObjectRequestManagementCallback &callback);
+              const ObjectRequestManagementCallback &callback);
 
   PullManager(const PullManager &other) = delete;
 
@@ -208,11 +209,11 @@ class PullManager {
   std::string DebugString() const;
 
  private:
-   /// Handle the fact that the timer for a pull has expired.
-   ///
-   /// \param object_id The ID of the object that the pull is for.
-   /// \return Void.
-   void TimerExpires(const ObjectID &object_id);
+  /// Handle the fact that the timer for a pull has expired.
+  ///
+  /// \param object_id The ID of the object that the pull is for.
+  /// \return Void.
+  void TimerExpires(const ObjectID &object_id);
 
   int64_t total_pull_calls_;
   int64_t total_cancel_calls_;

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -21,6 +21,13 @@ struct PullInfo {
            boost::asio::io_service &main_service,
            const std::function<void()> &timer_callback);
 
+  /// This struct cannot be copied or moved because it has a timer that captures
+  /// the "this" pointer.
+  PullInfo(const PullInfo &other) = delete;
+  PullInfo(PullInfo &&other) = delete;
+  PullInfo &operator=(const PullInfo &other) = delete;
+  PullInfo &operator=(PullInfo &&other) = delete;
+
   /// Fill out the total_num_chunks field. We won't know this until we know the
   /// object size and so can't always fill out this field in the constructor.
   ///

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -19,11 +19,6 @@ class PullManager;
 struct PullInfo {
   PullInfo(bool required, const ObjectID &object_id, boost::asio::io_service &main_service,
            const std::function<void()> &timer_callback);
-  // ~PullInfo();
-
-  // PullInfo(const PullInfo &other) = delete;
-  //
-  // PullInfo &operator=(const PullInfo &other) = delete;
 
   void InitializeChunksIfNecessary(int64_t num_chunks);
   bool LifetimeEnded();
@@ -35,23 +30,23 @@ struct PullInfo {
   /// guarantee that the object appears locally).
   bool required;
   /// Our most recent estimate of which object managers have the object.
-  std::unordered_set<ClientID> clients_with_object_;
+  std::unordered_set<ClientID> clients_with_object;
   /// The IDs of the remote object managers that we have already requested
   /// the object from. If we cancel a request, then we will remove that
   /// client from this set.
-  std::unordered_set<ClientID> clients_requested_from_;
+  std::unordered_set<ClientID> clients_requested_from;
   /// If this object manager is currently receiving the object from a remote
   /// object manager, this will be the client ID of the remote object
   /// manager. Otherwise, it will be nil.
-  ClientID client_receiving_from_;
+  ClientID client_receiving_from;
   /// The total number of chunks that the object is divided into. If this is
   /// -1, then the number is not known.
   int64_t total_num_chunks;
   /// The chunk IDs that have successfully been received.
-  std::unordered_set<int> received_chunk_ids_;
+  std::unordered_set<int> received_chunk_ids;
   /// The chunks that have not yet been received. This is the complement of
-  /// the values in received_chunk_ids_.
-  std::unordered_set<int> remaining_chunk_ids_;
+  /// the values in received_chunk_ids.
+  std::unordered_set<int> remaining_chunk_ids;
   // /// A mapping from chunk index to the number of outstanding receive tasks
   // /// that are about to read that chunk (for chunks where that number is
   // /// non-zero). Note that some of these chunks may have already been read.

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -226,7 +226,9 @@ class PullManager {
   boost::asio::io_service &main_service_;
   ClientID client_id_;
   const ObjectRequestManagementCallback callback_;
-  std::unordered_map<ObjectID, PullInfo> pulls_;
+  /// We use unique_ptr<PullInfo> instead of PullInfo because the PullInfo
+  /// object uses the "this" pointer and so cannot be moved around.
+  std::unordered_map<ObjectID, std::unique_ptr<PullInfo>> pulls_;
   std::mt19937_64 gen_;
 };
 


### PR DESCRIPTION
This PR creates a `PullManager` object inside of the `ObjectManager` that is responsible for deciding which remote object managers to request objects from and when to cancel requests.

In this PR, the `PullManager` gets used in addition to the existing code for issuing requests. The `ObjectManager` notifies the `PullManager` every time a new event happens (e.g., a relevant object location appears or a chunk is successfully read), but the `PullManager`'s callback, which in the future will actually issue requests and cancellation requests, is currently empty.