### PR TITLE
change kubernetes examples to use `Deployment`

### DIFF
--- a/doc/source/deploy-on-kubernetes.rst
+++ b/doc/source/deploy-on-kubernetes.rst
@@ -56,7 +56,9 @@ Start an IPython interpreter, e.g., ``ipython``
   import time
   import ray
 
-  ray.init(redis_address="{}:6379".format(socket.gethostbyname("ray-head")))
+  # Note that if you run this script on a non-head node, then you must replace
+  # "localhost" with socket.gethostbyname("ray-head").
+  ray.init(redis_address="localhost:6379")
 
   @ray.remote
   def f(x):

--- a/doc/source/deploy-on-kubernetes.rst
+++ b/doc/source/deploy-on-kubernetes.rst
@@ -35,17 +35,17 @@ minutes for the pods to enter the "Running" state).
 .. code-block:: shell
 
   $ kubectl get pods
-  NAME                          READY     STATUS    RESTARTS   AGE
-  ray-head-controller-2kkfq     1/1       Running   0          47s
-  ray-worker-controller-d6jml   1/1       Running   0          45s
-  ray-worker-controller-m7jxs   1/1       Running   0          45s
-  ray-worker-controller-rg2sl   1/1       Running   0          45s
+  NAME                          READY   STATUS    RESTARTS   AGE
+  ray-head-5455bb66c9-6bxvz     1/1     Running   0          10s
+  ray-worker-5c49b7cc57-c6xs8   1/1     Running   0          5s
+  ray-worker-5c49b7cc57-d9m86   1/1     Running   0          5s
+  ray-worker-5c49b7cc57-kzk4s   1/1     Running   0          5s
 
 To run tasks interactively on the cluster, connect to one of the pods, e.g.,
 
 .. code-block:: shell
 
-  kubectl exec -it ray-head-controller-2kkfq -- bash
+  kubectl exec -it ray-head-5455bb66c9-6bxvz -- bash
 
 Start an IPython interpreter, e.g., ``ipython``
 
@@ -86,24 +86,28 @@ running ``kubectl get all``. You'll see output like the following.
 .. code-block:: shell
 
   $ kubectl get all
-  NAME                              READY     STATUS    RESTARTS   AGE
-  pod/ray-head-controller-q6lck     1/1       Running   0          1m
-  pod/ray-worker-controller-kchfh   1/1       Running   0          1m
-  pod/ray-worker-controller-nmq5c   1/1       Running   0          1m
-  pod/ray-worker-controller-tfl2q   1/1       Running   0          1m
+  NAME                              READY   STATUS    RESTARTS   AGE
+  pod/ray-head-5486648dc9-c6hz2     1/1     Running   0          11s
+  pod/ray-worker-5c49b7cc57-2jz4l   1/1     Running   0          11s
+  pod/ray-worker-5c49b7cc57-8nwjk   1/1     Running   0          11s
+  pod/ray-worker-5c49b7cc57-xlksn   1/1     Running   0          11s
 
-  NAME                                          DESIRED   CURRENT   READY     AGE
-  replicationcontroller/ray-head-controller     1         1         1         1m
-  replicationcontroller/ray-worker-controller   3         3         3         1m
+  NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                          AGE
+  service/ray-head     ClusterIP   10.110.54.241   <none>        6379/TCP,6380/TCP,6381/TCP,12345/TCP,12346/TCP   11s
 
-  NAME               TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                                          AGE
-  service/ray-head   ClusterIP   10.64.5.153   <none>        6379/TCP,6380/TCP,6381/TCP,12345/TCP,12346/TCP   1m
+  NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
+  deployment.apps/ray-head     1/1     1            1           11s
+  deployment.apps/ray-worker   3/3     3            3           11s
 
-Find the name of the ``ray-head-controller`` pod and run the equivalent of
+  NAME                                    DESIRED   CURRENT   READY   AGE
+  replicaset.apps/ray-head-5486648dc9     1         1         1       11s
+  replicaset.apps/ray-worker-5c49b7cc57   3         3         3       11s
+
+Find the name of the ``ray-head`` pod and run the equivalent of
 
 .. code-block:: shell
 
-  kubectl logs ray-head-controller-q6lck
+  kubectl logs ray-head-5486648dc9-c6hz2
 
 Cleaning Up
 -----------
@@ -113,8 +117,8 @@ To remove the services you have created, run the following.
 .. code-block:: shell
 
   kubectl delete service/ray-head \
-                 replicationcontroller/ray-head-controller \
-                 replicationcontroller/ray-worker-controller
+                 deployment.apps/ray-head \
+                 deployment.apps/ray-worker
 
 
 Customization

--- a/kubernetes/example.py
+++ b/kubernetes/example.py
@@ -9,7 +9,9 @@ import time
 import ray
 
 if __name__ == "__main__":
-    ray.init(redis_address="{}:6379".format(socket.gethostbyname("ray-head")))
+    # Note that if you run this script on a non-head node, then you must
+    # replace "localhost" with socket.gethostbyname("ray-head").
+    ray.init(redis_address="localhost:6379")
 
     # Wait for all 4 nodes to join the cluster.
     while True:

--- a/kubernetes/head.yaml
+++ b/kubernetes/head.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ray-head
 spec:
   ports:
-  ports:
     - name: redis-primary
       port: 6379
       targetPort: 6379
@@ -23,14 +22,15 @@ spec:
   selector:
     component: ray-head
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: ray-head-controller
+  name: ray-head
 spec:
   replicas: 1
   selector:
-    component: ray-head
+    matchLabels:
+      component: ray-head
   template:
     metadata:
       labels:
@@ -54,4 +54,4 @@ spec:
                   fieldPath: status.podIP
           resources:
             requests:
-              cpu: 10
+              cpu: 2

--- a/kubernetes/submit.yaml
+++ b/kubernetes/submit.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ray-head
 spec:
   ports:
-  ports:
     - name: redis-primary
       port: 6379
       targetPort: 6379
@@ -23,14 +22,15 @@ spec:
   selector:
     component: ray-head
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: ray-head-controller
+  name: ray-head
 spec:
   replicas: 1
   selector:
-    component: ray-head
+    matchLabels:
+      component: ray-head
   template:
     metadata:
       labels:
@@ -57,16 +57,17 @@ spec:
                   fieldPath: status.podIP
           resources:
             requests:
-              cpu: 10
+              cpu: 2
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: ray-worker-controller
+  name: ray-worker
 spec:
   replicas: 3
   selector:
-    component: ray-worker
+    matchLabels:
+      component: ray-worker
   template:
     metadata:
       labels:
@@ -87,4 +88,4 @@ spec:
                   fieldPath: status.podIP
           resources:
             requests:
-              cpu: 10
+              cpu: 2

--- a/kubernetes/worker.yaml
+++ b/kubernetes/worker.yaml
@@ -1,11 +1,12 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: ray-worker-controller
+  name: ray-worker
 spec:
   replicas: 3
   selector:
-    component: ray-worker
+    matchLabels:
+      component: ray-worker
   template:
     metadata:
       labels:
@@ -26,4 +27,4 @@ spec:
                   fieldPath: status.podIP
           resources:
             requests:
-              cpu: 10
+              cpu: 2


### PR DESCRIPTION
## What do these changes do?

Change the kubernetes examples to use `Deployment` as this is now recommended over `ReplicationController`s.

Also reduce the CPU requirements to make it easier to try this out on a development environment (`kubeadm`, `MicroK8s` etc.).
