### PR TITLE
Run core stress tests within default aws limits

### DIFF
--- a/ci/stress_tests/stress_testing_config.yaml
+++ b/ci/stress_tests/stress_testing_config.yaml
@@ -7,11 +7,11 @@ cluster_name: stress-testing
 
 # The minimum number of workers nodes to launch in addition to the head
 # node. This number should be >= 0.
-min_workers: 105
+min_workers: 100
 
 # The maximum number of workers nodes to launch in addition to the head
 # node. This takes precedence over min_workers.
-max_workers: 105
+max_workers: 100
 
 # The autoscaler will scale up the cluster to this target fraction of resource
 # usage. For example, if a cluster of 10 nodes is 100% busy and

--- a/ci/stress_tests/test_many_tasks_and_transfers.py
+++ b/ci/stress_tests/test_many_tasks_and_transfers.py
@@ -18,7 +18,7 @@ ray.init(redis_address="localhost:6379")
 # These numbers need to correspond with the autoscaler config file.
 # The number of remote nodes in the autoscaler should upper bound
 # these because sometimes nodes fail to update.
-num_remote_nodes = 100
+num_remote_nodes = 95
 head_node_cpus = 2
 num_remote_cpus = num_remote_nodes * head_node_cpus
 


### PR DESCRIPTION
In https://github.com/ray-project/ray/pull/3789, we adapted the stress tests to be more robust if less than 100 nodes joined the cluster (@richardliaw was seeing 98 or 97 repeatedly), this PR slightly adjusted the fix so the core stress tests can be run on a vanilla AWS account where the limit on m5.x instances is 100. This will make it easier for future release managers to perform the stress testing.