### PR TITLE
On Kubernetes, set pod anti-affinity at the host level for pods of type 'ray'

### DIFF
--- a/kubernetes/head.yaml
+++ b/kubernetes/head.yaml
@@ -31,11 +31,20 @@ spec:
   selector:
     matchLabels:
       component: ray-head
+      type: ray
   template:
     metadata:
       labels:
         component: ray-head
+        type: ray
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+          - labelSelector:
+              matchLabels:
+                type: ray
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: ray-head
           image: rayproject/examples

--- a/kubernetes/submit.yaml
+++ b/kubernetes/submit.yaml
@@ -31,11 +31,20 @@ spec:
   selector:
     matchLabels:
       component: ray-head
+      type: ray
   template:
     metadata:
       labels:
         component: ray-head
+        type: ray
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+          - labelSelector:
+              matchLabels:
+                type: ray
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: ray-head
           image: rayproject/examples
@@ -68,11 +77,20 @@ spec:
   selector:
     matchLabels:
       component: ray-worker
+      type: ray
   template:
     metadata:
       labels:
         component: ray-worker
+        type: ray
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+          - labelSelector:
+              matchLabels:
+                type: ray
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: ray-worker
           image: rayproject/examples

--- a/kubernetes/worker.yaml
+++ b/kubernetes/worker.yaml
@@ -7,11 +7,20 @@ spec:
   selector:
     matchLabels:
       component: ray-worker
+      type: ray
   template:
     metadata:
       labels:
         component: ray-worker
+        type: ray
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+          - labelSelector:
+              matchLabels:
+                type: ray
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: ray-worker
           image: rayproject/examples


### PR DESCRIPTION
## What do these changes do?

Added 'type: ray' to the deployments' metadata and keyed off that type for pod anti-affinity on hosts.  This will cause kubernetes to not schedule more than one pod of type 'ray' onto the same host.

