### PR TITLE
[hotfix] Update test_trial_scheduler.py to fix unit test on Python 2

### DIFF
--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -886,8 +886,6 @@ class PopulationBasedTestingSuite(unittest.TestCase):
 
     def testLogConfig(self):
         def check_policy(policy):
-            self.assertIsInstance(policy[0], str)
-            self.assertIsInstance(policy[1], str)
             self.assertIsInstance(policy[2], int)
             self.assertIsInstance(policy[3], int)
             self.assertIn(policy[0], ["0tag", "2tag", "3tag", "4tag"])


### PR DESCRIPTION
I accidentally merged https://github.com/ray-project/ray/pull/4680/files, but the travis test is actually failing for Python 2.

This is since json.loads() returns a unicode type which is not of type str.