### PR TITLE
Fixes Inconsistent weight assignment operations in DQNPolicyGraph (#4…

### DIFF
--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -387,9 +387,7 @@ class DQNPolicyGraph(TFPolicyGraph):
         # update_target_fn will be called periodically to copy Q network to
         # target Q network
         update_target_expr = []
-        for var, var_target in zip(
-                sorted(self.q_func_vars, key=lambda v: v.name),
-                sorted(self.target_q_func_vars, key=lambda v: v.name)):
+        for var, var_target in zip(self.q_func_vars, self.target_q_func_vars):
             update_target_expr.append(var_target.assign(var))
         self.update_target_expr = tf.group(*update_target_expr)
 

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -387,6 +387,8 @@ class DQNPolicyGraph(TFPolicyGraph):
         # update_target_fn will be called periodically to copy Q network to
         # target Q network
         update_target_expr = []
+        assert len(self.q_func_vars) == len(self.target_q_func_vars), \
+            (self.q_func_vars, self.target_q_func_vars)
         for var, var_target in zip(self.q_func_vars, self.target_q_func_vars):
             update_target_expr.append(var_target.assign(var))
         self.update_target_expr = tf.group(*update_target_expr)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Fixes "Inconsistent weight assignment operations in DQNPolicyGraph #4502" by removing unnecessary `sorted` from `DQNPolicyGraph.__init__`.

<!-- Please give a short brief about these changes. -->

## Related issue number

Fixes #4502
<!-- Are there any issues opened that will be resolved by merging this change? -->
