### PR TITLE
Add actor name to log file name.

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -425,10 +425,15 @@ class Node(object):
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]
 
-    def new_worker_redirected_log_file(self, worker_id):
+    def new_worker_redirected_log_file(self, worker_id, actor_name):
         """Create new logging files for workers to redirect its output."""
+        if actor_name is None or len(actor_name) == 0:
+            actor_name_with_separator = ""
+        else:
+            actor_name_with_separator = actor_name + "-"
         worker_stdout_file, worker_stderr_file = (self.new_log_files(
-            "worker-" + ray.utils.binary_to_hex(worker_id), True))
+            "worker-" + actor_name_with_separator +
+            ray.utils.binary_to_hex(worker_id), True))
         return worker_stdout_file, worker_stderr_file
 
     def start_worker(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
1. Add the actor class name to the log file name. There are lots of log files with the name `worker-WORKER_ID.log` which contains no information about the actor information. If we can add the class name to the log file name, like `worker-ActorName-WORKER_ID.log`, that will be helpful for debugging.

2. At the creating time of a worker, it does not know whether it will become an actor or not. Once it becomes an actor, it will change the log name from `worker-WORKER_ID.log` to `worker-ActorName-WORKER_ID.log`. If the old log only contains one line, say `Ray worker pid: XXXX`, the old log will be deleted.


## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
