### PR TITLE
Update shipped modin to 0.3.1

### DIFF
--- a/thirdparty/scripts/build_modin.sh
+++ b/thirdparty/scripts/build_modin.sh
@@ -14,7 +14,7 @@ fi
 PYTHON_VERSION="$($PYTHON_EXECUTABLE -c 'import sys; print(sys.version_info[0])')"
 
 TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)/../
-MODIN_VERSION=0.3.0
+MODIN_VERSION=0.3.1
 MODIN_WHEELS_FNAME="modin-$MODIN_VERSION-py$PYTHON_VERSION-none-any.whl"
 MODIN_WHEELS_URL="https://github.com/modin-project/modin/releases/download/v$MODIN_VERSION/"
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Update modin to 0.3.1 to resolve the issue of getting a `ModuleNotFoundError: No module named 'dask'` when trying to import modin

## Related issue number

~#3998~
