### PR TITLE
Skip `test_multithreading` in Python 2

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -12,6 +12,7 @@ import random
 import re
 import setproctitle
 import shutil
+import six
 import socket
 import string
 import subprocess
@@ -1273,6 +1274,10 @@ def test_illegal_api_calls(shutdown_only):
         ray.get(3)
 
 
+@pytest.skipif(
+    six.PY2,
+    "Plasma client isn't thread-safe, see #4107.",
+)
 def test_multithreading(shutdown_only):
     # This test requires at least 2 CPUs to finish since the worker does not
     # relase resources when joining the threads.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1274,13 +1274,13 @@ def test_illegal_api_calls(shutdown_only):
         ray.get(3)
 
 
-@pytest.skipif(
-    six.PY2,
-    "Plasma client isn't thread-safe, see #4107.",
-)
+# TODO(hchen): This test currently doesn't work in Python 2. This is likely
+# because plasma client isn't thread-safe. This needs to be fixed from the
+# Arrow side. See #4107 for relevant discussions.
+@pytest.mark.skipif(six.PY2, reason="Doesn't work in Python 2.")
 def test_multithreading(shutdown_only):
     # This test requires at least 2 CPUs to finish since the worker does not
-    # relase resources when joining the threads.
+    # release resources when joining the threads.
     ray.init(num_cpus=2)
 
     def run_test_in_multi_threads(test_case, num_threads=10, num_repeats=25):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1278,7 +1278,7 @@ def test_multithreading(shutdown_only):
     # relase resources when joining the threads.
     ray.init(num_cpus=2)
 
-    def run_test_in_multi_threads(test_case, num_threads=20, num_repeats=50):
+    def run_test_in_multi_threads(test_case, num_threads=10, num_repeats=25):
         """A helper function that runs test cases in multiple threads."""
 
         def wrapper():
@@ -1376,8 +1376,8 @@ def test_multithreading(shutdown_only):
                     timeout=1000.0,
                 )
                 assert len(ready) == len(wait_objects)
-                for _ in range(50):
-                    num = 20
+                for _ in range(20):
+                    num = 10
                     # Test remote call
                     results = [echo.remote(i) for i in range(num)]
                     assert ray.get(results) == list(range(num))
@@ -1393,7 +1393,7 @@ def test_multithreading(shutdown_only):
                     self.thread_results.append("ok")
 
         def spawn(self):
-            wait_objects = [echo.remote(i, delay_ms=10) for i in range(20)]
+            wait_objects = [echo.remote(i, delay_ms=10) for i in range(10)]
             self.threads = [
                 threading.Thread(
                     target=self.background_thread, args=(wait_objects, ))

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -404,16 +404,6 @@ class Worker(object):
                                 object_ids[i + j],
                                 serialization_context,
                             ))
-                    with self.plasma_client.lock:
-                        # The `release` method of C++ plasma client is used in
-                        # `PlasmaBuffer.__dealloc__`, thus this needs to be
-                        # protected by a lock.
-                        # TODO(hchen): This doesn't work in Python 2. Because
-                        # in Python 2, the `__dealloc__` method doesn't get
-                        # called right after the reference count decreases to
-                        # 0. We need to fix this by making the underlying
-                        # Cython or C++ plasma client thread-safe.
-                        del metadata_data_pairs
                 return results
             except pyarrow.DeserializationCallbackError:
                 # Wait a little bit for the import thread to import the class.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -404,6 +404,16 @@ class Worker(object):
                                 object_ids[i + j],
                                 serialization_context,
                             ))
+                    with self.plasma_client.lock:
+                        # The `release` method of C++ plasma client is used in
+                        # `PlasmaBuffer.__dealloc__`, thus this needs to be
+                        # protected by a lock.
+                        # TODO(hchen): This doesn't work in Python 2. Because
+                        # in Python 2, the `__dealloc__` method doesn't get
+                        # called right after the reference count decreases to
+                        # 0. We need to fix this by making the underlying
+                        # Cython or C++ plasma client thread-safe.
+                        del metadata_data_pairs
                 return results
             except pyarrow.DeserializationCallbackError:
                 # Wait a little bit for the import thread to import the class.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- This test fails in Python 2. This is likely because the plasma client is not thread-safe. And when a PlasmaBuffer object gets GC'ed, `plasma_client.release` will be called. Moreover, the timing of GC is out of our control. So we can only fix this by making the plasma client itself thread-safe, as opposed to guarding it with a lock. 
- Speed up `test_multithreading` by reduce the work load (18s -> 7s on my machine).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
