### PR TITLE
Fix the issue about starting cross-lang cluster

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -268,6 +268,7 @@ class Node(object):
              redis_max_clients=self._ray_params.redis_max_clients,
              redirect_worker_output=True,
              password=self._ray_params.redis_password,
+             include_java=self._ray_params.include_java,
              redis_max_memory=self._ray_params.redis_max_memory)
         assert (
             ray_constants.PROCESS_TYPE_REDIS_SERVER not in self.all_processes)

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -196,7 +196,3 @@ class RayParams(object):
         if self.redirect_output is not None:
             raise DeprecationWarning(
                 "The redirect_output argument is deprecated.")
-
-        if self.include_java is None and self.java_worker_options is not None:
-            raise ValueError("Should not specify `java-worker-options` "
-                             "without providing `include-java`.")


### PR DESCRIPTION

1. Allow nodes specify their own options.
2. pass the argument to start_redis.
