### PR TITLE
[doc] Remove instructions for installing Python2 for webui.

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -62,7 +62,7 @@ For Ubuntu, run the following commands:
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install -y build-essential curl unzip psmisc python # we install python here because python2 is required to build the webui
+  sudo apt-get install -y build-essential curl unzip psmisc
 
   # If you are not using Anaconda, you need the following.
   sudo apt-get install python-dev  # For Python 2.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Removes `python` from the linux dependencies because the webui is no longer being used

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
