### PR TITLE
Make sure Bazel generated files get overwritten

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,8 +122,9 @@ else
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
   bazel build //:ray_pkg -c opt
-  # Copy files and skip existing files
-  cp -r -n $ROOT_DIR/bazel-genfiles/ray_pkg/ray $ROOT_DIR/python || true
+  # Copy files and do not overwrite ownership
+  find $ROOT_DIR/bazel-genfiles/ray_pkg/ -exec chmod +w {} \;
+  cp -r $ROOT_DIR/bazel-genfiles/ray_pkg/ray $ROOT_DIR/python || true
 fi
 
 popd

--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,11 @@ else
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
   bazel build //:ray_pkg -c opt
-  # Copy files and keep them writeable.
+  # Copy files and keep them writeable. This is a workaround, as Bazel
+  # marks all generated files non-writeable. If we would just copy them
+  # over without adding write permission, the copy would fail the next time.
+  # TODO(pcm): It would be great to have a solution here that does not
+  # require us to copy the files.
   find $ROOT_DIR/bazel-genfiles/ray_pkg/ -exec chmod +w {} \;
   cp -r $ROOT_DIR/bazel-genfiles/ray_pkg/ray $ROOT_DIR/python || true
 fi

--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,7 @@ else
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
   bazel build //:ray_pkg -c opt
-  # Copy files and do not overwrite ownership
+  # Copy files and keep them writeable.
   find $ROOT_DIR/bazel-genfiles/ray_pkg/ -exec chmod +w {} \;
   cp -r $ROOT_DIR/bazel-genfiles/ray_pkg/ray $ROOT_DIR/python || true
 fi


### PR DESCRIPTION
The files generated by Bazel in `bazel-genfiles/` are not writeable, so after they are copied into `$ROOT_DIR/python` they will stay non-writeable and then the next time we try to copy them, they won't be copied. So we make them writeable here. This is a hack but better than not updating files.

The files need to be copied because Bazel doesn't allow us to produce build products outside of `bazel-genfiles/`, therefore it has to be with a followup copy command (with cmake we used an install directive to do this).

@ericl Any ideas to do this better?

cc @stephanie-wang 