### PR TITLE
[autoscaler] Timeout ssh master connection after 5 minutes

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -31,7 +31,7 @@ def get_default_ssh_options(private_key, connect_timeout):
         ("StrictHostKeyChecking", "no"),
         ("ControlMaster", "auto"),
         ("ControlPath", "{}/%C".format(SSH_CONTROL_PATH)),
-        ("ControlPersist", "yes"),
+        ("ControlPersist", "5m"),
     ]
 
     return ["-i", private_key] + [


### PR DESCRIPTION
The master connection can become broken after your laptop is resumed from suspend. When this happens, further connections hang indefinitely until you 'killall ssh'. Add a timeout to make this less likely to happen, without sacrificing most of the perf advantages of persistent connections.