### PR TITLE
[tune] Fix setup-dev relative path

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -17,7 +17,7 @@ def do_link(package, force=False):
     package_home = os.path.abspath(
         os.path.join(ray.__file__, "../{}".format(package)))
     local_home = os.path.abspath(
-        os.path.join(__file__, "../../{}".format(package)))
+        os.path.join(__file__, "../{}".format(package)))
     assert os.path.isdir(package_home), package_home
     assert os.path.isdir(local_home), local_home
     if not force and not click.confirm(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Fix relative path issue with setup-dev.sh.

I believe it may have been assuming it was in `...ray/python/ray/rllib` instead of `...ray/python/ray`, so going back two folders put `local_home` in `...ray/python` instead of `...ray/python/ray`. This meant it could not find any of the subfolders.

Traceback (most recent call last):
 File "setup-dev.py", line 46, in <module>
   do_link("rllib", force=args.yes)
 File "setup-dev.py", line 22, in do_link
   assert os.path.isdir(local_home), local_home
AssertionError: /home/danny/Documents/ray/python/rllib

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
