### PR TITLE
[autoscaler] Move attach helper text under exec_cluster

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -280,6 +280,7 @@ def exec_cluster(config_file, cmd, screen, tmux, stop, start,
         override_cluster_name: set the name of the cluster
         port_forward: port to forward
     """
+    assert not (screen and tmux), "Can specify only one of `screen` or `tmux`."
 
     config = yaml.load(open(config_file).read())
     if override_cluster_name is not None:
@@ -305,6 +306,21 @@ def exec_cluster(config_file, cmd, screen, tmux, stop, start,
         tmux,
         expect_error=stop,
         port_forward=port_forward)
+
+    if tmux or screen:
+        attach_command_parts = ["ray attach", config_file]
+        if override_cluster_name is not None:
+            attach_command_parts.append(
+                "--cluster-name={}".format(override_cluster_name))
+        if tmux:
+            attach_command_parts.append("--tmux")
+        elif screen:
+            attach_command_parts.append("--screen")
+
+        attach_command = " ".join(attach_command_parts)
+        attach_info = "Use `{}` to check on command status.".format(
+            attach_command)
+        logger.info(attach_info)
 
 
 def _exec(updater, cmd, screen, tmux, expect_error=False, port_forward=None):

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -605,21 +605,6 @@ def submit(cluster_config_file, screen, tmux, stop, start, cluster_name,
     exec_cluster(cluster_config_file, cmd, screen, tmux, stop, False,
                  cluster_name, port_forward)
 
-    if tmux or screen:
-        attach_command_parts = ["ray attach", cluster_config_file]
-        if cluster_name is not None:
-            attach_command_parts.append(
-                "--cluster-name={}".format(cluster_name))
-        if tmux:
-            attach_command_parts.append("--tmux")
-        elif screen:
-            attach_command_parts.append("--screen")
-
-        attach_command = " ".join(attach_command_parts)
-        attach_info = "Use `{}` to check on command status.".format(
-            attach_command)
-        logger.info(attach_info)
-
 
 @cli.command()
 @click.argument("cluster_config_file", required=True, type=str)
@@ -651,25 +636,8 @@ def submit(cluster_config_file, screen, tmux, stop, start, cluster_name,
     "--port-forward", required=False, type=int, help="Port to forward.")
 def exec_cmd(cluster_config_file, cmd, screen, tmux, stop, start, cluster_name,
              port_forward):
-    assert not (screen and tmux), "Can specify only one of `screen` or `tmux`."
-
     exec_cluster(cluster_config_file, cmd, screen, tmux, stop, start,
                  cluster_name, port_forward)
-
-    if tmux or screen:
-        attach_command_parts = ["ray attach", cluster_config_file]
-        if cluster_name is not None:
-            attach_command_parts.append(
-                "--cluster-name={}".format(cluster_name))
-        if tmux:
-            attach_command_parts.append("--tmux")
-        elif screen:
-            attach_command_parts.append("--screen")
-
-        attach_command = " ".join(attach_command_parts)
-        attach_info = "Use `{}` to check on command status.".format(
-            attach_command)
-        logger.info(attach_info)
 
 
 @cli.command()


### PR DESCRIPTION
## What do these changes do?
Moves the attach command helper from cli commands to the actual `exec_cluster` function.