### PR TITLE
Add NoneTypeClient for RayletClient

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -201,9 +201,6 @@ cdef class ClientType:
             raise Exception("Unexpected error")
 
 
-# TODO(qwang): Client type enum values
-
-
 cdef unordered_map[c_string, double] resource_map_from_python_dict(resource_map):
     cdef:
         unordered_map[c_string, double] out

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -221,7 +221,7 @@ cdef class RayletClient:
                   ClientID client_id,
                   c_bool is_worker,
                   DriverID driver_id):
-        client_type = CLIENT_TYPE_WORKER if is_worer else CLIENT_TYPE_DRIVER
+        client_type = CLIENT_TYPE_WORKER if is_worker else CLIENT_TYPE_DRIVER
         # We know that we are using Python, so just skip the language parameter.
         # TODO(suquark): Should we allow unicode chars in "raylet_socket"?
         self.client.reset(new CRayletClient(raylet_socket.encode("ascii"), client_id.data,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -91,6 +91,9 @@ cdef extern from "ray/gcs/format/gcs_generated.h" nogil:
     cdef cppclass CLanguage "Language":
         pass
 
+    cdef cppclass CClientType "ClientType":
+        pass
+
 
 # This is a workaround for C++ enum class since Cython has no corresponding representation.
 cdef extern from "ray/gcs/format/gcs_generated.h" namespace "Language" nogil:
@@ -98,6 +101,10 @@ cdef extern from "ray/gcs/format/gcs_generated.h" namespace "Language" nogil:
     cdef CLanguage LANGUAGE_CPP "Language::CPP"
     cdef CLanguage LANGUAGE_JAVA "Language::JAVA"
 
+cdef extern from "ray/gcs/format/gcs_generated.h" namespace "ClientType" nogil:
+    cdef CClientType CLIENT_TYPE_NONE "ClientType::NONE"
+    cdef CClientType CLIENT_TYPE_WORKER "ClientType::WORKER"
+    cdef CClientType CLIENT_TYPE_DRIVER "ClientType::DRIVER"
 
 cdef extern from "ray/raylet/scheduling_resources.h" namespace "ray::raylet" nogil:
     cdef cppclass ResourceSet "ResourceSet":

--- a/python/ray/includes/libraylet.pxd
+++ b/python/ray/includes/libraylet.pxd
@@ -10,7 +10,7 @@ from libcpp.vector cimport vector as c_vector
 from ray.includes.common cimport (
     CUniqueID, CTaskID, CObjectID, CFunctionID, CActorClassID, CActorID,
     CActorHandleID, CWorkerID, CDriverID, CConfigID, CClientID,
-    CLanguage, CRayStatus)
+    CLanguage, CRayStatus, CClientType)
 from ray.includes.task cimport CTaskSpecification
 
 
@@ -38,16 +38,17 @@ cdef extern from "ray/raylet/raylet_client.h" nogil:
     cdef cppclass CRayletClient "RayletClient":
         CRayletClient(const c_string &raylet_socket,
                       const CClientID &client_id,
-                      c_bool is_worker, const CDriverID &driver_id,
+                      const CClientType &client_type,
+                      const CDriverID &driver_id,
                       const CLanguage &language)
         CRayStatus Disconnect()
         CRayStatus SubmitTask(const c_vector[CObjectID] &execution_dependencies,
-                             const CTaskSpecification &task_spec)
+                              const CTaskSpecification &task_spec)
         CRayStatus GetTask(unique_ptr[CTaskSpecification] *task_spec)
         CRayStatus TaskDone()
         CRayStatus FetchOrReconstruct(c_vector[CObjectID] &object_ids,
-                                     c_bool fetch_only,
-                                     const CTaskID &current_task_id)
+                                      c_bool fetch_only,
+                                      const CTaskID &current_task_id)
         CRayStatus NotifyUnblocked(const CTaskID &current_task_id)
         CRayStatus Wait(const c_vector[CObjectID] &object_ids, int num_returns,
                        int64_t timeout_milliseconds, c_bool wait_local,
@@ -56,7 +57,7 @@ cdef extern from "ray/raylet/raylet_client.h" nogil:
                              const c_string &error_message, double timestamp)
         CRayStatus PushProfileEvents(const GCSProfileTableDataT &profile_events)
         CRayStatus FreeObjects(const c_vector[CObjectID] &object_ids,
-                              c_bool local_only)
+                               c_bool local_only)
         CLanguage GetLanguage() const
         CClientID GetClientID() const
         CDriverID GetDriverID() const

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -4,6 +4,13 @@ enum Language:int {
   JAVA = 2
 }
 
+// The type of RayletClient.
+enum ClientType:int {
+  NONE = 0,
+  WORKER = 1,
+  DRIVER = 2,
+}
+
 // These indexes are mapped to strings in ray_redis_module.cc.
 enum TablePrefix:int {
   UNUSED = 0,

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -121,7 +121,7 @@ table GetTaskReply {
 // It is shipped as part of raylet_connect.
 table RegisterClientRequest {
   // Type of this client.
-  clientType: ClientType;
+  client_type: ClientType;
   // The ID of this client.
   client_id: string;
   // The process ID of this client.

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -117,18 +117,18 @@ table GetTaskReply {
   fractional_resource_ids: [ResourceIdSetInfo];
 }
 
-// This struct is used to register a new worker with the local scheduler.
+// This struct is used to register a new client with the local scheduler.
 // It is shipped as part of raylet_connect.
 table RegisterClientRequest {
-  // True if the client is a worker and false if the client is a driver.
-  is_worker: bool;
-  // The ID of the worker or driver.
+  // Type of this client.
+  clientType: ClientType;
+  // The ID of this client.
   client_id: string;
-  // The process ID of this worker.
+  // The process ID of this client.
   worker_pid: long;
   // The driver ID. This is non-nil if the client is a driver.
   driver_id: string;
-  // Language of this worker.
+  // Language of this client.
   language: Language;
 }
 

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -43,8 +43,8 @@ JNIEXPORT jlong JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeInit(
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
 
-  ClientType client_type = static_cast<bool>(isWorker) ?
-      ClientType::WORKER : ClientType::DRIVER;
+  ClientType client_type =
+      static_cast<bool>(isWorker) ? ClientType::WORKER : ClientType::DRIVER;
 
   auto raylet_client = new RayletClient(nativeString, *worker_id.PID, client_type,
                                         *driver_id.PID, Language::JAVA);

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -42,7 +42,11 @@ JNIEXPORT jlong JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeInit(
   UniqueIdFromJByteArray worker_id(env, workerId);
   UniqueIdFromJByteArray driver_id(env, driverId);
   const char *nativeString = env->GetStringUTFChars(sockName, JNI_FALSE);
-  auto raylet_client = new RayletClient(nativeString, *worker_id.PID, isWorker,
+
+  ClientType client_type = static_cast<bool>(isWorker) ?
+      ClientType::WORKER : ClientType::DRIVER;
+
+  auto raylet_client = new RayletClient(nativeString, *worker_id.PID, client_type,
                                         *driver_id.PID, Language::JAVA);
   env->ReleaseStringUTFChars(sockName, nativeString);
   return reinterpret_cast<jlong>(raylet_client);

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -202,10 +202,10 @@ ray::Status RayletConnection::AtomicRequestReply(
 }
 
 RayletClient::RayletClient(const std::string &raylet_socket, const UniqueID &client_id,
-                           bool is_worker, const JobID &driver_id,
+                           const ClientType &client_type, const JobID &driver_id,
                            const Language &language)
     : client_id_(client_id),
-      is_worker_(is_worker),
+      client_type_(client_type),
       driver_id_(driver_id),
       language_(language) {
   // For C++14, we could use std::make_unique
@@ -213,8 +213,8 @@ RayletClient::RayletClient(const std::string &raylet_socket, const UniqueID &cli
 
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateRegisterClientRequest(
-      fbb, is_worker, to_flatbuf(fbb, client_id), getpid(), to_flatbuf(fbb, driver_id),
-      language);
+      fbb, client_type, to_flatbuf(fbb, client_id), getpid(),
+      to_flatbuf(fbb, driver_id), language);
   fbb.Finish(message);
   // Register the process ID with the raylet.
   // NOTE(swang): If raylet exits and we are registered as a worker, we will get killed.

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -213,8 +213,8 @@ RayletClient::RayletClient(const std::string &raylet_socket, const UniqueID &cli
 
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateRegisterClientRequest(
-      fbb, client_type, to_flatbuf(fbb, client_id), getpid(),
-      to_flatbuf(fbb, driver_id), language);
+      fbb, client_type, to_flatbuf(fbb, client_id), getpid(), to_flatbuf(fbb, driver_id),
+      language);
   fbb.Finish(message);
   // Register the process ID with the raylet.
   // NOTE(swang): If raylet exits and we are registered as a worker, we will get killed.

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -63,12 +63,12 @@ class RayletClient {
   ///
   /// \param raylet_socket The name of the socket to use to connect to the raylet.
   /// \param worker_id A unique ID to represent the worker.
-  /// \param is_worker Whether this client is a worker. If it is a worker, an
-  /// additional message will be sent to register as one.
+  /// \param client_type The type of raylet client.
   /// \param driver_id The ID of the driver. This is non-nil if the client is a driver.
   /// \return The connection information.
   RayletClient(const std::string &raylet_socket, const UniqueID &client_id,
-               bool is_worker, const JobID &driver_id, const Language &language);
+               const ClientType &client_type, const JobID &driver_id,
+               const Language &language);
 
   ray::Status Disconnect() { return conn_->Disconnect(); };
 
@@ -152,13 +152,14 @@ class RayletClient {
 
   JobID GetDriverID() const { return driver_id_; }
 
-  bool IsWorker() const { return is_worker_; }
+  // TODO(qwang): IsWorker() -> ClientType()
+  bool IsWorker() const { return client_type_ == ClientType::WORKER; }
 
   const ResourceMappingType &GetResourceIDs() const { return resource_ids_; }
 
  private:
   const ClientID client_id_;
-  const bool is_worker_;
+  const ClientType client_type_;
   const JobID driver_id_;
   const Language language_;
   /// A map from resource name to the resource IDs that are currently reserved

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -152,7 +152,6 @@ class RayletClient {
 
   JobID GetDriverID() const { return driver_id_; }
 
-  // TODO(qwang): IsWorker() -> ClientType()
   bool IsWorker() const { return client_type_ == ClientType::WORKER; }
 
   const ResourceMappingType &GetResourceIDs() const { return resource_ids_; }


### PR DESCRIPTION
## What do these changes do?

We added a `None` type client， which is neither a worker nor a driver for `RayletClient`.
This makes our low-level programing more flexible.

More important, it also solves this painpoint：
In a worker or an actor, the main-thread is blocking at fetching task from raylet, and it lock this mutex:
> https://github.com/ray-project/ray/blob/master/src/ray/raylet/raylet_client.cc#L198

Therefore in other sub-threads, any `RayCall`(like wait or get) will hung at the place where it attempts to get the mutex.
This is the real case which we met in our production env.

After this change, we could create a None type client to do some `RayCall` in a in other threads in a worker.

## Related issue number
N/A
