### PR TITLE
[rllib] train-eval loop implementation for rllib.Trainer class

### DIFF
--- a/python/ray/rllib/tests/test_evaluators.py
+++ b/python/ray/rllib/tests/test_evaluators.py
@@ -6,11 +6,12 @@ import unittest
 
 import ray
 from ray.rllib.agents.dqn import DQNTrainer
+from ray.rllib.agents.a3c import A3CTrainer
 from ray.rllib.agents.dqn.dqn_policy_graph import _adjust_nstep
 
 
-class DQNTest(unittest.TestCase):
-    def testNStep(self):
+class EvalTest(unittest.TestCase):
+    def testDqnNStep(self):
         obs = [1, 2, 3, 4, 5, 6, 7]
         actions = ["a", "b", "a", "a", "a", "b", "a"]
         rewards = [10.0, 0.0, 100.0, 100.0, 100.0, 100.0, 100.0]
@@ -26,19 +27,24 @@ class DQNTest(unittest.TestCase):
 
     def testEvaluationOption(self):
         ray.init()
-        agent = DQNTrainer(
-            env="CartPole-v0", config={"evaluation_interval": 2})
-        r0 = agent.train()
-        r1 = agent.train()
-        r2 = agent.train()
-        r3 = agent.train()
-        r4 = agent.train()
-        self.assertTrue("evaluation" in r0)
-        self.assertTrue("episode_reward_mean" in r0["evaluation"])
-        self.assertEqual(r0["evaluation"], r1["evaluation"])
-        self.assertNotEqual(r1["evaluation"], r2["evaluation"])
-        self.assertEqual(r2["evaluation"], r3["evaluation"])
-        self.assertNotEqual(r3["evaluation"], r4["evaluation"])
+        agents_clsasses = [DQNTrainer, A3CTrainer]
+        for agent_cls in agents_clsasses:
+            agent = agent_cls(
+                env="CartPole-v0",
+                config={"evaluation_interval": 2, "evaluation_num_episodes": 1})
+            # Given evaluation_interval=2, r0, r2, r4 should not contain
+            # evaluation metrics while r1, r3 should do.
+            r0 = agent.train()
+            r1 = agent.train()
+            r2 = agent.train()
+            r3 = agent.train()
+
+            self.assertTrue("evaluation" in r1)
+            self.assertTrue("evaluation" in r3)
+            self.assertFalse("evaluation" in r0)
+            self.assertFalse("evaluation" in r2)
+            self.assertTrue("episode_reward_mean" in r1["evaluation"])
+            self.assertNotEqual(r1["evaluation"], r3["evaluation"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Adds periodic policy evaluation functionality for base rllib.Trainer class. Based on train-evaluate loop previously implemented for DQN trainer.
Does not addresses evaluation policy exploration issue (to be pulled separately)

## Related issue number

Partially addresses #4614

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
