### PR TITLE
[rllib] More efficient tuple flattening.

### DIFF
--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -44,7 +44,7 @@ class Preprocessor(object):
 
     def write(self, observation, array, offset):
         """Alternative to transform for more efficient flattening."""
-        array[offset:offset+self._size] = self.transform(observation)
+        array[offset:offset + self._size] = self.transform(observation)
 
     @property
     @PublicAPI
@@ -127,7 +127,7 @@ class OneHotPreprocessor(Preprocessor):
                              self._obs_space, observation)
         arr[observation] = 1
         return arr
-        
+
     @override(Preprocessor)
     def write(self, observation, array, offset):
         array[offset + observation] = 1
@@ -144,7 +144,7 @@ class NoPreprocessor(Preprocessor):
 
     @override(Preprocessor)
     def write(self, observation, array, offset):
-        array[offset:offset+self._size] = observation.ravel()
+        array[offset:offset + self._size] = observation.ravel()
 
 
 class TupleFlatteningPreprocessor(Preprocessor):
@@ -178,7 +178,7 @@ class TupleFlatteningPreprocessor(Preprocessor):
         for o, p in zip(observation, self.preprocessors):
             p.write(o, array, offset)
             offset += p.size
-        
+
 
 class DictFlatteningPreprocessor(Preprocessor):
     """Preprocesses each dict value, then flattens it all into a vector.
@@ -213,7 +213,7 @@ class DictFlatteningPreprocessor(Preprocessor):
         for o, p in zip(observation.values(), self.preprocessors):
             p.write(o, array, offset)
             offset += p.size
-        
+
 
 @PublicAPI
 def get_preprocessor(space):

--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -44,7 +44,7 @@ class Preprocessor(object):
 
     def write(self, observation, array, offset):
         """Alternative to transform for more efficient flattening."""
-        raise NotImplementedError
+        array[offset:offset+self._size] = self.transform(observation)
 
     @property
     @PublicAPI
@@ -144,7 +144,7 @@ class NoPreprocessor(Preprocessor):
 
     @override(Preprocessor)
     def write(self, observation, array, offset):
-        array[offset:offset+self.size] = observation.ravel()
+        array[offset:offset+self._size] = observation.ravel()
 
 
 class TupleFlatteningPreprocessor(Preprocessor):

--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -144,7 +144,8 @@ class NoPreprocessor(Preprocessor):
 
     @override(Preprocessor)
     def write(self, observation, array, offset):
-        array[offset:offset + self._size] = observation.ravel()
+        array[offset:offset + self._size] = np.array(
+            observation, copy=False).ravel()
 
 
 class TupleFlatteningPreprocessor(Preprocessor):

--- a/python/ray/rllib/tests/test_catalog.py
+++ b/python/ray/rllib/tests/test_catalog.py
@@ -16,12 +16,12 @@ from ray.rllib.models.visionnet import VisionNetwork
 
 class CustomPreprocessor(Preprocessor):
     def _init_shape(self, obs_space, options):
-        return None
+        return [1]
 
 
 class CustomPreprocessor2(Preprocessor):
     def _init_shape(self, obs_space, options):
-        return None
+        return [1]
 
 
 class CustomModel(Model):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

I found tuple flattening to take up quite a lot of time (30% of total sampling), mainly due to creating lots of numpy arrays. This change creates only one array and then writes into it.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
