### PR TITLE
Exit raylet process if plasma store dies

### DIFF
--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -42,6 +42,11 @@ void ObjectStoreNotificationManager::NotificationWait() {
 void ObjectStoreNotificationManager::ProcessStoreLength(
     const boost::system::error_code &error) {
   notification_.resize(length_);
+  if (error) {
+    RAY_LOG(FATAL)
+        << "Problem communicating with the object store from raylet, check logs or "
+        << "dmesg for previous errors: " << boost_to_ray_status(error).ToString();
+  }
   boost::asio::async_read(
       socket_, boost::asio::buffer(notification_),
       boost::bind(&ObjectStoreNotificationManager::ProcessStoreNotification, this,
@@ -50,7 +55,7 @@ void ObjectStoreNotificationManager::ProcessStoreLength(
 
 void ObjectStoreNotificationManager::ProcessStoreNotification(
     const boost::system::error_code &error) {
-  if (error.value() != boost::system::errc::success) {
+  if (error) {
     RAY_LOG(FATAL)
         << "Problem communicating with the object store from raylet, check logs or "
         << "dmesg for previous errors: " << boost_to_ray_status(error).ToString();


### PR DESCRIPTION
## What do these changes do?

Fixes a bug where plasma store failure is not caught by the raylet process, which leaves a zombie raylet process.

## Related issue number

Hopefully, closes #4260. Ran it 100x on an m4.large machine on EC2 and appears to pass consistently now.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
