### PR TITLE
More compact format for worker logs

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -10,6 +10,7 @@ import os
 import traceback
 
 import ray.ray_constants as ray_constants
+import ray.services as services
 import ray.utils
 
 # Logger for this module. It should be configured at the entry point
@@ -67,7 +68,7 @@ class LogMonitor(object):
 
     def __init__(self, logs_dir, redis_address, redis_password=None):
         """Initialize the log monitor object."""
-        self.host = os.uname()[1]
+        self.ip = services.get_node_ip_address()
         self.logs_dir = logs_dir
         self.redis_client = ray.services.create_redis_client(
             redis_address, password=redis_password)
@@ -192,7 +193,7 @@ class LogMonitor(object):
                 self.redis_client.publish(
                     ray.gcs_utils.LOG_FILE_CHANNEL,
                     json.dumps({
-                        "host": self.host,
+                        "ip": self.ip,
                         "pid": file_info.worker_pid,
                         "lines": lines_to_publish
                     }))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1588,7 +1588,7 @@ def print_logs(redis_client, threads_stopped):
     """
     pubsub_client = redis_client.pubsub(ignore_subscribe_messages=True)
     pubsub_client.subscribe(ray.gcs_utils.LOG_FILE_CHANNEL)
-    localhost = os.uname()[1]
+    localhost = services.get_node_ip_address()
     try:
         # Keep track of the number of consecutive log messages that have been
         # received with no break in between. If this number grows continually,
@@ -1609,16 +1609,16 @@ def print_logs(redis_client, threads_stopped):
 
             # strip messages from localhost
             data = json.loads(ray.utils.decode(msg["data"]))
-            if data["host"] == localhost:
+            if data["ip"] == localhost:
                 for line in data["lines"]:
                     print("{}{}(pid={}){} {}".format(
                         colorama.Style.DIM, colorama.Fore.CYAN, data["pid"],
                         colorama.Style.RESET_ALL, line))
             else:
                 for line in data["lines"]:
-                    print("{}{}(pid={}, host={}){} {}".format(
+                    print("{}{}(pid={}, ip={}){} {}".format(
                         colorama.Style.DIM, colorama.Fore.CYAN, data["pid"],
-                        data["host"], colorama.Style.RESET_ALL, line))
+                        data["ip"], colorama.Style.RESET_ALL, line))
 
             if (num_consecutive_messages_received % 100 == 0
                     and num_consecutive_messages_received > 0):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -3,10 +3,12 @@ from __future__ import division
 from __future__ import print_function
 
 from contextlib import contextmanager
+import colorama
 import atexit
 import faulthandler
 import hashlib
 import inspect
+import json
 import logging
 import numpy as np
 import os
@@ -1586,6 +1588,7 @@ def print_logs(redis_client, threads_stopped):
     """
     pubsub_client = redis_client.pubsub(ignore_subscribe_messages=True)
     pubsub_client.subscribe(ray.gcs_utils.LOG_FILE_CHANNEL)
+    localhost = os.uname()[1]
     try:
         # Keep track of the number of consecutive log messages that have been
         # received with no break in between. If this number grows continually,
@@ -1603,7 +1606,19 @@ def print_logs(redis_client, threads_stopped):
                 threads_stopped.wait(timeout=0.01)
                 continue
             num_consecutive_messages_received += 1
-            print(ray.utils.decode(msg["data"]), file=sys.stderr)
+
+            # strip messages from localhost
+            data = json.loads(ray.utils.decode(msg["data"]))
+            if data["host"] == localhost:
+                for line in data["lines"]:
+                    print("{}{}(pid={}){} {}".format(
+                        colorama.Style.DIM, colorama.Fore.CYAN, data["pid"],
+                        colorama.Style.RESET_ALL, line))
+            else:
+                for line in data["lines"]:
+                    print("{}{}(pid={}, host={}){} {}".format(
+                        colorama.Style.DIM, colorama.Fore.CYAN, data["pid"],
+                        data["host"], colorama.Style.RESET_ALL, line))
 
             if (num_consecutive_messages_received % 100 == 0
                     and num_consecutive_messages_received > 0):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1607,7 +1607,6 @@ def print_logs(redis_client, threads_stopped):
                 continue
             num_consecutive_messages_received += 1
 
-            # strip messages from localhost
             data = json.loads(ray.utils.decode(msg["data"]))
             if data["ip"] == localhost:
                 for line in data["lines"]:

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2535,10 +2535,10 @@ def test_logging_to_driver(shutdown_only):
         time.sleep(1)
 
     output_lines = captured["out"]
-    assert len(output_lines) == 0
-    error_lines = captured["err"]
     for i in range(200):
-        assert str(i) in error_lines
+        assert str(i) in output_lines
+    error_lines = captured["err"]
+    assert len(error_lines) == 0
 
 
 def test_not_logging_to_driver(shutdown_only):


### PR DESCRIPTION
Local workers: `(pid=XX)` in dim cyan
Remote workers: `(pid=XX, ip=YY.YY.YY.YY)` in dim cyan (using ip instead of host here since it's much more compact)

Sample:
```
(pid=4346) 2019-02-18 13:49:52,717	DEBUG multi_gpu_optimizer.py:195 ...
(pid=4346) 2019-02-18 13:49:52,921	DEBUG multi_gpu_optimizer.py:195 ...
```

I also switched it to print to stdout, since stderr shows up as red in Jupyter notebooks.

Closes https://github.com/ray-project/ray/issues/4079