### PR TITLE
Enable actor methods to be decorated on the caller side also and get postprocessors.

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -109,6 +109,26 @@ def method(*args, **kwargs):
 # Create objects to wrap method invocations. This is done so that we can
 # invoke methods with actor.method.remote() instead of actor.method().
 class ActorMethod(object):
+    """A class used to invoke an actor method.
+
+    Note: This class is instantiated only while the actor method is being
+    invoked (so that it doesn't keep a reference to the actor handle and
+    prevent it from going out of scope).
+
+    Attributes:
+        _actor: A handle to the actor.
+        _method_name: The name of the actor method.
+        _num_return_vals: The default number of return values that the method
+            invocation should return.
+        _decorator: An optional decorator that should be applied to the actor
+            method invocation (as opposed to the actor method execution) before
+            invoking the method. The decorator must return a function that
+            takes in two arguments ("args" and "kwargs"). In most cases, it
+            should call the function that was passed into the decorator and
+            return the resulting ObjectIDs. For an example, see
+            "test_decorated_method" in "python/ray/tests/test_actor.py".
+    """
+
     def __init__(self, actor, method_name, num_return_vals, decorator=None):
         self._actor = actor
         self._method_name = method_name
@@ -170,6 +190,10 @@ class ActorClass(object):
         _exported: True if the actor class has been exported and false
             otherwise.
         _actor_methods: The actor methods.
+        _method_decorators: Optional decorators that should be applied to the
+            method invocation function before invoking the actor methods. These
+            can be set by attaching the attribute "__ray_method_decorator__" to
+            the actor method.
         _method_signatures: The signatures of the methods.
         _actor_method_names: The names of the actor methods.
         _actor_method_num_return_vals: The default number of return values for

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -113,6 +113,11 @@ class ActorMethod(object):
         self._actor = actor
         self._method_name = method_name
         self._num_return_vals = num_return_vals
+        # This is a decorator that is used to wrap the function invocation (as
+        # opposed to the function execution). The decorator must return a
+        # function that takes in two arguments ("args" and "kwargs"). In most
+        # cases, it should call the function that was passed into the decorator
+        # and return the resulting ObjectIDs.
         self._decorator = decorator
 
     def __call__(self, *args, **kwargs):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -192,8 +192,8 @@ class ActorClass(object):
         _actor_methods: The actor methods.
         _method_decorators: Optional decorators that should be applied to the
             method invocation function before invoking the actor methods. These
-            can be set by attaching the attribute "__ray_method_decorator__" to
-            the actor method.
+            can be set by attaching the attribute
+            "__ray_invocation_decorator__" to the actor method.
         _method_signatures: The signatures of the methods.
         _actor_method_names: The names of the actor methods.
         _actor_method_num_return_vals: The default number of return values for
@@ -252,9 +252,9 @@ class ActorClass(object):
                 self._actor_method_num_return_vals[method_name] = (
                     ray_constants.DEFAULT_ACTOR_METHOD_NUM_RETURN_VALS)
 
-            if hasattr(method, "__ray_method_decorator__"):
+            if hasattr(method, "__ray_invocation_decorator__"):
                 self._method_decorators[method_name] = (
-                    method.__ray_method_decorator__)
+                    method.__ray_invocation_decorator__)
 
     def __call__(self, *args, **kwargs):
         raise Exception("Actors methods cannot be instantiated directly. "

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -2592,7 +2592,8 @@ def test_decorated_method(ray_start_regular):
             # Turn two arguments into one.
             return f(self, b + c)
 
-        new_f_execution.__ray_method_decorator__ = method_invocation_decorator
+        new_f_execution.__ray_invocation_decorator__ = (
+            method_invocation_decorator)
         return new_f_execution
 
     @ray.remote

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2892,3 +2892,13 @@ def test_redis_lru_with_set(ray_start_object_store_memory):
 
     # Now evict the object from the object store.
     ray.put(x)  # This should not crash.
+
+
+def test_get_postprocess(ray_start_regular):
+    def get_postprocessor(object_ids, values):
+        return [value for value in values if value > 0]
+
+    ray.worker.global_worker._post_get_hooks.append(get_postprocessor)
+
+    assert ray.get(
+        [ray.put(i) for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1496,7 +1496,10 @@ def shutdown(exiting_interpreter=False):
         _global_node.kill_all_processes(check_alive=False, allow_graceful=True)
         _global_node = None
 
+    # TODO(rkn): Instead of manually reseting some of the worker fields, we
+    # should simply set "global_worker" to equal "None" or something like that.
     global_worker.set_mode(None)
+    global_worker._post_get_hooks = []
 
 
 atexit.register(shutdown, True)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -156,6 +156,9 @@ class Worker(object):
         # increment every time when `ray.shutdown` is called.
         self._session_index = 0
         self._current_task = None
+        # Functions to run to process the values returned by ray.get. Each
+        # postprocessor must take two arguments ("object_ids", and "values").
+        self._post_get_hooks = []
 
     @property
     def connected(self):
@@ -1455,7 +1458,7 @@ def init(redis_address=None,
     return _global_node.address_info
 
 
-# Functions to run as callback after a successful ray init
+# Functions to run as callback after a successful ray init.
 _post_init_hooks = []
 
 
@@ -2175,23 +2178,29 @@ def get(object_ids):
             # In LOCAL_MODE, ray.get is the identity operation (the input will
             # actually be a value not an objectid).
             return object_ids
+
+        is_individual_id = isinstance(object_ids, ray.ObjectID)
+        if is_individual_id:
+            object_ids = [object_ids]
+
+        if not isinstance(object_ids, list):
+            raise ValueError("'object_ids' must either by an object ID "
+                             "or a list of object IDs.")
+
         global last_task_error_raise_time
-        if isinstance(object_ids, list):
-            values = worker.get_object(object_ids)
-            for i, value in enumerate(values):
-                if isinstance(value, RayError):
-                    last_task_error_raise_time = time.time()
-                    raise value
-            return values
-        else:
-            value = worker.get_object([object_ids])[0]
+        values = worker.get_object(object_ids)
+        for i, value in enumerate(values):
             if isinstance(value, RayError):
-                # If the result is a RayError, then the task that created
-                # this object failed, and we should propagate the error message
-                # here.
                 last_task_error_raise_time = time.time()
                 raise value
-            return value
+
+        # Run post processors.
+        for post_processor in worker._post_get_hooks:
+            values = post_processor(object_ids, values)
+
+        if is_individual_id:
+            values = values[0]
+        return values
 
 
 def put(value):


### PR DESCRIPTION
When we decorate an actor method, the actor will execute the decorated method. However, the caller will call the undecorated method. It'd be helpful to have a way to run decorated methods on both the caller and callee side. This is one way to do it.

This is very much a quick pass at it, and doesn't cover a lot of cases.

TODO
- [x] add tests

These are the changes needed to enable #4501 cleanly.

cc @visatish