### PR TITLE
Fix trying to install binary pyarrow for non-existent architectures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,7 +101,7 @@ fi
 
 pushd "$BUILD_DIR"
 
-if [ ! -z "$RAY_USE_CMAKE" ] ; then
+if [ ! -z "$RAY_USE_CMAKE" ] || [ `uname -m`!="x86_64" ]; then
   # avoid the command failed and exits
   # and cmake will check some directories to determine whether some targets built
   make clean || true


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

They force building pyarrow from source in case of the host is not of x86_64 architecture. This fixes the build for IBM Minsky, which has a PPC64 architecture.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#4309
