### PR TITLE
Change client table from Log to Set

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -222,11 +222,12 @@ def test_object_transfer_retry(ray_start_cluster):
     object_store_memory = 10**8
     cluster.add_node(
         object_store_memory=object_store_memory, _internal_config=config)
+    # Make sure the driver is connecting to the head node.
+    ray.init(redis_address=cluster.redis_address)
     cluster.add_node(
         num_gpus=1,
         object_store_memory=object_store_memory,
         _internal_config=config)
-    ray.init(redis_address=cluster.redis_address)
 
     @ray.remote(num_gpus=1)
     def f(size):

--- a/python/ray/tests/test_signal.py
+++ b/python/ray/tests/test_signal.py
@@ -274,7 +274,7 @@ def test_forget(ray_start_regular):
     assert len(result_list) == count
 
 
-def test_signal_on_node_failure(two_node_cluster):
+def test_signal_on_node_failure(ray_start_cluster_2_nodes):
     """Test actor checkpointing on a remote node."""
 
     class ActorSignal(object):
@@ -285,7 +285,8 @@ def test_signal_on_node_failure(two_node_cluster):
             return ray.worker.global_worker.plasma_client.store_socket_name
 
     # Place the actor on the remote node.
-    cluster, remote_node = two_node_cluster
+    cluster = ray_start_cluster_2_nodes
+    remote_node = list(cluster.worker_nodes)[0]
     actor_cls = ray.remote(max_reconstructions=0)(ActorSignal)
     actor = actor_cls.remote()
     # Try until we put an actor on a different node.

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -281,6 +281,13 @@ table ClientTableData {
   resources_total_capacity: [double];
 }
 
+table SetReplaceEntryData {
+  // The old packed data to remove.
+  old_data: string;
+  // The new packed data to add.
+  new_data: string;
+}
+
 table HeartbeatTableData {
   // Node manager client id
   client_id: string;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -698,7 +698,7 @@ using ConfigTable = Table<ConfigID, ConfigTableData>;
 /// it should append an entry to the log indicating that it is dead. A client
 /// that is marked as dead should never again be marked as alive; if it needs
 /// to reconnect, it must connect with a different ClientID.
-class ClientTable : private Set<ClientID, ClientTableData> {
+class ClientTable : public Set<ClientID, ClientTableData> {
  public:
   using ClientTableCallback = std::function<void(
       AsyncGcsClient *client, const ClientID &id, const ClientTableDataT &data)>;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1330,7 +1330,7 @@ void NodeManager::ProcessSetResourceRequest(
   }
   auto data_shared_ptr = std::make_shared<ClientTableDataT>(data);
   auto client_table = gcs_client_->client_table();
-  RAY_CHECK_OK(gcs_client_->client_table().Append(
+  RAY_CHECK_OK(gcs_client_->client_table().Add(
       DriverID::nil(), client_table.client_log_key_, data_shared_ptr, nullptr));
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -384,8 +384,9 @@ void NodeManager::ClientAdded(const ClientTableDataT &client_data) {
   auto status = ConnectRemoteNodeManager(client_id, client_data.node_manager_address,
                                          client_data.node_manager_port);
   if (!status.ok()) {
-    // This is not a fatal error for raylet, but it should not happen.
-    // We need to broadcase this message.
+    // This is not a fatal error for raylet, it may happen in a race condition.
+    // For example, the target raylet node just disconnected after this node finished
+    // reading the information from GCS.
     std::string type = "raylet_connection_error";
     std::ostringstream error_message;
     error_message << "Failed to connect to ray node " << client_id


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
1. Change client table from Log to Set.
2. We can totally delete the dead client entries from client table. However, we'd better keep information the clients that were connected before. Thus, I will remove the first entry that is added during the connection time. The 2-entry problem for a dead client caused many problems, so this change will make it clear.
3. Since we do not use insertion operation, `is_insertion` is changed to `is_connected` which is more meaningful. 


## Related issue number
https://github.com/ray-project/ray/pull/4154
https://github.com/ray-project/ray/issues/4140
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
