### PR TITLE
Use an alternative boost mirror

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,8 +32,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    commit = "6d6fd834281cb8f8e758dd9ad76df86304bf1869",
-    remote = "https://github.com/nelhage/rules_boost",
+    commit = "5171b9724fbb39c5fdad37b9ca9b544e8858d8ac",
+    remote = "https://github.com/ray-project/rules_boost",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Countries like China have many Ray users but suffer from slow network when connecting to certain websites. The bazel build exits with timeout constantly after a few minutes because it fails to download boost from sourceforge. This PR uses an alternative image given by the official boost website.

## Related issue number

Closes #4451

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
