### PR TITLE
[rllib]convert export format to lower case while validating

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -217,8 +217,9 @@ class ExportFormat(object):
         Raises:
             ValueError if the format is unknown.
         """
-        for export_format in export_formats:
-            if export_format not in [
+        for i in range(len(export_formats)):
+            export_formats[i] = export_formats[i].strip().lower()
+            if export_formats[i] not in [
                     ExportFormat.CHECKPOINT, ExportFormat.MODEL
             ]:
                 raise TuneError("Unsupported export format: " + export_format)

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -222,7 +222,8 @@ class ExportFormat(object):
             if export_formats[i] not in [
                     ExportFormat.CHECKPOINT, ExportFormat.MODEL
             ]:
-                raise TuneError("Unsupported export format: " + export_format)
+                raise TuneError("Unsupported export format: " +
+                                export_formats[i])
 
 
 class Trial(object):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Current implementation of `validate(export_formats)` function only accepts lower case 'checkpoint' or 'model' and raises TuneError if the user configures export formats using upper case characters.

It makes some of our users confusing. 

In this PR, I convert the export formats to lower case first while validating so `validate(export_formats)` also accepts configurations in upper case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
