### PR TITLE
[revert] [rllib] Add copy() in async samples optimizer

### DIFF
--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -167,8 +167,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                    for b in self.batch_buffer) >= self.train_batch_size:
                 train_batch = self.batch_buffer[0].concat_samples(
                     self.batch_buffer)
-                # defensive copy against plasma ref count bugs, see #3884
-                self.learner.inqueue.put(train_batch.copy())
+                self.learner.inqueue.put(train_batch)
                 self.batch_buffer = []
 
             # If the batch was replayed, skip the update below.


### PR DESCRIPTION
The copy seemed to be a red herring (not sure why I saw it mattering before).

This reverts https://github.com/ray-project/ray/pull/3938