### PR TITLE
[wingman -> rllib] Removed remote evaluators assert

### DIFF
--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -85,7 +85,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
         self.learner.start()
 
         if self.remote_evaluators == 0:
-            logger.warning("Starting optimizer without remote evaluators! Have you set num_workers to 0?")
+            logger.warning("Training will hang when remote_evaluators=0.")
 
         # Stats
         self._optimizer_step_timer = TimerStat()

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -84,7 +84,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                                          learner_queue_size)
         self.learner.start()
 
-        if self.remote_evaluators == 0:
+        if len(self.remote_evaluators) == 0:
             logger.warning("Starting optimizer without remote evaluators! Have you set num_workers to 0?")
 
         # Stats

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -85,7 +85,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
         self.learner.start()
 
         if len(self.remote_evaluators) == 0:
-            logger.warning("Starting optimizer without remote evaluators! Training will hang! Have you set num_workers to 0?")
+            logger.warning("Starting optimizer with num_workers=0. Training will hang!")
 
         # Stats
         self._optimizer_step_timer = TimerStat()

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -84,7 +84,8 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                                          learner_queue_size)
         self.learner.start()
 
-        assert len(self.remote_evaluators) > 0
+        if self.remote_evaluators == 0:
+            logger.warning("Starting optimizer without remote evaluators! Have you set num_workers to 0?")
 
         # Stats
         self._optimizer_step_timer = TimerStat()

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -85,7 +85,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
         self.learner.start()
 
         if len(self.remote_evaluators) == 0:
-            logger.warning("Starting optimizer with num_workers=0. Training will hang!")
+            logger.warning("Config num_workers=0 means training will hang!")
 
         # Stats
         self._optimizer_step_timer = TimerStat()


### PR DESCRIPTION
Not forcing remote evaluators not to be zero in the optimizer, as it makes sense for them to be 0 during the rollout. But for some reason, logger.warning is not written in the console (I don't know how rllib logging is working).