### PR TITLE
[build] Add debug info to Bazel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ else
   $PYTHON_EXECUTABLE -m pip install \
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
-  bazel build //:ray_pkg -c opt --sandbox_debug --verbose_failures
+  bazel build //:ray_pkg -c opt --verbose_failures
   # Copy files and keep them writeable. This is a workaround, as Bazel
   # marks all generated files non-writeable. If we would just copy them
   # over without adding write permission, the copy would fail the next time.

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ else
   $PYTHON_EXECUTABLE -m pip install \
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
-  bazel build //:ray_pkg -c opt
+  bazel build //:ray_pkg -c opt --sandbox_debug --verbose_failures
   # Copy files and keep them writeable. This is a workaround, as Bazel
   # marks all generated files non-writeable. If we would just copy them
   # over without adding write permission, the copy would fail the next time.


### PR DESCRIPTION
This doesn't make normal runs more verbose, but adds more debug info in case something goes wrong. Suggested by @zbarry.