### PR TITLE
Autoscaler hotfix for #4555.

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -158,6 +158,13 @@ class LoadMetrics(object):
 
     def update(self, ip, static_resources, dynamic_resources):
         self.static_resources_by_ip[ip] = static_resources
+        # TODO(romilb): This is a hotfix to make autoscaler work with #4555
+        dynamic_resources_update = dynamic_resources.copy()
+        for resource_name, capacity in static_resources.items():
+            if resource_name not in dynamic_resources_update:
+                dynamic_resources_update[resource_name] = 0.0
+        self.dynamic_resources_by_ip[ip] = dynamic_resources_update
+
         self.dynamic_resources_by_ip[ip] = dynamic_resources
         now = time.time()
         if ip not in self.last_used_time_by_ip or \

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -165,7 +165,6 @@ class LoadMetrics(object):
                 dynamic_resources_update[resource_name] = 0.0
         self.dynamic_resources_by_ip[ip] = dynamic_resources_update
 
-        self.dynamic_resources_by_ip[ip] = dynamic_resources
         now = time.time()
         if ip not in self.last_used_time_by_ip or \
                 static_resources != dynamic_resources:

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -158,7 +158,10 @@ class LoadMetrics(object):
 
     def update(self, ip, static_resources, dynamic_resources):
         self.static_resources_by_ip[ip] = static_resources
-        # TODO(romilb): This is a hotfix to make autoscaler work with #4555
+        # We are not guaranteed to have a corresponding dynamic resource for
+        # every static resource because dynamic resources are based on the
+        # available resources in the heartbeat, which does not exist if it is
+        # zero. Thus, we have to update dynamic resources here.
         dynamic_resources_update = dynamic_resources.copy()
         for resource_name, capacity in static_resources.items():
             if resource_name not in dynamic_resources_update:

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -112,7 +112,7 @@ class Monitor(object):
         for j in range(message.BatchLength()):
             heartbeat_message = message.Batch(j)
 
-            num_resources = heartbeat_message.ResourcesAvailableLabelLength()
+            num_resources = heartbeat_message.ResourcesTotalLabelLength()
             static_resources = {}
             dynamic_resources = {}
             for i in range(num_resources):


### PR DESCRIPTION
## What do these changes do?

These changes may fix the autoscaler bug introduced in #4555:

> With a head node with num-cpus=1, this commit results in the autoscaler LoadMetrics reporting an empty dict for both static and dynamic resouces once 1 job is scheduled on the head node.`

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
