### PR TITLE
Add teardown_module to test_queue.py

### DIFF
--- a/python/ray/test/test_queue.py
+++ b/python/ray/test/test_queue.py
@@ -11,12 +11,9 @@ from ray.experimental.queue import Queue, Empty, Full
 
 
 @pytest.fixture
-def ray_start():
+def startup_module():
     # Start the Ray process.
-    ray.init()
-    yield None
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
+    ray.init(num_cpus=1)
 
 
 def teardown_module():

--- a/python/ray/test/test_queue.py
+++ b/python/ray/test/test_queue.py
@@ -11,8 +11,8 @@ from ray.experimental.queue import Queue, Empty, Full
 
 
 def startup_module():
-    # Start the Ray process.
-    ray.init(num_cpus=1)
+    if not ray.worker.global_worker.connected:
+        ray.init(num_cpus=1)
 
 
 def teardown_module():

--- a/python/ray/test/test_queue.py
+++ b/python/ray/test/test_queue.py
@@ -10,9 +10,13 @@ import ray
 from ray.experimental.queue import Queue, Empty, Full
 
 
-def setup_module():
-    if not ray.worker.global_worker.connected:
-        ray.init()
+@pytest.fixture
+def ray_start():
+    # Start the Ray process.
+    ray.init()
+    yield None
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
 
 
 @ray.remote
@@ -27,7 +31,7 @@ def put_async(queue, item, block, timeout, sleep):
     queue.put(item, block, timeout)
 
 
-def test_simple_use():
+def test_simple_use(ray_start):
     q = Queue()
 
     items = list(range(10))
@@ -39,7 +43,7 @@ def test_simple_use():
         assert item == q.get()
 
 
-def test_async():
+def test_async(ray_start):
     q = Queue()
 
     items = set(range(10))
@@ -53,7 +57,7 @@ def test_async():
     assert items == result
 
 
-def test_put():
+def test_put(ray_start):
     q = Queue(1)
 
     item = 0
@@ -83,7 +87,7 @@ def test_put():
     assert ray.get(get_id) == 1
 
 
-def test_get():
+def test_get(ray_start):
     q = Queue()
 
     item = 0
@@ -108,7 +112,7 @@ def test_get():
     assert q.get() == item
 
 
-def test_qsize():
+def test_qsize(ray_start):
     q = Queue()
 
     items = list(range(10))

--- a/python/ray/test/test_queue.py
+++ b/python/ray/test/test_queue.py
@@ -19,6 +19,11 @@ def ray_start():
     ray.shutdown()
 
 
+def teardown_module():
+    if ray.worker.global_worker.connected:
+        ray.shutdown()
+
+
 @ray.remote
 def get_async(queue, block, timeout, sleep):
     time.sleep(sleep)

--- a/python/ray/test/test_queue.py
+++ b/python/ray/test/test_queue.py
@@ -10,7 +10,6 @@ import ray
 from ray.experimental.queue import Queue, Empty, Full
 
 
-@pytest.fixture
 def startup_module():
     # Start the Ray process.
     ray.init(num_cpus=1)
@@ -33,7 +32,7 @@ def put_async(queue, item, block, timeout, sleep):
     queue.put(item, block, timeout)
 
 
-def test_simple_use(ray_start):
+def test_simple_use():
     q = Queue()
 
     items = list(range(10))
@@ -45,7 +44,7 @@ def test_simple_use(ray_start):
         assert item == q.get()
 
 
-def test_async(ray_start):
+def test_async():
     q = Queue()
 
     items = set(range(10))
@@ -59,7 +58,7 @@ def test_async(ray_start):
     assert items == result
 
 
-def test_put(ray_start):
+def test_put():
     q = Queue(1)
 
     item = 0
@@ -89,7 +88,7 @@ def test_put(ray_start):
     assert ray.get(get_id) == 1
 
 
-def test_get(ray_start):
+def test_get():
     q = Queue()
 
     item = 0
@@ -114,7 +113,7 @@ def test_get(ray_start):
     assert q.get() == item
 
 
-def test_qsize(ray_start):
+def test_qsize():
     q = Queue()
 
     items = list(range(10))


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Adds a `teardown_module` to `test_queue.py` in order to ensure that after `test_queue.py` finishes running, that there is no ray process still running.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
