### PR TITLE
Increase timeout for object manager valgrind tests

### DIFF
--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -115,8 +115,7 @@ void ObjectDirectory::RegisterBackend() {
 ray::Status ObjectDirectory::ReportObjectAdded(
     const ObjectID &object_id, const ClientID &client_id,
     const object_manager::protocol::ObjectInfoT &object_info, bool inline_object_flag,
-    const std::vector<uint8_t> &inline_object_data,
-    const std::string &inline_object_metadata) {
+    const plasma::ObjectBuffer &plasma_buffer) {
   RAY_LOG(DEBUG) << "Reporting object added to GCS " << object_id << " inline? "
                  << inline_object_flag;
   // Append the addition entry to the object table.
@@ -128,9 +127,12 @@ ray::Status ObjectDirectory::ReportObjectAdded(
   data->inline_object_flag = inline_object_flag;
   if (inline_object_flag) {
     // Add object's data to its GCS entry.
-    data->inline_object_data.assign(inline_object_data.begin(), inline_object_data.end());
-    data->inline_object_metadata.assign(inline_object_metadata.begin(),
-                                        inline_object_metadata.end());
+    data->inline_object_data.assign(
+        plasma_buffer.data->data(),
+        plasma_buffer.data->data() + plasma_buffer.data->size());
+    data->inline_object_metadata.assign(
+        plasma_buffer.metadata->data(),
+        plasma_buffer.metadata->data() + plasma_buffer.metadata->size());
   }
   ray::Status status =
       gcs_client_->object_table().Append(JobID::nil(), object_id, data, nullptr);

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -7,6 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "plasma/client.h"
+
 #include "ray/gcs/client.h"
 #include "ray/id.h"
 #include "ray/object_manager/format/object_manager_generated.h"
@@ -100,14 +102,13 @@ class ObjectDirectoryInterface {
   /// \param client_id The client id corresponding to this node.
   /// \param object_info Additional information about the object.
   /// \param inline_object_flag Flag specifying whether object is inlined.
-  /// \param inline_object_data Object data. Only for inlined objects.
-  /// \param inline_object_metadata Object metadata. Only for inlined objects.
+  /// \param plasma_buffer Object data and metadata from plasma. This data is
+  /// only valid for inlined objects (i.e., when inline_object_flag=true).
   /// \return Status of whether this method succeeded.
   virtual ray::Status ReportObjectAdded(
       const ObjectID &object_id, const ClientID &client_id,
       const object_manager::protocol::ObjectInfoT &object_info, bool inline_object_flag,
-      const std::vector<uint8_t> &inline_object_data,
-      const std::string &inline_object_metadata) = 0;
+      const plasma::ObjectBuffer &plasma_buffer) = 0;
 
   /// Report objects removed from this client's store to the object directory.
   ///
@@ -162,8 +163,7 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   ray::Status ReportObjectAdded(const ObjectID &object_id, const ClientID &client_id,
                                 const object_manager::protocol::ObjectInfoT &object_info,
                                 bool inline_object_flag,
-                                const std::vector<uint8_t> &inline_object_data,
-                                const std::string &inline_object_metadata) override;
+                                const plasma::ObjectBuffer &plasma_buffer) override;
 
   ray::Status ReportObjectRemoved(const ObjectID &object_id,
                                   const ClientID &client_id) override;

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -7,6 +7,11 @@
 
 #include "ray/object_manager/object_manager.h"
 
+namespace {
+std::string store_executable;
+int64_t wait_timeout_ms;
+}
+
 namespace ray {
 
 static inline void flushall_redis(void) {
@@ -14,8 +19,6 @@ static inline void flushall_redis(void) {
   freeReplyObject(redisCommand(context, "FLUSHALL"));
   redisFree(context);
 }
-
-std::string store_executable;
 
 class MockServer {
  public:
@@ -342,27 +345,27 @@ class TestObjectManager : public TestObjectManagerBase {
     case 0: {
       // Ensure timeout_ms = 0 is handled correctly.
       // Out of 5 objects, we expect 3 ready objects and 2 remaining objects.
-      TestWait(600, 5, 3, /*timeout_ms=*/0, false, false);
+      TestWait(100, 5, 3, /*timeout_ms=*/0, false, false);
     } break;
     case 1: {
       // Ensure timeout_ms = 1000 is handled correctly.
       // Out of 5 objects, we expect 3 ready objects and 2 remaining objects.
-      TestWait(600, 5, 3, /*timeout_ms=*/1000, false, false);
+      TestWait(100, 5, 3, wait_timeout_ms, false, false);
     } break;
     case 2: {
       // Generate objects locally to ensure local object code-path works properly.
       // Out of 5 objects, we expect 3 ready objects and 2 remaining objects.
-      TestWait(600, 5, 3, 1000, false, /*test_local=*/true);
+      TestWait(100, 5, 3, wait_timeout_ms, false, /*test_local=*/true);
     } break;
     case 3: {
       // Wait on an object that's never registered with GCS to ensure timeout works
       // properly.
-      TestWait(600, /*num_objects=*/5, /*required_objects=*/6, 1000,
+      TestWait(100, /*num_objects=*/5, /*required_objects=*/6, wait_timeout_ms,
                /*include_nonexistent=*/true, false);
     } break;
     case 4: {
       // Ensure infinite time code-path works properly.
-      TestWait(600, 5, 5, /*timeout_ms=*/-1, false, false);
+      TestWait(100, 5, 5, /*timeout_ms=*/-1, false, false);
     } break;
     }
   }
@@ -484,6 +487,7 @@ TEST_F(TestObjectManager, StartTestObjectManager) {
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  ray::store_executable = std::string(argv[1]);
+  store_executable = std::string(argv[1]);
+  wait_timeout_ms = std::stoi(std::string(argv[2]));
   return RUN_ALL_TESTS();
 }

--- a/src/ray/raylet/reconstruction_policy_test.cc
+++ b/src/ray/raylet/reconstruction_policy_test.cc
@@ -60,10 +60,10 @@ class MockObjectDirectory : public ObjectDirectoryInterface {
                            const OnLocationsFound &));
   MOCK_METHOD2(UnsubscribeObjectLocations,
                ray::Status(const ray::UniqueID &, const ObjectID &));
-  MOCK_METHOD6(ReportObjectAdded,
+  MOCK_METHOD5(ReportObjectAdded,
                ray::Status(const ObjectID &, const ClientID &,
                            const object_manager::protocol::ObjectInfoT &, bool,
-                           const std::vector<uint8_t> &, const std::string &));
+                           const plasma::ObjectBuffer &));
 
   MOCK_METHOD2(ReportObjectRemoved, ray::Status(const ObjectID &, const ClientID &));
 

--- a/src/ray/test/run_object_manager_tests.sh
+++ b/src/ray/test/run_object_manager_tests.sh
@@ -48,7 +48,7 @@ sleep 1s
 # Use timeout=1000ms for the Wait tests.
 $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000
 # Run tests again with inlined objects.
-$CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000
+$CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000 true
 $REDIS_DIR/redis-cli -p 6379 shutdown
 sleep 1s
 

--- a/src/ray/test/run_object_manager_tests.sh
+++ b/src/ray/test/run_object_manager_tests.sh
@@ -47,6 +47,8 @@ $CORE_DIR/src/ray/object_manager/object_manager_stress_test $STORE_EXEC
 sleep 1s
 # Use timeout=1000ms for the Wait tests.
 $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000
+# Run tests again with inlined objects.
+$CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000
 $REDIS_DIR/redis-cli -p 6379 shutdown
 sleep 1s
 

--- a/src/ray/test/run_object_manager_tests.sh
+++ b/src/ray/test/run_object_manager_tests.sh
@@ -45,7 +45,8 @@ sleep 1s
 # Run tests.
 $CORE_DIR/src/ray/object_manager/object_manager_stress_test $STORE_EXEC
 sleep 1s
-$CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC
+# Use timeout=1000ms for the Wait tests.
+$CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 1000
 $REDIS_DIR/redis-cli -p 6379 shutdown
 sleep 1s
 

--- a/src/ray/test/run_object_manager_valgrind.sh
+++ b/src/ray/test/run_object_manager_valgrind.sh
@@ -48,8 +48,9 @@ sleep 1s
 ${REDIS_SERVER} --loglevel warning ${LOAD_MODULE_ARGS} --port 6379 &
 sleep 1s
 
-# Run tests.
-$VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC
+# Run tests. Use timeout=10000ms for the Wait tests since tests run slower
+# in valgrind.
+$VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 10000
 sleep 1s
 $VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_stress_test $STORE_EXEC
 $REDIS_DIR/redis-cli -p 6379 shutdown

--- a/src/ray/test/run_object_manager_valgrind.sh
+++ b/src/ray/test/run_object_manager_valgrind.sh
@@ -52,6 +52,9 @@ sleep 1s
 # in valgrind.
 $VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 10000
 sleep 1s
+# Run tests again with inlined objects.
+$VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_test $STORE_EXEC 10000 true
+sleep 1s
 $VALGRIND_CMD $CORE_DIR/src/ray/object_manager/object_manager_stress_test $STORE_EXEC
 $REDIS_DIR/redis-cli -p 6379 shutdown
 sleep 1s


### PR DESCRIPTION
## What do these changes do?

Since the inlined objects PR (#3756) was merged, one of the object manager tests was failing on valgrind due to a timing issue. This increases the timeout when running in valgrind.

This also removes an unnecessary data copy when retrieving the inline object data.

## Related issue number

Closes #3979.