### PR TITLE
Downgrade six to 1.0.0

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -7,7 +7,6 @@ import importlib
 import inspect
 import json
 import logging
-import six
 import sys
 import time
 import traceback
@@ -27,6 +26,7 @@ from ray.utils import (
     is_class_method,
     check_oversized_pickle,
     decode,
+    ensure_str,
     format_error_message,
     push_error_to_driver,
 )
@@ -89,9 +89,9 @@ class FunctionDescriptor(object):
             return FunctionDescriptor.for_driver_task()
         elif (len(function_descriptor_list) == 3
               or len(function_descriptor_list) == 4):
-            module_name = six.ensure_str(function_descriptor_list[0])
-            class_name = six.ensure_str(function_descriptor_list[1])
-            function_name = six.ensure_str(function_descriptor_list[2])
+            module_name = ensure_str(function_descriptor_list[0])
+            class_name = ensure_str(function_descriptor_list[1])
+            function_name = ensure_str(function_descriptor_list[2])
             if len(function_descriptor_list) == 4:
                 return cls(module_name, function_name, class_name,
                            function_descriptor_list[3])
@@ -705,10 +705,10 @@ class FunctionActorManager(object):
                  "actor_method_names"
              ])
 
-        class_name = six.ensure_str(class_name)
-        module_name = six.ensure_str(module)
+        class_name = ensure_str(class_name)
+        module_name = ensure_str(module)
         driver_id = ray.DriverID(driver_id_str)
-        actor_method_names = json.loads(six.ensure_str(actor_method_names))
+        actor_method_names = json.loads(ensure_str(actor_method_names))
 
         actor_class = None
         try:

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -201,7 +201,7 @@ def ensure_str(s, encoding="utf-8", errors="strict"):
         text_type = str
         binary_type = bytes
     else:
-        text_type = unicode
+        text_type = unicode  # noqa: F821
         binary_type = str
     if not isinstance(s, (text_type, binary_type)):
         raise TypeError("not expecting type '%s'" % type(s))

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import numpy as np
 import os
+import six
 import subprocess
 import sys
 import threading
@@ -178,6 +179,35 @@ def decode(byte_str, allow_none=False):
         return byte_str.decode("ascii")
     else:
         return byte_str
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+    To keep six with lower version, see Issue 4169,
+    we copy this function fron six == 1.12.0.
+    TODO(yuhguo): remove this function when six >= 1.12.0.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if six.PY3:
+        text_type = str
+        binary_type = bytes
+    else:
+        text_type = unicode
+        binary_type = str
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if six.PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif six.PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
 
 
 def binary_to_object_id(binary_object_id):

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -185,7 +185,7 @@ def ensure_str(s, encoding="utf-8", errors="strict"):
     """Coerce *s* to `str`.
 
     To keep six with lower version, see Issue 4169, we copy this function
-    fron six == 1.12.0.
+    from six == 1.12.0.
 
     TODO(yuhguo): remove this function when six >= 1.12.0.
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -181,10 +181,12 @@ def decode(byte_str, allow_none=False):
         return byte_str
 
 
-def ensure_str(s, encoding='utf-8', errors='strict'):
+def ensure_str(s, encoding="utf-8", errors="strict"):
     """Coerce *s* to `str`.
-    To keep six with lower version, see Issue 4169,
-    we copy this function fron six == 1.12.0.
+
+    To keep six with lower version, see Issue 4169, we copy this function
+    fron six == 1.12.0.
+
     TODO(yuhguo): remove this function when six >= 1.12.0.
 
     For Python 2:

--- a/python/setup.py
+++ b/python/setup.py
@@ -152,7 +152,7 @@ requires = [
     "pytest",
     "pyyaml",
     "redis",
-    "six >= 1.12.0",
+    "six >= 1.10.0",
     # The typing module is required by modin.
     "typing",
     "flatbuffers",

--- a/python/setup.py
+++ b/python/setup.py
@@ -152,7 +152,7 @@ requires = [
     "pytest",
     "pyyaml",
     "redis",
-    "six >= 1.10.0",
+    "six >= 1.0.0",
     # The typing module is required by modin.
     "typing",
     "flatbuffers",

--- a/python/setup.py
+++ b/python/setup.py
@@ -152,6 +152,8 @@ requires = [
     "pytest",
     "pyyaml",
     "redis",
+    # NOTE: Don't upgrade the version of six! Doing so causes installation
+    # problems. See https://github.com/ray-project/ray/issues/4169.
     "six >= 1.0.0",
     # The typing module is required by modin.
     "typing",


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Copy `ensure_str` to `utils.py` and downgrade six back to 1.0.0.
## Related issue number
https://github.com/ray-project/ray/issues/4169
<!-- Are there any issues opened that will be resolved by merging this change? -->
