### PR TITLE
[WIP] First pass at allowing worker processes to be started in tmux.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -192,11 +192,12 @@ cdef class RayletClient:
     def __cinit__(self, raylet_socket,
                   ClientID client_id,
                   c_bool is_worker,
-                  DriverID driver_id):
+                  DriverID driver_id,
+                  int worker_pid):
         # We know that we are using Python, so just skip the language parameter.
         # TODO(suquark): Should we allow unicode chars in "raylet_socket"?
         self.client.reset(new CRayletClient(raylet_socket.encode("ascii"), client_id.data,
-                          is_worker, driver_id.data, LANGUAGE_PYTHON))
+                          is_worker, driver_id.data, LANGUAGE_PYTHON, worker_pid))
 
     def disconnect(self):
         check_status(self.client.get().Disconnect())

--- a/python/ray/includes/libraylet.pxd
+++ b/python/ray/includes/libraylet.pxd
@@ -39,7 +39,8 @@ cdef extern from "ray/raylet/raylet_client.h" nogil:
         CRayletClient(const c_string &raylet_socket,
                       const CClientID &client_id,
                       c_bool is_worker, const CDriverID &driver_id,
-                      const CLanguage &language)
+                      const CLanguage &language,
+                      int worker_pid)
         CRayStatus Disconnect()
         CRayStatus SubmitTask(const c_vector[CObjectID] &execution_dependencies,
                              const CTaskSpecification &task_spec)

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -225,6 +225,7 @@ class Node(object):
             self._ray_params.redis_password,
             use_valgrind=use_valgrind,
             use_profiler=use_profiler,
+            workers_use_tmux=self._ray_params.workers_use_tmux,
             stdout_file=stdout_file,
             stderr_file=stderr_file,
             config=self._config,

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -53,6 +53,8 @@ class RayParams(object):
             be created.
         worker_path (str): The path of the source code that will be run by the
             worker.
+        workers_use_tmux (bool): True if the workers should be started in tmux
+            and false otherwise.
         huge_pages: Boolean flag indicating whether to start the Object
             Store with hugetlbfs support. Requires plasma_directory.
         include_webui: Boolean flag indicating whether to start the web
@@ -100,6 +102,7 @@ class RayParams(object):
                  redis_password=None,
                  plasma_directory=None,
                  worker_path=None,
+                 workers_use_tmux=False,
                  huge_pages=False,
                  include_webui=None,
                  logging_level=logging.INFO,
@@ -134,6 +137,7 @@ class RayParams(object):
         self.redis_password = redis_password
         self.plasma_directory = plasma_directory
         self.worker_path = worker_path
+        self.workers_use_tmux =workers_use_tmux
         self.huge_pages = huge_pages
         self.include_webui = include_webui
         self.plasma_store_socket_name = plasma_store_socket_name

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -963,6 +963,7 @@ def start_raylet(redis_address,
                  redis_password=None,
                  use_valgrind=False,
                  use_profiler=False,
+                 workers_use_tmux=False,
                  stdout_file=None,
                  stderr_file=None,
                  config=None,
@@ -990,6 +991,8 @@ def start_raylet(redis_address,
             of valgrind. If this is True, use_profiler must be False.
         use_profiler (bool): True if the raylet should be started inside
             a profiler. If this is True, use_valgrind must be False.
+        workers_use_tmux (bool): True if the workers should be started in tmux
+            and false otherwise.
         stdout_file: A file handle opened for writing to redirect stdout to. If
             no redirection should happen, then this should be None.
         stderr_file: A file handle opened for writing to redirect stderr to. If
@@ -1050,6 +1053,9 @@ def start_raylet(redis_address,
                                 get_temp_root()))
     if redis_password:
         start_worker_command += " --redis-password {}".format(redis_password)
+
+    if workers_use_tmux:
+        start_worker_command = "tmux new-session -d " + start_worker_command
 
     # If the object manager port is None, then use 0 to cause the object
     # manager to choose its own port.

--- a/python/ray/workers/default_worker.py
+++ b/python/ray/workers/default_worker.py
@@ -56,6 +56,14 @@ parser.add_argument(
     type=str,
     default=None,
     help="Specify the path of the temporary directory use by Ray process.")
+parser.add_argument(
+    "--pid",
+    required=False,
+    type=int,
+    default=None,
+    help="The PID of the worker process started by the raylet. This may "
+    "differ from the value returned by os.getpid() if the worker has been "
+    "started in tmux.")
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -74,7 +82,12 @@ if __name__ == "__main__":
     tempfile_services.set_temp_root(args.temp_dir)
 
     ray.worker.connect(
-        info, redis_password=args.redis_password, mode=ray.WORKER_MODE)
+        info, redis_password=args.redis_password, worker_pid=args.pid,
+        mode=ray.WORKER_MODE)
+
+    print("pid", args.pid)
+    import sys
+    sys.stdout.flush()
 
     error_explanation = """
   This error is unexpected and should not have happened. Somehow a worker

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -203,7 +203,7 @@ ray::Status RayletConnection::AtomicRequestReply(
 
 RayletClient::RayletClient(const std::string &raylet_socket, const UniqueID &client_id,
                            bool is_worker, const JobID &driver_id,
-                           const Language &language)
+                           const Language &language, int worker_pid)
     : client_id_(client_id),
       is_worker_(is_worker),
       driver_id_(driver_id),
@@ -213,7 +213,7 @@ RayletClient::RayletClient(const std::string &raylet_socket, const UniqueID &cli
 
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateRegisterClientRequest(
-      fbb, is_worker, to_flatbuf(fbb, client_id), getpid(), to_flatbuf(fbb, driver_id),
+      fbb, is_worker, to_flatbuf(fbb, client_id), worker_pid, to_flatbuf(fbb, driver_id),
       language);
   fbb.Finish(message);
   // Register the process ID with the raylet.

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -68,7 +68,8 @@ class RayletClient {
   /// \param driver_id The ID of the driver. This is non-nil if the client is a driver.
   /// \return The connection information.
   RayletClient(const std::string &raylet_socket, const UniqueID &client_id,
-               bool is_worker, const JobID &driver_id, const Language &language);
+               bool is_worker, const JobID &driver_id, const Language &language,
+               int worker_pid);
 
   ray::Status Disconnect() { return conn_->Disconnect(); };
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -134,7 +134,7 @@ void WorkerPool::StartWorkerProcess(const Language &language) {
   }
 }
 
-pid_t WorkerPool::StartProcess(const std::vector<const char *> &worker_command_args) {
+pid_t WorkerPool::StartProcess(std::vector<const char *> worker_command_args) {
   // Launch the process to create the worker.
   pid_t pid = fork();
 
@@ -142,9 +142,22 @@ pid_t WorkerPool::StartProcess(const std::vector<const char *> &worker_command_a
     return pid;
   }
 
+  // pid_t worker_pid = getpid();
+
+  worker_command_args.pop_back();
+  std::string pid_arg_string = "--pid=" + std::to_string(getpid());
+  worker_command_args.push_back(pid_arg_string.c_str());
+  worker_command_args.push_back(nullptr);
+
+  RAY_LOG(INFO) << "XXX " << pid_arg_string;
+
   // Child process case.
   // Reset the SIGCHLD handler for the worker.
   signal(SIGCHLD, SIG_DFL);
+
+  // extern char **environ;
+  // environ[0] = "RAY_WORKER_PID=" + std::to_string(worker_pid);
+  // environ[1] = NULL;
 
   // Try to execute the worker command.
   int rv = execvp(worker_command_args[0],

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -135,7 +135,7 @@ class WorkerPool {
   ///
   /// \param worker_command_args The command arguments of new worker process.
   /// \return The process ID of started worker process.
-  virtual pid_t StartProcess(const std::vector<const char *> &worker_command_args);
+  virtual pid_t StartProcess(std::vector<const char *> worker_command_args);
 
   /// An internal data structure that maintains the pool state per language.
   struct State {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -23,7 +23,7 @@ class WorkerPoolMock : public WorkerPool {
     states_by_lang_.clear();
   }
 
-  pid_t StartProcess(const std::vector<const char *> &worker_command_args) override {
+  pid_t StartProcess(std::vector<const char *> worker_command_args) override {
     return ++last_worker_pid_;
   }
 


### PR DESCRIPTION
In this PR:
- I needed to pipe the PID of the worker process started by the node manager into the worker process itself because the worker can't seem to get the pid of the parent tmux process (`os.getppid()` didn't seem to work). The worker process then needs to pass this pid back to the raylet when connecting.

This PR let's you do the following

```python
import ray
import ipdb

ray.init(num_cpus=1, redirect_worker_output=False, workers_use_tmux=True)

@ray.remote
def f():
    ipdb.set_trace()

f.remote()
```

Then you can attach to the tmux session by doing `tmux a -t 0`.

TODO:
- This doesn't play nicely with redirecting worker stdout, so we may need to disable redirecting worker stdout when starting workers in tmux (or duplicate the stdout/stderr).
- The way I'm currently starting workers in tmux is probably unreliable.
- We need a way to figure out which tmux session to attach to once a worker drops into ipdb.