### PR TITLE
Fix the import error

### DIFF
--- a/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
+++ b/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import logging
 import threading
+import math
 
 from six.moves import queue
 


### PR DESCRIPTION
I think the `import error` introduced from https://github.com/ray-project/ray/pull/4652 which also makes the CI failed.

I think we shouldn't merge this PR until the CI passes.