### PR TITLE
Disconnect object manager clients if receiving an object fails

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -52,16 +52,48 @@ template <class T>
 Status ServerConnection<T>::WriteBuffer(
     const std::vector<boost::asio::const_buffer> &buffer) {
   boost::system::error_code error;
-  boost::asio::write(socket_, buffer, error);
-  return boost_to_ray_status(error);
+  // Loop until all bytes are written while handling interrupts.
+  // When profiling with pprof, unhandled interrupts were being sent by the profiler to
+  // the raylet process, which was causing synchronous reads and writes to fail.
+  for (const auto &b : buffer) {
+    uint64_t bytes_remaining = boost::asio::buffer_size(b);
+    uint64_t position = 0;
+    while (bytes_remaining != 0) {
+      size_t bytes_written =
+          socket_.write_some(boost::asio::buffer(b + position, bytes_remaining), error);
+      position += bytes_written;
+      bytes_remaining -= bytes_written;
+      if (error.value() == EINTR) {
+        continue;
+      } else if (error.value() != boost::system::errc::errc_t::success) {
+        return boost_to_ray_status(error);
+      }
+    }
+  }
+  return ray::Status::OK();
 }
 
 template <class T>
 Status ServerConnection<T>::ReadBuffer(
     const std::vector<boost::asio::mutable_buffer> &buffer) {
   boost::system::error_code error;
-  boost::asio::read(socket_, buffer, error);
-  return boost_to_ray_status(error);
+  // Loop until all bytes are read while handling interrupts.
+  for (const auto &b : buffer) {
+    uint64_t bytes_remaining = boost::asio::buffer_size(b);
+    uint64_t position = 0;
+    while (bytes_remaining != 0) {
+      size_t bytes_read =
+          socket_.read_some(boost::asio::buffer(b + position, bytes_remaining), error);
+      position += bytes_read;
+      bytes_remaining -= bytes_read;
+      if (error.value() == EINTR) {
+        continue;
+      } else if (error.value() != boost::system::errc::errc_t::success) {
+        return boost_to_ray_status(error);
+      }
+    }
+  }
+  return Status::OK();
 }
 
 template <class T>

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -59,15 +59,14 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>
   /// Write a buffer to this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
+  /// \return Status.
   Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer);
 
   /// Read a buffer from this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
-  void ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer,
-                  boost::system::error_code &ec);
+  /// \return Status.
+  Status ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer);
 
   /// Shuts down socket for this connection.
   void Close() {

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -839,16 +839,18 @@ ray::Status ObjectManager::ExecuteReceiveObject(
 
   std::pair<const ObjectBufferPool::ChunkInfo &, ray::Status> chunk_status =
       buffer_pool_.CreateChunk(object_id, data_size, metadata_size, chunk_index);
+  ray::Status status;
   ObjectBufferPool::ChunkInfo chunk_info = chunk_status.first;
   if (chunk_status.second.ok()) {
     // Avoid handling this chunk if it's already being handled by another process.
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(chunk_info.data, chunk_info.buffer_length));
     boost::system::error_code ec;
-    conn.ReadBuffer(buffer, ec);
-    if (ec.value() == boost::system::errc::success) {
+    status = conn.ReadBuffer(buffer);
+    if (status.ok()) {
       buffer_pool_.SealChunk(object_id, chunk_index);
     } else {
+      // We may have not have read out the correct data, so abort this chunk.
       buffer_pool_.AbortCreateChunk(object_id, chunk_index);
       // TODO(hme): This chunk failed, so create a pull request for this chunk.
     }
@@ -861,18 +863,24 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(mutable_vec, buffer_length));
     boost::system::error_code ec;
-    conn.ReadBuffer(buffer, ec);
-    if (ec.value() != boost::system::errc::success) {
-      RAY_LOG(ERROR) << boost_to_ray_status(ec).ToString();
-    }
+    status = conn.ReadBuffer(buffer);
     // TODO(hme): If the object isn't local, create a pull request for this chunk.
   }
-  conn.ProcessMessages();
+
   RAY_LOG(DEBUG) << "ExecuteReceiveObject completed on " << client_id_ << " from "
                  << client_id << " of object " << object_id << " chunk " << chunk_index
                  << " at " << current_sys_time_ms();
+  if (status.ok()) {
+    // We successfully read the buffer, so we are ready to receive the next
+    // message.
+    conn.ProcessMessages();
+  } else {
+    // Close the connection by skipping the call to ProcessMessages.
+    RAY_LOG(ERROR) << "Failed to ExecuteReceiveObject from remote object manager, error: "
+                   << status;
+  }
 
-  return chunk_status.second;
+  return status;
 }
 
 void ObjectManager::ReceiveFreeRequest(std::shared_ptr<TcpClientConnection> &conn,

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -845,7 +845,6 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     // Avoid handling this chunk if it's already being handled by another process.
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(chunk_info.data, chunk_info.buffer_length));
-    boost::system::error_code ec;
     status = conn.ReadBuffer(buffer);
     if (status.ok()) {
       buffer_pool_.SealChunk(object_id, chunk_index);
@@ -862,7 +861,6 @@ ray::Status ObjectManager::ExecuteReceiveObject(
     mutable_vec.resize(buffer_length);
     std::vector<boost::asio::mutable_buffer> buffer;
     buffer.push_back(asio::buffer(mutable_vec, buffer_length));
-    boost::system::error_code ec;
     status = conn.ReadBuffer(buffer);
     // TODO(hme): If the object isn't local, create a pull request for this chunk.
   }

--- a/src/ray/object_manager/object_manager_client_connection.h
+++ b/src/ray/object_manager/object_manager_client_connection.h
@@ -59,7 +59,7 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   /// Write a buffer to this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
+  /// \return Status.
   Status WriteBuffer(const std::vector<boost::asio::const_buffer> &buffer) {
     return conn_->WriteBuffer(buffer);
   }
@@ -67,7 +67,7 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   /// Read a buffer from this connection.
   ///
   /// \param buffer The buffer.
-  /// \param ec The error code object in which to store error codes.
+  /// \return Status.
   Status ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer) {
     return conn_->ReadBuffer(buffer);
   }

--- a/src/ray/object_manager/object_manager_client_connection.h
+++ b/src/ray/object_manager/object_manager_client_connection.h
@@ -68,9 +68,8 @@ class SenderConnection : public boost::enable_shared_from_this<SenderConnection>
   ///
   /// \param buffer The buffer.
   /// \param ec The error code object in which to store error codes.
-  void ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer,
-                  boost::system::error_code &ec) {
-    return conn_->ReadBuffer(buffer, ec);
+  Status ReadBuffer(const std::vector<boost::asio::mutable_buffer> &buffer) {
+    return conn_->ReadBuffer(buffer);
   }
 
   /// \return The ClientID of this connection.

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -99,7 +99,10 @@ ray::Status Raylet::RegisterGcs(const std::string &node_ip_address,
 
   RAY_LOG(DEBUG) << "Node manager " << gcs_client_->client_table().GetLocalClientId()
                  << " started on " << client_info.node_manager_address << ":"
-                 << client_info.node_manager_port;
+                 << client_info.node_manager_port << " object manager at "
+                 << client_info.node_manager_address << ":"
+                 << client_info.object_manager_port;
+  ;
   RAY_RETURN_NOT_OK(gcs_client_->client_table().Connect(client_info));
 
   RAY_RETURN_NOT_OK(node_manager_.RegisterGcs());


### PR DESCRIPTION
## What do these changes do?

If an object manager fails to read out object data from another object manager, then previously the error would get silently dropped. The next time the object manager tries to read from the socket, it can fail because the previous data is still in the socket and doesn't match the message cookie.

This PR disconnects the sending object manager if the receiving manager fails to receive the data.

I'm not sure how to test this, but we could potentially test it through either object manager unit tests or random node failures.