### PR TITLE
[autoscaler] Environment Variable for SSH Key

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -115,6 +115,14 @@ def _configure_key_pair(config):
         assert "KeyName" in config["head_node"]
         assert "KeyName" in config["worker_nodes"]
         return config
+    elif "RAY_AWS_SSH_KEY" in os.environ:
+        key_path = os.environ["RAY_AWS_SSH_KEY"]
+        filename = os.path.basename(key_path)
+        key_name = os.path.splitext(filename)[0]
+        config["auth"]["ssh_private_key"] = key_path
+        config["head_node"]["KeyName"] = key_name
+        config["worker_nodes"]["KeyName"] = key_name
+        return config
 
     ec2 = _resource("ec2", config)
 


### PR DESCRIPTION
Enables user to set SSH key pair via environment. This is useful for CI. 

There is two use cases to consider - one is CI (automated stress tests) and one is manual. Ideally, you should be able to manually run the stress tests without changing the cluster configuration. You should also be able to run the stress tests on Jenkins by simply setting an environment variable.


This will unblock #3789.