### PR TITLE
[rllib] Fix bounds of space returned by preprocessor.observation_space

### DIFF
--- a/doc/source/rllib-concepts.rst
+++ b/doc/source/rllib-concepts.rst
@@ -99,7 +99,7 @@ This is how the example in the previous section looks when written using a polic
     
     # this optimizer implements the IMPALA architecture
     optimizer = AsyncSamplesOptimizer(
-        local_evaluator, remote_evaluator, train_batch_size=500)
+        local_evaluator, remote_evaluators, train_batch_size=500)
 
     while True:
         optimizer.step()

--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -73,7 +73,11 @@ class Preprocessor(object):
     @property
     @PublicAPI
     def observation_space(self):
-        obs_space = gym.spaces.Box(-1.0, 1.0, self.shape, dtype=np.float32)
+        obs_space = gym.spaces.Box(
+            np.finfo(np.float32).min,
+            np.finfo(np.float32).max,
+            self.shape,
+            dtype=np.float32)
         # Stash the unwrapped space so that we can unwrap dict and tuple spaces
         # automatically in model.py
         if (isinstance(self, TupleFlatteningPreprocessor)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

It was return -1, 1 before, which is not correct in general. Conservatively include the entire range.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
