### PR TITLE
Fix crash for Java task's `task.argument()` in state.

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -326,7 +326,7 @@ class GlobalState(object):
             # to Java object in `task.arguments()`.
             "Args": (task.arguments()
                      if task.language() == ray.gcs_utils.Language.PYTHON else
-                     "<java-argument>"),
+                     ["<java-argument>"]),
             "ReturnObjectIDs": task.returns(),
             "RequiredResources": task.required_resources(),
             "FunctionID": function_descriptor.function_id.hex(),

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -322,10 +322,11 @@ class GlobalState(object):
             "ActorCreationDummyObjectID": (
                 task.actor_creation_dummy_object_id().hex()),
             "ActorCounter": task.actor_counter(),
-            # For Java task, pickle will fail to loads a data
-            #  to Java object in `task.arguments()`.
+            # For Java task, pickle will fail to load a data
+            # to Java object in `task.arguments()`.
             "Args": (task.arguments()
-                     if task.language() == ray.gcs_utils.Language.PYTHON else None),
+                     if task.language() == ray.gcs_utils.Language.PYTHON else
+                     "<java-argument>"),
             "ReturnObjectIDs": task.returns(),
             "RequiredResources": task.required_resources(),
             "FunctionID": function_descriptor.function_id.hex(),

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -322,11 +322,7 @@ class GlobalState(object):
             "ActorCreationDummyObjectID": (
                 task.actor_creation_dummy_object_id().hex()),
             "ActorCounter": task.actor_counter(),
-            # For Java task, pickle will fail to load a data
-            # to Java object in `task.arguments()`.
-            "Args": (task.arguments()
-                     if task.language() == ray.gcs_utils.Language.PYTHON else
-                     ["<java-argument>"]),
+            "Args": task.arguments(),
             "ReturnObjectIDs": task.returns(),
             "RequiredResources": task.required_resources(),
             "FunctionID": function_descriptor.function_id.hex(),

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -311,6 +311,7 @@ class GlobalState(object):
         function_descriptor_list = task.function_descriptor_list()
         function_descriptor = FunctionDescriptor.from_bytes_list(
             function_descriptor_list)
+
         task_spec_info = {
             "DriverID": task.driver_id().hex(),
             "TaskID": task.task_id().hex(),
@@ -321,7 +322,10 @@ class GlobalState(object):
             "ActorCreationDummyObjectID": (
                 task.actor_creation_dummy_object_id().hex()),
             "ActorCounter": task.actor_counter(),
-            "Args": task.arguments(),
+            # For Java task, pickle will fail to loads a data
+            #  to Java object in `task.arguments()`.
+            "Args": (task.arguments()
+                     if task.language() == ray.gcs_utils.Language.PYTHON else None),
             "ReturnObjectIDs": task.returns(),
             "RequiredResources": task.required_resources(),
             "FunctionID": function_descriptor.function_id.hex(),

--- a/python/ray/includes/task.pxi
+++ b/python/ray/includes/task.pxi
@@ -12,7 +12,7 @@ from ray.includes.task cimport (
     SerializeTaskAsString,
 )
 
-from ray.utils import _random_string
+from ray.gcs_utils import Language
 
 cdef class Task:
     cdef:
@@ -143,7 +143,7 @@ cdef class Task:
             int count
         arg_list = []
 
-        if self.task_spec.get().GetLanguage() == LANGUAGE_PYTHON:
+        if self.language() == Language.PYTHON:
             for i in range(num_args):
                 count = task_spec.ArgIdCount(i)
                 if count > 0:
@@ -153,7 +153,7 @@ cdef class Task:
                     serialized_str = task_spec.ArgVal(i)[:task_spec.ArgValLength(i)]
                     obj = pickle.loads(serialized_str)
                     arg_list.append(obj)
-        elif self.task_spec.get().GetLanguage() == LANGUAGE_JAVA:
+        elif self.language() == LANGUAGE.JAVA:
             arg_list = num_args * ["<java-argument>"]
 
         return arg_list

--- a/python/ray/includes/task.pxi
+++ b/python/ray/includes/task.pxi
@@ -142,15 +142,20 @@ cdef class Task:
             int64_t num_args = task_spec.NumArgs()
             int count
         arg_list = []
-        for i in range(num_args):
-            count = task_spec.ArgIdCount(i)
-            if count > 0:
-                assert count == 1
-                arg_list.append(ObjectID.from_native(task_spec.ArgId(i, 0)))
-            else:
-                serialized_str = task_spec.ArgVal(i)[:task_spec.ArgValLength(i)]
-                obj = pickle.loads(serialized_str)
-                arg_list.append(obj)
+
+        if self.task_spec.get().GetLanguage() == LANGUAGE_PYTHON:
+            for i in range(num_args):
+                count = task_spec.ArgIdCount(i)
+                if count > 0:
+                    assert count == 1
+                    arg_list.append(ObjectID.from_native(task_spec.ArgId(i, 0)))
+                else:
+                    serialized_str = task_spec.ArgVal(i)[:task_spec.ArgValLength(i)]
+                    obj = pickle.loads(serialized_str)
+                    arg_list.append(obj)
+        elif self.task_spec.get().GetLanguage() == LANGUAGE_JAVA:
+            arg_list = num_args * ["<java-argument>"]
+
         return arg_list
 
     def returns(self):

--- a/python/ray/includes/task.pxi
+++ b/python/ray/includes/task.pxi
@@ -178,6 +178,10 @@ cdef class Task:
             postincrement(iterator)
         return required_resources
 
+    def language(self):
+        """Return the language of the task."""
+        return Language.from_native(self.task_spec.get().GetLanguage())
+
     def actor_creation_id(self):
         """Return the actor creation ID for the task."""
         return ActorID.from_native(self.task_spec.get().ActorCreationId())

--- a/python/ray/includes/task.pxi
+++ b/python/ray/includes/task.pxi
@@ -12,7 +12,6 @@ from ray.includes.task cimport (
     SerializeTaskAsString,
 )
 
-from ray.gcs_utils import Language
 
 cdef class Task:
     cdef:
@@ -140,10 +139,11 @@ cdef class Task:
         cdef:
             CTaskSpecification *task_spec = self.task_spec.get()
             int64_t num_args = task_spec.NumArgs()
+            int32_t lang = <int32_t>task_spec.GetLanguage()
             int count
         arg_list = []
 
-        if self.language() == Language.PYTHON:
+        if lang == <int32_t>LANGUAGE_PYTHON:
             for i in range(num_args):
                 count = task_spec.ArgIdCount(i)
                 if count > 0:
@@ -153,7 +153,7 @@ cdef class Task:
                     serialized_str = task_spec.ArgVal(i)[:task_spec.ArgValLength(i)]
                     obj = pickle.loads(serialized_str)
                     arg_list.append(obj)
-        elif self.language() == LANGUAGE.JAVA:
+        elif lang == <int32_t>LANGUAGE_JAVA:
             arg_list = num_args * ["<java-argument>"]
 
         return arg_list

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1134,7 +1134,7 @@ def build_java_worker_command(
         command += "-Dray.raylet.socket-name={} ".format(raylet_name)
 
     if redis_password is not None:
-        command += ("-Dray.redis-password=%s", redis_password)
+        command += "-Dray.redis.password={} ".format(redis_password)
 
     command += "-Dray.home={} ".format(RAY_HOME)
     # TODO(suquark): We should use temp_dir as the input of a java worker.


### PR DESCRIPTION
## What do these changes do?
Since `pickle.loads()` couldn't load the data to a Java object, skiping it for Java object does make sense.



## Related issue number
This fixes https://github.com/ray-project/ray/issues/3780
