### PR TITLE
Support non ascii characters in the source code

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -123,7 +123,9 @@ class FunctionDescriptor(object):
         try:
             # If we are running a script or are in IPython, include the source
             # code in the hash.
-            source = inspect.getsource(function).encode("ascii")
+            source = inspect.getsource(function)
+            if sys.version_info[0] >= 3:
+                source = source.encode()
             function_source_hasher.update(source)
             function_source_hash = function_source_hasher.digest()
         except (IOError, OSError, TypeError):

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -2764,6 +2765,15 @@ def test_raylet_is_robust_to_random_messages(shutdown_only):
 
     @ray.remote
     def f():
+        return 1
+
+    assert ray.get(f.remote()) == 1
+
+
+def test_non_ascii_comment(ray_start):
+    @ray.remote
+    def f():
+        # 日本語 Japanese comment
         return 1
 
     assert ray.get(f.remote()) == 1


### PR DESCRIPTION
Ray throws an exception when non ascii characters are used in the source code.

Sample code. I used Japanese in the comment.

```python
import time
import ray

@ray.remote
def f():
    # 日本語
    time.sleep(1)
    return 1

ray.init()
results = ray.get([f.remote() for i in range(4)])
print(results)
```

Raised exception.

```
Traceback (most recent call last):
  File "raytest.py", line 4, in <module>
    @ray.remote
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/worker.py", line 2382, in remote
    return make_decorator(worker=worker)(args[0])
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/worker.py", line 2291, in decorator
    num_return_vals, max_calls)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/remote_function.py", line 44, in __init__
    self._function_descriptor = FunctionDescriptor.from_function(function)
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/function_manager.py", line 126, in from_function
    source = inspect.getsource(function).encode("ascii")
UnicodeEncodeError: 'ascii' codec can't encode characters in position 27-29: ordinal not in range(128)
```