### PR TITLE
Fix ray.wait() to return methods completed by dead actors as ready

### DIFF
--- a/python/ray/tests/test_wait.py
+++ b/python/ray/tests/test_wait.py
@@ -4,6 +4,10 @@ from __future__ import print_function
 
 import json
 import pytest
+try:
+    import pytest_timeout
+except ImportError:
+    pytest_timeout = None
 import time
 
 import ray
@@ -34,6 +38,9 @@ def remote_node_cluster():
     cluster.shutdown()
 
 
+@pytest.mark.skipif(
+    pytest_timeout is None,
+    reason="Timeout package not installed; skipping test that may hang.")
 @pytest.mark.timeout(10)
 def test_dead_actor_methods_ready(remote_node_cluster):
     """Tests that methods completed by dead actors are returned as ready"""

--- a/python/ray/tests/test_wait.py
+++ b/python/ray/tests/test_wait.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+import pytest
+import time
+
+import ray
+from ray.exceptions import RayActorError
+from ray.tests.cluster_utils import Cluster
+
+
+@pytest.fixture
+def cluster_start():
+    # Start the Ray processes.
+    cluster = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "num_cpus": 0,
+            "_internal_config": json.dumps({
+                "initial_reconstruction_timeout_milliseconds": 10
+            })
+        })
+    yield cluster
+    ray.shutdown()
+    cluster.shutdown()
+
+
+@pytest.mark.timeout(45)
+def test_dead_actor_methods_ready(cluster_start):
+    """Tests that methods completed by dead actors are returned as ready"""
+    cluster = cluster_start
+
+    node = cluster.add_node(
+        num_cpus=1,
+        _internal_config=json.dumps({
+            "initial_reconstruction_timeout_milliseconds": 10
+        }))
+
+    @ray.remote
+    class Actor(object):
+        def __init__(self):
+            pass
+
+        def ping(self):
+            time.sleep(1)
+
+    a = Actor.remote()
+
+    ray.get(a.ping.remote())
+
+    ping_id = a.ping.remote()
+    cluster.remove_node(node)
+
+    ready = []
+    while len(ready) == 0:
+        ready, _ = ray.wait([ping_id], timeout=0.01)
+        time.sleep(1)
+
+    with pytest.raises(RayActorError):
+        ray.get(ready)

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -468,7 +468,7 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
     if (state != TaskState::INFEASIBLE) {
       // Don't unsubscribe for infeasible tasks because we never subscribed in
       // the first place.
-      RAY_CHECK(task_dependency_manager_.UnsubscribeAllDependencies(task_id));
+      RAY_CHECK(task_dependency_manager_.UnsubscribeGetDependencies(task_id));
     }
     // Attempt to forward the task. If this fails to forward the task,
     // the task will be resubmit locally.
@@ -997,9 +997,6 @@ void NodeManager::ProcessWaitRequestMessage(
                                  fbb.GetSize(), fbb.GetBufferPointer());
         if (status.ok()) {
           // The client is unblocked now because the wait call has returned.
-          for (const auto &object_id : found) {
-            task_dependency_manager_.UnsubscribeDependency(current_task_id, object_id);
-          }
           if (client_blocked) {
             HandleTaskUnblocked(client, current_task_id);
           }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -833,8 +833,10 @@ void NodeManager::ProcessDisconnectClientMessage(
         // not safe to pass in the iterator directly.
         const TaskID task_id = *worker->GetBlockedTaskIds().begin();
         HandleTaskUnblocked(client, task_id);
-        // TODO: this will only unsubscribe from the currently executing task.
-        // We should also unsubscribe from previous tasks that have an active ray.wait.
+        // TODO: This will only unsubscribe from the currently executing task.
+        // We should also unsubscribe from previous tasks that have an active
+        // ray.wait. Otherwise, these ray.wait calls may never be satisfied
+        // (e.g., because the driver has exited).
         RAY_CHECK(task_dependency_manager_.UnsubscribeAllDependencies(task_id));
       }
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1542,9 +1542,11 @@ void NodeManager::HandleTaskUnblocked(
   // If the task was previously blocked, then stop waiting for its dependencies
   // and mark the task as unblocked.
   worker->RemoveBlockedTaskId(current_task_id);
-  // Unsubscribe to the objects. Any fetch or reconstruction operations to
-  // make the objects local are canceled.
-  RAY_CHECK(task_dependency_manager_.UnsubscribeGetDependencies(current_task_id));
+  // Unsubscribe to any ray.get dependencies. Any fetch or reconstruction
+  // operations to make the objects local are canceled. We do not check the
+  // return value because the task may have been blocked in a ray.wait, in
+  // which case it would not have had any ray.get dependencies.
+  static_cast<void>(task_dependency_manager_.UnsubscribeGetDependencies(current_task_id));
   local_queues_.RemoveBlockedTaskId(current_task_id);
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1439,8 +1439,7 @@ void NodeManager::SubmitTask(const Task &task, const Lineage &uncommitted_lineag
 
 void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                                     const std::vector<ObjectID> &required_object_ids,
-                                    const TaskID &current_task_id,
-                                    bool ray_get) {
+                                    const TaskID &current_task_id, bool ray_get) {
   std::shared_ptr<Worker> worker = worker_pool_.GetRegisteredWorker(client);
   if (worker) {
     // The client is a worker. If the worker is not already blocked and the
@@ -1483,7 +1482,8 @@ void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection>
   // Subscribe to the objects required by the ray.get. These objects will
   // be fetched and/or reconstructed as necessary, until the objects become
   // local or are unsubscribed.
-  task_dependency_manager_.SubscribeDependencies(current_task_id, required_object_ids, ray_get);
+  task_dependency_manager_.SubscribeDependencies(current_task_id, required_object_ids,
+                                                 ray_get);
 }
 
 void NodeManager::HandleTaskUnblocked(
@@ -1553,7 +1553,7 @@ void NodeManager::EnqueuePlaceableTask(const Task &task) {
   // a vector of TaskIDs. Trigger MoveTask internally.
   // Subscribe to the task's dependencies.
   bool args_ready = task_dependency_manager_.SubscribeDependencies(
-      task.GetTaskSpecification().TaskId(), task.GetDependencies(), /*ray_get=*/ true);
+      task.GetTaskSpecification().TaskId(), task.GetDependencies(), /*ray_get=*/true);
   // Enqueue the task. If all dependencies are available, then the task is queued
   // in the READY state, else the WAITING state.
   // (See design_docs/task_states.rst for the state transition diagram.)

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -259,8 +259,7 @@ class NodeManager {
   /// \return Void.
   void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                          const std::vector<ObjectID> &required_object_ids,
-                         const TaskID &current_task_id,
-                         bool ray_get);
+                         const TaskID &current_task_id, bool ray_get);
 
   /// Handle a task that is unblocked. This could be a task assigned to a
   /// worker, an out-of-band task (e.g., a thread created by the application),

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -256,6 +256,7 @@ class NodeManager {
   /// \param client The client that is executing the blocked task.
   /// \param required_object_ids The IDs that the client is blocked waiting for.
   /// \param current_task_id The task that is blocked.
+  /// \param ray_get Whether the task is blocked in a ray.get or a ray.wait.
   /// \return Void.
   void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                          const std::vector<ObjectID> &required_object_ids,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -259,7 +259,8 @@ class NodeManager {
   /// \return Void.
   void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                          const std::vector<ObjectID> &required_object_ids,
-                         const TaskID &current_task_id);
+                         const TaskID &current_task_id,
+                         bool ray_get);
 
   /// Handle a task that is unblocked. This could be a task assigned to a
   /// worker, an out-of-band task (e.g., a thread created by the application),

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -214,15 +214,15 @@ bool TaskDependencyManager::SubscribeDependencies(
   return (task_entry.num_missing_dependencies == 0);
 }
 
-void TaskDependencyManager::RemoveTaskDependency(const TaskID &task_id,
+void TaskDependencyManager::RemoveTaskDependency(const TaskID &dependent_task_id,
                                                  const ObjectID &object_id) {
   // Remove the task from the list of tasks that are dependent on this
   // object.
   // Get the ID of the task that creates the dependency.
-  TaskID creating_task_id = ComputeTaskId(object_id);
+  const TaskID creating_task_id = ComputeTaskId(object_id);
   auto creating_task_entry = required_tasks_.find(creating_task_id);
   auto &dependent_tasks = creating_task_entry->second[object_id];
-  size_t erased = dependent_tasks.erase(task_id);
+  size_t erased = dependent_tasks.erase(dependent_task_id);
   RAY_CHECK(erased > 0);
   // If the unsubscribed task was the only task dependent on the object, then
   // erase the object entry.

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -88,7 +88,8 @@ std::vector<TaskID> TaskDependencyManager::HandleObjectLocal(
         UnsubscribeWaitDependency(dependent_task_id, object_id);
         // An task may ray.wait on an object and then call ray.get on it
         auto &task_entry = task_dependencies_[dependent_task_id];
-        if (task_entry.get_dependencies.find(object_id) == task_entry.get_dependencies.end()) {
+        if (task_entry.get_dependencies.find(object_id) ==
+            task_entry.get_dependencies.end()) {
           task_entry.num_missing_dependencies--;
         }
         // If the dependent task now has all of its arguments ready, it's ready
@@ -256,7 +257,8 @@ bool TaskDependencyManager::UnsubscribeAllDependencies(const TaskID &task_id) {
   return true;
 }
 
-bool TaskDependencyManager::UnsubscribeWaitDependency(const TaskID &task_id, const ObjectID &object_id) {
+bool TaskDependencyManager::UnsubscribeWaitDependency(const TaskID &task_id,
+                                                      const ObjectID &object_id) {
   // Remove the task from the table of subscribed tasks.
   auto it = task_dependencies_.find(task_id);
   if (it == task_dependencies_.end()) {

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -148,7 +148,8 @@ bool TaskDependencyManager::SubscribeDependencies(
 
   // Record the task's dependencies.
   for (const auto &object_id : required_objects) {
-    auto inserted = (ray_get) ? task_entry.get_dependencies.insert(object_id) : task_entry.wait_dependencies.insert(object_id);
+    auto inserted = (ray_get) ? task_entry.get_dependencies.insert(object_id)
+                              : task_entry.wait_dependencies.insert(object_id);
     if (inserted.second) {
       // Get the ID of the task that creates the dependency.
       TaskID creating_task_id = ComputeTaskId(object_id);
@@ -173,7 +174,8 @@ bool TaskDependencyManager::SubscribeDependencies(
   return (task_entry.num_missing_dependencies == 0);
 }
 
-void TaskDependencyManager::RemoveTaskDependency(const TaskID &task_id, const ObjectID &object_id) {
+void TaskDependencyManager::RemoveTaskDependency(const TaskID &task_id,
+                                                 const ObjectID &object_id) {
   // Remove the task from the list of tasks that are dependent on this
   // object.
   // Get the ID of the task that creates the dependency.

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -67,8 +67,6 @@ class TaskDependencyManager {
 
   bool UnsubscribeAllDependencies(const TaskID &task_id);
 
-  bool UnsubscribeDependency(const TaskID &task_id, const ObjectID &object_id);
-
   /// Mark that the given task is pending execution. Any objects that it creates
   /// are now considered to be pending creation. If there are any subscribed
   /// tasks that depend on these objects, then the objects will be canceled.
@@ -131,8 +129,9 @@ class TaskDependencyManager {
   struct TaskDependencies {
     /// The objects that the task is dependent on. These must be local before
     /// the task is ready to execute.
-    // std::unordered_set<ObjectID> object_dependencies;
     std::unordered_set<ObjectID> get_dependencies;
+    /// The objects that the task is fetching. These are fetched while the
+    /// the task is executing.
     std::unordered_set<ObjectID> wait_dependencies;
     /// The number of object arguments that are not available locally. This
     /// must be zero before the task is ready to execute.
@@ -173,6 +172,8 @@ class TaskDependencyManager {
   void AcquireTaskLease(const TaskID &task_id);
 
   void RemoveTaskDependency(const TaskID &task_id, const ObjectID &object_id);
+
+  bool UnsubscribeWaitDependency(const TaskID &task_id, const ObjectID &object_id);
 
   /// The object manager, used to fetch required objects from remote nodes.
   ObjectManagerInterface &object_manager_;

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -54,7 +54,8 @@ class TaskDependencyManager {
   /// \return Whether all of the given dependencies for the given task are
   /// local.
   bool SubscribeDependencies(const TaskID &task_id,
-                             const std::vector<ObjectID> &required_objects);
+                             const std::vector<ObjectID> &required_objects,
+                             bool ray_get);
 
   /// Unsubscribe from the object dependencies required by this task. If the
   /// objects were remote and are no longer required by any subscribed task,
@@ -62,7 +63,11 @@ class TaskDependencyManager {
   ///
   /// \param task_id The ID of the task whose dependencies to unsubscribe from.
   /// \return Whether the task was subscribed before.
-  bool UnsubscribeDependencies(const TaskID &task_id);
+  bool UnsubscribeGetDependencies(const TaskID &task_id);
+
+  bool UnsubscribeAllDependencies(const TaskID &task_id);
+
+  bool UnsubscribeDependency(const TaskID &task_id, const ObjectID &object_id);
 
   /// Mark that the given task is pending execution. Any objects that it creates
   /// are now considered to be pending creation. If there are any subscribed
@@ -126,7 +131,9 @@ class TaskDependencyManager {
   struct TaskDependencies {
     /// The objects that the task is dependent on. These must be local before
     /// the task is ready to execute.
-    std::unordered_set<ObjectID> object_dependencies;
+    // std::unordered_set<ObjectID> object_dependencies;
+    std::unordered_set<ObjectID> get_dependencies;
+    std::unordered_set<ObjectID> wait_dependencies;
     /// The number of object arguments that are not available locally. This
     /// must be zero before the task is ready to execute.
     int64_t num_missing_dependencies;
@@ -164,6 +171,8 @@ class TaskDependencyManager {
   /// The task lease has an expiration time. If we do not renew the lease
   /// before that time, then other nodes may choose to execute the task.
   void AcquireTaskLease(const TaskID &task_id);
+
+  void RemoveTaskDependency(const TaskID &task_id, const ObjectID &object_id);
 
   /// The object manager, used to fetch required objects from remote nodes.
   ObjectManagerInterface &object_manager_;

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -54,8 +54,7 @@ class TaskDependencyManager {
   /// \return Whether all of the given dependencies for the given task are
   /// local.
   bool SubscribeDependencies(const TaskID &task_id,
-                             const std::vector<ObjectID> &required_objects,
-                             bool ray_get);
+                             const std::vector<ObjectID> &required_objects, bool ray_get);
 
   /// Unsubscribe from the object dependencies required by this task. If the
   /// objects were remote and are no longer required by any subscribed task,

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -65,6 +65,12 @@ class TaskDependencyManager {
   /// \return Whether the task was subscribed before.
   bool UnsubscribeGetDependencies(const TaskID &task_id);
 
+  /// Unsubscribe from required and non-blocking object dependencies. If the
+  /// objects were remote and are no longer required by any subscribed task,
+  /// then they will be canceled.
+  ///
+  /// \param task_id The ID of the task whose dependencies to unsubscribe from.
+  /// \return Whether the task was subscribed before.
   bool UnsubscribeAllDependencies(const TaskID &task_id);
 
   /// Mark that the given task is pending execution. Any objects that it creates
@@ -170,9 +176,15 @@ class TaskDependencyManager {
   /// The task lease has an expiration time. If we do not renew the lease
   /// before that time, then other nodes may choose to execute the task.
   void AcquireTaskLease(const TaskID &task_id);
-
+  /// Removes the task from the stored list of tasks that depend on the object.
   void RemoveTaskDependency(const TaskID &task_id, const ObjectID &object_id);
-
+  /// Unsubscribe from the given non-blocking object dependency. If the
+  /// objects were remote and are no longer required by any subscribed task,
+  /// then they will be canceled.
+  ///
+  /// \param task_id The ID of the task whose dependency to unsubscribe from.
+  /// \param object_id The ID of the dependency to unsubscribe from.
+  /// \return Whether the task was subscribed before.
   bool UnsubscribeWaitDependency(const TaskID &task_id, const ObjectID &object_id);
 
   /// The object manager, used to fetch required objects from remote nodes.

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -128,7 +128,8 @@ class TaskDependencyManager {
   std::string DebugString() const;
 
  private:
-  using ObjectDependencyMap = std::unordered_map<ray::ObjectID, std::vector<ray::TaskID>>;
+  using ObjectDependencyMap =
+      std::unordered_map<ray::ObjectID, std::unordered_set<ray::TaskID>>;
 
   /// A struct to represent the object dependencies of a task.
   struct TaskDependencies {
@@ -138,7 +139,7 @@ class TaskDependencyManager {
     /// The objects that the task is fetching. These are fetched while the
     /// the task is executing.
     std::unordered_set<ObjectID> wait_dependencies;
-    /// The number of object arguments that are not available locally. This
+    /// The number of get_dependencies that are not available locally. This
     /// must be zero before the task is ready to execute.
     int64_t num_missing_dependencies;
   };

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -430,7 +430,7 @@ TEST_F(TaskDependencyManagerTest, TestRemoveTasksAndRelatedObjects) {
     // Subscribe to each of the tasks' arguments.
     const auto &arguments = task.GetDependencies();
     task_dependency_manager_.SubscribeDependencies(task.GetTaskSpecification().TaskId(),
-                                                   arguments);
+                                                   arguments, true);
     // Mark each task as pending. A lease entry should be added to the GCS for
     // each task.
     EXPECT_CALL(gcs_mock_, Add(_, task.GetTaskSpecification().TaskId(), _, _));
@@ -442,7 +442,7 @@ TEST_F(TaskDependencyManagerTest, TestRemoveTasksAndRelatedObjects) {
   auto task = tasks.front();
   TaskID task_id = task.GetTaskSpecification().TaskId();
   auto return_id = task.GetTaskSpecification().ReturnId(0);
-  task_dependency_manager_.UnsubscribeDependencies(task_id);
+  task_dependency_manager_.UnsubscribeGetDependencies(task_id);
   // Simulate the object notifications for the task's return values.
   auto ready_tasks = task_dependency_manager_.HandleObjectLocal(return_id);
   // The second task should be ready to run.


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

Calling `ray.wait()` on an `ObjectID` will keep a fetch request open until the object becomes local, even if the `ray.wait()` call is no longer blocking.

Modifies the raylet node manager and task dependency manager to support this behavior.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#3715