### PR TITLE
Skip dead nodes to avoid connection timeout.

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -56,6 +56,7 @@ MONITOR_DIED_ERROR = "monitor_died"
 LOG_MONITOR_DIED_ERROR = "log_monitor_died"
 REPORTER_DIED_ERROR = "reporter_died"
 DASHBOARD_DIED_ERROR = "dashboard_died"
+RAYLET_CONNECTION_ERROR = "raylet_connection_error"
 
 # Abort autoscaling if more than this number of errors are encountered. This
 # is a safety feature to prevent e.g. runaway node launches.

--- a/python/ray/tests/cluster_utils.py
+++ b/python/ray/tests/cluster_utils.py
@@ -102,7 +102,7 @@ class Cluster(object):
 
         return node
 
-    def remove_node(self, node):
+    def remove_node(self, node, allow_graceful=False):
         """Kills all processes associated with worker node.
 
         Args:
@@ -110,11 +110,13 @@ class Cluster(object):
                 will be removed.
         """
         if self.head_node == node:
-            self.head_node.kill_all_processes(check_alive=False)
+            self.head_node.kill_all_processes(
+                check_alive=False, allow_graceful=allow_graceful)
             self.head_node = None
             # TODO(rliaw): Do we need to kill all worker processes?
         else:
-            node.kill_all_processes(check_alive=False)
+            node.kill_all_processes(
+                check_alive=False, allow_graceful=allow_graceful)
             self.worker_nodes.remove(node)
 
         assert not node.any_processes_alive(), (

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2853,10 +2853,3 @@ def test_load_code_from_local(shutdown_only):
     base_actor_class = ray.remote(num_cpus=1)(BaseClass)
     base_actor = base_actor_class.remote(message)
     assert ray.get(base_actor.get_data.remote()) == message
-
-
-def test_connect_with_disconnected_node(ray_start_cluster):
-    ray_start_cluster.add_node()
-    dead_node = ray_start_cluster.add_node()
-    ray_start_cluster.remove_node(dead_node, allow_graceful=True)
-    ray_start_cluster.add_node()

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2853,3 +2853,10 @@ def test_load_code_from_local(shutdown_only):
     base_actor_class = ray.remote(num_cpus=1)(BaseClass)
     base_actor = base_actor_class.remote(message)
     assert ray.get(base_actor.get_data.remote()) == message
+
+
+def test_connect_with_disconnected_node(ray_start_cluster):
+    keeping_node = ray_start_cluster.add_node()
+    dead_node = ray_start_cluster.add_node()
+    ray_start_cluster.remove_node(dead_node, allow_graceful=True)
+    ray_start_cluster.add_node()

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2856,7 +2856,7 @@ def test_load_code_from_local(shutdown_only):
 
 
 def test_connect_with_disconnected_node(ray_start_cluster):
-    keeping_node = ray_start_cluster.add_node()
+    ray_start_cluster.add_node()
     dead_node = ray_start_cluster.add_node()
     ray_start_cluster.remove_node(dead_node, allow_graceful=True)
     ray_start_cluster.add_node()

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -418,10 +418,6 @@ Status ClientTable::Connect(const ClientTableDataT &local_client) {
         // This is temporary fix for Issue 4140 to avoid connect to dead nodes.
         // TODO(yuhguo): remove this temporary fix after GCS entry is removable.
         if (notification.is_insertion) {
-          auto iter = disconnected_nodes.find(notification.client_id);
-          if (iter != disconnected_nodes.end()) {
-            disconnected_nodes.erase(iter);
-          }
           connected_nodes.emplace(notification.client_id, notification);
         } else {
           auto iter = connected_nodes.find(notification.client_id);

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -485,6 +485,11 @@ const std::unordered_map<ClientID, ClientTableDataT> &ClientTable::GetAllClients
   return client_cache_;
 }
 
+Status ClientTable::Lookup(const Callback &lookup) {
+  RAY_CHECK(lookup != nullptr);
+  return Log::Lookup(JobID::nil(), client_log_key_, lookup);
+}
+
 std::string ClientTable::DebugString() const {
   std::stringstream result;
   result << Log<UniqueID, ClientTableData>::DebugString();

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -657,6 +657,13 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   /// \return The client ID to client information map.
   const std::unordered_map<ClientID, ClientTableDataT> &GetAllClients() const;
 
+  /// Lookup the client data in the client table.
+  ///
+  /// \param lookup Callback that is called after lookup. If the callback is
+  /// called with an empty vector, then there was no data at the key.
+  /// \return Status.
+  Status Lookup(const Callback &lookup);
+
   /// Returns debug string for class.
   ///
   /// \return string.

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -578,6 +578,7 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
  public:
   using ClientTableCallback = std::function<void(
       AsyncGcsClient *client, const ClientID &id, const ClientTableDataT &data)>;
+  using DisconnectCallback = std::function<void(void)>;
   ClientTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
               AsyncGcsClient *client, const ClientID &client_id)
       : Log(contexts, client),
@@ -606,7 +607,7 @@ class ClientTable : private Log<UniqueID, ClientTableData> {
   /// registration should never be reused after disconnecting.
   ///
   /// \return Status
-  ray::Status Disconnect();
+  ray::Status Disconnect(const DisconnectCallback &callback = nullptr);
 
   /// Mark a different client as disconnected. The client ID should never be
   /// reused for a new client.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
   // instead of returning immediately.
   // We should stop the service and remove the local socket file.
   auto handler = [&main_service, &raylet_socket_name, &server, &gcs_client](
-                     const boost::system::error_code &error, int signal_number) {
+      const boost::system::error_code &error, int signal_number) {
     auto shutdown_callback = [&server, &main_service, &raylet_socket_name]() {
       server.reset();
       main_service.stop();

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -45,22 +45,37 @@ void Monitor::Tick() {
     it->second--;
     if (it->second == 0) {
       if (dead_clients_.count(it->first) == 0) {
-        RAY_LOG(WARNING) << "Client timed out: " << it->first;
-        RAY_CHECK_OK(gcs_client_.client_table().MarkDisconnected(it->first));
+        auto client_id = it->first;
+        RAY_LOG(WARNING) << "Client timed out: " << client_id;
+        auto lookup_callback = [this, client_id](
+                                   gcs::AsyncGcsClient *client, const ClientID &id,
+                                   const std::vector<ClientTableDataT> &all_data) {
+          bool marked = false;
+          for (const auto &data : all_data) {
+            if (client_id.binary() == data.client_id && !data.is_insertion) {
+              // The node has been marked dead by itself.
+              marked = true;
+            }
+          }
+          if (!marked) {
+            RAY_CHECK_OK(gcs_client_.client_table().MarkDisconnected(client_id));
+          }
+        };
+        RAY_CHECK_OK(gcs_client_.client_table().Lookup(lookup_callback));
 
         // Broadcast a warning to all of the drivers indicating that the node
         // has been marked as dead.
         // TODO(rkn): Define this constant somewhere else.
         std::string type = "node_removed";
         std::ostringstream error_message;
-        error_message << "The node with client ID " << it->first << " has been marked "
+        error_message << "The node with client ID " << client_id << " has been marked "
                       << "dead because the monitor has missed too many heartbeats "
                       << "from it.";
         // We use the nil JobID to broadcast the message to all drivers.
         RAY_CHECK_OK(gcs_client_.error_table().PushErrorToDriver(
             JobID::nil(), type, error_message.str(), current_time_ms()));
 
-        dead_clients_.insert(it->first);
+        dead_clients_.insert(client_id);
       }
       it = heartbeats_.erase(it);
     } else {

--- a/src/ray/raylet/monitor.cc
+++ b/src/ray/raylet/monitor.cc
@@ -48,8 +48,8 @@ void Monitor::Tick() {
         auto client_id = it->first;
         RAY_LOG(WARNING) << "Client timed out: " << client_id;
         auto lookup_callback = [this, client_id](
-                                   gcs::AsyncGcsClient *client, const ClientID &id,
-                                   const std::vector<ClientTableDataT> &all_data) {
+            gcs::AsyncGcsClient *client, const ClientID &id,
+            const std::vector<ClientTableDataT> &all_data) {
           bool marked = false;
           for (const auto &data : all_data) {
             if (client_id.binary() == data.client_id && !data.is_insertion) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -346,9 +346,9 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
     // We need to broadcase this message.
     std::string type = "raylet_connection_error";
     std::ostringstream error_message;
-    error_message << "Failed to connect to client " << client_id
-                  << " in ClientAdded. TcpConnect returned status: " << status.ToString()
-                  << ". This error should not happen.";
+    error_message << "Failed to connect to ray node " << client_id
+                  << " with status: " << status.ToString()
+                  << ". This may be since the node was recently removed.";
     // We use the nil JobID to broadcast the message to all drivers.
     RAY_CHECK_OK(gcs_client_->error_table().PushErrorToDriver(
         JobID::nil(), type, error_message.str(), current_time_ms()));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -341,15 +341,17 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   // Establish a new NodeManager connection to this GCS client.
   auto status = ConnectRemoteNodeManager(client_id, client_data.node_manager_address,
                                          client_data.node_manager_port);
-  // A disconnected client has 2 entries in the client table (one for being
-  // inserted and one for being removed). When a new raylet starts, ClientAdded
-  // will be called with the disconnected client's first entry, which will cause
-  // IOError and "Connection refused".
   if (!status.ok()) {
-    RAY_LOG(WARNING) << "Failed to connect to client " << client_id
-                     << " in ClientAdded. TcpConnect returned status: "
-                     << status.ToString() << ". This may be caused by "
-                     << "trying to connect to a node manager that has failed.";
+    // This is not a fatal error for raylet, but it should not happen.
+    // We need to broadcase this message.
+    std::string type = "raylet_connection_error";
+    std::ostringstream error_message;
+    error_message << "Failed to connect to client " << client_id
+                  << " in ClientAdded. TcpConnect returned status: " << status.ToString()
+                  << ". This error should not happen.";
+    // We use the nil JobID to broadcast the message to all drivers.
+    RAY_CHECK_OK(gcs_client_->error_table().PushErrorToDriver(
+        JobID::nil(), type, error_message.str(), current_time_ms()));
     return;
   }
 

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -68,7 +68,7 @@ Raylet::Raylet(boost::asio::io_service &main_service, const std::string &socket_
   RAY_CHECK_OK(RegisterPeriodicTimer(main_service));
 }
 
-Raylet::~Raylet() { RAY_CHECK_OK(gcs_client_->client_table().Disconnect()); }
+Raylet::~Raylet() {}
 
 ray::Status Raylet::RegisterPeriodicTimer(boost::asio::io_service &io_service) {
   boost::posix_time::milliseconds timer_period_ms(100);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Skip the dead nodes when a node is newly connected to the cluster.

The time sequence is not as expected because there is a callback in another callback.
In `Raylet::RegisterGcs`, `client_table().Connect` is called first and `node_manager_.RegisterGcs()` which contains `client_table().RegisterClientAddedCallback` is called later. If the callback function `notification_callback` in `client_table().Connect` is finished before `client_table().RegisterClientAddedCallback`, the logic is correct. However, this function is called in the callback function of `Append`. That is to say  `client_table().RegisterClientAddedCallback` could be called ahead of `notification_callback`. In this case `HandleNotification` will call `client_added_callback_` to connect the dead node unexpectedly
<!-- Please give a short brief about these changes. -->


## Related issue number
https://github.com/ray-project/ray/issues/4140
<!-- Are there any issues opened that will be resolved by merging this change? -->
