### PR TITLE
Build wheels for macOS with Bazel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ matrix:
     # Build MacOS wheels.
     - os: osx
       osx_image: xcode7
-      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore RAY_USE_CMAKE=1
+      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore
       install:
         - ./ci/travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,8 @@ matrix:
       osx_image: xcode7
       env: MAC_WHEELS=1 PYTHONWARNINGS=ignore
       install:
-        - ./ci/travis/install-dependencies.sh
+        - ./ci/suppress_output ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
         - ./python/build-wheel-macos.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,6 @@ matrix:
       osx_image: xcode7
       env: MAC_WHEELS=1 PYTHONWARNINGS=ignore
       install:
-        - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         # This command should be kept in sync with ray/python/README-building-wheels.md.
         - ./python/build-wheel-macos.sh

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -56,7 +56,7 @@ if [[ "$platform" == "linux" ]]; then
 
   # Check that the other wheels are present.
   NUMBER_OF_WHEELS=$(ls -1q $ROOT_DIR/../../.whl/*.whl | wc -l)
-  if [[ "$NUMBER_OF_WHEELS" != "5" ]]; then
+  if [[ "$NUMBER_OF_WHEELS" != "4" ]]; then
     echo "Wrong number of wheels found."
     ls -l $ROOT_DIR/../.whl/
     exit 2
@@ -65,13 +65,11 @@ if [[ "$platform" == "linux" ]]; then
 elif [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
   PY_MMS=("2.7"
-          "3.4"
           "3.5"
           "3.6"
           "3.7")
   # This array is just used to find the right wheel.
   PY_WHEEL_VERSIONS=("27"
-                     "34"
                      "35"
                      "36"
                      "37")

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -29,7 +29,6 @@ Here are links to the latest wheels (which are built off of master). To install 
 `Linux Python 3.7`_  `MacOS Python 3.7`_
 `Linux Python 3.6`_  `MacOS Python 3.6`_
 `Linux Python 3.5`_  `MacOS Python 3.5`_
-`Linux Python 3.4`_  `MacOS Python 3.4`_
 `Linux Python 2.7`_  `MacOS Python 2.7`_
 ===================  ===================
 
@@ -37,12 +36,10 @@ Here are links to the latest wheels (which are built off of master). To install 
 .. _`Linux Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp37-cp37m-manylinux1_x86_64.whl
 .. _`Linux Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp36-cp36m-manylinux1_x86_64.whl
 .. _`Linux Python 3.5`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp35-cp35m-manylinux1_x86_64.whl
-.. _`Linux Python 3.4`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp34-cp34m-manylinux1_x86_64.whl
 .. _`Linux Python 2.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp27-cp27mu-manylinux1_x86_64.whl
 .. _`MacOS Python 3.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp37-cp37m-macosx_10_6_intel.whl
 .. _`MacOS Python 3.6`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp36-cp36m-macosx_10_6_intel.whl
 .. _`MacOS Python 3.5`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp35-cp35m-macosx_10_6_intel.whl
-.. _`MacOS Python 3.4`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp34-cp34m-macosx_10_6_intel.whl
 .. _`MacOS Python 2.7`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev1-cp27-cp27m-macosx_10_6_intel.whl
 
 

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -33,6 +33,8 @@ NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
                 "1.14.5")
 
+./ci/travis/install-bazel.sh
+
 mkdir -p $DOWNLOAD_DIR
 mkdir -p .whl
 

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -26,8 +26,8 @@ PY_MMS=("2.7"
         "3.6"
         "3.7")
 
-# The numpy version the arrow wheels are built against
-# https://github.com/apache/arrow/blob/4cfd6d3877e28624e271e022f7c98a8b1e3c5a5a/python/requirements-wheel.txt
+# The minimum supported numpy version is 1.14, see
+# https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
                 "1.14.5"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -25,10 +25,12 @@ PY_MMS=("2.7"
         "3.5"
         "3.6"
         "3.7")
-# On python 3.7, a newer version of numpy seems to be necessary.
-NUMPY_VERSIONS=("1.10.4"
-                "1.10.4"
-                "1.10.4"
+
+# The numpy version the arrow wheels are built against
+# https://github.com/apache/arrow/blob/4cfd6d3877e28624e271e022f7c98a8b1e3c5a5a/python/requirements-wheel.txt
+NUMPY_VERSIONS=("1.14.5"
+                "1.14.5"
+                "1.14.5"
                 "1.14.5")
 
 mkdir -p $DOWNLOAD_DIR

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -14,23 +14,19 @@ MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 DOWNLOAD_DIR=python_downloads
 
 PY_VERSIONS=("2.7.13"
-             "3.4.4"
              "3.5.3"
              "3.6.1"
              "3.7.0")
 PY_INSTS=("python-2.7.13-macosx10.6.pkg"
-          "python-3.4.4-macosx10.6.pkg"
           "python-3.5.3-macosx10.6.pkg"
           "python-3.6.1-macosx10.6.pkg"
           "python-3.7.0-macosx10.6.pkg")
 PY_MMS=("2.7"
-        "3.4"
         "3.5"
         "3.6"
         "3.7")
 # On python 3.7, a newer version of numpy seems to be necessary.
 NUMPY_VERSIONS=("1.10.4"
-                "1.10.4"
                 "1.10.4"
                 "1.10.4"
                 "1.14.5")

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -28,9 +28,9 @@ PY_MMS=("2.7"
 
 # The numpy version the arrow wheels are built against
 # https://github.com/apache/arrow/blob/4cfd6d3877e28624e271e022f7c98a8b1e3c5a5a/python/requirements-wheel.txt
-NUMPY_VERSIONS=("1.14.5"
-                "1.14.5"
-                "1.14.5"
+NUMPY_VERSIONS=("1.12.1"
+                "1.12.1"
+                "1.12.1"
                 "1.14.5")
 
 mkdir -p $DOWNLOAD_DIR

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -28,9 +28,9 @@ PY_MMS=("2.7"
 
 # The numpy version the arrow wheels are built against
 # https://github.com/apache/arrow/blob/4cfd6d3877e28624e271e022f7c98a8b1e3c5a5a/python/requirements-wheel.txt
-NUMPY_VERSIONS=("1.12.1"
-                "1.12.1"
-                "1.12.1"
+NUMPY_VERSIONS=("1.14.5"
+                "1.14.5"
+                "1.14.5"
                 "1.14.5")
 
 mkdir -p $DOWNLOAD_DIR

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -15,10 +15,10 @@ PYTHONS=("cp27-cp27mu"
          "cp37-cp37m")
 
 # On python 3.7, a newer version of numpy seems to be necessary.
-NUMPY_VERSIONS=("1.10.4"
-                "1.10.4"
-                "1.10.4"
-                "1.10.4"
+NUMPY_VERSIONS=("1.14.5"
+                "1.14.5"
+                "1.14.5"
+                "1.14.5"
                 "1.14.5")
 
 # Remove this old Python 2.4.3 executable, and make the "python2" command find

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -14,7 +14,8 @@ PYTHONS=("cp27-cp27mu"
          "cp36-cp36m"
          "cp37-cp37m")
 
-# On python 3.7, a newer version of numpy seems to be necessary.
+# The minimum supported numpy version is 1.14, see
+# https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
                 "1.14.5"
                 "1.14.5"

--- a/python/setup.py
+++ b/python/setup.py
@@ -137,7 +137,7 @@ def find_version(*filepath):
 
 
 requires = [
-    "numpy >= 1.10.4",
+    "numpy >= 1.14.5",
     "filelock",
     "funcsigs",
     "click",

--- a/python/setup.py
+++ b/python/setup.py
@@ -137,7 +137,7 @@ def find_version(*filepath):
 
 
 requires = [
-    "numpy >= 1.14.5",
+    "numpy >= 1.14",
     "filelock",
     "funcsigs",
     "click",


### PR DESCRIPTION
Due to https://issues.apache.org/jira/browse/ARROW-3141, we had to increase the minimum supported numpy version to 1.14.

#4272