### PR TITLE
[tune] Fix error when restore checkpoint at tune.run()

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -34,7 +34,7 @@ fi
 
 # Build the current Ray source
 git rev-parse HEAD > ./docker/deploy/git-rev
-git archive -o ./docker/deploy/ray.tar $(git rev-parse HEAD)
+git archive -o ./docker/deploy/ray.tar "$(git rev-parse HEAD)"
 if [ $OUTPUT_SHA ]; then
     IMAGE_SHA=$(docker build --no-cache -q -t ray-project/deploy docker/deploy)
 else
@@ -52,5 +52,5 @@ if [ ! $SKIP_EXAMPLES ]; then
 fi
 
 if [ $OUTPUT_SHA ]; then
-    echo $IMAGE_SHA | sed 's/sha256://'
+    echo "$IMAGE_SHA" | sed 's/sha256://'
 fi

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -124,8 +124,11 @@ class ImportThread(object):
             return
 
         try:
-            # Deserialize the function.
-            function = pickle.loads(serialized_function)
+            # FunctionActorManager may call pickle.loads at the same time.
+            # Importing the same module in different threads causes deadlock.
+            with self.worker.function_actor_manager.lock:
+                # Deserialize the function.
+                function = pickle.loads(serialized_function)
             # Run the function.
             function({"worker": self.worker})
         except Exception:

--- a/python/ray/tune/commands.py
+++ b/python/ray/tune/commands.py
@@ -27,9 +27,15 @@ EDITOR = os.getenv("EDITOR", "vim")
 
 TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S (%A)"
 
-DEFAULT_EXPERIMENT_INFO_KEYS = ("trainable_name", "experiment_tag", "trial_id",
-                                "status", "last_update_time",
-                                TRAINING_ITERATION, MEAN_ACCURACY, MEAN_LOSS)
+DEFAULT_EXPERIMENT_INFO_KEYS = (
+    "trainable_name",
+    "experiment_tag",
+    "trial_id",
+    "status",
+    "last_update_time",
+)
+
+DEFAULT_RESULT_KEYS = (TRAINING_ITERATION, MEAN_ACCURACY, MEAN_LOSS)
 
 DEFAULT_PROJECT_INFO_KEYS = (
     "name",
@@ -39,8 +45,6 @@ DEFAULT_PROJECT_INFO_KEYS = (
     "error_trials",
     "last_updated",
 )
-
-UNNEST_KEYS = ("config", "last_result")
 
 try:
     TERM_HEIGHT, TERM_WIDTH = subprocess.check_output(["stty", "size"]).split()
@@ -126,42 +130,35 @@ def list_trials(experiment_path,
                 output=None,
                 filter_op=None,
                 info_keys=None,
-                limit=None,
-                desc=False):
+                result_keys=None):
     """Lists trials in the directory subtree starting at the given path.
 
     Args:
         experiment_path (str): Directory where trials are located.
             Corresponds to Experiment.local_dir/Experiment.name.
-        sort (list): Keys to sort by.
+        sort (str): Key to sort by.
         output (str): Name of file where output is saved.
         filter_op (str): Filter operation in the format
             "<column> <operator> <value>".
         info_keys (list): Keys that are displayed.
-        limit (int): Number of rows to display.
-        desc (bool): Sort ascending vs. descending.
+        result_keys (list): Keys of last result that are displayed.
     """
     _check_tabulate()
     experiment_state = _get_experiment_state(
         experiment_path, exit_on_fail=True)
 
-    checkpoints = experiment_state["checkpoints"]
-
-    checkpoint_dicts = []
-    for g in checkpoints:
-        for key in UNNEST_KEYS:
-            if key not in g:
-                continue
-            unnest_dict = flatten_dict(g.pop(key))
-            g.update(unnest_dict)
-        g = flatten_dict(g)
-        checkpoint_dicts.append(g)
-
+    checkpoint_dicts = experiment_state["checkpoints"]
+    checkpoint_dicts = [flatten_dict(g) for g in checkpoint_dicts]
     checkpoints_df = pd.DataFrame(checkpoint_dicts)
 
     if not info_keys:
         info_keys = DEFAULT_EXPERIMENT_INFO_KEYS
-    col_keys = [k for k in list(info_keys) if k in checkpoints_df]
+    if not result_keys:
+        result_keys = DEFAULT_RESULT_KEYS
+    result_keys = ["last_result:{}".format(k) for k in result_keys]
+    col_keys = [
+        k for k in list(info_keys) + result_keys if k in checkpoints_df
+    ]
     checkpoints_df = checkpoints_df[col_keys]
 
     if "last_update_time" in checkpoints_df:
@@ -186,7 +183,7 @@ def list_trials(experiment_path,
             val = str(val)
         # TODO(Andrew): add support for datetime and boolean
         else:
-            raise ValueError("Unsupported dtype for {}: {}".format(
+            raise ValueError("Unsupported dtype for \"{}\": {}".format(
                 val, col_type))
         op = OPERATORS[op]
         filtered_index = op(checkpoints_df[col], val)
@@ -194,13 +191,9 @@ def list_trials(experiment_path,
 
     if sort:
         if sort not in checkpoints_df:
-            raise KeyError("{} not in: {}".format(sort, list(checkpoints_df)))
-        ascending = not desc
-        checkpoints_df = checkpoints_df.sort_values(
-            by=sort, ascending=ascending)
-
-    if limit:
-        checkpoints_df = checkpoints_df[:limit]
+            raise KeyError("Sort Index \"{}\" not in: {}".format(
+                sort, list(checkpoints_df)))
+        checkpoints_df = checkpoints_df.sort_values(by=sort)
 
     print_format_output(checkpoints_df)
 
@@ -219,21 +212,17 @@ def list_experiments(project_path,
                      sort=None,
                      output=None,
                      filter_op=None,
-                     info_keys=None,
-                     limit=None,
-                     desc=False):
+                     info_keys=None):
     """Lists experiments in the directory subtree.
 
     Args:
         project_path (str): Directory where experiments are located.
             Corresponds to Experiment.local_dir.
-        sort (list): Keys to sort by.
+        sort (str): Key to sort by.
         output (str): Name of file where output is saved.
         filter_op (str): Filter operation in the format
             "<column> <operator> <value>".
         info_keys (list): Keys that are displayed.
-        limit (int): Number of rows to display.
-        desc (bool): Sort ascending vs. descending.
     """
     _check_tabulate()
     base, experiment_folders, _ = next(os.walk(project_path))
@@ -295,7 +284,7 @@ def list_experiments(project_path,
             val = str(val)
         # TODO(Andrew): add support for datetime and boolean
         else:
-            raise ValueError("Unsupported dtype for {}: {}".format(
+            raise ValueError("Unsupported dtype for \"{}\": {}".format(
                 val, col_type))
         op = OPERATORS[op]
         filtered_index = op(info_df[col], val)
@@ -303,12 +292,9 @@ def list_experiments(project_path,
 
     if sort:
         if sort not in info_df:
-            raise KeyError("{} not in: {}".format(sort, list(info_df)))
-        ascending = not desc
-        info_df = info_df.sort_values(by=sort, ascending=ascending)
-
-    if limit:
-        info_df = info_df[:limit]
+            raise KeyError("Sort Index \"{}\" not in: {}".format(
+                sort, list(info_df)))
+        info_df = info_df.sort_values(by=sort)
 
     print_format_output(info_df)
 

--- a/python/ray/tune/scripts.py
+++ b/python/ray/tune/scripts.py
@@ -24,7 +24,6 @@ def cli():
 @click.option(
     "--filter",
     "filter_op",
-    nargs=1,
     default=None,
     type=str,
     help="Select filter in the format '<column> <operator> <value>'.")
@@ -34,20 +33,21 @@ def cli():
     type=str,
     help="Select columns to be displayed.")
 @click.option(
-    "--result-columns",
-    "result_columns",
+    "--limit",
     default=None,
-    type=str,
-    help="Select columns of last result to be displayed.")
-def list_trials(experiment_path, sort, output, filter_op, columns,
-                result_columns):
+    type=int,
+    help="Select number of rows to display.")
+@click.option(
+    "--desc", default=False, type=bool, help="Sort ascending vs. descending.")
+def list_trials(experiment_path, sort, output, filter_op, columns, limit,
+                desc):
     """Lists trials in the directory subtree starting at the given path."""
+    if sort:
+        sort = sort.split(",")
     if columns:
         columns = columns.split(",")
-    if result_columns:
-        result_columns = result_columns.split(",")
     commands.list_trials(experiment_path, sort, output, filter_op, columns,
-                         result_columns)
+                         limit, desc)
 
 
 @cli.command()
@@ -63,7 +63,6 @@ def list_trials(experiment_path, sort, output, filter_op, columns,
 @click.option(
     "--filter",
     "filter_op",
-    nargs=1,
     default=None,
     type=str,
     help="Select filter in the format '<column> <operator> <value>'.")
@@ -72,11 +71,22 @@ def list_trials(experiment_path, sort, output, filter_op, columns,
     default=None,
     type=str,
     help="Select columns to be displayed.")
-def list_experiments(project_path, sort, output, filter_op, columns):
+@click.option(
+    "--limit",
+    default=None,
+    type=int,
+    help="Select number of rows to display.")
+@click.option(
+    "--desc", default=False, type=bool, help="Sort ascending vs. descending.")
+def list_experiments(project_path, sort, output, filter_op, columns, limit,
+                     desc):
     """Lists experiments in the directory subtree."""
+    if sort:
+        sort = sort.split(",")
     if columns:
         columns = columns.split(",")
-    commands.list_experiments(project_path, sort, output, filter_op, columns)
+    commands.list_experiments(project_path, sort, output, filter_op, columns,
+                              limit, desc)
 
 
 @cli.command()

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import unittest
+
+import ray
+from ray import tune
+from ray.rllib.agents.registry import get_agent_class
+from ray.tune.registry import register_trainable
+from ray.tune.trial import has_trainable
+
+
+class TuneRestoreTest(unittest.TestCase):
+    def setUp(self):
+        self.algo = 'PG'
+
+        register_trainable(self.algo, get_agent_class(self.algo))
+        self.assertTrue(has_trainable(self.algo))
+
+        ray.init(num_cpus=1, num_gpus=0, local_mode=True)
+        tune.run(
+            self.algo,
+            name="TuneRestoreTest",
+            stop={"training_iteration": 1},
+            checkpoint_freq=1,
+            config={
+                "env": "CartPole-v0",
+            },
+        )
+
+        logdir = os.path.expanduser("~/ray_results/TuneRestoreTest/")
+        expdir = None
+        for i in os.listdir(logdir):
+            if i.startswith(self.algo) and os.path.isdir(os.path.join(logdir, i)):
+                expdir = os.path.join(logdir, i)
+                break
+        self.logdir = logdir  # should like: /user/../ray_results/TuneRestoreTest
+        self.expdir = expdir  # should like: /user/../ray_results/TuneRestoreTest/PG_CartPole_codes
+        self.checkpoint_path = os.path.join(self.expdir, "checkpoint_1/checkpoint-1")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.logdir)
+        ray.shutdown()
+
+    def testCheckpointPath(self):
+        self.assertIsNotNone(self.expdir)
+        self.assertTrue(os.path.isfile(self.checkpoint_path))
+
+    def testTuneRestore(self):
+        self.assertTrue(has_trainable(self.algo))
+        tune.run(
+            self.algo,
+            name="TuneRestoreTest",
+            stop={"training_iteration": 2},  # train one more iteration.
+            checkpoint_freq=1,
+            restore=self.checkpoint_path,  # Restore the checkpoint
+            config={
+                "env": "CartPole-v0",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -15,7 +15,7 @@ from ray.tune.trial import has_trainable
 
 class TuneRestoreTest(unittest.TestCase):
     def setUp(self):
-        self.algo = 'PG'
+        self.algo = "PG"
 
         register_trainable(self.algo, get_agent_class(self.algo))
         self.assertTrue(has_trainable(self.algo))
@@ -34,12 +34,16 @@ class TuneRestoreTest(unittest.TestCase):
         logdir = os.path.expanduser("~/ray_results/TuneRestoreTest/")
         expdir = None
         for i in os.listdir(logdir):
-            if i.startswith(self.algo) and os.path.isdir(os.path.join(logdir, i)):
+            if i.startswith(self.algo) and os.path.isdir(
+                    os.path.join(logdir, i)):
                 expdir = os.path.join(logdir, i)
                 break
-        self.logdir = logdir  # should like: /user/../ray_results/TuneRestoreTest
-        self.expdir = expdir  # should like: /user/../ray_results/TuneRestoreTest/PG_CartPole_codes
-        self.checkpoint_path = os.path.join(self.expdir, "checkpoint_1/checkpoint-1")
+        # /user/../ray_results/TuneRestoreTest
+        self.logdir = logdir
+        # /user/../ray_results/TuneRestoreTest/PG_CartPole_codes
+        self.expdir = expdir
+        self.checkpoint_path = os.path.join(self.expdir,
+                                            "checkpoint_1/checkpoint-1")
 
     def tearDown(self):
         import shutil

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -11,8 +11,6 @@ import glob
 import ray
 from ray import tune
 from ray.rllib import _register_all
-from ray.tune.registry import register_trainable
-from ray.tune.trial import has_trainable
 
 
 class TuneRestoreTest(unittest.TestCase):
@@ -34,9 +32,9 @@ class TuneRestoreTest(unittest.TestCase):
 
         logdir = os.path.expanduser(os.path.join(tmpdir, test_name))
         self.logdir = logdir
-        self.checkpoint_path = glob.glob(os.path.join(logdir,
-            "**/checkpoint_1/checkpoint-1"), recursive=True)[0]
-
+        self.checkpoint_path = glob.glob(
+            os.path.join(logdir, "**/checkpoint_1/checkpoint-1"),
+            recursive=True)[0]
 
     def tearDown(self):
         import shutil

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -241,7 +241,7 @@ class Trainable(object):
         saved_as_dict = False
         if isinstance(checkpoint, string_types):
             if (not checkpoint.startswith(checkpoint_dir)
-                or checkpoint == checkpoint_dir):
+                    or checkpoint == checkpoint_dir):
                 raise ValueError(
                     "The returned checkpoint path must be within the "
                     "given checkpoint dir {}: {}".format(
@@ -328,10 +328,16 @@ class Trainable(object):
         self._timesteps_since_restore = 0
         self._iterations_since_restore = 0
         self._restored = True
-        logger.info("Restored from checkpoint: {}".format(self._experiment_id, checkpoint_path))
-        logger.info(
-            "Current state after restoring: done iterations {}, done timesteps {}, passed time {}, done episodes {}".format(
-                self._iteration, self._timesteps_total, self._time_total, self._episodes_total))
+        logger.info("Restored from checkpoint: {}".format(
+            self._experiment_id, checkpoint_path))
+        state = {
+            "iter": self._iteration,
+            "ts": self._timesteps_total,
+            "time": self._time_total,
+            "eps": self._episodes_total
+        }
+        logger.info("Current state after restoring:" + ", ".join(
+            "{}: {}".format(k, v) for k, v in state.items()))
 
     def restore_from_object(self, obj):
         """Restores training state from a checkpoint object.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -2,18 +2,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from datetime import datetime
-
 import copy
 import io
 import logging
 import os
 import pickle
-from six import string_types
 import shutil
 import tempfile
 import time
 import uuid
+from datetime import datetime
 
 import ray
 from ray.tune.logger import UnifiedLogger
@@ -22,6 +20,7 @@ from ray.tune.result import (DEFAULT_RESULTS_DIR, TIME_THIS_ITER_S,
                              EPISODES_THIS_ITER, EPISODES_TOTAL,
                              TRAINING_ITERATION, RESULT_DUPLICATE)
 from ray.tune.trial import Resources
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +241,7 @@ class Trainable(object):
         saved_as_dict = False
         if isinstance(checkpoint, string_types):
             if (not checkpoint.startswith(checkpoint_dir)
-                    or checkpoint == checkpoint_dir):
+                or checkpoint == checkpoint_dir):
                 raise ValueError(
                     "The returned checkpoint path must be within the "
                     "given checkpoint dir {}: {}".format(
@@ -311,7 +310,6 @@ class Trainable(object):
         Subclasses should override ``_restore()`` instead to restore state.
         This method restores additional metadata saved with the checkpoint.
         """
-
         with open(checkpoint_path + ".tune_metadata", "rb") as f:
             metadata = pickle.load(f)
         self._experiment_id = metadata["experiment_id"]
@@ -330,6 +328,10 @@ class Trainable(object):
         self._timesteps_since_restore = 0
         self._iterations_since_restore = 0
         self._restored = True
+        logger.info("Restored from checkpoint: {}".format(self._experiment_id, checkpoint_path))
+        logger.info(
+            "Current state after restoring: done iterations {}, done timesteps {}, passed time {}, done episodes {}".format(
+                self._iteration, self._timesteps_total, self._time_total, self._episodes_total))
 
     def restore_from_object(self, obj):
         """Restores training state from a checkpoint object.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from datetime import datetime
+
 import copy
 import io
 import logging
 import os
 import pickle
+from six import string_types
 import shutil
 import tempfile
 import time
 import uuid
-from datetime import datetime
 
 import ray
 from ray.tune.logger import UnifiedLogger
@@ -20,7 +22,6 @@ from ray.tune.result import (DEFAULT_RESULTS_DIR, TIME_THIS_ITER_S,
                              EPISODES_THIS_ITER, EPISODES_TOTAL,
                              TRAINING_ITERATION, RESULT_DUPLICATE)
 from ray.tune.trial import Resources
-from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -310,6 +311,7 @@ class Trainable(object):
         Subclasses should override ``_restore()`` instead to restore state.
         This method restores additional metadata saved with the checkpoint.
         """
+
         with open(checkpoint_path + ".tune_metadata", "rb") as f:
             metadata = pickle.load(f)
         self._experiment_id = metadata["experiment_id"]

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -190,10 +190,22 @@ def run(run_or_experiment,
     experiment = run_or_experiment
     if not isinstance(run_or_experiment, Experiment):
         experiment = Experiment(
-            name, run_or_experiment, stop, config, resources_per_trial,
-            num_samples, local_dir, upload_dir, trial_name_creator, loggers,
-            sync_function, checkpoint_freq, checkpoint_at_end, export_formats,
-            max_failures, restore)
+            name=name,
+            run=run_or_experiment,
+            stop=stop,
+            config=config,
+            resources_per_trial=resources_per_trial,
+            num_samples=num_samples,
+            local_dir=local_dir,
+            upload_dir=upload_dir,
+            trial_name_creator=trial_name_creator,
+            loggers=loggers,
+            sync_function=sync_function,
+            checkpoint_freq=checkpoint_freq,
+            checkpoint_at_end=checkpoint_at_end,
+            export_formats=export_formats,
+            max_failures=max_failures,
+            restore=restore)
     else:
         logger.debug("Ignoring some parameters passed into tune.run.")
 

--- a/setup_thirdparty.sh
+++ b/setup_thirdparty.sh
@@ -7,7 +7,7 @@ set -e
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 if [[ -z  "$1" ]]; then
-  PYTHON_EXECUTABLE=`which python`
+  PYTHON_EXECUTABLE=$(which python)
 else
   PYTHON_EXECUTABLE=$1
 fi
@@ -15,5 +15,4 @@ echo "Using Python executable $PYTHON_EXECUTABLE."
 
 RAY_BUILD_PYTHON=$RAY_BUILD_PYTHON \
 RAY_BUILD_JAVA=$RAY_BUILD_JAVA \
-$ROOT_DIR/thirdparty/scripts/setup.sh $PYTHON_EXECUTABLE
-
+"$ROOT_DIR/thirdparty/scripts/setup.sh" "$PYTHON_EXECUTABLE"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Fix a problem causing checkpoint restoring fails when using `tune.run(..., restore='ckpt-path')`.

This issue is brought by PR #4490 



## Related issue number


Closes #4714 

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.