### PR TITLE
Don't delete files in rsync up, and also shorten timeout

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -240,9 +240,8 @@ class NodeUpdater(object):
         self.get_caller(check_error)(
             [
                 "rsync", "-e", " ".join(["ssh"] + get_default_ssh_options(
-                    self.ssh_private_key, 120, self.ssh_control_path)),
-                "--delete", "-avz", source, "{}@{}:{}".format(
-                    self.ssh_user, self.ssh_ip, target)
+                    self.ssh_private_key, 120, self.ssh_control_path)), "-avz",
+                source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip, target)
             ],
             stdout=redirect or sys.stdout,
             stderr=redirect or sys.stderr)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -31,7 +31,7 @@ def get_default_ssh_options(private_key, connect_timeout, ssh_control_path):
         ("StrictHostKeyChecking", "no"),
         ("ControlMaster", "auto"),
         ("ControlPath", "{}/%C".format(ssh_control_path)),
-        ("ControlPersist", "5m"),
+        ("ControlPersist", "10s"),
     ]
 
     return ["-i", private_key] + [


### PR DESCRIPTION
cc @hartikainen @ls-daniel 

10 s should be sufficient to speed up connections, yet hopefully never cause hangs.

Also, remove the delete flag from file mounts; this is dangerous because it can delete files created by the user on the remote end.