### PR TITLE
API cleanups. Remove worker argument. Remove some deprecated arguments.

### DIFF
--- a/doc/source/tempfile.rst
+++ b/doc/source/tempfile.rst
@@ -47,7 +47,7 @@ A typical layout of temporary files could look like this:
           │   ├── monitor.out
           │   ├── plasma_store_0.err  # array of plasma stores' outputs
           │   ├── plasma_store_0.out
-          │   ├── raylet_0.err  # array of raylets' outputs. Control it with `--no-redirect-worker-output` (in Ray's command line) or `redirect_worker_output` (in ray.init())
+          │   ├── raylet_0.err
           │   ├── raylet_0.out
           │   ├── redis-shard_0.err   # array of redis shards' outputs
           │   ├── redis-shard_0.out

--- a/examples/lbfgs/driver.py
+++ b/examples/lbfgs/driver.py
@@ -35,6 +35,7 @@ class LinearModel(object):
         variables (TensorFlowVariables): Extracted variables and methods to
             manipulate them.
     """
+
     def __init__(self, shape):
         """Creates a LinearModel object."""
         x = tf.placeholder(tf.float32, [None, shape[0]])
@@ -46,26 +47,33 @@ class LinearModel(object):
         y = tf.nn.softmax(tf.matmul(x, w) + b)
         y_ = tf.placeholder(tf.float32, [None, shape[1]])
         self.y_ = y_
-        cross_entropy = tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(y),
-                                       reduction_indices=[1]))
+        cross_entropy = tf.reduce_mean(
+            -tf.reduce_sum(y_ * tf.log(y), reduction_indices=[1]))
         self.cross_entropy = cross_entropy
         self.cross_entropy_grads = tf.gradients(cross_entropy, [w, b])
         self.sess = tf.Session()
         # In order to get and set the weights, we pass in the loss function to
         # Ray's TensorFlowVariables to automatically create methods to modify
         # the weights.
-        self.variables = ray.experimental.TensorFlowVariables(cross_entropy,
-                                                              self.sess)
+        self.variables = ray.experimental.TensorFlowVariables(
+            cross_entropy, self.sess)
 
     def loss(self, xs, ys):
         """Computes the loss of the network."""
-        return float(self.sess.run(self.cross_entropy,
-                                   feed_dict={self.x: xs, self.y_: ys}))
+        return float(
+            self.sess.run(
+                self.cross_entropy, feed_dict={
+                    self.x: xs,
+                    self.y_: ys
+                }))
 
     def grad(self, xs, ys):
         """Computes the gradients of the network."""
-        return self.sess.run(self.cross_entropy_grads,
-                             feed_dict={self.x: xs, self.y_: ys})
+        return self.sess.run(
+            self.cross_entropy_grads, feed_dict={
+                self.x: xs,
+                self.y_: ys
+            })
 
 
 @ray.remote
@@ -110,7 +118,7 @@ def full_grad(theta):
 
 
 if __name__ == "__main__":
-    ray.init(redirect_output=True)
+    ray.init()
 
     # From the perspective of scipy.optimize.fmin_l_bfgs_b, full_loss is simply
     # a function which takes some parameters theta, and computes a loss.
@@ -136,5 +144,5 @@ if __name__ == "__main__":
 
     # Use L-BFGS to minimize the loss function.
     print("Running L-BFGS.")
-    result = scipy.optimize.fmin_l_bfgs_b(full_loss, theta_init, maxiter=10,
-                                          fprime=full_grad, disp=True)
+    result = scipy.optimize.fmin_l_bfgs_b(
+        full_loss, theta_init, maxiter=10, fprime=full_grad, disp=True)

--- a/examples/rl_pong/driver.py
+++ b/examples/rl_pong/driver.py
@@ -146,17 +146,26 @@ class PongEnv(object):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train an RL agent on Pong.")
-    parser.add_argument("--batch-size", default=10, type=int,
-                        help="The number of rollouts to do per batch.")
-    parser.add_argument("--redis-address", default=None, type=str,
-                        help="The Redis address of the cluster.")
-    parser.add_argument("--iterations", default=-1, type=int,
-                        help="The number of model updates to perform. By "
-                             "default, training will not terminate.")
+    parser.add_argument(
+        "--batch-size",
+        default=10,
+        type=int,
+        help="The number of rollouts to do per batch.")
+    parser.add_argument(
+        "--redis-address",
+        default=None,
+        type=str,
+        help="The Redis address of the cluster.")
+    parser.add_argument(
+        "--iterations",
+        default=-1,
+        type=int,
+        help="The number of model updates to perform. By "
+        "default, training will not terminate.")
     args = parser.parse_args()
     batch_size = args.batch_size
 
-    ray.init(redis_address=args.redis_address, redirect_output=True)
+    ray.init(redis_address=args.redis_address)
 
     # Run the reinforcement learning.
 
@@ -187,8 +196,8 @@ if __name__ == "__main__":
             # Accumulate the gradient over batch.
             for k in model:
                 grad_buffer[k] += grad[k]
-            running_reward = (reward_sum if running_reward is None
-                              else running_reward * 0.99 + reward_sum * 0.01)
+            running_reward = (reward_sum if running_reward is None else
+                              running_reward * 0.99 + reward_sum * 0.01)
         end_time = time.time()
         print("Batch {} computed {} rollouts in {} seconds, "
               "running mean is {}".format(batch_num, batch_size,
@@ -196,8 +205,8 @@ if __name__ == "__main__":
                                           running_reward))
         for k, v in model.items():
             g = grad_buffer[k]
-            rmsprop_cache[k] = (decay_rate * rmsprop_cache[k] +
-                                (1 - decay_rate) * g ** 2)
+            rmsprop_cache[k] = (
+                decay_rate * rmsprop_cache[k] + (1 - decay_rate) * g**2)
             model[k] += learning_rate * g / (np.sqrt(rmsprop_cache[k]) + 1e-5)
             # Reset the batch gradient buffer.
             grad_buffer[k] = np.zeros_like(v)

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -125,12 +125,6 @@ class ActorMethod(object):
     def remote(self, *args, **kwargs):
         return self._remote(args, kwargs)
 
-    def _submit(self, args, kwargs, num_return_vals=None):
-        logger.warning(
-            "WARNING: _submit() is being deprecated. Please use _remote().")
-        return self._remote(
-            args=args, kwargs=kwargs, num_return_vals=num_return_vals)
-
     def _remote(self, args, kwargs, num_return_vals=None):
         if num_return_vals is None:
             num_return_vals = self._num_return_vals
@@ -237,21 +231,6 @@ class ActorClass(object):
             A handle to the newly created actor.
         """
         return self._remote(args=args, kwargs=kwargs)
-
-    def _submit(self,
-                args,
-                kwargs,
-                num_cpus=None,
-                num_gpus=None,
-                resources=None):
-        logger.warning(
-            "WARNING: _submit() is being deprecated. Please use _remote().")
-        return self._remote(
-            args=args,
-            kwargs=kwargs,
-            num_cpus=num_cpus,
-            num_gpus=num_gpus,
-            resources=resources)
 
     def _remote(self,
                 args,

--- a/python/ray/experimental/api.py
+++ b/python/ray/experimental/api.py
@@ -19,11 +19,8 @@ def get(object_ids):
     Returns:
         A Python object, a list of Python objects or a dict of {key: object}.
     """
-    # There is a dependency on ray.worker which prevents importing
-    # global_worker at the top of this file
-    worker = ray.worker.global_worker
     if isinstance(object_ids, (tuple, np.ndarray)):
-        return ray.get(list(object_ids), worker)
+        return ray.get(list(object_ids))
     elif isinstance(object_ids, dict):
         keys_to_get = [
             k for k, v in object_ids.items() if isinstance(v, ray.ObjectID)
@@ -38,7 +35,7 @@ def get(object_ids):
             result[key] = value
         return result
     else:
-        return ray.get(object_ids, worker)
+        return ray.get(object_ids)
 
 
 def wait(object_ids, num_returns=1, timeout=None):

--- a/python/ray/experimental/api.py
+++ b/python/ray/experimental/api.py
@@ -6,7 +6,7 @@ import ray
 import numpy as np
 
 
-def get(object_ids, worker=None):
+def get(object_ids):
     """Get a single or a collection of remote objects from the object store.
 
     This method is identical to `ray.get` except it adds support for tuples,
@@ -21,7 +21,7 @@ def get(object_ids, worker=None):
     """
     # There is a dependency on ray.worker which prevents importing
     # global_worker at the top of this file
-    worker = ray.worker.global_worker if worker is None else worker
+    worker = ray.worker.global_worker
     if isinstance(object_ids, (tuple, np.ndarray)):
         return ray.get(list(object_ids), worker)
     elif isinstance(object_ids, dict):
@@ -41,7 +41,7 @@ def get(object_ids, worker=None):
         return ray.get(object_ids, worker)
 
 
-def wait(object_ids, num_returns=1, timeout=None, worker=None):
+def wait(object_ids, num_returns=1, timeout=None):
     """Return a list of IDs that are ready and a list of IDs that are not.
 
     This method is identical to `ray.wait` except it adds support for tuples
@@ -59,13 +59,8 @@ def wait(object_ids, num_returns=1, timeout=None, worker=None):
         A list of object IDs that are ready and a list of the remaining object
             IDs.
     """
-    worker = ray.worker.global_worker if worker is None else worker
     if isinstance(object_ids, (tuple, np.ndarray)):
         return ray.wait(
-            list(object_ids),
-            num_returns=num_returns,
-            timeout=timeout,
-            worker=worker)
+            list(object_ids), num_returns=num_returns, timeout=timeout)
 
-    return ray.wait(
-        object_ids, num_returns=num_returns, timeout=timeout, worker=worker)
+    return ray.wait(object_ids, num_returns=num_returns, timeout=timeout)

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -441,7 +441,7 @@ class FunctionActorManager(object):
         # we spend too long in this loop.
         # The driver function may not be found in sys.path. Try to load
         # the function from GCS.
-        with profiling.profile("wait_for_function", worker=self._worker):
+        with profiling.profile("wait_for_function"):
             self._wait_for_function(function_descriptor, driver_id)
         try:
             info = self._function_execution_info[driver_id][function_id]

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -91,21 +91,18 @@ class ImportThread(object):
         # Handle the driver case first.
         if self.mode != ray.WORKER_MODE:
             if key.startswith(b"FunctionsToRun"):
-                with profiling.profile(
-                        "fetch_and_run_function", worker=self.worker):
+                with profiling.profile("fetch_and_run_function"):
                     self.fetch_and_execute_function_to_run(key)
             # Return because FunctionsToRun are the only things that
             # the driver should import.
             return
 
         if key.startswith(b"RemoteFunction"):
-            with profiling.profile(
-                    "register_remote_function", worker=self.worker):
+            with profiling.profile("register_remote_function"):
                 (self.worker.function_actor_manager.
                  fetch_and_register_remote_function(key))
         elif key.startswith(b"FunctionsToRun"):
-            with profiling.profile(
-                    "fetch_and_run_function", worker=self.worker):
+            with profiling.profile("fetch_and_run_function"):
                 self.fetch_and_execute_function_to_run(key)
         elif key.startswith(b"ActorClass"):
             # Keep track of the fact that this actor class has been

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -8,7 +8,7 @@ from ray import profiling
 __all__ = ["free"]
 
 
-def free(object_ids, local_only=False, worker=None):
+def free(object_ids, local_only=False):
     """Free a list of IDs from object stores.
 
     This function is a low-level API which should be used in restricted
@@ -26,8 +26,7 @@ def free(object_ids, local_only=False, worker=None):
         local_only (bool): Whether only deleting the list of objects in local
             object store or all object stores.
     """
-    if worker is None:
-        worker = ray.worker.get_global_worker()
+    worker = ray.worker.get_global_worker()
 
     if isinstance(object_ids, ray.ObjectID):
         object_ids = [object_ids]
@@ -37,7 +36,7 @@ def free(object_ids, local_only=False, worker=None):
             type(object_ids)))
 
     worker.check_connected()
-    with profiling.profile("ray.free", worker=worker):
+    with profiling.profile("ray.free"):
         if len(object_ids) == 0:
             return
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -197,7 +197,7 @@ class Node(object):
         raise FileExistsError(errno.EEXIST,
                               "No usable temporary filename found")
 
-    def new_log_files(self, name, redirect_output=None):
+    def new_log_files(self, name, redirect_output=True):
         """Generate partially randomized filenames for log files.
 
         Args:
@@ -262,7 +262,7 @@ class Node(object):
              redis_shard_ports=self._ray_params.redis_shard_ports,
              num_redis_shards=self._ray_params.num_redis_shards,
              redis_max_clients=self._ray_params.redis_max_clients,
-             redirect_worker_output=self._ray_params.redirect_worker_output,
+             redirect_worker_output=True,
              password=self._ray_params.redis_password,
              redis_max_memory=self._ray_params.redis_max_memory)
         assert (
@@ -272,7 +272,7 @@ class Node(object):
 
     def start_log_monitor(self):
         """Start the log monitor."""
-        stdout_file, stderr_file = self.new_log_files("log_monitor", True)
+        stdout_file, stderr_file = self.new_log_files("log_monitor")
         process_info = ray.services.start_log_monitor(
             self.redis_address,
             self._logs_dir,
@@ -286,7 +286,7 @@ class Node(object):
 
     def start_ui(self):
         """Start the web UI."""
-        stdout_file, stderr_file = self.new_log_files("webui", True)
+        stdout_file, stderr_file = self.new_log_files("webui")
         notebook_name = self._make_inc_temp(
             suffix=".ipynb", prefix="ray_ui", directory_name=self._temp_dir)
         self._webui_url, process_info = ray.services.start_ui(

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -90,11 +90,10 @@ class RayParams(object):
                  node_manager_port=None,
                  node_ip_address=None,
                  object_id_seed=None,
-                 num_workers=None,
                  local_mode=False,
                  driver_mode=None,
-                 redirect_worker_output=True,
-                 redirect_output=True,
+                 redirect_worker_output=None,
+                 redirect_output=None,
                  num_redis_shards=None,
                  redis_max_clients=None,
                  redis_password=None,
@@ -124,7 +123,6 @@ class RayParams(object):
         self.object_manager_port = object_manager_port
         self.node_manager_port = node_manager_port
         self.node_ip_address = node_ip_address
-        self.num_workers = num_workers
         self.local_mode = local_mode
         self.driver_mode = driver_mode
         self.redirect_worker_output = redirect_worker_output
@@ -186,10 +184,15 @@ class RayParams(object):
                 "'GPU' should not be included in the resource dictionary. Use "
                 "num_gpus instead.")
 
-        if self.num_workers is not None:
-            raise ValueError(
-                "The 'num_workers' argument is deprecated. Please use "
-                "'num_cpus' instead.")
+        if self.redirect_worker_output is not None:
+            raise DeprecationWarning(
+                "The redirect_worker_output argument is deprecated. To "
+                "control logging to the driver, use the 'log_to_driver' "
+                "argument to 'ray.init()'")
+
+        if self.redirect_output is not None:
+            raise DeprecationWarning(
+                "The redirect_output argument is deprecated.")
 
         if self.include_java is None and self.java_worker_options is not None:
             raise ValueError("Should not specify `java-worker-options` "

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -27,7 +27,7 @@ class _NullLogSpan(object):
 NULL_LOG_SPAN = _NullLogSpan()
 
 
-def profile(event_type, extra_data=None, worker=None):
+def profile(event_type, extra_data=None):
     """Profile a span of time so that it appears in the timeline visualization.
 
     Note that this only works in the raylet code path.
@@ -57,8 +57,7 @@ def profile(event_type, extra_data=None, worker=None):
     Returns:
         An object that can profile a span of time via a "with" statement.
     """
-    if worker is None:
-        worker = ray.worker.global_worker
+    worker = ray.worker.global_worker
     return RayLogSpanRaylet(worker.profiler, event_type, extra_data=extra_data)
 
 

--- a/python/ray/rllib/examples/carla/train_ppo.py
+++ b/python/ray/rllib/examples/carla/train_ppo.py
@@ -21,7 +21,7 @@ env_config.update({
 })
 register_carla_model()
 
-ray.init(redirect_output=True)
+ray.init()
 run_experiments({
     "carla": {
         "run": "PPO",

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -124,15 +124,6 @@ def cli(logging_level, logging_format):
     "applies to the sharded redis tables (task, object, and profile tables). "
     "By default this is capped at 10GB but can be set higher.")
 @click.option(
-    "--num-workers",
-    required=False,
-    type=int,
-    help=("The initial number of workers to start on this node, "
-          "note that the local scheduler may start additional "
-          "workers. If you wish to control the total number of "
-          "concurent tasks, then use --resources instead and "
-          "specify the CPU field."))
-@click.option(
     "--num-cpus",
     required=False,
     type=int,
@@ -220,8 +211,8 @@ def cli(logging_level, logging_format):
 def start(node_ip_address, redis_address, redis_port, num_redis_shards,
           redis_max_clients, redis_password, redis_shard_ports,
           object_manager_port, node_manager_port, object_store_memory,
-          redis_max_memory, num_workers, num_cpus, num_gpus, resources, head,
-          no_ui, block, plasma_directory, huge_pages, autoscaling_config,
+          redis_max_memory, num_cpus, num_gpus, resources, head, no_ui, block,
+          plasma_directory, huge_pages, autoscaling_config,
           no_redirect_worker_output, no_redirect_output,
           plasma_store_socket_name, raylet_socket_name, temp_dir, include_java,
           java_worker_options, internal_config):
@@ -239,15 +230,16 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
                         "    --resources='{\"CustomResource1\": 3, "
                         "\"CustomReseource2\": 2}'")
 
+    redirect_worker_output = None if not no_redirect_worker_output else True
+    redirect_output = None if not no_redirect_output else True
     ray_params = ray.parameter.RayParams(
         node_ip_address=node_ip_address,
         object_manager_port=object_manager_port,
         node_manager_port=node_manager_port,
-        num_workers=num_workers,
         object_store_memory=object_store_memory,
         redis_password=redis_password,
-        redirect_worker_output=not no_redirect_worker_output,
-        redirect_output=not no_redirect_output,
+        redirect_worker_output=redirect_worker_output,
+        redirect_output=redirect_output,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         resources=resources,

--- a/python/ray/tune/examples/bayesopt_example.py
+++ b/python/ray/tune/examples/bayesopt_example.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", easy_objective)
 

--- a/python/ray/tune/examples/genetic_example.py
+++ b/python/ray/tune/examples/genetic_example.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", michalewicz_function)
 

--- a/python/ray/tune/examples/hyperopt_example.py
+++ b/python/ray/tune/examples/hyperopt_example.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", easy_objective)
 

--- a/python/ray/tune/examples/nevergrad_example.py
+++ b/python/ray/tune/examples/nevergrad_example.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", easy_objective)
 

--- a/python/ray/tune/examples/sigopt_example.py
+++ b/python/ray/tune/examples/sigopt_example.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", easy_objective)
 

--- a/python/ray/tune/examples/skopt_example.py
+++ b/python/ray/tune/examples/skopt_example.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(redirect_output=True)
+    ray.init()
 
     register_trainable("exp", easy_objective)
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2502,7 +2502,7 @@ def test_not_logging_to_driver(shutdown_only):
     reason="New GCS API doesn't have a Python API yet.")
 def test_workers(shutdown_only):
     num_workers = 3
-    ray.init(redirect_worker_output=True, num_cpus=num_workers)
+    ray.init(num_cpus=num_workers)
 
     @ray.remote
     def f():

--- a/test/stress_tests.py
+++ b/test/stress_tests.py
@@ -204,7 +204,6 @@ def ray_start_reconstruction(request):
             "num_cpus": 1,
             "object_store_memory": plasma_store_memory // num_nodes,
             "redis_max_memory": 10**7,
-            "redirect_output": True,
             "_internal_config": json.dumps({
                 "initial_reconstruction_timeout_milliseconds": 200
             })
@@ -213,7 +212,6 @@ def ray_start_reconstruction(request):
         cluster.add_node(
             num_cpus=1,
             object_store_memory=plasma_store_memory // num_nodes,
-            redirect_output=True,
             _internal_config=json.dumps({
                 "initial_reconstruction_timeout_milliseconds": 200
             }))

--- a/test/tempfile_test.py
+++ b/test/tempfile_test.py
@@ -64,7 +64,7 @@ def test_temp_plasma_store_socket():
 
 
 def test_raylet_tempfiles():
-    ray.init(redirect_worker_output=False)
+    ray.init(num_cpus=0)
     node = ray.worker._global_node
     top_levels = set(os.listdir(node.get_temp_dir_path()))
     assert top_levels == {"ray_ui.ipynb", "sockets", "logs"}
@@ -80,23 +80,7 @@ def test_raylet_tempfiles():
     assert socket_files == {"plasma_store", "raylet"}
     ray.shutdown()
 
-    ray.init(redirect_worker_output=True, num_cpus=0)
-    node = ray.worker._global_node
-    top_levels = set(os.listdir(node.get_temp_dir_path()))
-    assert top_levels == {"ray_ui.ipynb", "sockets", "logs"}
-    log_files = set(os.listdir(node.get_logs_dir_path()))
-    assert log_files == {
-        "log_monitor.out", "log_monitor.err", "plasma_store.out",
-        "plasma_store.err", "webui.out", "webui.err", "monitor.out",
-        "monitor.err", "raylet_monitor.out", "raylet_monitor.err",
-        "redis-shard_0.out", "redis-shard_0.err", "redis.out", "redis.err",
-        "raylet.out", "raylet.err"
-    }  # with raylet logs
-    socket_files = set(os.listdir(node.get_sockets_dir_path()))
-    assert socket_files == {"plasma_store", "raylet"}
-    ray.shutdown()
-
-    ray.init(redirect_worker_output=True, num_cpus=2)
+    ray.init(num_cpus=2)
     node = ray.worker._global_node
     top_levels = set(os.listdir(node.get_temp_dir_path()))
     assert top_levels == {"ray_ui.ipynb", "sockets", "logs"}


### PR DESCRIPTION
This PR does the following:
- Removes `driver_mode` and `use_raylet` arguments to `ray.init()`.
- Deprecates `redirect_ouput` and `redirect_worker_output` arguments to `ray.init()`.
- Removes `_submit`.
- Removes `worker` argument from Ray API methods.