### PR TITLE
[tune] Fix trial result fetching

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -219,12 +219,11 @@ class RayTrialExecutor(TrialExecutor):
     def get_next_available_trial(self):
         shuffled_results = random.sample(
             self._running.keys(), len(self._running))
-        # Note: We shuffle the results and add timeout because `ray.wait` by
-        # default returns the first available result, and we want to guarantee
-        # that slower trials (i.e. trials that run remotely) also get fairly
-        # reported. See https://github.com/ray-project/ray/issues/4211 for
-        # details.
-        [result_id], _ = ray.wait(shuffled_results, timeout=0.1)
+        # Note: We shuffle the results because `ray.wait` by default returns
+        # the first available result, and we want to guarantee that slower
+        # trials (i.e. trials that run remotely) also get fairly reported.
+        # See https://github.com/ray-project/ray/issues/4211 for details.
+        [result_id], _ = ray.wait(shuffled_results)
         return self._running[result_id]
 
     def fetch_result(self, trial):

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -217,8 +217,8 @@ class RayTrialExecutor(TrialExecutor):
         return list(self._running.values())
 
     def get_next_available_trial(self):
-        shuffled_results = random.sample(
-            self._running.keys(), len(self._running))
+        shuffled_results = list(self._running.keys())
+        random.shuffle(shuffled_results)
         # Note: We shuffle the results because `ray.wait` by default returns
         # the first available result, and we want to guarantee that slower
         # trials (i.e. trials that run remotely) also get fairly reported.

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -219,6 +219,11 @@ class RayTrialExecutor(TrialExecutor):
     def get_next_available_trial(self):
         shuffled_results = random.sample(
             self._running.keys(), len(self._running))
+        # Note: We shuffle the results and add timeout because `ray.wait` by
+        # default returns the first available result, and we want to guarantee
+        # that slower trials (i.e. trials that run remotely) also get fairly
+        # reported. See https://github.com/ray-project/ray/issues/4211 for
+        # details.
         [result_id], _ = ray.wait(shuffled_results, timeout=0.1)
         return self._running[result_id]
 

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import logging
 import os
+import random
 import time
 import traceback
 
@@ -216,7 +217,9 @@ class RayTrialExecutor(TrialExecutor):
         return list(self._running.values())
 
     def get_next_available_trial(self):
-        [result_id], _ = ray.wait(list(self._running))
+        shuffled_results = random.sample(
+            self._running.keys(), len(self._running))
+        [result_id], _ = ray.wait(shuffled_results, timeout=0.1)
         return self._running[result_id]
 
     def fetch_result(self, trial):


### PR DESCRIPTION
## What do these changes do?
Fixes trial result fetching in `RayTrialExecutor` by shuffling the results fetch objects.

## Related issue number
#4211 