### PR TITLE
Cast MultiCategorical num_outputs to int.

### DIFF
--- a/python/ray/rllib/models/catalog.py
+++ b/python/ray/rllib/models/catalog.py
@@ -147,7 +147,7 @@ class ModelCatalog(object):
         elif isinstance(action_space, gym.spaces.multi_discrete.MultiDiscrete):
             if torch:
                 raise NotImplementedError
-            return MultiCategorical, sum(action_space.nvec)
+            return MultiCategorical, int(sum(action_space.nvec))
 
         raise NotImplementedError("Unsupported args: {} {}".format(
             action_space, dist_type))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Changes the num_outputs type to int. Otherwise you see errors like

`ValueError: num_outputs type should be one of [<class 'int'>], got <class 'numpy.int64'>`


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
