### PR TITLE
Change resource bookkeeping to account for machine precision.

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1402,13 +1402,13 @@ def test_actor_init_fails(ray_start_cluster_head):
             return self.x
 
     # Create many actors. It should take a while to finish initializing them.
-    actors = [Counter.remote() for _ in range(100)]
+    actors = [Counter.remote() for _ in range(15)]
     # Allow some time to forward the actor creation tasks to the other node.
     time.sleep(0.1)
     # Kill the second node.
     cluster.remove_node(remote_node)
 
-    # Get all of the results
+    # Get all of the results.
     results = ray.get([actor.inc.remote() for actor in actors])
     assert results == [1 for actor in actors]
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2189,20 +2189,23 @@ def test_many_custom_resources(shutdown_only):
     ray.get(results)
 
 
+# TODO: 5 retry attempts may be too little for Travis and we may need to increase
+# it if this test begins to be flaky on Travis.
 def test_zero_capacity_deletion_semantics(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"test_resource": 1})
 
     def test():
         resources = ray.global_state.available_resources()
+        MAX_RETRY_ATTEMPTS = 5
         retry_count = 0
 
-        while resources and retry_count < 5:
+        while resources and retry_count < MAX_RETRY_ATTEMPTS:
             time.sleep(0.1)
             resources = ray.global_state.available_resources()
             retry_count += 1
 
-        if retry_count >= 5:
-            raise RuntimeError("Resources were available even after retries.")
+        if retry_count >= MAX_RETRY_ATTEMPTS:
+            raise RuntimeError("Resources were available even after five retries.")
 
         return resources
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -878,11 +878,14 @@ def test_submit_many(shutdown_only):
         for _ in range(100)
     ])
 
-    assert ray.global_state.available_resources() == {
-        'CPU': 2.0,
-        'Custom': 2.0,
-        'GPU': 2.0
-    }
+    while True:
+        if ray.global_state.available_resources() == {
+                "CPU": 2.0,
+                "Custom": 2.0,
+                "GPU": 2.0
+        }:
+            break
+    assert True
 
 
 def test_get_multiple(ray_start_regular):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -884,7 +884,7 @@ def test_many_fractional_resources(shutdown_only):
             resources={"Custom": np.random.uniform()}) for _ in range(100)
     ])
 
-    stop_time = time.time() + 60 * 10
+    stop_time = time.time() + 10
     correct_available_resources = False
     while time.time() < stop_time:
         if ray.global_state.available_resources() == {

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -877,13 +877,15 @@ def test_many_fractional_resources(shutdown_only):
         f._remote(resources={"Custom": np.random.uniform()})
         for _ in range(100)
     ])
-    ray.get([f._remote(num_cpus=np.random.uniform(),
-                       num_gpus=np.random.uniform(),
-                       resources={"Custom": np.random.uniform()})
-             for _ in range(100)])
+    ray.get([
+        f._remote(
+            num_cpus=np.random.uniform(),
+            num_gpus=np.random.uniform(),
+            resources={"Custom": np.random.uniform()}) for _ in range(100)
+    ])
 
     stop_time = time.time() + 60 * 10
-    correct_available_resources = False;
+    correct_available_resources = False
     while time.time() < stop_time:
         if ray.global_state.available_resources() == {
                 "Custom": 2.0,

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -868,33 +868,53 @@ def test_many_fractional_resources(shutdown_only):
     ray.init(num_cpus=2, num_gpus=2, resources={"Custom": 2})
 
     @ray.remote
-    def f():
+    def g():
         return 1
 
-    ray.get([f._remote(num_cpus=np.random.uniform()) for _ in range(100)])
-    ray.get([f._remote(num_gpus=np.random.uniform()) for _ in range(100)])
-    ray.get([
-        f._remote(resources={"Custom": np.random.uniform()})
-        for _ in range(100)
-    ])
-    ray.get([
-        f._remote(
-            num_cpus=np.random.uniform(),
-            num_gpus=np.random.uniform(),
-            resources={"Custom": np.random.uniform()}) for _ in range(100)
-    ])
+    @ray.remote
+    def f(block, accepted_resources):
+        true_resources = {resource: value[0][1] for resource, value in ray.get_resource_ids().items()}
+        if block:
+            ray.get(g.remote())
+        return true_resources == accepted_resources
 
+    # Check that the resource are assigned correctly.
+    for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
+        resource_set = {"CPU": int(rand1*10000)/10000}
+        assert ray.get(f._remote([False, resource_set], num_cpus=rand1))
+
+        resource_set = {"CPU": 1, "GPU": int(rand1*10000)/10000}
+        assert ray.get(f._remote([False, resource_set], num_gpus=rand1))
+
+        resource_set = {"CPU": 1, "Custom": int(rand1*10000)/10000}
+        assert ray.get(f._remote([False, resource_set], resources={"Custom": rand1}))
+
+        resource_set = {"CPU": int(rand1*10000)/10000, "GPU": int(rand2*10000)/10000, "Custom": int(rand3*10000)/10000}
+        assert ray.get(f._remote([False, resource_set],
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3})
+        )
+        assert ray.get(
+            f._remote([True, resource_set],
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3})
+        )
+
+    # Check that the available resources at the end are the same as the
+    # beginning.
     stop_time = time.time() + 10
     correct_available_resources = False
     while time.time() < stop_time:
         if ray.global_state.available_resources() == {
-                "Custom": 2.0,
-                "GPU": 2.0,
                 "CPU": 2.0,
+                "GPU": 2.0,
+                "Custom": 2.0,
         }:
             correct_available_resources = True
             break
-    if (not correct_available_resources):
+    if not correct_available_resources:
         assert False, "Did not get correct available resources."
 
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -882,15 +882,16 @@ def test_many_fractional_resources(shutdown_only):
         return true_resources == accepted_resources
 
     # Check that the resource are assigned correctly.
+    result_ids = []
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
         resource_set = {"CPU": int(rand1 * 10000) / 10000}
-        assert ray.get(f._remote([False, resource_set], num_cpus=rand1))
+        result_ids.append(f._remote([False, resource_set], num_cpus=rand1))
 
         resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
-        assert ray.get(f._remote([False, resource_set], num_gpus=rand1))
+        result_ids.append(f._remote([False, resource_set], num_gpus=rand1))
 
         resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
-        assert ray.get(
+        result_ids.append(
             f._remote([False, resource_set], resources={"Custom": rand1}))
 
         resource_set = {
@@ -898,18 +899,19 @@ def test_many_fractional_resources(shutdown_only):
             "GPU": int(rand2 * 10000) / 10000,
             "Custom": int(rand3 * 10000) / 10000
         }
-        assert ray.get(
+        result_ids.append(
             f._remote(
                 [False, resource_set],
                 num_cpus=rand1,
                 num_gpus=rand2,
                 resources={"Custom": rand3}))
-        assert ray.get(
+        result_ids.append(
             f._remote(
                 [True, resource_set],
                 num_cpus=rand1,
                 num_gpus=rand2,
                 resources={"Custom": rand3}))
+    assert all(ray.get(result_ids))
 
     # Check that the available resources at the end are the same as the
     # beginning.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2189,7 +2189,7 @@ def test_many_custom_resources(shutdown_only):
     ray.get(results)
 
 
-# TODO: 5 retry attempts may be too little for Travis and we may need to 
+# TODO: 5 retry attempts may be too little for Travis and we may need to
 # increase it if this test begins to be flaky on Travis.
 def test_zero_capacity_deletion_semantics(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"test_resource": 1})

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2189,8 +2189,8 @@ def test_many_custom_resources(shutdown_only):
     ray.get(results)
 
 
-# TODO: 5 retry attempts may be too little for Travis and we may need to increase
-# it if this test begins to be flaky on Travis.
+# TODO: 5 retry attempts may be too little for Travis and we may need to 
+# increase it if this test begins to be flaky on Travis.
 def test_zero_capacity_deletion_semantics(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"test_resource": 1})
 
@@ -2205,7 +2205,8 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
             retry_count += 1
 
         if retry_count >= MAX_RETRY_ATTEMPTS:
-            raise RuntimeError("Resources were available even after five retries.")
+            raise RuntimeError(
+                "Resources were available even after five retries.")
 
         return resources
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -873,34 +873,43 @@ def test_many_fractional_resources(shutdown_only):
 
     @ray.remote
     def f(block, accepted_resources):
-        true_resources = {resource: value[0][1] for resource, value in ray.get_resource_ids().items()}
+        true_resources = {
+            resource: value[0][1]
+            for resource, value in ray.get_resource_ids().items()
+        }
         if block:
             ray.get(g.remote())
         return true_resources == accepted_resources
 
     # Check that the resource are assigned correctly.
     for rand1, rand2, rand3 in np.random.uniform(size=(100, 3)):
-        resource_set = {"CPU": int(rand1*10000)/10000}
+        resource_set = {"CPU": int(rand1 * 10000) / 10000}
         assert ray.get(f._remote([False, resource_set], num_cpus=rand1))
 
-        resource_set = {"CPU": 1, "GPU": int(rand1*10000)/10000}
+        resource_set = {"CPU": 1, "GPU": int(rand1 * 10000) / 10000}
         assert ray.get(f._remote([False, resource_set], num_gpus=rand1))
 
-        resource_set = {"CPU": 1, "Custom": int(rand1*10000)/10000}
-        assert ray.get(f._remote([False, resource_set], resources={"Custom": rand1}))
-
-        resource_set = {"CPU": int(rand1*10000)/10000, "GPU": int(rand2*10000)/10000, "Custom": int(rand3*10000)/10000}
-        assert ray.get(f._remote([False, resource_set],
-                num_cpus=rand1,
-                num_gpus=rand2,
-                resources={"Custom": rand3})
-        )
+        resource_set = {"CPU": 1, "Custom": int(rand1 * 10000) / 10000}
         assert ray.get(
-            f._remote([True, resource_set],
+            f._remote([False, resource_set], resources={"Custom": rand1}))
+
+        resource_set = {
+            "CPU": int(rand1 * 10000) / 10000,
+            "GPU": int(rand2 * 10000) / 10000,
+            "Custom": int(rand3 * 10000) / 10000
+        }
+        assert ray.get(
+            f._remote(
+                [False, resource_set],
                 num_cpus=rand1,
                 num_gpus=rand2,
-                resources={"Custom": rand3})
-        )
+                resources={"Custom": rand3}))
+        assert ray.get(
+            f._remote(
+                [True, resource_set],
+                num_cpus=rand1,
+                num_gpus=rand2,
+                resources={"Custom": rand3}))
 
     # Check that the available resources at the end are the same as the
     # beginning.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -872,18 +872,23 @@ def test_submit_many(shutdown_only):
         return 1
 
     ray.get([f._remote(num_cpus=np.random.uniform()) for _ in range(100)])
+    print("AAAAAAAAAA")
     ray.get([f._remote(num_gpus=np.random.uniform()) for _ in range(100)])
+    print("BBBBBBBBBB")
     ray.get([
         f._remote(resources={"Custom": np.random.uniform()})
         for _ in range(100)
     ])
+    print("DDDDDDDDDDD")
 
     while True:
+        print(ray.global_state.available_resources())
         if ray.global_state.available_resources() == {
                 "CPU": 2.0,
                 "Custom": 2.0,
                 "GPU": 2.0
         }:
+            print("SSSSSSSSSSSSSS")
             break
     assert True
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -872,23 +872,18 @@ def test_submit_many(shutdown_only):
         return 1
 
     ray.get([f._remote(num_cpus=np.random.uniform()) for _ in range(100)])
-    print("AAAAAAAAAA")
     ray.get([f._remote(num_gpus=np.random.uniform()) for _ in range(100)])
-    print("BBBBBBBBBB")
     ray.get([
         f._remote(resources={"Custom": np.random.uniform()})
         for _ in range(100)
     ])
-    print("DDDDDDDDDDD")
 
     while True:
-        print(ray.global_state.available_resources())
         if ray.global_state.available_resources() == {
                 "CPU": 2.0,
                 "Custom": 2.0,
                 "GPU": 2.0
         }:
-            print("SSSSSSSSSSSSSS")
             break
     assert True
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -171,11 +171,11 @@ ray::Status NodeManager::RegisterGcs() {
       /*done_callback=*/nullptr));
 
   // Subscribe to driver table updates.
-  const auto driver_table_handler =
-      [this](gcs::AsyncGcsClient *client, const DriverID &client_id,
-             const std::vector<DriverTableDataT> &driver_data) {
-        HandleDriverTableUpdate(client_id, driver_data);
-      };
+  const auto driver_table_handler = [this](
+      gcs::AsyncGcsClient *client, const DriverID &client_id,
+      const std::vector<DriverTableDataT> &driver_data) {
+    HandleDriverTableUpdate(client_id, driver_data);
+  };
   RAY_RETURN_NOT_OK(gcs_client_->driver_table().Subscribe(
       DriverID::nil(), ClientID::nil(), driver_table_handler, nullptr));
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -153,17 +153,18 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientAddedCallback(node_manager_client_added);
   // Register a callback on the client table for removed clients.
-  auto node_manager_client_removed =
-      [this](gcs::AsyncGcsClient *client, const UniqueID &id,
-             const ClientTableDataT &data) { ClientRemoved(data); };
+  auto node_manager_client_removed = [this](
+      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
+    ClientRemoved(data);
+  };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
   // Subscribe to heartbeat batches from the monitor.
-  const auto &heartbeat_batch_added =
-      [this](gcs::AsyncGcsClient *client, const ClientID &id,
-             const HeartbeatBatchTableDataT &heartbeat_batch) {
-        HeartbeatBatchAdded(heartbeat_batch);
-      };
+  const auto &heartbeat_batch_added = [this](
+      gcs::AsyncGcsClient *client, const ClientID &id,
+      const HeartbeatBatchTableDataT &heartbeat_batch) {
+    HeartbeatBatchAdded(heartbeat_batch);
+  };
   RAY_RETURN_NOT_OK(gcs_client_->heartbeat_batch_table().Subscribe(
       DriverID::nil(), ClientID::nil(), heartbeat_batch_added,
       /*subscribe_callback=*/nullptr,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2028,8 +2028,6 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
     RAY_LOG(INFO) << "Failed to forward task " << task_id << " to node manager "
                   << node_manager_id;
 
-    // TODO(romilb): We should probably revert the load subtraction from
-    // SchedulingPolicy::Schedule()
     // Mark the failed task as pending to let other raylets know that we still
     // have the task. TaskDependencyManager::TaskPending() is assumed to be
     // idempotent.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -153,18 +153,17 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientAddedCallback(node_manager_client_added);
   // Register a callback on the client table for removed clients.
-  auto node_manager_client_removed = [this](
-      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
-    ClientRemoved(data);
-  };
+  auto node_manager_client_removed =
+      [this](gcs::AsyncGcsClient *client, const UniqueID &id,
+             const ClientTableDataT &data) { ClientRemoved(data); };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
   // Subscribe to heartbeat batches from the monitor.
-  const auto &heartbeat_batch_added = [this](
-      gcs::AsyncGcsClient *client, const ClientID &id,
-      const HeartbeatBatchTableDataT &heartbeat_batch) {
-    HeartbeatBatchAdded(heartbeat_batch);
-  };
+  const auto &heartbeat_batch_added =
+      [this](gcs::AsyncGcsClient *client, const ClientID &id,
+             const HeartbeatBatchTableDataT &heartbeat_batch) {
+        HeartbeatBatchAdded(heartbeat_batch);
+      };
   RAY_RETURN_NOT_OK(gcs_client_->heartbeat_batch_table().Subscribe(
       DriverID::nil(), ClientID::nil(), heartbeat_batch_added,
       /*subscribe_callback=*/nullptr,
@@ -1624,7 +1623,8 @@ bool NodeManager::AssignTask(const Task &task) {
 
   if (spec.IsActorCreationTask()) {
     // Check that we are not placing an actor creation task on a node with 0 CPUs.
-    RAY_CHECK(cluster_resource_map_[my_client_id].GetTotalResources().GetResourceMap().at(kCPU_ResourceLabel) != 0);
+    RAY_CHECK(cluster_resource_map_[my_client_id].GetTotalResources().GetResourceMap().at(
+                  kCPU_ResourceLabel) != 0);
     worker->SetLifetimeResourceIds(acquired_resources);
   } else {
     worker->SetTaskResourceIds(acquired_resources);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -170,11 +170,11 @@ ray::Status NodeManager::RegisterGcs() {
       /*done_callback=*/nullptr));
 
   // Subscribe to driver table updates.
-  const auto driver_table_handler = [this](
-      gcs::AsyncGcsClient *client, const DriverID &client_id,
-      const std::vector<DriverTableDataT> &driver_data) {
-    HandleDriverTableUpdate(client_id, driver_data);
-  };
+  const auto driver_table_handler =
+      [this](gcs::AsyncGcsClient *client, const DriverID &client_id,
+             const std::vector<DriverTableDataT> &driver_data) {
+        HandleDriverTableUpdate(client_id, driver_data);
+      };
   RAY_RETURN_NOT_OK(gcs_client_->driver_table().Subscribe(
       DriverID::nil(), ClientID::nil(), driver_table_handler, nullptr));
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -111,6 +111,7 @@ class NodeManager {
   /// \param data Data associated with the new client.
   /// \return Void.
   void ClientAdded(const ClientTableDataT &data);
+
   /// Handler for the removal of a GCS client.
   /// \param client_data Data associated with the removed client.
   /// \return Void.

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -49,6 +49,8 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       const auto &node_resources = client_resource_pair.second;
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
+      // We have to subtract the load resources from the available resources
+      // here to make sure that there is space for the task.
       available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -49,8 +49,9 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       const auto &node_resources = client_resource_pair.second;
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
-      // We have to subtract the load resources from the available resources
-      // here to make sure that there is space for the task.
+      // We have to subtract the current "load" because we set the current "load"
+      // to be the resources used by the ready_queue_ in
+      // NodeManager::ProcessGetTaskMessage's call to SchedulingQueue::GetResourceLoad.
       available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -52,7 +52,7 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       // TODO(romilb): Why do we need to subtract load from available resources?
       // Even if we don't the code path below for choosing a dst_client_id would be
       // similar.
-      available_node_resources.SubtractResources(node_resources.GetLoadResources());
+      // available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()
                      << " load: " << node_resources.GetLoadResources().ToString();

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -49,10 +49,6 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       const auto &node_resources = client_resource_pair.second;
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
-      // TODO(romilb): Why do we need to subtract load from available resources?
-      // Even if we don't the code path below for choosing a dst_client_id would be
-      // similar.
-      // available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()
                      << " load: " << node_resources.GetLoadResources().ToString();

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -50,8 +50,9 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
       // We have to subtract the current "load" because we set the current "load"
-      // to be the resources used by the ready_queue_ in
-      // NodeManager::ProcessGetTaskMessage's call to SchedulingQueue::GetResourceLoad.
+      // to be the resources used by tasks that are in the
+      // `SchedulingQueue::ready_queue_` in NodeManager::ProcessGetTaskMessage's
+      // call to SchedulingQueue::GetResourceLoad.
       available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -49,6 +49,7 @@ std::unordered_map<TaskID, ClientID> SchedulingPolicy::Schedule(
       const auto &node_resources = client_resource_pair.second;
       ResourceSet available_node_resources =
           ResourceSet(node_resources.GetAvailableResources());
+      available_node_resources.SubtractResources(node_resources.GetLoadResources());
       RAY_LOG(DEBUG) << "client_id " << node_client_id
                      << " avail: " << node_resources.GetAvailableResources().ToString()
                      << " load: " << node_resources.GetLoadResources().ToString();

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -228,12 +228,8 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   std::vector<Task> removed_tasks;
   // Try to find the tasks to remove from the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_ids, &removed_tasks);
   }
@@ -247,12 +243,8 @@ Task SchedulingQueue::RemoveTask(const TaskID &task_id, TaskState *removed_task_
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_id_set, &removed_tasks);
     if (task_id_set.empty()) {
@@ -393,12 +385,8 @@ std::string SchedulingQueue::DebugString() const {
   std::stringstream result;
   result << "SchedulingQueue:";
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     result << "\n- num " << GetTaskStateString(task_state)
            << " tasks: " << GetTaskQueue(task_state)->GetTasks().size();

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -67,7 +67,7 @@ bool TaskQueue::RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tas
 
   auto list_iterator = task_found_iterator->second;
   // Resource bookkeeping
-  current_resource_load_.SubtractResources(
+  current_resource_load_.SubtractResourcesStrict(
       list_iterator->GetTaskSpecification().GetRequiredResources());
   if (removed_tasks) {
     removed_tasks->push_back(std::move(*list_iterator));

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -228,8 +228,12 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   std::vector<Task> removed_tasks;
   // Try to find the tasks to remove from the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_ids, &removed_tasks);
   }
@@ -243,8 +247,12 @@ Task SchedulingQueue::RemoveTask(const TaskID &task_id, TaskState *removed_task_
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_id_set, &removed_tasks);
     if (task_id_set.empty()) {
@@ -385,8 +393,12 @@ std::string SchedulingQueue::DebugString() const {
   std::stringstream result;
   result << "SchedulingQueue:";
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     result << "\n- num " << GetTaskStateString(task_state)
            << " tasks: " << GetTaskQueue(task_state)->GetTasks().size();

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -67,7 +67,7 @@ bool TaskQueue::RemoveTask(const TaskID &task_id, std::vector<Task> *removed_tas
 
   auto list_iterator = task_found_iterator->second;
   // Resource bookkeeping
-  current_resource_load_.SubtractResourcesStrict(
+  current_resource_load_.SubtractResources(
       list_iterator->GetTaskSpecification().GetRequiredResources());
   if (removed_tasks) {
     removed_tasks->push_back(std::move(*list_iterator));

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -141,10 +141,10 @@ void ResourceSet::SubtractResources(const ResourceSet &other) {
   for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
     const FractionalResourceQuantity &resource_capacity = resource_pair.second;
-    RAY_CHECK(resource_capacity_.count(resource_label) == 1)
-        << "Attempt to acquire unknown resource: " << resource_label;
-    resource_capacity_[resource_label] -= resource_capacity;
-    if (resource_capacity_[resource_label] < 0) {
+    if (resource_capacity_.count(resource_label) == 1) {
+      resource_capacity_[resource_label] -= resource_capacity;
+    }
+    if (resource_capacity_[resource_label] <= 0) {
       resource_capacity_.erase(resource_label);
     }
   }

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -22,9 +22,9 @@ FractionalResourceQuantity::FractionalResourceQuantity(int resource_quantity) {
 
 FractionalResourceQuantity::FractionalResourceQuantity(std::string resource_name,
                                                        double resource_quantity) {
-  RAY_CHECK(resource_quantity > 0)
-      << "Resource " << resource_name << " capacity is " << resource_quantity
-      << ". Should have been greater than zero.";
+  RAY_CHECK(resource_quantity > 0) << "Resource " << resource_name << " capacity is " 
+                                   << resource_quantity 
+                                   << ". Should have been greater than zero.";
 
   resource_name_ = "";
   resource_quantity_ =

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -9,28 +9,75 @@ namespace ray {
 
 namespace raylet {
 
-bool EqualsZeroEpsilon(double quantity) {
-  if ((quantity <= EPSILON) && (quantity >= -1 * EPSILON)) {
-    return true;
-  }
-  return false;
+FractionalResourceQuantity::FractionalResourceQuantity () {
+  resource_quantity_ = 0;
 }
 
-bool EqualsOneEpsilon(double quantity) {
-  if ((quantity <= 1 + EPSILON) && (quantity >= 1 - EPSILON)) {
-    return true;
-  }
-  return false;
+FractionalResourceQuantity::FractionalResourceQuantity (double resource_quantity) {
+  resource_quantity_ = static_cast<int>(std::round(resource_quantity * conversion_factor_));
+}
+
+const FractionalResourceQuantity FractionalResourceQuantity::operator+(const FractionalResourceQuantity& rhs) const {
+  FractionalResourceQuantity result = *this;
+  result += rhs;
+  return result;
+}
+
+const FractionalResourceQuantity FractionalResourceQuantity::operator-(const FractionalResourceQuantity& rhs) const {
+  FractionalResourceQuantity result = *this;
+  result -= rhs;
+  return result;
+}
+
+FractionalResourceQuantity& FractionalResourceQuantity::operator+=(const FractionalResourceQuantity& rhs) {
+  resource_quantity_ += rhs.resource_quantity_;
+
+  return *this;
+}
+
+FractionalResourceQuantity& FractionalResourceQuantity::operator-=(const FractionalResourceQuantity& rhs) {
+  resource_quantity_ -= rhs.resource_quantity_;
+
+  return *this;
+}
+
+bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity& rhs) const {
+  return resource_quantity_ == rhs.resource_quantity_;
+}
+
+bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity& rhs) const {
+  return !(*this == rhs);
+}
+
+bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity& rhs) const {
+  return resource_quantity_ < rhs.resource_quantity_;
+}
+
+bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity& rhs) const {
+  return rhs < *this;
+}
+
+bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity& rhs) const {
+  return !(*this > rhs);
+}
+
+bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity& rhs) const {
+  bool result = !(*this < rhs);
+  return result;
+}
+
+double FractionalResourceQuantity::ToDouble() const {
+  return static_cast<double>(resource_quantity_ / conversion_factor_);
 }
 
 ResourceSet::ResourceSet() {}
 
-ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map)
-    : resource_capacity_(resource_map) {
-  for (auto const &resource_pair : resource_capacity_) {
-    RAY_CHECK(resource_pair.second > 0 + EPSILON)
+ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
+  for (auto const &resource_pair : resource_map) {
+    RAY_CHECK(resource_pair.second > 0)
         << "Resource " << resource_pair.first << " capacity is " << resource_pair.second
         << ". Should have been greater than zero.";
+    resource_capacity_[resource_pair.first] = FractionalResourceQuantity(resource_pair.second);
   }
 }
 
@@ -38,7 +85,7 @@ ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
                          const std::vector<double> resource_capacity) {
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (uint i = 0; i < resource_labels.size(); i++) {
-    RAY_CHECK(resource_capacity[i] > 0 + EPSILON)
+    RAY_CHECK(resource_capacity[i] > 0)
         << "Resource " << resource_labels[i] << " capacity is " << resource_capacity[i]
         << ". Should have been greater than zero.";
     resource_capacity_[resource_labels[i]] = resource_capacity[i];
@@ -60,8 +107,8 @@ bool ResourceSet::IsSubset(const ResourceSet &other) const {
   // Check to make sure all keys of this are in other.
   for (const auto &resource_pair : resource_capacity_) {
     const auto &resource_name = resource_pair.first;
-    const double lhs_quantity = resource_pair.second;
-    double rhs_quantity = other.GetResource(resource_name);
+    const FractionalResourceQuantity lhs_quantity = resource_pair.second;
+    FractionalResourceQuantity rhs_quantity = other.GetResource(resource_name);
     if (lhs_quantity > rhs_quantity) {
       // Resource found in rhs, but lhs capacity exceeds rhs capacity.
       return false;
@@ -83,14 +130,15 @@ bool ResourceSet::IsEqual(const ResourceSet &rhs) const {
 bool ResourceSet::RemoveResource(const std::string &resource_name) {
   throw std::runtime_error("Method not implemented");
 }
+
 void ResourceSet::SubtractResources(const ResourceSet &other) {
   // Subtract the resources and delete any if new capacity is zero.
   for (const auto &resource_pair : other.GetResourceMap()) {
     const std::string &resource_label = resource_pair.first;
-    const double &resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
     if (resource_capacity_.count(resource_label) == 1) {
       resource_capacity_[resource_label] -= resource_capacity;
-      if (resource_capacity_[resource_label] < 0 + EPSILON) {
+      if (resource_capacity_[resource_label] <= 0) {
         resource_capacity_.erase(resource_label);
       }
     }
@@ -102,17 +150,15 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
   // is zero.
   for (const auto &resource_pair : other.GetResourceMap()) {
     const std::string &resource_label = resource_pair.first;
-    const double &resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
     RAY_CHECK(resource_capacity_.count(resource_label) == 1)
         << "Attempt to acquire unknown resource: " << resource_label;
     resource_capacity_[resource_label] -= resource_capacity;
-    // TODO(romilb): Double precision subtraction may sometimes be less than zero by a
-    // small epsilon - need to fix.
-    RAY_CHECK(resource_capacity_[resource_label] >= 0 - EPSILON)
+    RAY_CHECK(resource_capacity_[resource_label] >= 0)
         << "Capacity of resource " << resource_label << " after subtraction is negative ("
-        << resource_capacity_[resource_label] << ")."
+        << resource_capacity_[resource_label].ToDouble() << ")."
         << " Debug: resource_capacity_:" << ToString() << ", other: " << other.ToString();
-    if (EqualsZeroEpsilon(resource_capacity_[resource_label])) {
+    if (resource_capacity_[resource_label] == 0) {
       resource_capacity_.erase(resource_label);
     }
   }
@@ -120,25 +166,27 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
 
 // Perform an outer join.
 void ResourceSet::AddResources(const ResourceSet &other) {
-  for (const auto &resource_pair : other.GetResourceMap()) {
+  for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
-    const double &resource_capacity = resource_pair.second;
+    const FractionalResourceQuantity &resource_capacity = resource_pair.second;
     resource_capacity_[resource_label] += resource_capacity;
   }
 }
 
-double ResourceSet::GetResource(const std::string &resource_name) const {
-  if (EqualsZeroEpsilon(resource_capacity_.count(resource_name))) {
+FractionalResourceQuantity ResourceSet::GetResource(const std::string &resource_name) const {
+  if (resource_capacity_.count(resource_name) == 0) {
     return 0;
   }
-  double capacity = resource_capacity_.at(resource_name);
-  RAY_CHECK(capacity > 0 + EPSILON) << "Resource " << resource_name << " capacity is "
-                                    << capacity
-                                    << ". Should have been greater than zero.";
+  FractionalResourceQuantity capacity = resource_capacity_.at(resource_name);
+  RAY_CHECK(capacity > 0) << "Resource " << resource_name << " capacity is "
+                          << capacity.ToDouble()
+                          << ". Should have been greater than zero.";
   return capacity;
 }
 
-double ResourceSet::GetNumCpus() const { return GetResource(kCPU_ResourceLabel); }
+double ResourceSet::GetNumCpus() const {
+  return GetResource(kCPU_ResourceLabel).ToDouble();
+}
 
 const std::string ResourceSet::ToString() const {
   std::string return_string = "";
@@ -147,19 +195,30 @@ const std::string ResourceSet::ToString() const {
 
   // Convert the first element to a string.
   if (it != resource_capacity_.end()) {
-    return_string += "{" + it->first + "," + std::to_string(it->second) + "}";
+    double resource_amount = (it->second).ToDouble();
+    return_string += "{" + it->first + "," + std::to_string(resource_amount) + "}";
     it++;
   }
 
   // Add the remaining elements to the string (along with a comma).
   for (; it != resource_capacity_.end(); ++it) {
-    return_string += ",{" + it->first + "," + std::to_string(it->second) + "}";
+    double resource_amount = (it->second).ToDouble();
+    return_string += ",{" + it->first + "," + std::to_string(resource_amount) + "}";
   }
 
   return return_string;
 }
 
-const std::unordered_map<std::string, double> &ResourceSet::GetResourceMap() const {
+const std::unordered_map<std::string, double> ResourceSet::GetResourceMap() const {
+  std::unordered_map<std::string, double> result;
+  for (const auto resource_pair : resource_capacity_) {
+    result[resource_pair.first] = resource_pair.second.ToDouble();
+  }
+  return result;
+};
+
+const std::unordered_map<std::string, FractionalResourceQuantity>
+    &ResourceSet::GetResourceAmountMap() const {
   return resource_capacity_;
 };
 
@@ -177,18 +236,20 @@ ResourceIds::ResourceIds(double resource_quantity) {
 
 ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids) : whole_ids_(whole_ids) {}
 
-ResourceIds::ResourceIds(const std::vector<std::pair<int64_t, double>> &fractional_ids)
+ResourceIds::ResourceIds(
+    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
     : fractional_ids_(fractional_ids) {}
 
-ResourceIds::ResourceIds(const std::vector<int64_t> &whole_ids,
-                         const std::vector<std::pair<int64_t, double>> &fractional_ids)
+ResourceIds::ResourceIds(
+    const std::vector<int64_t> &whole_ids,
+    const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids)
     : whole_ids_(whole_ids), fractional_ids_(fractional_ids) {}
 
-bool ResourceIds::Contains(double resource_quantity) const {
-  RAY_CHECK(resource_quantity >= 0);
+bool ResourceIds::Contains(FractionalResourceQuantity resource_quantity) const {
   if (resource_quantity >= 1) {
-    RAY_CHECK(IsWhole(resource_quantity));
-    return whole_ids_.size() >= resource_quantity;
+    double whole_quantity = resource_quantity.ToDouble();
+    RAY_CHECK(IsWhole(whole_quantity));
+    return whole_ids_.size() >= whole_quantity;
   } else {
     if (whole_ids_.size() > 0) {
       return true;
@@ -203,13 +264,12 @@ bool ResourceIds::Contains(double resource_quantity) const {
   }
 }
 
-ResourceIds ResourceIds::Acquire(double resource_quantity) {
-  RAY_CHECK(resource_quantity >= 0);
+ResourceIds ResourceIds::Acquire(FractionalResourceQuantity resource_quantity) {
   if (resource_quantity >= 1) {
     // Handle the whole case.
-    RAY_CHECK(IsWhole(resource_quantity));
-    int64_t whole_quantity = resource_quantity;
-    RAY_CHECK(static_cast<int64_t>(whole_ids_.size()) >= whole_quantity);
+    double whole_quantity = resource_quantity.ToDouble();
+    RAY_CHECK(IsWhole(whole_quantity));
+    RAY_CHECK(static_cast<int64_t>(whole_ids_.size()) >= static_cast<int64_t>(whole_quantity));
 
     std::vector<int64_t> ids_to_return;
     for (int64_t i = 0; i < whole_quantity; ++i) {
@@ -227,7 +287,7 @@ ResourceIds ResourceIds::Acquire(double resource_quantity) {
         fractional_pair.second -= resource_quantity;
 
         // Remove the fractional pair if the new capacity is 0
-        if (EqualsZeroEpsilon(fractional_pair.second)) {
+        if (fractional_pair.second == 0) {
           std::swap(fractional_pair, fractional_ids_[fractional_ids_.size() - 1]);
           fractional_ids_.pop_back();
         }
@@ -242,7 +302,8 @@ ResourceIds ResourceIds::Acquire(double resource_quantity) {
     whole_ids_.pop_back();
 
     auto return_pair = std::make_pair(whole_id, resource_quantity);
-    fractional_ids_.push_back(std::make_pair(whole_id, 1 - resource_quantity));
+    FractionalResourceQuantity remaining_amount = FractionalResourceQuantity(1) - resource_quantity;
+    fractional_ids_.push_back(std::make_pair(whole_id, remaining_amount));
     return ResourceIds({return_pair});
   }
 }
@@ -260,22 +321,18 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
     int64_t resource_id = fractional_pair_to_return.first;
     auto const &fractional_pair_it =
         std::find_if(fractional_ids_.begin(), fractional_ids_.end(),
-                     [resource_id](std::pair<int64_t, double> &fractional_pair) {
+                     [resource_id](std::pair<int64_t, FractionalResourceQuantity> &fractional_pair) {
                        return fractional_pair.first == resource_id;
                      });
     if (fractional_pair_it == fractional_ids_.end()) {
       fractional_ids_.push_back(fractional_pair_to_return);
     } else {
       fractional_pair_it->second += fractional_pair_to_return.second;
-      // TODO(romilb): Double precision addition may sometimes exceed 1 by a small epsilon
-      // - need to fix this.
-      RAY_CHECK(fractional_pair_it->second <= 1 + EPSILON)
+      RAY_CHECK(fractional_pair_it->second <= 1)
           << "Fractional Resource Id " << fractional_pair_it->first << " capacity is "
-          << fractional_pair_it->second << ". Should have been less than one.";
+          << fractional_pair_it->second.ToDouble() << ". Should have been less than one.";
       // If this makes the ID whole, then return it to the list of whole IDs.
-      // TODO(romilb): Double precision addition may sometimes exceed 1 by a small epsilon
-      // - need to fix this.
-      if (EqualsOneEpsilon(fractional_pair_it->second)) {
+      if (fractional_pair_it->second == 1) {
         whole_ids_.push_back(resource_id);
         fractional_ids_.erase(fractional_pair_it);
       }
@@ -291,7 +348,8 @@ ResourceIds ResourceIds::Plus(const ResourceIds &resource_ids) const {
 
 const std::vector<int64_t> &ResourceIds::WholeIds() const { return whole_ids_; }
 
-const std::vector<std::pair<int64_t, double>> &ResourceIds::FractionalIds() const {
+const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &ResourceIds::FractionalIds()
+    const {
   return fractional_ids_;
 }
 
@@ -300,11 +358,11 @@ bool ResourceIds::TotalQuantityIsZero() const {
 }
 
 double ResourceIds::TotalQuantity() const {
-  double total_quantity = whole_ids_.size();
+  FractionalResourceQuantity total_quantity = FractionalResourceQuantity(whole_ids_.size());
   for (auto const &fractional_pair : fractional_ids_) {
     total_quantity += fractional_pair.second;
   }
-  return total_quantity;
+  return total_quantity.ToDouble();
 }
 
 std::string ResourceIds::ToString() const {
@@ -314,8 +372,9 @@ std::string ResourceIds::ToString() const {
   }
   return_string += "], Fractional IDs: ";
   for (auto const &fractional_pair : fractional_ids_) {
+    double fractional_amount = fractional_pair.second.ToDouble();
     return_string += "(" + std::to_string(fractional_pair.first) + ", " +
-                     std::to_string(fractional_pair.second) + "), ";
+                     std::to_string(fractional_amount) + "), ";
   }
   return_string += "]";
   return return_string;
@@ -343,12 +402,12 @@ ResourceIdSet::ResourceIdSet(
     : available_resources_(available_resources) {}
 
 bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
-  for (auto const &resource_pair : resource_set.GetResourceMap()) {
+  for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    double resource_quantity = resource_pair.second;
-    RAY_CHECK(resource_quantity > 0 + EPSILON) << "Resource " << resource_name
-                                               << " capacity is " << resource_quantity
-                                               << ". Should have been greater than zero.";
+    FractionalResourceQuantity resource_quantity = resource_pair.second;
+    RAY_CHECK(resource_quantity > 0) << "Resource " << resource_name
+                                     << " capacity is " << resource_quantity.ToDouble()
+                                     << ". Should have been greater than zero.";
 
     auto it = available_resources_.find(resource_name);
     if (it == available_resources_.end()) {
@@ -365,12 +424,12 @@ bool ResourceIdSet::Contains(const ResourceSet &resource_set) const {
 ResourceIdSet ResourceIdSet::Acquire(const ResourceSet &resource_set) {
   std::unordered_map<std::string, ResourceIds> acquired_resources;
 
-  for (auto const &resource_pair : resource_set.GetResourceMap()) {
+  for (auto const &resource_pair : resource_set.GetResourceAmountMap()) {
     auto const &resource_name = resource_pair.first;
-    double resource_quantity = resource_pair.second;
-    RAY_CHECK(resource_quantity > 0 + EPSILON) << "Resource " << resource_name
-                                               << " capacity is " << resource_quantity
-                                               << ". Should have been greater than zero.";
+    FractionalResourceQuantity resource_quantity = resource_pair.second;
+    RAY_CHECK(resource_quantity > 0) << "Resource " << resource_name
+                                     << " capacity is " << resource_quantity.ToDouble()
+                                     << ". Should have been greater than zero.";
 
     auto it = available_resources_.find(resource_name);
     RAY_CHECK(it != available_resources_.end());
@@ -460,7 +519,7 @@ std::vector<flatbuffers::Offset<protocol::ResourceIdSetInfo>> ResourceIdSet::ToF
 
     for (auto const &fractional_pair : resource_pair.second.FractionalIds()) {
       resource_ids.push_back(fractional_pair.first);
-      resource_fractions.push_back(fractional_pair.second);
+      resource_fractions.push_back(fractional_pair.second.ToDouble());
     }
 
     auto resource_id_set_message = protocol::CreateResourceIdSetInfo(

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -22,8 +22,8 @@ FractionalResourceQuantity::FractionalResourceQuantity(int resource_quantity) {
 
 FractionalResourceQuantity::FractionalResourceQuantity(std::string resource_name,
                                                        double resource_quantity) {
-  RAY_CHECK(resource_quantity > 0) << "Resource " << resource_name << " capacity is " 
-                                   << resource_quantity 
+  RAY_CHECK(resource_quantity > 0) << "Resource " << resource_name << " capacity is "
+                                   << resource_quantity
                                    << ". Should have been greater than zero.";
 
   resource_name_ = "";
@@ -154,7 +154,7 @@ bool ResourceSet::RemoveResource(const std::string &resource_name) {
 void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
   // Subtract the resources, make sure none goes below zero and delete any if new capacity
   // is zero.
-  for (const auto &resource_pair : other.GetResourceMap()) {
+  for (const auto &resource_pair : other.GetResourceAmountMap()) {
     const std::string &resource_label = resource_pair.first;
     const FractionalResourceQuantity &resource_capacity = resource_pair.second;
     RAY_CHECK(resource_capacity_.count(resource_label) == 1)

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -198,24 +198,28 @@ const ResourceSet ResourceSet::GetNumCpus() const {
 }
 
 const std::string ResourceSet::ToString() const {
-  std::string return_string = "";
+  if (resource_capacity_.size() == 0) {
+    return "{}";
+  } else {
+    std::string return_string = "";
 
-  auto it = resource_capacity_.begin();
+    auto it = resource_capacity_.begin();
 
-  // Convert the first element to a string.
-  if (it != resource_capacity_.end()) {
-    double resource_amount = (it->second).ToDouble();
-    return_string += "{" + it->first + "," + std::to_string(resource_amount) + "}";
-    it++;
+    // Convert the first element to a string.
+    if (it != resource_capacity_.end()) {
+      double resource_amount = (it->second).ToDouble();
+      return_string += "{" + it->first + "," + std::to_string(resource_amount) + "}";
+      it++;
+    }
+
+    // Add the remaining elements to the string (along with a comma).
+    for (; it != resource_capacity_.end(); ++it) {
+      double resource_amount = (it->second).ToDouble();
+      return_string += ",{" + it->first + "," + std::to_string(resource_amount) + "}";
+    }
+
+    return return_string;
   }
-
-  // Add the remaining elements to the string (along with a comma).
-  for (; it != resource_capacity_.end(); ++it) {
-    double resource_amount = (it->second).ToDouble();
-    return_string += ",{" + it->first + "," + std::to_string(resource_amount) + "}";
-  }
-
-  return return_string;
 }
 
 const std::unordered_map<std::string, double> ResourceSet::GetResourceMap() const {

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -15,8 +15,8 @@ FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity)
   // We check for nonnegativeity due to the implicit conversion to
   // FractionalResourceQuantity from ints/doubles when we do logical
   // comparisons.
-  RAY_CHECK(resource_quantity >= 0)
-      << "Resource capacity, " << resource_quantity << ", should be nonnegative.";
+  RAY_CHECK(resource_quantity >= 0) << "Resource capacity, " << resource_quantity
+                                    << ", should be nonnegative.";
 
   resource_quantity_ = static_cast<int>(resource_quantity * kResourceConversionFactor);
 }

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -42,11 +42,6 @@ void FractionalResourceQuantity::operator+=(const FractionalResourceQuantity &rh
 
 void FractionalResourceQuantity::operator-=(const FractionalResourceQuantity &rhs) {
   resource_quantity_ -= rhs.resource_quantity_;
-
-  // Ensure that quantity is nonnegative.
-  // RAY_CHECK(resource_quantity_ >= 0)
-  //     << "Capacity of resource after subtraction is negative, "
-  //     << this->ToDouble() << ".";
 }
 
 bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity &rhs) const {
@@ -150,6 +145,8 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
       resource_capacity_.erase(resource_label);
     }
 
+
+    // Ensure that quantity is nonnegative.
     RAY_CHECK(resource_capacity_[resource_label] >= 0)
         << "Capacity of resource after subtraction is negative, "
         << resource_capacity_[resource_label].ToDouble() << ".";

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -18,8 +18,7 @@ FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity)
   RAY_CHECK(resource_quantity >= 0)
       << "Resource capacity, " << resource_quantity << ", should be nonnegative.";
 
-  resource_quantity_ =
-      static_cast<int>(resource_quantity * kResourceConversionFactor);
+  resource_quantity_ = static_cast<int>(resource_quantity * kResourceConversionFactor);
 }
 
 const FractionalResourceQuantity FractionalResourceQuantity::operator+(
@@ -75,7 +74,9 @@ double FractionalResourceQuantity::ToDouble() const {
 
 ResourceSet::ResourceSet() {}
 
-ResourceSet::ResourceSet(const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map) : resource_capacity_(resource_map) {}
+ResourceSet::ResourceSet(
+    const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map)
+    : resource_capacity_(resource_map) {}
 
 ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
   for (auto const &resource_pair : resource_map) {
@@ -145,7 +146,6 @@ void ResourceSet::SubtractResourcesStrict(const ResourceSet &other) {
       resource_capacity_.erase(resource_label);
     }
 
-
     // Ensure that quantity is nonnegative.
     RAY_CHECK(resource_capacity_[resource_label] >= 0)
         << "Capacity of resource after subtraction is negative, "
@@ -188,7 +188,8 @@ FractionalResourceQuantity ResourceSet::GetResource(
 
 const ResourceSet ResourceSet::GetNumCpus() const {
   ResourceSet cpu_resource_set;
-  cpu_resource_set.resource_capacity_[kCPU_ResourceLabel] = GetResource(kCPU_ResourceLabel);
+  cpu_resource_set.resource_capacity_[kCPU_ResourceLabel] =
+      GetResource(kCPU_ResourceLabel);
   return cpu_resource_set;
 }
 

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -16,69 +16,76 @@ FractionalResourceQuantity::FractionalResourceQuantity() {
 
 FractionalResourceQuantity::FractionalResourceQuantity(int resource_quantity) {
   resource_name_ = "";
-  resource_quantity_ = static_cast<int>(std::round(resource_quantity * conversion_factor_));
+  resource_quantity_ =
+      static_cast<int>(std::round(resource_quantity * conversion_factor_));
 }
 
-FractionalResourceQuantity::FractionalResourceQuantity(std::string resource_name, double resource_quantity) {
+FractionalResourceQuantity::FractionalResourceQuantity(std::string resource_name,
+                                                       double resource_quantity) {
   RAY_CHECK(resource_quantity > 0)
       << "Resource " << resource_name << " capacity is " << resource_quantity
       << ". Should have been greater than zero.";
 
   resource_name_ = "";
-  resource_quantity_ = static_cast<int>(std::round(resource_quantity * conversion_factor_));
+  resource_quantity_ =
+      static_cast<int>(std::round(resource_quantity * conversion_factor_));
 }
 
-const FractionalResourceQuantity FractionalResourceQuantity::operator+(const FractionalResourceQuantity& rhs) const {
+const FractionalResourceQuantity FractionalResourceQuantity::operator+(
+    const FractionalResourceQuantity &rhs) const {
   FractionalResourceQuantity result = *this;
   result += rhs;
   return result;
 }
 
-const FractionalResourceQuantity FractionalResourceQuantity::operator-(const FractionalResourceQuantity& rhs) const {
+const FractionalResourceQuantity FractionalResourceQuantity::operator-(
+    const FractionalResourceQuantity &rhs) const {
   FractionalResourceQuantity result = *this;
   result -= rhs;
   return result;
 }
 
-FractionalResourceQuantity& FractionalResourceQuantity::operator+=(const FractionalResourceQuantity& rhs) {
+FractionalResourceQuantity &FractionalResourceQuantity::operator+=(
+    const FractionalResourceQuantity &rhs) {
   resource_quantity_ += rhs.resource_quantity_;
 
   return *this;
 }
 
-FractionalResourceQuantity& FractionalResourceQuantity::operator-=(const FractionalResourceQuantity& rhs) {
+FractionalResourceQuantity &FractionalResourceQuantity::operator-=(
+    const FractionalResourceQuantity &rhs) {
   resource_quantity_ -= rhs.resource_quantity_;
 
   // Ensure that quantity is nonnegative.
   RAY_CHECK(resource_quantity_ >= 0)
       << "Capacity of resource " << resource_name_ << " after subtraction is negative ("
       << this->ToDouble() << ")."
-      << " Debug: resource_capacity_: (" << resource_name_ << ", " << this->ToDouble() << "), other: ("
-      << rhs.resource_name_ << ", " << rhs.ToDouble() << ").";
+      << " Debug: resource_capacity_: (" << resource_name_ << ", " << this->ToDouble()
+      << "), other: (" << rhs.resource_name_ << ", " << rhs.ToDouble() << ").";
   return *this;
 }
 
-bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity &rhs) const {
   return resource_quantity_ == rhs.resource_quantity_;
 }
 
-bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator!=(const FractionalResourceQuantity &rhs) const {
   return !(*this == rhs);
 }
 
-bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator<(const FractionalResourceQuantity &rhs) const {
   return resource_quantity_ < rhs.resource_quantity_;
 }
 
-bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator>(const FractionalResourceQuantity &rhs) const {
   return rhs < *this;
 }
 
-bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator<=(const FractionalResourceQuantity &rhs) const {
   return !(*this > rhs);
 }
 
-bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity& rhs) const {
+bool FractionalResourceQuantity::operator>=(const FractionalResourceQuantity &rhs) const {
   bool result = !(*this < rhs);
   return result;
 }
@@ -91,7 +98,8 @@ ResourceSet::ResourceSet() {}
 
 ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
   for (auto const &resource_pair : resource_map) {
-    resource_capacity_[resource_pair.first] = FractionalResourceQuantity(resource_pair.first, resource_pair.second);
+    resource_capacity_[resource_pair.first] =
+        FractionalResourceQuantity(resource_pair.first, resource_pair.second);
   }
 }
 
@@ -99,7 +107,8 @@ ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
                          const std::vector<double> resource_capacity) {
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (uint i = 0; i < resource_labels.size(); i++) {
-    resource_capacity_[resource_labels[i]] = FractionalResourceQuantity(resource_labels[i], resource_capacity[i]);
+    resource_capacity_[resource_labels[i]] =
+        FractionalResourceQuantity(resource_labels[i], resource_capacity[i]);
   }
 }
 
@@ -166,7 +175,8 @@ void ResourceSet::AddResources(const ResourceSet &other) {
   }
 }
 
-FractionalResourceQuantity ResourceSet::GetResource(const std::string &resource_name) const {
+FractionalResourceQuantity ResourceSet::GetResource(
+    const std::string &resource_name) const {
   if (resource_capacity_.count(resource_name) == 0) {
     return 0;
   }
@@ -259,7 +269,8 @@ ResourceIds ResourceIds::Acquire(FractionalResourceQuantity resource_quantity) {
     // Handle the whole case.
     double whole_quantity = resource_quantity.ToDouble();
     RAY_CHECK(IsWhole(whole_quantity));
-    RAY_CHECK(static_cast<int64_t>(whole_ids_.size()) >= static_cast<int64_t>(whole_quantity));
+    RAY_CHECK(static_cast<int64_t>(whole_ids_.size()) >=
+              static_cast<int64_t>(whole_quantity));
 
     std::vector<int64_t> ids_to_return;
     for (int64_t i = 0; i < whole_quantity; ++i) {
@@ -292,7 +303,8 @@ ResourceIds ResourceIds::Acquire(FractionalResourceQuantity resource_quantity) {
     whole_ids_.pop_back();
 
     auto return_pair = std::make_pair(whole_id, resource_quantity);
-    FractionalResourceQuantity remaining_amount = FractionalResourceQuantity(1) - resource_quantity;
+    FractionalResourceQuantity remaining_amount =
+        FractionalResourceQuantity(1) - resource_quantity;
     fractional_ids_.push_back(std::make_pair(whole_id, remaining_amount));
     return ResourceIds({return_pair});
   }
@@ -309,11 +321,11 @@ void ResourceIds::Release(const ResourceIds &resource_ids) {
   auto const &fractional_ids_to_return = resource_ids.FractionalIds();
   for (auto const &fractional_pair_to_return : fractional_ids_to_return) {
     int64_t resource_id = fractional_pair_to_return.first;
-    auto const &fractional_pair_it =
-        std::find_if(fractional_ids_.begin(), fractional_ids_.end(),
-                     [resource_id](std::pair<int64_t, FractionalResourceQuantity> &fractional_pair) {
-                       return fractional_pair.first == resource_id;
-                     });
+    auto const &fractional_pair_it = std::find_if(
+        fractional_ids_.begin(), fractional_ids_.end(),
+        [resource_id](std::pair<int64_t, FractionalResourceQuantity> &fractional_pair) {
+          return fractional_pair.first == resource_id;
+        });
     if (fractional_pair_it == fractional_ids_.end()) {
       fractional_ids_.push_back(fractional_pair_to_return);
     } else {
@@ -338,8 +350,8 @@ ResourceIds ResourceIds::Plus(const ResourceIds &resource_ids) const {
 
 const std::vector<int64_t> &ResourceIds::WholeIds() const { return whole_ids_; }
 
-const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &ResourceIds::FractionalIds()
-    const {
+const std::vector<std::pair<int64_t, FractionalResourceQuantity>>
+    &ResourceIds::FractionalIds() const {
   return fractional_ids_;
 }
 
@@ -348,7 +360,8 @@ bool ResourceIds::TotalQuantityIsZero() const {
 }
 
 double ResourceIds::TotalQuantity() const {
-  FractionalResourceQuantity total_quantity = FractionalResourceQuantity(whole_ids_.size());
+  FractionalResourceQuantity total_quantity =
+      FractionalResourceQuantity(whole_ids_.size());
   for (auto const &fractional_pair : fractional_ids_) {
     total_quantity += fractional_pair.second;
   }

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -9,18 +9,14 @@ namespace ray {
 
 namespace raylet {
 
-FractionalResourceQuantity::FractionalResourceQuantity() {
-  resource_quantity_ = 0;
-}
+FractionalResourceQuantity::FractionalResourceQuantity() { resource_quantity_ = 0; }
 
 FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity) {
   // We check for nonnegativeity due to the implicit conversion to
   // FractionalResourceQuantity from ints/doubles when we do logical
   // comparisons.
   RAY_CHECK(resource_quantity >= 0)
-      << "Resource capacity, "
-      << resource_quantity
-      << ", should be nonnegative.";
+      << "Resource capacity, " << resource_quantity << ", should be nonnegative.";
 
   resource_quantity_ =
       static_cast<int>(std::round(resource_quantity * kResourceConversionFactor));
@@ -40,19 +36,17 @@ const FractionalResourceQuantity FractionalResourceQuantity::operator-(
   return result;
 }
 
-void FractionalResourceQuantity::operator+=(
-    const FractionalResourceQuantity &rhs) {
+void FractionalResourceQuantity::operator+=(const FractionalResourceQuantity &rhs) {
   resource_quantity_ += rhs.resource_quantity_;
 }
 
-void FractionalResourceQuantity::operator-=(
-    const FractionalResourceQuantity &rhs) {
+void FractionalResourceQuantity::operator-=(const FractionalResourceQuantity &rhs) {
   resource_quantity_ -= rhs.resource_quantity_;
 
   // Ensure that quantity is nonnegative.
   RAY_CHECK(resource_quantity_ >= 0)
-      << "Capacity of resource after subtraction is negative, "
-      << this->ToDouble() << ".";
+      << "Capacity of resource after subtraction is negative, " << this->ToDouble()
+      << ".";
 }
 
 bool FractionalResourceQuantity::operator==(const FractionalResourceQuantity &rhs) const {
@@ -88,7 +82,8 @@ ResourceSet::ResourceSet() {}
 
 ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource_map) {
   for (auto const &resource_pair : resource_map) {
-    resource_capacity_[resource_pair.first] = FractionalResourceQuantity(resource_pair.second);
+    resource_capacity_[resource_pair.first] =
+        FractionalResourceQuantity(resource_pair.second);
   }
 }
 
@@ -96,7 +91,8 @@ ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
                          const std::vector<double> resource_capacity) {
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (uint i = 0; i < resource_labels.size(); i++) {
-    resource_capacity_[resource_labels[i]] = FractionalResourceQuantity(resource_capacity[i]);
+    resource_capacity_[resource_labels[i]] =
+        FractionalResourceQuantity(resource_capacity[i]);
   }
 }
 

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -32,23 +32,23 @@ class FractionalResourceQuantity {
   FractionalResourceQuantity(std::string resource_name, double resource_quantity);
 
   /// \brief Addition of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator+(const FractionalResourceQuantity& rhs) const;
+  const FractionalResourceQuantity operator+(const FractionalResourceQuantity &rhs) const;
 
   /// \brief Subtraction of FractionalResourceQuantity.
-  const FractionalResourceQuantity operator-(const FractionalResourceQuantity& rhs) const;
+  const FractionalResourceQuantity operator-(const FractionalResourceQuantity &rhs) const;
 
   /// \brief Addition and assignment of FractionalResourceQuantity.
-  FractionalResourceQuantity& operator+=(const FractionalResourceQuantity& rhs);
+  FractionalResourceQuantity &operator+=(const FractionalResourceQuantity &rhs);
 
   /// \brief Subtraction and assignment of FractionalResourceQuantity.
-  FractionalResourceQuantity& operator-=(const FractionalResourceQuantity& rhs);
+  FractionalResourceQuantity &operator-=(const FractionalResourceQuantity &rhs);
 
-  bool operator==(const FractionalResourceQuantity& rhs) const;
-  bool operator!=(const FractionalResourceQuantity& rhs) const;
-  bool operator< (const FractionalResourceQuantity& rhs) const;
-  bool operator> (const FractionalResourceQuantity& rhs) const;
-  bool operator<=(const FractionalResourceQuantity& rhs) const;
-  bool operator>=(const FractionalResourceQuantity& rhs) const;
+  bool operator==(const FractionalResourceQuantity &rhs) const;
+  bool operator!=(const FractionalResourceQuantity &rhs) const;
+  bool operator<(const FractionalResourceQuantity &rhs) const;
+  bool operator>(const FractionalResourceQuantity &rhs) const;
+  bool operator<=(const FractionalResourceQuantity &rhs) const;
+  bool operator>=(const FractionalResourceQuantity &rhs) const;
 
   /// \brief Return actual resource amount as a double.
   double ToDouble() const;
@@ -162,7 +162,8 @@ class ResourceSet {
   /// size is in kResourceConversionFactor of a unit.
   ///
   /// \return map of resource in string to size in FractionalResourceQuantity.
-  const std::unordered_map<std::string, FractionalResourceQuantity> &GetResourceAmountMap() const;
+  const std::unordered_map<std::string, FractionalResourceQuantity>
+      &GetResourceAmountMap() const;
 
   const std::string ToString() const;
 
@@ -203,8 +204,9 @@ class ResourceIds {
   ///
   /// \param whole_ids: A vector of the resource IDs that are completely available.
   /// \param fractional_ids: A vector of the resource IDs that are partially available.
-  ResourceIds(const std::vector<int64_t> &whole_ids,
-              const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
+  ResourceIds(
+      const std::vector<int64_t> &whole_ids,
+      const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &fractional_ids);
 
   /// \brief Check if we have at least the requested amount.
   ///
@@ -245,7 +247,8 @@ class ResourceIds {
   /// \brief Return just the fractional IDs.
   ///
   /// \return The fractional IDs.
-  const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &FractionalIds() const;
+  const std::vector<std::pair<int64_t, FractionalResourceQuantity>> &FractionalIds()
+      const;
 
   /// \brief Check if ResourceIds has any resources.
   ///

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -12,6 +12,11 @@ namespace ray {
 
 namespace raylet {
 
+/// Conversion factor that is the amount in internal units is equivalent to
+/// one actual resource. Multiply to convert from actual to interal and
+/// divide to convert from internal to actual.
+constexpr double kResourceConversionFactor = 10000;
+
 const std::string kCPU_ResourceLabel = "CPU";
 
 /// \class FractionalResourceQuantity
@@ -20,16 +25,13 @@ const std::string kCPU_ResourceLabel = "CPU";
 class FractionalResourceQuantity {
  public:
   /// \brief Construct a FractionalResourceQuantity representing zero
-  /// resources.
+  /// resources. This constructor is used by std::unordered_map when we try
+  /// to add a new FractionalResourceQuantity in ResourceSets.
   FractionalResourceQuantity();
-
-  /// \brief Construct a FractionalResourceQuantity for implicit conversion of
-  /// operators.
-  FractionalResourceQuantity(int resource_quantity);
 
   /// \brief Construct a FractionalResourceQuantity representing
   /// resource_quantity.
-  FractionalResourceQuantity(std::string resource_name, double resource_quantity);
+  FractionalResourceQuantity(double resource_quantity);
 
   /// \brief Addition of FractionalResourceQuantity.
   const FractionalResourceQuantity operator+(const FractionalResourceQuantity &rhs) const;
@@ -38,10 +40,10 @@ class FractionalResourceQuantity {
   const FractionalResourceQuantity operator-(const FractionalResourceQuantity &rhs) const;
 
   /// \brief Addition and assignment of FractionalResourceQuantity.
-  FractionalResourceQuantity &operator+=(const FractionalResourceQuantity &rhs);
+  void operator+=(const FractionalResourceQuantity &rhs);
 
   /// \brief Subtraction and assignment of FractionalResourceQuantity.
-  FractionalResourceQuantity &operator-=(const FractionalResourceQuantity &rhs);
+  void operator-=(const FractionalResourceQuantity &rhs);
 
   bool operator==(const FractionalResourceQuantity &rhs) const;
   bool operator!=(const FractionalResourceQuantity &rhs) const;
@@ -54,17 +56,9 @@ class FractionalResourceQuantity {
   double ToDouble() const;
 
  private:
-  /// The resource name with the associated quantity. This is used only for
-  /// error messages.
-  std::string resource_name_;
-  /// The resource quantity represented as 1/10,000th of a unit. This value
-  /// will never exceed 10,000 because all resources are either in [0, 1] or
-  /// an integer.
+  /// The resource quantity represented as 1/kResourceConversionFactor-th of a
+  /// unit.
   int resource_quantity_;
-  /// Conversion factor that is the amount in internal units is equivalent to
-  /// one actual resource. Multiply to convert from actual to interal and
-  /// divide to convert from internal to actual.
-  static constexpr double conversion_factor_ = 10000;
 };
 
 /// \class ResourceSet

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -22,16 +22,6 @@ const std::string kCPU_ResourceLabel = "CPU";
 /// \class FractionalResourceQuantity
 /// \brief Converts the resource quantities to an internal representation to
 /// avoid machine precision errors.
-
-
-
-///**************************
-/// Test to make sure new tests does not succeed on master
-///**************************
-
-
-
-
 class FractionalResourceQuantity {
  public:
   /// \brief Construct a FractionalResourceQuantity representing zero
@@ -80,7 +70,8 @@ class ResourceSet {
   ResourceSet();
 
   /// \brief Constructs ResourceSet from the specified resource map.
-  ResourceSet(const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map);
+  ResourceSet(
+      const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map);
 
   /// \brief Constructs ResourceSet from the specified resource map.
   ResourceSet(const std::unordered_map<std::string, double> &resource_map);

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -135,12 +135,17 @@ class ResourceSet {
   /// \brief Subtract a set of resources from the current set of resources and
   /// check that the post-subtraction result nonnegative. Assumes other
   /// is a subset of the ResourceSet. Deletes any resource if the capacity after
-  /// subtraction is zero. Throws error if any are negative.
+  /// subtraction is zero.
   ///
   /// \param other: The resource set to subtract from the current resource set.
   /// \return Void.
   void SubtractResources(const ResourceSet &other);
 
+  /// \brief Same as SubtractResources but throws an error if the resource value
+  /// goes below zero.
+  ///
+  /// \param other: The resource set to subtract from the current resource set.
+  /// \return Void.
   void SubtractResourcesStrict(const ResourceSet &other);
 
   /// Return the capacity value associated with the specified resource.

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -141,6 +141,8 @@ class ResourceSet {
   /// \return Void.
   void SubtractResources(const ResourceSet &other);
 
+  void SubtractResourcesStrict(const ResourceSet &other);
+
   /// Return the capacity value associated with the specified resource.
   ///
   /// \param resource_name: Resource name for which capacity is requested.

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -23,9 +23,13 @@ class FractionalResourceQuantity {
   /// resources.
   FractionalResourceQuantity();
 
+  /// \brief Construct a FractionalResourceQuantity for implicit conversion of
+  /// operators.
+  FractionalResourceQuantity(int resource_quantity);
+
   /// \brief Construct a FractionalResourceQuantity representing
   /// resource_quantity.
-  FractionalResourceQuantity(double resource_quantity);
+  FractionalResourceQuantity(std::string resource_name, double resource_quantity);
 
   /// \brief Addition of FractionalResourceQuantity.
   const FractionalResourceQuantity operator+(const FractionalResourceQuantity& rhs) const;
@@ -50,6 +54,9 @@ class FractionalResourceQuantity {
   double ToDouble() const;
 
  private:
+  /// The resource name with the associated quantity. This is used only for
+  /// error messages.
+  std::string resource_name_;
   /// The resource quantity represented as 1/10,000th of a unit. This value
   /// will never exceed 10,000 because all resources are either in [0, 1] or
   /// an integer.
@@ -117,13 +124,6 @@ class ResourceSet {
   /// \param other: The other resource set to add.
   /// \return Void.
   void AddResources(const ResourceSet &other);
-
-  /// \brief Subtract a set of resources from the current set of resources.
-  /// Deletes any resource if the capacity after subtraction is zero or negative.
-  ///
-  /// \param other: The resource set to subtract from the current resource set.
-  /// \return Void.
-  void SubtractResources(const ResourceSet &other);
 
   /// \brief Subtract a set of resources from the current set of resources and
   /// check that the post-subtraction result nonnegative. Assumes other

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -22,6 +22,16 @@ const std::string kCPU_ResourceLabel = "CPU";
 /// \class FractionalResourceQuantity
 /// \brief Converts the resource quantities to an internal representation to
 /// avoid machine precision errors.
+
+
+
+///**************************
+/// Test to make sure new tests does not succeed on master
+///**************************
+
+
+
+
 class FractionalResourceQuantity {
  public:
   /// \brief Construct a FractionalResourceQuantity representing zero
@@ -68,6 +78,9 @@ class ResourceSet {
  public:
   /// \brief empty ResourceSet constructor.
   ResourceSet();
+
+  /// \brief Constructs ResourceSet from the specified resource map.
+  ResourceSet(const std::unordered_map<std::string, FractionalResourceQuantity> &resource_map);
 
   /// \brief Constructs ResourceSet from the specified resource map.
   ResourceSet(const std::unordered_map<std::string, double> &resource_map);
@@ -122,11 +135,11 @@ class ResourceSet {
   /// \brief Subtract a set of resources from the current set of resources and
   /// check that the post-subtraction result nonnegative. Assumes other
   /// is a subset of the ResourceSet. Deletes any resource if the capacity after
-  /// subtraction is zero.
+  /// subtraction is zero. Throws error if any are negative.
   ///
   /// \param other: The resource set to subtract from the current resource set.
   /// \return Void.
-  void SubtractResourcesStrict(const ResourceSet &other);
+  void SubtractResources(const ResourceSet &other);
 
   /// Return the capacity value associated with the specified resource.
   ///
@@ -138,7 +151,7 @@ class ResourceSet {
   /// Return the number of CPUs.
   ///
   /// \return Number of CPUs.
-  double GetNumCpus() const;
+  const ResourceSet GetNumCpus() const;
 
   /// Return true if the resource set is empty. False otherwise.
   ///
@@ -146,6 +159,8 @@ class ResourceSet {
   bool IsEmpty() const;
 
   // TODO(atumanov): implement const_iterator class for the ResourceSet container.
+  // TODO(williamma12): Make sure that everywhere we use doubles we don't
+  // convert it back to FractionalResourceQuantity.
   /// \brief Return a map of the resource and size in doubles. Note, size is in
   /// regular units and does not need to be multiplied by kResourceConversionFactor.
   ///
@@ -252,7 +267,7 @@ class ResourceIds {
   /// \brief Return the total quantity of resources, ignoring the specific IDs.
   ///
   /// \return The total quantity of the resource.
-  double TotalQuantity() const;
+  FractionalResourceQuantity TotalQuantity() const;
 
   /// \brief Return a string representation of the object.
   ///

--- a/src/ray/raylet/task_spec.cc
+++ b/src/ray/raylet/task_spec.cc
@@ -203,13 +203,6 @@ size_t TaskSpecification::ArgValLength(int64_t arg_index) const {
   return message->args()->Get(arg_index)->data()->size();
 }
 
-double TaskSpecification::GetRequiredResource(const std::string &resource_name) const {
-  RAY_CHECK(required_resources_.GetResourceMap().empty() == false);
-  auto it = required_resources_.GetResourceMap().find(resource_name);
-  RAY_CHECK(it != required_resources_.GetResourceMap().end());
-  return it->second;
-}
-
 const ResourceSet TaskSpecification::GetRequiredResources() const {
   return required_resources_;
 }

--- a/src/ray/raylet/task_spec.h
+++ b/src/ray/raylet/task_spec.h
@@ -183,7 +183,6 @@ class TaskSpecification {
   ObjectID ReturnId(int64_t return_index) const;
   const uint8_t *ArgVal(int64_t arg_index) const;
   size_t ArgValLength(int64_t arg_index) const;
-  double GetRequiredResource(const std::string &resource_name) const;
   /// Return the resources that are to be acquired during the execution of this
   /// task.
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Changes the internal representation of resource to integers that represent 1/10000 of a unit of each resource to avoid machine precision of doubles

## Related issue number

Closes #4503 

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
