### PR TITLE
[tune] Fix performance issue and fix reuse tests

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -381,7 +381,12 @@ class RayTrialExecutor(TrialExecutor):
         self._resources_initialized = True
 
     def has_resources(self, resources):
-        """Returns whether this runner has at least the specified resources."""
+        """Returns whether this runner has at least the specified resources.
+
+        This refreshes the Ray cluster resources if the time since last update
+        has exceeded self._refresh_period. This also assumes that the
+        cluster is not resizing very frequently.
+        """
         if time.time() - self._last_resource_refresh > self._refresh_period:
             self._update_avail_resources()
 

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -358,7 +358,6 @@ class RayTrialExecutor(TrialExecutor):
 
     def has_resources(self, resources):
         """Returns whether this runner has at least the specified resources."""
-        self._update_avail_resources()
         currently_available = Resources.subtract(self._avail_resources,
                                                  self._committed_resources)
 
@@ -429,7 +428,6 @@ class RayTrialExecutor(TrialExecutor):
 
     def on_step_begin(self):
         """Before step() called, update the available resources."""
-
         self._update_avail_resources()
 
     def save(self, trial, storage=Checkpoint.DISK):

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -50,6 +50,7 @@ class RayTrialExecutor(TrialExecutor):
 
         self._avail_resources = Resources(cpu=0, gpu=0)
         self._committed_resources = Resources(cpu=0, gpu=0)
+        self._resources_initialized = False
         self._refresh_period = refresh_period
         self._last_resource_refresh = float("-inf")
         self._last_nontrivial_wait = time.time()

--- a/python/ray/tune/tests/test_actor_reuse.py
+++ b/python/ray/tune/tests/test_actor_reuse.py
@@ -15,7 +15,7 @@ class FrequentPausesScheduler(FIFOScheduler):
         return TrialScheduler.PAUSE
 
 
-def create_class():
+def create_resettable_class():
     class MyResettableClass(Trainable):
         def _setup(self, config):
             self.config = config
@@ -52,7 +52,7 @@ class ActorReuseTest(unittest.TestCase):
         trials = run_experiments(
             {
                 "foo": {
-                    "run": create_class(),
+                    "run": create_resettable_class(),
                     "num_samples": 4,
                     "config": {},
                 }
@@ -66,7 +66,7 @@ class ActorReuseTest(unittest.TestCase):
         trials = run_experiments(
             {
                 "foo": {
-                    "run": create_class(),
+                    "run": create_resettable_class(),
                     "num_samples": 4,
                     "config": {},
                 }
@@ -81,7 +81,7 @@ class ActorReuseTest(unittest.TestCase):
             run_experiments(
                 {
                     "foo": {
-                        "run": create_class(),
+                        "run": create_resettable_class(),
                         "max_failures": 1,
                         "num_samples": 4,
                         "config": {

--- a/python/ray/tune/tests/test_actor_reuse.py
+++ b/python/ray/tune/tests/test_actor_reuse.py
@@ -15,27 +15,30 @@ class FrequentPausesScheduler(FIFOScheduler):
         return TrialScheduler.PAUSE
 
 
-class MyResettableClass(Trainable):
-    def _setup(self, config):
-        self.config = config
-        self.num_resets = 0
-        self.iter = 0
+def create_class():
+    class MyResettableClass(Trainable):
+        def _setup(self, config):
+            self.config = config
+            self.num_resets = 0
+            self.iter = 0
 
-    def _train(self):
-        self.iter += 1
-        return {"num_resets": self.num_resets, "done": self.iter > 1}
+        def _train(self):
+            self.iter += 1
+            return {"num_resets": self.num_resets, "done": self.iter > 1}
 
-    def _save(self, chkpt_dir):
-        return {"iter": self.iter}
+        def _save(self, chkpt_dir):
+            return {"iter": self.iter}
 
-    def _restore(self, item):
-        self.iter = item["iter"]
+        def _restore(self, item):
+            self.iter = item["iter"]
 
-    def reset_config(self, new_config):
-        if "fake_reset_not_supported" in self.config:
-            return False
-        self.num_resets += 1
-        return True
+        def reset_config(self, new_config):
+            if "fake_reset_not_supported" in self.config:
+                return False
+            self.num_resets += 1
+            return True
+
+    return MyResettableClass
 
 
 class ActorReuseTest(unittest.TestCase):
@@ -49,7 +52,7 @@ class ActorReuseTest(unittest.TestCase):
         trials = run_experiments(
             {
                 "foo": {
-                    "run": MyResettableClass,
+                    "run": create_class(),
                     "num_samples": 4,
                     "config": {},
                 }
@@ -63,7 +66,7 @@ class ActorReuseTest(unittest.TestCase):
         trials = run_experiments(
             {
                 "foo": {
-                    "run": MyResettableClass,
+                    "run": create_class(),
                     "num_samples": 4,
                     "config": {},
                 }
@@ -78,7 +81,7 @@ class ActorReuseTest(unittest.TestCase):
             run_experiments(
                 {
                     "foo": {
-                        "run": MyResettableClass,
+                        "run": create_class(),
                         "max_failures": 1,
                         "num_samples": 4,
                         "config": {

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -376,8 +376,8 @@ class TrialRunner(object):
             return "Memory usage on this node: {}/{} GB{}".format(
                 round(used_gb, 1), round(total_gb, 1), warn)
         except ImportError:
+            global _MEMORY_USAGE_WARNED
             if not _MEMORY_USAGE_WARNED:
-                global _MEMORY_USAGE_WARNED
                 _MEMORY_USAGE_WARNED = True
                 return (
                     "Unknown memory usage. Please run `pip install psutil` "

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -19,6 +19,7 @@ from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 from ray.tune.util import warn_if_slow
 from ray.tune.web_server import TuneServer
 
+_MEMORY_USAGE_WARNED = False
 MAX_DEBUG_TRIALS = 20
 
 logger = logging.getLogger(__name__)
@@ -375,7 +376,11 @@ class TrialRunner(object):
             return "Memory usage on this node: {}/{} GB{}".format(
                 round(used_gb, 1), round(total_gb, 1), warn)
         except ImportError:
-            return ("Unknown memory usage. Please run `pip install psutil` "
+            if not _MEMORY_USAGE_WARNED:
+                global _MEMORY_USAGE_WARNED
+                _MEMORY_USAGE_WARNED = True
+                return (
+                    "Unknown memory usage. Please run `pip install psutil` "
                     "(or ray[debug]) to resolve)")
 
     def has_resources(self, resources):

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -19,7 +19,6 @@ from ray.tune.schedulers import FIFOScheduler, TrialScheduler
 from ray.tune.util import warn_if_slow
 from ray.tune.web_server import TuneServer
 
-_MEMORY_USAGE_WARNED = False
 MAX_DEBUG_TRIALS = 20
 
 logger = logging.getLogger(__name__)
@@ -380,11 +379,7 @@ class TrialRunner(object):
             return "Memory usage on this node: {}/{} GB{}".format(
                 round(used_gb, 1), round(total_gb, 1), warn)
         except ImportError:
-            global _MEMORY_USAGE_WARNED
-            if not _MEMORY_USAGE_WARNED:
-                _MEMORY_USAGE_WARNED = True
-                return (
-                    "Unknown memory usage. Please run `pip install psutil` "
+            return ("Unknown memory usage. Please run `pip install psutil` "
                     "(or ray[debug]) to resolve)")
 
     def has_resources(self, resources):


### PR DESCRIPTION
Pytest I think uses some multi-threaded importing, so
classes often fail to import, hence the hanging on Jenkins. This gets around that 
but using a constructor.

Performance issue reported earlier is also mitigated by only updating resources
once per TrialRunner step (Fixes #4366).

This also avoids a recurring warning.
<!-- Are there any issues opened that will be resolved by merging this change? -->