### PR TITLE
[Java] Add runtime context

### DIFF
--- a/java/api/src/main/java/org/ray/api/Ray.java
+++ b/java/api/src/main/java/org/ray/api/Ray.java
@@ -120,4 +120,11 @@ public final class Ray extends RayCall {
   public static RayRuntime internal() {
     return runtime;
   }
+
+  /**
+   * Get the runtime context.
+   */
+  public static RuntimeContext getRuntimeContext() {
+    return runtime.getRuntimeContext();
+  }
 }

--- a/java/api/src/main/java/org/ray/api/RuntimeContext.java
+++ b/java/api/src/main/java/org/ray/api/RuntimeContext.java
@@ -3,40 +3,44 @@ package org.ray.api;
 import org.ray.api.id.UniqueId;
 
 /**
- * A class used for getting runtime context fields.
+ * A class used for getting information of Ray runtime.
  */
 public interface RuntimeContext {
 
   /**
-   * Get the current Driver id. If called by a driver,
-   * this returns the driver ID. If called in a task,
-   * return the driver ID of the associated driver.
+   * Get the current Driver ID.
+   *
+   * If called in a driver, this returns the driver ID. If called in a worker, this returns the ID
+   * of the associated driver.
    */
   UniqueId getCurrentDriverId();
 
   /**
-   * Get the current actor id. This only could be
-   * called in actor task, not in driver or normal task.
+   * Get the current actor ID.
+   *
+   * Note, this can only be called in actors.
    */
   UniqueId getCurrentActorId();
 
   /**
-   * Whether the current actor was reconstructed.
+   * Returns true if the current actor was reconstructed, false if it's created for the first time.
+   *
+   * Note, this method should only be called from an actor creation task.
    */
   boolean wasCurrentActorReconstructed();
 
   /**
-   * Get the raylet socket name that we can connect to.
+   * Get the raylet socket name.
    */
   String getRayletSocketName();
 
   /**
-   * Get the object store socket name that we can connect to.
+   * Get the object store socket name.
    */
   String getObjectStoreSocketName();
 
   /**
-   * Whether the run mode equals `SINGLE_PROCESS`.
+   * Return true if Ray is running in single-process mode, false if Ray is running in cluster mode.
    */
   boolean isSingleProcess();
 }

--- a/java/api/src/main/java/org/ray/api/RuntimeContext.java
+++ b/java/api/src/main/java/org/ray/api/RuntimeContext.java
@@ -1,0 +1,20 @@
+package org.ray.api;
+
+import org.ray.api.id.UniqueId;
+
+/**
+ * A class used for getting runtime context fields.
+ */
+public interface RuntimeContext {
+
+  UniqueId getCurrentDriverId();
+
+  UniqueId getCurrentActorId();
+
+  boolean wasCurrentActorReconstructed();
+
+  String getRayletSocketName();
+
+  String getObjectStoreSocketName();
+
+}

--- a/java/api/src/main/java/org/ray/api/RuntimeContext.java
+++ b/java/api/src/main/java/org/ray/api/RuntimeContext.java
@@ -7,14 +7,36 @@ import org.ray.api.id.UniqueId;
  */
 public interface RuntimeContext {
 
+  /**
+   * Get the current Driver id. If called by a driver,
+   * this returns the driver ID. If called in a task,
+   * return the driver ID of the associated driver.
+   */
   UniqueId getCurrentDriverId();
 
+  /**
+   * Get the current actor id. This only could be
+   * called in actor task, not in driver or normal task.
+   */
   UniqueId getCurrentActorId();
 
+  /**
+   * Whether the current actor was reconstructed.
+   */
   boolean wasCurrentActorReconstructed();
 
+  /**
+   * Get the raylet socket name that we can connect to.
+   */
   String getRayletSocketName();
 
+  /**
+   * Get the object store socket name that we can connect to.
+   */
   String getObjectStoreSocketName();
 
+  /**
+   * Whether the run mode equals `SINGLE_PROCESS`.
+   */
+  boolean isSingleProcess();
 }

--- a/java/api/src/main/java/org/ray/api/runtime/RayRuntime.java
+++ b/java/api/src/main/java/org/ray/api/runtime/RayRuntime.java
@@ -3,6 +3,7 @@ package org.ray.api.runtime;
 import java.util.List;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
+import org.ray.api.RuntimeContext;
 import org.ray.api.WaitResult;
 import org.ray.api.function.RayFunc;
 import org.ray.api.id.UniqueId;
@@ -93,4 +94,6 @@ public interface RayRuntime {
    */
   <T> RayActor<T> createActor(RayFunc actorFactoryFunc, Object[] args,
       ActorCreationOptions options);
+
+  RuntimeContext getRuntimeContext();
 }

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
+import org.ray.api.RuntimeContext;
 import org.ray.api.WaitResult;
 import org.ray.api.exception.RayException;
 import org.ray.api.function.RayFunc;
@@ -61,6 +62,8 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   protected RayletClient rayletClient;
   protected ObjectStoreProxy objectStoreProxy;
   protected FunctionManager functionManager;
+  protected RuntimeContext runtimeContext;
+  protected UniqueId currentActorId = UniqueId.NIL;
 
   public AbstractRayRuntime(RayConfig rayConfig) {
     this.rayConfig = rayConfig;
@@ -68,6 +71,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
     worker = new Worker(this);
     workerContext = new WorkerContext(rayConfig.workerMode,
             rayConfig.driverId, rayConfig.runMode);
+    runtimeContext = new RuntimeContextImpl(this);
   }
 
   /**
@@ -346,4 +350,17 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   public RayConfig getRayConfig() {
     return rayConfig;
   }
+
+  public void setCurrentActorId(UniqueId actorId) {
+    currentActorId = actorId;
+  }
+
+  public UniqueId getCurrentActorId() {
+    return currentActorId;
+  }
+
+  public RuntimeContext getRuntimeContext() {
+    return runtimeContext;
+  }
+
 }

--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -63,7 +63,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
   protected ObjectStoreProxy objectStoreProxy;
   protected FunctionManager functionManager;
   protected RuntimeContext runtimeContext;
-  protected UniqueId currentActorId = UniqueId.NIL;
 
   public AbstractRayRuntime(RayConfig rayConfig) {
     this.rayConfig = rayConfig;
@@ -349,14 +348,6 @@ public abstract class AbstractRayRuntime implements RayRuntime {
 
   public RayConfig getRayConfig() {
     return rayConfig;
-  }
-
-  public void setCurrentActorId(UniqueId actorId) {
-    currentActorId = actorId;
-  }
-
-  public UniqueId getCurrentActorId() {
-    return currentActorId;
   }
 
   public RuntimeContext getRuntimeContext() {

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -173,4 +173,22 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
     checkpoints.sort((x, y) -> Long.compare(y.timestamp, x.timestamp));
     return checkpoints;
   }
+
+
+  /**
+   * Query whether the actor exists in Gcs.
+   */
+  boolean actorExistsInGcs(UniqueId actorId) {
+    byte[] key = ArrayUtils.addAll("ACTOR".getBytes(), actorId.getBytes());
+
+    // TODO(qwang): refactor this with `GlobalState` after this issue
+    // getting finished. https://github.com/ray-project/ray/issues/3933
+    for (RedisClient client : redisClients) {
+      if (client.exists(key)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -22,7 +22,7 @@ public class RuntimeContextImpl implements RuntimeContext {
   @Override
   public UniqueId getCurrentActorId() {
     Preconditions.checkState(runtime.rayConfig.workerMode == WorkerMode.WORKER);
-    return runtime.getCurrentActorId();
+    return runtime.getWorker().getCurrentActorId();
   }
 
   @Override

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -1,8 +1,10 @@
 package org.ray.runtime;
 
+import com.google.common.base.Preconditions;
 import org.ray.api.RuntimeContext;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.RunMode;
+import org.ray.runtime.config.WorkerMode;
 
 public class RuntimeContextImpl implements RuntimeContext {
 
@@ -19,6 +21,7 @@ public class RuntimeContextImpl implements RuntimeContext {
 
   @Override
   public UniqueId getCurrentActorId() {
+    Preconditions.checkState(runtime.rayConfig.workerMode == WorkerMode.WORKER);
     return runtime.getCurrentActorId();
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -27,10 +27,12 @@ public class RuntimeContextImpl implements RuntimeContext {
 
   @Override
   public boolean wasCurrentActorReconstructed() {
+    Preconditions.checkState(
+        runtime.getWorkerContext().getCurrentTask().isActorCreationTask());
+
     if (isSingleProcess()) {
       return false;
     }
-
     return ((RayNativeRuntime) runtime).actorExistsInGcs(getCurrentActorId());
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -5,6 +5,7 @@ import org.ray.api.RuntimeContext;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.RunMode;
 import org.ray.runtime.config.WorkerMode;
+import org.ray.runtime.task.TaskSpec;
 
 public class RuntimeContextImpl implements RuntimeContext {
 
@@ -27,12 +28,13 @@ public class RuntimeContextImpl implements RuntimeContext {
 
   @Override
   public boolean wasCurrentActorReconstructed() {
-    Preconditions.checkState(
-        runtime.getWorkerContext().getCurrentTask().isActorCreationTask());
-
+    TaskSpec currentTask = runtime.getWorkerContext().getCurrentTask();
+    Preconditions.checkState(currentTask != null && currentTask.isActorCreationTask(),
+        "This method can only be called from an actor creation task.");
     if (isSingleProcess()) {
       return false;
     }
+
     return ((RayNativeRuntime) runtime).actorExistsInGcs(getCurrentActorId());
   }
 

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -1,0 +1,44 @@
+package org.ray.runtime;
+
+import org.ray.api.RuntimeContext;
+import org.ray.api.id.UniqueId;
+import org.ray.runtime.config.RunMode;
+
+public class RuntimeContextImpl implements RuntimeContext {
+
+  private AbstractRayRuntime runtime;
+
+  public RuntimeContextImpl(AbstractRayRuntime runtime) {
+    this.runtime = runtime;
+  }
+
+  @Override
+  public UniqueId getCurrentDriverId() {
+    return runtime.getWorkerContext().getCurrentDriverId();
+  }
+
+  @Override
+  public UniqueId getCurrentActorId() {
+    return runtime.getCurrentActorId();
+  }
+
+  @Override
+  public boolean wasCurrentActorReconstructed() {
+    if (RunMode.SINGLE_PROCESS == runtime.getRayConfig().runMode) {
+      return false;
+    }
+
+    return ((RayNativeRuntime) runtime).actorExistsInGcs(getCurrentActorId());
+  }
+
+  @Override
+  public String getRayletSocketName() {
+    return runtime.getRayConfig().rayletSocketName;
+  }
+
+  @Override
+  public String getObjectStoreSocketName() {
+    return runtime.getRayConfig().objectStoreSocketName;
+  }
+
+}

--- a/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RuntimeContextImpl.java
@@ -27,7 +27,7 @@ public class RuntimeContextImpl implements RuntimeContext {
 
   @Override
   public boolean wasCurrentActorReconstructed() {
-    if (RunMode.SINGLE_PROCESS == runtime.getRayConfig().runMode) {
+    if (isSingleProcess()) {
       return false;
     }
 
@@ -42,6 +42,11 @@ public class RuntimeContextImpl implements RuntimeContext {
   @Override
   public String getObjectStoreSocketName() {
     return runtime.getRayConfig().objectStoreSocketName;
+  }
+
+  @Override
+  public boolean isSingleProcess() {
+    return RunMode.SINGLE_PROCESS == runtime.getRayConfig().runMode;
   }
 
 }

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -63,6 +63,10 @@ public class Worker {
     this.runtime = runtime;
   }
 
+  public UniqueId getCurrentActorId() {
+    return currentActorId;
+  }
+
   public void loop() {
     while (true) {
       LOGGER.info("Fetching new task in thread {}.", Thread.currentThread().getName());
@@ -89,9 +93,6 @@ public class Worker {
       // Get local actor object and arguments.
       Object actor = null;
       if (spec.isActorTask()) {
-        // TODO(qwang): Remove `worker.currentActorId`,
-        // and use `runtime.currentActorId` instead.
-        runtime.setCurrentActorId(spec.actorId);
         Preconditions.checkState(spec.actorId.equals(currentActorId));
         if (actorCreationException != null) {
           throw actorCreationException;

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -90,6 +90,11 @@ public class Worker {
       // Set context
       runtime.getWorkerContext().setCurrentTask(spec, rayFunction.classLoader);
       Thread.currentThread().setContextClassLoader(rayFunction.classLoader);
+
+      if (spec.isActorCreationTask()) {
+        currentActorId = returnId;
+      }
+
       // Get local actor object and arguments.
       Object actor = null;
       if (spec.isActorTask()) {
@@ -117,7 +122,6 @@ public class Worker {
       } else {
         maybeLoadCheckpoint(result, returnId);
         currentActor = result;
-        currentActorId = returnId;
       }
       LOGGER.info("Finished executing task {}", spec.taskId);
     } catch (Exception e) {
@@ -126,7 +130,6 @@ public class Worker {
         runtime.put(returnId, new RayTaskException("Error executing task " + spec, e));
       } else {
         actorCreationException = e;
-        currentActorId = returnId;
       }
     } finally {
       Thread.currentThread().setContextClassLoader(oldLoader);

--- a/java/runtime/src/main/java/org/ray/runtime/Worker.java
+++ b/java/runtime/src/main/java/org/ray/runtime/Worker.java
@@ -89,11 +89,15 @@ public class Worker {
       // Get local actor object and arguments.
       Object actor = null;
       if (spec.isActorTask()) {
+        // TODO(qwang): Remove `worker.currentActorId`,
+        // and use `runtime.currentActorId` instead.
+        runtime.setCurrentActorId(spec.actorId);
         Preconditions.checkState(spec.actorId.equals(currentActorId));
         if (actorCreationException != null) {
           throw actorCreationException;
         }
         actor = currentActor;
+
       }
       Object[] args = ArgumentsBuilder.unwrap(spec, rayFunction.classLoader);
       // Execute the task.

--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -26,6 +26,8 @@ public class WorkerContext {
    */
   private ThreadLocal<Integer> taskIndex;
 
+  private ThreadLocal<TaskSpec> currentTask;
+
   private UniqueId currentDriverId;
 
   private ClassLoader currentClassLoader;
@@ -46,6 +48,7 @@ public class WorkerContext {
     putIndex = ThreadLocal.withInitial(() -> 0);
     currentTaskId = ThreadLocal.withInitial(UniqueId::randomId);
     this.runMode = runMode;
+    currentTask = ThreadLocal.withInitial(() -> null);
     currentClassLoader = null;
     if (workerMode == WorkerMode.DRIVER) {
       workerId = driverId;
@@ -83,6 +86,7 @@ public class WorkerContext {
     this.currentDriverId = task.driverId;
     taskIndex.set(0);
     putIndex.set(0);
+    this.currentTask.set(task);
     currentClassLoader = classLoader;
   }
 
@@ -124,4 +128,10 @@ public class WorkerContext {
     return currentClassLoader;
   }
 
+  /**
+   * Get the current task.
+   */
+  public TaskSpec getCurrentTask() {
+    return this.currentTask.get();
+  }
 }

--- a/java/runtime/src/main/java/org/ray/runtime/gcs/RedisClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/gcs/RedisClient.java
@@ -85,4 +85,14 @@ public class RedisClient {
       return jedis.lrange(key, start, end);
     }
   }
+
+  /**
+   * Whether the key exists in Redis.
+   */
+  public boolean exists(byte[] key) {
+    try (Jedis jedis = jedisPool.getResource()) {
+      return jedis.exists(key);
+    }
+  }
+
 }

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -268,6 +268,10 @@ public class RunManager {
       cmd.add("-Dray.logging.file.path=" + logFile);
     }
 
+    // socket names
+    cmd.add("-Dray.raylet.socket-name=" + rayConfig.rayletSocketName);
+    cmd.add("-Dray.object-store.socket-name=" + rayConfig.objectStoreSocketName);
+
     // Config overwrite
     cmd.add("-Dray.redis.address=" + rayConfig.getRedisAddress());
 

--- a/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
@@ -24,6 +24,16 @@ public class ActorReconstructionTest extends BaseTest {
 
     protected int value = 0;
 
+    private boolean wasCurrentActorReconstructed = false;
+
+    public Counter() {
+      wasCurrentActorReconstructed = Ray.getRuntimeContext().wasCurrentActorReconstructed();
+    }
+
+    public boolean wasCurrentActorReconstructed() {
+      return wasCurrentActorReconstructed;
+    }
+
     public int increase() {
       value += 1;
       return value;
@@ -48,6 +58,8 @@ public class ActorReconstructionTest extends BaseTest {
       Ray.call(Counter::increase, actor).get();
     }
 
+    Assert.assertFalse(Ray.call(Counter::wasCurrentActorReconstructed, actor).get());
+
     // Kill the actor process.
     int pid = Ray.call(Counter::getPid, actor).get();
     Runtime.getRuntime().exec("kill -9 " + pid);
@@ -57,6 +69,8 @@ public class ActorReconstructionTest extends BaseTest {
     // Try calling increase on this actor again and check the value is now 4.
     int value = Ray.call(Counter::increase, actor).get();
     Assert.assertEquals(value, 4);
+
+    Assert.assertTrue(Ray.call(Counter::wasCurrentActorReconstructed, actor).get());
 
     // Kill the actor process again.
     pid = Ray.call(Counter::getPid, actor).get();

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -9,7 +9,8 @@ import org.testng.annotations.Test;
 
 public class RuntimeContextTest extends BaseTest {
 
-  private static UniqueId DRIVER_ID = UniqueId.randomId();
+  private static UniqueId DRIVER_ID =
+      UniqueId.fromHexString("0011223344556677889900112233445566778899");
   private static String RAYLET_SOCKET_NAME = "/tmp/ray/test/raylet_socket";
   private static String OBJECT_STORE_SOCKET_NAME = "/tmp/ray/test/object_store_socket";
 
@@ -32,8 +33,9 @@ public class RuntimeContextTest extends BaseTest {
   @RayRemote
   public static class RuntimeContextTester {
 
-    public String testRuntimeContext() {
+    public String testRuntimeContext(UniqueId actorId) {
       Assert.assertEquals(DRIVER_ID, Ray.getRuntimeContext().getCurrentDriverId());
+      Assert.assertEquals(actorId, Ray.getRuntimeContext().getCurrentActorId());
       Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.getRuntimeContext().getRayletSocketName());
       Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
           Ray.getRuntimeContext().getObjectStoreSocketName());
@@ -45,7 +47,7 @@ public class RuntimeContextTest extends BaseTest {
   public void testRuntimeContextInActor() {
     RayActor<RuntimeContextTester> actor = Ray.createActor(RuntimeContextTester::new);
     Assert.assertEquals("ok",
-        Ray.call(RuntimeContextTester::testRuntimeContext, actor).get());
+        Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()).get());
 
   }
 

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -30,38 +30,23 @@ public class RuntimeContextTest extends BaseTest {
 
   // test in actor.
   @RayRemote
-  public static class Info {
+  public static class RuntimeContextTester {
 
-    public Info() {
-
-    }
-
-    public UniqueId getCurrentDriverId() {
-      return Ray.getRuntimeContext().getCurrentDriverId();
-    }
-
-    public UniqueId getCurrentActorId() {
-      return Ray.getRuntimeContext().getCurrentActorId();
-    }
-
-    public String getRayletSocketName() {
-      return Ray.getRuntimeContext().getRayletSocketName();
-    }
-
-    public String getObjectStoreSocketName() {
-      return Ray.getRuntimeContext().getObjectStoreSocketName();
+    public String testRuntimeContext(UniqueId actorId) {
+      Assert.assertEquals(DRIVER_ID, Ray.getRuntimeContext().getCurrentDriverId());
+      Assert.assertEquals(actorId, Ray.getRuntimeContext().getCurrentActorId());
+      Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.getRuntimeContext().getRayletSocketName());
+      Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
+          Ray.getRuntimeContext().getObjectStoreSocketName());
+      return "ok";
     }
   }
 
   @Test
   public void testRuntimeContextInActor() {
-    RayActor<Info> actor = Ray.createActor(Info::new);
-
-    Assert.assertEquals(DRIVER_ID, Ray.call(Info::getCurrentDriverId, actor).get());
-    Assert.assertEquals(actor.getId(), Ray.call(Info::getCurrentActorId, actor).get());
-    Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.call(Info::getRayletSocketName, actor).get());
-    Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
-        Ray.call(Info::getObjectStoreSocketName, actor).get());
+    RayActor<RuntimeContextTester> actor = Ray.createActor(RuntimeContextTester::new);
+    Assert.assertEquals("ok",
+        Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()));
 
   }
 

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -46,7 +46,7 @@ public class RuntimeContextTest extends BaseTest {
   public void testRuntimeContextInActor() {
     RayActor<RuntimeContextTester> actor = Ray.createActor(RuntimeContextTester::new);
     Assert.assertEquals("ok",
-        Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()));
+        Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()).get());
 
   }
 

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -22,14 +22,13 @@ public class RuntimeContextTest extends BaseTest {
   }
 
   @Test
-  public void testRuntimeContext() {
+  public void testRuntimeContextInDriver() {
     Assert.assertEquals(DRIVER_ID, Ray.getRuntimeContext().getCurrentDriverId());
     Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.getRuntimeContext().getRayletSocketName());
     Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
         Ray.getRuntimeContext().getObjectStoreSocketName());
   }
 
-  // test in actor.
   @RayRemote
   public static class RuntimeContextTester {
 
@@ -48,7 +47,6 @@ public class RuntimeContextTest extends BaseTest {
     RayActor<RuntimeContextTester> actor = Ray.createActor(RuntimeContextTester::new);
     Assert.assertEquals("ok",
         Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()).get());
-
   }
 
 }

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -1,0 +1,68 @@
+package org.ray.api.test;
+
+import org.ray.api.Ray;
+import org.ray.api.RayActor;
+import org.ray.api.annotation.RayRemote;
+import org.ray.api.id.UniqueId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RuntimeContextTest extends BaseTest {
+
+  private static UniqueId DRIVER_ID = UniqueId.randomId();
+  private static String RAYLET_SOCKET_NAME = "/tmp/ray/test/raylet_socket";
+  private static String OBJECT_STORE_SOCKET_NAME = "/tmp/ray/test/object_store_socket";
+
+  @Override
+  public void beforeInitRay() {
+    System.setProperty("ray.driver.id", DRIVER_ID.toString());
+    System.setProperty("ray.raylet.socket-name", RAYLET_SOCKET_NAME);
+    System.setProperty("ray.object-store.socket-name", OBJECT_STORE_SOCKET_NAME);
+  }
+
+  @Test
+  public void testRuntimeContext() {
+    Assert.assertEquals(DRIVER_ID, Ray.getRuntimeContext().getCurrentDriverId());
+    Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.getRuntimeContext().getRayletSocketName());
+    Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
+        Ray.getRuntimeContext().getObjectStoreSocketName());
+  }
+
+  // test in actor.
+  @RayRemote
+  public static class Info {
+
+    public Info() {
+
+    }
+
+    public UniqueId getCurrentDriverId() {
+      return Ray.getRuntimeContext().getCurrentDriverId();
+    }
+
+    public UniqueId getCurrentActorId() {
+      return Ray.getRuntimeContext().getCurrentActorId();
+    }
+
+    public String getRayletSocketName() {
+      return Ray.getRuntimeContext().getRayletSocketName();
+    }
+
+    public String getObjectStoreSocketName() {
+      return Ray.getRuntimeContext().getObjectStoreSocketName();
+    }
+  }
+
+  @Test
+  public void testRuntimeContextInActor() {
+    RayActor<Info> actor = Ray.createActor(Info::new);
+
+    Assert.assertEquals(DRIVER_ID, Ray.call(Info::getCurrentDriverId, actor).get());
+    Assert.assertEquals(actor.getId(), Ray.call(Info::getCurrentActorId, actor).get());
+    Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.call(Info::getRayletSocketName, actor).get());
+    Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
+        Ray.call(Info::getObjectStoreSocketName, actor).get());
+
+  }
+
+}

--- a/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RuntimeContextTest.java
@@ -32,9 +32,8 @@ public class RuntimeContextTest extends BaseTest {
   @RayRemote
   public static class RuntimeContextTester {
 
-    public String testRuntimeContext(UniqueId actorId) {
+    public String testRuntimeContext() {
       Assert.assertEquals(DRIVER_ID, Ray.getRuntimeContext().getCurrentDriverId());
-      Assert.assertEquals(actorId, Ray.getRuntimeContext().getCurrentActorId());
       Assert.assertEquals(RAYLET_SOCKET_NAME, Ray.getRuntimeContext().getRayletSocketName());
       Assert.assertEquals(OBJECT_STORE_SOCKET_NAME,
           Ray.getRuntimeContext().getObjectStoreSocketName());
@@ -46,7 +45,7 @@ public class RuntimeContextTest extends BaseTest {
   public void testRuntimeContextInActor() {
     RayActor<RuntimeContextTester> actor = Ray.createActor(RuntimeContextTester::new);
     Assert.assertEquals("ok",
-        Ray.call(RuntimeContextTester::testRuntimeContext, actor, actor.getId()).get());
+        Ray.call(RuntimeContextTester::testRuntimeContext, actor).get());
 
   }
 


### PR DESCRIPTION
## What do these changes do?
This PR enables the runtime context in Java part.
usage:

```Java
Ray.getRuntimeContext().getCurrentDriverId();
```
or
```Java
RuntimeContext context = Ray.getRuntimeContext();
// do many other things, then:
context.getCurrentDriverId();
```



## Related PR
runtime context in Python part: https://github.com/ray-project/ray/pull/4065