### PR TITLE
[tune] Change `<= 0` to `< 0` in over-commit check

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -405,11 +405,11 @@ class RayTrialExecutor(TrialExecutor):
 
         can_overcommit = self._queue_trials
 
-        if ((resources.cpu_total() > 0 and currently_available.cpu < 0) or
-            (resources.gpu_total() > 0 and currently_available.gpu < 0) or
-            any((resources.get_res_total(res_name) > 0
-                 and currently_available.get(res_name) < 0)
-                for res_name in resources.custom_resources)):
+        if ((resources.cpu_total() > 0 and currently_available.cpu < 0)
+                or (resources.gpu_total() > 0 and currently_available.gpu < 0)
+                or any((resources.get_res_total(res_name) > 0
+                        and currently_available.get(res_name) < 0)
+                       for res_name in resources.custom_resources)):
             can_overcommit = False  # requested resource is already saturated
 
         if can_overcommit:

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -405,11 +405,11 @@ class RayTrialExecutor(TrialExecutor):
 
         can_overcommit = self._queue_trials
 
-        if (resources.cpu_total() > 0 and currently_available.cpu <= 0) or \
-           (resources.gpu_total() > 0 and currently_available.gpu <= 0) or \
-           any((resources.get_res_total(res_name) > 0
-                and currently_available.get(res_name) <= 0)
-               for res_name in resources.custom_resources):
+        if ((resources.cpu_total() > 0 and currently_available.cpu < 0) or
+            (resources.gpu_total() > 0 and currently_available.gpu < 0) or
+            any((resources.get_res_total(res_name) > 0
+                 and currently_available.get(res_name) < 0)
+                for res_name in resources.custom_resources)):
             can_overcommit = False  # requested resource is already saturated
 
         if can_overcommit:


### PR DESCRIPTION
I was trying to run Tune experiment where my head node had 0 gpus and workers have > 0 gpus using `queue_trials=True`. I expected the trials (which required 1 gpu each) to be queued until the first worker comes up, but instead the cluster failed with:
> ray.tune.error.TuneError: Insufficient cluster resources to launch trial: trial requested 4 CPUs, 1.0 GPUs but the cluster has only 4 CPUs, 0 GPUs. Pass `queue_trials=True` in ray.tune.run() or on the command line to queue trials until the cluster scales up.

If I understand the Tune resource usage correctly, the overcommit check in trial executor should check strict inequality when deciding whether the cluster is saturated. Correct me if I'm wrong.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
