### PR TITLE
[Java] Package native dependencies into jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ java/**/lib
 java/**/.settings
 java/**/.classpath
 java/**/.project
+java/runtime/bin/
 
 # python virtual env
 venv

--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ java/**/lib
 java/**/.settings
 java/**/.classpath
 java/**/.project
-java/runtime/bin/
+java/runtime/native_dependencies/
 
 # python virtual env
 venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,23 +152,23 @@ if ("${CMAKE_RAY_LANG_JAVA}" STREQUAL "YES")
   get_raylet_library("java" RAYLET_LIBRARY_JAVA)
   add_dependencies(copy_ray ${RAYLET_LIBRARY_JAVA})
 
-  # Copy java binary dependencies.
+  # Copy java native dependencies.
   add_custom_command(TARGET copy_ray POST_BUILD
-    COMMAND mkdir -p ${CMAKE_SOURCE_DIR}/java/runtime/bin)
-  set(java_binary_dependencies
+    COMMAND mkdir -p ${CMAKE_SOURCE_DIR}/java/runtime/native_dependencies)
+  set(java_native_dependencies
     "src/ray/thirdparty/redis/src/redis-server"
     "src/ray/gcs/redis_module/libray_redis_module.so"
     "src/ray/raylet/raylet"
     "src/ray/raylet/libraylet_library_java.*")
-  foreach(file ${java_binary_dependencies})
+  foreach(file ${java_native_dependencies})
   add_custom_command(TARGET copy_ray POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${file}
-      ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+      ${CMAKE_SOURCE_DIR}/java/runtime/native_dependencies)
   endforeach()
 add_custom_command(TARGET copy_ray POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${ARROW_HOME}/bin/plasma_store_server
-    ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+    ${CMAKE_SOURCE_DIR}/java/runtime/native_dependencies)
   add_custom_command(TARGET copy_ray POST_BUILD
     COMMAND $(CMAKE_COMMAND) -E copy ${ARROW_LIBRARY_DIR}/libplasma_java.*
-      ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+      ${CMAKE_SOURCE_DIR}/java/runtime/native_dependencies)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,23 @@ if ("${CMAKE_RAY_LANG_JAVA}" STREQUAL "YES")
   get_raylet_library("java" RAYLET_LIBRARY_JAVA)
   add_dependencies(copy_ray ${RAYLET_LIBRARY_JAVA})
 
-  # copy libplasma_java files
+  # Copy java binary dependencies.
   add_custom_command(TARGET copy_ray POST_BUILD
-    COMMAND bash -c "mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/src/plasma"
-    COMMAND bash -c "cp ${ARROW_LIBRARY_DIR}/libplasma_java.* ${CMAKE_CURRENT_BINARY_DIR}/src/plasma/")
+    COMMAND mkdir -p ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+  set(java_binary_dependencies
+    "src/ray/thirdparty/redis/src/redis-server"
+    "src/ray/gcs/redis_module/libray_redis_module.so"
+    "src/ray/raylet/raylet"
+    "src/ray/raylet/libraylet_library_java.*")
+  foreach(file ${java_binary_dependencies})
+  add_custom_command(TARGET copy_ray POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/${file}
+      ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+  endforeach()
+add_custom_command(TARGET copy_ray POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy ${ARROW_HOME}/bin/plasma_store_server
+    ${CMAKE_SOURCE_DIR}/java/runtime/bin)
+  add_custom_command(TARGET copy_ray POST_BUILD
+    COMMAND $(CMAKE_COMMAND) -E copy ${ARROW_LIBRARY_DIR}/libplasma_java.*
+      ${CMAKE_SOURCE_DIR}/java/runtime/bin)
 endif()

--- a/java/README.rst
+++ b/java/README.rst
@@ -5,7 +5,7 @@ Configuration
 -------------
 Ray will read your configurations in the following order:
 
-* Java system properties: e.g., ``-Dray.home=/path/to/ray``.
+* Java system properties: e.g., ``-Dray.run-mode=SINGLE_PROCESS``.
 * A ``ray.conf`` file in the classpath: `example <https://github.com/ray-project/ray/blob/master/java/example.conf>`_.
 * Customise your own ``ray.conf`` path using system property ``-Dray.config=/path/to/ray.conf``
 

--- a/java/example.conf
+++ b/java/example.conf
@@ -6,11 +6,6 @@
 # For config file format, see 'https://github.com/lightbend/config/blob/master/HOCON.md'.
 
 ray {
-  // This is the path to the directory where Ray is installed, e.g.,
-  // something like /home/ubmutu/ray. This can be an absolute path or
-  // a relative path from the current working directory.
-  home = "/path/to/your/ray/home"
-
   // Run mode, available options are:
   //
   // `SINGLE_PROCESS`: Ray is running in one single Java process, without Raylet backend,

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -79,6 +79,14 @@
   </dependencies>
 
   <build>
+	<resources>
+	  <resource>
+		<directory>src/main/resources</directory>
+	  </resource>
+	  <resource>
+		<directory>bin</directory>
+	  </resource>
+	</resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -84,7 +84,7 @@
         <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>bin</directory>
+        <directory>native_dependencies</directory>
       </resource>
     </resources>
     <plugins>

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -79,14 +79,14 @@
   </dependencies>
 
   <build>
-	<resources>
-	  <resource>
-		<directory>src/main/resources</directory>
-	  </resource>
-	  <resource>
-		<directory>bin</directory>
-	  </resource>
-	</resources>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>bin</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -2,14 +2,19 @@ package org.ray.runtime;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.ray.api.Checkpointable.Checkpoint;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.RayConfig;
@@ -72,11 +77,28 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
 
   @Override
   public void start() throws Exception {
-    // Load native libraries.
     try {
+      // Reset library path at runtime.
       resetLibraryPath();
-      System.loadLibrary("raylet_library_java");
-      System.loadLibrary("plasma_java");
+
+      // Load native libraries.
+      String[] libraries = new String[]{"raylet_library_java", "plasma_java"};
+      for (String library : libraries) {
+        String fileName = "lib" + library;
+        if (SystemUtils.IS_OS_LINUX) {
+          fileName += ".so";
+        } else if (SystemUtils.IS_OS_MAC) {
+          fileName += ".dylib";
+        } else {
+          throw new RuntimeException("Unsupported OS: " + System.getProperty("os.name"));
+        }
+        // Copy the file from resources to a temp dir, and load the native library.
+        File file = File.createTempFile(fileName, "");
+        file.deleteOnExit();
+        Files.copy(RayNativeRuntime.class.getResourceAsStream("/" + fileName),
+            Paths.get(file.getAbsolutePath()), StandardCopyOption.REPLACE_EXISTING);
+        System.load(file.getAbsolutePath());
+      }
     } catch (Exception e) {
       LOGGER.error("Failed to load native libraries.", e);
       throw e;

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.ray.api.Checkpointable.Checkpoint;
 import org.ray.api.id.UniqueId;
 import org.ray.runtime.config.RayConfig;
@@ -85,14 +84,7 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
       // Load native libraries.
       String[] libraries = new String[]{"raylet_library_java", "plasma_java"};
       for (String library : libraries) {
-        String fileName = "lib" + library;
-        if (SystemUtils.IS_OS_LINUX) {
-          fileName += ".so";
-        } else if (SystemUtils.IS_OS_MAC) {
-          fileName += ".dylib";
-        } else {
-          throw new RuntimeException("Unsupported OS: " + System.getProperty("os.name"));
-        }
+        String fileName = System.mapLibraryName(library);
         // Copy the file from resources to a temp dir, and load the native library.
         File file = File.createTempFile(fileName, "");
         file.deleteOnExit();

--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -3,6 +3,7 @@ package org.ray.runtime;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.File;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -95,8 +96,9 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
         // Copy the file from resources to a temp dir, and load the native library.
         File file = File.createTempFile(fileName, "");
         file.deleteOnExit();
-        Files.copy(RayNativeRuntime.class.getResourceAsStream("/" + fileName),
-            Paths.get(file.getAbsolutePath()), StandardCopyOption.REPLACE_EXISTING);
+        InputStream in = RayNativeRuntime.class.getResourceAsStream("/" + fileName);
+        Preconditions.checkNotNull(in, "{} doesn't exist.", fileName);
+        Files.copy(in, Paths.get(file.getAbsolutePath()), StandardCopyOption.REPLACE_EXISTING);
         System.load(file.getAbsolutePath());
       }
     } catch (Exception e) {

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -7,11 +7,6 @@ ray {
   // Basic configurations
   // ----------------------
 
-  // This is the path to the directory where Ray is installed, e.g.,
-  // something like /home/ubmutu/ray. This can be an absolute path or
-  // a relative path from the current working directory.
-  home: ""
-
   // IP of this node. if not provided, IP will be automatically detected.
   node-ip: ""
 

--- a/java/test/src/main/java/org/ray/api/test/BaseTest.java
+++ b/java/test/src/main/java/org/ray/api/test/BaseTest.java
@@ -14,7 +14,7 @@ public class BaseTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseTest.class);
 
-  private List<String> filesToDelete;
+  private List<File> filesToDelete;
 
   @BeforeMethod
   public void setUpBase(Method method) {
@@ -22,18 +22,21 @@ public class BaseTest {
         + method.getDeclaringClass().getName() + "." + method.getName());
     System.setProperty("ray.resources", "CPU:4,RES-A:4");
     Ray.init();
-    // Delete socket files in tear-down.
-    filesToDelete = ImmutableList.of(Ray.getRuntimeContext().getRayletSocketName(),
-        Ray.getRuntimeContext().getObjectStoreSocketName());
+    // These files need to be deleted after each test case.
+    filesToDelete = ImmutableList.of(
+        new File(Ray.getRuntimeContext().getRayletSocketName()),
+        new File(Ray.getRuntimeContext().getObjectStoreSocketName())
+    );
+    // Make sure the files will be deleted even if the test doesn't exit gracefully.
+    filesToDelete.forEach(File::deleteOnExit);
   }
 
   @AfterMethod
   public void tearDownBase() {
-
     Ray.shutdown();
 
-    for (String file : filesToDelete) {
-      new File(file).delete();
+    for (File file : filesToDelete) {
+      file.delete();
     }
 
     // Unset system properties.

--- a/java/test/src/main/java/org/ray/api/test/MultiLanguageClusterTest.java
+++ b/java/test/src/main/java/org/ray/api/test/MultiLanguageClusterTest.java
@@ -66,8 +66,7 @@ public class MultiLanguageClusterTest {
 
     // Start ray cluster.
     String testDir = System.getProperty("user.dir");
-    String workerOptions = String.format("-Dray.home=%s/../../", testDir);
-    workerOptions +=
+    String workerOptions =
         " -classpath " + String.format("%s/../../build/java/*:%s/target/*", testDir, testDir);
     final List<String> startCommand = ImmutableList.of(
         "ray",
@@ -85,7 +84,6 @@ public class MultiLanguageClusterTest {
     }
 
     // Connect to the cluster.
-    System.setProperty("ray.home", "../..");
     System.setProperty("ray.redis.address", "127.0.0.1:6379");
     System.setProperty("ray.object-store.socket-name", PLASMA_STORE_SOCKET_NAME);
     System.setProperty("ray.raylet.socket-name", RAYLET_SOCKET_NAME);
@@ -96,7 +94,6 @@ public class MultiLanguageClusterTest {
   public void tearDown() {
     // Disconnect to the cluster.
     Ray.shutdown();
-    System.clearProperty("ray.home");
     System.clearProperty("ray.redis.address");
     System.clearProperty("ray.object-store.socket-name");
     System.clearProperty("ray.raylet.socket-name");

--- a/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
+++ b/java/test/src/main/java/org/ray/api/test/RayConfigTest.java
@@ -10,24 +10,12 @@ public class RayConfigTest {
   @Test
   public void testCreateRayConfig() {
     try {
-      System.setProperty("ray.home", "/path/to/ray");
       System.setProperty("ray.driver.resource-path", "path/to/ray/driver/resource/path");
       RayConfig rayConfig = RayConfig.create();
-
-      Assert.assertEquals("/path/to/ray", rayConfig.rayHome);
       Assert.assertEquals(WorkerMode.DRIVER, rayConfig.workerMode);
-
-      System.setProperty("ray.home", "");
-      rayConfig = RayConfig.create();
-
-      Assert.assertEquals(System.getProperty("user.dir"), rayConfig.rayHome);
-      Assert.assertEquals(System.getProperty("user.dir") +
-          "/build/src/ray/thirdparty/redis/src/redis-server", rayConfig.redisServerExecutablePath);
-
       Assert.assertEquals("path/to/ray/driver/resource/path", rayConfig.driverResourcePath);
     } finally {
-      //unset the system property
-      System.clearProperty("ray.home");
+      // Unset system properties.
       System.clearProperty("ray.driver.resource-path");
     }
 

--- a/java/tutorial/README.rst
+++ b/java/tutorial/README.rst
@@ -12,7 +12,7 @@ To run them, execute the following command under ``ray/java`` folder.
 
 .. code-block:: shell
 
-    java -Dray.home=.. -classpath "tutorial/target/ray-tutorial-1.0.jar:tutorial/lib/*" org.ray.exercise.Exercise01
+    java -classpath "tutorial/target/ray-tutorial-1.0.jar:tutorial/lib/*" org.ray.exercise.Exercise01
 
 `Exercise 1 <https://github.com/ray-project/ray/tree/master/java/tutorial/src/main/java/org/ray/exercise/Exercise01.java>`_: Define a remote function, and execute multiple remote functions in parallel.
 

--- a/java/tutorial/src/main/resources/ray.conf
+++ b/java/tutorial/src/main/resources/ray.conf
@@ -1,5 +1,4 @@
-ray{
-  home: ".."
+ray {
   run-mode: CLUSTER
   redirect-output: false
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Package Java binary dependencies into the jar file, so the runtime won't depend on any relative paths. This change would make it easier to support maven and bazel simultaneously (#4284, cc @alegithub111 ).

Later, we can also build and distribute jars for mainstream platforms (just like the python wheels), so users don't need to compile the code by themselves. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
