### PR TITLE
[autoscaler] Remove unnecessary apt installations in docker commands

### DIFF
--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -107,11 +107,7 @@ def docker_start_cmds(user, image, mount, cname, user_options):
         image, "bash"
     ]
     cmds.append(" ".join(docker_check + docker_run))
-    docker_update = [
-        " && ".join(("apt-get -y update", "apt-get -y upgrade",
-                     "apt-get install -y git wget psmisc"))
-    ]
-    cmds.extend(with_docker_exec(docker_update, container_name=cname))
+
     return cmds
 
 

--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -62,7 +62,7 @@ head_node:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/ml-images/global/images/family/tf-1-13-gpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
 
     # Additional options can be found in in the compute docs at
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
@@ -85,7 +85,7 @@ worker_nodes:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/ml-images/global/images/family/tf-1-13-gpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cpu
     # Run workers on preemtible instance by default.
     # Comment this out to use on-demand.
     scheduling:

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -23,6 +23,14 @@ docker:
     run_options:
       - --runtime=nvidia
 
+    # # Example of running a GPU head with CPU workers
+    # head_image: "tensorflow/tensorflow:1.13.1-gpu-py3"
+    # head_run_options:
+    #     - --runtime=nvidia
+
+    # worker_image: "ubuntu:18.04"
+    # worker_run_options: []
+
 
 # The autoscaler will scale up the cluster to this target fraction of resource
 # usage. For example, if a cluster of 10 nodes is 100% busy and

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -18,7 +18,7 @@ initial_workers: 0
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.
 docker:
-    image: "tensorflow/tensorflow:1.12.0-gpu-py3"
+    image: "tensorflow/tensorflow:1.13.1-gpu-py3"
     container_name: "ray-nvidia-docker-test" # e.g. ray_docker
     run_options:
       - --runtime=nvidia

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -71,7 +71,7 @@ head_node:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-latest-gpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cu100
     guestAccelerators:
       - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
         acceleratorCount: 1
@@ -94,7 +94,7 @@ worker_nodes:
         initializeParams:
           diskSizeGb: 50
           # See https://cloud.google.com/compute/docs/images for more images
-          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-latest-gpu
+          sourceImage: projects/deeplearning-platform-release/global/images/family/tf-1-13-cu100
     guestAccelerators:
       - acceleratorType: projects/<project_id>/zones/us-west1-b/acceleratorTypes/nvidia-tesla-k80
         acceleratorCount: 1

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -47,7 +47,7 @@ provider:
     type: gcp
     region: us-west1
     availability_zone: us-west1-b
-    project_id: <project_id> # Globally unique project id
+    project_id: null # Globally unique project id
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
## What do these changes do?
Removes unnecessary `apt-get install` from autoscaler setup docker commands. These commands are problematic if the docker container is run as some other user than root. I believe there's no particular reason we install these packages so it seems better to just get rid of them.

## Linter
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
