### PR TITLE
Fix message type to string crash

### DIFF
--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -24,7 +24,8 @@ const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_p
     enum_names.push_back(name);
     i++;
   }
-  RAY_CHECK(end_index == enum_names.size() - 1) << "Message Type mismatch!";
+  RAY_CHECK(static_cast<size_t>(end_index) == enum_names.size() - 1)
+      << "Message Type mismatch!";
   return enum_names;
 }
 
@@ -32,10 +33,10 @@ static const std::vector<std::string> node_manager_message_enum =
     GenerateEnumNames(ray::protocol::EnumNamesMessageType(),
                       static_cast<int>(ray::protocol::MessageType::MIN),
                       static_cast<int>(ray::protocol::MessageType::MAX));
-static const std::vector<std::string> object_manager_message_enum = GenerateEnumNames(
-    ray::object_manager::protocol::EnumNamesMessageType(),
-    static_cast<int>(ray::object_manager::protocol::MessageType::MIN),
-    static_cast<int>(ray::object_manager::protocol::MessageType::MAX));
+static const std::vector<std::string> object_manager_message_enum =
+    GenerateEnumNames(ray::object_manager::protocol::EnumNamesMessageType(),
+                      static_cast<int>(ray::object_manager::protocol::MessageType::MIN),
+                      static_cast<int>(ray::object_manager::protocol::MessageType::MAX));
 }
 
 namespace ray {

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -9,8 +9,12 @@
 
 namespace {
 
-const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_ptr) {
+const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_ptr,
+                                                 int start_index, int end_index) {
   std::vector<std::string> enum_names;
+  for (int i = 0; i < start_index; ++i) {
+    enum_names.push_back("EmptyMessageType");
+  }
   size_t i = 0;
   while (true) {
     const char *name = enum_names_ptr[i];
@@ -20,13 +24,18 @@ const std::vector<std::string> GenerateEnumNames(const char *const *enum_names_p
     enum_names.push_back(name);
     i++;
   }
+  RAY_CHECK(end_index == enum_names.size() - 1) << "Message Type mismatch!";
   return enum_names;
 }
 
 static const std::vector<std::string> node_manager_message_enum =
-    GenerateEnumNames(ray::protocol::EnumNamesMessageType());
-static const std::vector<std::string> object_manager_message_enum =
-    GenerateEnumNames(ray::object_manager::protocol::EnumNamesMessageType());
+    GenerateEnumNames(ray::protocol::EnumNamesMessageType(),
+                      static_cast<int>(ray::protocol::MessageType::MIN),
+                      static_cast<int>(ray::protocol::MessageType::MAX));
+static const std::vector<std::string> object_manager_message_enum = GenerateEnumNames(
+    ray::object_manager::protocol::EnumNamesMessageType(),
+    static_cast<int>(ray::object_manager::protocol::MessageType::MIN),
+    static_cast<int>(ray::object_manager::protocol::MessageType::MAX));
 }
 
 namespace ray {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
According to https://github.com/ray-project/ray/blob/master/src/ray/raylet/format/node_manager.fbs#L13 , the message enum has the range of `1~N`, while the `EnumNamesMessageType` has the range of `0~N-1`. If we use the enum number to [get the message](https://github.com/ray-project/ray/blob/master/src/ray/common/client_connection.cc#L319-L321), there will be message mismatch. What is worse, when the message enum is N, and raylet tries to get a message name from an array with `0~N-1` indexes, raylet will crash.

<!-- Please give a short brief about these changes. -->

## Related issue number
PR: https://github.com/ray-project/ray/pull/3819
<!-- Are there any issues opened that will be resolved by merging this change? -->
