### PR TITLE
Fix broken pipe callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,8 @@ install:
   # Raylet tests.
   - ./ci/suppress_output bash src/ray/test/run_object_manager_tests.sh
   - ./ci/suppress_output bazel test --build_tests_only --test_lang_filters=cc //:all
+  # Shutdown bazel to release the memory held by bazel.
+  - bazel shutdown
 
 script:
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,8 @@ install:
 
 script:
   - export PATH="$HOME/miniconda/bin:$PATH"
+  - python -m pytest -v -s --durations=10 --timeout=300 python/ray/tests/test_object_manager.py::test_actor_broadcast
+  - python -m pytest -v -s --durations=10 --timeout=300 python/ray/tests/test_component_failures.py::test_plasma_store_failed
   # The following is needed so cloudpickle can find some of the
   # class definitions: The main module of tests that are run
   # with pytest have the same name as the test file -- and this

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,8 +169,6 @@ install:
 
 script:
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - python -m pytest -v -s --durations=10 --timeout=300 python/ray/tests/test_object_manager.py::test_actor_broadcast
-  - python -m pytest -v -s --durations=10 --timeout=300 python/ray/tests/test_component_failures.py::test_plasma_store_failed
   # The following is needed so cloudpickle can find some of the
   # class definitions: The main module of tests that are run
   # with pytest have the same name as the test file -- and this

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -573,8 +573,10 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
-            ray_constants.PROCESS_TYPE_REPORTER, check_alive=check_alive)
+        # reporter is started only in PY3.
+        if PY3:
+            self._kill_process_type(
+                ray_constants.PROCESS_TYPE_REPORTER, check_alive=check_alive)
 
     def kill_dashboard(self, check_alive=True):
         """Kill the dashboard.

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -519,6 +519,8 @@ def test_resource_assignment(shutdown_only):
             return ray.get_resource_ids()
 
     decorator_resource_args = [{}, {
+        "num_cpus": 0.1
+    }, {
         "num_gpus": 0.1
     }, {
         "resources": {
@@ -526,6 +528,8 @@ def test_resource_assignment(shutdown_only):
         }
     }]
     instantiation_resource_args = [{}, {
+        "num_cpus": 0.2
+    }, {
         "num_gpus": 0.2
     }, {
         "resources": {

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -519,8 +519,6 @@ def test_resource_assignment(shutdown_only):
             return ray.get_resource_ids()
 
     decorator_resource_args = [{}, {
-        "num_cpus": 0.1
-    }, {
         "num_gpus": 0.1
     }, {
         "resources": {
@@ -528,8 +526,6 @@ def test_resource_assignment(shutdown_only):
         }
     }]
     instantiation_resource_args = [{}, {
-        "num_cpus": 0.2
-    }, {
         "num_gpus": 0.2
     }, {
         "resources": {

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -329,7 +329,7 @@ def test_raylet_failed(ray_start_cluster):
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 8,
-        "num_nodes": 4
+        "num_nodes": 2
     }], indirect=True)
 def test_plasma_store_failed(ray_start_cluster):
     cluster = ray_start_cluster

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -84,6 +84,7 @@ def test_worker_plasma_store_failure(ray_start_cluster_head):
     cluster.wait_for_nodes()
     # Log monitor doesn't die for some reason
     worker.kill_log_monitor()
+    worker.kill_reporter()
     worker.kill_plasma_store()
     worker.all_processes[ray_constants.PROCESS_TYPE_RAYLET][0].process.wait()
     assert not worker.any_processes_alive(), worker.live_processes()

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -185,7 +185,8 @@ void ServerConnection<T>::DoAsyncWrites() {
   };
 
   if (async_write_broken_pipe_) {
-    // The connection is not healthy and the heartbeat is not timeout yet.
+    // Call the handlers directly. Because writing messages to a connection
+    // with broken-pipe status will result in the callbacks never being called.
     call_handlers(ray::Status::IOError("Broken pipe"), num_messages);
     return;
   }

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -101,7 +101,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>
   /// Whether we are in the middle of an async write.
   bool async_write_in_flight_;
 
-  /// Whether we meet broken-pipe message during writing.
+  /// Whether we've met a broken-pipe error during writing.
   bool async_write_broken_pipe_;
 
   /// Count of async messages sent total.

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -101,6 +101,9 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection<T>
   /// Whether we are in the middle of an async write.
   bool async_write_in_flight_;
 
+  /// Whether we meet broken-pipe message during writing.
+  bool async_write_broken_pipe_;
+
   /// Count of async messages sent total.
   int64_t async_writes_ = 0;
 

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -257,12 +257,15 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
     if (fractional_pair_it == fractional_ids_.end()) {
       fractional_ids_.push_back(fractional_pair_to_return);
     } else {
+      RAY_CHECK(fractional_pair_it->second < 1);
       fractional_pair_it->second += fractional_pair_to_return.second;
-      RAY_CHECK(fractional_pair_it->second <= 1);
       // If this makes the ID whole, then return it to the list of whole IDs.
-      if (fractional_pair_it->second == 1) {
+      if (fractional_pair_it->second >= 1) {
         whole_ids_.push_back(resource_id);
-        fractional_ids_.erase(fractional_pair_it);
+        fractional_pair_it->second -= 1;
+        if (fractional_pair_it->second < 1e-6) {
+          fractional_ids_.erase(fractional_pair_it);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
1. Better handle `Broken Pipe` status, say don't 'send' message when the status is `Broken Pipe`. If we continue to send message, the callback won't get called.
2. Fix `test_multi_node_2.py:: test_worker_plasma_store_failure` by killing reporter when running in Python3.
3. Fix `test_component_failures.py::test_plasma_store_failed` by reducing the node from 4 to 2. This test passes in my local envs, but it may be two heavy for travis machines.
4. Fix `test_actor.py::test_resource_assignment` by refine scheduling_resources.cc. The test fails when there is 0.9 GPU and 0.2 GPU is returned. 1.1 GPU will make the check fail. Furthermore, it not right to compare a double number to int number. The crash in the test is as follows (the actual number of `fractional_pair_it->second` is 1.1 and the released resource is 0.2):
```
F0329 16:15:18.325944 207971776 scheduling_resources.cc:261]  Check failed: fractional_pair_it->second <= 1
*** Check failure stack trace: ***
*** Aborted at 1553847318 (unix time) try "date -d @1553847318" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x7fff678a32c6) received by PID 21869 (TID 0x10c6565c0) stack trace: ***
    @     0x7fff6794db5d _sigtramp
    @        0x10c5d1f87 (unknown)
    @     0x7fff6780d6a6 abort
    @        0x10898cfa9 google::logging_fail()
    @        0x10898bcd3 google::LogMessage::SendToLog()
    @        0x10898c3a5 google::LogMessage::Flush()
    @        0x10898c482 google::LogMessage::~LogMessage()
    @        0x108985c35 ray::RayLog::~RayLog()
    @        0x1088ce6f5 ray::raylet::ResourceIds::Release()
    @        0x1088d03a4 ray::raylet::ResourceIdSet::Release()
    @        0x1088a7230 ray::raylet::NodeManager::ProcessDisconnectClientMessage()
    @        0x1088a5d9d ray::raylet::NodeManager::ProcessClientMessage()
    @        0x1088c390c std::__1::__function::__func<>::operator()()
    @        0x10897b446 ray::ClientConnection<>::ProcessMessage()
    @        0x1089822f5 boost::asio::detail::reactive_socket_recv_op<>::do_complete()
    @        0x10888ac48 boost::asio::detail::scheduler::do_run_one()
    @        0x10888a682 boost::asio::detail::scheduler::run()
    @        0x10887f70e main
    @     0x7fff677683d5 start
    @               0x10 (unknown)
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
