### PR TITLE
[travis] Add back '-v' option to pytest and install psutil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,13 +104,12 @@ matrix:
         # - export RAY_RAYLET_MONITOR_VALGRIND=1
         # - export RAY_REDIS_SERVER_VALGRIND=1
 
-        - alias pytest_cmd="pytest -v --duration=5 --timeout=300"
         # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-        - python -c 'import sys;exit(sys.version_info>=(3,5))' || pytest_cmd python/ray/experimental/test/async_test.py
-        - pytest_cmd python/ray/tests/test_mini.py
-        - pytest_cmd python/ray/tests/test_array.py
-        - pytest_cmd python/ray/tests/test_multi_node_2.py
-        - pytest_cmd python/ray/tests/test_node_manager.py
+        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_mini.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_array.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_multi_node_2.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_node_manager.py
 
 
     # Build Linux wheels.
@@ -177,12 +176,11 @@ script:
   # with pytest have the same name as the test file -- and this
   # module is only found if the test directory is in the PYTHONPATH.
   # - export PYTHONPATH="$PYTHONPATH:./ci/"
-  - alias pytest_cmd="pytest -v --duration=10 --timeout=300"
 
   # ray tune tests
   - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
   # `cluster_tests.py` runs on Jenkins, not Travis.
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then pytest_cmd --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
 
   # ray rllib tests
   - if [ $RAY_CI_RLLIB_AFFECTED == "1" ]; then python/ray/rllib/tests/run_silent.sh tests/test_catalog.py; fi
@@ -192,8 +190,8 @@ script:
 
   # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || pytest_cmd python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest_cmd python/ray/tests; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 python/ray/tests; fi
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,10 +106,10 @@ matrix:
 
         # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
         - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_mini.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_array.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_multi_node_2.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_node_manager.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_mini.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_array.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_multi_node_2.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_node_manager.py
 
 
     # Build Linux wheels.
@@ -180,7 +180,7 @@ script:
   # ray tune tests
   - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
   # `cluster_tests.py` runs on Jenkins, not Travis.
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --timeout=300 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
 
   # ray rllib tests
   - if [ $RAY_CI_RLLIB_AFFECTED == "1" ]; then python/ray/rllib/tests/run_silent.sh tests/test_catalog.py; fi
@@ -190,8 +190,8 @@ script:
 
   # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 python/ray/tests; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --timeout=300 python/ray/tests; fi
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,12 +104,13 @@ matrix:
         # - export RAY_RAYLET_MONITOR_VALGRIND=1
         # - export RAY_REDIS_SERVER_VALGRIND=1
 
+        - alias pytest_cmd="pytest -v --duration=5 --timeout=300"
         # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_mini.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_array.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_multi_node_2.py
-        - python -m pytest -v --durations=5 python/ray/tests/test_node_manager.py
+        - python -c 'import sys;exit(sys.version_info>=(3,5))' || pytest_cmd python/ray/experimental/test/async_test.py
+        - pytest_cmd python/ray/tests/test_mini.py
+        - pytest_cmd python/ray/tests/test_array.py
+        - pytest_cmd python/ray/tests/test_multi_node_2.py
+        - pytest_cmd python/ray/tests/test_node_manager.py
 
 
     # Build Linux wheels.
@@ -176,11 +177,12 @@ script:
   # with pytest have the same name as the test file -- and this
   # module is only found if the test directory is in the PYTHONPATH.
   # - export PYTHONPATH="$PYTHONPATH:./ci/"
+  - alias pytest_cmd="pytest -v --duration=10 --timeout=300"
 
   # ray tune tests
   - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
   # `cluster_tests.py` runs on Jenkins, not Travis.
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then pytest_cmd --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
 
   # ray rllib tests
   - if [ $RAY_CI_RLLIB_AFFECTED == "1" ]; then python/ray/rllib/tests/run_silent.sh tests/test_catalog.py; fi
@@ -190,8 +192,8 @@ script:
 
   # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 python/ray/tests; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || pytest_cmd python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest_cmd python/ray/tests; fi
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,11 +105,11 @@ matrix:
         # - export RAY_REDIS_SERVER_VALGRIND=1
 
         # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest --durations=5 python/ray/experimental/test/async_test.py
-        - python -m pytest --durations=5 python/ray/tests/test_mini.py
-        - python -m pytest --durations=5 python/ray/tests/test_array.py
-        - python -m pytest --durations=5 python/ray/tests/test_multi_node_2.py
-        - python -m pytest --durations=5 python/ray/tests/test_node_manager.py
+        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_mini.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_array.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_multi_node_2.py
+        - python -m pytest -v --durations=5 python/ray/tests/test_node_manager.py
 
 
     # Build Linux wheels.
@@ -180,7 +180,7 @@ script:
   # ray tune tests
   - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
   # `cluster_tests.py` runs on Jenkins, not Travis.
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest --durations=10 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
 
   # ray rllib tests
   - if [ $RAY_CI_RLLIB_AFFECTED == "1" ]; then python/ray/rllib/tests/run_silent.sh tests/test_catalog.py; fi
@@ -190,8 +190,8 @@ script:
 
   # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest --durations=5 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest --durations=10 python/ray/tests; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 python/ray/tests; fi
 
 deploy:
   - provider: s3

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -25,7 +25,7 @@ if [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "linux" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q scipy tensorflow cython==0.29.0 gym opencv-python-headless pyyaml pandas==0.23.4 requests \
-    feather-format lxml openpyxl xlrd py-spy setproctitle faulthandler pytest-timeout mock flaky networkx tabulate
+    feather-format lxml openpyxl xlrd py-spy setproctitle faulthandler pytest-timeout mock flaky networkx tabulate psutil
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y python-dev python-numpy build-essential curl unzip tmux gdb
@@ -34,7 +34,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q scipy tensorflow cython==0.29.0 gym opencv-python-headless pyyaml pandas==0.23.4 requests \
-    feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout flaky networkx tabulate
+    feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout flaky networkx tabulate psutil
 elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -50,7 +50,7 @@ elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q cython==0.29.0 tensorflow gym opencv-python-headless pyyaml pandas==0.23.4 requests \
-    feather-format lxml openpyxl xlrd py-spy setproctitle faulthandler pytest-timeout mock flaky networkx tabulate
+    feather-format lxml openpyxl xlrd py-spy setproctitle faulthandler pytest-timeout mock flaky networkx tabulate psutil
 elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   # check that brew is installed
   which -s brew
@@ -66,7 +66,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q cython==0.29.0 tensorflow gym opencv-python-headless pyyaml pandas==0.23.4 requests \
-    feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout flaky networkx tabulate
+    feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout flaky networkx tabulate psutil
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y build-essential curl unzip


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Add back the `-v` option. So when a test hangs, we know which test it is.
- pip install psutil to suppress the verbose warning log.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
