### PR TITLE
Fix Twin-Q bug of DDPG

### DIFF
--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -138,7 +138,7 @@ class ActorCriticLoss(object):
 
         q_t_selected = tf.squeeze(q_t, axis=len(q_t.shape) - 1)
         if twin_q:
-            twin_q_t_selected = tf.squeeze(q_t, axis=len(q_t.shape) - 1)
+            twin_q_t_selected = tf.squeeze(twin_q_t, axis=len(q_t.shape) - 1)
             q_tp1 = tf.minimum(q_tp1, twin_q_tp1)
 
         q_tp1_best = tf.squeeze(input=q_tp1, axis=len(q_tp1.shape) - 1)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
In TD3, we must optimize both of the Q-nets (see the 14-th line of the pseudocode of https://spinningup.openai.com/en/latest/algorithms/td3.html )

<!-- Please give a short brief about these changes. -->

## Related issue number
fixes #4103 
<!-- Are there any issues opened that will be resolved by merging this change? -->
