### PR TITLE
Don't check fail on missing lineage cache entry

### DIFF
--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -338,6 +338,8 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
     if (entry) {
       RAY_CHECK(uncommitted_lineage.SetEntry(entry->TaskData(), entry->GetStatus()));
     } else {
+      // TODO: We expected the lineage to be in cache, but it was evicted (#3813).
+      // This is a bug but is not fatal to the application.
       RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
     }
   }

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -167,7 +167,7 @@ const std::unordered_map<const TaskID, LineageEntry> &Lineage::GetEntries() cons
 
 flatbuffers::Offset<protocol::ForwardTaskRequest> Lineage::ToFlatbuffer(
     flatbuffers::FlatBufferBuilder &fbb, const TaskID &task_id) const {
-  RAY_DCHECK(GetEntry(task_id));
+  RAY_CHECK(GetEntry(task_id));
   // Serialize the task and object entries.
   std::vector<flatbuffers::Offset<protocol::Task>> uncommitted_tasks;
   for (const auto &entry : entries_) {
@@ -335,14 +335,8 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
   // already explicitly forwarded to this node before.
   if (uncommitted_lineage.GetEntries().empty()) {
     auto entry = lineage_.GetEntry(task_id);
-    if (entry) {
-      RAY_CHECK(uncommitted_lineage.SetEntry(entry->TaskData(), entry->GetStatus()));
-    } else {
-      // TODO: We expected the lineage to be in cache, but it was evicted (#3813).
-      // This is a bug but is not fatal to the application.
-      RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
-      RAY_DCHECK(false);
-    }
+    RAY_CHECK(entry);
+    RAY_CHECK(uncommitted_lineage.SetEntry(entry->TaskData(), entry->GetStatus()));
   }
   return uncommitted_lineage;
 }

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -341,6 +341,7 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
       // TODO: We expected the lineage to be in cache, but it was evicted (#3813).
       // This is a bug but is not fatal to the application.
       RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
+      RAY_DCHECK(false);
     }
   }
   return uncommitted_lineage;

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -167,7 +167,7 @@ const std::unordered_map<const TaskID, LineageEntry> &Lineage::GetEntries() cons
 
 flatbuffers::Offset<protocol::ForwardTaskRequest> Lineage::ToFlatbuffer(
     flatbuffers::FlatBufferBuilder &fbb, const TaskID &task_id) const {
-  RAY_CHECK(GetEntry(task_id));
+  RAY_DCHECK(GetEntry(task_id));
   // Serialize the task and object entries.
   std::vector<flatbuffers::Offset<protocol::Task>> uncommitted_tasks;
   for (const auto &entry : entries_) {

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -335,8 +335,11 @@ Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
   // already explicitly forwarded to this node before.
   if (uncommitted_lineage.GetEntries().empty()) {
     auto entry = lineage_.GetEntry(task_id);
-    RAY_CHECK(entry);
-    RAY_CHECK(uncommitted_lineage.SetEntry(entry->TaskData(), entry->GetStatus()));
+    if (entry) {
+      RAY_CHECK(uncommitted_lineage.SetEntry(entry->TaskData(), entry->GetStatus()));
+    } else {
+      RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
+    }
   }
   return uncommitted_lineage;
 }

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -324,8 +324,8 @@ void GetUncommittedLineageHelper(const TaskID &task_id, const Lineage &lineage_f
   }
 }
 
-Lineage LineageCache::GetUncommittedLineage(const TaskID &task_id,
-                                            const ClientID &node_id) const {
+Lineage LineageCache::GetUncommittedLineageOrDie(const TaskID &task_id,
+                                                 const ClientID &node_id) const {
   Lineage uncommitted_lineage;
   // Add all uncommitted ancestors from the lineage cache to the uncommitted
   // lineage of the requested task.
@@ -445,7 +445,7 @@ void LineageCache::HandleEntryCommitted(const TaskID &task_id) {
   UnsubscribeTask(task_id);
 }
 
-const Task &LineageCache::GetTask(const TaskID &task_id) const {
+const Task &LineageCache::GetTaskOrDie(const TaskID &task_id) const {
   const auto &entries = lineage_.GetEntries();
   auto it = entries.find(task_id);
   RAY_CHECK(it != entries.end());

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -263,11 +263,13 @@ class LineageCache {
   /// The uncommitted lineage consists of all tasks in the given task's lineage
   /// that have not been committed in the GCS, as far as we know.
   ///
-  /// \param task_id The ID of the task to get the uncommitted lineage for.
+  /// \param task_id The ID of the task to get the uncommitted lineage for. It is
+  ///                a fatal error if the task is not found.
   /// \param node_id The ID of the receiving node.
   /// \return The uncommitted, unforwarded lineage of the task. The returned lineage
   /// includes the entry for the requested entry_id.
-  Lineage GetUncommittedLineage(const TaskID &task_id, const ClientID &node_id) const;
+  Lineage GetUncommittedLineageOrDie(const TaskID &task_id,
+                                     const ClientID &node_id) const;
 
   /// Handle the commit of a task entry in the GCS. This attempts to evict the
   /// task if possible.
@@ -279,7 +281,7 @@ class LineageCache {
   ///
   /// \param task_id The ID of the task to get.
   /// \return A const reference to the task data.
-  const Task &GetTask(const TaskID &task_id) const;
+  const Task &GetTaskOrDie(const TaskID &task_id) const;
 
   /// Get whether the lineage cache contains the task.
   ///

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1905,9 +1905,13 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
   // Get and serialize the task's unforwarded, uncommitted lineage.
   Lineage uncommitted_lineage;
   if (lineage_cache_.ContainsTask(task_id)) {
-      uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
+    uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
   } else {
-      uncommitted_lineage.SetEntry(task, GcsStatus::NONE);
+    // TODO: We expected the lineage to be in cache, but it was evicted (#3813).
+    // This is a bug but is not fatal to the application.
+    RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
+    RAY_DCHECK(false);
+    uncommitted_lineage.SetEntry(task, GcsStatus::NONE);
   }
   auto entry = uncommitted_lineage.GetEntryMutable(task_id);
   Task &lineage_cache_entry_task = entry->TaskDataMutable();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1903,9 +1903,14 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
   auto task_id = spec.TaskId();
 
   // Get and serialize the task's unforwarded, uncommitted lineage.
-  auto uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
-  Task &lineage_cache_entry_task =
-      uncommitted_lineage.GetEntryMutable(task_id)->TaskDataMutable();
+  Lineage uncommitted_lineage;
+  if (lineage_cache_.ContainsTask(task_id)) {
+      uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
+  } else {
+      uncommitted_lineage.SetEntry(task, GcsStatus::NONE);
+  }
+  auto entry = uncommitted_lineage.GetEntryMutable(task_id)
+  Task &lineage_cache_entry_task = entry->TaskDataMutable();
 
   // Increment forward count for the forwarded task.
   lineage_cache_entry_task.IncrementNumForwards();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1752,7 +1752,7 @@ void NodeManager::HandleTaskReconstruction(const TaskID &task_id) {
                "allocation via "
             << "ray.init(redis_max_memory=<max_memory_bytes>).";
         // Use a copy of the cached task spec to re-execute the task.
-        const Task task = lineage_cache_.GetTask(task_id);
+        const Task task = lineage_cache_.GetTaskOrDie(task_id);
         ResubmitTask(task);
 
       }));
@@ -1905,12 +1905,11 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
   // Get and serialize the task's unforwarded, uncommitted lineage.
   Lineage uncommitted_lineage;
   if (lineage_cache_.ContainsTask(task_id)) {
-    uncommitted_lineage = lineage_cache_.GetUncommittedLineage(task_id, node_id);
+    uncommitted_lineage = lineage_cache_.GetUncommittedLineageOrDie(task_id, node_id);
   } else {
     // TODO: We expected the lineage to be in cache, but it was evicted (#3813).
     // This is a bug but is not fatal to the application.
-    RAY_LOG(ERROR) << "No lineage cache entry found for task " << task_id;
-    RAY_DCHECK(false);
+    RAY_DCHECK(false) << "No lineage cache entry found for task " << task_id;
     uncommitted_lineage.SetEntry(task, GcsStatus::NONE);
   }
   auto entry = uncommitted_lineage.GetEntryMutable(task_id);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1909,7 +1909,7 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
   } else {
       uncommitted_lineage.SetEntry(task, GcsStatus::NONE);
   }
-  auto entry = uncommitted_lineage.GetEntryMutable(task_id)
+  auto entry = uncommitted_lineage.GetEntryMutable(task_id);
   Task &lineage_cache_entry_task = entry->TaskDataMutable();
 
   // Increment forward count for the forwarded task.

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -24,10 +24,11 @@ enum class RayLogLevel { DEBUG = -1, INFO = 0, WARNING = 1, ERROR = 2, FATAL = 3
 
 #ifdef NDEBUG
 
-#define RAY_DCHECK(condition) \
-  RAY_IGNORE_EXPR(condition); \
-  while (false) ::ray::RayLogBase()
-
+#define RAY_DCHECK(condition)                                                  \
+  (condition) ? RAY_IGNORE_EXPR(0)                                             \
+              : ::ray::Voidify() &                                             \
+                    ::ray::RayLog(__FILE__, __LINE__, ray::RayLogLevel::ERROR) \
+                        << " Debug check failed: " #condition " "
 #else
 
 #define RAY_DCHECK(condition) RAY_CHECK(condition)


### PR DESCRIPTION

## What do these changes do?

Under some race conditions with slow actor creation tasks, it seems like we hit this check. Be defensive and just return empty lineage in this case.

## Related issue number

https://github.com/ray-project/ray/issues/3813