### PR TITLE
Consodiate CI Python tests and fix bug about multiple ray.init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,7 @@ script:
 
   # ray tune tests
   - python python/ray/tune/test/dependency_test.py
+  # `cluster_tests.py` runs on Jenkins, not Travis.
   - python -m pytest -v --durations=30 --ignore=python/ray/tune/cluster_tests.py python/ray/tune/test
 
   # ray rllib tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,12 +158,7 @@ script:
 
   # ray tune tests
   - python python/ray/tune/test/dependency_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/trial_runner_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/trial_scheduler_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/experiment_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/tune_server_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/ray_trial_executor_test.py
-  - python -m pytest -v --durations=10 python/ray/tune/test/automl_searcher_test.py
+  - python -m pytest -v --durations=30 --ignore=python/ray/tune/cluster_tests.py python/ray/tune/test
 
   # ray rllib tests
   - python python/ray/rllib/test/test_catalog.py
@@ -171,53 +166,10 @@ script:
   - python python/ray/rllib/test/test_optimizers.py
   - python python/ray/rllib/test/test_evaluators.py
 
-  # streaming library tests
-  - python -m pytest -v --durations=10 python/ray/tests/test_batched_queue.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_logical_graph.py
-
+  # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
   - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=10 python/ray/experimental/test/async_test.py
-
-  # ray tests
-  # TODO(williamma12): We cannot use pytests built-in test discovery because
-  # it causes a lot of the tests to fail on travis' apple builds even though
-  # it runs without issue on an apple build locally.
-  - python -m pytest -v --durations=10 python/ray/tests/test_global_state.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_queue.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_ray_init.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_mini.py
-
-  - python -m pytest -v --durations=10 python/ray/tests/test_basic.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_array.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_actor.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_autoscaler.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_tensorflow.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_failure.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_microbenchmarks.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_stress.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_component_failures.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_multi_node.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_multi_node_2.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_recursion.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_monitors.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_cython.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_credis.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_node_manager.py
-  - python -m pytest -v --durations=10 python/ray/tests/test_signal.py
-  # TODO(yuhguo): object_manager_test.py requires a lot of CPU/memory, and
-  # better be put in Jenkins. However, it fails frequently in Jenkins, but
-  # works well in Travis. We should consider moving it back to Jenkins once
-  # we figure out the reason.
-  - python -m pytest -v --durations=10 python/ray/tests/test_object_manager.py
-
-  # ray temp file tests
-  - python -m pytest -v --durations=10 python/ray/tests/test_tempfile.py
-
-  # ray debug tools tests
-  - python -m pytest -v --durations=10 python/ray/tests/test_debug_tools.py
-
-  # modin test files
-  - python -m pytest -v --durations=10 python/ray/tests/test_modin.py
+  - python -m pytest -v --durations=30 python/ray/tests
 deploy:
   - provider: s3
     access_key_id: AKIAJ2L7XDUSZVTXI5QA

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import copy
 import logging
-import time
 
 from ray.function_manager import FunctionDescriptor
 import ray.signature

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -61,7 +61,7 @@ class RemoteFunction(object):
         worker = ray.worker.get_global_worker()
         worker.function_actor_manager.export(self)
         # In which session this function was exported last time.
-        self._last_export_session = worker._session_index:
+        self._last_export_session = worker._session_index
 
     def __call__(self, *args, **kwargs):
         raise Exception("Remote functions cannot be called directly. Instead "

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -13,6 +13,11 @@ import warnings
 import ray
 from ray.tests.cluster_utils import Cluster
 
+# TODO(yuhguo): This test file requires a lot of CPU/memory, and
+# better be put in Jenkins. However, it fails frequently in Jenkins, but
+# works well in Travis. We should consider moving it back to Jenkins once
+# we figure out the reason.
+
 if (multiprocessing.cpu_count() < 40
         or ray.utils.get_system_memory() < 50 * 10**9):
     warnings.warn("This test must be run on large machines.")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -161,6 +161,8 @@ class Worker(object):
         # This event is checked regularly by all of the threads so that they
         # know when to exit.
         self.threads_stopped = threading.Event()
+        # Time of this worker's last shutdown.
+        self._last_shutdown_time = 0
 
     @property
     def task_context(self):
@@ -2061,6 +2063,7 @@ def disconnect():
         if hasattr(worker, "logger_thread"):
             worker.logger_thread.join()
         worker.threads_stopped.clear()
+        worker._last_shutdown_time = time.time()
 
     worker.connected = False
     worker.cached_functions_to_run = []

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -161,8 +161,9 @@ class Worker(object):
         # This event is checked regularly by all of the threads so that they
         # know when to exit.
         self.threads_stopped = threading.Event()
-        # Time of this worker's last shutdown.
-        self._last_shutdown_time = 0
+        # Index of the current session. This number will
+        # increment every time when `ray.shutdown` is called.
+        self._session_index = 0
 
     @property
     def task_context(self):
@@ -2063,7 +2064,7 @@ def disconnect():
         if hasattr(worker, "logger_thread"):
             worker.logger_thread.join()
         worker.threads_stopped.clear()
-        worker._last_shutdown_time = time.time()
+        worker._session_index += 1
 
     worker.connected = False
     worker.cached_functions_to_run = []


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Use the test directory as the parameter of pytest, instead of listing test files one by one. So we don't need to modify here when we add or remove test files. Also, it'd be easier to find the globally slowest test cases.

Also fixes #4192.

## Related issue number

Closes #4192.