### PR TITLE
Only mark tasks as forwarded if they are in the lineage cache

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1948,10 +1948,11 @@ void NodeManager::ForwardTask(const Task &task, const ClientID &node_id,
           if (!lineage_cache_.RemoveWaitingTask(task_id)) {
             RAY_LOG(WARNING) << "Task " << task_id << " already removed from the lineage"
                              << " cache. This is most likely due to reconstruction.";
+          } else {
+            // Mark as forwarded so that the task and its lineage is not
+            // re-forwarded in the future to the receiving node.
+            lineage_cache_.MarkTaskAsForwarded(task_id, node_id);
           }
-          // Mark as forwarded so that the task and its lineage is not re-forwarded
-          // in the future to the receiving node.
-          lineage_cache_.MarkTaskAsForwarded(task_id, node_id);
 
           // Notify the task dependency manager that we are no longer responsible
           // for executing this task.


### PR DESCRIPTION
## What do these changes do?

Tasks get removed from the local lineage cache when they are forwarded to another node, but sometimes if a task is resubmitted on the same node, it will have already been removed the first time the task was forwarded. This fixes a part of the code that assumes the task is always in the lineage cache.

## Related issue number

May be related to #3813.
