### PR TITLE
Updates to scheduling objects to support dynamic custom resources

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -119,9 +119,8 @@ cdef extern from "ray/raylet/scheduling_resources.h" \
         c_bool IsEqual(const ResourceSet &other) const
         c_bool IsSubset(const ResourceSet &other) const
         c_bool IsSuperset(const ResourceSet &other) const
-        c_bool AddResource(const c_string &resource_name, double capacity)
+        c_bool AddOrUpdateResource(const c_string &resource_name, double capacity)
         c_bool RemoveResource(const c_string &resource_name)
-        c_bool AddResourcesStrict(const ResourceSet &other)
         void AddResources(const ResourceSet &other)
         c_bool SubtractResourcesStrict(const ResourceSet &other)
         c_bool GetResource(const c_string &resource_name, double *value) const

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -784,7 +784,8 @@ void SchedulingResources::UpdateResource(const std::string &resource_name,
       resources_total_.GetResource(resource_name);
   if (current_capacity > 0) {
     // If the resource exists, add to total and available resources
-    const FractionalResourceQuantity capacity_difference = new_capacity - current_capacity;
+    const FractionalResourceQuantity capacity_difference =
+        new_capacity - current_capacity;
     const FractionalResourceQuantity &current_available_capacity =
         resources_available_.GetResource(resource_name);
     FractionalResourceQuantity new_available_capacity =

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -132,7 +132,7 @@ bool ResourceSet::IsEqual(const ResourceSet &rhs) const {
 }
 
 void ResourceSet::AddOrUpdateResource(const std::string &resource_name,
-                                      FractionalResourceQuantity capacity) {
+                                      const FractionalResourceQuantity &capacity) {
   if (capacity > 0) {
     resource_capacity_[resource_name] = capacity;
   }
@@ -192,12 +192,12 @@ void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
       total_resources.GetResourceAmountMap();
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &to_add_resource_label = resource_pair.first;
-    FractionalResourceQuantity to_add_resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &to_add_resource_capacity = resource_pair.second;
     if (total_resource_map.count(to_add_resource_label) != 0) {
       // If resource exists in total map, add to the local capacity map.
       // If the new capacity will be greater the total capacity, set the new capacity to
       // total capacity (capping to the total)
-      FractionalResourceQuantity total_capacity =
+      const FractionalResourceQuantity &total_capacity =
           total_resource_map.at(to_add_resource_label);
       resource_capacity_[to_add_resource_label] =
           std::min(resource_capacity_[to_add_resource_label] + to_add_resource_capacity,
@@ -227,7 +227,7 @@ FractionalResourceQuantity ResourceSet::GetResource(
   if (resource_capacity_.count(resource_name) == 0) {
     return 0;
   }
-  const FractionalResourceQuantity capacity = resource_capacity_.at(resource_name);
+  const FractionalResourceQuantity &capacity = resource_capacity_.at(resource_name);
   return capacity;
 }
 
@@ -282,10 +282,10 @@ ResourceSet ResourceSet::FindUpdatedResources(
   ResourceSet updated_resource_set;
   for (const auto &resource_pair : new_resource_set.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
-    FractionalResourceQuantity new_resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &new_resource_capacity = resource_pair.second;
     if (resource_capacity_.count(resource_label) == 1) {
       // Resource exists, check if updated
-      FractionalResourceQuantity old_resource_capacity =
+      const FractionalResourceQuantity &old_resource_capacity =
           resource_capacity_.at(resource_label);
       if (old_resource_capacity != new_resource_capacity) {
         updated_resource_set.AddOrUpdateResource(resource_label, new_resource_capacity);
@@ -305,7 +305,7 @@ ResourceSet ResourceSet::FindDeletedResources(
   auto &new_resource_map = new_resource_set.GetResourceAmountMap();
   for (const auto &resource_pair : resource_capacity_) {
     const std::string &resource_label = resource_pair.first;
-    FractionalResourceQuantity old_resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &old_resource_capacity = resource_pair.second;
     if (new_resource_map.count(resource_label) != 1) {
       // Resource does not exist, add to return set
       deleted_resource_set.AddOrUpdateResource(resource_label, old_resource_capacity);
@@ -345,7 +345,7 @@ ResourceIds::ResourceIds(
       total_capacity_(TotalQuantity()),
       decrement_backlog_(0) {}
 
-bool ResourceIds::Contains(FractionalResourceQuantity resource_quantity) const {
+bool ResourceIds::Contains(const FractionalResourceQuantity &resource_quantity) const {
   if (resource_quantity >= 1) {
     double whole_quantity = resource_quantity.ToDouble();
     RAY_CHECK(IsWhole(whole_quantity));
@@ -364,7 +364,7 @@ bool ResourceIds::Contains(FractionalResourceQuantity resource_quantity) const {
   }
 }
 
-ResourceIds ResourceIds::Acquire(FractionalResourceQuantity resource_quantity) {
+ResourceIds ResourceIds::Acquire(const FractionalResourceQuantity &resource_quantity) {
   if (resource_quantity >= 1) {
     // Handle the whole case.
     double whole_quantity = resource_quantity.ToDouble();
@@ -405,7 +405,7 @@ ResourceIds ResourceIds::Acquire(FractionalResourceQuantity resource_quantity) {
     auto return_pair = std::make_pair(whole_id, resource_quantity);
     // We cannot make use of the implicit conversion because ints have no
     // operator-(const FractionalResourceQuantity&) function.
-    FractionalResourceQuantity remaining_amount =
+    const FractionalResourceQuantity remaining_amount =
         FractionalResourceQuantity(1) - resource_quantity;
     fractional_ids_.push_back(std::make_pair(whole_id, remaining_amount));
     return ResourceIds({return_pair});
@@ -574,7 +574,7 @@ ResourceIdSet::ResourceIdSet(
 bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
   for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    FractionalResourceQuantity resource_quantity = resource_pair.second;
+    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     if (it == available_resources_.end()) {
@@ -593,7 +593,7 @@ ResourceIdSet ResourceIdSet::Acquire(const ResourceSet &resource_set) {
 
   for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    FractionalResourceQuantity resource_quantity = resource_pair.second;
+    const FractionalResourceQuantity &resource_quantity = resource_pair.second;
 
     auto it = available_resources_.find(resource_name);
     RAY_CHECK(it != available_resources_.end());
@@ -779,13 +779,13 @@ void SchedulingResources::Acquire(const ResourceSet &resources) {
 
 void SchedulingResources::UpdateResource(const std::string &resource_name,
                                          int64_t capacity) {
-  FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
-  FractionalResourceQuantity current_capacity =
+  const FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
+  const FractionalResourceQuantity &current_capacity =
       resources_total_.GetResource(resource_name);
   if (current_capacity > 0) {
     // If the resource exists, add to total and available resources
-    FractionalResourceQuantity capacity_difference = new_capacity - current_capacity;
-    FractionalResourceQuantity current_available_capacity =
+    const FractionalResourceQuantity capacity_difference = new_capacity - current_capacity;
+    const FractionalResourceQuantity &current_available_capacity =
         resources_available_.GetResource(resource_name);
     FractionalResourceQuantity new_available_capacity =
         current_available_capacity + capacity_difference;

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -193,9 +193,6 @@ void ResourceSet::AddResourcesCapacityConstrained(const ResourceSet &other,
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &to_add_resource_label = resource_pair.first;
     FractionalResourceQuantity to_add_resource_capacity = resource_pair.second;
-    RAY_CHECK(to_add_resource_capacity > 0) << "Trying to add nonpositive resource "
-                                            << to_add_resource_label << ", capacity"
-                                            << to_add_resource_capacity.ToDouble();
     if (total_resource_map.count(to_add_resource_label) != 0) {
       // If resource exists in total map, add to the local capacity map.
       // If the new capacity will be greater the total capacity, set the new capacity to

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -116,7 +116,7 @@ class ResourceSet {
   /// \param capacity: numeric capacity value for the resource to add.
   /// \return True, if the resource was successfully added. False otherwise.
   void AddOrUpdateResource(const std::string &resource_name,
-                           FractionalResourceQuantity capacity);
+                           const FractionalResourceQuantity &capacity);
 
   /// \brief Delete a resource from the resource set.
   ///
@@ -256,14 +256,14 @@ class ResourceIds {
   ///
   /// \param resource_quantity Either a whole number or a fraction less than 1.
   /// \return True if there we have enough of the resource.
-  bool Contains(FractionalResourceQuantity resource_quantity) const;
+  bool Contains(const FractionalResourceQuantity &resource_quantity) const;
 
   /// \brief Acquire the requested amount of the resource.
   ///
   /// \param resource_quantity The amount to acquire. Either a whole number or a
   /// fraction less than 1.
   /// \return A ResourceIds representing the specific acquired IDs.
-  ResourceIds Acquire(FractionalResourceQuantity resource_quantity);
+  ResourceIds Acquire(const FractionalResourceQuantity &resource_quantity);
 
   /// \brief Return some resource IDs.
   ///


### PR DESCRIPTION
## What do these changes do?

These changes add support to scheduling objects (ResourceSet, ResourceIdSet) to support adding, updating and removing resources at runtime. This is a split of the larger PR #3742.