### PR TITLE
[doc] add "restoring or resuming" docs

### DIFF
--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -115,6 +115,60 @@ be sure to wrap it with `tune.function`:
 An example can be found in `logging_example.py <https://github.com/ray-project/ray/blob/master/python/ray/tune/examples/logging_example.py>`__.
 
 
+Restoring or Resuming Previous Experiments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Restoring and resuming are useful features allowing you to restore and continue previous experiments.
+
+The ``resume=True`` argument passing into ``tune.run`` enables you to continue an uncompleted experiment until the stop criterion is matched.
+You can set ``resume='prompt'`` and specify an experiment's name, so that ray will automatically detect uncompleted experiment with the same experiment name and continue it.
+
+Note that whatever modifications on the experiment setting will be ignored when resuming from previous experiments.
+For example, if previous experiment has reached it's termination, then resuming it with a new stop criterion makes no effect: the new experiment will terminate immediately after initialization.
+To change the setting, you need to use ``restore`` argument and specify a checkpoint file. By doing this you can change whatever experiments' configuration such as the experiment's name, the training iteration or so.
+
+It's important to set ``checkpoint_freq=<int>`` or ``checkpoint_at_end=True`` in the previous experiment, otherwise the checkpoint files would not generated!
+Note that a checkpoint file typically has path likes ``~/ray_results/exp_name/trial_name/checkpoint_1/checkpoint-1``.
+
+.. code-block:: python
+
+    # Previous experiment
+    tune.run(
+        "PG",
+        name="Original",
+        # train more iteration than previous exp.
+        stop={"training_iteration": 5},
+        checkpoint_freq=1,
+        # Restore the checkpoint
+        config={
+            "env": "CartPole-v0",
+        },
+        )
+
+    # Resumed experiment, if original experiment terminated accidentally.
+    tune.run(
+        "PG",
+        name="Original", # The name should be same.
+        stop={"training_iteration": 5},
+        resume=True,
+        config={
+            "env": "CartPole-v0",
+        },
+        )
+
+    # Restored preivous experiment
+    tune.run(
+        "PG",
+        name="RestoredExp", # The name can be different.
+        # train 5 more iterations than previous.
+        stop={"training_iteration": 10},
+        # Restore the checkpoint
+        restore="~/ray_results/Original/PG_<xxx>/checkpoint_5/checpoint-5",
+        config={
+            "env": "CartPole-v0",
+        },
+        )
+
 Training Features
 -----------------
 

--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -121,13 +121,13 @@ Restoring or Resuming Previous Experiments
 Restoring and resuming are useful features allowing you to restore and continue previous experiments.
 
 The ``resume=True`` argument passing into ``tune.run`` enables you to continue an uncompleted experiment until the stop criterion is matched.
-You can set ``resume='prompt'`` and specify an experiment's name, so that ray will automatically detect uncompleted experiment with the same experiment name and continue it.
+You can set ``resume='prompt'`` and specify an experiment's name so that ray will automatically detect uncompleted experiment with the same experiment name and continue it.
 
 Note that whatever modifications on the experiment setting will be ignored when resuming from previous experiments.
-For example, if previous experiment has reached it's termination, then resuming it with a new stop criterion makes no effect: the new experiment will terminate immediately after initialization.
-To change the setting, you need to use ``restore`` argument and specify a checkpoint file. By doing this you can change whatever experiments' configuration such as the experiment's name, the training iteration or so.
+For example, if the previous experiment has reached its termination, then resuming it with a new stop criterion makes no effect: the new experiment will terminate immediately after initialization.
+To change the setting, you need to use ``restore`` argument and specify a checkpoint file. By doing this, you can change whatever experiments' configuration such as the experiment's name, the training iteration or so.
 
-It's important to set ``checkpoint_freq=<int>`` or ``checkpoint_at_end=True`` in the previous experiment, otherwise the checkpoint files would not generated!
+It's important to set ``checkpoint_freq=<int>`` or ``checkpoint_at_end=True`` in the previous experiment; otherwise, the checkpoint files would not be generated!
 Note that a checkpoint file typically has path likes ``~/ray_results/exp_name/trial_name/checkpoint_1/checkpoint-1``.
 
 .. code-block:: python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Add "restoring or resuming" docs at `tune-usage.rst`

I hope somebody helps to add some links at rllib/training and other places.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.