### PR TITLE
[rllib] replace the assertion in SyncReplayOptimizer by a warning

### DIFF
--- a/python/ray/rllib/optimizers/sync_replay_optimizer.py
+++ b/python/ray/rllib/optimizers/sync_replay_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
 import collections
 import numpy as np
 
@@ -16,6 +17,8 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.compression import pack_if_needed
 from ray.rllib.utils.timer import TimerStat
 from ray.rllib.utils.schedules import LinearSchedule
+
+logger = logging.getLogger(__name__)
 
 
 class SyncReplayOptimizer(PolicyOptimizer):
@@ -69,7 +72,8 @@ class SyncReplayOptimizer(PolicyOptimizer):
 
         self.replay_buffers = collections.defaultdict(new_buffer)
 
-        assert buffer_size >= self.replay_starts
+        if buffer_size < self.replay_starts:
+            logger.warning("buffer_size={} < replay_starts={}".format(buffer_size, self.replay_starts))
 
     @override(PolicyOptimizer)
     def step(self):

--- a/python/ray/rllib/optimizers/sync_replay_optimizer.py
+++ b/python/ray/rllib/optimizers/sync_replay_optimizer.py
@@ -73,7 +73,8 @@ class SyncReplayOptimizer(PolicyOptimizer):
         self.replay_buffers = collections.defaultdict(new_buffer)
 
         if buffer_size < self.replay_starts:
-            logger.warning("buffer_size={} < replay_starts={}".format(buffer_size, self.replay_starts))
+            logger.warning("buffer_size={} < replay_starts={}".format(
+                buffer_size, self.replay_starts))
 
     @override(PolicyOptimizer)
     def step(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
enable use cases that drop out the samples collected at the beginning.


## Related issue number
#4497
<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
