### PR TITLE
[tune] Fix _SafeFallbackEncoder type checks

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -256,7 +256,7 @@ class _SafeFallbackEncoder(json.JSONEncoder):
     def default(self, value):
         try:
             if np.isnan(value):
-                return None
+                return self.nan_str
 
             if (type(value).__module__ == np.__name__
                     and isinstance(value, np.ndarray)):

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -5,11 +5,12 @@ from __future__ import print_function
 import csv
 import json
 import logging
-import numpy as np
 import os
 import yaml
 import distutils.version
 import numbers
+
+import numpy as np
 
 import ray.cloudpickle as cloudpickle
 from ray.tune.log_sync import get_syncer
@@ -258,7 +259,7 @@ class _SafeFallbackEncoder(json.JSONEncoder):
                 return None
 
             if (type(value).__module__ == np.__name__
-                and isinstance(value, np.ndarray)):
+                    and isinstance(value, np.ndarray)):
                 return value.tolist()
 
             if issubclass(type(value), numbers.Integral):


### PR DESCRIPTION
## What do these changes do?
Currently, the type checks in logger.py result in a bunch of warnings like this:
```
/home/kristian/github/hartikainen/ray/python/ray/tune/logger.py:1: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
```

This fixes those type checks.

## Related issue number
n/a