### PR TITLE
Fix temp file issues

### DIFF
--- a/ci/long_running_tests/README.rst
+++ b/ci/long_running_tests/README.rst
@@ -21,8 +21,7 @@ will print the tail of the output for each workload.
 
 To debug workloads that have failed, you may find it useful to ssh to the
 relevant machine, attach to the tmux session (usually ``tmux a -t 0``), inspect
-the logs under ``/tmp/ray/session*/logs/``, and also inspect
-``/tmp/ray/session*/debug_state.txt``.
+the logs under ``/tmp/ray/session*/logs/``.
 
 Shut Down the Workloads
 -----------------------

--- a/doc/source/tempfile.rst
+++ b/doc/source/tempfile.rst
@@ -62,6 +62,7 @@ A typical layout of temporary files could look like this:
           │   ├── redis.out
           │   ├── webui.err  # ipython notebook web ui
           │   ├── webui.out
+          │   ├── debug_state.txt  # dumped state of raylet
           │   ├── worker-{worker_id}.err  # redirected output of workers
           │   ├── worker-{worker_id}.out
           │   └── {other workers}

--- a/doc/source/tempfile.rst
+++ b/doc/source/tempfile.rst
@@ -66,7 +66,7 @@ A typical layout of temporary files could look like this:
           │   ├── worker-{worker_id}.out
           │   └── {other workers}
           └── sockets  # for sockets
-              ├── plasma_store
+              ├── plasma_store  # this could be deleted by Ray's shutdown cleanup.
               └── raylet  # this could be deleted by Ray's shutdown cleanup.
 
 

--- a/doc/source/tempfile.rst
+++ b/doc/source/tempfile.rst
@@ -27,7 +27,7 @@ For each session, Ray will place all its temporary files under the
 *session directory*. A *session directory* is a subdirectory of the
 *root temporary path* (``/tmp/ray`` by default),
 so the default session directory is ``/tmp/ray/{ray_session_name}``.
-You can sort by their names to find the latest session.
+You can sort by their names to find the latest session (e.g. ``ls | sort``).
 
 You are allowed to change the *root temporary directory* in one of these ways:
 
@@ -46,7 +46,7 @@ A typical layout of temporary files could look like this:
 
   /tmp
   └── ray
-      └── session_{datetime}_{pid}
+      └── {ray_session_name}
           ├── logs  # for logging
           │   ├── log_monitor.err
           │   ├── log_monitor.out
@@ -66,9 +66,9 @@ A typical layout of temporary files could look like this:
           │   ├── worker-{worker_id}.err  # redirected output of workers
           │   ├── worker-{worker_id}.out
           │   └── {other workers}
-          └── sockets  # for sockets
-              ├── plasma_store  # this could be deleted by Ray's shutdown cleanup.
-              └── raylet  # this could be deleted by Ray's shutdown cleanup.
+          └── sockets  # for sockets; all sockets will be deleted by Ray's shutdown cleanup.
+              ├── plasma_store  # plasma store
+              └── raylet  # raylet
 
 
 Plasma Object Store Socket

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -267,7 +267,8 @@ public class RunManager {
         String.format("--config_list=%s", String.join(",", rayConfig.rayletConfigParameters)),
         String.format("--python_worker_command=%s", buildPythonWorkerCommand()),
         String.format("--java_worker_command=%s", buildWorkerCommandRaylet()),
-        String.format("--redis_password=%s", redisPasswordOption)
+        String.format("--redis_password=%s", redisPasswordOption),
+        String.format("--debug_state_filename=%s", "/tmp/ray/debug_state.txt")
     );
 
     startProcess(command, null, "raylet");

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -355,6 +355,7 @@ class FunctionActorManager(object):
         """
         if self._worker.load_code_from_local:
             return
+        remote_function._last_export_session = self._worker.session_name
         # Work around limitations of Python pickling.
         function = remote_function._function
         function_name_global_valid = function.__name__ in function.__globals__

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -129,6 +129,9 @@ class Node(object):
             self._raylet_socket_name = self._prepare_socket_file(
                 self._ray_params.raylet_socket_name, default_prefix="raylet")
 
+        self._raylet_debug_state_filename = self._make_inc_temp(
+            prefix="debug_state.txt", directory_name=self._logs_dir)
+
         if head:
             ray_params.update_if_absent(num_redis_shards=1, include_webui=True)
             self._webui_url = None
@@ -228,6 +231,7 @@ class Node(object):
             "raylet_socket_name": self._raylet_socket_name,
             "webui_url": self._webui_url,
             "session_dir": self._session_dir,
+            "raylet_debug_state_filename": self._raylet_debug_state_filename,
         }
 
     def create_redis_client(self):
@@ -436,6 +440,7 @@ class Node(object):
             self._ray_params.worker_path,
             self._temp_dir,
             self._session_dir,
+            self._raylet_debug_state_filename,
             self._ray_params.num_cpus,
             self._ray_params.num_gpus,
             self._ray_params.resources,

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -829,6 +829,12 @@ class Node(object):
 class LocalNode(object):
     """Imitate the node that manages the processes in local mode."""
 
+    def __init__(self):
+        # date including microsecond
+        date_str = datetime.datetime.today().strftime("%Y-%m-%d_%H-%M-%S_%f")
+        self.session_name = "session_{date_str}_{pid}".format(
+            pid=os.getpid(), date_str=date_str)
+
     def kill_all_processes(self, *args, **kwargs):
         """Kill all of the processes."""
         pass  # Keep this function empty because it will be used in worker.py

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -69,7 +69,7 @@ class RemoteFunction(object):
         # Export the function.
         worker = ray.worker.get_global_worker()
         # In which session this function was exported last time.
-        self._last_export_session = worker._session_index
+        self._last_export_session = None
         worker.function_actor_manager.export(self)
 
     def __call__(self, *args, **kwargs):
@@ -109,10 +109,10 @@ class RemoteFunction(object):
         worker = ray.worker.get_global_worker()
         worker.check_connected()
 
-        if self._last_export_session < worker._session_index:
-            # If this function was exported in a previous session, we need to
+        if self._last_export_session != worker.session_name:
+            # If this function was exported in a different session, we need to
             # export this function again, because current GCS doesn't have it.
-            self._last_export_session = worker._session_index
+            self._last_export_session = worker.session_name
             worker.function_actor_manager.export(self)
 
         kwargs = {} if kwargs is None else kwargs

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1064,6 +1064,7 @@ def start_raylet(redis_address,
                  worker_path,
                  temp_dir,
                  session_dir,
+                 debug_state_filename,
                  num_cpus=None,
                  num_gpus=None,
                  resources=None,
@@ -1090,6 +1091,7 @@ def start_raylet(redis_address,
             processes will execute.
         temp_dir (str): The path of the temporary directory Ray will use.
         session_dir (str): The path of this session.
+        debug_state_filename (str): The path of the debug state file.
         num_cpus: The CPUs allocated for this raylet.
         num_gpus: The GPUs allocated for this raylet.
         resources: The custom resources allocated for this raylet.
@@ -1193,7 +1195,8 @@ def start_raylet(redis_address,
         "--python_worker_command={}".format(start_worker_command),
         "--java_worker_command={}".format(java_worker_command),
         "--redis_password={}".format(redis_password or ""),
-        "--temp_dir={}".format(temp_dir),
+        "--session_dir={}".format(session_dir),
+        "--debug_state_filename={}".format(debug_state_filename),
     ]
     process_info = start_ray_process(
         command,

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -2,12 +2,26 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import shutil
 import os
 import time
 import pytest
 import ray
 from ray.tests.cluster_utils import Cluster
-from ray.tests.utils import try_remove_directory
+
+
+@pytest.fixture
+def backup_and_shutdown():
+    """Protect the original /tmp/ray"""
+    if os.path.exists("/tmp/ray"):
+        shutil.move("/tmp/ray", "/tmp/__ray_backup")
+    yield None
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    if os.path.exists("/tmp/ray"):
+        shutil.rmtree("/tmp/ray")
+    if os.path.exists("/tmp/__ray_backup"):
+        shutil.move("/tmp/__ray_backup", "/tmp/ray")
 
 
 def test_conn_cluster(shutdown_only):
@@ -38,24 +52,32 @@ def test_conn_cluster(shutdown_only):
         "temp_dir must not be provided.")
 
 
-def test_tempdir(shutdown_only):
-    try_remove_directory("/tmp/ray")
+def test_tempdir(backup_and_shutdown):
     ray.init(temp_dir="/tmp/i_am_a_temp_dir")
     assert os.path.exists(
         "/tmp/i_am_a_temp_dir"), "Specified temp dir not found."
     assert not os.path.exists("/tmp/ray"), "Default temp dir should not exist."
     ray.shutdown()
-    try_remove_directory("/tmp/i_am_a_temp_dir")
+    shutil.rmtree("/tmp/i_am_a_temp_dir")
 
 
-def test_tempdir_commandline():
-    try_remove_directory("/tmp/ray")
+def test_tempdir_commandline(backup_and_shutdown):
     os.system("ray start --head --temp-dir=/tmp/i_am_a_temp_dir2")
     assert os.path.exists(
         "/tmp/i_am_a_temp_dir2"), "Specified temp dir not found."
     assert not os.path.exists("/tmp/ray"), "Default temp dir should not exist."
     os.system("ray stop")
-    try_remove_directory("/tmp/i_am_a_temp_dir2")
+    shutil.rmtree("/tmp/i_am_a_temp_dir2")
+
+
+def test_socket_file_lifetime(shutdown_only):
+    ray.init(num_cpus=1)
+    node = ray.worker._global_node
+    assert os.path.exists(node.plasma_store_socket_name)
+    assert os.path.exists(node.raylet_socket_name)
+    ray.shutdown()
+    assert not os.path.exists(node.plasma_store_socket_name)
+    assert not os.path.exists(node.raylet_socket_name)
 
 
 def test_raylet_socket_name(shutdown_only):
@@ -63,19 +85,15 @@ def test_raylet_socket_name(shutdown_only):
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket"), "Specified socket path not found."
     ray.shutdown()
-    try:
-        os.remove("/tmp/i_am_a_temp_socket")
-    except OSError:
-        pass  # It could have been removed by Ray.
+    assert not os.path.exists("/tmp/i_am_a_temp_socket"), (
+        "The raylet socket file hasn't been removed on exit.")
     cluster = Cluster(True)
     cluster.add_node(raylet_socket_name="/tmp/i_am_a_temp_socket_2")
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket_2"), "Specified socket path not found."
     cluster.shutdown()
-    try:
-        os.remove("/tmp/i_am_a_temp_socket_2")
-    except OSError:
-        pass  # It could have been removed by Ray.
+    assert not os.path.exists("/tmp/i_am_a_temp_socket_2"), (
+        "The raylet socket file hasn't been removed on exit.")
 
 
 def test_temp_plasma_store_socket(shutdown_only):
@@ -83,19 +101,15 @@ def test_temp_plasma_store_socket(shutdown_only):
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket"), "Specified socket path not found."
     ray.shutdown()
-    try:
-        os.remove("/tmp/i_am_a_temp_socket")
-    except OSError:
-        pass  # It could have been removed by Ray.
+    assert not os.path.exists("/tmp/i_am_a_temp_socket"), (
+        "The plasma store socket file hasn't been removed on exit.")
     cluster = Cluster(True)
     cluster.add_node(plasma_store_socket_name="/tmp/i_am_a_temp_socket_2")
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket_2"), "Specified socket path not found."
     cluster.shutdown()
-    try:
-        os.remove("/tmp/i_am_a_temp_socket_2")
-    except OSError:
-        pass  # It could have been removed by Ray.
+    assert not os.path.exists("/tmp/i_am_a_temp_socket_2"), (
+        "The plasma store socket file hasn't been removed on exit.")
 
 
 def test_raylet_tempfiles(shutdown_only):
@@ -133,7 +147,6 @@ def test_raylet_tempfiles(shutdown_only):
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
     assert socket_files == {"plasma_store", "raylet"}
-    ray.shutdown()
 
 
 def test_tempdir_privilege(shutdown_only):
@@ -143,7 +156,6 @@ def test_tempdir_privilege(shutdown_only):
     ray.init(num_cpus=1)
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Specified socket path not found."
-    ray.shutdown()
 
 
 def test_session_dir_uniqueness(shutdown_only):

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -149,6 +149,13 @@ def test_raylet_tempfiles(shutdown_only):
     assert socket_files == {"plasma_store", "raylet"}
 
 
+def test_raylet_dump_state(shutdown_only):
+    ray.init(num_cpus=1)
+    node = ray.worker._global_node
+    time.sleep(15)  # wait raylet to dump state
+    assert "debug_state.txt" in os.listdir(node.get_logs_dir_path())
+
+
 def test_tempdir_privilege(shutdown_only):
     if not os.path.exists("/tmp/ray"):
         os.mkdir("/tmp/ray")

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import shutil
 import os
 import subprocess
 import sys
@@ -95,17 +94,3 @@ def wait_for_errors(error_type, num_errors, timeout=10):
             return
         time.sleep(0.1)
     raise Exception("Timing out of wait.")
-
-
-def try_remove_directory(path):
-    if not os.path.exists(path):
-        return
-
-    for _ in range(3):
-        try:
-            shutil.rmtree(path)
-            return
-        except Exception:
-            time.sleep(1)
-
-    shutil.rmtree(path)

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import shutil
 import os
 import subprocess
 import sys
@@ -94,3 +95,17 @@ def wait_for_errors(error_type, num_errors, timeout=10):
             return
         time.sleep(0.1)
     raise Exception("Timing out of wait.")
+
+
+def try_remove_directory(path):
+    if not os.path.exists(path):
+        return
+
+    for _ in range(3):
+        try:
+            shutil.rmtree(path)
+            return
+        except Exception:
+            time.sleep(1)
+
+    shutil.rmtree(path)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -152,13 +152,15 @@ class Worker(object):
         # This event is checked regularly by all of the threads so that they
         # know when to exit.
         self.threads_stopped = threading.Event()
-        # Index of the current session. This number will
-        # increment every time when `ray.shutdown` is called.
-        self._session_index = 0
         self._current_task = None
         # Functions to run to process the values returned by ray.get. Each
         # postprocessor must take two arguments ("object_ids", and "values").
         self._post_get_hooks = []
+
+    @property
+    def session_name(self):
+        self.check_connected()
+        return self.node.session_name
 
     @property
     def connected(self):
@@ -1986,7 +1988,6 @@ def disconnect():
         if hasattr(worker, "logger_thread"):
             worker.logger_thread.join()
         worker.threads_stopped.clear()
-        worker._session_index += 1
 
     worker.node = None  # Disconnect the worker from the node.
     worker.cached_functions_to_run = []

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -22,7 +22,8 @@ DEFINE_string(python_worker_command, "", "Python worker command.");
 DEFINE_string(java_worker_command, "", "Java worker command.");
 DEFINE_string(redis_password, "", "The password of redis.");
 DEFINE_string(session_dir, "", "Session directory.");
-DEFINE_string(debug_state_filename, "/tmp/ray/debug_state.txt", "The path of the debug state file.");
+DEFINE_string(debug_state_filename, "/tmp/ray/debug_state.txt",
+              "The path of the debug state file.");
 DEFINE_bool(disable_stats, false, "Whether disable the stats.");
 DEFINE_string(stat_address, "127.0.0.1:8888", "The address that we report metrics to.");
 DEFINE_bool(enable_stdout_exporter, false,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -21,7 +21,8 @@ DEFINE_string(config_list, "", "The raylet config list of this node.");
 DEFINE_string(python_worker_command, "", "Python worker command.");
 DEFINE_string(java_worker_command, "", "Java worker command.");
 DEFINE_string(redis_password, "", "The password of redis.");
-DEFINE_string(temp_dir, "", "Temporary directory.");
+DEFINE_string(session_dir, "", "Session directory.");
+DEFINE_string(debug_state_filename, "/tmp/ray/debug_state.txt", "The path of the debug state file.");
 DEFINE_bool(disable_stats, false, "Whether disable the stats.");
 DEFINE_string(stat_address, "127.0.0.1:8888", "The address that we report metrics to.");
 DEFINE_bool(enable_stdout_exporter, false,
@@ -60,7 +61,8 @@ int main(int argc, char *argv[]) {
   const std::string python_worker_command = FLAGS_python_worker_command;
   const std::string java_worker_command = FLAGS_java_worker_command;
   const std::string redis_password = FLAGS_redis_password;
-  const std::string temp_dir = FLAGS_temp_dir;
+  const std::string session_dir = FLAGS_session_dir;
+  const std::string debug_state_filename = FLAGS_debug_state_filename;
   const bool disable_stats = FLAGS_disable_stats;
   const std::string stat_address = FLAGS_stat_address;
   const bool enable_stdout_exporter = FLAGS_enable_stdout_exporter;
@@ -131,7 +133,8 @@ int main(int argc, char *argv[]) {
       RayConfig::instance().debug_dump_period_milliseconds();
   node_manager_config.max_lineage_size = RayConfig::instance().max_lineage_size();
   node_manager_config.store_socket_name = store_socket_name;
-  node_manager_config.temp_dir = temp_dir;
+  node_manager_config.session_dir = session_dir;
+  node_manager_config.debug_state_filename = debug_state_filename;
 
   // Configuration for the object manager.
   ray::ObjectManagerConfig object_manager_config;

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -22,8 +22,9 @@ DEFINE_string(python_worker_command, "", "Python worker command.");
 DEFINE_string(java_worker_command, "", "Java worker command.");
 DEFINE_string(redis_password, "", "The password of redis.");
 DEFINE_string(session_dir, "", "Session directory.");
-DEFINE_string(debug_state_filename, "/tmp/ray/debug_state.txt",
-              "The path of the debug state file.");
+DEFINE_string(debug_state_filename, "",
+              "The path of the debug state file. This will be something like "
+              "/tmp/ray/session_*/logs/debug_state.txt.");
 DEFINE_bool(disable_stats, false, "Whether disable the stats.");
 DEFINE_string(stat_address, "127.0.0.1:8888", "The address that we report metrics to.");
 DEFINE_bool(enable_stdout_exporter, false,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -103,7 +103,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       remote_clients_(),
       remote_server_connections_(),
       actor_registry_() {
-  RAY_LOG(INFO) << "Dumping state to: " <<  debug_state_file_;
+  RAY_LOG(INFO) << "Dumping state to: " << debug_state_file_;
   RAY_CHECK(heartbeat_period_.count() > 0);
   // Initialize the resource map with own cluster resource configuration.
   ClientID local_client_id = gcs_client_->client_table().GetLocalClientId();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -78,7 +78,8 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       heartbeat_timer_(io_service),
       heartbeat_period_(std::chrono::milliseconds(config.heartbeat_period_ms)),
       debug_dump_period_(config.debug_dump_period_ms),
-      temp_dir_(config.temp_dir),
+      session_dir_(config.session_dir),
+      debug_state_file_(config.debug_state_filename),
       object_manager_profile_timer_(io_service),
       initial_config_(config),
       local_available_resources_(config.resource_config),
@@ -102,6 +103,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       remote_clients_(),
       remote_server_connections_(),
       actor_registry_() {
+  RAY_LOG(INFO) << "Dumping state to: " <<  debug_state_file_;
   RAY_CHECK(heartbeat_period_.count() > 0);
   // Initialize the resource map with own cluster resource configuration.
   ClientID local_client_id = gcs_client_->client_table().GetLocalClientId();
@@ -2367,7 +2369,7 @@ void NodeManager::ForwardTask(
 
 void NodeManager::DumpDebugState() const {
   std::fstream fs;
-  fs.open(temp_dir_ + "/debug_state.txt", std::fstream::out | std::fstream::trunc);
+  fs.open(debug_state_file_, std::fstream::out | std::fstream::trunc);
   fs << DebugString();
   fs.close();
 }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -46,8 +46,10 @@ struct NodeManagerConfig {
   uint64_t max_lineage_size;
   /// The store socket name.
   std::string store_socket_name;
-  /// The path to the ray temp dir.
-  std::string temp_dir;
+  /// The path to the ray session dir.
+  std::string session_dir;
+  /// The name of the debug state file.
+  std::string debug_state_filename;
 };
 
 class NodeManager {
@@ -476,8 +478,10 @@ class NodeManager {
   std::chrono::milliseconds heartbeat_period_;
   /// The period between debug state dumps.
   int64_t debug_dump_period_;
-  /// The path to the ray temp dir.
-  std::string temp_dir_;
+  /// The path to the ray session dir.
+  std::string session_dir_;
+  /// The path to the raylet debug state file.
+  std::string debug_state_file_;
   /// The timer used to get profiling information from the object manager and
   /// push it to the GCS.
   boost::asio::steady_timer object_manager_profile_timer_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

* Move "debug_state.txt" under the control of temp file utils.
* Ensure socket files removed properly after raylet is killed.
* Improve stability of tempfile tests
* Remote function exporter is defined by `session_name`, which could be more logical consistent with the gcs because `session_name` is unique for gcs.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
