### PR TITLE
Prepare socket file when start ray

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -107,18 +107,18 @@ class Node(object):
         """Prepare the socket file for raylet and plasma.
 
         This method helps to prepare a socket file.
-        1. Make the directory if the directory does not eixt.
-        2. Remove the socket file if the file exists.
+        1. Make the directory if the directory does not exist.
+        2. If the socket file exists, raise exception.
 
         Args:
             socket_path (string): the socket file to prepare.
         """
-        if not os.path.isfile(socket_path):
+        if not os.path.exists(socket_path):
             path = os.path.dirname(socket_path)
             if not os.path.isdir(path):
                 try_to_create_directory(path)
         else:
-            os.remove(socket_path)
+            raise Exception("Socket file {} exists!".format(socket_path))
 
     def start_redis(self):
         """Start the Redis servers."""

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -16,7 +16,8 @@ from ray.tempfile_services import (
     get_logs_dir_path, get_object_store_socket_name, get_raylet_socket_name,
     new_log_monitor_log_file, new_monitor_log_file,
     new_raylet_monitor_log_file, new_plasma_store_log_file,
-    new_raylet_log_file, new_webui_log_file, set_temp_root)
+    new_raylet_log_file, new_webui_log_file, set_temp_root,
+    try_to_create_directory)
 
 # Logger for this module. It should be configured at the entry point
 # into the program using Ray. Ray configures it by default automatically
@@ -102,6 +103,23 @@ class Node(object):
         """Get the node's raylet socket name."""
         return self._raylet_socket_name
 
+    def prepare_socket_file(self, socket_path):
+        """Prepare the socket file for raylet and plasma.
+
+        This method helps to prepare a socket file.
+        1. Make the directory if the directory does not eixt.
+        2. Remove the socket file if the file exists.
+
+        Args:
+            socket_path (string): the socket file to prepare.
+        """
+        if not os.path.isfile(socket_path):
+            path = os.path.dirname(socket_path)
+            if not os.path.isdir(path):
+                try_to_create_directory(path)
+        else:
+            os.remove(socket_path)
+
     def start_redis(self):
         """Start the Redis servers."""
         assert self._redis_address is None
@@ -155,6 +173,7 @@ class Node(object):
         self._plasma_store_socket_name = (
             self._ray_params.plasma_store_socket_name
             or get_object_store_socket_name())
+        self.prepare_socket_file(self._plasma_store_socket_name)
         stdout_file, stderr_file = (new_plasma_store_log_file(
             self._ray_params.redirect_output))
         process_info = ray.services.start_plasma_store(
@@ -186,6 +205,7 @@ class Node(object):
         # If the user specified a socket name, use it.
         self._raylet_socket_name = (self._ray_params.raylet_socket_name
                                     or get_raylet_socket_name())
+        self.prepare_socket_file(self._raylet_socket_name)
         stdout_file, stderr_file = new_raylet_log_file(
             redirect_output=self._ray_params.redirect_worker_output)
         process_info = ray.services.start_raylet(

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2607,3 +2607,20 @@ def test_pandas_parquet_serialization():
     pd.DataFrame({"col1": [0, 1], "col2": [0, 1]}).to_parquet(filename)
     # Clean up
     shutil.rmtree(tempdir)
+
+
+def test_socket_directory_none_existant(shutdown_only):
+    level1_name = ray.ObjectID(_random_string()).hex()
+    level2_name = ray.ObjectID(_random_string()).hex()
+    temp_raylet_socket_dir = "/tmp/{}/{}".format(level1_name, level2_name)
+    temp_raylet_socket_name = os.path.join(temp_raylet_socket_dir,
+                                           "raylet_socket")
+    ray.init(num_cpus=1, raylet_socket_name=temp_raylet_socket_name)
+
+
+def test_socket_file_already_exists(shutdown_only):
+    file_name = ray.ObjectID(_random_string()).hex()
+    temp_raylet_socket_name = "/tmp/{}".format(file_name)
+    with open(temp_raylet_socket_name, 'a'):
+        os.utime(temp_raylet_socket_name, None)
+    ray.init(num_cpus=1, raylet_socket_name=temp_raylet_socket_name)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -23,7 +23,6 @@ import pickle
 import pytest
 
 import ray
-from ray.tempfile_services import try_to_create_directory
 import ray.test.cluster_utils
 import ray.test.test_utils
 from ray.utils import _random_string

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -23,6 +23,7 @@ import pickle
 import pytest
 
 import ray
+from ray.tempfile_services import try_to_create_directory
 import ray.test.cluster_utils
 import ray.test.test_utils
 from ray.utils import _random_string
@@ -2609,18 +2610,9 @@ def test_pandas_parquet_serialization():
     shutil.rmtree(tempdir)
 
 
-def test_socket_directory_none_existant(shutdown_only):
-    level1_name = ray.ObjectID(_random_string()).hex()
-    level2_name = ray.ObjectID(_random_string()).hex()
-    temp_raylet_socket_dir = "/tmp/{}/{}".format(level1_name, level2_name)
+def test_socket_dir_not_existing(shutdown_only):
+    random_name = ray.ObjectID(_random_string()).hex()
+    temp_raylet_socket_dir = "/tmp/ray/tests/{}".format(random_name)
     temp_raylet_socket_name = os.path.join(temp_raylet_socket_dir,
                                            "raylet_socket")
-    ray.init(num_cpus=1, raylet_socket_name=temp_raylet_socket_name)
-
-
-def test_socket_file_already_exists(shutdown_only):
-    file_name = ray.ObjectID(_random_string()).hex()
-    temp_raylet_socket_name = "/tmp/{}".format(file_name)
-    with open(temp_raylet_socket_name, 'a'):
-        os.utime(temp_raylet_socket_name, None)
     ray.init(num_cpus=1, raylet_socket_name=temp_raylet_socket_name)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Sometimes, users want to specify their own socket file name. However, there are two cases that they could fail. 
1. The directory specified does not exist. In this case, ray should make the directory.
2. The socket file exists before they start the cluster, which may due to that we are test failover functionality and send SIGKILL to raylet.  In this case, ray should clean the uncleaned file.

For the first case, raylet will crash with:
```
libc++abi.dylib: terminating with uncaught exception of type boost::exception_detail::clone_impl<boost::exception_detail::  error_info_injector<boost::system::system_error> >: bind: No such file or directory
*** Aborted at 1549001100 (unix time) try "date -d @1549001100" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x7fff6972ab86) received by PID 76085 (TID 0x10cef95c0) stack trace: ***
    @     0x7fff697d5b3d _sigtramp
```
For the second case, raylet will crash with:
```
libc++abi.dylib: terminating with uncaught exception of type boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >: bind: Address already in use
*** Aborted at 1549001712 (unix time) try "date -d @1549001712" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x7fff6972ab86) received by PID 77036 (TID 0x1161875c0) stack trace: ***
    @     0x7fff697d5b3d _sigtramp
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
