### PR TITLE
[autoscaler] Fix submit

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -587,7 +587,7 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     help="Override the configured cluster name.")
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
-@click.argument("script", required=True, type=str, help="Script to upload.")
+@click.argument("script", required=True, type=str)
 @click.option("--args", required=False, type=str, help="Script args.")
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
            cluster_name, port_forward, script, args):
@@ -609,7 +609,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
     target = os.path.join("~", os.path.basename(script))
     rsync(cluster_config_file, script, target, cluster_name, down=False)
 
-    cmd = " ".join(["python", target] + args.split(" "))
+    cmd = " ".join(["python", target, args])
     exec_cluster(cluster_config_file, cmd, docker, screen, tmux, stop, False,
                  cluster_name, port_forward)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -555,7 +555,7 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     rsync(cluster_config_file, source, target, cluster_name, down=False)
 
 
-@cli.command()
+@cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("cluster_config_file", required=True, type=str)
 @click.option(
     "--docker",
@@ -588,7 +588,8 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
 @click.argument("script", required=True, type=str)
-@click.argument("script_args", required=False, type=str, nargs=-1)
+@click.argument(
+    "script_args", required=False, type=click.UNPROCESSED, nargs=-1)
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
            cluster_name, port_forward, script, script_args):
     """Uploads and runs a script on the specified cluster.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -587,16 +587,18 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     help="Override the configured cluster name.")
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
-@click.argument("script", required=True, type=str)
-@click.argument(
-    "script_args", required=False, type=click.UNPROCESSED, nargs=-1)
+@click.argument("script", required=True, type=str, help="Script to upload.")
+@click.option("--args", required=False, type=str, help="Script args.")
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
-           cluster_name, port_forward, script, script_args):
+           cluster_name, port_forward, script, args):
     """Uploads and runs a script on the specified cluster.
 
     The script is automatically synced to the following location:
 
         os.path.join("~", os.path.basename(script))
+
+    Example:
+        >>> ray submit [CLUSTER.YAML] experiment.py --args="--smoke-test"
     """
     assert not (screen and tmux), "Can specify only one of `screen` or `tmux`."
 
@@ -607,7 +609,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
     target = os.path.join("~", os.path.basename(script))
     rsync(cluster_config_file, script, target, cluster_name, down=False)
 
-    cmd = " ".join(["python", target] + list(script_args))
+    cmd = " ".join(["python", target] + args.split(" "))
     exec_cluster(cluster_config_file, cmd, docker, screen, tmux, stop, False,
                  cluster_name, port_forward)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Submit should now work with arbitrary arguments passed in for execution:

`ray submit CLUSTER.YAML script.py --script-args`

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.