### PR TITLE
Integrate metric items into raylet

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -27,9 +27,6 @@ void ProcessCallback(int64_t callback_index, const std::string &data) {
   if (!callback_item.is_subscription) {
     // Record the redis latency for non-subscription redis operations.
     auto end_time = current_sys_time_us();
-    RAY_LOG(DEBUG) << "Record a redis latency, start time is " << callback_item.start_time
-                   << "us, end time is " << end_time << "us, and the elapsed time is "
-                   << end_time - callback_item.start_time << "us.";
     ray::stats::RedisLatency().Record(end_time - callback_item.start_time);
   }
   // Invoke the callback.
@@ -125,7 +122,7 @@ int64_t RedisCallbackManager::add(const RedisCallback &function, bool is_subscri
   return num_callbacks_++;
 }
 
-RedisCallbackManager::CallbackItem RedisCallbackManager::get(int64_t callback_index) {
+RedisCallbackManager::CallbackItem &RedisCallbackManager::get(int64_t callback_index) {
   RAY_CHECK(callback_items_.find(callback_index) != callback_items_.end());
   return callback_items_[callback_index];
 }

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -25,7 +25,7 @@ void ProcessCallback(int64_t callback_index, const std::string &data) {
                                  << "but it actually is " << callback_index;
   auto callback_item = ray::gcs::RedisCallbackManager::instance().get(callback_index);
   if (!callback_item.is_subscription) {
-    // Record the redis latency for non-subscription redis operator.
+    // Record the redis latency for non-subscription redis operations.
     auto end_time = current_sys_time_us();
     RAY_LOG(DEBUG) << "Record a redis latency, start time is " << callback_item.start_time
                    << "us, end time is " << end_time << "us, and the elapsed time is "

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -4,6 +4,9 @@
 
 #include <sstream>
 
+#include "ray/stats/stats.h"
+#include "ray/util/util.h"
+
 extern "C" {
 #include "ray/thirdparty/hiredis/adapters/ae.h"
 #include "ray/thirdparty/hiredis/async.h"
@@ -18,13 +21,24 @@ namespace {
 /// A helper function to call the callback and delete it from the callback
 /// manager if necessary.
 void ProcessCallback(int64_t callback_index, const std::string &data) {
-  if (callback_index >= 0) {
-    bool delete_callback =
-        ray::gcs::RedisCallbackManager::instance().get(callback_index)(data);
-    // Delete the callback if necessary.
-    if (delete_callback) {
-      ray::gcs::RedisCallbackManager::instance().remove(callback_index);
-    }
+  RAY_CHECK(callback_index >= 0) << "The callback index must be greater than 0, "
+                                 << "but it actually be " << callback_index;
+  auto callback_item = ray::gcs::RedisCallbackManager::instance().get(callback_index);
+  if (!callback_item.is_subscription) {
+    // Record the redis latency for non-subscription redis operator.
+    auto end_time = current_sys_time_us();
+    RAY_LOG(ERROR) << "Record a redis latency, start time is " << callback_item.start_time
+                   << "us, end time is " << end_time << "us, and the elapsed time is "
+                   << end_time - callback_item.start_time << "us.";
+    ray::stats::RedisLatency().Record(end_time - callback_item.start_time);
+  }
+  // Invoke the callback.
+  if (callback_item.callback != nullptr) {
+    callback_item.callback(data);
+  }
+  if (!callback_item.is_subscription) {
+    // Delete the callback if it's not a subscription callback.
+    ray::gcs::RedisCallbackManager::instance().remove(callback_index);
   }
 }
 
@@ -104,18 +118,20 @@ void SubscribeRedisCallback(void *c, void *r, void *privdata) {
   ProcessCallback(callback_index, data);
 }
 
-int64_t RedisCallbackManager::add(const RedisCallback &function) {
-  callbacks_.emplace(num_callbacks_, function);
+int64_t RedisCallbackManager::add(const RedisCallback &function, bool is_subscription) {
+  auto start_time = current_sys_time_us();
+  callback_items_.emplace(num_callbacks_,
+                          CallbackItem(function, is_subscription, start_time));
   return num_callbacks_++;
 }
 
-RedisCallback &RedisCallbackManager::get(int64_t callback_index) {
-  RAY_CHECK(callbacks_.find(callback_index) != callbacks_.end());
-  return callbacks_[callback_index];
+RedisCallbackManager::CallbackItem RedisCallbackManager::get(int64_t callback_index) {
+  RAY_CHECK(callback_items_.find(callback_index) != callback_items_.end());
+  return callback_items_[callback_index];
 }
 
 void RedisCallbackManager::remove(int64_t callback_index) {
-  callbacks_.erase(callback_index);
+  callback_items_.erase(callback_index);
 }
 
 #define REDIS_CHECK_ERROR(CONTEXT, REPLY)                     \
@@ -217,8 +233,7 @@ Status RedisContext::RunAsync(const std::string &command, const UniqueID &id,
                               const uint8_t *data, int64_t length,
                               const TablePrefix prefix, const TablePubsub pubsub_channel,
                               RedisCallback redisCallback, int log_length) {
-  int64_t callback_index =
-      redisCallback != nullptr ? RedisCallbackManager::instance().add(redisCallback) : -1;
+  int64_t callback_index = RedisCallbackManager::instance().add(redisCallback, false);
   if (length > 0) {
     if (log_length >= 0) {
       std::string redis_command = command + " %d %d %b %b %d";
@@ -278,7 +293,7 @@ Status RedisContext::SubscribeAsync(const ClientID &client_id,
   RAY_CHECK(pubsub_channel != TablePubsub::NO_PUBLISH)
       << "Client requested subscribe on a table that does not support pubsub";
 
-  int64_t callback_index = RedisCallbackManager::instance().add(redisCallback);
+  int64_t callback_index = RedisCallbackManager::instance().add(redisCallback, true);
   RAY_CHECK(out_callback_index != nullptr);
   *out_callback_index = callback_index;
   int status = 0;

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -22,7 +22,7 @@ namespace {
 /// manager if necessary.
 void ProcessCallback(int64_t callback_index, const std::string &data) {
   RAY_CHECK(callback_index >= 0) << "The callback index must be greater than 0, "
-                                 << "but it actually be " << callback_index;
+                                 << "but it actually is " << callback_index;
   auto callback_item = ray::gcs::RedisCallbackManager::instance().get(callback_index);
   if (!callback_item.is_subscription) {
     // Record the redis latency for non-subscription redis operator.

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -27,7 +27,7 @@ void ProcessCallback(int64_t callback_index, const std::string &data) {
   if (!callback_item.is_subscription) {
     // Record the redis latency for non-subscription redis operator.
     auto end_time = current_sys_time_us();
-    RAY_LOG(ERROR) << "Record a redis latency, start time is " << callback_item.start_time
+    RAY_LOG(DEBUG) << "Record a redis latency, start time is " << callback_item.start_time
                    << "us, end time is " << end_time << "us, and the elapsed time is "
                    << end_time - callback_item.start_time << "us.";
     ray::stats::RedisLatency().Record(end_time - callback_item.start_time);

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -19,8 +19,7 @@ namespace ray {
 
 namespace gcs {
 /// Every callback should take in a vector of the results from the Redis
-/// operation and return a bool indicating whether the callback is a subscription
-/// callback.
+/// operation.
 using RedisCallback = std::function<void(const std::string &)>;
 
 class RedisCallbackManager {
@@ -47,7 +46,7 @@ class RedisCallbackManager {
 
   int64_t add(const RedisCallback &function, bool is_subscription);
 
-  CallbackItem get(int64_t callback_index);
+  CallbackItem &get(int64_t callback_index);
 
   /// Remove a callback.
   void remove(int64_t callback_index);

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -19,9 +19,9 @@ namespace ray {
 
 namespace gcs {
 /// Every callback should take in a vector of the results from the Redis
-/// operation and return a bool indicating whether the callback should be
-/// deleted once called.
-using RedisCallback = std::function<bool(const std::string &)>;
+/// operation and return a bool indicating whether the callback is a subscription
+/// callback.
+using RedisCallback = std::function<void(const std::string &)>;
 
 class RedisCallbackManager {
  public:
@@ -30,9 +30,24 @@ class RedisCallbackManager {
     return instance;
   }
 
-  int64_t add(const RedisCallback &function);
+  struct CallbackItem {
+    CallbackItem() = default;
 
-  RedisCallback &get(int64_t callback_index);
+    CallbackItem(const RedisCallback &callback, bool is_subscription,
+                 int64_t start_time) {
+      this->callback = callback;
+      this->is_subscription = is_subscription;
+      this->start_time = start_time;
+    }
+
+    RedisCallback callback;
+    bool is_subscription;
+    int64_t start_time;
+  };
+
+  int64_t add(const RedisCallback &function, bool is_subscription);
+
+  CallbackItem get(int64_t callback_index);
 
   /// Remove a callback.
   void remove(int64_t callback_index);
@@ -43,7 +58,7 @@ class RedisCallbackManager {
   ~RedisCallbackManager() {}
 
   int64_t num_callbacks_ = 0;
-  std::unordered_map<int64_t, RedisCallback> callbacks_;
+  std::unordered_map<int64_t, CallbackItem> callback_items_;
 };
 
 class RedisContext {

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -428,8 +428,8 @@ void ClientTable::HandleNotification(AsyncGcsClient *client,
 
 void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientTableDataT &data) {
   auto connected_client_id = ClientID::from_binary(data.client_id);
-  RAY_CHECK(client_id_ == connected_client_id)
-      << connected_client_id << " " << client_id_;
+  RAY_CHECK(client_id_ == connected_client_id) << connected_client_id << " "
+                                               << client_id_;
 }
 
 const ClientID &ClientTable::GetLocalClientId() const { return client_id_; }
@@ -458,8 +458,8 @@ Status ClientTable::Connect(const ClientTableDataT &local_client) {
 
     // Callback for a notification from the client table.
     auto notification_callback = [this](
-                                     AsyncGcsClient *client, const UniqueID &log_key,
-                                     const std::vector<ClientTableDataT> &notifications) {
+        AsyncGcsClient *client, const UniqueID &log_key,
+        const std::vector<ClientTableDataT> &notifications) {
       RAY_CHECK(log_key == client_log_key_);
       std::unordered_map<std::string, ClientTableDataT> connected_nodes;
       std::unordered_map<std::string, ClientTableDataT> disconnected_nodes;
@@ -551,8 +551,8 @@ Status ActorCheckpointIdTable::AddCheckpointId(const JobID &job_id,
                                                const ActorID &actor_id,
                                                const ActorCheckpointID &checkpoint_id) {
   auto lookup_callback = [this, checkpoint_id, job_id, actor_id](
-                             ray::gcs::AsyncGcsClient *client, const UniqueID &id,
-                             const ActorCheckpointIdDataT &data) {
+      ray::gcs::AsyncGcsClient *client, const UniqueID &id,
+      const ActorCheckpointIdDataT &data) {
     std::shared_ptr<ActorCheckpointIdDataT> copy =
         std::make_shared<ActorCheckpointIdDataT>(data);
     copy->timestamps.push_back(current_sys_time_ms());
@@ -571,7 +571,7 @@ Status ActorCheckpointIdTable::AddCheckpointId(const JobID &job_id,
     RAY_CHECK_OK(Add(job_id, actor_id, copy, nullptr));
   };
   auto failure_callback = [this, checkpoint_id, job_id, actor_id](
-                              ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
+      ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
     std::shared_ptr<ActorCheckpointIdDataT> data =
         std::make_shared<ActorCheckpointIdDataT>();
     data->actor_id = id.binary();

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -147,4 +147,19 @@ std::string ConnectionPool::DebugString() const {
   return result.str();
 }
 
+void ConnectionPool::RecordMetrics() const {
+  stats::ConnectionPoolStats().Record(message_send_connections_.size(),
+      {{stats::ValueTypeKey, "num_message_send_connections"}});
+  stats::ConnectionPoolStats().Record(transfer_send_connections_.size(),
+      {{stats::ValueTypeKey, "num_transfer_send_connections"}});
+  stats::ConnectionPoolStats().Record(available_transfer_send_connections_.size(),
+      {{stats::ValueTypeKey, "num_avail_message_send_connections"}});
+  stats::ConnectionPoolStats().Record(available_transfer_send_connections_.size(),
+      {{stats::ValueTypeKey, "num_avail_transfer_send_connections"}});
+  stats::ConnectionPoolStats().Record(message_receive_connections_.size(),
+      {{stats::ValueTypeKey, "num_message_receive_connections"}});
+  stats::ConnectionPoolStats().Record(transfer_receive_connections_.size(),
+      {{stats::ValueTypeKey, "num_transfer_receive_connections"}});
+}
+
 }  // namespace ray

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -148,17 +148,23 @@ std::string ConnectionPool::DebugString() const {
 }
 
 void ConnectionPool::RecordMetrics() const {
-  stats::ConnectionPoolStats().Record(message_send_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      message_send_connections_.size(),
       {{stats::ValueTypeKey, "num_message_send_connections"}});
-  stats::ConnectionPoolStats().Record(transfer_send_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      transfer_send_connections_.size(),
       {{stats::ValueTypeKey, "num_transfer_send_connections"}});
-  stats::ConnectionPoolStats().Record(available_transfer_send_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      available_transfer_send_connections_.size(),
       {{stats::ValueTypeKey, "num_avail_message_send_connections"}});
-  stats::ConnectionPoolStats().Record(available_transfer_send_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      available_transfer_send_connections_.size(),
       {{stats::ValueTypeKey, "num_avail_transfer_send_connections"}});
-  stats::ConnectionPoolStats().Record(message_receive_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      message_receive_connections_.size(),
       {{stats::ValueTypeKey, "num_message_receive_connections"}});
-  stats::ConnectionPoolStats().Record(transfer_receive_connections_.size(),
+  stats::ConnectionPoolStats().Record(
+      transfer_receive_connections_.size(),
       {{stats::ValueTypeKey, "num_transfer_receive_connections"}});
 }
 

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -19,6 +19,7 @@
 #include "ray/object_manager/format/object_manager_generated.h"
 #include "ray/object_manager/object_directory.h"
 #include "ray/object_manager/object_manager_client_connection.h"
+#include "ray/stats/stats.h"
 
 namespace asio = boost::asio;
 
@@ -94,6 +95,9 @@ class ConnectionPool {
   ///
   /// \return string.
   std::string DebugString() const;
+
+  /// Record metrics.
+  void RecordMetrics() const;
 
   /// This object cannot be copied for thread-safety.
   RAY_DISALLOW_COPY_AND_ASSIGN(ConnectionPool);

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -961,15 +961,15 @@ std::string ObjectManager::DebugString() const {
   result << "\n- num pull requests: " << pull_requests_.size();
   result << "\n- num buffered profile events: " << profile_events_.size();
   stats::ObjectStats().Record(local_objects_.size(),
-      {{stats::ObjectStatsValueTypeKey, "num_local_objects"}});
+      {{stats::ValueTypeKey, "num_local_objects"}});
   stats::ObjectStats().Record(active_wait_requests_.size(),
-      {{stats::ObjectStatsValueTypeKey, "num_active_wait_requests"}});
+      {{stats::ValueTypeKey, "num_active_wait_requests"}});
   stats::ObjectStats().Record(unfulfilled_push_requests_.size(),
-      {{stats::ObjectStatsValueTypeKey, "num_unfulfilled_push_requests"}});
+      {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
   stats::ObjectStats().Record(pull_requests_.size(),
-      {{stats::ObjectStatsValueTypeKey, "num_pull_requests"}});
+      {{stats::ValueTypeKey, "num_pull_requests"}});
   stats::ObjectStats().Record(profile_events_.size(),
-      {{stats::ObjectStatsValueTypeKey, "num_profile_events"}});
+      {{stats::ValueTypeKey, "num_profile_events"}});
   result << "\n" << object_directory_->DebugString();
   result << "\n" << store_notification_.DebugString();
   result << "\n" << buffer_pool_.DebugString();

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -1,6 +1,7 @@
 #include "ray/object_manager/object_manager.h"
 #include "ray/common/common_protocol.h"
 #include "ray/util/util.h"
+#include "ray/stats/stats.h"
 
 namespace asio = boost::asio;
 
@@ -959,6 +960,16 @@ std::string ObjectManager::DebugString() const {
   result << "\n- num unfulfilled push requests: " << unfulfilled_push_requests_.size();
   result << "\n- num pull requests: " << pull_requests_.size();
   result << "\n- num buffered profile events: " << profile_events_.size();
+  stats::ObjectStats().Record(local_objects_.size(),
+      {{stats::ObjectStatsValueTypeKey, "num_local_objects"}});
+  stats::ObjectStats().Record(active_wait_requests_.size(),
+      {{stats::ObjectStatsValueTypeKey, "num_active_wait_requests"}});
+  stats::ObjectStats().Record(unfulfilled_push_requests_.size(),
+      {{stats::ObjectStatsValueTypeKey, "num_unfulfilled_push_requests"}});
+  stats::ObjectStats().Record(pull_requests_.size(),
+      {{stats::ObjectStatsValueTypeKey, "num_pull_requests"}});
+  stats::ObjectStats().Record(profile_events_.size(),
+      {{stats::ObjectStatsValueTypeKey, "num_profile_events"}});
   result << "\n" << object_directory_->DebugString();
   result << "\n" << store_notification_.DebugString();
   result << "\n" << buffer_pool_.DebugString();

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -968,16 +968,16 @@ std::string ObjectManager::DebugString() const {
 }
 
 void ObjectManager::RecordMetrics() const {
-  stats::ObjectStats().Record(local_objects_.size(),
-                              {{stats::ValueTypeKey, "num_local_objects"}});
-  stats::ObjectStats().Record(active_wait_requests_.size(),
-                              {{stats::ValueTypeKey, "num_active_wait_requests"}});
-  stats::ObjectStats().Record(unfulfilled_push_requests_.size(),
-                              {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
-  stats::ObjectStats().Record(pull_requests_.size(),
-                              {{stats::ValueTypeKey, "num_pull_requests"}});
-  stats::ObjectStats().Record(profile_events_.size(),
-                              {{stats::ValueTypeKey, "num_profile_events"}});
+  stats::ObjectManagerStats().Record(local_objects_.size(),
+      {{stats::ValueTypeKey, "num_local_objects"}});
+  stats::ObjectManagerStats().Record(active_wait_requests_.size(),
+      {{stats::ValueTypeKey, "num_active_wait_requests"}});
+  stats::ObjectManagerStats().Record(unfulfilled_push_requests_.size(),
+      {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
+  stats::ObjectManagerStats().Record(pull_requests_.size(),
+      {{stats::ValueTypeKey, "num_pull_requests"}});
+  stats::ObjectManagerStats().Record(profile_events_.size(),
+      {{stats::ValueTypeKey, "num_profile_events"}});
   connection_pool_.RecordMetrics();
 }
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -1,7 +1,7 @@
 #include "ray/object_manager/object_manager.h"
 #include "ray/common/common_protocol.h"
-#include "ray/util/util.h"
 #include "ray/stats/stats.h"
+#include "ray/util/util.h"
 
 namespace asio = boost::asio;
 
@@ -969,15 +969,15 @@ std::string ObjectManager::DebugString() const {
 
 void ObjectManager::RecordMetrics() const {
   stats::ObjectStats().Record(local_objects_.size(),
-      {{stats::ValueTypeKey, "num_local_objects"}});
+                              {{stats::ValueTypeKey, "num_local_objects"}});
   stats::ObjectStats().Record(active_wait_requests_.size(),
-      {{stats::ValueTypeKey, "num_active_wait_requests"}});
+                              {{stats::ValueTypeKey, "num_active_wait_requests"}});
   stats::ObjectStats().Record(unfulfilled_push_requests_.size(),
-      {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
+                              {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
   stats::ObjectStats().Record(pull_requests_.size(),
-      {{stats::ValueTypeKey, "num_pull_requests"}});
+                              {{stats::ValueTypeKey, "num_pull_requests"}});
   stats::ObjectStats().Record(profile_events_.size(),
-      {{stats::ValueTypeKey, "num_profile_events"}});
+                              {{stats::ValueTypeKey, "num_profile_events"}});
   connection_pool_.RecordMetrics();
 }
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -960,6 +960,14 @@ std::string ObjectManager::DebugString() const {
   result << "\n- num unfulfilled push requests: " << unfulfilled_push_requests_.size();
   result << "\n- num pull requests: " << pull_requests_.size();
   result << "\n- num buffered profile events: " << profile_events_.size();
+  result << "\n" << object_directory_->DebugString();
+  result << "\n" << store_notification_.DebugString();
+  result << "\n" << buffer_pool_.DebugString();
+  result << "\n" << connection_pool_.DebugString();
+  return result.str();
+}
+
+void ObjectManager::RecordMetrics() const {
   stats::ObjectStats().Record(local_objects_.size(),
       {{stats::ValueTypeKey, "num_local_objects"}});
   stats::ObjectStats().Record(active_wait_requests_.size(),
@@ -970,11 +978,7 @@ std::string ObjectManager::DebugString() const {
       {{stats::ValueTypeKey, "num_pull_requests"}});
   stats::ObjectStats().Record(profile_events_.size(),
       {{stats::ValueTypeKey, "num_profile_events"}});
-  result << "\n" << object_directory_->DebugString();
-  result << "\n" << store_notification_.DebugString();
-  result << "\n" << buffer_pool_.DebugString();
-  result << "\n" << connection_pool_.DebugString();
-  return result.str();
+  connection_pool_.RecordMetrics();
 }
 
 }  // namespace ray

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -970,9 +970,8 @@ std::string ObjectManager::DebugString() const {
 void ObjectManager::RecordMetrics() const {
   stats::ObjectManagerStats().Record(local_objects_.size(),
                                      {{stats::ValueTypeKey, "num_local_objects"}});
-  stats::ObjectManagerStats().Record(
-      active_wait_requests_.size(),
-      {{stats::ValueTypeKey, "num_active_wait_requests"}});
+  stats::ObjectManagerStats().Record(active_wait_requests_.size(),
+                                     {{stats::ValueTypeKey, "num_active_wait_requests"}});
   stats::ObjectManagerStats().Record(
       unfulfilled_push_requests_.size(),
       {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -969,15 +969,17 @@ std::string ObjectManager::DebugString() const {
 
 void ObjectManager::RecordMetrics() const {
   stats::ObjectManagerStats().Record(local_objects_.size(),
-      {{stats::ValueTypeKey, "num_local_objects"}});
-  stats::ObjectManagerStats().Record(active_wait_requests_.size(),
+                                     {{stats::ValueTypeKey, "num_local_objects"}});
+  stats::ObjectManagerStats().Record(
+      active_wait_requests_.size(),
       {{stats::ValueTypeKey, "num_active_wait_requests"}});
-  stats::ObjectManagerStats().Record(unfulfilled_push_requests_.size(),
+  stats::ObjectManagerStats().Record(
+      unfulfilled_push_requests_.size(),
       {{stats::ValueTypeKey, "num_unfulfilled_push_requests"}});
   stats::ObjectManagerStats().Record(pull_requests_.size(),
-      {{stats::ValueTypeKey, "num_pull_requests"}});
+                                     {{stats::ValueTypeKey, "num_pull_requests"}});
   stats::ObjectManagerStats().Record(profile_events_.size(),
-      {{stats::ValueTypeKey, "num_profile_events"}});
+                                     {{stats::ValueTypeKey, "num_profile_events"}});
   connection_pool_.RecordMetrics();
 }
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -187,6 +187,9 @@ class ObjectManager : public ObjectManagerInterface {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   friend class TestObjectManager;
 

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -461,7 +461,6 @@ bool LineageCache::ContainsTask(const TaskID &task_id) const {
 
 const Lineage &LineageCache::GetLineage() const { return lineage_; }
 
-// TODO(qwang): Move records to `RecordMetrics` method.
 std::string LineageCache::DebugString() const {
   std::stringstream result;
   result << "LineageCache:";

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -347,10 +347,9 @@ void LineageCache::FlushTask(const TaskID &task_id) {
   RAY_CHECK(entry);
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_READY);
 
-  gcs::raylet::TaskTable::WriteCallback task_callback = [this](
-      ray::gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
-    HandleEntryCommitted(id);
-  };
+  gcs::raylet::TaskTable::WriteCallback task_callback =
+      [this](ray::gcs::AsyncGcsClient *client, const TaskID &id,
+             const protocol::TaskT &data) { HandleEntryCommitted(id); };
   auto task = lineage_.GetEntry(task_id);
   // TODO(swang): Make this better...
   flatbuffers::FlatBufferBuilder fbb;
@@ -475,13 +474,13 @@ std::string LineageCache::DebugString() const {
 
 void LineageCache::RecordMetrics() const {
   stats::LineageCacheStats().Record(committed_tasks_.size(),
-      {{stats::ValueTypeKey, "num_committed_tasks"}});
+                                    {{stats::ValueTypeKey, "num_committed_tasks"}});
   stats::LineageCacheStats().Record(lineage_.GetChildrenSize(),
-      {{stats::ValueTypeKey, "num_children"}});
+                                    {{stats::ValueTypeKey, "num_children"}});
   stats::LineageCacheStats().Record(subscribed_tasks_.size(),
-      {{stats::ValueTypeKey, "num_subscribed_tasks"}});
+                                    {{stats::ValueTypeKey, "num_subscribed_tasks"}});
   stats::LineageCacheStats().Record(lineage_.GetEntries().size(),
-      {{stats::ValueTypeKey, "num_lineages"}});
+                                    {{stats::ValueTypeKey, "num_lineages"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -475,13 +475,13 @@ std::string LineageCache::DebugString() const {
 
 void LineageCache::RecordMetrics() const {
   stats::LineageCacheStats().Record(committed_tasks_.size(),
-      {{stats::LineageCacheStatsValueTypeKey, "num_committed_tasks"}});
+      {{stats::ValueTypeKey, "num_committed_tasks"}});
   stats::LineageCacheStats().Record(lineage_.GetChildrenSize(),
-      {{stats::LineageCacheStatsValueTypeKey, "num_children"}});
+      {{stats::ValueTypeKey, "num_children"}});
   stats::LineageCacheStats().Record(subscribed_tasks_.size(),
-      {{stats::LineageCacheStatsValueTypeKey, "num_subscribed_tasks"}});
+      {{stats::ValueTypeKey, "num_subscribed_tasks"}});
   stats::LineageCacheStats().Record(lineage_.GetEntries().size(),
-      {{stats::LineageCacheStatsValueTypeKey, "num_lineages"}});
+      {{stats::ValueTypeKey, "num_lineages"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -347,9 +347,10 @@ void LineageCache::FlushTask(const TaskID &task_id) {
   RAY_CHECK(entry);
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED_READY);
 
-  gcs::raylet::TaskTable::WriteCallback task_callback =
-      [this](ray::gcs::AsyncGcsClient *client, const TaskID &id,
-             const protocol::TaskT &data) { HandleEntryCommitted(id); };
+  gcs::raylet::TaskTable::WriteCallback task_callback = [this](
+      ray::gcs::AsyncGcsClient *client, const TaskID &id, const protocol::TaskT &data) {
+    HandleEntryCommitted(id);
+  };
   auto task = lineage_.GetEntry(task_id);
   // TODO(swang): Make this better...
   flatbuffers::FlatBufferBuilder fbb;

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -1,4 +1,5 @@
 #include "lineage_cache.h"
+#include "ray/stats/stats.h"
 
 #include <sstream>
 
@@ -461,6 +462,7 @@ bool LineageCache::ContainsTask(const TaskID &task_id) const {
 
 const Lineage &LineageCache::GetLineage() const { return lineage_; }
 
+// TODO(qwang): Move records to `RecordMetrics` method.
 std::string LineageCache::DebugString() const {
   std::stringstream result;
   result << "LineageCache:";
@@ -469,6 +471,17 @@ std::string LineageCache::DebugString() const {
   result << "\n- num subscribed tasks: " << subscribed_tasks_.size();
   result << "\n- lineage size: " << lineage_.GetEntries().size();
   return result.str();
+}
+
+void LineageCache::RecordMetrics() const {
+  stats::LineageCacheStats().Record(committed_tasks_.size(),
+      {{stats::LineageCacheStatsValueTypeKey, "num_committed_tasks"}});
+  stats::LineageCacheStats().Record(lineage_.GetChildrenSize(),
+      {{stats::LineageCacheStatsValueTypeKey, "num_children"}});
+  stats::LineageCacheStats().Record(subscribed_tasks_.size(),
+      {{stats::LineageCacheStatsValueTypeKey, "num_subscribed_tasks"}});
+  stats::LineageCacheStats().Record(lineage_.GetEntries().size(),
+      {{stats::LineageCacheStatsValueTypeKey, "num_lineages"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -299,6 +299,9 @@ class LineageCache {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   FRIEND_TEST(LineageCacheTest, BarReturnsZeroOnNull);
   /// Flush a task that is in UNCOMMITTED_READY state.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2203,9 +2203,18 @@ std::string NodeManager::DebugString() const {
     }
   }
   result << "\n- num live actors: " << live_actors;
-  result << "\n- num reconstructing actors: " << live_actors;
+  result << "\n- num reconstructing actors: " << reconstructing_actors;
   result << "\n- num dead actors: " << dead_actors;
   result << "\n- max num handles: " << max_num_handles;
+  stats::ActorStats().Record(live_actors,
+      {{stats::ActorStatsValueTypeKey, "live_actors"}});
+  stats::ActorStats().Record(reconstructing_actors,
+      {{stats::ActorStatsValueTypeKey, "reconstructing_actors"}});
+  stats::ActorStats().Record(dead_actors,
+      {{stats::ActorStatsValueTypeKey, "dead_actors"}});
+  stats::ActorStats().Record(max_num_handles,
+      {{stats::ActorStatsValueTypeKey, "max_num_handles"}});
+
   result << "\nRemoteConnections:";
   for (auto &pair : remote_server_connections_) {
     result << "\n" << pair.first.hex() << ": " << pair.second->DebugString();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2185,6 +2185,7 @@ std::string NodeManager::DebugString() const {
   result << "\n" << reconstruction_policy_.DebugString();
   result << "\n" << task_dependency_manager_.DebugString();
   result << "\n" << lineage_cache_.DebugString();
+  lineage_cache_.RecordMetrics();
   result << "\nActorRegistry:";
   int live_actors = 0;
   int dead_actors = 0;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -179,28 +179,29 @@ ray::Status NodeManager::RegisterGcs() {
   };
   gcs_client_->client_table().RegisterClientAddedCallback(node_manager_client_added);
   // Register a callback on the client table for removed clients.
-  auto node_manager_client_removed =
-      [this](gcs::AsyncGcsClient *client, const UniqueID &id,
-             const ClientTableDataT &data) { ClientRemoved(data); };
+  auto node_manager_client_removed = [this](
+      gcs::AsyncGcsClient *client, const UniqueID &id, const ClientTableDataT &data) {
+    ClientRemoved(data);
+  };
   gcs_client_->client_table().RegisterClientRemovedCallback(node_manager_client_removed);
 
   // Subscribe to heartbeat batches from the monitor.
-  const auto &heartbeat_batch_added =
-      [this](gcs::AsyncGcsClient *client, const ClientID &id,
-             const HeartbeatBatchTableDataT &heartbeat_batch) {
-        HeartbeatBatchAdded(heartbeat_batch);
-      };
+  const auto &heartbeat_batch_added = [this](
+      gcs::AsyncGcsClient *client, const ClientID &id,
+      const HeartbeatBatchTableDataT &heartbeat_batch) {
+    HeartbeatBatchAdded(heartbeat_batch);
+  };
   RAY_RETURN_NOT_OK(gcs_client_->heartbeat_batch_table().Subscribe(
       JobID::nil(), ClientID::nil(), heartbeat_batch_added,
       /*subscribe_callback=*/nullptr,
       /*done_callback=*/nullptr));
 
   // Subscribe to driver table updates.
-  const auto driver_table_handler =
-      [this](gcs::AsyncGcsClient *client, const DriverID &client_id,
-             const std::vector<DriverTableDataT> &driver_data) {
-        HandleDriverTableUpdate(client_id, driver_data);
-      };
+  const auto driver_table_handler = [this](
+      gcs::AsyncGcsClient *client, const DriverID &client_id,
+      const std::vector<DriverTableDataT> &driver_data) {
+    HandleDriverTableUpdate(client_id, driver_data);
+  };
   RAY_RETURN_NOT_OK(gcs_client_->driver_table().Subscribe(JobID::nil(), ClientID::nil(),
                                                           driver_table_handler, nullptr));
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -34,7 +34,7 @@ int64_t GetExpectedTaskCounter(
   return expected_task_counter;
 };
 
-struct ResultItem {
+struct ActorStats {
   int live_actors = 0;
   int dead_actors = 0;
   int reconstructing_actors = 0;
@@ -42,9 +42,9 @@ struct ResultItem {
 };
 
 /// A helper function to return the statistical data of actors in this node manager.
-ResultItem GetActorStatisticalData(
+ActorStats GetActorStatisticalData(
     std::unordered_map<ray::ActorID, ray::raylet::ActorRegistration> actor_registry) {
-  ResultItem item;
+  ActorStats item;
   for (auto &pair : actor_registry) {
     if (pair.second.GetState() == ActorState::ALIVE) {
       item.live_actors += 1;
@@ -302,6 +302,7 @@ void NodeManager::Heartbeat() {
   if (debug_dump_period_ > 0 &&
       static_cast<int64_t>(now_ms - last_debug_dump_at_ms_) > debug_dump_period_) {
     DumpDebugState();
+    RecordMetrics();
     last_debug_dump_at_ms_ = now_ms;
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -276,6 +276,7 @@ void NodeManager::Heartbeat() {
   if (debug_dump_period_ > 0 &&
       static_cast<int64_t>(now_ms - last_debug_dump_at_ms_) > debug_dump_period_) {
     DumpDebugState();
+    RecordMetrics();
     last_debug_dump_at_ms_ = now_ms;
   }
 
@@ -2211,6 +2212,21 @@ std::string NodeManager::DebugString() const {
   }
   result << "\nDebugString() time ms: " << (current_time_ms() - now_ms);
   return result.str();
+}
+
+void NodeManager::RecordMetrics() {
+  // Record available resources of this node.
+  const auto &available_resources = cluster_resource_map_[client_id_]
+      .GetAvailableResources().GetResourceMap();
+  for (const auto &pair : available_resources) {
+    stats::LocalAvailableResource().Record(pair.second, {{stats::ResourceNameKey, pair.first}});
+  }
+  // Record total resources of this node.
+  const auto &total_resources = cluster_resource_map_[client_id_]
+      .GetTotalResources().GetResourceMap();
+  for (const auto &pair : total_resources) {
+    stats::LocalTotalResource().Record(pair.second, {{stats::ResourceNameKey, pair.first}});
+  }
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2184,6 +2184,7 @@ std::string NodeManager::DebugString() const {
   result << "\n" << local_queues_.DebugString();
   result << "\n" << reconstruction_policy_.DebugString();
   result << "\n" << task_dependency_manager_.DebugString();
+  task_dependency_manager_.RecordMetrics();
   result << "\n" << lineage_cache_.DebugString();
   lineage_cache_.RecordMetrics();
   result << "\nActorRegistry:";
@@ -2208,13 +2209,13 @@ std::string NodeManager::DebugString() const {
   result << "\n- num dead actors: " << dead_actors;
   result << "\n- max num handles: " << max_num_handles;
   stats::ActorStats().Record(live_actors,
-      {{stats::ActorStatsValueTypeKey, "live_actors"}});
+      {{stats::ValueTypeKey, "live_actors"}});
   stats::ActorStats().Record(reconstructing_actors,
-      {{stats::ActorStatsValueTypeKey, "reconstructing_actors"}});
+      {{stats::ValueTypeKey, "reconstructing_actors"}});
   stats::ActorStats().Record(dead_actors,
-      {{stats::ActorStatsValueTypeKey, "dead_actors"}});
+      {{stats::ValueTypeKey, "dead_actors"}});
   stats::ActorStats().Record(max_num_handles,
-      {{stats::ActorStatsValueTypeKey, "max_num_handles"}});
+      {{stats::ValueTypeKey, "max_num_handles"}});
 
   result << "\nRemoteConnections:";
   for (auto &pair : remote_server_connections_) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2200,8 +2200,7 @@ std::string NodeManager::DebugString() const {
   }
 
   object_manager_.RecordMetrics();
-  // gcs_client_->RecordMetrics();
-  // worker_pool_.RecordMetrics();
+  worker_pool_.RecordMetrics();
   local_queues_.RecordMetrics();
   reconstruction_policy_.RecordMetrics();
   task_dependency_manager_.RecordMetrics();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2184,10 +2184,17 @@ std::string NodeManager::DebugString() const {
   result << "\n" << local_queues_.DebugString();
   result << "\n" << reconstruction_policy_.DebugString();
   result << "\n" << task_dependency_manager_.DebugString();
-  task_dependency_manager_.RecordMetrics();
   result << "\n" << lineage_cache_.DebugString();
-  lineage_cache_.RecordMetrics();
   result << "\nActorRegistry:";
+
+  // record resources metrics.
+  // object_manager_.RecordMetrics();
+  // gcs_client_.RecordMetrics();
+  // worker_pool_.RecordMetrics();
+  local_queues_.RecordMetrics();
+  task_dependency_manager_.RecordMetrics();
+  lineage_cache_.RecordMetrics();
+
   int live_actors = 0;
   int dead_actors = 0;
   int reconstructing_actors = 0;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2189,9 +2189,10 @@ std::string NodeManager::DebugString() const {
 
   // record resources metrics.
   // object_manager_.RecordMetrics();
-  // gcs_client_.RecordMetrics();
+  // gcs_client_->RecordMetrics();
   // worker_pool_.RecordMetrics();
   local_queues_.RecordMetrics();
+  reconstruction_policy_.RecordMetrics();
   task_dependency_manager_.RecordMetrics();
   lineage_cache_.RecordMetrics();
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2228,6 +2228,10 @@ std::string NodeManager::DebugString() const {
 }
 
 void NodeManager::RecordMetrics() const {
+  if (StatsConfig::instance().IsStatsDisabled()) {
+    return;
+  }
+
   // Record available resources of this node.
   const auto &available_resources =
       cluster_resource_map_.at(client_id_).GetAvailableResources().GetResourceMap();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2228,7 +2228,7 @@ std::string NodeManager::DebugString() const {
 }
 
 void NodeManager::RecordMetrics() const {
-  if (StatsConfig::instance().IsStatsDisabled()) {
+  if (stats::StatsConfig::instance().IsStatsDisabled()) {
     return;
   }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -122,9 +122,6 @@ class NodeManager {
   /// Write out debug state to a file.
   void DumpDebugState();
 
-  /// Record metrics of this node manager.
-  void RecordMetrics();
-
   /// Get profiling information from the object manager and push it to the GCS.
   ///
   /// \return Void.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -122,6 +122,9 @@ class NodeManager {
   /// Write out debug state to a file.
   void DumpDebugState();
 
+  /// Record metrics of this node manager.
+  void RecordMetrics();
+
   /// Get profiling information from the object manager and push it to the GCS.
   ///
   /// \return Void.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -103,6 +103,9 @@ class NodeManager {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   /// Methods for handling clients.
 
@@ -120,7 +123,7 @@ class NodeManager {
   void Heartbeat();
 
   /// Write out debug state to a file.
-  void DumpDebugState();
+  void DumpDebugState() const;
 
   /// Get profiling information from the object manager and push it to the GCS.
   ///

--- a/src/ray/raylet/reconstruction_policy.cc
+++ b/src/ray/raylet/reconstruction_policy.cc
@@ -213,8 +213,8 @@ std::string ReconstructionPolicy::DebugString() const {
 }
 
 void ReconstructionPolicy::RecordMetrics() const {
-  stats::ReconstructionPolicyStats().Record(listening_tasks_.size(),
-      {{stats::ValueTypeKey, "num_reconstructing_tasks"}});
+  stats::ReconstructionPolicyStats().Record(
+      listening_tasks_.size(), {{stats::ValueTypeKey, "num_reconstructing_tasks"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/reconstruction_policy.cc
+++ b/src/ray/raylet/reconstruction_policy.cc
@@ -1,5 +1,7 @@
 #include "reconstruction_policy.h"
 
+#include "ray/stats/stats.h"
+
 namespace ray {
 
 namespace raylet {
@@ -208,6 +210,11 @@ std::string ReconstructionPolicy::DebugString() const {
   result << "ReconstructionPolicy:";
   result << "\n- num reconstructing: " << listening_tasks_.size();
   return result.str();
+}
+
+void ReconstructionPolicy::RecordMetrics() const {
+  stats::ReconstructionPolicyStats().Record(listening_tasks_.size(),
+      {{stats::ValueTypeKey, "num_reconstructing_tasks"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/reconstruction_policy.h
+++ b/src/ray/raylet/reconstruction_policy.h
@@ -76,6 +76,9 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   struct ReconstructionTask {
     ReconstructionTask(boost::asio::io_service &io_service)

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-#include "ray/status.h"
 #include "ray/stats/stats.h"
+#include "ray/status.h"
 
 namespace {
 
@@ -229,8 +229,12 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   std::vector<Task> removed_tasks;
   // Try to find the tasks to remove from the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_ids, &removed_tasks);
   }
@@ -244,8 +248,12 @@ Task SchedulingQueue::RemoveTask(const TaskID &task_id, TaskState *removed_task_
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_id_set, &removed_tasks);
     if (task_id_set.empty()) {
@@ -386,8 +394,12 @@ std::string SchedulingQueue::DebugString() const {
   std::stringstream result;
   result << "SchedulingQueue:";
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     result << "\n- num " << GetTaskStateString(task_state)
            << " tasks: " << GetTaskQueue(task_state)->GetTasks().size();
@@ -398,11 +410,17 @@ std::string SchedulingQueue::DebugString() const {
 
 void SchedulingQueue::RecordMetrics() const {
   for (const auto &task_state : {
-           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
-           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
-           }) {
-    stats::SchedulingQueueStats().Record(static_cast<double>(GetTaskQueue(task_state)->GetTasks().size()),
-        {{stats::ValueTypeKey, std::string("num_") + GetTaskStateString(task_state) + "tasks"}});
+           TaskState::PLACEABLE,
+           TaskState::WAITING,
+           TaskState::READY,
+           TaskState::RUNNING,
+           TaskState::INFEASIBLE,
+           TaskState::WAITING_FOR_ACTOR_CREATION,
+       }) {
+    stats::SchedulingQueueStats().Record(
+        static_cast<double>(GetTaskQueue(task_state)->GetTasks().size()),
+        {{stats::ValueTypeKey,
+          std::string("num_") + GetTaskStateString(task_state) + "tasks"}});
   }
 }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -229,12 +229,8 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   std::vector<Task> removed_tasks;
   // Try to find the tasks to remove from the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_ids, &removed_tasks);
   }
@@ -248,12 +244,8 @@ Task SchedulingQueue::RemoveTask(const TaskID &task_id, TaskState *removed_task_
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     RemoveTasksFromQueue(task_state, task_id_set, &removed_tasks);
     if (task_id_set.empty()) {
@@ -394,12 +386,8 @@ std::string SchedulingQueue::DebugString() const {
   std::stringstream result;
   result << "SchedulingQueue:";
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     result << "\n- num " << GetTaskStateString(task_state)
            << " tasks: " << GetTaskQueue(task_state)->GetTasks().size();
@@ -410,12 +398,8 @@ std::string SchedulingQueue::DebugString() const {
 
 void SchedulingQueue::RecordMetrics() const {
   for (const auto &task_state : {
-           TaskState::PLACEABLE,
-           TaskState::WAITING,
-           TaskState::READY,
-           TaskState::RUNNING,
-           TaskState::INFEASIBLE,
-           TaskState::WAITING_FOR_ACTOR_CREATION,
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
        }) {
     stats::SchedulingQueueStats().Record(
         static_cast<double>(GetTaskQueue(task_state)->GetTasks().size()),

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -9,7 +9,7 @@ namespace {
 
 static constexpr const char *task_state_strings[] = {
     "placeable", "waiting",    "ready",
-    "running",   "infeasible", "waiting for actor creation"};
+    "running",   "infeasible", "waiting_for_actor_creation"};
 static_assert(sizeof(task_state_strings) / sizeof(const char *) ==
                   static_cast<int>(ray::raylet::TaskState::kNumTaskQueues),
               "Must specify a TaskState name for every task queue");
@@ -420,7 +420,7 @@ void SchedulingQueue::RecordMetrics() const {
     stats::SchedulingQueueStats().Record(
         static_cast<double>(GetTaskQueue(task_state)->GetTasks().size()),
         {{stats::ValueTypeKey,
-          std::string("num_") + GetTaskStateString(task_state) + "tasks"}});
+          std::string("num_") + GetTaskStateString(task_state) + "_tasks"}});
   }
 }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include "ray/status.h"
+#include "ray/stats/stats.h"
 
 namespace {
 
@@ -393,6 +394,16 @@ std::string SchedulingQueue::DebugString() const {
   }
   result << "\n- num tasks blocked: " << blocked_task_ids_.size();
   return result.str();
+}
+
+void SchedulingQueue::RecordMetrics() const {
+  for (const auto &task_state : {
+           TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY, TaskState::RUNNING,
+           TaskState::INFEASIBLE, TaskState::WAITING_FOR_ACTOR_CREATION,
+           }) {
+    stats::SchedulingQueueStats().Record(static_cast<double>(GetTaskQueue(task_state)->GetTasks().size()),
+        {{stats::ValueTypeKey, std::string("num_") + GetTaskStateString(task_state) + "tasks"}});
+  }
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -294,6 +294,9 @@ class SchedulingQueue {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   /// Get the task queue in the given state. The requested task state must
   /// correspond to one of the task queues (has value <

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -142,11 +142,8 @@ class SchedulingQueue {
   /// Create a scheduling queue.
   SchedulingQueue() : ready_queue_(std::make_shared<ReadyQueue>()) {
     for (const auto &task_state : {
-             TaskState::PLACEABLE,
-             TaskState::WAITING,
-             TaskState::READY,
-             TaskState::RUNNING,
-             TaskState::INFEASIBLE,
+             TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY,
+             TaskState::RUNNING, TaskState::INFEASIBLE,
              TaskState::WAITING_FOR_ACTOR_CREATION,
          }) {
       if (task_state == TaskState::READY) {

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -142,8 +142,11 @@ class SchedulingQueue {
   /// Create a scheduling queue.
   SchedulingQueue() : ready_queue_(std::make_shared<ReadyQueue>()) {
     for (const auto &task_state : {
-             TaskState::PLACEABLE, TaskState::WAITING, TaskState::READY,
-             TaskState::RUNNING, TaskState::INFEASIBLE,
+             TaskState::PLACEABLE,
+             TaskState::WAITING,
+             TaskState::READY,
+             TaskState::RUNNING,
+             TaskState::INFEASIBLE,
              TaskState::WAITING_FOR_ACTOR_CREATION,
          }) {
       if (task_state == TaskState::READY) {

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -1,5 +1,7 @@
 #include "task_dependency_manager.h"
 
+#include "ray/stats/stats.h"
+
 namespace ray {
 
 namespace raylet {
@@ -345,6 +347,19 @@ std::string TaskDependencyManager::DebugString() const {
   result << "\n- local objects map size: " << local_objects_.size();
   result << "\n- pending tasks map size: " << pending_tasks_.size();
   return result.str();
+}
+
+void TaskDependencyManager::RecordMetrics() const {
+  stats::TaskDependencyManagerStats().Record(task_dependencies_.size(),
+      {{stats::ValueTypeKey, "num_task_dependencies"}});
+  stats::TaskDependencyManagerStats().Record(required_tasks_.size(),
+      {{stats::ValueTypeKey, "num_required_tasks"}});
+  stats::TaskDependencyManagerStats().Record(required_objects_.size(),
+      {{stats::ValueTypeKey, "num_required_objects"}});
+  stats::TaskDependencyManagerStats().Record(local_objects_.size(),
+      {{stats::ValueTypeKey, "num_local_objects"}});
+  stats::TaskDependencyManagerStats().Record(pending_tasks_.size(),
+      {{stats::ValueTypeKey, "num_pending_tasks"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -350,16 +350,16 @@ std::string TaskDependencyManager::DebugString() const {
 }
 
 void TaskDependencyManager::RecordMetrics() const {
-  stats::TaskDependencyManagerStats().Record(task_dependencies_.size(),
-      {{stats::ValueTypeKey, "num_task_dependencies"}});
-  stats::TaskDependencyManagerStats().Record(required_tasks_.size(),
-      {{stats::ValueTypeKey, "num_required_tasks"}});
-  stats::TaskDependencyManagerStats().Record(required_objects_.size(),
-      {{stats::ValueTypeKey, "num_required_objects"}});
-  stats::TaskDependencyManagerStats().Record(local_objects_.size(),
-      {{stats::ValueTypeKey, "num_local_objects"}});
-  stats::TaskDependencyManagerStats().Record(pending_tasks_.size(),
-      {{stats::ValueTypeKey, "num_pending_tasks"}});
+  stats::TaskDependencyManagerStats().Record(
+      task_dependencies_.size(), {{stats::ValueTypeKey, "num_task_dependencies"}});
+  stats::TaskDependencyManagerStats().Record(
+      required_tasks_.size(), {{stats::ValueTypeKey, "num_required_tasks"}});
+  stats::TaskDependencyManagerStats().Record(
+      required_objects_.size(), {{stats::ValueTypeKey, "num_required_objects"}});
+  stats::TaskDependencyManagerStats().Record(
+      local_objects_.size(), {{stats::ValueTypeKey, "num_local_objects"}});
+  stats::TaskDependencyManagerStats().Record(
+      pending_tasks_.size(), {{stats::ValueTypeKey, "num_pending_tasks"}});
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -119,6 +119,9 @@ class TaskDependencyManager {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
  private:
   using ObjectDependencyMap = std::unordered_map<ray::ObjectID, std::vector<ray::TaskID>>;
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -177,6 +177,9 @@ void WorkerPool::RegisterDriver(const std::shared_ptr<Worker> &driver) {
   RAY_CHECK(!driver->GetAssignedTaskId().is_nil());
   auto &state = GetStateForLanguage(driver->GetLanguage());
   state.registered_drivers.insert(std::move(driver));
+  stats::CurrentDriver().Record(driver->Pid(),
+      {{stats::LanguageKey, EnumNameLanguage(driver->GetLanguage())},
+       {stats::WorkerPidKey, std::to_string(driver->Pid())}});
 }
 
 std::shared_ptr<Worker> WorkerPool::GetRegisteredWorker(
@@ -247,6 +250,9 @@ bool WorkerPool::DisconnectWorker(const std::shared_ptr<Worker> &worker) {
 void WorkerPool::DisconnectDriver(const std::shared_ptr<Worker> &driver) {
   auto &state = GetStateForLanguage(driver->GetLanguage());
   RAY_CHECK(RemoveWorker(state.registered_drivers, driver));
+  stats::CurrentDriver().Record(
+      0, {{stats::LanguageKey, EnumNameLanguage(driver->GetLanguage())},
+          {stats::WorkerPidKey, std::to_string(driver->Pid())}});
 }
 
 inline WorkerPool::State &WorkerPool::GetStateForLanguage(const Language &language) {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -307,16 +307,16 @@ void WorkerPool::RecordMetrics() const {
   for (const auto &entry : states_by_lang_) {
     // Record worker.
     for (auto worker : entry.second.registered_workers) {
-      stats::CurrentWorker().Record(worker->Pid(),
-          {{stats::LanguageKey, EnumNameLanguage(worker->GetLanguage())},
-           {stats::WorkerPidKey, std::to_string(worker->Pid())}});
+      stats::CurrentWorker().Record(
+          worker->Pid(), {{stats::LanguageKey, EnumNameLanguage(worker->GetLanguage())},
+                          {stats::WorkerPidKey, std::to_string(worker->Pid())}});
     }
 
     // Record driver.
     for (auto driver : entry.second.registered_drivers) {
-      stats::CurrentDriver().Record(driver->Pid(),
-          {{stats::LanguageKey, EnumNameLanguage(driver->GetLanguage())},
-           {stats::WorkerPidKey, std::to_string(driver->Pid())}});
+      stats::CurrentDriver().Record(
+          driver->Pid(), {{stats::LanguageKey, EnumNameLanguage(driver->GetLanguage())},
+                          {stats::WorkerPidKey, std::to_string(driver->Pid())}});
     }
   }
 }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -123,6 +123,9 @@ class WorkerPool {
   /// \return string.
   std::string DebugString() const;
 
+  /// Record metrics.
+  void RecordMetrics() const;
+
   /// Generate a warning about the number of workers that have registered or
   /// started if appropriate.
   ///

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -17,8 +17,8 @@ static Gauge CurrentWorker("current_worker",
                            "1 pcs", {LanguageKey, WorkerPidKey});
 
 static Gauge CurrentDriver("current_driver",
-                           "This metric is used for reporting states of drivers.", "1 pcs",
-                           {LanguageKey, DriverPidKey});
+                           "This metric is used for reporting states of drivers.",
+                           "1 pcs", {LanguageKey, DriverPidKey});
 
 static Count TaskCountReceived("task_count_received",
                                "Number of tasks received by raylet.", "pcs", {});
@@ -35,12 +35,12 @@ static Gauge LocalTotalResource("local_total_resource",
                                 "The total resources on this node.", "pcs",
                                 {ResourceNameKey});
 
-static Gauge ActorStats("actor_stats", "Stat metrics of the actors in raylet.",
-                        "pcs", {ValueTypeKey});
+static Gauge ActorStats("actor_stats", "Stat metrics of the actors in raylet.", "pcs",
+                        {ValueTypeKey});
 
 static Gauge ObjectManagerStats("object_manager_stats",
-                                "Stat the metric values of object in raylet",
-                                "pcs",  {ValueTypeKey});
+                                "Stat the metric values of object in raylet", "pcs",
+                                {ValueTypeKey});
 
 static Gauge LineageCacheStats("lineage_cache_stats",
                                "Stats the metric values of lineage cache.", "pcs",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -35,7 +35,7 @@ static Gauge LocalTotalResource("local_total_resource",
                                 "The total resources on this node.", "pcs",
                                 {ResourceNameKey});
 
-static Gauge ActorStats("actor_stats", "Stat the metric values of actor in raylet.",
+static Gauge ActorStats("actor_stats", "Stat metrics of the actors in raylet.",
                         "pcs", {ValueTypeKey});
 
 static Gauge ObjectManagerStats("object_stats", "Stat the metric values of object in raylet",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -12,7 +12,7 @@
 /// You can follow these examples to define your metrics.
 
 static Gauge CurrentWorker("current_worker",
-                           "This metric is used for report states of workers."
+                           "This metric is used for reporting states of workers."
                            "Through this, we can see the worker's state on dashboard.",
                            "1 pcs", {LanguageKey, WorkerPidKey});
 

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -12,9 +12,13 @@
 /// You can follow these examples to define your metrics.
 
 static Gauge CurrentWorker("current_worker",
-                           "This metric is used for report states of workers. "
+                           "This metric is used for report states of workers."
                            "Through this, we can see the worker's state on dashboard.",
                            "1 pcs", {LanguageKey, WorkerPidKey});
+
+static Gauge CurrentDriver("current_driver",
+                           "This metric is used for report states of workers.",
+                           "1 pcs", {LanguageKey, DriverPidKey});
 
 static Count TaskCountReceived("task_count_received",
                                "The count that the raylet received.", "pcs",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -60,4 +60,8 @@ static Gauge ReconstructionPolicyStats("reconstruction_policy_stats",
                                        "Stats the metric values of reconstruction policy.", "pcs",
                                        {ValueTypeKey});
 
+static Gauge ConnectionPoolStats("connection_pool_stats",
+                                 "Stats the connection pool metrics.", "pcs",
+                                 {ValueTypeKey});
+
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -17,12 +17,11 @@ static Gauge CurrentWorker("current_worker",
                            "1 pcs", {LanguageKey, WorkerPidKey});
 
 static Gauge CurrentDriver("current_driver",
-                           "This metric is used for report states of workers.",
-                           "1 pcs", {LanguageKey, DriverPidKey});
+                           "This metric is used for report states of workers.", "1 pcs",
+                           {LanguageKey, DriverPidKey});
 
 static Count TaskCountReceived("task_count_received",
-                               "The count that the raylet received.", "pcs",
-                               {});
+                               "The count that the raylet received.", "pcs", {});
 
 static Histogram RedisLatency("redis_latency", "The latency of a Redis operation.", "us",
                               {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000},
@@ -36,29 +35,27 @@ static Gauge LocalTotalResource("local_total_resource",
                                 "The total resource of this node.", "pcs",
                                 {ResourceNameKey});
 
-static Gauge ActorStats("actor_stats",
-                        "Stat the metric values of actor in raylet.", "pcs",
-                        {ValueTypeKey});
+static Gauge ActorStats("actor_stats", "Stat the metric values of actor in raylet.",
+                        "pcs", {ValueTypeKey});
 
-static Gauge ObjectStats("object_stats",
-                         "Stat the metric values of object in raylet", "pcs",
-                         {ValueTypeKey});
+static Gauge ObjectStats("object_stats", "Stat the metric values of object in raylet",
+                         "pcs", {ValueTypeKey});
 
 static Gauge LineageCacheStats("lineage_cache_stats",
                                "Stats the metric values of lineage cache.", "pcs",
                                {ValueTypeKey});
 
 static Gauge TaskDependencyManagerStats("task_dependency_manager_stats",
-                                        "Stat the metric values of task dependency.", "pcs",
-                                        {ValueTypeKey});
+                                        "Stat the metric values of task dependency.",
+                                        "pcs", {ValueTypeKey});
 
 static Gauge SchedulingQueueStats("scheduling_queue_stats",
                                   "Stats the metric values of scheduling queue.", "pcs",
                                   {ValueTypeKey});
 
-static Gauge ReconstructionPolicyStats("reconstruction_policy_stats",
-                                       "Stats the metric values of reconstruction policy.", "pcs",
-                                       {ValueTypeKey});
+static Gauge ReconstructionPolicyStats(
+    "reconstruction_policy_stats", "Stats the metric values of reconstruction policy.",
+    "pcs", {ValueTypeKey});
 
 static Gauge ConnectionPoolStats("connection_pool_stats",
                                  "Stats the connection pool metrics.", "pcs",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -14,14 +14,22 @@
 static Gauge CurrentWorker("current_worker",
                            "This metric is used for report states of workers. "
                            "Through this, we can see the worker's state on dashboard.",
-                           "1 pcs", {NodeAddressKey, LanguageKey, WorkerPidKey});
+                           "1 pcs", {LanguageKey, WorkerPidKey});
 
 static Count TaskCountReceived("task_count_received",
                                "The count that the raylet received.", "pcs",
-                               {NodeAddressKey});
+                               {});
 
 static Histogram RedisLatency("redis_latency", "The latency of a Redis operation.", "us",
                               {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000},
-                              {NodeAddressKey, CustomKey});
+                              {CustomKey});
+
+static Gauge LocalAvailableResource("local_available_resource",
+                                    "The available resource of this node.", "pcs",
+                                    {ResourceNameKey});
+
+static Gauge LocalTotalResource("local_total_resource",
+                                "The total resource of this node.", "pcs",
+                                {ResourceNameKey});
 
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -38,14 +38,18 @@ static Gauge LocalTotalResource("local_total_resource",
 
 static Gauge ActorStats("actor_stats",
                         "Stat the metric values of actor in raylet.", "pcs",
-                        {ActorStatsValueTypeKey});
+                        {ValueTypeKey});
 
 static Gauge ObjectStats("object_stats",
                          "Stat the metric values of object in raylet", "pcs",
-                         {ObjectStatsValueTypeKey});
+                         {ValueTypeKey});
 
 static Gauge LineageCacheStats("lineage_cache_stats",
                                "Stats the metric values of lineage cache.", "pcs",
-                               {LineageCacheStatsValueTypeKey});
+                               {ValueTypeKey});
+
+static Gauge TaskDependencyManagerStats("task_dependency_manager_stats",
+                                        "Stat the metric values of task dependency.", "pcs",
+                                        {ValueTypeKey});
 
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -37,7 +37,11 @@ static Gauge LocalTotalResource("local_total_resource",
                                 {ResourceNameKey});
 
 static Gauge ActorStats("actor_stats",
-                        "Stat the metric values of actor.", "pcs",
+                        "Stat the metric values of actor in raylet.", "pcs",
                         {ActorStatsValueTypeKey});
+
+static Gauge ObjectStats("object_stats",
+                         "Stat the metric values of object in raylet", "pcs",
+                         {ObjectStatsValueTypeKey});
 
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -52,4 +52,8 @@ static Gauge TaskDependencyManagerStats("task_dependency_manager_stats",
                                         "Stat the metric values of task dependency.", "pcs",
                                         {ValueTypeKey});
 
+static Gauge SchedulingQueueStats("scheduling_queue_stats",
+                                  "Stats the metric values of scheduling queue.", "pcs",
+                                  {ValueTypeKey});
+
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -36,4 +36,8 @@ static Gauge LocalTotalResource("local_total_resource",
                                 "The total resource of this node.", "pcs",
                                 {ResourceNameKey});
 
+static Gauge ActorStats("actor_stats",
+                        "Stat the metric values of actor.", "pcs",
+                        {ActorStatsValueTypeKey});
+
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -44,4 +44,8 @@ static Gauge ObjectStats("object_stats",
                          "Stat the metric values of object in raylet", "pcs",
                          {ObjectStatsValueTypeKey});
 
+static Gauge LineageCacheStats("lineage_cache_stats",
+                               "Stats the metric values of lineage cache.", "pcs",
+                               {LineageCacheStatsValueTypeKey});
+
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -32,7 +32,7 @@ static Gauge LocalAvailableResource("local_available_resource",
                                     {ResourceNameKey});
 
 static Gauge LocalTotalResource("local_total_resource",
-                                "The total resource of this node.", "pcs",
+                                "The total resources on this node.", "pcs",
                                 {ResourceNameKey});
 
 static Gauge ActorStats("actor_stats", "Stat the metric values of actor in raylet.",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -38,8 +38,9 @@ static Gauge LocalTotalResource("local_total_resource",
 static Gauge ActorStats("actor_stats", "Stat metrics of the actors in raylet.",
                         "pcs", {ValueTypeKey});
 
-static Gauge ObjectManagerStats("object_stats", "Stat the metric values of object in raylet",
-                         "pcs", {ValueTypeKey});
+static Gauge ObjectManagerStats("object_manager_stats",
+                                "Stat the metric values of object in raylet",
+                                "pcs",  {ValueTypeKey});
 
 static Gauge LineageCacheStats("lineage_cache_stats",
                                "Stats the metric values of lineage cache.", "pcs",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -28,7 +28,7 @@ static Histogram RedisLatency("redis_latency", "The latency of a Redis operation
                               {CustomKey});
 
 static Gauge LocalAvailableResource("local_available_resource",
-                                    "The available resource of this node.", "pcs",
+                                    "The available resources on this node.", "pcs",
                                     {ResourceNameKey});
 
 static Gauge LocalTotalResource("local_total_resource",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -17,11 +17,11 @@ static Gauge CurrentWorker("current_worker",
                            "1 pcs", {LanguageKey, WorkerPidKey});
 
 static Gauge CurrentDriver("current_driver",
-                           "This metric is used for report states of workers.", "1 pcs",
+                           "This metric is used for report states of drivers.", "1 pcs",
                            {LanguageKey, DriverPidKey});
 
 static Count TaskCountReceived("task_count_received",
-                               "The count that the raylet received.", "pcs", {});
+                               "Number of tasks received by raylet.", "pcs", {});
 
 static Histogram RedisLatency("redis_latency", "The latency of a Redis operation.", "us",
                               {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000},

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -17,7 +17,7 @@ static Gauge CurrentWorker("current_worker",
                            "1 pcs", {LanguageKey, WorkerPidKey});
 
 static Gauge CurrentDriver("current_driver",
-                           "This metric is used for report states of drivers.", "1 pcs",
+                           "This metric is used for reporting states of drivers.", "1 pcs",
                            {LanguageKey, DriverPidKey});
 
 static Count TaskCountReceived("task_count_received",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -38,7 +38,7 @@ static Gauge LocalTotalResource("local_total_resource",
 static Gauge ActorStats("actor_stats", "Stat the metric values of actor in raylet.",
                         "pcs", {ValueTypeKey});
 
-static Gauge ObjectStats("object_stats", "Stat the metric values of object in raylet",
+static Gauge ObjectManagerStats("object_stats", "Stat the metric values of object in raylet",
                          "pcs", {ValueTypeKey});
 
 static Gauge LineageCacheStats("lineage_cache_stats",

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -56,4 +56,8 @@ static Gauge SchedulingQueueStats("scheduling_queue_stats",
                                   "Stats the metric values of scheduling queue.", "pcs",
                                   {ValueTypeKey});
 
+static Gauge ReconstructionPolicyStats("reconstruction_policy_stats",
+                                       "Stats the metric values of reconstruction policy.", "pcs",
+                                       {ValueTypeKey});
+
 #endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/stats_test.cc
+++ b/src/ray/stats/stats_test.cc
@@ -44,7 +44,7 @@ class MockExporter : public opencensus::stats::StatsExporter::Handler {
 class StatsTest : public ::testing::Test {
  public:
   void SetUp() {
-    ray::stats::Init("127.0.0.1:8888", {}, false);
+    ray::stats::Init("127.0.0.1:8888", {{stats::NodeAddressKey, "Localhost"}}, false);
     MockExporter::Register();
   }
 
@@ -54,7 +54,7 @@ class StatsTest : public ::testing::Test {
 TEST_F(StatsTest, F) {
   for (size_t i = 0; i < 500; ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    stats::CurrentWorker().Record(2345, {{stats::NodeAddressKey, "Localhost"}});
+    stats::CurrentWorker().Record(2345);
   }
 }
 

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -19,4 +19,6 @@ static const TagKeyType LanguageKey = TagKeyType::Register("Language");
 
 static const TagKeyType WorkerPidKey = TagKeyType::Register("WorkerPid");
 
+static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
+
 #endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -19,6 +19,8 @@ static const TagKeyType LanguageKey = TagKeyType::Register("Language");
 
 static const TagKeyType WorkerPidKey = TagKeyType::Register("WorkerPid");
 
+static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
+
 static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
 #endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -23,11 +23,6 @@ static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
 
 static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
-static const TagKeyType ActorStatsValueTypeKey = TagKeyType::Register("ValueType");
-
-static const TagKeyType ObjectStatsValueTypeKey = TagKeyType::Register("ValueType");
-
-static const TagKeyType LineageCacheStatsValueTypeKey =
-    TagKeyType::Register("ValueType");
+static const TagKeyType ValueTypeKey = TagKeyType::Register("ValueType");
 
 #endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -25,4 +25,6 @@ static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
 static const TagKeyType ActorStatsValueTypeKey = TagKeyType::Register("ValueType");
 
+static const TagKeyType ObjectStatsValueTypeKey = TagKeyType::Register("ValueType");
+
 #endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -23,4 +23,6 @@ static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
 
 static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
+static const TagKeyType ActorStatsValueTypeKey = TagKeyType::Register("ValueType");
+
 #endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -27,4 +27,7 @@ static const TagKeyType ActorStatsValueTypeKey = TagKeyType::Register("ValueType
 
 static const TagKeyType ObjectStatsValueTypeKey = TagKeyType::Register("ValueType");
 
+static const TagKeyType LineageCacheStatsValueTypeKey =
+    TagKeyType::Register("ValueType");
+
 #endif  // RAY_STATS_TAG_DEFS_H


### PR DESCRIPTION
## What do these changes do?
Integrate these metric items into raylet:
- [x] `RedisLatency`(Also, I refined the redis_context callback.)
- [x] `AvailableResource`
- [x] `TotalResource`
- [x] `CurrentDriver`
- [x] `ObjectManagerStats`
- [x] `ActorStats`
- [x]  `ConnectionPoolStats`
- [x] `LineageCacheStats`
- [x]  `ReconstructionPolicyStats`
- [x] `SchedulingQueueStats`
- [x]  `TaskDependencyManagerStats`

## Related issue number
https://github.com/ray-project/ray/issues/3858
## Linter

- [x]  I've run `scripts/format.sh` to lint the changes in this PR.
