### PR TITLE
Direct people to stackoverflow for questions about usage.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!--
 General questions should be asked on the mailing list ray-dev@googlegroups.com.
+Questions about how to use Ray should be asked on
+[StackOverflow](https://stackoverflow.com/questions/tagged/ray).
 
 Before submitting an issue, please fill out the following form.
 -->

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,10 +4,12 @@ Contributing to Ray
 Reporting bugs and asking questions
 -----------------------------------
 
-We use `GitHub issues`_ for bug reports and feature requests. For discussions
-about development or any general questions, we use our mailing list
-`ray-dev@googlegroups.com`_. For questions about how to use Ray, please post on
-`StackOverflow`_.
+You can post questions or issues or feedback through the following channels:
+
+1. `ray-dev@googlegroups.com`_: For discussions about development or any general
+   questions and feedback.
+2. `StackOverflow`_: For questions about how to use Ray.
+3. `GitHub Issues`_: For bug reports and feature requests.
 
 To contribute a patch:
 ----------------------
@@ -18,6 +20,6 @@ To contribute a patch:
 3. Make sure that your code passes the unit tests.
 4. Add new unit tests for your code.
 
-.. _`GitHub issues`: https://github.com/ray-project/ray/issues
 .. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
+.. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,8 +5,9 @@ Reporting bugs and asking questions
 -----------------------------------
 
 We use `GitHub issues`_ for bug reports and feature requests. For discussions
-about development, questions about usage, or any general questions, we use our
-mailing list `ray-dev@googlegroups.com`_.
+about development or any general questions, we use our mailing list
+`ray-dev@googlegroups.com`_. For questions about how to use Ray, please post on
+`StackOverflow`_.
 
 To contribute a patch:
 ----------------------
@@ -19,3 +20,4 @@ To contribute a patch:
 
 .. _`GitHub issues`: https://github.com/ray-project/ray/issues
 .. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,11 @@ Getting Involved
 ----------------
 
 - Ask questions on our mailing list `ray-dev@googlegroups.com`_.
+- Questions about how to use Ray should be asked on `StackOverflow`_.
 - Please report bugs by submitting a `GitHub issue`_.
 - Submit contributions using `pull requests`_.
 
 .. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`GitHub issue`: https://github.com/ray-project/ray/issues
 .. _`pull requests`: https://github.com/ray-project/ray/pulls
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,13 @@ More Information
 Getting Involved
 ----------------
 
-- Ask questions on our mailing list `ray-dev@googlegroups.com`_.
-- Questions about how to use Ray should be asked on `StackOverflow`_.
-- Please report bugs by submitting a `GitHub issue`_.
-- Submit contributions using `pull requests`_.
+- `ray-dev@googlegroups.com`_: For discussions about development or any general
+  questions.
+- `StackOverflow`_: For questions about how to use Ray.
+- `GitHub Issues`_: For reporting bugs and feature requests.
+- `Pull Requests`_: For submitting code contributions.
 
 .. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
-.. _`GitHub issue`: https://github.com/ray-project/ray/issues
-.. _`pull requests`: https://github.com/ray-project/ray/pulls
+.. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
+.. _`Pull Requests`: https://github.com/ray-project/ray/pulls

--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -295,9 +295,11 @@ Questions or Issues?
 
 You can post questions or issues or feedback through the following channels:
 
-1. `Our Mailing List`_: For discussions about development, questions about
-   usage, or any general questions and feedback.
-2. `GitHub Issues`_: For bug reports and feature requests.
+1. `Our Mailing List`_: For discussions about development or any general
+   questions and feedback.
+2. `StackOverflow`_: For questions about how to use Ray.
+3. `GitHub Issues`_: For bug reports and feature requests.
 
 .. _`Our Mailing List`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -295,11 +295,11 @@ Questions or Issues?
 
 You can post questions or issues or feedback through the following channels:
 
-1. `Our Mailing List`_: For discussions about development or any general
+1. `ray-dev@googlegroups.com`_: For discussions about development or any general
    questions and feedback.
 2. `StackOverflow`_: For questions about how to use Ray.
 3. `GitHub Issues`_: For bug reports and feature requests.
 
-.. _`Our Mailing List`: https://groups.google.com/forum/#!forum/ray-dev
-.. _`GitHub Issues`: https://github.com/ray-project/ray/issues
+.. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
+.. _`GitHub Issues`: https://github.com/ray-project/ray/issues

--- a/doc/source/contact.rst
+++ b/doc/source/contact.rst
@@ -3,11 +3,11 @@ Contact
 
 The following are good places to discuss Ray.
 
-1. `Our Mailing List`_: For discussions about development or any general
+1. `ray-dev@googlegroups.com`_: For discussions about development or any general
    questions.
-2. `Stackoverflow`_: For questions about how to use Ray.
+2. `StackOverflow`_: For questions about how to use Ray.
 3. `GitHub Issues`_: For bug reports and feature requests.
 
-.. _`Our Mailing List`: https://groups.google.com/forum/#!forum/ray-dev
+.. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/doc/source/contact.rst
+++ b/doc/source/contact.rst
@@ -3,9 +3,11 @@ Contact
 
 The following are good places to discuss Ray.
 
-1. `Our Mailing List`_: For discussions about development, questions about
-   usage, or any general questions.
-2. `GitHub Issues`_: For bug reports and feature requests.
+1. `Our Mailing List`_: For discussions about development or any general
+   questions.
+2. `Stackoverflow`_: For questions about how to use Ray.
+3. `GitHub Issues`_: For bug reports and feature requests.
 
 .. _`Our Mailing List`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray

--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -486,9 +486,11 @@ Further Questions or Issues?
 
 You can post questions or issues or feedback through the following channels:
 
-1. `Our Mailing List`_: For discussions about development, questions about
-   usage, or any general questions and feedback.
-2. `GitHub Issues`_: For bug reports and feature requests.
+1. `ray-dev@googlegroups.com`_: For discussions about development or any general
+   questions and feedback.
+2. `StackOverflow`_: For questions about how to use Ray.
+3. `GitHub Issues`_: For bug reports and feature requests.
 
-.. _`Our Mailing List`: https://groups.google.com/forum/#!forum/ray-dev
+.. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
+.. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues


### PR DESCRIPTION
Ultimately, I think StackOverflow is probably a better way for people in the community to help each other out (whereas the Ray developers are the ones primarily responding to questions on the mailing list and on GitHub). The Ray tag for stackoverflow is at https://stackoverflow.com/questions/tagged/ray.