### PR TITLE
[DO NOT MERGE] Shutdown ray after test_conn_cluster to avoid reinit errors

### DIFF
--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -37,6 +37,8 @@ def test_conn_cluster():
         "When connecting to an existing cluster, "
         "temp_dir must not be provided.")
 
+    ray.shutdown()
+
 
 def test_tempdir():
     shutil.rmtree("/tmp/ray", ignore_errors=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Tests on master are failing after this one due to Ray not being shutdown. It doesn't happen every time, and I haven't been able to reproduce locally, so this is more or less a test of the CI on Travis to see if this fixes it.

Link to Travis Failure: https://travis-ci.com/ray-project/ray/jobs/197801280

Rerunning the test seems to fix the error, meaning there is some flakiness that needs to be fixed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
