### PR TITLE
Fix RemoteFunction._last_export_session

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -59,9 +59,9 @@ class RemoteFunction(object):
 
         # Export the function.
         worker = ray.worker.get_global_worker()
-        worker.function_actor_manager.export(self)
         # In which session this function was exported last time.
         self._last_export_session = worker._session_index
+        worker.function_actor_manager.export(self)
 
     def __call__(self, *args, **kwargs):
         raise Exception("Remote functions cannot be called directly. Instead "


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This bug was introduced by #4195.

We should set the attribute before exporting this function, otherwise this function won't have this attribute on remote nodes.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
