### PR TITLE
protect raylet against bad messages

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -8,7 +8,7 @@ cdef extern from "ray/ray_config.h" nogil:
         @staticmethod
         RayConfig &instance()
 
-        int64_t ray_protocol_version() const
+        int64_t ray_cookie() const
 
         int64_t handler_warning_timeout_ms() const
 

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -2,8 +2,8 @@ from ray.includes.ray_config cimport RayConfig
 
 cdef class Config:
     @staticmethod
-    def ray_protocol_version():
-        return RayConfig.instance().ray_protocol_version()
+    def ray_cookie():
+        return RayConfig.instance().ray_cookie()
 
     @staticmethod
     def handler_warning_timeout_ms():

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -272,8 +272,7 @@ bool ClientConnection<T>::CheckRayCookie() {
   // is received from local unknown program which crashes raylet.
   std::ostringstream ss;
   ss << " ray cookie mismatch for received message. "
-     << "received cookie: " << read_cookie_
-     << ", debug label: " << debug_label_
+     << "received cookie: " << read_cookie_ << ", debug label: " << debug_label_
      << ", remote client ID: " << client_id_;
   auto remote_endpoint_info = RemoteEndpointInfo();
   if (!remote_endpoint_info.empty()) {
@@ -298,9 +297,9 @@ std::string ClientConnection<T>::RemoteEndpointInfo() {
 template <>
 std::string ClientConnection<boost::asio::ip::tcp>::RemoteEndpointInfo() {
   const auto &remote_endpoint =
-    ServerConnection<boost::asio::ip::tcp>::socket_.remote_endpoint();
+      ServerConnection<boost::asio::ip::tcp>::socket_.remote_endpoint();
   return remote_endpoint.address().to_string() + ":" +
-      std::to_string(remote_endpoint.port());
+         std::to_string(remote_endpoint.port());
 }
 
 template <class T>

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -83,7 +83,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>
 
   /// A message that is queued for writing asynchronously.
   struct AsyncWriteBuffer {
-    int64_t write_version;
+    int64_t write_cookie;
     int64_t write_type;
     uint64_t write_length;
     std::vector<uint8_t> write_message;
@@ -184,12 +184,12 @@ class ClientConnection : public ServerConnection<T> {
   /// Process an error from reading the message header, then process the
   /// message from the client.
   void ProcessMessage(const boost::system::error_code &error);
-  /// Check if the protocol version in a received message is correct. Note, if the version
+  /// Check if the ray cookie in a received message is correct. Note, if the cookie
   /// is wrong and the remote endpoint is known, raylet process will crash. If the remote
   /// endpoint is unknown, this method will only print a warning.
   ///
-  /// \return If the protocal version is correct.
-  bool CheckProtocolVersion();
+  /// \return If the cookie is correct.
+  bool CheckRayCookie();
   /// Return information about IP and port for the remote endpoint. For local connection
   /// this returns an empty string.
   ///
@@ -209,7 +209,7 @@ class ClientConnection : public ServerConnection<T> {
   /// The value for disconnect client message.
   int64_t error_message_type_;
   /// Buffers for the current message being read from the client.
-  int64_t read_version_;
+  int64_t read_cookie_;
   int64_t read_type_;
   uint64_t read_length_;
   std::vector<uint8_t> read_message_;

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -184,6 +184,18 @@ class ClientConnection : public ServerConnection<T> {
   /// Process an error from reading the message header, then process the
   /// message from the client.
   void ProcessMessage(const boost::system::error_code &error);
+  /// Check if the protocol version in a received message is correct. Note, if the version
+  /// is wrong and the remote endpoint is known, raylet process will crash. If the remote
+  /// endpoint is unknown, this method will only print a warning.
+  ///
+  /// \return If the protocal version is correct.
+  bool CheckProtocolVersion();
+  /// Return information about IP and port for the remote endpoint. For local connection
+  /// this returns an empty string.
+  ///
+  /// \return Information of remote endpoint.
+  std::string RemoteEndpointInfo();
+
 
   /// The ClientID of the remote client.
   ClientID client_id_;

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -196,7 +196,6 @@ class ClientConnection : public ServerConnection<T> {
   /// \return Information of remote endpoint.
   std::string RemoteEndpointInfo();
 
-
   /// The ClientID of the remote client.
   ClientID client_id_;
   /// The handler for a message from the client.

--- a/src/ray/ray_config_def.h
+++ b/src/ray/ray_config_def.h
@@ -9,8 +9,12 @@
 //     1. You must update the file "ray/python/ray/includes/ray_config.pxd".
 //     2. You must update the file "ray/python/ray/includes/ray_config.pxi".
 
-/// In theory, this is used to detect Ray version mismatches.
-RAY_CONFIG(int64_t, ray_protocol_version, 0x0000000000000000);
+/// In theory, this is used to detect Ray cookie mismatches.
+/// This magic number (hex for "RAY") is used instead of zero, rationale is
+/// that it could still be possible that some random program sends an int64_t
+/// which is zero, but it's much less likely that a program sends this
+/// particular magic number.
+RAY_CONFIG(int64_t, ray_cookie, 0x5241590000000000);
 
 /// The duration that a single handler on the event loop can take before a
 /// warning is logged that the handler is taking too long.

--- a/src/ray/raylet/client_connection_test.cc
+++ b/src/ray/raylet/client_connection_test.cc
@@ -19,17 +19,15 @@ class ClientConnectionTest : public ::testing::Test {
   }
 
   ray::Status WriteBadMessage(std::shared_ptr<ray::LocalClientConnection> conn,
-                              int64_t type, int64_t length,
-                              const uint8_t *message) {
+                              int64_t type, int64_t length, const uint8_t *message) {
     std::vector<boost::asio::const_buffer> message_buffers;
-    auto write_cookie = 123456; // incorrect version.
+    auto write_cookie = 123456;  // incorrect version.
     message_buffers.push_back(boost::asio::buffer(&write_cookie, sizeof(write_cookie)));
     message_buffers.push_back(boost::asio::buffer(&type, sizeof(type)));
     message_buffers.push_back(boost::asio::buffer(&length, sizeof(length)));
     message_buffers.push_back(boost::asio::buffer(message, length));
     return conn->WriteBuffer(message_buffers);
   }
-
 
  protected:
   boost::asio::io_service io_service_;
@@ -177,8 +175,9 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
   auto writer = LocalClientConnection::Create(
       client_handler, message_handler, std::move(in_), "writer", {}, error_message_type_);
 
-  auto reader = LocalClientConnection::Create(
-      client_handler, message_handler, std::move(out_), "reader", {}, error_message_type_);
+  auto reader =
+      LocalClientConnection::Create(client_handler, message_handler, std::move(out_),
+                                    "reader", {}, error_message_type_);
 
   // If client ID is set, bad message would crash the test.
   // reader->SetClientID(UniqueID::from_random());

--- a/src/ray/raylet/client_connection_test.cc
+++ b/src/ray/raylet/client_connection_test.cc
@@ -22,8 +22,8 @@ class ClientConnectionTest : public ::testing::Test {
                               int64_t type, int64_t length,
                               const uint8_t *message) {
     std::vector<boost::asio::const_buffer> message_buffers;
-    auto write_version = 123456; // incorrect version.
-    message_buffers.push_back(boost::asio::buffer(&write_version, sizeof(write_version)));
+    auto write_cookie = 123456; // incorrect version.
+    message_buffers.push_back(boost::asio::buffer(&write_cookie, sizeof(write_cookie)));
     message_buffers.push_back(boost::asio::buffer(&type, sizeof(type)));
     message_buffers.push_back(boost::asio::buffer(&length, sizeof(length)));
     message_buffers.push_back(boost::asio::buffer(message, length));
@@ -160,7 +160,7 @@ TEST_F(ClientConnectionTest, CallbackWithSharedRefDoesNotLeakConnection) {
   io_service_.run();
 }
 
-TEST_F(ClientConnectionTest, processbadmessage) {
+TEST_F(ClientConnectionTest, ProcessBadMessage) {
   const uint8_t arr[5] = {1, 2, 3, 4, 5};
   int num_messages = 0;
 
@@ -183,7 +183,7 @@ TEST_F(ClientConnectionTest, processbadmessage) {
   // If client ID is set, bad message would crash the test.
   // reader->SetClientID(UniqueID::from_random());
 
-  // Intentionally write a message with incorrect protocol version.
+  // Intentionally write a message with incorrect cookie.
   // Verify it won't crash as long as client ID is not set.
   RAY_CHECK_OK(WriteBadMessage(writer, 0, 5, arr));
   reader->ProcessMessages();

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -71,6 +71,8 @@ enum MessageType:int {
   PushProfileEventsRequest,
   // Free the objects in objects store.
   FreeObjectsInObjectStoreRequest,
+  // A node manager requests to connect to another node manager.
+  ConnectClient,
 }
 
 table TaskExecutionSpecification {
@@ -203,4 +205,9 @@ table FreeObjectsRequest {
   local_only: bool;
   // List of object ids we'll delete from object store.
   object_ids: [string];
+}
+
+table ConnectClient {
+  // ID of the connecting client.
+  client_id: string;
 }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -397,6 +397,17 @@ class NodeManager {
   void HandleDisconnectedActor(const ActorID &actor_id, bool was_local,
                                bool intentional_disconnect);
 
+  /// connect to a remote node manager.
+  ///
+  /// \param client_id The client ID for the remote node manager.
+  /// \param client_address The IP address for the remote node manager.
+  /// \param client_port The listening port for the remote node manager.
+  /// \return True if the connect succeeds.
+  ray::Status ConnectRemoteNodeManager(const ClientID &client_id, const std::string &client_address,
+                                       int32_t client_port);
+
+  // GCS client ID for this node.
+  ClientID client_id_;
   boost::asio::io_service &io_service_;
   ObjectManager &object_manager_;
   /// A Plasma object store client. This is used exclusively for creating new

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -403,7 +403,8 @@ class NodeManager {
   /// \param client_address The IP address for the remote node manager.
   /// \param client_port The listening port for the remote node manager.
   /// \return True if the connect succeeds.
-  ray::Status ConnectRemoteNodeManager(const ClientID &client_id, const std::string &client_address,
+  ray::Status ConnectRemoteNodeManager(const ClientID &client_id,
+                                       const std::string &client_address,
                                        int32_t client_port);
 
   // GCS client ID for this node.


### PR DESCRIPTION
This is the PR for issue #3915. This fixes the raylet crashes caused by malformed messages.

This change updates node manager so that when it discovers a new node manager, it first sends a `ConnectClient` message to it with its client ID, before sending any other messages, so that the remote node manager knows that further messages from this connection come from a valid source.

This change then modifies client_connection, so that when receiving a malformed message (with incorrect protocol version), we'll check if it's from a valid source that has previously sent us a `ConnectClient` message, if it is then it's likely to be a real bug, otherwise we can know it's not from a legitimate source, and we just print a message and don't further process this connection. 
