### PR TITLE
[rllib] Don't merge unrolls from same episode when calculating seq lens

### DIFF
--- a/python/ray/rllib/agents/qmix/qmix_policy_graph.py
+++ b/python/ray/rllib/agents/qmix/qmix_policy_graph.py
@@ -245,7 +245,7 @@ class QMixPolicyGraph(PolicyGraph):
         [rew, action_mask, act, dones, obs], initial_states, seq_lens = \
             chop_into_sequences(
                 samples[SampleBatch.EPS_ID],
-                samples[SampleBatch.BATCH_ID],
+                samples[SampleBatch.UNROLL_ID],
                 samples[SampleBatch.AGENT_INDEX], [
                     group_rewards, action_mask, samples[SampleBatch.ACTIONS],
                     samples[SampleBatch.DONES], obs_batch

--- a/python/ray/rllib/agents/qmix/qmix_policy_graph.py
+++ b/python/ray/rllib/agents/qmix/qmix_policy_graph.py
@@ -245,6 +245,7 @@ class QMixPolicyGraph(PolicyGraph):
         [rew, action_mask, act, dones, obs], initial_states, seq_lens = \
             chop_into_sequences(
                 samples[SampleBatch.EPS_ID],
+                samples[SampleBatch.BATCH_ID],
                 samples[SampleBatch.AGENT_INDEX], [
                     group_rewards, action_mask, samples[SampleBatch.ACTIONS],
                     samples[SampleBatch.DONES], obs_batch

--- a/python/ray/rllib/evaluation/sample_batch.py
+++ b/python/ray/rllib/evaluation/sample_batch.py
@@ -106,6 +106,9 @@ class SampleBatch(object):
     # Uniquely identifies an episode
     EPS_ID = "eps_id"
 
+    # Uniquely identifies a sample batch
+    BATCH_ID = "batch_id"
+
     # Uniquely identifies an agent within an episode
     AGENT_INDEX = "agent_index"
 

--- a/python/ray/rllib/evaluation/sample_batch.py
+++ b/python/ray/rllib/evaluation/sample_batch.py
@@ -106,7 +106,9 @@ class SampleBatch(object):
     # Uniquely identifies an episode
     EPS_ID = "eps_id"
 
-    # Uniquely identifies a sample batch
+    # Uniquely identifies a sample batch. This is important to distinguish RNN
+    # sequences from the same episode when multiple sample batches are
+    # concatenated (fusing sequences across batches can be unsafe).
     BATCH_ID = "batch_id"
 
     # Uniquely identifies an agent within an episode

--- a/python/ray/rllib/evaluation/sample_batch.py
+++ b/python/ray/rllib/evaluation/sample_batch.py
@@ -109,7 +109,7 @@ class SampleBatch(object):
     # Uniquely identifies a sample batch. This is important to distinguish RNN
     # sequences from the same episode when multiple sample batches are
     # concatenated (fusing sequences across batches can be unsafe).
-    BATCH_ID = "batch_id"
+    UNROLL_ID = "unroll_id"
 
     # Uniquely identifies an agent within an episode
     AGENT_INDEX = "agent_index"

--- a/python/ray/rllib/evaluation/sample_batch_builder.py
+++ b/python/ray/rllib/evaluation/sample_batch_builder.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import collections
 import logging
-import random
 import numpy as np
 
 from ray.rllib.evaluation.sample_batch import SampleBatch, MultiAgentBatch
@@ -33,7 +32,7 @@ class SampleBatchBuilder(object):
     def __init__(self):
         self.buffers = collections.defaultdict(list)
         self.count = 0
-        self.batch_id = random.randrange(2e9)
+        self.unroll_id = 0  # disambiguates unrolls within a single episode
 
     @PublicAPI
     def add_values(self, **values):
@@ -58,11 +57,11 @@ class SampleBatchBuilder(object):
         batch = SampleBatch(
             {k: to_float_array(v)
              for k, v in self.buffers.items()})
-        batch.data[SampleBatch.BATCH_ID] = np.repeat(self.batch_id,
-                                                     batch.count)
+        batch.data[SampleBatch.UNROLL_ID] = np.repeat(self.unroll_id,
+                                                      batch.count)
         self.buffers.clear()
         self.count = 0
-        self.batch_id = random.randrange(2e9)
+        self.unroll_id += 1
         return batch
 
 

--- a/python/ray/rllib/evaluation/sample_batch_builder.py
+++ b/python/ray/rllib/evaluation/sample_batch_builder.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import collections
 import logging
+import random
 import numpy as np
 
 from ray.rllib.evaluation.sample_batch import SampleBatch, MultiAgentBatch
@@ -32,6 +33,7 @@ class SampleBatchBuilder(object):
     def __init__(self):
         self.buffers = collections.defaultdict(list)
         self.count = 0
+        self.batch_id = random.randrange(2e9)
 
     @PublicAPI
     def add_values(self, **values):
@@ -56,8 +58,11 @@ class SampleBatchBuilder(object):
         batch = SampleBatch(
             {k: to_float_array(v)
              for k, v in self.buffers.items()})
+        batch.data[SampleBatch.BATCH_ID] = np.repeat(self.batch_id,
+                                                     batch.count)
         self.buffers.clear()
         self.count = 0
+        self.batch_id = random.randrange(2e9)
         return batch
 
 

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -464,7 +464,7 @@ class TFPolicyGraph(PolicyGraph):
         ]
         feature_sequences, initial_states, seq_lens = chop_into_sequences(
             batch[SampleBatch.EPS_ID],
-            batch[SampleBatch.BATCH_ID],
+            batch[SampleBatch.UNROLL_ID],
             batch[SampleBatch.AGENT_INDEX], [batch[k] for k in feature_keys],
             [batch[k] for k in state_keys],
             max_seq_len,

--- a/python/ray/rllib/evaluation/tf_policy_graph.py
+++ b/python/ray/rllib/evaluation/tf_policy_graph.py
@@ -464,6 +464,7 @@ class TFPolicyGraph(PolicyGraph):
         ]
         feature_sequences, initial_states, seq_lens = chop_into_sequences(
             batch[SampleBatch.EPS_ID],
+            batch[SampleBatch.BATCH_ID],
             batch[SampleBatch.AGENT_INDEX], [batch[k] for k in feature_keys],
             [batch[k] for k in state_keys],
             max_seq_len,

--- a/python/ray/rllib/models/lstm.py
+++ b/python/ray/rllib/models/lstm.py
@@ -121,6 +121,7 @@ def add_time_dimension(padded_inputs, seq_lens):
 
 @DeveloperAPI
 def chop_into_sequences(episode_ids,
+                        batch_ids,
                         agent_indices,
                         feature_columns,
                         state_columns,
@@ -131,6 +132,8 @@ def chop_into_sequences(episode_ids,
 
     Arguments:
         episode_ids (list): List of episode ids for each step.
+        batch_ids (list): List of identifiers for the sample batch. This is
+            used to make sure sequences are cut between sample batches.
         agent_indices (list): List of agent ids for each step. Note that this
             has to be combined with episode_ids for uniqueness.
         feature_columns (list): List of arrays containing features.
@@ -150,7 +153,9 @@ def chop_into_sequences(episode_ids,
 
     Examples:
         >>> f_pad, s_init, seq_lens = chop_into_sequences(
-                episode_id=[1, 1, 5, 5, 5, 5],
+                episode_ids=[1, 1, 5, 5, 5, 5],
+                batch_ids=[4, 4, 4, 4, 4, 4],
+                agent_indices=[0, 0, 0, 0, 0, 0],
                 feature_columns=[[4, 4, 8, 8, 8, 8],
                                  [1, 1, 0, 1, 1, 0]],
                 state_columns=[[4, 5, 4, 5, 5, 5]],
@@ -167,7 +172,9 @@ def chop_into_sequences(episode_ids,
     prev_id = None
     seq_lens = []
     seq_len = 0
-    unique_ids = np.add(episode_ids, agent_indices)
+    unique_ids = np.add(
+        np.add(episode_ids, agent_indices),
+        np.array(batch_ids) << 32)
     for uid in unique_ids:
         if (prev_id is not None and uid != prev_id) or \
                 seq_len >= max_seq_len:

--- a/python/ray/rllib/models/lstm.py
+++ b/python/ray/rllib/models/lstm.py
@@ -121,7 +121,7 @@ def add_time_dimension(padded_inputs, seq_lens):
 
 @DeveloperAPI
 def chop_into_sequences(episode_ids,
-                        batch_ids,
+                        unroll_ids,
                         agent_indices,
                         feature_columns,
                         state_columns,
@@ -132,7 +132,7 @@ def chop_into_sequences(episode_ids,
 
     Arguments:
         episode_ids (list): List of episode ids for each step.
-        batch_ids (list): List of identifiers for the sample batch. This is
+        unroll_ids (list): List of identifiers for the sample batch. This is
             used to make sure sequences are cut between sample batches.
         agent_indices (list): List of agent ids for each step. Note that this
             has to be combined with episode_ids for uniqueness.
@@ -154,7 +154,7 @@ def chop_into_sequences(episode_ids,
     Examples:
         >>> f_pad, s_init, seq_lens = chop_into_sequences(
                 episode_ids=[1, 1, 5, 5, 5, 5],
-                batch_ids=[4, 4, 4, 4, 4, 4],
+                unroll_ids=[4, 4, 4, 4, 4, 4],
                 agent_indices=[0, 0, 0, 0, 0, 0],
                 feature_columns=[[4, 4, 8, 8, 8, 8],
                                  [1, 1, 0, 1, 1, 0]],
@@ -174,7 +174,7 @@ def chop_into_sequences(episode_ids,
     seq_len = 0
     unique_ids = np.add(
         np.add(episode_ids, agent_indices),
-        np.array(batch_ids) << 32)
+        np.array(unroll_ids) << 32)
     for uid in unique_ids:
         if (prev_id is not None and uid != prev_id) or \
                 seq_len >= max_seq_len:

--- a/python/ray/rllib/optimizers/multi_gpu_impl.py
+++ b/python/ray/rllib/optimizers/multi_gpu_impl.py
@@ -181,6 +181,13 @@ class LocalSyncParallelOptimizer(object):
             sequences_per_minibatch = make_divisible_by(
                 len(smallest_array), len(self.devices))
 
+        if log_once("data_slicing"):
+            logger.info(
+                ("Divided {} rollout sequences, each of length {}, among "
+                 "{} devices.").format(
+                     len(smallest_array), self._loaded_max_seq_len,
+                     len(self.devices)))
+
         if sequences_per_minibatch < len(self.devices):
             raise ValueError(
                 "Must load at least 1 tuple sequence per device. Try "

--- a/python/ray/rllib/optimizers/multi_gpu_impl.py
+++ b/python/ray/rllib/optimizers/multi_gpu_impl.py
@@ -181,13 +181,6 @@ class LocalSyncParallelOptimizer(object):
             sequences_per_minibatch = make_divisible_by(
                 len(smallest_array), len(self.devices))
 
-        if log_once("data_slicing"):
-            logger.info(
-                ("Divided {} rollout sequences, each of length {}, among "
-                 "{} devices.").format(
-                     len(smallest_array), self._loaded_max_seq_len,
-                     len(self.devices)))
-
         if sequences_per_minibatch < len(self.devices):
             raise ValueError(
                 "Must load at least 1 tuple sequence per device. Try "

--- a/python/ray/rllib/tests/test_lstm.py
+++ b/python/ray/rllib/tests/test_lstm.py
@@ -25,8 +25,9 @@ class LSTMUtilsTest(unittest.TestCase):
         f = [[101, 102, 103, 201, 202, 203, 204, 205],
              [[101], [102], [103], [201], [202], [203], [204], [205]]]
         s = [[209, 208, 207, 109, 108, 107, 106, 105]]
-        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids, agent_ids, f, s,
-                                                      4)
+        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids,
+                                                      np.ones_like(eps_ids),
+                                                      agent_ids, f, s, 4)
         self.assertEqual([f.tolist() for f in f_pad], [
             [101, 102, 103, 0, 201, 202, 203, 204, 205, 0, 0, 0],
             [[101], [102], [103], [0], [201], [202], [203], [204], [205], [0],
@@ -35,6 +36,17 @@ class LSTMUtilsTest(unittest.TestCase):
         self.assertEqual([s.tolist() for s in s_init], [[209, 109, 105]])
         self.assertEqual(seq_lens.tolist(), [3, 4, 1])
 
+    def testBatchId(self):
+        eps_ids = [1, 1, 1, 5, 5, 5, 5, 5]
+        batch_ids = [1, 1, 2, 2, 3, 3, 4, 4]
+        agent_ids = [1, 1, 1, 1, 1, 1, 1, 1]
+        f = [[101, 102, 103, 201, 202, 203, 204, 205],
+             [[101], [102], [103], [201], [202], [203], [204], [205]]]
+        s = [[209, 208, 207, 109, 108, 107, 106, 105]]
+        _, _, seq_lens = chop_into_sequences(eps_ids, batch_ids, agent_ids, f,
+                                             s, 4)
+        self.assertEqual(seq_lens.tolist(), [2, 1, 1, 2, 2])
+
     def testMultiAgent(self):
         eps_ids = [1, 1, 1, 5, 5, 5, 5, 5]
         agent_ids = [1, 1, 2, 1, 1, 2, 2, 3]
@@ -42,7 +54,13 @@ class LSTMUtilsTest(unittest.TestCase):
              [[101], [102], [103], [201], [202], [203], [204], [205]]]
         s = [[209, 208, 207, 109, 108, 107, 106, 105]]
         f_pad, s_init, seq_lens = chop_into_sequences(
-            eps_ids, agent_ids, f, s, 4, dynamic_max=False)
+            eps_ids,
+            np.ones_like(eps_ids),
+            agent_ids,
+            f,
+            s,
+            4,
+            dynamic_max=False)
         self.assertEqual(seq_lens.tolist(), [2, 1, 2, 2, 1])
         self.assertEqual(len(f_pad[0]), 20)
         self.assertEqual(len(s_init[0]), 5)
@@ -52,8 +70,9 @@ class LSTMUtilsTest(unittest.TestCase):
         agent_ids = [2, 2, 2]
         f = [[1, 1, 1]]
         s = [[1, 1, 1]]
-        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids, agent_ids, f, s,
-                                                      4)
+        f_pad, s_init, seq_lens = chop_into_sequences(eps_ids,
+                                                      np.ones_like(eps_ids),
+                                                      agent_ids, f, s, 4)
         self.assertEqual([f.tolist() for f in f_pad], [[1, 0, 1, 1]])
         self.assertEqual([s.tolist() for s in s_init], [[1, 1]])
         self.assertEqual(seq_lens.tolist(), [1, 2])

--- a/python/ray/rllib/tests/test_policy_evaluator.py
+++ b/python/ray/rllib/tests/test_policy_evaluator.py
@@ -16,7 +16,7 @@ from ray.rllib.evaluation.policy_evaluator import PolicyEvaluator
 from ray.rllib.evaluation.metrics import collect_metrics
 from ray.rllib.evaluation.policy_graph import PolicyGraph
 from ray.rllib.evaluation.postprocessing import compute_advantages
-from ray.rllib.evaluation.sample_batch import DEFAULT_POLICY_ID
+from ray.rllib.evaluation.sample_batch import DEFAULT_POLICY_ID, SampleBatch
 from ray.rllib.env.vector_env import VectorEnv
 from ray.tune.registry import register_env
 
@@ -154,6 +154,17 @@ class TestPolicyEvaluator(unittest.TestCase):
         self.assertEqual(batch["prev_actions"].tolist(),
                          to_prev(batch["actions"]))
         self.assertGreater(batch["advantages"][0], 1)
+
+    def testBatchIds(self):
+        ev = PolicyEvaluator(
+            env_creator=lambda _: gym.make("CartPole-v0"),
+            policy_graph=MockPolicyGraph)
+        batch1 = ev.sample()
+        batch2 = ev.sample()
+        self.assertEqual(len(set(batch1["unroll_id"])), 1)
+        self.assertEqual(len(set(batch2["unroll_id"])), 1)
+        self.assertEqual(
+            len(set(SampleBatch.concat(batch1, batch2)["unroll_id"])), 2)
 
     # 11/23/18: Samples per second 8501.125113727468
     def testBaselinePerformance(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This fixes a bug where sequences would be concatenated across sample batches if the batches were from the same episode, by adding a unique batch id for each sample batch. This is somewhat dangerous behaviour since those batches aren't guaranteed to be contiguous in the rollout.

There is also an edge case where we raise an error if the minibatch size is smaller than the RNN seq len. Instead, automatically bump up the minibatch size to the min RNN seq len. The previous assumption made was that the seq len would always be smaller than 1 minibatch, which is incorrect.

## Related issue number

Closes https://github.com/ray-project/ray/issues/4530

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
