### PR TITLE
Reduce memory usage of test_simple in test_stress.py.

### DIFF
--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -196,7 +196,7 @@ def test_wait(ray_start_combination):
 def ray_start_reconstruction(request):
     num_nodes = request.param
 
-    plasma_store_memory = int(0.5 * 10**9)
+    plasma_store_memory = int(0.1 * 10**9)
 
     cluster = Cluster(
         initialize_head=True,


### PR DESCRIPTION
`python/ray/tests/test_stress.py::test_simple` has been failing a lot recently. This is an attempt to stop it from failing.