### PR TITLE
Set TCP_NODELAY on all TCP connections

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -12,7 +12,7 @@ namespace ray {
 
 ray::Status TcpConnect(boost::asio::ip::tcp::socket &socket,
                        const std::string &ip_address_string, int port) {
-  // Disable Nagle's algorithm. This causes transfer delays of 10s of ms in
+  // Disable Nagle's algorithm, which caused transfer delays of 10s of ms in
   // certain cases.
   socket.open(boost::asio::ip::tcp::v4());
   boost::asio::ip::tcp::no_delay option(true);

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -12,6 +12,12 @@ namespace ray {
 
 ray::Status TcpConnect(boost::asio::ip::tcp::socket &socket,
                        const std::string &ip_address_string, int port) {
+  // Disable Nagle's algorithm. This causes transfer delays of 10s of ms in
+  // certain cases.
+  socket.open(boost::asio::ip::tcp::v4());
+  boost::asio::ip::tcp::no_delay option(true);
+  socket.set_option(option);
+
   boost::asio::ip::address ip_address =
       boost::asio::ip::address::from_string(ip_address_string);
   boost::asio::ip::tcp::endpoint endpoint(ip_address, port);


### PR DESCRIPTION
## What do these changes do?

I found that [Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm) sometimes leads to delays of 10s of ms before a message is delivered. This disables the algorithm with `TCP_NODELAY`.