### PR TITLE
[tune]Auto restore the newest checkpoint file.

### DIFF
--- a/python/ray/tune/tests/test_trial_runner.py
+++ b/python/ray/tune/tests/test_trial_runner.py
@@ -1639,6 +1639,38 @@ class TrialRunnerTest(unittest.TestCase):
         self.assertGreater(trials[1].last_result["time_since_restore"], 0)
         self.addCleanup(os.remove, path)
 
+    def testRestoreNewestMetricsAfterCheckpointing(self):
+        ray.init(num_cpus=1, num_gpus=1)
+        runner = TrialRunner()
+        kwargs = {
+            "resources": Resources(cpu=1, gpu=1),
+        }
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.RUNNING)
+        self.assertEqual(ray.get(trials[0].runner.set_info.remote(1)), 1)
+        path = runner.trial_executor.save(trials[0])
+        runner.trial_executor.stop_trial(trials[0])
+        kwargs["restore_path"] = os.path.abspath(os.path.join(path, "../.."))
+
+        runner.add_trial(Trial("__fake", **kwargs))
+        trials = runner.get_trials()
+
+        runner.step()
+        self.assertEqual(trials[0].status, Trial.TERMINATED)
+        self.assertEqual(trials[1].status, Trial.RUNNING)
+        runner.step()
+        self.assertEqual(trials[1].last_result["timesteps_since_restore"], 10)
+        self.assertEqual(trials[1].last_result["iterations_since_restore"], 1)
+        self.assertGreater(trials[1].last_result["time_since_restore"], 0)
+        runner.step()
+        self.assertEqual(trials[1].last_result["timesteps_since_restore"], 20)
+        self.assertEqual(trials[1].last_result["iterations_since_restore"], 2)
+        self.assertGreater(trials[1].last_result["time_since_restore"], 0)
+        self.addCleanup(os.remove, path)
+
     def testCheckpointingAtEnd(self):
         ray.init(num_cpus=1, num_gpus=1)
         runner = TrialRunner()

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -180,11 +180,13 @@ def has_trainable(trainable_name):
     return ray.tune.registry._global_registry.contains(
         ray.tune.registry.TRAINABLE_CLASS, trainable_name)
 
+
 def _find_newest_ckpt(ckpt_dir):
     try:
         full_paths = [
             os.path.join(ckpt_dir, fname) for fname in os.listdir(ckpt_dir)
-            if fname.startswith("experiment_state") and fname.endswith(".json")]
+            if fname.startswith("experiment_state") and fname.endswith(".json")
+        ]
         with open(max(full_paths), "r") as f:
             runner_state = json.load(f)
         log_path = runner_state["checkpoints"][-1]["logdir"]
@@ -194,10 +196,12 @@ def _find_newest_ckpt(ckpt_dir):
             if ckptname.startswith("checkpoint")
         ]
         newest_ckpt_path = max(log_paths)
-        logger.info("Find newest checkpoint file {} in {}.".format(newest_ckpt_path, ckpt_dir))
+        logger.info("Find newest checkpoint file {} in {}.".format(
+            newest_ckpt_path, ckpt_dir))
         return newest_ckpt_path
     except:
         return ckpt_dir
+
 
 class Checkpoint(object):
     """Describes a checkpoint of trial state.
@@ -333,8 +337,8 @@ class Trial(object):
         self.checkpoint_score_attr = checkpoint_score_attr \
             if self._cmp_greater else checkpoint_score_attr[4:]
 
-        self._checkpoint = Checkpoint(
-            storage=Checkpoint.DISK, value=_find_newest_ckpt(restore_path))
+        self._checkpoint = Checkpoint(storage=Checkpoint.DISK,
+                                      value=_find_newest_ckpt(restore_path))
         self.export_formats = export_formats
         self.status = Trial.PENDING
         self.logdir = None

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -337,8 +337,8 @@ class Trial(object):
         self.checkpoint_score_attr = checkpoint_score_attr \
             if self._cmp_greater else checkpoint_score_attr[4:]
 
-        self._checkpoint = Checkpoint(storage=Checkpoint.DISK,
-                                      value=_find_newest_ckpt(restore_path))
+        self._checkpoint = Checkpoint(
+            storage=Checkpoint.DISK, value=_find_newest_ckpt(restore_path))
         self.export_formats = export_formats
         self.status = Trial.PENDING
         self.logdir = None

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -142,8 +142,12 @@ def run(run_or_experiment,
             checkpoint at least this many times. Only applies if
             checkpointing is enabled. Setting to -1 will lead to infinite
             recovery retries. Defaults to 3.
-        restore (str): Path to checkpoint. Only makes sense to set if
-            running 1 trial. Defaults to None.
+        restore (str): Path to a specific checkpoint (e.g. ``~/ray_results/
+            {experiment_name}/{trial_name}/checkpoint_7/checkpoint-7``
+            or the trial path (e.g. ``~/ray_results/{experiment_name}/
+            {trial_name}``). If a trial path, then it will find the newest
+            checkpoint under the path automatically. Only makes sense to set
+            if running 1 trial. Defaults to None.
         search_alg (SearchAlgorithm): Search Algorithm. Defaults to
             BasicVariantGenerator.
         scheduler (TrialScheduler): Scheduler for executing


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

The reinforcement learning model has two processes of training and prediction. And the restored newest checkpoint is required for prediction.
Tune currently provides two related parameters. `resume` as the run_experiment parameter, `resume=true` will automatically load the latest checkpoint, but with a `TERMINATE` trial state if training successfully completed, so prediction process will not continue to run. `restore` parameter can only specify a specific metadata checkpoint directory which is inconvenient to use, so we make it automatically restore latest checkpoint with the path of `~/ray_results/experiment_id`

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [yes ] I've run `scripts/format.sh` to lint the changes in this PR.

@adoda 
