### PR TITLE
Add the Delete function in GCS

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -82,6 +82,6 @@ cdef extern from "ray/ray_config.h" nogil:
 
         uint32_t num_actor_checkpoints_to_keep() const
 
-        uint32_t num_maximum_num_gcs_deletion() const
+        uint32_t maximum_gcs_deletion_batch_size() const
 
         void initialize(const unordered_map[c_string, int] &config_map)

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -82,4 +82,6 @@ cdef extern from "ray/ray_config.h" nogil:
 
         uint32_t num_actor_checkpoints_to_keep() const
 
+        uint32_t num_maximum_num_gcs_deletion() const
+
         void initialize(const unordered_map[c_string, int] &config_map)

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -148,3 +148,7 @@ cdef class Config:
     @staticmethod
     def num_actor_checkpoints_to_keep():
         return RayConfig.instance().num_actor_checkpoints_to_keep()
+
+    @staticmethod
+    def num_maximum_num_gcs_deletion():
+        return RayConfig.instance().num_maximum_num_gcs_deletion()

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -150,5 +150,5 @@ cdef class Config:
         return RayConfig.instance().num_actor_checkpoints_to_keep()
 
     @staticmethod
-    def num_maximum_num_gcs_deletion():
-        return RayConfig.instance().num_maximum_num_gcs_deletion()
+    def maximum_gcs_deletion_batch_size():
+        return RayConfig.instance().maximum_gcs_deletion_batch_size()

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -276,8 +276,8 @@ void TestDeleteKeysFromLog(const JobID &job_id,
   for (const auto &object_id : ids) {
     // Check that lookup returns the added object entries.
     auto lookup_callback = [object_id, data_vector](
-                               gcs::AsyncGcsClient *client, const ObjectID &id,
-                               const std::vector<ObjectTableDataT> &data) {
+        gcs::AsyncGcsClient *client, const ObjectID &id,
+        const std::vector<ObjectTableDataT> &data) {
       ASSERT_EQ(id, object_id);
       ASSERT_EQ(data.size(), 1);
       test->IncrementNumCallbacks();

--- a/src/ray/gcs/client_test.cc
+++ b/src/ray/gcs/client_test.cc
@@ -274,8 +274,8 @@ void TestDeleteKey(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> cli
   }
   // Check that lookup returns the added object entries.
   auto lookup_callback = [object_id, managers](
-                             gcs::AsyncGcsClient *client, const ObjectID &id,
-                             const std::vector<ObjectTableDataT> &data) {
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     ASSERT_EQ(id, object_id);
     ASSERT_EQ(data.size(), managers.size());
     test->IncrementNumCallbacks();
@@ -284,8 +284,8 @@ void TestDeleteKey(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> cli
   RAY_CHECK_OK(client->object_table().Lookup(job_id, object_id, lookup_callback));
   client->object_table().Delete(job_id, object_id);
   auto lookup_fail_callback = [object_id, managers](
-                                  gcs::AsyncGcsClient *client, const ObjectID &id,
-                                  const std::vector<ObjectTableDataT> &data) {
+      gcs::AsyncGcsClient *client, const ObjectID &id,
+      const std::vector<ObjectTableDataT> &data) {
     ASSERT_EQ(id, object_id);
     ASSERT_TRUE(data.size() == 0);
     test->IncrementNumCallbacks();
@@ -296,8 +296,7 @@ void TestDeleteKey(const JobID &job_id, std::shared_ptr<gcs::AsyncGcsClient> cli
   task_data->task_specification = "Test Specification.";
   RAY_CHECK_OK(client->raylet_task_table().Add(job_id, task_id, task_data, nullptr));
   auto task_lookup_callback = [task_id, task_data](gcs::AsyncGcsClient *client,
-                                                   const TaskID &id,
-                                                   const protocol::TaskT &data) {
+      const TaskID &id, const protocol::TaskT &data) {
     ASSERT_EQ(id, task_id);
     ASSERT_EQ(task_data->task_specification, data.task_specification);
     test->IncrementNumCallbacks();
@@ -335,8 +334,7 @@ void TestDeleteKeyInBatch(const JobID &job_id,
     ObjectID object_id = ObjectID::from_random();
     object_ids.push_back(object_id);
     auto add_callback = [object_id, object_data](gcs::AsyncGcsClient *client,
-                                                 const UniqueID &id,
-                                                 const ObjectTableDataT &d) {
+        const UniqueID &id, const ObjectTableDataT &d) {
       ASSERT_EQ(id, object_id);
       ASSERT_EQ(object_data->manager, d.manager);
       test->IncrementNumCallbacks();

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -534,44 +534,18 @@ static Status DeleteKeyHelper(RedisModuleCtx *ctx, RedisModuleString *prefix_str
   return Status::OK();
 }
 
-/// Delete the redis table associated with a key.
-///
-/// This is called from a client with the command:
-//
-///    RAY.TABLE_DELETE <table_prefix> <pubsub_channel> <id>
-///
-/// \param table_prefix The prefix string for keys in this table.
-/// \param pubsub_channel Unused but follow the interface.
-/// \param id The ID of the key to delete.
-/// \return OK if the deletion succeeds, or an error message string if the
-///         deletion fails.
-int TableDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  if (argc != 4) {
-    return RedisModule_WrongArity(ctx);
-  }
-  RedisModuleString *prefix_str = argv[1];
-  RedisModuleString *id = argv[3];
-  Status status = DeleteKeyHelper(ctx, prefix_str, id);
-  if (status.ok()) {
-    return RedisModule_ReplyWithSimpleString(ctx, "OK");
-  } else {
-    return RedisModule_ReplyWithError(ctx, status.message().c_str());
-  }
-}
-
 /// Delete the redis table associated with a list of keys in batch mode.
 ///
 /// This is called from a client with the command:
 //
-///    RAY.TABLE_BATCH_DELETE <table_prefix> <pubsub_channel> <id> <data>
+///    RAY.TABLE_DELETE <table_prefix> <pubsub_channel> <id> <data>
 ///
 /// \param table_prefix The prefix string for keys in this table.
 /// \param pubsub_channel Unused but follow the interface.
 /// \param id This id will be ignored but follow the interface.
 /// \param data The list of Unique Ids, kUniqueIDSize bytes for each.
 /// \return Always return OK, empty key will be ignored.
-int TableBatchDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                  int argc) {
+int TableDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc != 5) {
     return RedisModule_WrongArity(ctx);
   }
@@ -778,7 +752,6 @@ AUTO_MEMORY(TableAppend_RedisCommand);
 AUTO_MEMORY(TableLookup_RedisCommand);
 AUTO_MEMORY(TableRequestNotifications_RedisCommand);
 AUTO_MEMORY(TableDelete_RedisCommand);
-AUTO_MEMORY(TableBatchDelete_RedisCommand);
 AUTO_MEMORY(TableCancelNotifications_RedisCommand);
 AUTO_MEMORY(TableTestAndUpdate_RedisCommand);
 AUTO_MEMORY(DebugString_RedisCommand);
@@ -816,12 +789,6 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
   if (RedisModule_CreateCommand(ctx, "ray.table_delete", TableDelete_RedisCommand,
                                 "write", 0, 0, 0) == REDISMODULE_ERR) {
-    return REDISMODULE_ERR;
-  }
-
-  if (RedisModule_CreateCommand(ctx, "ray.table_batch_delete",
-                                TableBatchDelete_RedisCommand, "write", 0, 0,
-                                0) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
 

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -512,7 +512,7 @@ static Status DeleteKeyHelper(RedisModuleCtx *ctx, RedisModuleString *prefix_str
   RAY_RETURN_NOT_OK(
       OpenPrefixedKey(&delete_key, ctx, prefix_str, id_data, REDISMODULE_READ));
   if (delete_key == nullptr) {
-    return Status::RedisError("Non-existing key");
+    return Status::RedisError("Key does not exist.");
   }
   auto key_type = RedisModule_KeyType(delete_key);
   if (key_type == REDISMODULE_KEYTYPE_STRING || key_type == REDISMODULE_KEYTYPE_LIST) {
@@ -556,7 +556,7 @@ int TableDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   data_ptr = RedisModule_StringPtrLen(data, &len);
   REPLY_AND_RETURN_IF_FALSE(
       len % kUniqueIDSize == 0,
-      "deletion data lenghth should be multiples of UniqueID for TABLE_DELETE");
+      "The deletion data length must be a multiple of the UniqueID size.");
   size_t ids_to_delete = len / kUniqueIDSize;
   for (size_t i = 0; i < ids_to_delete; ++i) {
     RedisModuleString *id_data =

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -181,8 +181,9 @@ void Log<ID, Data>::Delete(const JobID &job_id, const std::vector<ID> &ids) {
   for (const auto &id : ids) {
     sharded_data[GetRedisContext(id).get()] << id.binary();
   }
-  // Breaking really large deletion commands into batches of size 1000.
-  const size_t batch_size = 1000 * kUniqueIDSize;
+  // Breaking really large deletion commands into batches of smaller size.
+  const size_t batch_size =
+      RayConfig::instance().num_maximum_num_gcs_deletion() * kUniqueIDSize;
   for (const auto &pair : sharded_data) {
     std::string current_data = pair.second.str();
     for (size_t cur = 0; cur < pair.second.str().size(); cur += batch_size) {

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -490,7 +490,7 @@ Status ActorCheckpointIdTable::AddCheckpointId(const JobID &job_id,
                      << actor_id;
       copy->timestamps.erase(copy->timestamps.begin());
       copy->checkpoint_ids.erase(0, kUniqueIDSize);
-      // TODO(hchen): also delete checkpoint data from GCS.
+      client_->actor_checkpoint_table().Delete(job_id, checkpoint_id);
     }
     RAY_CHECK_OK(Add(job_id, actor_id, copy, nullptr));
   };

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -181,10 +181,10 @@ void Log<ID, Data>::Delete(const JobID &job_id, const std::vector<ID> &ids) {
   for (const auto &id : ids) {
     sharded_data[GetRedisContext(id).get()] << id.binary();
   }
+  // Breaking really large deletion commands into batches of size 1000.
   const size_t batch_size = 1000 * kUniqueIDSize;
   for (const auto &pair : sharded_data) {
     std::string current_data = pair.second.str();
-    // Make sure the sending buffer is not too big.
     for (size_t cur = 0; cur < pair.second.str().size(); cur += batch_size) {
       RAY_IGNORE_EXPR(pair.first->RunAsync(
           "RAY.TABLE_DELETE", UniqueID::nil(),

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -183,7 +183,7 @@ void Log<ID, Data>::Delete(const JobID &job_id, const std::vector<ID> &ids) {
   }
   // Breaking really large deletion commands into batches of smaller size.
   const size_t batch_size =
-      RayConfig::instance().num_maximum_num_gcs_deletion() * kUniqueIDSize;
+      RayConfig::instance().maximum_gcs_deletion_batch_size() * kUniqueIDSize;
   for (const auto &pair : sharded_data) {
     std::string current_data = pair.second.str();
     for (size_t cur = 0; cur < pair.second.str().size(); cur += batch_size) {

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -188,12 +188,14 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   ///
   /// \param job_id The ID of the job (= driver).
   /// \param id The ID of the data to delete from the GCS.
+  /// \return Void.
   void Delete(const JobID &job_id, const ID &id);
 
   /// Delete several keys from redis.
   ///
   /// \param job_id The ID of the job (= driver).
   /// \param ids The vector of IDs to delete from the GCS.
+  /// \return Void.
   void Delete(const JobID &job_id, const std::vector<ID> &ids);
 
   /// Returns debug string for class.

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -187,13 +187,13 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// Delete an entire key from redis.
   ///
   /// \param job_id The ID of the job (= driver).
-  /// \param id The ID of the data that is deleted from the GCS.
+  /// \param id The ID of the data to delete from the GCS.
   void Delete(const JobID &job_id, const ID &id);
 
   /// Delete several keys from redis.
   ///
   /// \param job_id The ID of the job (= driver).
-  /// \param ids The vector of IDs that are deleted from the GCS.
+  /// \param ids The vector of IDs to delete from the GCS.
   void Delete(const JobID &job_id, const std::vector<ID> &ids);
 
   /// Returns debug string for class.

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -184,6 +184,18 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   Status CancelNotifications(const JobID &job_id, const ID &id,
                              const ClientID &client_id);
 
+  /// Delete an entire key from redis.
+  ///
+  /// \param job_id The ID of the job (= driver).
+  /// \param id The ID of the data that is deleted from the GCS.
+  void Delete(const JobID &job_id, const ID &id);
+
+  /// Delete several keys from redis.
+  ///
+  /// \param job_id The ID of the job (= driver).
+  /// \param ids The vector of IDs that are deleted from the GCS.
+  void Delete(const JobID &job_id, const std::vector<ID> &ids);
+
   /// Returns debug string for class.
   ///
   /// \return string.
@@ -303,6 +315,12 @@ class Table : private Log<ID, Data>,
   Status Subscribe(const JobID &job_id, const ClientID &client_id,
                    const Callback &subscribe, const FailureCallback &failure,
                    const SubscriptionCallback &done);
+
+  void Delete(const JobID &job_id, const ID &id) { Log<ID, Data>::Delete(job_id, id); }
+
+  void Delete(const JobID &job_id, const std::vector<ID> &ids) {
+    Log<ID, Data>::Delete(job_id, ids);
+  }
 
   /// Returns debug string for class.
   ///

--- a/src/ray/ray_config_def.h
+++ b/src/ray/ray_config_def.h
@@ -150,3 +150,6 @@ RAY_CONFIG(int64_t, max_task_lease_timeout_ms, 60000);
 /// checkpoint isn't atomic with saving the backend checkpoint, and it will break
 /// if this number is set to 1 and users save application checkpoints in place.
 RAY_CONFIG(uint32_t, num_actor_checkpoints_to_keep, 20);
+
+/// Maximum number of ids in one batch to send to GCS to delete keys.
+RAY_CONFIG(uint32_t, num_maximum_num_gcs_deletion, 1000);

--- a/src/ray/ray_config_def.h
+++ b/src/ray/ray_config_def.h
@@ -152,4 +152,4 @@ RAY_CONFIG(int64_t, max_task_lease_timeout_ms, 60000);
 RAY_CONFIG(uint32_t, num_actor_checkpoints_to_keep, 20);
 
 /// Maximum number of ids in one batch to send to GCS to delete keys.
-RAY_CONFIG(uint32_t, num_maximum_num_gcs_deletion, 1000);
+RAY_CONFIG(uint32_t, maximum_gcs_deletion_batch_size, 1000);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Enable GCS to delete GCS keys. This is useful when users want to clean some GCS memory by themself. For example, users want to call `ray.internal.free` to free objects in Plasma Store and the corresponding metadata in GCS. Actor checkpoint may also leverage this function to clean some old and useless checkpoints.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
