### PR TITLE
Send task error instead of raw exception for signal

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -898,7 +898,7 @@ class Worker(object):
         if not self.actor_id.is_nil() and function_name == "__init__":
             self.mark_actor_init_failed(error)
         # Send signal with the error.
-        ray_signal.send(ray_signal.ErrorSignal(failure_object))
+        ray_signal.send(ray_signal.ErrorSignal(str(failure_object)))
 
     def _wait_for_and_process_task(self, task):
         """Wait for a task to be ready and process the task.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -898,7 +898,7 @@ class Worker(object):
         if not self.actor_id.is_nil() and function_name == "__init__":
             self.mark_actor_init_failed(error)
         # Send signal with the error.
-        ray_signal.send(ray_signal.ErrorSignal(error))
+        ray_signal.send(ray_signal.ErrorSignal(failure_object))
 
     def _wait_for_and_process_task(self, task):
         """Wait for a task to be ready and process the task.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Exceptions are not always serializable, so we cannot send them safely. Send the RayTaskError instead.

## Related issue number

Fixes https://github.com/ray-project/ray/issues/4149