### PR TITLE
Fix `ray stop` by killing raylet before plasma

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -381,8 +381,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
 @cli.command()
 def stop():
     processes_to_kill = [
-        "plasma_store_server",
         "raylet",
+        "plasma_store_server",
         "raylet_monitor",
         "monitor.py",
         "redis-server",

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -380,6 +380,8 @@ def start(node_ip_address, redis_address, redis_port, num_redis_shards,
 
 @cli.command()
 def stop():
+    # Note that raylet needs to exit before object store, otherwise
+    # it cannot exit gracefully.
     processes_to_kill = [
         "raylet",
         "plasma_store_server",


### PR DESCRIPTION
Currently `ray stop` may cause error in `raylet.err`:
```sh
I0513 11:57:02.106292 2062856192 stats.h:48] Succeeded to initialize stats: exporter address is 127.0.0.1:8888
external/plasma/cpp/src/plasma/io.cc:168: Connection to IPC socket failed for pathname /tmp/ray/session_2019-05-13_11-57-01_831002_47110/sockets/plasma_store, retrying 300 more times
*** Aborted at 1557719832 (unix time) try "date -d @1557719832" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGSEGV (@0x0) received by PID 47119 (TID 0x7fff7af4b000) stack trace: ***
    @     0x7fff914f152a _sigtramp
    @        0x10847a000 (unknown)
    @        0x108110de0 boost::asio::detail::reactive_socket_recv_op<>::do_complete()
    @        0x108081014 boost::asio::detail::scheduler::do_run_one()
    @        0x108080aec boost::asio::detail::scheduler::run()
    @        0x108073497 main
    @     0x7fff920d25ad start
    @               0x10 (unknown)
```


