### PR TITLE
Change the num of parallel jobs when building.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ function usage()
 # Determine how many parallel jobs to use for make based on the number of cores
 unamestr="$(uname)"
 if [[ "$unamestr" == "Linux" ]]; then
-  PARALLEL=$(nproc --all)
+  PARALLEL=$(nproc)
 elif [[ "$unamestr" == "Darwin" ]]; then
   PARALLEL=$(sysctl -n hw.ncpu)
 else


### PR DESCRIPTION
`nproc --all` can't get the number of CPUs in containers in linux.

some discussions for this are in the PR https://github.com/ray-project/ray/pull/3228