### PR TITLE
Avoid redundant bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,5 +2,3 @@
 build --compilation_mode=opt
 build --action_env=PATH
 build --action_env=PYTHON_BIN_PATH
-test --action_env=PATH
-test --action_env=PYTHON_BIN_PATH

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,6 @@
 # build config
 build --compilation_mode=opt
+build --action_env=PATH
+build --action_env=PYTHON_BIN_PATH
+test --action_env=PATH
+test --action_env=PYTHON_BIN_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
+        - ./ci/travis/install-ray.sh
       script:
         - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
         - ./java/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/travis/install-ray.sh
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
       script:
         - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
         - ./java/test.sh

--- a/build.sh
+++ b/build.sh
@@ -121,14 +121,15 @@ else
   $PYTHON_EXECUTABLE -m pip install \
       --target=$ROOT_DIR/python/ray/pyarrow_files pyarrow==0.12.0.RAY \
       --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/9357dc130789ee42f8181d8724bee1d5d1509060/index.html
+  export PYTHON_BIN_PATH="$PYTHON_EXECUTABLE"
 
   if [ "$RAY_BUILD_JAVA" == "YES" ]; then
     bazel run //java:bazel_deps -- generate -r $ROOT_DIR -s java/third_party/workspace.bzl -d java/dependencies.yaml
-    bazel build //java:all --verbose_failures --action_env=PATH
+    bazel build //java:all --verbose_failures
   fi
 
   if [ "$RAY_BUILD_PYTHON" == "YES" ]; then
-    bazel build //:ray_pkg --verbose_failures --action_env=PYTHON_BIN_PATH=$PYTHON_EXECUTABLE
+    bazel build //:ray_pkg --verbose_failures
   fi
 fi
 

--- a/java/test.sh
+++ b/java/test.sh
@@ -9,7 +9,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 pushd $ROOT_DIR/..
 echo "Linting Java code with checkstyle."
-bazel test //java:all --test_tag_filters="checkstyle" --action_env=PATH
+bazel test //java:all --test_tag_filters="checkstyle"
 
 echo "Running tests under cluster mode."
 # TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,

--- a/java/test.sh
+++ b/java/test.sh
@@ -9,7 +9,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 pushd $ROOT_DIR/..
 echo "Linting Java code with checkstyle."
-bazel test //java:all --test_tag_filters="checkstyle"
+bazel test //java:all --test_tag_filters="checkstyle" --build_tests_only
 
 echo "Running tests under cluster mode."
 # TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,

--- a/java/test.sh
+++ b/java/test.sh
@@ -9,6 +9,8 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 pushd $ROOT_DIR/..
 echo "Linting Java code with checkstyle."
+# NOTE(hchen): The `test_tag_filters` option causes bazel to ignore caches.
+# Thus, we add the `build_tests_only` option to avoid re-building everything.
 bazel test //java:all --test_tag_filters="checkstyle" --build_tests_only
 
 echo "Running tests under cluster mode."

--- a/java/test.sh
+++ b/java/test.sh
@@ -9,9 +9,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 pushd $ROOT_DIR/..
 echo "Linting Java code with checkstyle."
-# NOTE(hchen): the following `--trim_test_configuration` option is used to prevent
-# bazel from discarding caches, see https://github.com/bazelbuild/bazel/issues/6737.
-bazel test //java:all --test_tag_filters="checkstyle" --trim_test_configuration
+bazel test //java:all --test_tag_filters="checkstyle"
 
 echo "Running tests under cluster mode."
 # TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,

--- a/java/test.sh
+++ b/java/test.sh
@@ -9,7 +9,9 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 pushd $ROOT_DIR/..
 echo "Linting Java code with checkstyle."
-bazel test //java:all --test_tag_filters="checkstyle"
+# NOTE(hchen): the following `--trim_test_configuration` option is used to prevent
+# bazel from discarding caches, see https://github.com/bazelbuild/bazel/issues/6737.
+bazel test //java:all --test_tag_filters="checkstyle" --trim_test_configuration
 
 echo "Running tests under cluster mode."
 # TODO(hchen): Ideally, we should use the following bazel command to run Java tests. However, if there're skipped tests,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Bazel will invalidate caches if the command-line options are different. This PR puts all needed `action_env`s in the `.bazelrc` file to avoid cache invalidation. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
