### PR TITLE
Fix master branch compilation error and lint error

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,6 +39,7 @@ MOCK_MODULES = [
     "ray.core.generated.ray.protocol.Task",
     "scipy",
     "scipy.signal",
+    "scipy.stats",
     "tensorflow",
     "tensorflow.contrib",
     "tensorflow.contrib.all_reduce",

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <sstream>
 
 #include "ray/common/common_protocol.h"
 #include "ray/gcs/format/gcs_generated.h"


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

A recent pull request [#4081](https://github.com/ray-project/ray/pull/4081) led to master branch compilation error.
![image](https://user-images.githubusercontent.com/4970790/53152158-d516ae00-35ef-11e9-9cbd-a88afca74232.png)

This [line](https://github.com/ray-project/ray/blob/master/src/ray/gcs/redis_module/ray_redis_module.cc#L524) of code referenced `std:ostringstream` but didn't include necessary header file `sstream`.  

Another pull request [#4048](https://github.com/ray-project/ray/pull/4048) imported a python lint error.
![image](https://user-images.githubusercontent.com/4970790/53172175-a9132100-361f-11e9-936c-bd42703878d7.png)
This is probably due to that sphinx can not find `scipy.stats` in sys path. We can solve this by mocking it in [conf.py#L41](https://github.com/ray-project/ray/blob/master/doc/source/conf.py#L41) 
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
