### PR TITLE
[tune][rllib] Add export_formats option to export models

### DIFF
--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -584,7 +584,7 @@ class Agent(Trainable):
             output_creator=output_creator)
 
     @override(Trainable)
-    def _export_default_policy(self, export_formats, export_dir):
+    def _export_model(self, export_formats, export_dir):
         ExportFormat.validate(export_formats)
         exported = {}
         if ExportFormat.CHECKPOINT in export_formats:

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -588,11 +588,11 @@ class Agent(Trainable):
         exported = {}
         if ExportFormat.CHECKPOINT in export_formats:
             path = os.path.join(export_dir, ExportFormat.CHECKPOINT)
-            self.export_policy_checkpoint(export_dir)
+            self.export_policy_checkpoint(path)
             exported[ExportFormat.CHECKPOINT] = path
         if ExportFormat.MODEL in export_formats:
             path = os.path.join(export_dir, ExportFormat.MODEL)
-            self.export_policy_model(export_dir)
+            self.export_policy_model(path)
             exported[ExportFormat.MODEL] = path
         return exported
 

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -584,7 +584,7 @@ class Agent(Trainable):
             output_creator=output_creator)
 
     @override(Trainable)
-    def _export_default_policy(self, export_dir, export_formats):
+    def _export_default_policy(self, export_formats, export_dir):
         exported = {}
         if ExportFormat.CHECKPOINT in export_formats:
             path = os.path.join(export_dir, ExportFormat.CHECKPOINT)

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -7,7 +7,6 @@ import copy
 import logging
 import os
 import pickle
-import shutil
 import six
 import tempfile
 import tensorflow as tf
@@ -587,13 +586,9 @@ class Agent(Trainable):
 
     def _export_default_policy(self, export_dir):
         model_path = os.path.join(export_dir, "policy_model")
-        if os.path.exists(model_path):
-            shutil.rmtree(model_path)
         self.export_policy_model(export_dir)
 
         ckpt_path = os.path.join(export_dir, "policy_checkpoint")
-        if os.path.exists(ckpt_path):
-            shutil.rmtree(ckpt_path)
         self.export_policy_checkpoint(export_dir)
 
     def __getstate__(self):

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -585,6 +585,7 @@ class Agent(Trainable):
 
     @override(Trainable)
     def _export_default_policy(self, export_formats, export_dir):
+        ExportFormat.validate(export_formats)
         exported = {}
         if ExportFormat.CHECKPOINT in export_formats:
             path = os.path.join(export_dir, ExportFormat.CHECKPOINT)

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -7,6 +7,7 @@ import copy
 import logging
 import os
 import pickle
+import shutil
 import six
 import tempfile
 import tensorflow as tf
@@ -337,6 +338,7 @@ class Agent(Trainable):
         checkpoint_path = os.path.join(checkpoint_dir,
                                        "checkpoint-{}".format(self.iteration))
         pickle.dump(self.__getstate__(), open(checkpoint_path, "wb"))
+        self._export_default_policy(checkpoint_dir)
         return checkpoint_path
 
     @override(Trainable)
@@ -582,6 +584,17 @@ class Agent(Trainable):
             input_creator=input_creator,
             input_evaluation_method=config["input_evaluation"],
             output_creator=output_creator)
+
+    def _export_default_policy(self, export_dir):
+        model_path = os.path.join(export_dir, "policy_model")
+        if os.path.exists(model_path):
+            shutil.rmtree(model_path)
+        self.export_policy_model(export_dir)
+
+        ckpt_path = os.path.join(export_dir, "policy_checkpoint")
+        if os.path.exists(ckpt_path):
+            shutil.rmtree(ckpt_path)
+        self.export_policy_checkpoint(export_dir)
 
     def __getstate__(self):
         state = {}

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -192,7 +192,9 @@ class TFPolicyGraph(PolicyGraph):
 
     @override(PolicyGraph)
     def export_model(self, export_dir):
-        """Export tensorflow graph to export_dir for serving."""
+        """Export tensorflow graph to export_dir for serving.
+           Existing dir will be overwritten.
+        """
         if os.path.exists(export_dir):
             shutil.rmtree(export_dir)
         with self._sess.graph.as_default():
@@ -205,7 +207,9 @@ class TFPolicyGraph(PolicyGraph):
 
     @override(PolicyGraph)
     def export_checkpoint(self, export_dir, filename_prefix="model"):
-        """Export tensorflow checkpoint to export_dir."""
+        """Export tensorflow checkpoint to export_dir.
+           Existing dir will be overwritten.
+        """
         if os.path.exists(export_dir):
             shutil.rmtree(export_dir)
         save_path = os.path.join(export_dir, filename_prefix)

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -207,10 +207,9 @@ class TFPolicyGraph(PolicyGraph):
         try:
             os.makedirs(export_dir)
         except OSError as e:
-            # Ignore error if export_dir already exists
+            # ignore error if export dir already exists
             if e.errno != errno.EEXIST:
                 raise
-
         save_path = os.path.join(export_dir, filename_prefix)
         with self._sess.graph.as_default():
             saver = tf.train.Saver()

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -212,6 +212,7 @@ class TFPolicyGraph(PolicyGraph):
         """
         if os.path.exists(export_dir):
             shutil.rmtree(export_dir)
+        os.makedirs(export_dir)
         save_path = os.path.join(export_dir, filename_prefix)
         with self._sess.graph.as_default():
             saver = tf.train.Saver()

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import os
 import logging
+import shutil
 import tensorflow as tf
 import numpy as np
 
@@ -192,6 +193,8 @@ class TFPolicyGraph(PolicyGraph):
     @override(PolicyGraph)
     def export_model(self, export_dir):
         """Export tensorflow graph to export_dir for serving."""
+        if os.path.exists(export_dir):
+            shutil.rmtree(export_dir)
         with self._sess.graph.as_default():
             builder = tf.saved_model.builder.SavedModelBuilder(export_dir)
             signature_def_map = self._build_signature_def()
@@ -203,6 +206,8 @@ class TFPolicyGraph(PolicyGraph):
     @override(PolicyGraph)
     def export_checkpoint(self, export_dir, filename_prefix="model"):
         """Export tensorflow checkpoint to export_dir."""
+        if os.path.exists(export_dir):
+            shutil.rmtree(export_dir)
         save_path = os.path.join(export_dir, filename_prefix)
         with self._sess.graph.as_default():
             saver = tf.train.Saver()

--- a/python/ray/rllib/test/test_checkpoint_restore.py
+++ b/python/ray/rllib/test/test_checkpoint_restore.py
@@ -89,18 +89,16 @@ def test_ckpt_restore(use_object_store, alg_name, failures):
             failures.append((alg_name, [a1, a2]))
 
 
-def valid_tf_model(model_dir):
-    return os.path.exists(os.path.join(model_dir, "saved_model.pb")) \
-        and os.listdir(os.path.join(model_dir, "variables"))
-
-
-def valid_tf_checkpoint(checkpoint_dir):
-    return os.path.exists(os.path.join(checkpoint_dir, "model.meta")) \
-        and os.path.exists(os.path.join(checkpoint_dir, "model.index")) \
-        and os.path.exists(os.path.join(checkpoint_dir, "checkpoint"))
-
-
 def test_export(algo_name, failures):
+    def valid_tf_model(model_dir):
+        return os.path.exists(os.path.join(model_dir, "saved_model.pb")) \
+            and os.listdir(os.path.join(model_dir, "variables"))
+
+    def valid_tf_checkpoint(checkpoint_dir):
+        return os.path.exists(os.path.join(checkpoint_dir, "model.meta")) \
+            and os.path.exists(os.path.join(checkpoint_dir, "model.index")) \
+            and os.path.exists(os.path.join(checkpoint_dir, "checkpoint"))
+    
     cls = get_agent_class(algo_name)
     if "DDPG" in algo_name:
         algo = cls(config=CONFIGS[name], env="Pendulum-v0")

--- a/python/ray/rllib/test/test_checkpoint_restore.py
+++ b/python/ray/rllib/test/test_checkpoint_restore.py
@@ -10,6 +10,7 @@ import numpy as np
 import ray
 
 from ray.rllib.agents.registry import get_agent_class
+from ray.tune.trial import ExportFormat
 
 
 def get_mean_action(alg, obs):
@@ -88,6 +89,17 @@ def test_ckpt_restore(use_object_store, alg_name, failures):
             failures.append((alg_name, [a1, a2]))
 
 
+def valid_tf_model(model_dir):
+    return os.path.exists(os.path.join(model_dir, "saved_model.pb")) \
+        and os.listdir(os.path.join(model_dir, "variables"))
+
+
+def valid_tf_checkpoint(checkpoint_dir):
+    return os.path.exists(os.path.join(checkpoint_dir, "model.meta")) \
+        and os.path.exists(os.path.join(checkpoint_dir, "model.index")) \
+        and os.path.exists(os.path.join(checkpoint_dir, "checkpoint"))
+
+
 def test_export(algo_name, failures):
     cls = get_agent_class(algo_name)
     if "DDPG" in algo_name:
@@ -102,16 +114,22 @@ def test_export(algo_name, failures):
     export_dir = "/tmp/export_dir_%s" % algo_name
     print("Exporting model ", algo_name, export_dir)
     algo.export_policy_model(export_dir)
-    if not os.path.exists(os.path.join(export_dir, "saved_model.pb")) \
-            or not os.listdir(os.path.join(export_dir, "variables")):
+    if not valid_tf_model(export_dir):
         failures.append(algo_name)
     shutil.rmtree(export_dir)
 
     print("Exporting checkpoint", algo_name, export_dir)
     algo.export_policy_checkpoint(export_dir)
-    if not os.path.exists(os.path.join(export_dir, "model.meta")) \
-            or not os.path.exists(os.path.join(export_dir, "model.index")) \
-            or not os.path.exists(os.path.join(export_dir, "checkpoint")):
+    if not valid_tf_checkpoint(export_dir):
+        failures.append(algo_name)
+    shutil.rmtree(export_dir)
+
+    print("Exporting default policy", algo_name, export_dir)
+    algo.export_default_policy([ExportFormat.CHECKPOINT, ExportFormat.MODEL],
+                               export_dir)
+    if not valid_tf_model(os.path.join(export_dir, ExportFormat.MODEL)) \
+            or not valid_tf_checkpoint(os.path.join(export_dir,
+                                                    ExportFormat.CHECKPOINT)):
         failures.append(algo_name)
     shutil.rmtree(export_dir)
 

--- a/python/ray/rllib/test/test_checkpoint_restore.py
+++ b/python/ray/rllib/test/test_checkpoint_restore.py
@@ -98,7 +98,7 @@ def test_export(algo_name, failures):
         return os.path.exists(os.path.join(checkpoint_dir, "model.meta")) \
             and os.path.exists(os.path.join(checkpoint_dir, "model.index")) \
             and os.path.exists(os.path.join(checkpoint_dir, "checkpoint"))
-    
+
     cls = get_agent_class(algo_name)
     if "DDPG" in algo_name:
         algo = cls(config=CONFIGS[name], env="Pendulum-v0")

--- a/python/ray/rllib/test/test_checkpoint_restore.py
+++ b/python/ray/rllib/test/test_checkpoint_restore.py
@@ -123,8 +123,8 @@ def test_export(algo_name, failures):
     shutil.rmtree(export_dir)
 
     print("Exporting default policy", algo_name, export_dir)
-    algo.export_default_policy([ExportFormat.CHECKPOINT, ExportFormat.MODEL],
-                               export_dir)
+    algo.export_model([ExportFormat.CHECKPOINT, ExportFormat.MODEL],
+                      export_dir)
     if not valid_tf_model(os.path.join(export_dir, ExportFormat.MODEL)) \
             or not valid_tf_checkpoint(os.path.join(export_dir,
                                                     ExportFormat.CHECKPOINT)):

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -105,7 +105,9 @@ def make_parser(parser_creator=None, **kwargs):
     parser.add_argument(
         "--export-formats",
         default=None,
-        help="List of formats that exported at the end of the experiment.")
+        help="List of formats that exported at the end of the experiment. "
+        "Default is None. 'checkpoint' and 'model' are supported for "
+        "TensorFlow policy graphs.")
     parser.add_argument(
         "--max-failures",
         default=3,

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -103,6 +103,11 @@ def make_parser(parser_creator=None, **kwargs):
         help="Whether to checkpoint at the end of the experiment. "
         "Default is False.")
     parser.add_argument(
+        "--export-formats",
+        default=None,
+
+            )
+    parser.add_argument(
         "--max-failures",
         default=3,
         type=int,

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -106,8 +106,8 @@ def make_parser(parser_creator=None, **kwargs):
         "--export-formats",
         default=None,
         help="List of formats that exported at the end of the experiment. "
-        "Default is None. 'checkpoint' and 'model' are supported for "
-        "TensorFlow policy graphs.")
+        "Default is None. For RLlib, 'checkpoint' and 'model' are "
+        "supported for TensorFlow policy graphs.")
     parser.add_argument(
         "--max-failures",
         default=3,

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -105,8 +105,7 @@ def make_parser(parser_creator=None, **kwargs):
     parser.add_argument(
         "--export-formats",
         default=None,
-
-            )
+        help="List of formats that exported at the end of the experiment.")
     parser.add_argument(
         "--max-failures",
         default=3,
@@ -186,6 +185,7 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
         stopping_criterion=spec.get("stop", {}),
         checkpoint_freq=args.checkpoint_freq,
         checkpoint_at_end=args.checkpoint_at_end,
+        export_formats=spec.get("export_formats", []),
         # str(None) doesn't create None
         restore_path=spec.get("restore"),
         upload_dir=args.upload_dir,

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -72,6 +72,8 @@ class Experiment(object):
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
+        export_formats (list): List of formats that exported at the end of
+            the experiment. Default is None.
         max_failures (int): Try to recover a trial from its last
             checkpoint at least this many times. Only applies if
             checkpointing is enabled. Defaults to 3.
@@ -118,6 +120,7 @@ class Experiment(object):
                  sync_function=None,
                  checkpoint_freq=0,
                  checkpoint_at_end=False,
+                 export_formats=None,
                  max_failures=3,
                  restore=None,
                  repeat=None,
@@ -145,6 +148,7 @@ class Experiment(object):
             "sync_function": sync_function,
             "checkpoint_freq": checkpoint_freq,
             "checkpoint_at_end": checkpoint_at_end,
+            "export_formats": export_formats or [],
             "max_failures": max_failures,
             "restore": restore
         }

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -346,10 +346,12 @@ class RayTrialExecutor(TrialExecutor):
             logger.exception("Error restoring runner for Trial %s.", trial)
             self.set_status(trial, Trial.ERROR)
             return False
-    
+
     def export_trial_if_needed(self, trial):
         """Exports policy graph of this trial based on trial.export_formats.
         """
         if trial.export_formats and len(trial.export_formats) > 0:
-            return ray.get(trial.runner.export_default_policy.remote(trial.export_formats))
+            return ray.get(
+                trial.runner.export_default_policy.remote(
+                    trial.export_formats))
         return {}

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -346,3 +346,10 @@ class RayTrialExecutor(TrialExecutor):
             logger.exception("Error restoring runner for Trial %s.", trial)
             self.set_status(trial, Trial.ERROR)
             return False
+    
+    def export_trial_if_needed(self, trial):
+        """Exports policy graph of this trial based on trial.export_formats.
+        """
+        if trial.export_formats and len(trial.export_formats) > 0:
+            return ray.get(trial.runner.export_default_policy.remote(trial.export_formats))
+        return {}

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -348,10 +348,9 @@ class RayTrialExecutor(TrialExecutor):
             return False
 
     def export_trial_if_needed(self, trial):
-        """Exports policy graph of this trial based on trial.export_formats.
+        """Exports model of this trial based on trial.export_formats.
         """
         if trial.export_formats and len(trial.export_formats) > 0:
             return ray.get(
-                trial.runner.export_default_policy.remote(
-                    trial.export_formats))
+                trial.runner.export_model.remote(trial.export_formats))
         return {}

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -349,6 +349,9 @@ class RayTrialExecutor(TrialExecutor):
 
     def export_trial_if_needed(self, trial):
         """Exports model of this trial based on trial.export_formats.
+
+        Return:
+            A dict that maps ExportFormats to successfully exported models.
         """
         if trial.export_formats and len(trial.export_formats) > 0:
             return ray.get(

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -23,7 +23,7 @@ from ray.tune.result import (DEFAULT_RESULTS_DIR, TIMESTEPS_TOTAL, DONE,
 from ray.tune.logger import Logger
 from ray.tune.util import pin_in_object_store, get_pinned_object
 from ray.tune.experiment import Experiment
-from ray.tune.trial import Trial, Resources
+from ray.tune.trial import Trial, Resources, ExportFormat
 from ray.tune.trial_runner import TrialRunner
 from ray.tune.suggest import grid_search, BasicVariantGenerator
 from ray.tune.suggest.suggestion import (_MockSuggestionAlgorithm,
@@ -700,6 +700,25 @@ class RunExperimentTest(unittest.TestCase):
             self.assertEqual(trial.status, Trial.TERMINATED)
             self.assertTrue(
                 os.path.exists(os.path.join(trial.logdir, "exported")))
+
+    def testInvalidExportFormats(self):
+        class train(Trainable):
+            def _train(self):
+                return {"timesteps_this_iter": 1, "done": True}
+
+            def _export_default_policy(self, export_formats, export_dir):
+                ExportFormat.validate(export_formats)
+                return {}
+
+        def fail_trial():
+            run_experiments({
+                "foo": {
+                    "run": train,
+                    "export_formats": ["format"]
+                }
+            })
+
+        self.assertRaises(TuneError, fail_trial)
 
     def testDeprecatedResources(self):
         class train(Trainable):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -679,6 +679,28 @@ class RunExperimentTest(unittest.TestCase):
             self.assertEqual(trial.status, Trial.TERMINATED)
             self.assertTrue(trial.has_checkpoint())
 
+    def testExportFormats(self):
+        class train(Trainable):
+            def _train(self):
+                return {"timesteps_this_iter": 1, "done": True}
+
+            def _export_default_policy(self, export_formats, export_dir):
+                path = export_dir + "/exported"
+                with open(path, "w") as f:
+                    f.write("OK")
+                return {export_formats[0]: path}
+
+        trials = run_experiments({
+            "foo": {
+                "run": train,
+                "export_formats": ["format"]
+            }
+        })
+        for trial in trials:
+            self.assertEqual(trial.status, Trial.TERMINATED)
+            self.assertTrue(os.path.exists(os.path.join(trial.logdir,
+                                                        "exported")))
+
     def testDeprecatedResources(self):
         class train(Trainable):
             def _train(self):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -698,8 +698,8 @@ class RunExperimentTest(unittest.TestCase):
         })
         for trial in trials:
             self.assertEqual(trial.status, Trial.TERMINATED)
-            self.assertTrue(os.path.exists(os.path.join(trial.logdir,
-                                                        "exported")))
+            self.assertTrue(
+                os.path.exists(os.path.join(trial.logdir,"exported")))
 
     def testDeprecatedResources(self):
         class train(Trainable):

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -684,7 +684,7 @@ class RunExperimentTest(unittest.TestCase):
             def _train(self):
                 return {"timesteps_this_iter": 1, "done": True}
 
-            def _export_default_policy(self, export_formats, export_dir):
+            def _export_model(self, export_formats, export_dir):
                 path = export_dir + "/exported"
                 with open(path, "w") as f:
                     f.write("OK")
@@ -706,7 +706,7 @@ class RunExperimentTest(unittest.TestCase):
             def _train(self):
                 return {"timesteps_this_iter": 1, "done": True}
 
-            def _export_default_policy(self, export_formats, export_dir):
+            def _export_model(self, export_formats, export_dir):
                 ExportFormat.validate(export_formats)
                 return {}
 

--- a/python/ray/tune/test/trial_runner_test.py
+++ b/python/ray/tune/test/trial_runner_test.py
@@ -699,7 +699,7 @@ class RunExperimentTest(unittest.TestCase):
         for trial in trials:
             self.assertEqual(trial.status, Trial.TERMINATED)
             self.assertTrue(
-                os.path.exists(os.path.join(trial.logdir,"exported")))
+                os.path.exists(os.path.join(trial.logdir, "exported")))
 
     def testDeprecatedResources(self):
         class train(Trainable):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -331,21 +331,21 @@ class Trainable(object):
         self.restore(checkpoint_path)
         shutil.rmtree(tmpdir)
 
-    def export_default_policy(self, export_dir=None, export_formats):
+    def export_default_policy(self, export_formats, export_dir=None):
         """Exports default policy graph based on export_formats.
         Subclasses should override _export_default_policy() to actually
         export policy graph to local directory.
 
         Args:
-            export_dir (str): Optional dir to place the exported model.
             export_formats (list): List of formats that should be exported.
+            export_dir (str): Optional dir to place the exported model.
 
         Returns:
             A Python dict of directories containing the exported policy graphs
             corresponding to export_formats if exported otherwise empty dict.
         """
         export_dir = export_dir or self.logdir
-        return self._export_default_policy(export_dir, export_formats)
+        return self._export_default_policy(export_formats, export_dir)
 
     def reset_config(self, new_config):
         """Resets configuration without restarting the trial.
@@ -418,18 +418,19 @@ class Trainable(object):
         """Subclasses should override this for any cleanup on stop."""
         pass
 
-    def _export_default_policy(self, export_dir, export_formats):
+    def _export_default_policy(self, export_formats, export_dir):
         """Subclasses should override this to actually export policy graphs.
 
         Args:
-            export_dir (str): Local directory to place exported policy graphs.
             export_formats (list): List of formats that should be exported.
+            export_dir (str): Local directory to place exported policy graphs.
 
         Returns:
             A Python dict of directories containing the exported policy graphs
             corresponding to export_formats if exported otherwise empty dict.
         """
         return {}
+
 
 def wrap_function(train_func):
     from ray.tune.function_runner import FunctionRunner

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -333,16 +333,17 @@ class Trainable(object):
 
     def export_model(self, export_formats, export_dir=None):
         """Exports model based on export_formats.
+
         Subclasses should override _export_model() to actually
         export model to local directory.
 
         Args:
             export_formats (list): List of formats that should be exported.
             export_dir (str): Optional dir to place the exported model.
+                Defaults to self.logdir.
 
-        Returns:
-            A Python dict mapping export formats to exported models
-            if exported successfully otherwise empty dict.
+        Return:
+            A dict that maps ExportFormats to successfully exported models.
         """
         export_dir = export_dir or self.logdir
         return self._export_model(export_formats, export_dir)
@@ -419,15 +420,14 @@ class Trainable(object):
         pass
 
     def _export_model(self, export_formats, export_dir):
-        """Subclasses should override this to actually export model.
+        """Subclasses should override this to export model.
 
         Args:
             export_formats (list): List of formats that should be exported.
-            export_dir (str): Local directory to place exported models.
+            export_dir (str): Directory to place exported models.
 
-        Returns:
-            A Python dict mapping export formats to exported models
-            if exported successfully otherwise empty dict.
+        Return:
+            A dict that maps ExportFormats to successfully exported models.
         """
         return {}
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -331,21 +331,21 @@ class Trainable(object):
         self.restore(checkpoint_path)
         shutil.rmtree(tmpdir)
 
-    def export_default_policy(self, export_formats, export_dir=None):
-        """Exports default policy graph based on export_formats.
-        Subclasses should override _export_default_policy() to actually
-        export policy graph to local directory.
+    def export_model(self, export_formats, export_dir=None):
+        """Exports model based on export_formats.
+        Subclasses should override _export_model() to actually
+        export model to local directory.
 
         Args:
             export_formats (list): List of formats that should be exported.
             export_dir (str): Optional dir to place the exported model.
 
         Returns:
-            A Python dict of directories containing the exported policy graphs
-            corresponding to export_formats if exported otherwise empty dict.
+            A Python dict mapping export formats to exported models
+            if exported successfully otherwise empty dict.
         """
         export_dir = export_dir or self.logdir
-        return self._export_default_policy(export_formats, export_dir)
+        return self._export_model(export_formats, export_dir)
 
     def reset_config(self, new_config):
         """Resets configuration without restarting the trial.
@@ -418,16 +418,16 @@ class Trainable(object):
         """Subclasses should override this for any cleanup on stop."""
         pass
 
-    def _export_default_policy(self, export_formats, export_dir):
-        """Subclasses should override this to actually export policy graphs.
+    def _export_model(self, export_formats, export_dir):
+        """Subclasses should override this to actually export model.
 
         Args:
             export_formats (list): List of formats that should be exported.
-            export_dir (str): Local directory to place exported policy graphs.
+            export_dir (str): Local directory to place exported models.
 
         Returns:
-            A Python dict of directories containing the exported policy graphs
-            corresponding to export_formats if exported otherwise empty dict.
+            A Python dict mapping export formats to exported models
+            if exported successfully otherwise empty dict.
         """
         return {}
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -331,6 +331,22 @@ class Trainable(object):
         self.restore(checkpoint_path)
         shutil.rmtree(tmpdir)
 
+    def export_default_policy(self, export_dir=None, export_formats):
+        """Exports default policy graph based on export_formats.
+        Subclasses should override _export_default_policy() to actually
+        export policy graph to local directory.
+
+        Args:
+            export_dir (str): Optional dir to place the exported model.
+            export_formats (list): List of formats that should be exported.
+
+        Returns:
+            A Python dict of directories containing the exported policy graphs
+            corresponding to export_formats if exported otherwise empty dict.
+        """
+        export_dir = export_dir or self.logdir
+        return self._export_default_policy(export_dir, export_formats)
+
     def reset_config(self, new_config):
         """Resets configuration without restarting the trial.
 
@@ -402,6 +418,18 @@ class Trainable(object):
         """Subclasses should override this for any cleanup on stop."""
         pass
 
+    def _export_default_policy(self, export_dir, export_formats):
+        """Subclasses should override this to actually export policy graphs.
+
+        Args:
+            export_dir (str): Local directory to place exported policy graphs.
+            export_formats (list): List of formats that should be exported.
+
+        Returns:
+            A Python dict of directories containing the exported policy graphs
+            corresponding to export_formats if exported otherwise empty dict.
+        """
+        return {}
 
 def wrap_function(train_func):
     from ray.tune.function_runner import FunctionRunner

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -133,6 +133,15 @@ class Checkpoint(object):
         return Checkpoint(Checkpoint.MEMORY, value)
 
 
+class ExportFormat(object):
+    """Describes the format to export trial policy graph.
+
+    Format may correspond to different file formats based on the
+    policy graph implementation.
+    """
+    CHECKPOINT = "checkpoint"
+    MODEL = "model"
+
 class Trial(object):
     """A trial object holds the state for one model training run.
 
@@ -159,6 +168,7 @@ class Trial(object):
                  stopping_criterion=None,
                  checkpoint_freq=0,
                  checkpoint_at_end=False,
+                 export_formats=None,
                  restore_path=None,
                  upload_dir=None,
                  trial_name_creator=None,
@@ -195,6 +205,7 @@ class Trial(object):
         self.checkpoint_at_end = checkpoint_at_end
         self._checkpoint = Checkpoint(
             storage=Checkpoint.DISK, value=restore_path)
+        self.export_formats = export_formats
         self.status = Trial.PENDING
         self.logdir = None
         self.runner = None

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -142,6 +142,16 @@ class ExportFormat(object):
     CHECKPOINT = "checkpoint"
     MODEL = "model"
 
+    @staticmethod
+    def validate(export_formats):
+        """Validates export_formats and raises ValueError
+        if the format is unknown.
+        """
+        for export_format in export_formats:
+            if export_format not in \
+                    [ExportFormat.CHECKPOINT, ExportFormat.MODEL]:
+                raise TuneError("Unsupported export format: " + export_format)
+
 
 class Trial(object):
     """A trial object holds the state for one model training run.

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -142,6 +142,7 @@ class ExportFormat(object):
     CHECKPOINT = "checkpoint"
     MODEL = "model"
 
+
 class Trial(object):
     """A trial object holds the state for one model training run.
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -134,22 +134,25 @@ class Checkpoint(object):
 
 
 class ExportFormat(object):
-    """Describes the format to export trial policy graph.
+    """Describes the format to export the trial Trainable.
 
-    Format may correspond to different file formats based on the
-    policy graph implementation.
+    This may correspond to different file formats based on the
+    Trainable implementation.
     """
     CHECKPOINT = "checkpoint"
     MODEL = "model"
 
     @staticmethod
     def validate(export_formats):
-        """Validates export_formats and raises ValueError
-        if the format is unknown.
+        """Validates export_formats.
+
+        Raises:
+            ValueError if the format is unknown.
         """
         for export_format in export_formats:
-            if export_format not in \
-                    [ExportFormat.CHECKPOINT, ExportFormat.MODEL]:
+            if export_format not in [
+                    ExportFormat.CHECKPOINT, ExportFormat.MODEL
+            ]:
                 raise TuneError("Unsupported export format: " + export_format)
 
 

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -213,7 +213,7 @@ class TrialExecutor(object):
             trial (Trial): The state of this trial to be saved.
 
         Return:
-            A dict that maps export formats to successfully exported models.
+            A dict that maps ExportFormats to successfully exported models.
         """
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "export_trial_if_needed() method")

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -205,3 +205,17 @@ class TrialExecutor(object):
         """
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "save() method")
+
+    def export_trial_if_needed(self, trial):
+        """Exports policy graph of this trial based on trial.export_formats.
+
+        Args:
+            trial (Trial): The state of this trial to be saved.  
+        
+        Return:
+            A Python dict of directories containing the exported policy graphs
+            corresponding to trial.export_formats if exported otherwise empty
+            dict.
+        """
+        raise NotImplementedError("Subclasses of TrialExecutor must provide "
+                                  "export_trial_if_needed() method")

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -213,8 +213,7 @@ class TrialExecutor(object):
             trial (Trial): The state of this trial to be saved.
 
         Return:
-            A Python dict mapping export formats to exported models
-            if exported successfully otherwise empty dict.
+            A dict that maps export formats to successfully exported models.
         """
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "export_trial_if_needed() method")

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -207,15 +207,14 @@ class TrialExecutor(object):
                                   "save() method")
 
     def export_trial_if_needed(self, trial):
-        """Exports policy graph of this trial based on trial.export_formats.
+        """Exports model of this trial based on trial.export_formats.
 
         Args:
             trial (Trial): The state of this trial to be saved.
 
         Return:
-            A Python dict of directories containing the exported policy graphs
-            corresponding to trial.export_formats if exported otherwise empty
-            dict.
+            A Python dict mapping export formats to exported models
+            if exported successfully otherwise empty dict.
         """
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "export_trial_if_needed() method")

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -210,8 +210,8 @@ class TrialExecutor(object):
         """Exports policy graph of this trial based on trial.export_formats.
 
         Args:
-            trial (Trial): The state of this trial to be saved.  
-        
+            trial (Trial): The state of this trial to be saved.
+
         Return:
             A Python dict of directories containing the exported policy graphs
             corresponding to trial.export_formats if exported otherwise empty

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -404,7 +404,7 @@ class TrialRunner(object):
                 # Checkpoint before ending the trial
                 # if checkpoint_at_end experiment option is set to True
                 self._checkpoint_trial_if_needed(trial)
-                self.trail_executor.export_trial_if_needed(trial)
+                self.trial_executor.export_trial_if_needed(trial)
                 self.trial_executor.stop_trial(trial)
             else:
                 assert False, "Invalid scheduling decision: {}".format(

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -404,6 +404,7 @@ class TrialRunner(object):
                 # Checkpoint before ending the trial
                 # if checkpoint_at_end experiment option is set to True
                 self._checkpoint_trial_if_needed(trial)
+                self.trail_executor.export_trial_if_needed(trial)
                 self.trial_executor.stop_trial(trial)
             else:
                 assert False, "Invalid scheduling decision: {}".format(


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
In early [PR#3585](https://github.com/ray-project/ray/pull/3585) and [PR#3637](https://github.com/ray-project/ray/pull/3637), `export_policy_model` and `export_policy_checkpoint` were introduced for users to export TensorFlow model and checkpoint.

For Ray Tune users, these APIs are not accessible through YAML configurations. 

In this pull request, `export_formats` option is provided to enable users to choose the desired export format.

* It is optional and nothing is exported by default.
* It accepts a list of strings to specify the desired export formats.
* Currently, 'checkpoint' and 'model' are valid values for TensorFlow policy graphs. Invalid values are ignored silently.
* It can be extended by overriding `_export_default_policy` of `Trainable` class. The default implementation of `_export_default_policy` is empty which ignores `export_formats` option silently.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
