### PR TITLE
Fix excessive buffering of worker stdout/stderr.

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -223,7 +223,7 @@ class Node(object):
             suffix=".out", prefix=name, directory_name=self._logs_dir)
         log_stderr = self._make_inc_temp(
             suffix=".err", prefix=name, directory_name=self._logs_dir)
-        # Line-buffer the output (mode 1)
+        # Line-buffer the output (mode 1).
         log_stdout_file = open(log_stdout, "a", buffering=1)
         log_stderr_file = open(log_stderr, "a", buffering=1)
         return log_stdout_file, log_stderr_file

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1046,9 +1046,8 @@ def start_raylet(redis_address,
     else:
         java_worker_command = ""
 
-    # Create the command that the Raylet will use to start workers. We use -u
-    # to prevent buffering of worker stdout/stderr.
-    start_worker_command = ("{} -u {} "
+    # Create the command that the Raylet will use to start workers.
+    start_worker_command = ("{} {} "
                             "--node-ip-address={} "
                             "--object-store-name={} "
                             "--raylet-name={} "

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1046,8 +1046,9 @@ def start_raylet(redis_address,
     else:
         java_worker_command = ""
 
-    # Create the command that the Raylet will use to start workers.
-    start_worker_command = ("{} {} "
+    # Create the command that the Raylet will use to start workers. We use -u
+    # to prevent buffering of worker stdout/stderr.
+    start_worker_command = ("{} -u {} "
                             "--node-ip-address={} "
                             "--object-store-name={} "
                             "--raylet-name={} "

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1863,6 +1863,8 @@ def connect(info,
             # be redirected.
             os.dup2(log_stdout_file.fileno(), sys.stdout.fileno())
             os.dup2(log_stderr_file.fileno(), sys.stderr.fileno())
+            sys.stdout = log_stdout_file
+            sys.stderr = log_stderr_file
             # This should always be the first message to appear in the worker's
             # stdout and stderr log files. The string "Ray worker pid:" is
             # parsed in the log monitor process.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1863,6 +1863,10 @@ def connect(info,
             # be redirected.
             os.dup2(log_stdout_file.fileno(), sys.stdout.fileno())
             os.dup2(log_stderr_file.fileno(), sys.stderr.fileno())
+            # We also manually set sys.stdout and sys.stderr because that seems
+            # to have an affect on the output buffering. Without doing this,
+            # stdout and stderr are heavily buffered resulting in seemingly
+            # lost logging statements.
             sys.stdout = log_stdout_file
             sys.stderr = log_stderr_file
             # This should always be the first message to appear in the worker's

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2523,11 +2523,11 @@ def test_logging_to_driver(shutdown_only):
 
     @ray.remote
     def f():
+        # It's important to make sure that these print statements occur even
+        # without calling sys.stdout.flush() and sys.stderr.flush().
         for i in range(100):
             print(i)
             print(100 + i, file=sys.stderr)
-            sys.stdout.flush()
-            sys.stderr.flush()
 
     captured = {}
     with CaptureOutputAndError(captured):


### PR DESCRIPTION
This addresses at least part of the issue in #4082. There may still be more issues @ericl.