### PR TITLE
[autoscaler] Make commands `bash -i` to support newer bash

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -271,9 +271,9 @@ class NodeUpdater(object):
             ssh.append("-tt")
         if emulate_interactive:
             force_interactive = (
-                "set -i || true && source ~/.bashrc && "
+                "true && source ~/.bashrc && "
                 "export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ")
-            cmd = "bash --login -c {}".format(quote(force_interactive + cmd))
+            cmd = "bash --login -c -i {}".format(quote(force_interactive + cmd))
 
         if port_forward is None:
             ssh_opt = []

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -273,7 +273,8 @@ class NodeUpdater(object):
             force_interactive = (
                 "true && source ~/.bashrc && "
                 "export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ")
-            cmd = "bash --login -c -i {}".format(quote(force_interactive + cmd))
+            cmd = "bash --login -c -i {}".format(
+                quote(force_interactive + cmd))
 
         if port_forward is None:
             ssh_opt = []


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
the generated command in autoscaler/updater.py throws non-zero exit status 127 on Ubuntu 18.04, for detailed description please check the related issue below.
<!-- Please give a short brief about these changes. -->

## Related issue number
Closes #4155, Closes #1444.
<!-- Are there any issues opened that will be resolved by merging this change? -->
