### PR TITLE
Fix ray.wait bug for tasks on remote nodes and timeout=0

### DIFF
--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -204,9 +204,20 @@ ray::Status ObjectDirectory::LookupLocations(const ObjectID &object_id,
                                              const OnLocationsFound &callback) {
   ray::Status status;
   auto it = listeners_.find(object_id);
-  if (it == listeners_.end() || !it->second.has_been_created) {
-    // Look up the object's locations directly from the GCS if we do not have
-    // any locations cached.
+  if (it != listeners_.end() && it->second.has_been_created) {
+    // If we have locations cached due to a concurrent SubscribeObjectLocations
+    // call, and we have received at least one notification from the GCS about
+    // the object's creation, then call the callback immediately with the
+    // cached locations.
+    auto &locations = it->second.current_object_locations;
+    bool has_been_created = it->second.has_been_created;
+    io_service_.post([callback, object_id, locations, has_been_created]() {
+      callback(object_id, locations, has_been_created);
+    });
+  } else {
+    // We do not have any locations cached due to a concurrent
+    // SubscribeObjectLocations call, so look up the object's locations
+    // directly from the GCS.
     status = gcs_client_->object_table().Lookup(
         JobID::nil(), object_id,
         [this, callback](gcs::AsyncGcsClient *client, const ObjectID &object_id,
@@ -220,14 +231,6 @@ ray::Status ObjectDirectory::LookupLocations(const ObjectID &object_id,
           // in the GCS client's lookup callback stack.
           callback(object_id, client_ids, has_been_created);
         });
-  } else {
-    // If we have locations cached due to a concurrent SubscribeObjectLocations
-    // call, call the callback immediately with the cached locations.
-    auto &locations = it->second.current_object_locations;
-    bool has_been_created = it->second.has_been_created;
-    io_service_.post([callback, object_id, locations, has_been_created]() {
-      callback(object_id, locations, has_been_created);
-    });
   }
   return status;
 }

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -204,7 +204,9 @@ ray::Status ObjectDirectory::LookupLocations(const ObjectID &object_id,
                                              const OnLocationsFound &callback) {
   ray::Status status;
   auto it = listeners_.find(object_id);
-  if (it == listeners_.end()) {
+  if (it == listeners_.end() || !it->second.has_been_created) {
+    // Look up the object's locations directly from the GCS if we do not have
+    // any locations cached.
     status = gcs_client_->object_table().Lookup(
         JobID::nil(), object_id,
         [this, callback](gcs::AsyncGcsClient *client, const ObjectID &object_id,


### PR DESCRIPTION
## What do these changes do?

As an optimization when looking up objects from the object table, we use cached results if we can instead of going to the GCS directly. However, the cached results are always initialized as empty, and we only update them when we receive a notification. This caused a bug in `ray.wait` when called on remote objects with a timeout=0:
1. Client calls `ray.wait`
2. Object manager tries to `Pull` the object from a remote node. This makes an *async* call to subscribe to the object's locations in the GCS and initializes the request results as empty.
3. In the same invocation, we call `ObjectManager::Wait`, which tries to lookup the object's locations. The empty cached result gets returned to the lookup.
4. We return "no objects ready" to the client, since timeout=0.

This PR fixes the bug so that we only use the cached result in step 3 if we've received at least one notification after the `Subscribe` call.

## Related issue number

Probably fixes #4211.
