### PR TITLE
recover num_initial_workers parameter in ray config start script

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -200,6 +200,7 @@ class Node(object):
             self._ray_params.object_manager_port,
             self._ray_params.node_manager_port,
             self._ray_params.redis_password,
+            num_initial_workers=self._ray_params.num_workers,
             use_valgrind=use_valgrind,
             use_profiler=use_profiler,
             stdout_file=stdout_file,

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -175,8 +175,3 @@ class RayParams(object):
             assert "GPU" not in self.resources, (
                 "'GPU' should not be included in the resource dictionary. Use "
                 "num_gpus instead.")
-
-        if self.num_workers is not None:
-            raise Exception(
-                "The 'num_workers' argument is deprecated. Please use "
-                "'num_cpus' instead.")

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -926,6 +926,7 @@ def start_raylet(redis_address,
                  object_manager_port=None,
                  node_manager_port=None,
                  redis_password=None,
+                 num_initial_workers=None,
                  use_valgrind=False,
                  use_profiler=False,
                  stdout_file=None,
@@ -949,6 +950,7 @@ def start_raylet(redis_address,
         node_manager_port: The port to use for the node manager. If this is
             None, then the node manager will choose its own port.
         redis_password: The password to use when connecting to Redis.
+        num_initial_workers: the number of initial starting workers for raylet
         use_valgrind (bool): True if the raylet should be started inside
             of valgrind. If this is True, use_profiler must be False.
         use_profiler (bool): True if the raylet should be started inside
@@ -969,8 +971,9 @@ def start_raylet(redis_address,
     if use_valgrind and use_profiler:
         raise Exception("Cannot use valgrind and profiler at the same time.")
 
-    num_initial_workers = (num_cpus if num_cpus is not None else
-                           multiprocessing.cpu_count())
+    if num_initial_workers is None:
+        num_initial_workers = (num_cpus if num_cpus is not None else
+                               multiprocessing.cpu_count())
 
     static_resources = check_and_update_resources(num_cpus, num_gpus,
                                                   resources)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

currently, `ray start --head` command will also start `num-cpus` workers on node, but sometimes, we only need 1 or 2 workers for test or controlled by `--resources`, which is less than the `num-cpus`. So we need to clearly control the initial worker number for raylet.

I found it had `--num-workers` in `ray start` command, which is already forbidden in master. So I post the PR to recover the parameter back.

And I think the `parameters.RayParams` is a good design, and in ray python, we should avoid passing too many parameters.

## Related issue number

No.
