### PR TITLE
Limit maximum starting workers per language

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -42,8 +42,8 @@ WorkerPool::WorkerPool(
     int maximum_startup_concurrency,
     const std::unordered_map<Language, std::vector<std::string>> &worker_commands)
     : num_workers_per_process_(num_workers_per_process),
-      multiple_for_warning_(std::max(num_worker_processes, maximum_startup_concurrency)),
       maximum_startup_concurrency_(maximum_startup_concurrency),
+      multiple_for_warning_(std::max(num_worker_processes, maximum_startup_concurrency)),
       last_warning_multiple_(0) {
   RAY_CHECK(num_workers_per_process > 0) << "num_workers_per_process must be positive.";
   RAY_CHECK(maximum_startup_concurrency > 0);
@@ -253,10 +253,12 @@ std::vector<std::shared_ptr<Worker>> WorkerPool::GetWorkersRunningTasksForDriver
 }
 
 std::string WorkerPool::WarningAboutSize() {
-  int64_t num_workers_started_or_registered = starting_worker_processes_.size();
+  int64_t num_workers_started_or_registered = 0;
   for (const auto &entry : states_by_lang_) {
     num_workers_started_or_registered +=
         static_cast<int64_t>(entry.second.registered_workers.size());
+    num_workers_started_or_registered +=
+        static_cast<int64_t>(entry.second.starting_worker_processes.size());
   }
   int64_t multiple = num_workers_started_or_registered / multiple_for_warning_;
   std::stringstream warning_message;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -123,7 +123,8 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   } else if (pid > 0) {
     // Parent process case.
     RAY_LOG(DEBUG) << "Started worker process with pid " << pid;
-    state.starting_worker_processes.emplace(std::make_pair(pid, num_workers_per_process_));
+    state.starting_worker_processes.emplace(
+        std::make_pair(pid, num_workers_per_process_));
     return;
   }
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -103,9 +103,8 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   if (static_cast<int>(state.starting_worker_processes.size()) >=
       maximum_startup_concurrency_) {
     // Workers have been started, but not registered. Force start disabled -- returning.
-    RAY_LOG(DEBUG) << "Worker not started, "
-                   << state.starting_worker_processes.size() << " worker processes"
-                   << " of language type " << static_cast<int>(language)
+    RAY_LOG(DEBUG) << "Worker not started, " << state.starting_worker_processes.size()
+                   << " worker processes of language type " << static_cast<int>(language)
                    << " pending registration";
     return;
   }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -132,6 +132,7 @@ class WorkerPool {
 
  protected:
   /// The implementation of how to start a new worker process with command arguments.
+  ///
   /// \param worker_command_args The command arguments of new worker process.
   /// \return The process ID of started worker process.
   virtual pid_t StartProcess(const std::vector<const char *> &worker_command_args);

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -131,6 +131,11 @@ class WorkerPool {
   std::string WarningAboutSize();
 
  protected:
+  /// The implementation of how to start a new worker process with command arguments.
+  /// \param worker_command_args The command arguments of new worker process.
+  /// \return The process ID of started worker process.
+  virtual pid_t StartProcess(const std::vector<const char *> &worker_command_args);
+
   /// An internal data structure that maintains the pool state per language.
   struct State {
     /// The commands and arguments used to start the worker process
@@ -149,23 +154,21 @@ class WorkerPool {
     std::unordered_map<pid_t, int> starting_worker_processes;
   };
 
-  /// A helper function that returns the reference of the pool state
-  /// for a given language.
-  State &GetStateForLanguage(const Language &language);
-
+  /// The number of workers per process.
+  int num_workers_per_process_;
   /// Pool states per language.
   std::unordered_map<Language, State> states_by_lang_;
 
-  /// The number of workers per process.
-  int num_workers_per_process_;
-
-  /// The maximum number of workers that can be started concurrently.
-  int maximum_startup_concurrency_;
-
  private:
+  /// A helper function that returns the reference of the pool state
+  /// for a given language.
+  inline State &GetStateForLanguage(const Language &language);
+
   /// We'll push a warning to the user every time a multiple of this many
   /// workers has been started.
   int multiple_for_warning_;
+  /// The maximum number of workers that can be started concurrently.
+  int maximum_startup_concurrency_;
   /// The last size at which a warning about the number of registered workers
   /// was generated.
   int64_t last_warning_multiple_;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -131,13 +131,6 @@ class WorkerPool {
   std::string WarningAboutSize();
 
  protected:
-  /// A map from the pids of starting worker processes
-  /// to the number of their unregistered workers.
-  std::unordered_map<pid_t, int> starting_worker_processes_;
-  /// The number of workers per process.
-  int num_workers_per_process_;
-
- private:
   /// An internal data structure that maintains the pool state per language.
   struct State {
     /// The commands and arguments used to start the worker process
@@ -151,19 +144,28 @@ class WorkerPool {
     std::unordered_set<std::shared_ptr<Worker>> registered_workers;
     /// All drivers that have registered and are still connected.
     std::unordered_set<std::shared_ptr<Worker>> registered_drivers;
+    /// A map from the pids of starting worker processes
+    /// to the number of their unregistered workers.
+    std::unordered_map<pid_t, int> starting_worker_processes;
   };
 
   /// A helper function that returns the reference of the pool state
   /// for a given language.
-  inline State &GetStateForLanguage(const Language &language);
+  State &GetStateForLanguage(const Language &language);
 
+  /// Pool states per language.
+  std::unordered_map<Language, State> states_by_lang_;
+
+  /// The number of workers per process.
+  int num_workers_per_process_;
+
+  /// The maximum number of workers that can be started concurrently.
+  int maximum_startup_concurrency_;
+
+ private:
   /// We'll push a warning to the user every time a multiple of this many
   /// workers has been started.
   int multiple_for_warning_;
-  /// The maximum number of workers that can be started concurrently.
-  int maximum_startup_concurrency_;
-  /// Pool states per language.
-  std::unordered_map<Language, State> states_by_lang_;
   /// The last size at which a warning about the number of registered workers
   /// was generated.
   int64_t last_warning_multiple_;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -27,9 +27,7 @@ class WorkerPoolMock : public WorkerPool {
     return ++last_worker_pid_;
   }
 
-  pid_t LastStartedWorkerProcess() const {
-    return last_worker_pid_;
-  }
+  pid_t LastStartedWorkerProcess() const { return last_worker_pid_; }
 
   int NumWorkerProcessesStarting() const {
     int total = 0;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -116,8 +116,9 @@ TEST_F(WorkerPoolTest, StartupWorkerCount) {
   }
   // Check that number of starting worker processes equals to
   // maximum_startup_concurrency_ * 2. (because we started both python and java workers)
-  ASSERT_EQ(worker_pool_.NumWorkerProcessesStarting(),
-  /* Provided in constructor of WorkerPoolMock */ MAXIMUM_STARTUP_CONCURRENCY * 2);
+  ASSERT_EQ(
+      worker_pool_.NumWorkerProcessesStarting(),
+      /* Provided in constructor of WorkerPoolMock */ MAXIMUM_STARTUP_CONCURRENCY * 2);
 }
 
 TEST_F(WorkerPoolTest, HandleWorkerPushPop) {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -115,7 +115,8 @@ TEST_F(WorkerPoolTest, StartupWorkerCount) {
   }
   // Check that number of starting worker processes equals to
   // maximum_startup_concurrency_ * 2. (because we started both python and java workers)
-  ASSERT_EQ(worker_pool_.NumWorkerProcessesStarting(), 5 * 2);
+  ASSERT_EQ(worker_pool_.NumWorkerProcessesStarting(),
+  /* Provided in constructor of WorkerPoolMock */ 5 * 2);
 }
 
 TEST_F(WorkerPoolTest, HandleWorkerPushPop) {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -9,11 +9,12 @@ namespace ray {
 namespace raylet {
 
 int NUM_WORKERS_PER_PROCESS = 3;
+int MAXIMUM_STARTUP_CONCURRENCY = 5;
 
 class WorkerPoolMock : public WorkerPool {
  public:
   WorkerPoolMock()
-      : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 5,
+      : WorkerPool(0, NUM_WORKERS_PER_PROCESS, MAXIMUM_STARTUP_CONCURRENCY,
                    {{Language::PYTHON, {"dummy_py_worker_command"}},
                     {Language::JAVA, {"dummy_java_worker_command"}}}),
         last_worker_pid_(0) {}
@@ -116,7 +117,7 @@ TEST_F(WorkerPoolTest, StartupWorkerCount) {
   // Check that number of starting worker processes equals to
   // maximum_startup_concurrency_ * 2. (because we started both python and java workers)
   ASSERT_EQ(worker_pool_.NumWorkerProcessesStarting(),
-  /* Provided in constructor of WorkerPoolMock */ 5 * 2);
+  /* Provided in constructor of WorkerPoolMock */ MAXIMUM_STARTUP_CONCURRENCY * 2);
 }
 
 TEST_F(WorkerPoolTest, HandleWorkerPushPop) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Assumes that a node has 4 CPUs and we enabled both java and python workers. Before this change, raylet will start 4 java workers and 0 python workers by default at startup. After this change, raylet will start 4 java workers and 4 python workers by default at startup.
## Related issue number

