### PR TITLE
Use Redis lists in the GCS instead of zset

### DIFF
--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -130,8 +130,6 @@ table ObjectTableData {
   manager: string;
   // Whether this entry is an addition or a deletion.
   is_eviction: bool;
-  // The number of times this object has been evicted from this node so far.
-  num_evictions: int;
   // In-line object data.
   inline_object_data: [ubyte];
   // In-line object metadata.

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -205,9 +205,6 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   std::shared_ptr<gcs::AsyncGcsClient> gcs_client_;
   /// Info about subscribers to object locations.
   std::unordered_map<ObjectID, LocationListenerState> listeners_;
-  /// Map from object ID to the number of times it's been evicted on this
-  /// node before.
-  std::unordered_map<ObjectID, int> object_evictions_;
 };
 
 }  // namespace ray

--- a/test/failure_test.py
+++ b/test/failure_test.py
@@ -648,13 +648,17 @@ def test_redis_module_failure(shutdown_only):
                      "RAY.TABLE_ADD", 1, 10000, 1, 1)
     run_failure_test("Pubsub channel must be a valid integer", "RAY.TABLE_ADD",
                      1, b"a", 1, 1)
-    run_failure_test("Index is less than 0.", "RAY.TABLE_APPEND", 1, 1, 1, 1,
+    # Change the key from 1 to 2, since the previous command should have
+    # succeeded at writing the key, but not publishing it.
+    run_failure_test("Index is less than 0.", "RAY.TABLE_APPEND", 1, 1, 2, 1,
                      -1)
-    run_failure_test("Index is not a number.", "RAY.TABLE_APPEND", 1, 1, 1, 1,
+    run_failure_test("Index is not a number.", "RAY.TABLE_APPEND", 1, 1, 2, 1,
                      b"a")
-    run_one_command("RAY.TABLE_APPEND", 1, 1, 1, 1)
-    run_failure_test("Appended a duplicate entry", "RAY.TABLE_APPEND", 1, 1, 1,
-                     1, 1)
+    run_one_command("RAY.TABLE_APPEND", 1, 1, 2, 1)
+    # It's okay to add duplicate entries.
+    run_one_command("RAY.TABLE_APPEND", 1, 1, 2, 1)
+    run_one_command("RAY.TABLE_APPEND", 1, 1, 2, 1, 0)
+    run_one_command("RAY.TABLE_APPEND", 1, 1, 2, 1, 1)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What do these changes do?

This replaces the implementation for append-only GCS tables with Redis lists instead of zsets. There may be a slight performance penalty, since low-level list iteration isn't implemented yet in Redis modules. On the other hand, we no longer have to check for duplicate entries, so we can remove the `object_evictions_` map from `ObjectDirectory` (this was only used to make sure that each object table entry was unique).

## Related issue number

Closes #3470 and closes #3336.