### PR TITLE
Enable External GCS.

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -340,18 +340,21 @@ class Node(object):
         for i in range(self._ray_params.num_redis_shards):
             redis_log_files.append(self.new_log_files("redis-shard_" + str(i)))
 
-        (self._redis_address, redis_shards,
-         process_infos) = ray.services.start_redis(
-             self._node_ip_address,
-             redis_log_files,
-             port=self._ray_params.redis_port,
-             redis_shard_ports=self._ray_params.redis_shard_ports,
-             num_redis_shards=self._ray_params.num_redis_shards,
-             redis_max_clients=self._ray_params.redis_max_clients,
-             redirect_worker_output=True,
-             password=self._ray_params.redis_password,
-             include_java=self._ray_params.include_java,
-             redis_max_memory=self._ray_params.redis_max_memory)
+        (
+            self._redis_address, redis_shards, process_infos
+        ) = ray.services.start_redis(
+            self._node_ip_address,
+            redis_log_files,
+            port=self._ray_params.redis_port,
+            redis_shard_ports=self._ray_params.redis_shard_ports,
+            num_redis_shards=self._ray_params.num_redis_shards,
+            redis_max_clients=self._ray_params.redis_max_clients,
+            redirect_worker_output=True,
+            password=self._ray_params.redis_password,
+            include_java=self._ray_params.include_java,
+            redis_max_memory=self._ray_params.redis_max_memory,
+            external_gcs_addresses=self._ray_params.external_gcs_addresses,
+        )
         assert (
             ray_constants.PROCESS_TYPE_REDIS_SERVER not in self.all_processes)
         self.all_processes[ray_constants.PROCESS_TYPE_REDIS_SERVER] = (

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -340,21 +340,21 @@ class Node(object):
         for i in range(self._ray_params.num_redis_shards):
             redis_log_files.append(self.new_log_files("redis-shard_" + str(i)))
 
-        (
-            self._redis_address, redis_shards, process_infos
-        ) = ray.services.start_redis(
-            self._node_ip_address,
-            redis_log_files,
-            port=self._ray_params.redis_port,
-            redis_shard_ports=self._ray_params.redis_shard_ports,
-            num_redis_shards=self._ray_params.num_redis_shards,
-            redis_max_clients=self._ray_params.redis_max_clients,
-            redirect_worker_output=True,
-            password=self._ray_params.redis_password,
-            include_java=self._ray_params.include_java,
-            redis_max_memory=self._ray_params.redis_max_memory,
-            external_gcs_addresses=self._ray_params.external_gcs_addresses,
-        )
+        (self._redis_address, redis_shards,
+         process_infos) = ray.services.start_redis(
+             self._node_ip_address,
+             redis_log_files,
+             port=self._ray_params.redis_port,
+             redis_shard_ports=self._ray_params.redis_shard_ports,
+             num_redis_shards=self._ray_params.num_redis_shards,
+             redis_max_clients=self._ray_params.redis_max_clients,
+             redirect_worker_output=True,
+             password=self._ray_params.redis_password,
+             include_java=self._ray_params.include_java,
+             redis_max_memory=self._ray_params.redis_max_memory,
+             external_gcs_addresses=self._ray_params.external_gcs_addresses,
+             flush_external_gcs=self._ray_params.flush_external_gcs,
+         )
         assert (
             ray_constants.PROCESS_TYPE_REDIS_SERVER not in self.all_processes)
         self.all_processes[ray_constants.PROCESS_TYPE_REDIS_SERVER] = (

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -114,6 +114,7 @@ class RayParams(object):
                  java_worker_options=None,
                  load_code_from_local=False,
                  external_gcs_addresses=None,
+                 flush_external_gcs=None,
                  _internal_config=None):
         self.object_id_seed = object_id_seed
         self.redis_address = redis_address
@@ -147,6 +148,7 @@ class RayParams(object):
         self.java_worker_options = java_worker_options
         self.load_code_from_local = load_code_from_local
         self.external_gcs_addresses = external_gcs_addresses
+        self.flush_external_gcs = flush_external_gcs
         self._internal_config = _internal_config
         self._check_usage()
 

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -73,6 +73,8 @@ class RayParams(object):
             Java worker.
         java_worker_options (str): The command options for Java worker.
         load_code_from_local: Whether load code from local file or from GCS.
+        external_gcs_addresses (str): The external redis address list.
+            The 1st one is the primary shard, the rests are the other shards.
         _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
     """
@@ -111,6 +113,7 @@ class RayParams(object):
                  include_java=False,
                  java_worker_options=None,
                  load_code_from_local=False,
+                 external_gcs_addresses=None,
                  _internal_config=None):
         self.object_id_seed = object_id_seed
         self.redis_address = redis_address
@@ -143,6 +146,7 @@ class RayParams(object):
         self.include_java = include_java
         self.java_worker_options = java_worker_options
         self.load_code_from_local = load_code_from_local
+        self.external_gcs_addresses = external_gcs_addresses
         self._internal_config = _internal_config
         self._check_usage()
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1241,6 +1241,7 @@ def init(redis_address=None,
          temp_dir=None,
          load_code_from_local=False,
          external_gcs_addresses=None,
+         flush_external_gcs=True,
          _internal_config=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
@@ -1320,6 +1321,8 @@ def init(redis_address=None,
             or from the GCS.
         external_gcs_addresses (str): The external redis address list.
             The 1st one is the primary shard, the rests are the other shards.
+        flush_external_gcs (bool): Whether the head node should flush the
+            external GCS data.
         _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
@@ -1392,6 +1395,7 @@ def init(redis_address=None,
             temp_dir=temp_dir,
             load_code_from_local=load_code_from_local,
             external_gcs_addresses=external_gcs_addresses,
+            flush_external_gcs=flush_external_gcs,
             _internal_config=_internal_config,
         )
         # Start the Ray processes. We set shutdown_at_exit=False because we

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1240,6 +1240,7 @@ def init(redis_address=None,
          raylet_socket_name=None,
          temp_dir=None,
          load_code_from_local=False,
+         external_gcs_addresses=None,
          _internal_config=None):
     """Connect to an existing Ray cluster or start one and connect to it.
 
@@ -1317,6 +1318,8 @@ def init(redis_address=None,
             directory for the Ray process.
         load_code_from_local: Whether code should be loaded from a local module
             or from the GCS.
+        external_gcs_addresses (str): The external redis address list.
+            The 1st one is the primary shard, the rests are the other shards.
         _internal_config (str): JSON configuration for overriding
             RayConfig defaults. For testing purposes ONLY.
 
@@ -1388,6 +1391,7 @@ def init(redis_address=None,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
             load_code_from_local=load_code_from_local,
+            external_gcs_addresses=external_gcs_addresses,
             _internal_config=_internal_config,
         )
         # Start the Ray processes. We set shutdown_at_exit=False because we


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Users may have their own version GCS, e.g. failover supported redis, running outside the head node. In this case, we need to add the option to support external GCS.

In YARN case, when head node is down, we may restart the head node without flushing the  external GCS, so the option to flush external GCS is also added.


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
