### PR TITLE
Kills gdb processes with ray stop

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -383,18 +383,29 @@ def stop():
     subprocess.call(
         ["killall plasma_store_server raylet raylet_monitor"], shell=True)
 
-    # Kill lingering gdb processes if they still exist
-    ray_processes = [
-        "monitor", "raylet_monitor", "log_monitor", "worker", "raylet",
-        "plasma_store", "redis_server", "web_ui"
-    ]
-    for ray_process in ray_processes:
-        subprocess.call(
-            [
-                "kill $(ps aux | grep {} | grep -v grep | awk '{{ print $2 }}') 2> /dev/null".
-                format(ray_process)
-            ],
-            shell=True)
+    # Find the PID of the plasma_store_server process and kill it.
+    subprocess.call(
+        [
+            "kill $(ps aux | grep plasma_store_server | grep -v grep | "
+            "awk '{ print $2 }') 2> /dev/null"
+        ],
+        shell=True)
+
+    # Find the PID of the raylet process and kill it.
+    subprocess.call(
+        [
+            "kill $(ps aux | grep raylet | grep -v grep | "
+            "awk '{ print $2 }') 2> /dev/null"
+        ],
+        shell=True)
+
+    # Find the PID of the raylet_monitor process and kill it.
+    subprocess.call(
+        [
+            "kill $(ps aux | grep raylet_monitor | grep -v grep | "
+            "awk '{ print $2 }') 2> /dev/null"
+        ],
+        shell=True)
 
     # Find the PID of the monitor process and kill it.
     subprocess.call(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -380,9 +380,6 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
 
 @cli.command()
 def stop():
-    subprocess.call(
-        ["killall plasma_store_server raylet raylet_monitor"], shell=True)
-
     # Find the PID of the plasma_store_server process and kill it.
     subprocess.call(
         [

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -384,11 +384,15 @@ def stop():
         ["killall plasma_store_server raylet raylet_monitor"], shell=True)
 
     # Kill lingering gdb processes if they still exist
-    ray_processes = ["monitor", "raylet_monitor", "log_monitor", "worker", "raylet", "plasma_store", "redis_server", "web_ui"]
+    ray_processes = [
+        "monitor", "raylet_monitor", "log_monitor", "worker", "raylet",
+        "plasma_store", "redis_server", "web_ui"
+    ]
     for ray_process in ray_processes:
         subprocess.call(
             [
-                "kill $(ps aux | grep {} | grep -v grep | awk '{{ print $2 }}') 2> /dev/null".format(ray_process)
+                "kill $(ps aux | grep {} | grep -v grep | awk '{{ print $2 }}') 2> /dev/null".
+                format(ray_process)
             ],
             shell=True)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -386,7 +386,7 @@ def stop():
     # Kill lingering gdb processes if they still exist
     ray_processes = ["MONITOR", "RAYLET_MONITOR", "LOG_MONITOR", "WORKER", "RAYLET", "PLASMA_STORE", "REDIS_SERVER", "WEB_UI"]
     for ray_process in ray_processes:
-        if os.environ["RAY_{}_GDB".format(ray_process)] == "1":
+        if os.environ.get("RAY_{}_GDB".format(ray_process)) == "1":
             subprocess.call(["kill $(ps aux | grep gdb | grep {} | grep -v grep)".format(ray_process)], shell=True)
 
     # Find the PID of the monitor process and kill it.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -384,10 +384,13 @@ def stop():
         ["killall plasma_store_server raylet raylet_monitor"], shell=True)
 
     # Kill lingering gdb processes if they still exist
-    ray_processes = ["MONITOR", "RAYLET_MONITOR", "LOG_MONITOR", "WORKER", "RAYLET", "PLASMA_STORE", "REDIS_SERVER", "WEB_UI"]
+    ray_processes = ["monitor", "raylet_monitor", "log_monitor", "worker", "raylet", "plasma_store", "redis_server", "web_ui"]
     for ray_process in ray_processes:
-        if os.environ.get("RAY_{}_GDB".format(ray_process)) == "1":
-            subprocess.call(["kill $(ps aux | grep gdb | grep {} | grep -v grep)".format(ray_process)], shell=True)
+        subprocess.call(
+            [
+                "kill $(ps aux | grep {} | grep -v grep | awk '{{ print $2 }}') 2> /dev/null".format(ray_process)
+            ],
+            shell=True)
 
     # Find the PID of the monitor process and kill it.
     subprocess.call(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -383,6 +383,12 @@ def stop():
     subprocess.call(
         ["killall plasma_store_server raylet raylet_monitor"], shell=True)
 
+    # Kill lingering gdb processes if they still exist
+    ray_processes = ["MONITOR", "RAYLET_MONITOR", "LOG_MONITOR", "WORKER", "RAYLET", "PLASMA_STORE", "REDIS_SERVER", "WEB_UI"]
+    for ray_process in ray_processes:
+        if os.environ["RAY_{}_GDB".format(ray_process)] == "1":
+            subprocess.call(["kill $(ps aux | grep gdb | grep {} | grep -v grep)".format(ray_process)], shell=True)
+
     # Find the PID of the monitor process and kill it.
     subprocess.call(
         [


### PR DESCRIPTION
## What do these changes do?

Makes sure that all gdb processes related to ray get killed when `ray stop` is ran

## Related issue number

#3960 