### PR TITLE
[rllib] Support prev_state/prev_action in rollout and fix multiagent

### DIFF
--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -120,7 +120,10 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
             policy_agent_mapping = agent.config["multiagent"][
                 "policy_mapping_fn"]
         else:
-            policy_agent_mapping = lambda _: DEFAULT_POLICY_ID
+
+            def policy_agent_mapping(unused_agent_id):
+                return DEFAULT_POLICY_ID
+
         mapping_cache = {}  # in case policy_agent_mapping is stochastic
         policy_map = agent.local_evaluator.policy_map
         state_init = {p: m.get_initial_state() for p, m in policy_map.items()}

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -147,7 +147,6 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         if out is not None:
             rollout = []
         obs = env.reset()
-        multi_obs = obs if multiagent else {_DUMMY_AGENT_ID: obs}
         agent_states = DefaultMapping(lambda agent_id: state_init[
             mapping_cache[agent_id]])
         prev_actions = DefaultMapping(lambda agent_id: action_init[
@@ -156,6 +155,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         done = False
         reward_total = 0.0
         while not done and steps < (num_steps or steps + 1):
+            multi_obs = obs if multiagent else {_DUMMY_AGENT_ID: obs}
             action_dict = {}
             for agent_id, a_obs in multi_obs.items():
                 if a_obs is not None:
@@ -180,6 +180,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
                     prev_actions[agent_id] = a_action
             action = action_dict
 
+            action = action if multiagent else action[_DUMMY_AGENT_ID]
             next_obs, reward, done, _ = env.step(action)
             if multiagent:
                 for agent_id, r in reward.items():

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -169,7 +169,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
                             prev_action=prev_actions[agent_id],
                             prev_reward=prev_rewards[agent_id],
                             policy_id=policy_id)
-                        agent_states[policy_id] = p_state
+                        agent_states[agent_id] = p_state
                     else:
                         a_action = agent.compute_action(
                             a_obs,

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -113,19 +113,20 @@ class DefaultMapping(collections.defaultdict):
         return value
 
 
+def default_policy_agent_mapping(unused_agent_id):
+    return DEFAULT_POLICY_ID
+
+
 def rollout(agent, env_name, num_steps, out=None, no_render=True):
+    policy_agent_mapping = default_policy_agent_mapping
+
     if hasattr(agent, "local_evaluator"):
         env = agent.local_evaluator.env
         multiagent = isinstance(env, MultiAgentEnv)
         if agent.local_evaluator.multiagent:
             policy_agent_mapping = agent.config["multiagent"][
                 "policy_mapping_fn"]
-        else:
 
-            def policy_agent_mapping(unused_agent_id):
-                return DEFAULT_POLICY_ID
-
-        mapping_cache = {}  # in case policy_agent_mapping is stochastic
         policy_map = agent.local_evaluator.policy_map
         state_init = {p: m.get_initial_state() for p, m in policy_map.items()}
         use_lstm = {p: len(s) > 0 for p, s in state_init.items()}
@@ -142,6 +143,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         rollouts = []
     steps = 0
     while steps < (num_steps or steps + 1):
+        mapping_cache = {}  # in case policy_agent_mapping is stochastic
         if out is not None:
             rollout = []
         obs = env.reset()

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -148,10 +148,10 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
             rollout = []
         obs = env.reset()
         multi_obs = obs if multiagent else {_DUMMY_AGENT_ID: obs}
-        agent_states = DefaultMapping(lambda agent_id: state_init[
-            mapping_cache[agent_id]])
-        prev_actions = DefaultMapping(lambda agent_id: action_init[
-            mapping_cache[agent_id]])
+        agent_states = DefaultMapping(
+            lambda agent_id: state_init[mapping_cache[agent_id]])
+        prev_actions = DefaultMapping(
+            lambda agent_id: action_init[mapping_cache[agent_id]])
         prev_rewards = collections.defaultdict(lambda: 0.)
         done = False
         reward_total = 0.0

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -106,9 +106,11 @@ def run(args, parser):
 
 class DefaultMapping(collections.defaultdict):
     """default_factory now takes as an argument the missing key."""
+
     def __missing__(self, key):
         self[key] = value = self.default_factory(key)
         return value
+
 
 def rollout(agent, env_name, num_steps, out=None, no_render=True):
     if hasattr(agent, "local_evaluator"):
@@ -123,7 +125,10 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         policy_map = agent.local_evaluator.policy_map
         state_init = {p: m.get_initial_state() for p, m in policy_map.items()}
         use_lstm = {p: len(s) > 0 for p, s in state_init.items()}
-        action_init = {p: m.action_space.sample() for p, m in policy_map.items()}
+        action_init = {
+            p: m.action_space.sample()
+            for p, m in policy_map.items()
+        }
     else:
         env = gym.make(env_name)
         multiagent = False
@@ -137,10 +142,10 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
             rollout = []
         obs = env.reset()
         multi_obs = obs if multiagent else {0: obs}
-        agent_states = DefaultMapping(
-            lambda agent_id: state_init[mapping_cache[agent_id]])
-        prev_actions = DefaultMapping(
-            lambda agent_id: action_init[mapping_cache[agent_id]])
+        agent_states = DefaultMapping(lambda agent_id: state_init[
+            mapping_cache[agent_id]])
+        prev_actions = DefaultMapping(lambda agent_id: action_init[
+            mapping_cache[agent_id]])
         prev_rewards = collections.defaultdict(lambda: 0.)
         done = False
         reward_total = 0.0

--- a/python/ray/rllib/rollout.py
+++ b/python/ray/rllib/rollout.py
@@ -14,6 +14,7 @@ import gym
 import ray
 from ray.rllib.agents.registry import get_agent_class
 from ray.rllib.env import MultiAgentEnv
+from ray.rllib.env.base_env import _DUMMY_AGENT_ID
 from ray.rllib.evaluation.sample_batch import DEFAULT_POLICY_ID
 from ray.tune.util import merge_dicts
 
@@ -144,7 +145,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
         if out is not None:
             rollout = []
         obs = env.reset()
-        multi_obs = obs if multiagent else {0: obs}
+        multi_obs = obs if multiagent else {_DUMMY_AGENT_ID: obs}
         agent_states = DefaultMapping(lambda agent_id: state_init[
             mapping_cache[agent_id]])
         prev_actions = DefaultMapping(lambda agent_id: action_init[
@@ -182,7 +183,7 @@ def rollout(agent, env_name, num_steps, out=None, no_render=True):
                 for agent_id, r in reward.items():
                     prev_rewards[agent_id] = r
             else:
-                prev_rewards[0] = reward
+                prev_rewards[_DUMMY_AGENT_ID] = reward
 
             if multiagent:
                 done = done["__all__"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Fixes a few issues with rollout.py:
1. Multiagent envs were not properly handled.
2. prev_state and prev_action weren't passed in to the agent.

The code has also been simplified and should be more readable.

Closes https://github.com/ray-project/ray/issues/4573
## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
