### PR TITLE
[wip] Add automated fault tolerance testing to `run_stress_tests.sh`

### DIFF
--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -428,6 +428,7 @@ class TaskLeaseTable : public Table<TaskID, TaskLeaseData> {
 
   Status Add(const JobID &job_id, const TaskID &id, std::shared_ptr<TaskLeaseDataT> &data,
              const WriteCallback &done) override {
+    RAY_LOG(DEBUG) << "Adding task lease " << id << " for " << data->timeout;
     RAY_RETURN_NOT_OK((Table<TaskID, TaskLeaseData>::Add(job_id, id, data, done)));
     // Mark the entry for expiration in Redis. It's okay if this command fails
     // since the lease entry itself contains the expiration period. In the

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -9,8 +9,12 @@
 
 namespace {
 
-const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_ptr) {
+const std::vector<std::string> GenerateEnumNames(int32_t enum_min,
+                                                 const char *const *enum_names_ptr) {
   std::vector<std::string> enum_names;
+  for (int i = 0; i < enum_min; i++) {
+    enum_names.push_back("");
+  }
   size_t i = 0;
   while (true) {
     const char *name = enum_names_ptr[i];
@@ -24,9 +28,11 @@ const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_p
 }
 
 static const std::vector<std::string> node_manager_message_enum =
-    GenerateEnumNames(ray::protocol::EnumNamesMessageType());
-static const std::vector<std::string> object_manager_message_enum =
-    GenerateEnumNames(ray::object_manager::protocol::EnumNamesMessageType());
+    GenerateEnumNames(static_cast<int32_t>(ray::protocol::MessageType::MIN),
+                      ray::protocol::EnumNamesMessageType());
+static const std::vector<std::string> object_manager_message_enum = GenerateEnumNames(
+    static_cast<int32_t>(ray::object_manager::protocol::MessageType::MIN),
+    ray::object_manager::protocol::EnumNamesMessageType());
 }
 
 namespace ray {

--- a/test/stress_tests/run_stress_tests.sh
+++ b/test/stress_tests/run_stress_tests.sh
@@ -8,6 +8,15 @@ RESULT_FILE=$ROOT_DIR/results-$(date '+%Y-%m-%d_%H-%M-%S').log
 echo "Logging to" $RESULT_FILE
 touch $RESULT_FILE
 
+kill_nodes() {
+  # Wait for the cluster to come up.
+  sleep 30;
+  for i in `seq 1 10`; do
+    echo "Killing $i$-th node";
+    nohup ray kill_random_node -y --cluster-name test_shuffle stress_testing_config.yaml;
+  done
+}
+
 run_test(){
     local test_name=$1
 
@@ -27,9 +36,59 @@ run_test(){
     fi
 }
 
+run_failure_test(){
+    local test_name=$1
+
+    local CLUSTER="stress_testing_config.yaml"
+    echo "Try running $test_name."
+    {
+        ray up -y $CLUSTER --cluster-name "$test_name" &&
+        sleep 1 &&
+        (sleep 20 &&
+        for i in `seq 1 10`; do
+          echo "Killing node $i";
+          nohup ray kill_random_node -y --cluster-name test_shuffle stress_testing_config.yaml;
+        done) & pid=$! &&
+        ray submit $CLUSTER --cluster-name "$test_name" "$test_name.py" &&
+        wait $pid
+    } || echo "FAIL: $test_name" >> $RESULT_FILE
+
+    # Tear down cluster.
+    if [ "$DEBUG_MODE" = "" ]; then
+        ray down -y $CLUSTER --cluster-name "$test_name"
+    else
+        echo "Not tearing down cluster" $CLUSTER
+    fi
+}
+
+run_failure_test(){
+    local test_name="$1-failure"
+
+    local CLUSTER="stress_testing_config.yaml"
+    echo "Try running $test_name."
+    {
+        ray up -y $CLUSTER --cluster-name "$test_name" &&
+        sleep 1
+        # Kill 10 nodes in the background.
+        kill_nodes & pid=$!
+        ray submit $CLUSTER --cluster-name "$test_name" "$test_name.py" &&
+        wait $pid
+    } || echo "FAIL: $test_name" >> $RESULT_FILE
+
+    # Tear down cluster.
+    if [ "$DEBUG_MODE" = "" ]; then
+        ray down -y $CLUSTER --cluster-name "$test_name"
+    else
+        echo "Not tearing down cluster" $CLUSTER
+    fi
+}
+
 pushd "$ROOT_DIR"
     run_test test_many_tasks_and_transfers
     run_test test_dead_actors
+    run_test test_shuffle
+    # Blocked on #3958.
+    #run_failure_test test_shuffle
 popd
 
 cat $RESULT_FILE

--- a/test/stress_tests/run_stress_tests.sh
+++ b/test/stress_tests/run_stress_tests.sh
@@ -87,6 +87,7 @@ pushd "$ROOT_DIR"
     run_test test_many_tasks_and_transfers
     run_test test_dead_actors
     run_test test_shuffle
+    run_test test_actor_event_loop
     # Blocked on #3958.
     #run_failure_test test_shuffle
 popd

--- a/test/stress_tests/stress_testing_config.yaml
+++ b/test/stress_tests/stress_testing_config.yaml
@@ -105,11 +105,14 @@ head_setup_commands: []
 worker_setup_commands: []
 
 # Command to start ray on the head node. You don't need to change this.
+# TODO(swang): Starting the cluster with num_heartbeats_timeout=10, then
+# submitting test_shuffle.py or test_many_tasks_and_transfer often causes at
+# least 1 node to be mistakenly marked as dead.
 head_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --head --num-redis-shards=5 --redis-port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml
+    - ulimit -n 65536; ray start --head --num-redis-shards=5 --redis-port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml --internal-config='{"initial_reconstruction_timeout_milliseconds":1000,"num_heartbeats_timeout":20}'
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --redis-address=$RAY_HEAD_IP:6379 --num-gpus=100
+    - ulimit -n 65536; ray start --redis-address=$RAY_HEAD_IP:6379 --num-gpus=100 --internal-config='{"initial_reconstruction_timeout_milliseconds":1000,"num_heartbeats_timeout":20}'

--- a/test/stress_tests/test_actor_event_loop.py
+++ b/test/stress_tests/test_actor_event_loop.py
@@ -1,0 +1,119 @@
+import ray
+import numpy as np
+import time
+from collections import Counter
+import json
+import sys
+
+LOCAL = len(sys.argv) > 1
+
+# Start the Ray processes.
+if LOCAL:
+    print("Starting test locally...")
+    from ray.test.cluster_utils import Cluster
+    cluster = Cluster(
+        initialize_head=True,
+        head_node_args={
+            "num_cpus": 10,
+            "_internal_config": json.dumps({
+                "initial_reconstruction_timeout_milliseconds": 1000,
+                "num_heartbeats_timeout": 10,
+            })
+        })
+    num_nodes = 10
+    for i in range(num_nodes - 1):
+        node_to_kill = cluster.add_node(
+            num_cpus=10,
+            num_gpus=10,
+            _internal_config=json.dumps({
+                "initial_reconstruction_timeout_milliseconds": 1000,
+                "num_heartbeats_timeout": 10,
+            }))
+    ray.init(redis_address=cluster.redis_address)
+else:
+    num_nodes = 100
+    ray.init(redis_address="localhost:6379")
+
+
+@ray.remote(num_gpus=1)
+class EventLoop(object):
+    def __init__(self, num_children):
+        self.children = [Child.remote() for _ in range(num_children)]
+        self.nodes = ray.get([child.node.remote() for child in self.children])
+        self.counts = Counter()
+
+        self.tasks = [child.ping.remote() for child in self.children]
+        self.index = {task: i for i, task in enumerate(self.tasks)}
+
+    def ping(self):
+        ready, unready = ray.wait(self.tasks, num_returns=1)
+        for task in ready:
+            i = self.index[task]
+            new_task = self.children[i].ping.remote()
+            self.tasks[i] = new_task
+            self.index[new_task] = i
+            self.counts[self.nodes[i]] += 1
+
+    def counts(self):
+        return dict(self.counts)
+
+
+@ray.remote
+class Child(object):
+    def __init__(self):
+        return
+
+    def ping(self):
+        time.sleep(np.random.rand())
+        return
+
+    def node(self):
+        return ray.worker.global_worker.plasma_client.store_socket_name
+
+
+num_children = 4
+num_actors = num_nodes // 3
+actors = [EventLoop.remote(num_children) for _ in range(num_actors)]
+
+start_time = time.time()
+interval_time = start_time
+num_rounds = 0
+
+tasks = [actor.ping.remote() for actor in actors]
+index = {task: i for i, task in enumerate(tasks)}
+
+while time.time() - start_time < 60:
+    ready, unready = ray.wait(tasks, num_returns=1)
+    for task in ready:
+        i = index[task]
+        new_task = actors[i].ping.remote()
+        tasks[i] = new_task
+        index[new_task] = i
+
+    num_rounds += 1
+    if time.time() - interval_time > 10:
+        print(num_rounds, "more tasks after", time.time() - start_time)
+        interval_time = time.time()
+        num_rounds = 0
+
+        if LOCAL and time.time() - start_time > 20 and time.time(
+        ) - start_time < 30:
+            print("Removing node")
+            node_to_kill = cluster.list_all_nodes()[-1]
+            cluster.remove_node(node_to_kill)
+
+node_count = Counter()
+for i, actor in enumerate(actors):
+    print("Collecting results from EventLoop actor", i)
+    try:
+        counts = ray.get(actor.counts.remote())
+    except Exception:
+        print("EventLoop actor", i, "died")
+        continue
+
+    for node, count in counts.items():
+        node_count[node] += count
+
+print("Final task counts per node:")
+for node, count in node_count.items():
+    print(node, count)

--- a/test/stress_tests/test_shuffle.py
+++ b/test/stress_tests/test_shuffle.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import numpy as np
+import sys
+import time
+import json
+
+import ray
+
+logger = logging.getLogger(__name__)
+
+LOCAL = len(sys.argv) > 1
+
+# Start the Ray processes.
+if LOCAL:
+    print("Starting test locally...")
+    from ray.test.cluster_utils import Cluster
+    cluster = Cluster(
+        initialize_head=True,
+        head_node_args={
+            "num_cpus": 10,
+            "_internal_config": json.dumps({
+                "initial_reconstruction_timeout_milliseconds": 1000,
+                "num_heartbeats_timeout": 10,
+            })
+        })
+    num_nodes = 10
+    for i in range(num_nodes - 1):
+        node_to_kill = cluster.add_node(
+            num_cpus=10,
+            _internal_config=json.dumps({
+                "initial_reconstruction_timeout_milliseconds": 1000,
+                "num_heartbeats_timeout": 10,
+            }))
+    ray.init(redis_address=cluster.redis_address)
+else:
+    num_nodes = 100
+    ray.init(redis_address="localhost:6379")
+
+
+# Require 1 GPU to force the tasks to be on remote machines.
+@ray.remote(num_gpus=1)
+def shuffle(array):
+    return array + 1
+
+
+@ray.remote
+def zeros():
+    if LOCAL:
+        return np.zeros(10**1)
+    else:
+        # Create some data of size ~8MB.
+        return np.zeros(10**6)
+
+
+# Run shuffles for 60s. This shuffles about 2 * 100 * 8MB = 1.6GB/round.
+data = [zeros.remote() for _ in range(num_nodes * 2)]
+num_rounds = 0
+start_time = time.time()
+round_start = start_time
+num_nodes_to_kill = num_nodes // 10
+while time.time() - start_time < 300:
+    data = [shuffle.remote(array) for array in data]
+    num_rounds += 1
+
+    if num_rounds % 10 == 0:
+        print("Waiting for round", num_rounds)
+        ray.wait(data, num_returns=len(data))
+        print("Finished round", num_rounds, "in", time.time() - round_start)
+        round_start = time.time()
+
+        # Kill some nodes.
+        if LOCAL and num_rounds > 100 and num_nodes_to_kill > 0:
+            node_to_kill = cluster.list_all_nodes()[-1]
+            cluster.remove_node(node_to_kill)
+            num_nodes_to_kill -= 1
+
+# Check that the output is correct.
+for array in data:
+    assert all(ray.get(array) == num_rounds)


### PR DESCRIPTION
## What do these changes do?

Adds fault tolerance testing to `run_stress_tests.sh`. Also adds some tests:
- `test_shuffle.py` - meant to stress plasma memory usage and task reconstruction.
- `test_actor_event_loop.py` - meant to stress actors that cannot be reconstructed.

- [x] Tested `test_shuffle.py` on an autoscaler cluster
- [ ]  Tested `test_actor_event_loop.py` on an autoscaler cluster

## Related issue number

#609.