### PR TITLE
[tune] Add number of trials to the trial runner logger

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -305,6 +305,15 @@ class TrialRunner(object):
 
         for local_dir in sorted({t.local_dir for t in self._trials}):
             messages.append("Result logdir: {}".format(local_dir))
+
+        num_trials_per_state = {
+            state: len(trials) for state, trials in states.items()
+        }
+        total_number_of_trials = sum(num_trials_per_state.values())
+        messages.append(
+            "Number of trials: {} ({})"
+            "".format(total_number_of_trials, num_trials_per_state))
+
         for state, trials in sorted(states.items()):
             limit = limit_per_state[state]
             messages.append("{} trials:".format(state))

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -307,12 +307,13 @@ class TrialRunner(object):
             messages.append("Result logdir: {}".format(local_dir))
 
         num_trials_per_state = {
-            state: len(trials) for state, trials in states.items()
+            state: len(trials)
+            for state, trials in states.items()
         }
         total_number_of_trials = sum(num_trials_per_state.values())
-        messages.append(
-            "Number of trials: {} ({})"
-            "".format(total_number_of_trials, num_trials_per_state))
+        messages.append("Number of trials: {} ({})"
+                        "".format(total_number_of_trials,
+                                  num_trials_per_state))
 
         for state, trials in sorted(states.items()):
             limit = limit_per_state[state]


### PR DESCRIPTION
Adds the number of trials (total and per status) to the tune trial runner status log.

Example output:
```
Using FIFO scheduling algorithm.
Resources requested: 1/12 CPUs, 0.05/1 GPUs (1/1.0 debug-resource)
Memory usage on this node: 21.2/33.7 GB
Result logdir: ~/ray_results/gym/Point2DEnv/Wall-v0/2019-02-15T16-10-35-terminate-at-goal-test-1
Number of trials: 12 ({'RUNNING': 1, 'PENDING': 11})
PENDING trials:
 - id=851f8552-seed=258:        PENDING
 - id=904c53d5-seed=13: PENDING
 - id=fddbadf1-seed=1467:       PENDING
 - id=8e765406-seed=6687:       PENDING
 - id=7463f813-seed=2068:       PENDING
 - id=24c388d2-seed=3970:       PENDING
 - id=be17c7ea-seed=1420:       PENDING
 - id=5c0f74d7-seed=3506:       PENDING
 - id=6d420c2b-seed=1779:       PENDING
 - id=2e5df4c4-seed=7364:       PENDING
 - id=6bd5056d-seed=1902:       PENDING
RUNNING trials:
 - id=2ea69587-seed=6858:       RUNNING
```