### PR TITLE
Fix checkpoint crash for actor creation task.

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -783,8 +783,10 @@ class FunctionActorManager(object):
                     method_returns = method(actor, *args)
             except Exception as e:
                 # Save the checkpoint before allowing the method exception
-                # to be thrown.
-                if isinstance(actor, ray.actor.Checkpointable):
+                # to be thrown, but don't save the checkpoint for actor
+                # creation task.
+                if (isinstance(actor, ray.actor.Checkpointable)
+                        and self._worker.actor_task_counter != 1):
                     self._save_and_log_checkpoint(actor)
                 raise e
             else:

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -787,6 +787,6 @@ def test_init_exception_in_checkpointable_actor(short_heartbeat_timeout):
             pass
 
     # This call should not trigger save_checkpoint which would cause crash.
-    actor = CheckpointableActor.remote()
+    CheckpointableActor.remote()
     with pytest.raises(Exception, match=('Timing out of wait.')):
         wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 1, timeout=1.5)

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -48,6 +48,23 @@ def shutdown_only():
     ray.shutdown()
 
 
+@pytest.fixture
+def short_heartbeat_timeout():
+    internal_config = json.dumps({
+        "num_heartbeats_timeout": 40,
+        "heartbeat_timeout_milliseconds": 10,
+    })
+    cluster = ray.tests.cluster_utils.Cluster()
+    remote_node = cluster.add_node(
+        num_cpus=1, _internal_config=internal_config)
+    ray.init(redis_address=cluster.redis_address)
+    yield cluster, remote_node
+
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    cluster.shutdown()
+
+
 def test_failed_task(ray_start_regular):
     @ray.remote
     def throw_exception_fct1():
@@ -727,29 +744,49 @@ def test_raylet_crash_when_get(ray_start_regular):
     thread.join()
 
 
-def test_connect_with_disconnected_node(shutdown_only):
-    config = json.dumps({
-        "num_heartbeats_timeout": 50,
-        "heartbeat_timeout_milliseconds": 10,
-    })
-    cluster = Cluster()
-    cluster.add_node(num_cpus=0, _internal_config=config)
-    ray.init(redis_address=cluster.redis_address)
+def test_connect_with_disconnected_node(short_heartbeat_timeout):
+    cluster, _ = short_heartbeat_timeout
+    cluster.add_node(num_cpus=0)
     info = relevant_errors(ray_constants.REMOVED_NODE_ERROR)
     assert len(info) == 0
     # This node is killed by SIGKILL, ray_monitor will mark it to dead.
-    dead_node = cluster.add_node(num_cpus=0, _internal_config=config)
+    dead_node = cluster.add_node(num_cpus=0)
     cluster.remove_node(dead_node, allow_graceful=False)
     wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 1, timeout=2)
     # This node is killed by SIGKILL, ray_monitor will mark it to dead.
-    dead_node = cluster.add_node(num_cpus=0, _internal_config=config)
+    dead_node = cluster.add_node(num_cpus=0)
     cluster.remove_node(dead_node, allow_graceful=False)
     wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 2, timeout=2)
     # This node is killed by SIGTERM, ray_monitor will not mark it again.
-    removing_node = cluster.add_node(num_cpus=0, _internal_config=config)
+    removing_node = cluster.add_node(num_cpus=0)
     cluster.remove_node(removing_node, allow_graceful=True)
     with pytest.raises(Exception, match=('Timing out of wait.')):
         wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 3, timeout=2)
     # There is no connection error to a dead node.
     info = relevant_errors(ray_constants.RAYLET_CONNECTION_ERROR)
     assert len(info) == 0
+
+
+def test_init_exception_in_checkpointable_actor(short_heartbeat_timeout):
+    @ray.remote(max_reconstructions=1)
+    class CheckpointableActor(ray.actor.Checkpointable):
+        def __init__(self):
+            raise Exception("Exception in __init__.")
+
+        def should_checkpoint(self, checkpoint_context):
+            # Checkpoint the actor when value is increased to 3.
+            return True
+
+        def save_checkpoint(self, actor_id, checkpoint_id):
+            pass
+
+        def load_checkpoint(self, actor_id, available_checkpoints):
+            pass
+
+        def checkpoint_expired(self, actor_id, checkpoint_id):
+            pass
+
+    # This call should not trigger save_checkpoint which would cause crash.
+    actor = CheckpointableActor.remote()
+    with pytest.raises(Exception, match=('Timing out of wait.')):
+        wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 1, timeout=1.5)

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -81,3 +81,16 @@ def run_string_as_driver_nonblocking(driver_script):
         f.flush()
         return subprocess.Popen(
             [sys.executable, f.name], stdout=subprocess.PIPE)
+
+
+def relevant_errors(error_type):
+    return [info for info in ray.error_info() if info["type"] == error_type]
+
+
+def wait_for_errors(error_type, num_errors, timeout=10):
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if len(relevant_errors(error_type)) >= num_errors:
+            return
+        time.sleep(0.1)
+    raise Exception("Timing out of wait.")


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Actor should not try to save checkpoint when the actor creation task raises exception. Since actor creation task fails, raylet does not treat the actor as created. There will be crashes. 
In this PR, this bug is fixed and a test is added to cover this.

<!-- Please give a short brief about these changes. -->

## Related issue number
1. Python exception in `__init__`:
```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File “XXX/python/ray/function_manager.py", line 837, in _save_and_log_checkpoint
    prepare_actor_checkpoint(actor_id))
  File "_raylet.pyx", line 327, in ray._raylet.RayletClient.prepare_actor_checkpoint
  File "_raylet.pyx", line 60, in ray._raylet.check_status
Exception: [RayletClient] Raylet connection closed.
```
2. Corresponding raylet crash:
```
2019-03-11 17:19:16,820 F 58656 58656 node_manager.cc:1313:]  Check failed: actor_entry != actor_registry_.end() 
*** Check failure stack trace: ***
2019-03-11 17:19:16,821 E 58656 58656 logging.cc:130:] *** Aborted at 1552295956 (unix time) try "date -d @1552295956" if you are using GNU date ***
2019-03-11 17:19:16,821 E 58656 58656 logging.cc:130:] PC: @                0x0 (unknown)
2019-03-11 17:19:16,821 E 58656 58656 logging.cc:130:] *** SIGABRT (@0x7090000e520) received by PID 58656 (TID 0x7f86249be000) from PID 58656; stack trace: ***
2019-03-11 17:19:16,822 E 58656 58656 logging.cc:130:]     @     0x7f8623fa1100 (unknown)
2019-03-11 17:19:16,822 E 58656 58656 logging.cc:130:]     @     0x7f8622b37617 __GI_raise
2019-03-11 17:19:16,823 E 58656 58656 logging.cc:130:]     @     0x7f8622b38d08 __GI_abort
2019-03-11 17:19:16,824 E 58656 58656 logging.cc:130:]     @           0x76ecef google::logging_fail()
2019-03-11 17:19:16,825 E 58656 58656 logging.cc:130:]     @           0x76ed18 google::LogMessage::Fail()
2019-03-11 17:19:16,825 E 58656 58656 logging.cc:130:]     @           0x76ec6f google::LogMessage::SendToLog()
2019-03-11 17:19:16,826 E 58656 58656 logging.cc:130:]     @           0x76e5d2 google::LogMessage::Flush()
2019-03-11 17:19:16,826 E 58656 58656 logging.cc:130:]     @           0x76e39f google::LogMessage::~LogMessage()
2019-03-11 17:19:16,827 E 58656 58656 logging.cc:130:]     @           0x5f5336 ray::RayLog::~RayLog()
2019-03-11 17:19:16,827 E 58656 58656 logging.cc:130:]     @           0x66d168 ray::raylet::NodeManager::ProcessPrepareActorCheckpointRequest()
2019-03-11 17:19:16,828 E 58656 58656 logging.cc:130:]     @           0x6751ae ray::raylet::NodeManager::ProcessClientMessage()
2019-03-11 17:19:16,828 E 58656 58656 logging.cc:130:]     @           0x5878a9 _ZNSt17_Function_handlerIFvSt10shared_ptrIN3ray16ClientConnectionIN5boost4asio5local15stream_protocolEEEElPKhEZNS1_6raylet6Raylet12HandleAcceptERKNS3_6system10error_codeEEUlS8_lSA_E0_E9_M_invokeERKSt9_Any_dataS8_lSA_
2019-03-11 17:19:16,828 E 58656 58656 logging.cc:130:]     @           0x5ff008 ray::ClientConnection<>::ProcessMessage()
2019-03-11 17:19:16,829 E 58656 58656 logging.cc:130:]     @           0x5fba03 boost::asio::detail::read_op<>::operator()()
2019-03-11 17:19:16,829 E 58656 58656 logging.cc:130:]     @           0x5fbbaf boost::asio::detail::reactive_socket_recv_op<>::do_complete()
2019-03-11 17:19:16,830 E 58656 58656 logging.cc:130:]     @           0x581324 boost::asio::detail::scheduler::run()
2019-03-11 17:19:16,830 E 58656 58656 logging.cc:130:]     @           0x5746d3 main
2019-03-11 17:19:16,831 E 58656 58656 logging.cc:130:]     @     0x7f8622b23b35 __libc_start_main
2019-03-11 17:19:16,831 E 58656 58656 logging.cc:130:]     @           0x57d6d9 (unknown)
2019-03-11 17:19:16,832 E 58656 58656 logging.cc:130:]     @                0x0 (unknown)
```

<!-- Are there any issues opened that will be resolved by merging this change? -->
