### PR TITLE
(wip) [tune] Programmatic Stopping Criteria

### DIFF
--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -108,7 +108,7 @@ def run(args, parser):
                 "resources_per_trial": (
                     args.resources_per_trial and
                     resources_to_json(args.resources_per_trial)),
-                "stop": args.stop,
+                "stop": args.stop and json.loads(args.stop),
                 "config": dict(args.config, env=args.env),
                 "restore": args.restore,
                 "num_samples": args.num_samples,

--- a/python/ray/tune/commands.py
+++ b/python/ray/tune/commands.py
@@ -136,7 +136,6 @@ def list_trials(experiment_path,
     checkpoint_dicts = experiment_state["checkpoints"]
     checkpoint_dicts = [flatten_dict(g) for g in checkpoint_dicts]
     checkpoints_df = pd.DataFrame(checkpoint_dicts)
-
     result_keys = ["last_result:{}".format(k) for k in result_keys]
     col_keys = [
         k for k in list(info_keys) + result_keys if k in checkpoints_df

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -40,9 +40,8 @@ def make_parser(parser_creator=None, **kwargs):
         "tune registry.")
     parser.add_argument(
         "--stop",
-        default="{}",
-        type=json.loads,
-        help="The stopping criteria, specified in JSON. The keys may be any "
+        default=None,
+        help="The stopping criteria. If JSON, the keys may be any "
         "field returned by 'train()' e.g. "
         "'{\"time_total_s\": 600, \"training_iteration\": 100000}' to stop "
         "after 600 seconds or 100k iterations, whichever is reached first.")

--- a/python/ray/tune/stop.py
+++ b/python/ray/tune/stop.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ray.tune import TuneError
+
+
+class StoppingCriteria():
+    def __init__(self, criteria):
+        self.stopping_criterion = criteria
+
+    def __call__(self, result):
+        for criteria, stop_value in self.stopping_criterion.items():
+            if criteria not in result:
+                raise TuneError(
+                    "Stopping criteria {} not provided in result {}.".format(
+                        criteria, result))
+            if result[criteria] >= stop_value:
+                return True
+        return False

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -103,9 +103,10 @@ def run(run_or_experiment,
             If Experiment, then Tune will execute training based on
             Experiment.spec.
         name (str): Name of experiment.
-        stop (dict): The stopping criteria. The keys may be any field in
+        stop (dict | fn): The stopping criteria. The keys may be any field in
             the return result of 'train()', whichever is reached first.
-            Defaults to empty dict.
+            Defaults to empty dict. If function, then the function is expected
+            to have a signature: func(result: dict) -> bool.
         config (dict): Algorithm-specific configuration for Tune variant
             generation (e.g. env, hyperparams). Defaults to empty dict.
             Custom search algorithms may ignore this.


### PR DESCRIPTION
Allow Tune to support both a function and dict for stopping trials.


<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->