### PR TITLE
 Fix global_state not disconnected after ray.shutdown

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -120,6 +120,14 @@ class GlobalState(object):
             raise Exception("The ray.global_state API cannot be used before "
                             "ray.init has been called.")
 
+
+    def disconnect(self):
+        """Disconnect global state from GCS.
+        """
+        self.redis_client = None
+        self.redis_clients = None
+
+
     def _initialize_global_state(self,
                                  redis_ip_address,
                                  redis_port,

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -120,13 +120,11 @@ class GlobalState(object):
             raise Exception("The ray.global_state API cannot be used before "
                             "ray.init has been called.")
 
-
     def disconnect(self):
         """Disconnect global state from GCS.
         """
         self.redis_client = None
         self.redis_clients = None
-
 
     def _initialize_global_state(self,
                                  redis_ip_address,

--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -121,8 +121,7 @@ class GlobalState(object):
                             "ray.init has been called.")
 
     def disconnect(self):
-        """Disconnect global state from GCS.
-        """
+        """Disconnect global state from GCS."""
         self.redis_client = None
         self.redis_clients = None
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2890,7 +2890,7 @@ def test_load_code_from_local(shutdown_only):
 
 
 def test_shutdown_disconnect_global_state():
-    ray.init()
+    ray.init(num_cpus=0)
     ray.shutdown()
 
     with pytest.raises(Exception) as e:

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2887,3 +2887,12 @@ def test_load_code_from_local(shutdown_only):
     base_actor_class = ray.remote(num_cpus=1)(BaseClass)
     base_actor = base_actor_class.remote(message)
     assert ray.get(base_actor.get_data.remote()) == message
+
+
+def test_shutdown_disconnect_global_state():
+    ray.init()
+    ray.shutdown()
+
+    with pytest.raises(Exception) as e:
+        ray.global_state.object_table()
+    assert str(e.value).endswith("ray.init has been called.")

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2057,7 +2057,7 @@ def connect(info,
 
 
 def disconnect():
-    """Disconnect this worker from the raylet and object store"""
+    """Disconnect this worker from the raylet and object store."""
     # Reset the list of cached remote functions and actors so that if more
     # remote functions or actors are defined and then connect is called again,
     # the remote functions will be exported. This is mostly relevant for the

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2054,7 +2054,7 @@ def connect(info,
 
 
 def disconnect():
-    """Disconnect this worker from the scheduler and object store."""
+    """Disconnect this worker from the scheduler, object store and GCS."""
     # Reset the list of cached remote functions and actors so that if more
     # remote functions or actors are defined and then connect is called again,
     # the remote functions will be exported. This is mostly relevant for the
@@ -2087,6 +2087,9 @@ def disconnect():
         del worker.raylet_client
     if hasattr(worker, "plasma_client"):
         worker.plasma_client.disconnect()
+
+    # Disconnect global state from GCS.
+    global_state.disconnect()
 
 
 @contextmanager

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1566,6 +1566,9 @@ def shutdown(exiting_interpreter=False):
 
     disconnect()
 
+    # Disconnect global state from GCS.
+    global_state.disconnect()
+
     # Shut down the Ray processes.
     global _global_node
     if _global_node is not None:
@@ -2054,7 +2057,7 @@ def connect(info,
 
 
 def disconnect():
-    """Disconnect this worker from the scheduler, object store and GCS."""
+    """Disconnect this worker from the raylet and object store"""
     # Reset the list of cached remote functions and actors so that if more
     # remote functions or actors are defined and then connect is called again,
     # the remote functions will be exported. This is mostly relevant for the
@@ -2087,9 +2090,6 @@ def disconnect():
         del worker.raylet_client
     if hasattr(worker, "plasma_client"):
         worker.plasma_client.disconnect()
-
-    # Disconnect global state from GCS.
-    global_state.disconnect()
 
 
 @contextmanager


### PR DESCRIPTION
## What do these changes do?
Considering this script:
```python
import ray
ray.init()
ray.shutdown()
ray.global_state.object_table()
```
It throws a `ConnectionRefusedError` error. Worse, `_check_connected ()` will pass.
