### PR TITLE
Fix rlib test failure caused by deadlock

### DIFF
--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -124,8 +124,11 @@ class ImportThread(object):
             return
 
         try:
-            # Deserialize the function.
-            function = pickle.loads(serialized_function)
+            # FunctionActorManager may call pickle.loads at the same time.
+            # Importing the same module in different threads causes deadlock.
+            with self.worker.function_actor_manager.lock:
+                # Deserialize the function.
+                function = pickle.loads(serialized_function)
             # Run the function.
             function({"worker": self.worker})
         except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Add lock in `fetch_and_execute_function_to_run` of import_thread.py. 
`import_thread.py` and main thread may both call `pickle.loads` to import a certain class. If they do the importing at the same time, there will be exception. Thus, the lock is necessary.
```
2019-04-29 06:12:41,440	ERROR worker.py:1672 -- Failed to unpickle actor class 'PolicyEvaluator' for actor ID 50e34046a1fe558cbeaf18b48516ab015b832bc6. Traceback:
Traceback (most recent call last):
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/function_manager.py", line 729, in _load_actor_class_from_gcs
    actor_class = pickle.loads(pickled_class)
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/__init__.py", line 11, in <module>
    from ray.rllib.evaluation.policy_graph import PolicyGraph
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/__init__.py", line 2, in <module>
    from ray.rllib.evaluation.policy_evaluator import PolicyEvaluator
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/policy_evaluator.py", line 21, in <module>
    from ray.rllib.evaluation.sampler import AsyncSampler, SyncSampler
ImportError: cannot import name 'AsyncSampler'
2019-04-29 06:12:41,440	ERROR worker.py:1672 -- Traceback (most recent call last):
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/import_thread.py", line 128, in fetch_and_execute_function_to_run
    function = pickle.loads(serialized_function)
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/sampler.py", line 15, in <module>
    from ray.rllib.evaluation.tf_policy_graph import TFPolicyGraph
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/tf_policy_graph.py", line 14, in <module>
    from ray.rllib.evaluation.policy_graph import PolicyGraph
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/__init__.py", line 11, in <module>
    from ray.rllib.evaluation.policy_graph import PolicyGraph
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/__init__.py", line 2, in <module>
    from ray.rllib.evaluation.policy_evaluator import PolicyEvaluator
  File "/home/travis/.local/lib/python3.6/site-packages/ray-0.7.0.dev3-py3.6-linux-x86_64.egg/ray/rllib/evaluation/policy_evaluator.py", line 21, in <module>
    from ray.rllib.evaluation.sampler import AsyncSampler, SyncSampler
ImportError: cannot import name 'AsyncSampler'
```


## Related issue number
https://travis-ci.com/ray-project/ray/jobs/196114212
https://github.com/ray-project/ray/pull/4499
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
