### PR TITLE
Non-interactive frontend for apt-get in Docker

### DIFF
--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -108,9 +108,11 @@ def docker_start_cmds(user, image, mount, cname, user_options):
     ]
     cmds.append(" ".join(docker_check + docker_run))
     docker_update = [
-        " && ".join(("apt-get -qy update",
-                     "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
-                     "DEBIAN_FRONTEND=noninteractive apt-get install -y git wget psmisc"))
+        " && ".join((
+            "apt-get -qy update",
+            "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
+            "DEBIAN_FRONTEND=noninteractive apt-get install -y git wget psmisc"
+        ))
     ]
     cmds.extend(with_docker_exec(docker_update, container_name=cname))
     return cmds

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -108,8 +108,9 @@ def docker_start_cmds(user, image, mount, cname, user_options):
     ]
     cmds.append(" ".join(docker_check + docker_run))
     docker_update = [
-        " && ".join(("apt-get -y update", "apt-get -y upgrade",
-                     "apt-get install -y git wget psmisc"))
+        " && ".join(("apt-get -qy update",
+                     "DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
+                     "DEBIAN_FRONTEND=noninteractive apt-get install -y git wget psmisc"))
     ]
     cmds.extend(with_docker_exec(docker_update, container_name=cname))
     return cmds


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
When using Docker with the autoscaler, Ray calls `apt-get` update and upgrade. Previously they were running assuming an interactive frontend, which could result in the autoscaler hanging indefinitely when an upgraded package expects keyboard input. This patch makes `apt-get` run in a non-interactive mode preventing this.

I'm a little uneasy about running `apt-get` automatically in general: it forces the Docker image to be Debian-based, and also means the installed versions can change between runs, which negates part of the benefit of Docker. However, I assume there's a good reason for this to be here.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
