### PR TITLE
Find bazel even if it isn't in the PATH.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -34,7 +34,7 @@ fi
 
 # Build the current Ray source
 git rev-parse HEAD > ./docker/deploy/git-rev
-git archive -o ./docker/deploy/ray.tar $(git rev-parse HEAD)
+git archive -o ./docker/deploy/ray.tar "$(git rev-parse HEAD)"
 if [ $OUTPUT_SHA ]; then
     IMAGE_SHA=$(docker build --no-cache -q -t ray-project/deploy docker/deploy)
 else
@@ -52,5 +52,5 @@ if [ ! $SKIP_EXAMPLES ]; then
 fi
 
 if [ $OUTPUT_SHA ]; then
-    echo $IMAGE_SHA | sed 's/sha256://'
+    echo "$IMAGE_SHA" | sed 's/sha256://'
 fi

--- a/setup_thirdparty.sh
+++ b/setup_thirdparty.sh
@@ -7,7 +7,7 @@ set -e
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 if [[ -z  "$1" ]]; then
-  PYTHON_EXECUTABLE=`which python`
+  PYTHON_EXECUTABLE=$(which python)
 else
   PYTHON_EXECUTABLE=$1
 fi
@@ -15,5 +15,4 @@ echo "Using Python executable $PYTHON_EXECUTABLE."
 
 RAY_BUILD_PYTHON=$RAY_BUILD_PYTHON \
 RAY_BUILD_JAVA=$RAY_BUILD_JAVA \
-$ROOT_DIR/thirdparty/scripts/setup.sh $PYTHON_EXECUTABLE
-
+"$ROOT_DIR/thirdparty/scripts/setup.sh" "$PYTHON_EXECUTABLE"


### PR DESCRIPTION
This should fix #4317. Assuming that the `install-bazel.sh` script puts bazel in `$HOME/.bazel/bin/`.