### PR TITLE
Make test_submitting_many_actors_to_one less stressful.

### DIFF
--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -133,7 +133,7 @@ def test_submitting_many_actors_to_one(ray_start_sharded):
             return ray.get(self.actor.ping.remote())
 
     a = Actor.remote()
-    workers = [Worker.remote(a) for _ in range(100)]
+    workers = [Worker.remote(a) for _ in range(10)]
     for _ in range(10):
         out = ray.get([w.ping.remote() for w in workers])
         assert out == [None for _ in workers]


### PR DESCRIPTION
`test_submitting_many_actors_to_one` has been failing a lot, so this makes it less stressful. We should probably remove all of `stress_tests.py` and migrate them to the long running stress tests.