### PR TITLE
Enable uploading wheels from Travis for release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,8 +189,6 @@ deploy:
     local_dir: .whl
     upload-dir: $TRAVIS_COMMIT
     skip_cleanup: true
-    only:
-      - master
     on:
       repo: ray-project/ray
       condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Removes condition for uploading wheels to enable release branches to upload wheels to S3.

Travis documentation:
https://docs.travis-ci.com/user/deployment/#pull-requests
https://docs.travis-ci.com/user/deployment/s3/

## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
