### PR TITLE
Fix raylet bug in driver cleanup

### DIFF
--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -324,8 +324,15 @@ void TaskDependencyManager::RemoveTasksAndRelatedObjects(
   for (const auto &object_id : required_objects) {
     TaskID creating_task_id = ComputeTaskId(object_id);
     required_tasks_.erase(creating_task_id);
-    RAY_CHECK(!CheckObjectRequired(object_id));
     HandleRemoteDependencyCanceled(object_id);
+  }
+
+  // Make sure that the tasks in task_ids no longer have tasks dependent on
+  // them.
+  for (const auto &task_id : task_ids) {
+    RAY_CHECK(required_tasks_.find(task_id) == required_tasks_.end())
+        << "RemoveTasksAndRelatedObjects was called on" << task_id
+        << ", but another task depends on it that was not included in the argument";
   }
 }
 

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -304,28 +304,28 @@ void TaskDependencyManager::TaskCanceled(const TaskID &task_id) {
 
 void TaskDependencyManager::RemoveTasksAndRelatedObjects(
     const std::unordered_set<TaskID> &task_ids) {
-  if (task_ids.empty()) {
-    return;
-  }
-
+  // Collect a list of all the unique objects that these tasks were subscribed
+  // to.
+  std::unordered_set<ObjectID> required_objects;
   for (auto it = task_ids.begin(); it != task_ids.end(); it++) {
+    auto task_it = task_dependencies_.find(*it);
+    if (task_it != task_dependencies_.end()) {
+      // Add the objects that this task was subscribed to.
+      required_objects.insert(task_it->second.object_dependencies.begin(),
+                              task_it->second.object_dependencies.end());
+    }
+    // The task no longer depends on anything.
     task_dependencies_.erase(*it);
-    required_tasks_.erase(*it);
+    // The task is no longer pending execution.
     pending_tasks_.erase(*it);
   }
 
-  // TODO: the size of required_objects_ could be large, consider to add
-  // an index if this turns out to be a perf problem.
-  for (auto it = required_objects_.begin(); it != required_objects_.end();) {
-    const auto object_id = *it;
+  // Cancel all of the objects that were required by the removed tasks.
+  for (const auto &object_id : required_objects) {
     TaskID creating_task_id = ComputeTaskId(object_id);
-    if (task_ids.find(creating_task_id) != task_ids.end()) {
-      object_manager_.CancelPull(object_id);
-      reconstruction_policy_.Cancel(object_id);
-      it = required_objects_.erase(it);
-    } else {
-      it++;
-    }
+    required_tasks_.erase(creating_task_id);
+    RAY_CHECK(!CheckObjectRequired(object_id));
+    HandleRemoteDependencyCanceled(object_id);
   }
 }
 

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -106,10 +106,12 @@ class TaskDependencyManager {
   /// \return Return a vector of TaskIDs for tasks registered as pending.
   std::vector<TaskID> GetPendingTasks() const;
 
-  /// Remove all of the tasks specified, and all the objects created by
-  /// these tasks from task dependency manager.
+  /// Remove all of the tasks specified. These tasks will no longer be
+  /// considered pending and the objects they depend on will no longer be
+  /// required.
   ///
-  /// \param task_ids The collection of task IDs.
+  /// \param task_ids The collection of task IDs. For a given task in this set,
+  /// all tasks that depend on the task must also be included in the set.
   void RemoveTasksAndRelatedObjects(const std::unordered_set<TaskID> &task_ids);
 
   /// Returns debug string for class.


### PR DESCRIPTION
## What do these changes do?

When a driver exits, we clean up all of the task and object dependencies for related tasks on each node. However, there was a bug in the backend that caused us to miss some of the dependencies. Then, the raylet would crash [here](https://github.com/ray-project/ray/blob/244fd473f4cca66cc02b156fa304bd6a0b774435/src/ray/raylet/node_manager.cc#L1845) because a task that had been removed from all of the queues was still tracked by the `TaskDependencyManager`.

## Related issue number

Not sure if there are any open related issues, but this can cause crashes when a driver exits early.
