### PR TITLE
Release gil when doing ray.wait.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -263,9 +263,11 @@ cdef class RayletClient:
             WaitResultPair result
             c_vector[CObjectID] wait_ids
         wait_ids = ObjectIDsToVector(object_ids)
-        check_status(self.client.get().Wait(wait_ids, num_returns,
-                                            timeout_milliseconds, wait_local,
-                                            current_task_id.data, &result))
+        with nogil:
+            check_status(self.client.get().Wait(wait_ids, num_returns,
+                                                timeout_milliseconds,
+                                                wait_local,
+                                                current_task_id.data, &result))
         return (VectorToObjectIDs(result.first),
                 VectorToObjectIDs(result.second))
 


### PR DESCRIPTION
This fixes #4082. Some logs weren't getting printed because the driver was blocked in `ray.wait` which didn't release the GIL so the error printing thread didn't get to print. Note that some prints can still be missed if the driver exits before the prints get streamed from the log monitor to the driver.