### PR TITLE
[tune] Make examples more verbose

### DIFF
--- a/python/ray/tune/examples/mnist_pytorch.py
+++ b/python/ray/tune/examples/mnist_pytorch.py
@@ -171,7 +171,6 @@ if __name__ == "__main__":
     tune.run(
         "TRAIN_FN",
         name="exp",
-        verbose=0,
         scheduler=sched,
         **{
             "stop": {

--- a/python/ray/tune/examples/mnist_pytorch_trainable.py
+++ b/python/ray/tune/examples/mnist_pytorch_trainable.py
@@ -179,7 +179,6 @@ if __name__ == "__main__":
         time_attr="training_iteration", reward_attr="neg_mean_loss")
     tune.run(
         TrainMNIST,
-        verbose=0,
         scheduler=sched,
         **{
             "stop": {

--- a/python/ray/tune/examples/tune_mnist_keras.py
+++ b/python/ray/tune/examples/tune_mnist_keras.py
@@ -183,7 +183,6 @@ if __name__ == "__main__":
     tune.run(
         "TRAIN_FN",
         name="exp",
-        verbose=0,
         scheduler=sched,
         **{
             "stop": {


### PR DESCRIPTION
## What do these changes do?
Verbosity defaults to "1", so here we default verbosity for a couple
examples.

## Related issue number

Fixes #4467