### PR TITLE
Add type check in free and change Exception to TypeError

### DIFF
--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -35,6 +35,12 @@ def free(object_ids, local_only=False):
         raise TypeError("free() expects a list of ObjectID, got {}".format(
             type(object_ids)))
 
+    # Make sure that the values are object IDs.
+    for object_id in object_ids:
+        if not isinstance(object_id, ray.ObjectID):
+            raise TypeError("Attempting to call `free` on the value {}, "
+                            "which is not an ray.ObjectID.".format(object_id))
+
     worker.check_connected()
     with profiling.profile("ray.free"):
         if len(object_ids) == 0:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -347,7 +347,7 @@ class Worker(object):
         """
         # Make sure that the value is not an object ID.
         if isinstance(value, ObjectID):
-            raise Exception(
+            raise TypeError(
                 "Calling 'put' on an ray.ObjectID is not allowed "
                 "(similarly, returning an ray.ObjectID from a remote "
                 "function is not allowed). If you really want to "
@@ -470,7 +470,7 @@ class Worker(object):
         # Make sure that the values are object IDs.
         for object_id in object_ids:
             if not isinstance(object_id, ObjectID):
-                raise Exception(
+                raise TypeError(
                     "Attempting to call `get` on the value {}, "
                     "which is not an ray.ObjectID.".format(object_id))
         # Do an initial fetch for remote objects. We divide the fetch into
@@ -1800,7 +1800,7 @@ def connect(info,
             driver_id = DriverID(_random_string())
 
         if not isinstance(driver_id, DriverID):
-            raise Exception("The type of given driver id must be DriverID.")
+            raise TypeError("The type of given driver id must be DriverID.")
 
         worker.worker_id = driver_id.binary()
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
We found strange worker error without call stack.
```
TypeError: Cannot convert ray._raylet.TaskID to ray._raylet.ObjectID
Exception ignored in: 'ray._raylet.ObjectIDsToVector'
```
Finally, it is found that there is no type check in `ray.internal.free`. We add the similar type check like `ray.get` and `ray.wait`.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
