### PR TITLE
Fix Java worker log dir

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -435,6 +435,7 @@ class Node(object):
             self._plasma_store_socket_name,
             self._ray_params.worker_path,
             self._temp_dir,
+            self._session_dir,
             self._ray_params.num_cpus,
             self._ray_params.num_gpus,
             self._ray_params.resources,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1063,6 +1063,7 @@ def start_raylet(redis_address,
                  plasma_store_name,
                  worker_path,
                  temp_dir,
+                 session_dir,
                  num_cpus=None,
                  num_gpus=None,
                  resources=None,
@@ -1088,6 +1089,7 @@ def start_raylet(redis_address,
         worker_path (str): The path of the Python file that new worker
             processes will execute.
         temp_dir (str): The path of the temporary directory Ray will use.
+        session_dir (str): The path of this session.
         num_cpus: The CPUs allocated for this raylet.
         num_gpus: The GPUs allocated for this raylet.
         resources: The custom resources allocated for this raylet.
@@ -1145,7 +1147,7 @@ def start_raylet(redis_address,
             plasma_store_name,
             raylet_name,
             redis_password,
-            os.path.join(temp_dir, "sockets"),
+            session_dir,
         )
     else:
         java_worker_command = ""
@@ -1212,7 +1214,7 @@ def build_java_worker_command(
         plasma_store_name,
         raylet_name,
         redis_password,
-        temp_dir,
+        session_dir,
 ):
     """This method assembles the command used to start a Java worker.
 
@@ -1223,7 +1225,7 @@ def build_java_worker_command(
            to.
         raylet_name (str): The name of the raylet socket to create.
         redis_password (str): The password of connect to redis.
-        temp_dir (str): The path of the temporary directory Ray will use.
+        session_dir (str): The path of this session.
     Returns:
         The command string for starting Java worker.
     """
@@ -1244,8 +1246,7 @@ def build_java_worker_command(
         command += "-Dray.redis.password={} ".format(redis_password)
 
     command += "-Dray.home={} ".format(RAY_HOME)
-    # TODO(suquark): We should use temp_dir as the input of a java worker.
-    command += "-Dray.log-dir={} ".format(os.path.join(temp_dir, "sockets"))
+    command += "-Dray.log-dir={} ".format(os.path.join(session_dir, "logs"))
 
     if java_worker_options:
         # Put `java_worker_options` in the last, so it can overwrite the


### PR DESCRIPTION
Currently, the log dirs of Java workers is be created under `temp_dir/sockets/sockets/` which is a wrong path.