### PR TITLE
Travis CI: Test on both old and new versions of xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
 
     - os: osx
-      osx_image: xcode7
+      osx_image: xcode10.2
       env: PYTHON=2.7 PYTHONWARNINGS=ignore
 
     - os: osx


### PR DESCRIPTION
Python 2 runs on the latest version of xcode and Python 3 runs on a version of xcode that is no longer supported by Apple.