### PR TITLE
[tune] Add Initial Parameter Suggestion for HyperOpt

### DIFF
--- a/python/ray/tune/examples/hyperopt_example.py
+++ b/python/ray/tune/examples/hyperopt_example.py
@@ -43,6 +43,19 @@ if __name__ == '__main__':
         'activation': hp.choice("activation", ["relu", "tanh"])
     }
 
+    current_best_params = [
+        {
+            "width": 1,
+            "height": 2,
+            "activation": 0  # Activation will be relu
+        },
+        {
+            "width": 4,
+            "height": 2,
+            "activation": 1  # Activation will be tanh
+        }
+    ]
+
     config = {
         "my_exp": {
             "run": "exp",
@@ -55,6 +68,10 @@ if __name__ == '__main__':
             },
         }
     }
-    algo = HyperOptSearch(space, max_concurrent=4, reward_attr="neg_mean_loss")
+    algo = HyperOptSearch(
+        space,
+        max_concurrent=4,
+        reward_attr="neg_mean_loss",
+        points_to_evaluate=current_best_params)
     scheduler = AsyncHyperBandScheduler(reward_attr="neg_mean_loss")
     run_experiments(config, search_alg=algo, scheduler=scheduler)

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -56,7 +56,7 @@ class HyperOptSearch(SuggestionAlgorithm):
         >>> config = {
         >>>     "my_exp": {
         >>>         "run": "exp",
-        >>>         "num_samples": 10 if args.smoke_test else 1000
+        >>>         "num_samples": 10 if args.smoke_test else 1000,
         >>>         "stop": {
         >>>             "training_iteration": 100
         >>>         },

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -34,6 +34,11 @@ class HyperOptSearch(SuggestionAlgorithm):
             to 10.
         reward_attr (str): The training result objective value attribute.
             This refers to an increasing value.
+        points_to_evaluate (list): Initial parameter suggestions to be run
+            first. This is for when you already have some good parameters
+            you want hyperopt to run first to help the TPE algorithm
+            make better suggestions for future parameters. Needs to be
+            a list of dict of hyperopt-named variables (see example)
 
     Example:
         >>> space = {
@@ -41,10 +46,16 @@ class HyperOptSearch(SuggestionAlgorithm):
         >>>     'height': hp.uniform('height', -100, 100),
         >>>     'activation': hp.choice("activation", ["relu", "tanh"])
         >>> }
+        >>> current_best_params = [{
+        >>>     'width': 10,
+        >>>     'height': 0,
+        >>>     'activation': "relu",
+        >>> }]
         >>> config = {
         >>>     "my_exp": {
         >>>         "run": "exp",
         >>>         "num_samples": 10 if args.smoke_test else 1000,
+        >>>         "points_to_evaluate": current_best_params
         >>>         "stop": {
         >>>             "training_iteration": 100
         >>>         },

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -10,6 +10,7 @@ try:
     hyperopt_logger = logging.getLogger("hyperopt")
     hyperopt_logger.setLevel(logging.WARNING)
     import hyperopt as hpo
+    from hyperopt.fmin import generate_trials_to_calculate
 except Exception:
     hpo = None
 
@@ -57,6 +58,7 @@ class HyperOptSearch(SuggestionAlgorithm):
                  space,
                  max_concurrent=10,
                  reward_attr="episode_reward_mean",
+                 points_to_evaluate=None,
                  **kwargs):
         assert hpo is not None, "HyperOpt must be installed!"
         assert type(max_concurrent) is int and max_concurrent > 0
@@ -64,7 +66,14 @@ class HyperOptSearch(SuggestionAlgorithm):
         self._reward_attr = reward_attr
         self.algo = hpo.tpe.suggest
         self.domain = hpo.Domain(lambda spc: spc, space)
-        self._hpopt_trials = hpo.Trials()
+        if points_to_evaluate is None:
+            self._hpopt_trials = hpo.Trials()
+            self._points_to_evaluate = 0
+        else:
+            assert type(points_to_evaluate) == list
+            self._hpopt_trials = generate_trials_to_calculate(points_to_evaluate)
+            self._hpopt_trials.refresh()
+            self._points_to_evaluate = len(points_to_evaluate)
         self._live_trial_mapping = {}
         self.rstate = np.random.RandomState()
 
@@ -73,15 +82,20 @@ class HyperOptSearch(SuggestionAlgorithm):
     def _suggest(self, trial_id):
         if self._num_live_trials() >= self._max_concurrent:
             return None
-        new_ids = self._hpopt_trials.new_trial_ids(1)
-        self._hpopt_trials.refresh()
 
-        # Get new suggestion from Hyperopt
-        new_trials = self.algo(new_ids, self.domain, self._hpopt_trials,
-                               self.rstate.randint(2**31 - 1))
-        self._hpopt_trials.insert_trial_docs(new_trials)
-        self._hpopt_trials.refresh()
-        new_trial = new_trials[0]
+        if self._points_to_evaluate > 0:
+            new_trial = self._hpopt_trials.trials[self._points_to_evaluate - 1]
+            self._points_to_evaluate -= 1
+        else:
+            new_ids = self._hpopt_trials.new_trial_ids(1)
+            self._hpopt_trials.refresh()
+
+            # Get new suggestion from Hyperopt
+            new_trials = self.algo(new_ids, self.domain, self._hpopt_trials,
+                                   self.rstate.randint(2**31 - 1))
+            self._hpopt_trials.insert_trial_docs(new_trials)
+            self._hpopt_trials.refresh()
+            new_trial = new_trials[0]
         self._live_trial_mapping[trial_id] = (new_trial["tid"], new_trial)
 
         # Taken from HyperOpt.base.evaluate

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -82,7 +82,8 @@ class HyperOptSearch(SuggestionAlgorithm):
             self._points_to_evaluate = 0
         else:
             assert type(points_to_evaluate) == list
-            self._hpopt_trials = generate_trials_to_calculate(points_to_evaluate)
+            self._hpopt_trials = generate_trials_to_calculate(
+                points_to_evaluate)
             self._hpopt_trials.refresh()
             self._points_to_evaluate = len(points_to_evaluate)
         self._live_trial_mapping = {}

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -38,7 +38,9 @@ class HyperOptSearch(SuggestionAlgorithm):
             first. This is for when you already have some good parameters
             you want hyperopt to run first to help the TPE algorithm
             make better suggestions for future parameters. Needs to be
-            a list of dict of hyperopt-named variables (see example)
+            a list of dict of hyperopt-named variables.
+            Choice variables should be indicated by their index in the
+            list (see example)
 
     Example:
         >>> space = {
@@ -49,20 +51,20 @@ class HyperOptSearch(SuggestionAlgorithm):
         >>> current_best_params = [{
         >>>     'width': 10,
         >>>     'height': 0,
-        >>>     'activation': "relu",
+        >>>     'activation': 0, # The index of "relu"
         >>> }]
         >>> config = {
         >>>     "my_exp": {
         >>>         "run": "exp",
-        >>>         "num_samples": 10 if args.smoke_test else 1000,
-        >>>         "points_to_evaluate": current_best_params
+        >>>         "num_samples": 10 if args.smoke_test else 1000
         >>>         "stop": {
         >>>             "training_iteration": 100
         >>>         },
         >>>     }
         >>> }
         >>> algo = HyperOptSearch(
-        >>>     space, max_concurrent=4, reward_attr="neg_mean_loss")
+        >>>     space, max_concurrent=4, reward_attr="neg_mean_loss",
+        >>>     points_to_evaluate=current_best_params)
     """
 
     def __init__(self,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Allows users of the HyperOptSearch suggestion algorithm to specify initial experiment values to run (typically already known good baseline parameters within the domain specified)

## Related issue number

Discussed in the [ray dev forums](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/ray-dev/hopdEj2mHx8)
<!-- Are there any issues opened that will be resolved by merging this change? -->
