### PR TITLE
[tune] Reduce the times for flushing json object to file

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -159,10 +159,10 @@ class _JsonLogger(Logger):
     def on_result(self, result):
         json.dump(result, self, cls=_SafeFallbackEncoder)
         self.write("\n")
+        self.local_out.flush()
 
     def write(self, b):
         self.local_out.write(b)
-        self.local_out.flush()
 
     def flush(self):
         self.local_out.flush()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When we write one result using JsonLogger, it will call 'flush' many times, which may cost a lot of time when writing  to a remote distributed filesystem.

## Related issue number
#4197 
<!-- Are there any issues opened that will be resolved by merging this change? -->
