### PR TITLE
[tune] Fix testTrialNoSave

### DIFF
--- a/python/ray/tune/tests/test_trial_runner.py
+++ b/python/ray/tune/tests/test_trial_runner.py
@@ -1970,7 +1970,7 @@ class TrialRunnerTest(unittest.TestCase):
         self.assertTrue(
             runner2.get_trial("checkpoint").status == Trial.TERMINATED)
         self.assertTrue(runner2.get_trial("pending").status == Trial.PENDING)
-        self.assertTrue(runner2.get_trial("pending").last_result is None)
+        self.assertTrue(not runner2.get_trial("pending").last_result)
         runner2.step()
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
Left a `last_result == None` after changing last_result to always be a
dict.


<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

Fixes https://github.com/ray-project/ray/issues/4259.