### PR TITLE
[serve] Double Serialization Optimization

### DIFF
--- a/python/ray/experimental/serve/router/routers.py
+++ b/python/ray/experimental/serve/router/routers.py
@@ -125,13 +125,13 @@ class DeadlineAwareRouter:
 
         result_object_id = get_new_oid()
 
-        # - `data_oid` is either an ObjectID or inlined object
-        # - This is equivalent to `data_oid = data`, although it avoids
-        #   double serialization for large object.
-        data_oid = ray.worker.global_worker._current_task.arguments()[1]
+        # Here, 'data_object_id' is either an ObjectID or an actual object.
+        # When it is an object ID, this is an optimization to avoid creating
+        # an extra copy of 'data' in the object store.
+        data_object_id = ray.worker.global_worker._current_task.arguments()[1]
 
         self.query_queues[actor_name].push(
-            SingleQuery(data_oid, result_object_id, deadline_s))
+            SingleQuery(data_object_id, result_object_id, deadline_s))
 
         return [result_object_id]
 

--- a/python/ray/experimental/serve/router/routers.py
+++ b/python/ray/experimental/serve/router/routers.py
@@ -126,7 +126,7 @@ class DeadlineAwareRouter:
         result_object_id = get_new_oid()
 
         # Here, 'data_object_id' is either an ObjectID or an actual object.
-        # When it is an object ID, this is an optimization to avoid creating
+        # When it is an ObjectID, this is an optimization to avoid creating
         # an extra copy of 'data' in the object store.
         data_object_id = ray.worker.global_worker._current_task.arguments()[1]
 

--- a/python/ray/experimental/serve/router/routers.py
+++ b/python/ray/experimental/serve/router/routers.py
@@ -124,8 +124,14 @@ class DeadlineAwareRouter:
             ACTOR_NOT_REGISTERED_MSG(actor_name))
 
         result_object_id = get_new_oid()
+
+        # - `data_oid` is either an ObjectID or inlined object
+        # - This is equivalent to `data_oid = data`, although it avoids
+        #   double serialization for large object.
+        data_oid = ray.worker.global_worker._current_task.arguments()[1]
+
         self.query_queues[actor_name].push(
-            SingleQuery(data, result_object_id, deadline_s))
+            SingleQuery(data_oid, result_object_id, deadline_s))
 
         return [result_object_id]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Use `ray.worker.global_worker._current_task.arguments()` to retrieve ObjectID for large object in `router.call` method. This prevents big object being serialized twice:
1. user's `router.call.remote`
2. router's `actor_handle.call.remote`

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
