### PR TITLE
[rllib] Add option to proceed even if some workers crashed

### DIFF
--- a/ci/jenkins_tests/run_rllib_tests.sh
+++ b/ci/jenkins_tests/run_rllib_tests.sh
@@ -412,4 +412,7 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     --config '{"num_workers": 1, "num_gpus": 0, "num_envs_per_worker": 64, "sample_batch_size": 50, "train_batch_size": 50, "learner_queue_size": 1}'
 
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
-    python /ray/python/ray/rllib/agents/impala/vtrace_test.py
+    /ray/python/ray/rllib/tests/run_silent.sh agents/impala/vtrace_test.py
+
+docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
+    /ray/python/ray/rllib/tests/run_silent.sh tests/test_ignore_worker_failure.py

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -13,6 +13,7 @@ import tensorflow as tf
 from types import FunctionType
 
 import ray
+from ray.exceptions import RayTaskError
 from ray.rllib.offline import NoopOutput, JsonReader, MixedInput, JsonWriter, \
     ShuffledInput
 from ray.rllib.models import MODEL_DEFAULTS
@@ -48,6 +49,8 @@ COMMON_CONFIG = {
         "on_sample_end": None,     # arg: {"samples": .., "evaluator": ...}
         "on_train_result": None,   # arg: {"agent": ..., "result": ...}
     },
+    # Whether to attempt to continue training if a worker crashes.
+    "ignore_worker_failures": False,
 
     # === Policy ===
     # Arguments to pass to model. See models/catalog.py for a full list of the
@@ -99,7 +102,7 @@ COMMON_CONFIG = {
     "train_batch_size": 200,
     # Whether to rollout "complete_episodes" or "truncate_episodes"
     "batch_mode": "truncate_episodes",
-    # Whether to use a background thread for sampling (slightly off-policy)
+    # (Deprecated) Use a background thread for sampling (slightly off-policy)
     "sample_async": False,
     # Element-wise observation filter, either "NoFilter" or "MeanStdFilter"
     "observation_filter": "NoFilter",
@@ -285,15 +288,32 @@ class Agent(Trainable):
     def train(self):
         """Overrides super.train to synchronize global vars."""
 
-        if hasattr(self, "optimizer") and isinstance(self.optimizer,
-                                                     PolicyOptimizer):
+        if self._has_policy_optimizer():
             self.global_vars["timestep"] = self.optimizer.num_steps_sampled
             self.optimizer.local_evaluator.set_global_vars(self.global_vars)
             for ev in self.optimizer.remote_evaluators:
                 ev.set_global_vars.remote(self.global_vars)
             logger.debug("updated global vars: {}".format(self.global_vars))
 
-        result = Trainable.train(self)
+        result = None
+        for _ in range(4):
+            try:
+                result = Trainable.train(self)
+            except RayTaskError as e:
+                if self.config["ignore_worker_failures"]:
+                    logger.exception(
+                        "Error in train call, attempting to recover")
+                    self._try_recover()
+                else:
+                    logger.info(
+                        "Worker crashed during call to train(). To attempt to "
+                        "continue training without the failed worker, set "
+                        "`'ignore_worker_failures': True`.")
+                    raise e
+            else:
+                break
+        if result is None:
+            raise RuntimeError("Failed to recover from worker crash")
 
         if (self.config.get("observation_filter", "NoFilter") != "NoFilter"
                 and hasattr(self, "local_evaluator")):
@@ -304,6 +324,9 @@ class Agent(Trainable):
             logger.debug("synchronized filters: {}".format(
                 self.local_evaluator.filters))
 
+        if self._has_policy_optimizer():
+            result["num_healthy_workers"] = len(
+                self.optimizer.remote_evaluators)
         return result
 
     @override(Trainable)
@@ -557,6 +580,49 @@ class Agent(Trainable):
             raise ValueError(
                 "`input_evaluation` must be a list of strings, got {}".format(
                     config["input_evaluation"]))
+
+    def _try_recover(self):
+        """Try to identify and blacklist any unhealthy workers.
+
+        This method is called after an unexpected remote error is encountered
+        from a worker. It issues check requests to all current workers and
+        blacklists any that respond with error. If no healthy workers remain,
+        an error is raised.
+        """
+
+        if not self._has_policy_optimizer():
+            raise NotImplementedError(
+                "Recovery is not supported for this algorithm")
+
+        logger.info("Health checking all workers...")
+        checks = []
+        for ev in self.optimizer.remote_evaluators:
+            _, obj_id = ev.sample_with_count.remote()
+            checks.append(obj_id)
+
+        healthy_evaluators = []
+        for i, obj_id in enumerate(checks):
+            ev = self.optimizer.remote_evaluators[i]
+            try:
+                ray.get(obj_id)
+                healthy_evaluators.append(ev)
+                logger.info("Worker {} looks healthy".format(i + 1))
+            except RayTaskError:
+                logger.exception("Blacklisting worker {}".format(i + 1))
+                try:
+                    ev.__ray_terminate__.remote()
+                except Exception:
+                    logger.exception("Error terminating unhealthy worker")
+
+        if len(healthy_evaluators) < 1:
+            raise RuntimeError(
+                "Not enough healthy workers remain to continue.")
+
+        self.optimizer.reset(healthy_evaluators)
+
+    def _has_policy_optimizer(self):
+        return hasattr(self, "optimizer") and isinstance(
+            self.optimizer, PolicyOptimizer)
 
     def _make_evaluator(self, cls, env_creator, policy_graph, worker_index,
                         config):

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 from types import FunctionType
 
 import ray
-from ray.exceptions import RayTaskError
+from ray.exceptions import RayError
 from ray.rllib.offline import NoopOutput, JsonReader, MixedInput, JsonWriter, \
     ShuffledInput
 from ray.rllib.models import MODEL_DEFAULTS
@@ -299,7 +299,7 @@ class Agent(Trainable):
         for _ in range(4):
             try:
                 result = Trainable.train(self)
-            except RayTaskError as e:
+            except RayError as e:
                 if self.config["ignore_worker_failures"]:
                     logger.exception(
                         "Error in train call, attempting to recover")
@@ -607,7 +607,7 @@ class Agent(Trainable):
                 ray.get(obj_id)
                 healthy_evaluators.append(ev)
                 logger.info("Worker {} looks healthy".format(i + 1))
-            except RayTaskError:
+            except RayError:
                 logger.exception("Blacklisting worker {}".format(i + 1))
                 try:
                     ev.__ray_terminate__.remote()

--- a/python/ray/rllib/agents/agent.py
+++ b/python/ray/rllib/agents/agent.py
@@ -30,6 +30,10 @@ from ray.tune.result import DEFAULT_RESULTS_DIR
 
 logger = logging.getLogger(__name__)
 
+# Max number of times to retry a worker failure. We shouldn't try too many
+# times in a row since that would indicate a persistent cluster issue.
+MAX_WORKER_FAILURE_RETRIES = 3
+
 # yapf: disable
 # __sphinx_doc_begin__
 COMMON_CONFIG = {
@@ -296,7 +300,7 @@ class Agent(Trainable):
             logger.debug("updated global vars: {}".format(self.global_vars))
 
         result = None
-        for _ in range(4):
+        for _ in range(1 + MAX_WORKER_FAILURE_RETRIES):
             try:
                 result = Trainable.train(self)
             except RayError as e:

--- a/python/ray/rllib/agents/impala/impala.py
+++ b/python/ray/rllib/agents/impala/impala.py
@@ -116,7 +116,8 @@ class ImpalaAgent(Agent):
         prev_steps = self.optimizer.num_steps_sampled
         start = time.time()
         self.optimizer.step()
-        while time.time() - start < self.config["min_iter_time_s"]:
+        while (time.time() - start < self.config["min_iter_time_s"]
+               or self.optimizer.num_steps_sampled == prev_steps):
             self.optimizer.step()
         result = self.optimizer.collect_metrics(
             self.config["collect_metrics_timeout"])

--- a/python/ray/rllib/env/external_env.py
+++ b/python/ray/rllib/env/external_env.py
@@ -205,12 +205,12 @@ class _ExternalEnvEpisode(object):
         self.new_observation = observation
         self.new_action = action
         self._send()
-        self.action_queue.get(True, timeout=600.0)
+        self.action_queue.get(True, timeout=60.0)
 
     def wait_for_action(self, observation):
         self.new_observation = observation
         self._send()
-        return self.action_queue.get(True, timeout=600.0)
+        return self.action_queue.get(True, timeout=60.0)
 
     def done(self, observation):
         self.new_observation = observation

--- a/python/ray/rllib/env/external_env.py
+++ b/python/ray/rllib/env/external_env.py
@@ -205,12 +205,12 @@ class _ExternalEnvEpisode(object):
         self.new_observation = observation
         self.new_action = action
         self._send()
-        self.action_queue.get(True, timeout=60.0)
+        self.action_queue.get(True, timeout=600.0)
 
     def wait_for_action(self, observation):
         self.new_observation = observation
         self._send()
-        return self.action_queue.get(True, timeout=60.0)
+        return self.action_queue.get(True, timeout=600.0)
 
     def done(self, observation):
         self.new_observation = observation

--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -171,6 +171,8 @@ class AsyncSampler(threading.Thread, SamplerInput):
                 queue_putter(item)
 
     def get_data(self):
+        if not self.is_alive():
+            raise RuntimeError("Sampling thread has died")
         rollout = self.queue.get(timeout=600.0)
 
         # Propagate errors

--- a/python/ray/rllib/optimizers/async_replay_optimizer.py
+++ b/python/ray/rllib/optimizers/async_replay_optimizer.py
@@ -134,6 +134,11 @@ class AsyncReplayOptimizer(PolicyOptimizer):
         self.learner.stopped = True
 
     @override(PolicyOptimizer)
+    def reset(self, remote_evaluators):
+        self.remote_evaluators = remote_evaluators
+        self.sample_tasks.reset_evaluators(remote_evaluators)
+
+    @override(PolicyOptimizer)
     def stats(self):
         replay_stats = ray.get(self.replay_actors[0].stats.remote(self.debug))
         timing = {

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -153,6 +153,11 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
         self.learner.stopped = True
 
     @override(PolicyOptimizer)
+    def reset(self, remote_evaluators):
+        self.remote_evaluators = remote_evaluators
+        self.sample_tasks.reset_evaluators(remote_evaluators)
+
+    @override(PolicyOptimizer)
     def stats(self):
         def timer_to_ms(timer):
             return round(1000 * timer.mean, 3)

--- a/python/ray/rllib/optimizers/policy_optimizer.py
+++ b/python/ray/rllib/optimizers/policy_optimizer.py
@@ -143,6 +143,12 @@ class PolicyOptimizer(object):
         return res
 
     @DeveloperAPI
+    def reset(self, remote_evaluators):
+        """Called to change the set of remote evaluators being used."""
+
+        self.remote_evaluators = remote_evaluators
+
+    @DeveloperAPI
     def foreach_evaluator(self, func):
         """Apply the given function to each evaluator instance."""
 

--- a/python/ray/rllib/tests/test_ignore_worker_failure.py
+++ b/python/ray/rllib/tests/test_ignore_worker_failure.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import gym
+import unittest
+
+import ray
+from ray.rllib import _register_all
+from ray.rllib.agents.registry import get_agent_class
+from ray.tune.registry import register_env
+
+
+class FaultInjectEnv(gym.Env):
+    def __init__(self, config):
+        self.env = gym.make("CartPole-v0")
+        self.action_space = self.env.action_space
+        self.observation_space = self.env.observation_space
+        self.config = config
+
+    def reset(self):
+        return self.env.reset()
+
+    def step(self, action):
+        if self.config.worker_index in self.config["bad_indices"]:
+            raise ValueError("This is a simulated error from {}".format(self.config.worker_index))
+        return self.env.step(action)
+
+
+class IgnoresWorkerFailure(unittest.TestCase):
+    def doTest(self, alg, config, fn=None):
+        fn = fn or self._doTestFaultRecover
+        try:
+            ray.init(num_cpus=6)
+            fn(alg, config)
+        finally:
+            ray.shutdown()
+            _register_all()  # re-register the evicted objects
+
+    def _doTestFaultRecover(self, alg, config):
+        register_env("fault_env", lambda c: FaultInjectEnv(c))
+        agent_cls = get_agent_class(alg)
+
+        # Test fault handling
+        config["num_workers"] = 2
+        config["ignore_worker_failures"] = True
+        config["env_config"] = {"bad_indices": [1]}
+        a = agent_cls(config=config, env="fault_env")
+        result = a.train()
+        self.assertTrue(result["num_healthy_workers"], 1)
+        a.stop()
+
+    def _doTestFaultFatal(self, alg, config):
+        register_env("fault_env", lambda c: FaultInjectEnv(c))
+        agent_cls = get_agent_class(alg)
+
+        # Test raises real error when out of workers
+        config["num_workers"] = 2
+        config["ignore_worker_failures"] = True
+        config["env_config"] = {"bad_indices": [1, 2]}
+        a = agent_cls(config=config, env="fault_env")
+        self.assertRaises(Exception, lambda: a.train())
+        a.stop()
+
+    def testFatal(self):
+        # test the case where all workers fail
+        self.doTest("PG", {"optimizer": {}}, fn=self._doTestFaultFatal)
+
+    def testAsyncGrads(self):
+        self.doTest("A3C", {
+            "optimizer": {
+                "grads_per_step": 1
+            }
+        })
+
+    def testAsyncReplay(self):
+        self.doTest(
+            "APEX", {
+                "timesteps_per_iteration": 1000,
+                "num_gpus": 0,
+                "min_iter_time_s": 1,
+                "learning_starts": 1000,
+                "target_network_update_freq": 100,
+                "optimizer": {
+                    "num_replay_buffer_shards": 1,
+                },
+            })
+
+    def testAsyncSamples(self):
+        self.doTest("IMPALA", {"num_gpus": 0})
+
+    def testSyncReplay(self):
+        self.doTest("DQN", {"timesteps_per_iteration": 1})
+
+    def testMultiGPU(self):
+        self.doTest(
+            "PPO", {
+                "num_sgd_iter": 1,
+                "train_batch_size": 10,
+                "sample_batch_size": 10,
+                "sgd_minibatch_size": 1,
+            })
+
+    def testSyncSamples(self):
+        self.doTest("PG", {"optimizer": {}})
+
+    def testAsyncSamplingOption(self):
+        self.doTest("PG", {"optimizer": {}, "sample_async": True})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/ray/rllib/tests/test_ignore_worker_failure.py
+++ b/python/ray/rllib/tests/test_ignore_worker_failure.py
@@ -23,7 +23,8 @@ class FaultInjectEnv(gym.Env):
 
     def step(self, action):
         if self.config.worker_index in self.config["bad_indices"]:
-            raise ValueError("This is a simulated error from {}".format(self.config.worker_index))
+            raise ValueError("This is a simulated error from {}".format(
+                self.config.worker_index))
         return self.env.step(action)
 
 
@@ -67,11 +68,7 @@ class IgnoresWorkerFailure(unittest.TestCase):
         self.doTest("PG", {"optimizer": {}}, fn=self._doTestFaultFatal)
 
     def testAsyncGrads(self):
-        self.doTest("A3C", {
-            "optimizer": {
-                "grads_per_step": 1
-            }
-        })
+        self.doTest("A3C", {"optimizer": {"grads_per_step": 1}})
 
     def testAsyncReplay(self):
         self.doTest(

--- a/python/ray/rllib/utils/actors.py
+++ b/python/ray/rllib/utils/actors.py
@@ -53,6 +53,18 @@ class TaskPool(object):
                 remaining.append((worker, obj_id))
         self._fetching = remaining
 
+    def reset_evaluators(self, evaluators):
+        """Notify that some evaluators may be removed."""
+        for obj_id, ev in self._tasks.copy().items():
+            if ev not in evaluators:
+                del self._tasks[obj_id]
+                del self._objects[obj_id]
+        ok = []
+        for ev, obj_id in self._fetching:
+            if ev in evaluators:
+                ok.append((ev, obj_id))
+        self._fetching = ok
+
     @property
     def count(self):
         return len(self._tasks)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

This adds a `ignore_worker_failures` option, which can be set to keep going even if a worker crashes. Since it's pretty hard to track down the source of a RayTaskError in a nice, algorithm-agnostic way, we do this via a more brute force approach:
- If RayTaskError is encountered in a call to train, we health check each worker by calling sample() on it.
- Workers that respond with error on sample() will be blacklisted
- If the number of available workers drops to zero then we raise a permanent error

The number of healthy workers can be tracked via the `num_healthy_workers` metric now reported.

## Related issue number

Closes https://github.com/ray-project/ray/issues/4358