### PR TITLE
Add bazel build for JNI code

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -338,27 +338,44 @@ pyx_library(
     deps = ["//:raylet_lib"]
 )
 
-cc_library(
-    name = "raylet_library_java",
+cc_binary(
+    name = "raylet_library_java.so",
     srcs = [
         "@bazel_tools//tools/jdk:current_java_runtime",
         "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h",
-        "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc"
-        ],
-    hdrs = [
+        "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc",
         "src/ray/id.h",
         "src/ray/raylet/raylet_client.h",
         "src/ray/util/logging.h"
-    ],
+        ],
     includes = [
-        "src" ,
+        "src",
         "external/local_jdk/include"] + select({
             "@bazel_tools//src/conditions:darwin": ["external/local_jdk/include/darwin"],
             "//conditions:default": ["external/local_jdk/include/linux"]
         }),
+    linkshared = 1,
+    linkstatic = 1,
     deps = ["@plasma//:plasma_client",
             "//:raylet_lib"],
-)	
+)
+
+genrule(
+    name = "raylet-jni-darwin-compat",
+    srcs = [":raylet_library_java.so"],
+    outs = ["raylet_library_java.dylib"],
+    cmd = "cp $< $@",
+    output_to_bindir = 1,
+)
+
+filegroup(
+    name = "raylet_library_java",
+    visibility = ["//visibility:public"],
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": [":raylet_library_java.dylib"],
+        "//conditions:default": [":raylet_library_java.so"],
+    })
+)
 
 flatbuffer_py_library(
     name = "python_gcs_fbs",
@@ -502,14 +519,7 @@ genrule(
         cp $(location //:raylet) python/ray/core/src/ray/raylet/ &&
         mv python $(location ray_pkg) &&
         mkdir -p $(location ray_pkg)/java_lib &&
-        for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/java_lib/"""
-        + select({
-            "@bazel_tools//src/conditions:darwin": "libraylet_library_java.dylib",
-            "//conditions:default": "libraylet_library_java.so"})
-        + "; fi done &&" +
-        """for f in $(locations @plasma//:plasma_client_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/java_lib/"""
-        + select({
-            "@bazel_tools//src/conditions:darwin": "libplasma_java.dylib",
-            "//conditions:default": "libplasma_java.so"})
-        + "; fi done"
+        cp $(location @plasma//:plasma_client_java) $(location ray_pkg)/java_lib &&
+        cp $(location //:raylet_library_java) $(location ray_pkg)/java_lib
+        """
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -338,6 +338,33 @@ pyx_library(
     deps = ["//:raylet_lib"]
 )
 
+cc_library(
+    name = "raylet_library_java",
+    srcs = [
+        "@local_jdk//:jni_header",
+        "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h",
+        "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc"
+        ] + select({
+            "@bazel_tools//src/conditions:windows": ["@local_jdk//:jni_md_header-windows"],
+            "@bazel_tools//src/conditions:darwin": ["@local_jdk//:jni_md_header-darwin"],
+            "//conditions:default": ["@local_jdk//:jni_md_header-linux"]
+        }),
+    hdrs = [
+        "src/ray/id.h",
+        "src/ray/raylet/raylet_client.h",
+        "src/ray/util/logging.h"
+    ],
+    includes = [
+        "src" ,
+        "external/local_jdk/include"] + select({
+            "@bazel_tools//src/conditions:windows": ["external/local_jdk/include/win32"],
+            "@bazel_tools//src/conditions:darwin": ["external/local_jdk/include/darwin"],
+            "//conditions:default": ["external/local_jdk/include/linux"]
+        }),
+    deps = ["@plasma//:plasma_client",
+            "//:raylet_lib"],
+)	
+
 flatbuffer_py_library(
     name = "python_gcs_fbs",
     srcs = [
@@ -460,7 +487,8 @@ genrule(
         "//:ray_redis_module",
         "//:raylet",
         "//:raylet_monitor",
-        "@plasma//:plasma_store_server"
+        "@plasma//:plasma_store_server",
+        "//:raylet_library_java"
     ],
     outs = ["ray_pkg"],
     cmd = """
@@ -476,6 +504,12 @@ genrule(
         mkdir -p python/ray/core/src/plasma &&
         cp $(location @plasma//:plasma_store_server) python/ray/core/src/plasma/ &&
         cp $(location //:raylet) python/ray/core/src/ray/raylet/ &&
-        mv python $(location ray_pkg)
-    """,
+        mv python $(location ray_pkg) &&
+        mkdir -p $(location ray_pkg)/src/ray/raylet &&
+        for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/src/ray/raylet/"""
+        + select({
+            "@bazel_tools//src/conditions:windows": "liblibraylet_library_java.dll",
+            "@bazel_tools//src/conditions:darwin": "liblibraylet_library_java.dylib",
+            "//conditions:default": "liblibraylet_library_java.so"})
+        + "; fi done"
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -484,6 +484,7 @@ genrule(
         "//:raylet",
         "//:raylet_monitor",
         "@plasma//:plasma_store_server",
+        "@plasma//:plasma_client_java",
         "//:raylet_library_java"
     ],
     outs = ["ray_pkg"],
@@ -504,8 +505,14 @@ genrule(
         mkdir -p $(location ray_pkg)/src/ray/raylet &&
         for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/src/ray/raylet/"""
         + select({
-            "@bazel_tools//src/conditions:windows": "liblibraylet_library_java.dll",
-            "@bazel_tools//src/conditions:darwin": "liblibraylet_library_java.dylib",
-            "//conditions:default": "liblibraylet_library_java.so"})
+            "@bazel_tools//src/conditions:windows": "libraylet_library_java.dll",
+            "@bazel_tools//src/conditions:darwin": "libraylet_library_java.dylib",
+            "//conditions:default": "libraylet_library_java.so"})
+        + "; fi done &&" +
+        """for f in $(locations @plasma//:plasma_client_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/src/ray/raylet/"""
+        + select({
+            "@bazel_tools//src/conditions:windows": "libplasma_java.dll",
+            "@bazel_tools//src/conditions:darwin": "libplasma_java.dylib",
+            "//conditions:default": "libplasma_java.so"})
         + "; fi done"
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -341,14 +341,10 @@ pyx_library(
 cc_library(
     name = "raylet_library_java",
     srcs = [
-        "@local_jdk//:jni_header",
+        "@bazel_tools//tools/jdk:current_java_runtime",
         "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.h",
         "src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc"
-        ] + select({
-            "@bazel_tools//src/conditions:windows": ["@local_jdk//:jni_md_header-windows"],
-            "@bazel_tools//src/conditions:darwin": ["@local_jdk//:jni_md_header-darwin"],
-            "//conditions:default": ["@local_jdk//:jni_md_header-linux"]
-        }),
+        ],
     hdrs = [
         "src/ray/id.h",
         "src/ray/raylet/raylet_client.h",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -353,9 +353,8 @@ cc_library(
     includes = [
         "src" ,
         "external/local_jdk/include"] + select({
-            "@bazel_tools//src/conditions:windows": ["external/local_jdk/include/win32"],
             "@bazel_tools//src/conditions:darwin": ["external/local_jdk/include/darwin"],
-            "//conditions:default": ["external/local_jdk/include/linux"]
+            "//conditions:default": []
         }),
     deps = ["@plasma//:plasma_client",
             "//:raylet_lib"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -471,15 +471,6 @@ cc_library(
     ]
 )
 
-java_library(
-    name="ray_java_pkg",
-    srcs=glob([
-        "java/*.java",
-        "java/*.properties",
-        ]),
-    runtime_deps=["@plasma//:arrow_plasma_java_pkg"]
-)
-
 genrule(
     name = "ray_pkg",
     srcs = [
@@ -493,9 +484,7 @@ genrule(
         "//:raylet_monitor",
         "@plasma//:plasma_store_server",
         "@plasma//:plasma_client_java",
-        "@plasma//:arrow_plasma_java_pkg",
         "//:raylet_library_java",
-        "//:ray_java_pkg"
     ],
     outs = ["ray_pkg"],
     cmd = """
@@ -513,8 +502,6 @@ genrule(
         cp $(location //:raylet) python/ray/core/src/ray/raylet/ &&
         mv python $(location ray_pkg) &&
         mkdir -p $(location ray_pkg)/java_lib &&
-        cp $(location @plasma//:arrow_plasma_java_pkg) $(location ray_pkg)/java_lib &&
-        cp $(location //:ray_java_pkg) $(location ray_pkg)/java_lib &&
         for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/java_lib/"""
         + select({
             "@bazel_tools//src/conditions:darwin": "libraylet_library_java.dylib",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -354,7 +354,7 @@ cc_library(
         "src" ,
         "external/local_jdk/include"] + select({
             "@bazel_tools//src/conditions:darwin": ["external/local_jdk/include/darwin"],
-            "//conditions:default": []
+            "//conditions:default": ["external/local_jdk/include/linux"]
         }),
     deps = ["@plasma//:plasma_client",
             "//:raylet_lib"],
@@ -471,6 +471,15 @@ cc_library(
     ]
 )
 
+java_library(
+    name="ray_java_pkg",
+    srcs=glob([
+        "java/*.java",
+        "java/*.properties",
+        ]),
+    runtime_deps=["@plasma//:arrow_plasma_java_pkg"]
+)
+
 genrule(
     name = "ray_pkg",
     srcs = [
@@ -484,7 +493,9 @@ genrule(
         "//:raylet_monitor",
         "@plasma//:plasma_store_server",
         "@plasma//:plasma_client_java",
-        "//:raylet_library_java"
+        "@plasma//:arrow_plasma_java_pkg",
+        "//:raylet_library_java",
+        "//:ray_java_pkg"
     ],
     outs = ["ray_pkg"],
     cmd = """
@@ -501,16 +512,16 @@ genrule(
         cp $(location @plasma//:plasma_store_server) python/ray/core/src/plasma/ &&
         cp $(location //:raylet) python/ray/core/src/ray/raylet/ &&
         mv python $(location ray_pkg) &&
-        mkdir -p $(location ray_pkg)/src/ray/raylet &&
-        for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/src/ray/raylet/"""
+        mkdir -p $(location ray_pkg)/java_lib &&
+        cp $(location @plasma//:arrow_plasma_java_pkg) $(location ray_pkg)/java_lib &&
+        cp $(location //:ray_java_pkg) $(location ray_pkg)/java_lib &&
+        for f in $(locations //:raylet_library_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/java_lib/"""
         + select({
-            "@bazel_tools//src/conditions:windows": "libraylet_library_java.dll",
             "@bazel_tools//src/conditions:darwin": "libraylet_library_java.dylib",
             "//conditions:default": "libraylet_library_java.so"})
         + "; fi done &&" +
-        """for f in $(locations @plasma//:plasma_client_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/src/ray/raylet/"""
+        """for f in $(locations @plasma//:plasma_client_java); do if [[ $$f == *".so"* ]]; then cp $$f $(location ray_pkg)/java_lib/"""
         + select({
-            "@bazel_tools//src/conditions:windows": "libplasma_java.dll",
             "@bazel_tools//src/conditions:darwin": "libplasma_java.dylib",
             "//conditions:default": "libplasma_java.so"})
         + "; fi done"

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -60,24 +60,40 @@ cc_library(
     strip_include_prefix = "cpp/src",
 )
 
-cc_library(
-    name = "plasma_client_java",
-    visibility = ["//visibility:public"],
+cc_binary(
+    name = "plasma_client_java.so",
     srcs = [
         "@bazel_tools//tools/jdk:current_java_runtime",
-        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc"
+        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc",
+        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.h"
         ],
-    hdrs = [
-        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.h",
-    ],
     includes = [
         "cpp/src",
         "../../external/local_jdk/include"] + select({
             "@bazel_tools//src/conditions:darwin": ["../../external/local_jdk/include/darwin"],
             "//conditions:default": ["../../external/local_jdk/include/linux"]
         }),
+    linkshared = 1,
+    linkstatic = 1,
     deps = [":plasma_client"],
-)	
+)
+
+genrule(
+    name = "plasma-jni-darwin-compat",
+    srcs = [":plasma_client_java.so"],
+    outs = ["plasma_client_java.dylib"],
+    cmd = "cp $< $@",
+    output_to_bindir = 1,
+)
+
+filegroup(
+    name = "plasma_client_java",
+    visibility = ["//visibility:public"],
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": [":plasma_client_java.dylib"],
+        "//conditions:default": [":plasma_client_java.so"],
+    })
+)
 
 cc_library(
     name = "plasma_lib",

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -74,9 +74,9 @@ cc_library(
         "cpp/src",
         "../../external/local_jdk/include"] + select({
             "@bazel_tools//src/conditions:darwin": ["../../external/local_jdk/include/darwin"],
-            "//conditions:default": []
+            "//conditions:default": ["../../external/local_jdk/include/linux"]
         }),
-    deps = ["@plasma//:plasma_client"],
+    deps = [":plasma_client"],
 )	
 
 cc_library(
@@ -136,3 +136,13 @@ flatbuffer_cc_library(
 )
 
 exports_files(["cpp/src/plasma/format/common.fbs"])
+
+java_library(
+    name="arrow_plasma_java_pkg",
+    visibility = ["//visibility:public"],
+    srcs=glob([
+        "java/*.java",
+        "java/*.properties",
+        ]),
+    runtime_deps=[":plasma_client_java"],
+)

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -61,6 +61,26 @@ cc_library(
 )
 
 cc_library(
+    name = "plasma_client_java",
+    visibility = ["//visibility:public"],
+    srcs = [
+        "@bazel_tools//tools/jdk:current_java_runtime",
+        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc"
+        ],
+    hdrs = [
+        "cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.h",
+    ],
+    includes = [
+        "cpp/src",
+        "../../external/local_jdk/include"] + select({
+            "@bazel_tools//src/conditions:windows": ["../../external/local_jdk/include/win32"],
+            "@bazel_tools//src/conditions:darwin": ["../../external/local_jdk/include/darwin"],
+            "//conditions:default": ["external/local_jdk/include/linux"]
+        }),
+    deps = ["@plasma//:plasma_client"],
+)	
+
+cc_library(
     name = "plasma_lib",
     hdrs = [
         "cpp/src/plasma/events.h",

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -136,13 +136,3 @@ flatbuffer_cc_library(
 )
 
 exports_files(["cpp/src/plasma/format/common.fbs"])
-
-java_library(
-    name="arrow_plasma_java_pkg",
-    visibility = ["//visibility:public"],
-    srcs=glob([
-        "java/*.java",
-        "java/*.properties",
-        ]),
-    runtime_deps=[":plasma_client_java"],
-)

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -73,9 +73,8 @@ cc_library(
     includes = [
         "cpp/src",
         "../../external/local_jdk/include"] + select({
-            "@bazel_tools//src/conditions:windows": ["../../external/local_jdk/include/win32"],
             "@bazel_tools//src/conditions:darwin": ["../../external/local_jdk/include/darwin"],
-            "//conditions:default": ["external/local_jdk/include/linux"]
+            "//conditions:default": []
         }),
     deps = ["@plasma//:plasma_client"],
 )	


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR adds the bazel code to build the Java Raylet Client JNI code. From current cmake process, the output lib name differs in MacOS than in Linux.

Currently, I copy this file to folder `$(location ray_pkg)/src/ray/raylet/` corresponding to `build/src/ray/raylet` of cmake. I think the final path should be determine in https://github.com/ray-project/ray/pull/3898 . 

Now I can use `find bazel-genfiles/ -name *libraylet_library_java.*` to find the dynamic lib.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
