### PR TITLE
[rllib] Add copy() in async samples optimizer to fix memory leak

### DIFF
--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -167,7 +167,8 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                    for b in self.batch_buffer) >= self.train_batch_size:
                 train_batch = self.batch_buffer[0].concat_samples(
                     self.batch_buffer)
-                self.learner.inqueue.put(train_batch)
+                # defensive copy against plasma ref count bugs, see #3884
+                self.learner.inqueue.put(train_batch.copy())
                 self.batch_buffer = []
 
             # If the batch was replayed, skip the update below.


### PR DESCRIPTION


## What do these changes do?

I'm not exactly sure why this copy() matters, since concat_samples() should have already copied the memory via np.concatenate() in the lines above. It is possible that doesn't actually do a copy in all cases.

However, it does seem to fix the issue. The root cause might be similar to https://github.com/ray-project/ray/issues/3452 which was also fixed with a copy().

## Related issue number

https://github.com/ray-project/ray/issues/3884