### PR TITLE
[rllib] TF model custom_loss() should actually allow access to full rollout data

### DIFF
--- a/doc/source/rllib-models.rst
+++ b/doc/source/rllib-models.rst
@@ -103,7 +103,6 @@ Custom TF models should subclass the common RLlib `model class <https://github.c
             Arguments:
                 policy_loss (Tensor): scalar policy loss from the policy graph.
                 loss_inputs (dict): map of input placeholders for rollout data.
-                policy_graph (TFPolicyGraph): policy graph holding this model.
 
             Returns:
                 Scalar tensor for the customized loss for this model.

--- a/doc/source/rllib-models.rst
+++ b/doc/source/rllib-models.rst
@@ -90,7 +90,7 @@ Custom TF models should subclass the common RLlib `model class <https://github.c
             return tf.reshape(
                 linear(self.last_layer, 1, "value", normc_initializer(1.0)), [-1])
 
-        def custom_loss(self, policy_loss, loss_inputs, policy_graph):
+        def custom_loss(self, policy_loss, loss_inputs):
             """Override to customize the loss function used to optimize this model.
 
             This can be used to incorporate self-supervised losses (by defining

--- a/doc/source/rllib-models.rst
+++ b/doc/source/rllib-models.rst
@@ -90,7 +90,7 @@ Custom TF models should subclass the common RLlib `model class <https://github.c
             return tf.reshape(
                 linear(self.last_layer, 1, "value", normc_initializer(1.0)), [-1])
 
-        def custom_loss(self, policy_loss):
+        def custom_loss(self, policy_loss, loss_inputs, policy_graph):
             """Override to customize the loss function used to optimize this model.
 
             This can be used to incorporate self-supervised losses (by defining
@@ -102,6 +102,8 @@ Custom TF models should subclass the common RLlib `model class <https://github.c
 
             Arguments:
                 policy_loss (Tensor): scalar policy loss from the policy graph.
+                loss_inputs (dict): map of input placeholders for rollout data.
+                policy_graph (TFPolicyGraph): policy graph holding this model.
 
             Returns:
                 Scalar tensor for the customized loss for this model.

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -372,12 +372,12 @@ class DDPGPolicyGraph(TFPolicyGraph):
 
         # Model self-supervised losses
         self.loss.actor_loss = self.p_model.custom_loss(
-            self.loss.actor_loss, input_dict, self)
+            self.loss.actor_loss, input_dict)
         self.loss.critic_loss = self.q_model.custom_loss(
-            self.loss.critic_loss, input_dict, self)
+            self.loss.critic_loss, input_dict)
         if self.config["twin_q"]:
             self.loss.critic_loss = self.twin_q_model.custom_loss(
-                self.loss.critic_loss, input_dict, self)
+                self.loss.critic_loss, input_dict)
 
         TFPolicyGraph.__init__(
             self,

--- a/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy_graph.py
@@ -359,6 +359,7 @@ class DDPGPolicyGraph(TFPolicyGraph):
                                   (1.0 - self.tau) * var_target))
         self.update_target_expr = tf.group(*update_target_expr)
 
+        self.sess = tf.get_default_session()
         self.loss_inputs = [
             ("obs", self.obs_t),
             ("actions", self.act_t),
@@ -378,7 +379,6 @@ class DDPGPolicyGraph(TFPolicyGraph):
             self.loss.critic_loss = self.twin_q_model.custom_loss(
                 self.loss.critic_loss, input_dict, self)
 
-        self.sess = tf.get_default_session()
         TFPolicyGraph.__init__(
             self,
             observation_space,

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -120,11 +120,8 @@ class TFPolicyGraph(PolicyGraph):
         self._max_seq_len = max_seq_len
         self._batch_divisibility_req = batch_divisibility_req
 
-        # Call custom_loss() as late as possible so that it can access the
-        # above attrs of `self` if needed.
         if self.model:
-            self._loss = self.model.custom_loss(loss, self._loss_input_dict,
-                                                self)
+            self._loss = self.model.custom_loss(loss, self._loss_input_dict)
             self._stats_fetches = {"model": self.model.custom_stats()}
         else:
             self._loss = loss

--- a/python/ray/rllib/examples/custom_loss.py
+++ b/python/ray/rllib/examples/custom_loss.py
@@ -43,7 +43,7 @@ class CustomLossModel(Model):
                                            num_outputs, options)
         return self.fcnet.outputs, self.fcnet.last_layer
 
-    def custom_loss(self, policy_loss):
+    def custom_loss(self, policy_loss, loss_inputs, policy_graph):
         # create a new input reader per worker
         reader = JsonReader(self.options["custom_options"]["input_files"])
         input_ops = reader.tf_input_ops()
@@ -59,7 +59,11 @@ class CustomLossModel(Model):
         # You can also add self-supervised losses easily by referencing tensors
         # created during _build_layers_v2(). For example, an autoencoder-style
         # loss can be added as follows:
-        # ae_loss = squared_diff(self.obs_in, Decoder(self.fcnet.last_layer))
+        # ae_loss = squared_diff(
+        #     loss_inputs["obs"], Decoder(self.fcnet.last_layer))
+        print(
+            "FYI: You can also use these tensors: {}, ".format(loss_inputs) +
+            "or other attributes of the policy graph {}.".format(policy_graph))
 
         # compute the IL loss
         action_dist = Categorical(logits)

--- a/python/ray/rllib/examples/custom_loss.py
+++ b/python/ray/rllib/examples/custom_loss.py
@@ -43,7 +43,7 @@ class CustomLossModel(Model):
                                            num_outputs, options)
         return self.fcnet.outputs, self.fcnet.last_layer
 
-    def custom_loss(self, policy_loss, loss_inputs, policy_graph):
+    def custom_loss(self, policy_loss, loss_inputs):
         # create a new input reader per worker
         reader = JsonReader(self.options["custom_options"]["input_files"])
         input_ops = reader.tf_input_ops()
@@ -61,9 +61,7 @@ class CustomLossModel(Model):
         # loss can be added as follows:
         # ae_loss = squared_diff(
         #     loss_inputs["obs"], Decoder(self.fcnet.last_layer))
-        print(
-            "FYI: You can also use these tensors: {}, ".format(loss_inputs) +
-            "or other attributes of the policy graph {}.".format(policy_graph))
+        print("FYI: You can also use these tensors: {}, ".format(loss_inputs))
 
         # compute the IL loss
         action_dist = Categorical(logits)

--- a/python/ray/rllib/models/model.py
+++ b/python/ray/rllib/models/model.py
@@ -146,7 +146,7 @@ class Model(object):
             linear(self.last_layer, 1, "value", normc_initializer(1.0)), [-1])
 
     @PublicAPI
-    def custom_loss(self, policy_loss):
+    def custom_loss(self, policy_loss, loss_inputs, policy_graph):
         """Override to customize the loss function used to optimize this model.
 
         This can be used to incorporate self-supervised losses (by defining
@@ -158,6 +158,8 @@ class Model(object):
 
         Arguments:
             policy_loss (Tensor): scalar policy loss from the policy graph.
+            loss_inputs (dict): map of input placeholders for rollout data.
+            policy_graph (TFPolicyGraph): policy graph holding this model.
 
         Returns:
             Scalar tensor for the customized loss for this model.

--- a/python/ray/rllib/models/model.py
+++ b/python/ray/rllib/models/model.py
@@ -146,7 +146,7 @@ class Model(object):
             linear(self.last_layer, 1, "value", normc_initializer(1.0)), [-1])
 
     @PublicAPI
-    def custom_loss(self, policy_loss, loss_inputs, policy_graph):
+    def custom_loss(self, policy_loss, loss_inputs):
         """Override to customize the loss function used to optimize this model.
 
         This can be used to incorporate self-supervised losses (by defining
@@ -159,7 +159,6 @@ class Model(object):
         Arguments:
             policy_loss (Tensor): scalar policy loss from the policy graph.
             loss_inputs (dict): map of input placeholders for rollout data.
-            policy_graph (TFPolicyGraph): policy graph holding this model.
 
         Returns:
             Scalar tensor for the customized loss for this model.

--- a/python/ray/rllib/offline/input_reader.py
+++ b/python/ray/rllib/offline/input_reader.py
@@ -42,7 +42,7 @@ class InputReader(object):
 
         Example:
             >>> class MyModel(rllib.model.Model):
-            ...     def custom_loss(self, policy_loss, loss_inputs):
+            ...     def custom_loss(self, policy_loss, loss_inputs, pol_graph):
             ...         reader = JsonReader(...)
             ...         input_ops = reader.tf_input_ops()
             ...         with tf.variable_scope(

--- a/python/ray/rllib/offline/input_reader.py
+++ b/python/ray/rllib/offline/input_reader.py
@@ -42,7 +42,7 @@ class InputReader(object):
 
         Example:
             >>> class MyModel(rllib.model.Model):
-            ...     def custom_loss(self, policy_loss):
+            ...     def custom_loss(self, policy_loss, loss_inputs):
             ...         reader = JsonReader(...)
             ...         input_ops = reader.tf_input_ops()
             ...         with tf.variable_scope(

--- a/python/ray/rllib/offline/input_reader.py
+++ b/python/ray/rllib/offline/input_reader.py
@@ -42,7 +42,7 @@ class InputReader(object):
 
         Example:
             >>> class MyModel(rllib.model.Model):
-            ...     def custom_loss(self, policy_loss, loss_inputs, pol_graph):
+            ...     def custom_loss(self, policy_loss, loss_inputs):
             ...         reader = JsonReader(...)
             ...         input_ops = reader.tf_input_ops()
             ...         with tf.variable_scope(


### PR DESCRIPTION


## What do these changes do?

The docs say you can access the batch data, but this is actually not the case in TF models. Fix this by passing in loss_inputs and the policy graph instance.