### PR TITLE
Make sure the right Python interpreter is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,6 @@ matrix:
       script:
       - ./java/test.sh
 
-      # Test Bazel build
-      - rm -rf build
-      - ./ci/suppress_output ./ci/travis/install-bazel.sh
-      - bazel build ...
-
     - os: linux
       dist: trusty
       env: LINT=1 PYTHONWARNINGS=ignore

--- a/bazel/BUILD.cython
+++ b/bazel/BUILD.cython
@@ -20,11 +20,9 @@ py_library(
 )
 
 # May not be named "cython", since that conflicts with Cython/ on OSX
-py_binary(
+filegroup(
     name="cython_binary",
     srcs=["cython.py"],
-    main="cython.py",
-    srcs_version="PY2AND3",
     visibility=["//visibility:public"],
-    deps=["cython_lib"],
+    data=["cython_lib"],
 )

--- a/bazel/cython_library.bzl
+++ b/bazel/cython_library.bzl
@@ -46,7 +46,7 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
             # Optionally use PYTHON_BIN_PATH on Linux platforms so that python 3
             # works. Windows has issues with cython_binary so skip PYTHON_BIN_PATH.
             cmd=
-            "PYTHONHASHSEED=0 $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
+            "PYTHONHASHSEED=0 $${PYTHON_BIN_PATH} $(location @cython//:cython_binary) --cplus $(SRCS) --output-file $(OUTS)",
             tools=["@cython//:cython_binary"] + pxd_srcs,
         )
 

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ else
   $PYTHON_EXECUTABLE -m pip install \
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
-  bazel build //:ray_pkg -c opt --verbose_failures
+  bazel build //:ray_pkg -c opt --verbose_failures --action_env=PYTHON_BIN_PATH=$PYTHON_EXECUTABLE
   # Copy files and keep them writeable. This is a workaround, as Bazel
   # marks all generated files non-writeable. If we would just copy them
   # over without adding write permission, the copy would fail the next time.


### PR DESCRIPTION
This makes sure that Bazel will use the right python interpreter.

@devin-petersohn @williamma12 can you try if this fixes the problem for you? You might need to delete the bazel cache under `~/.cache/bazel/_bazel_user/` first.