### PR TITLE
[autoscaler] rsync cluster

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -423,6 +423,8 @@ def rsync(config_file, source, target, override_cluster_name, down):
         override_cluster_name: set the name of the cluster
         down: whether we're syncing remote -> local
     """
+    assert bool(source) == bool(target), (
+        "Must either provide both or neither source and target.")
 
     config = yaml.load(open(config_file).read())
     if override_cluster_name is not None:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -448,7 +448,12 @@ def rsync(config_file, source, target, override_cluster_name, down):
             rsync = updater.rsync_down
         else:
             rsync = updater.rsync_up
-        rsync(source, target, check_error=False)
+
+        if source and target:
+            rsync(source, target, check_error=False)
+        else:
+            updater.sync_file_mounts(rsync)
+
     finally:
         provider.cleanup()
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -185,8 +185,6 @@ class NodeUpdater(object):
 
     def sync_file_mounts(self, sync_cmd):
         # Rsync file mounts
-        self.provider.set_node_tags(self.node_id,
-                                    {TAG_RAY_NODE_STATUS: "syncing-files"})
         for remote_path, local_path in self.file_mounts.items():
             assert os.path.exists(local_path), local_path
             if os.path.isdir(local_path):
@@ -217,6 +215,8 @@ class NodeUpdater(object):
             ssh_ok = self.wait_for_ssh(deadline)
             assert ssh_ok, "Unable to SSH to node"
 
+        self.provider.set_node_tags(self.node_id,
+                                    {TAG_RAY_NODE_STATUS: "syncing-files"})
         self.sync_file_mounts(self.rsync_up)
 
         # Run init commands

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -183,25 +183,11 @@ class NodeUpdater(object):
 
         return False
 
-    def do_update(self):
-        self.provider.set_node_tags(self.node_id,
-                                    {TAG_RAY_NODE_STATUS: "waiting-for-ssh"})
-
-        deadline = time.time() + NODE_START_WAIT_S
-        self.set_ssh_ip_if_required()
-
-        # Wait for SSH access
-        with LogTimer("NodeUpdater: " "{}: Got SSH".format(self.node_id)):
-            ssh_ok = self.wait_for_ssh(deadline)
-            assert ssh_ok, "Unable to SSH to node"
-
+    def sync_file_mounts(self, sync_cmd):
         # Rsync file mounts
         self.provider.set_node_tags(self.node_id,
                                     {TAG_RAY_NODE_STATUS: "syncing-files"})
         for remote_path, local_path in self.file_mounts.items():
-            logger.info("NodeUpdater: "
-                        "{}: Syncing {} to {}...".format(
-                            self.node_id, local_path, remote_path))
             assert os.path.exists(local_path), local_path
             if os.path.isdir(local_path):
                 if not local_path.endswith("/"):
@@ -217,7 +203,21 @@ class NodeUpdater(object):
                         "mkdir -p {}".format(os.path.dirname(remote_path)),
                         redirect=redirect,
                     )
-                    self.rsync_up(local_path, remote_path, redirect=redirect)
+                    sync_cmd(local_path, remote_path, redirect=redirect)
+
+    def do_update(self):
+        self.provider.set_node_tags(self.node_id,
+                                    {TAG_RAY_NODE_STATUS: "waiting-for-ssh"})
+
+        deadline = time.time() + NODE_START_WAIT_S
+        self.set_ssh_ip_if_required()
+
+        # Wait for SSH access
+        with LogTimer("NodeUpdater: " "{}: Got SSH".format(self.node_id)):
+            ssh_ok = self.wait_for_ssh(deadline)
+            assert ssh_ok, "Unable to SSH to node"
+
+        self.sync_file_mounts(self.rsync_up)
 
         # Run init commands
         self.provider.set_node_tags(self.node_id,
@@ -236,6 +236,9 @@ class NodeUpdater(object):
                     self.ssh_cmd(cmd, redirect=redirect)
 
     def rsync_up(self, source, target, redirect=None, check_error=True):
+        logger.info("NodeUpdater: "
+                    "{}: Syncing {} to {}...".format(self.node_id, source,
+                                                     target))
         self.set_ssh_ip_if_required()
         self.get_caller(check_error)(
             [
@@ -247,6 +250,9 @@ class NodeUpdater(object):
             stderr=redirect or sys.stderr)
 
     def rsync_down(self, source, target, redirect=None, check_error=True):
+        logger.info("NodeUpdater: "
+                    "{}: Syncing {} from {}...".format(self.node_id, source,
+                                                       target))
         self.set_ssh_ip_if_required()
         self.get_caller(check_error)(
             [

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -587,7 +587,7 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     help="Override the configured cluster name.")
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
-@click.argument("script", required=True, type=str, help="Script to upload.")
+@click.argument("script", required=True, type=str)
 @click.option("--args", required=False, type=str, help="Script args.")
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
            cluster_name, port_forward, script, args):
@@ -609,7 +609,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
     target = os.path.join("~", os.path.basename(script))
     rsync(cluster_config_file, script, target, cluster_name, down=False)
 
-    cmd = " ".join(["python", target] + args.split(" "))
+    cmd = " ".join(["python", target, args])
     exec_cluster(cluster_config_file, cmd, docker, screen, tmux, stop, False,
                  cluster_name, port_forward)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -555,7 +555,7 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     rsync(cluster_config_file, source, target, cluster_name, down=False)
 
 
-@cli.command()
+@cli.command(context_settings={"ignore_unknown_options": True})
 @click.argument("cluster_config_file", required=True, type=str)
 @click.option(
     "--docker",
@@ -588,7 +588,8 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
 @click.argument("script", required=True, type=str)
-@click.argument("script_args", required=False, type=str, nargs=-1)
+@click.argument(
+    "script_args", required=False, type=click.UNPROCESSED, nargs=-1)
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
            cluster_name, port_forward, script, script_args):
     """Uploads and runs a script on the specified cluster.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -538,7 +538,6 @@ def attach(cluster_config_file, start, tmux, cluster_name, new):
     type=str,
     help="Override the configured cluster name.")
 def rsync_down(cluster_config_file, source, target, cluster_name):
-    assert bool(source) == bool(target), "Must provide source and target."
     rsync(cluster_config_file, source, target, cluster_name, down=True)
 
 
@@ -553,7 +552,6 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     type=str,
     help="Override the configured cluster name.")
 def rsync_up(cluster_config_file, source, target, cluster_name):
-    assert bool(source) == bool(target), "Must provide source and target."
     rsync(cluster_config_file, source, target, cluster_name, down=False)
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -587,16 +587,18 @@ def rsync_up(cluster_config_file, source, target, cluster_name):
     help="Override the configured cluster name.")
 @click.option(
     "--port-forward", required=False, type=int, help="Port to forward.")
-@click.argument("script", required=True, type=str)
-@click.argument(
-    "script_args", required=False, type=click.UNPROCESSED, nargs=-1)
+@click.argument("script", required=True, type=str, help="Script to upload.")
+@click.option("--args", required=False, type=str, help="Script args.")
 def submit(cluster_config_file, docker, screen, tmux, stop, start,
-           cluster_name, port_forward, script, script_args):
+           cluster_name, port_forward, script, args):
     """Uploads and runs a script on the specified cluster.
 
     The script is automatically synced to the following location:
 
         os.path.join("~", os.path.basename(script))
+
+    Example:
+        >>> ray submit [CLUSTER.YAML] experiment.py --args="--smoke-test"
     """
     assert not (screen and tmux), "Can specify only one of `screen` or `tmux`."
 
@@ -607,7 +609,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
     target = os.path.join("~", os.path.basename(script))
     rsync(cluster_config_file, script, target, cluster_name, down=False)
 
-    cmd = " ".join(["python", target] + list(script_args))
+    cmd = " ".join(["python", target] + args.split(" "))
     exec_cluster(cluster_config_file, cmd, docker, screen, tmux, stop, False,
                  cluster_name, port_forward)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -529,8 +529,8 @@ def attach(cluster_config_file, start, tmux, cluster_name, new):
 
 @cli.command()
 @click.argument("cluster_config_file", required=True, type=str)
-@click.argument("source", required=True, type=str)
-@click.argument("target", required=True, type=str)
+@click.argument("source", required=False, type=str)
+@click.argument("target", required=False, type=str)
 @click.option(
     "--cluster-name",
     "-n",
@@ -538,13 +538,14 @@ def attach(cluster_config_file, start, tmux, cluster_name, new):
     type=str,
     help="Override the configured cluster name.")
 def rsync_down(cluster_config_file, source, target, cluster_name):
+    assert bool(source) == bool(target), "Must provide source and target."
     rsync(cluster_config_file, source, target, cluster_name, down=True)
 
 
 @cli.command()
 @click.argument("cluster_config_file", required=True, type=str)
-@click.argument("source", required=True, type=str)
-@click.argument("target", required=True, type=str)
+@click.argument("source", required=False, type=str)
+@click.argument("target", required=False, type=str)
 @click.option(
     "--cluster-name",
     "-n",
@@ -552,6 +553,7 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     type=str,
     help="Override the configured cluster name.")
 def rsync_up(cluster_config_file, source, target, cluster_name):
+    assert bool(source) == bool(target), "Must provide source and target."
     rsync(cluster_config_file, source, target, cluster_name, down=False)
 
 

--- a/python/ray/tune/examples/mnist_pytorch_trainable.py
+++ b/python/ray/tune/examples/mnist_pytorch_trainable.py
@@ -50,6 +50,11 @@ parser.add_argument(
     default=False,
     help="disables CUDA training")
 parser.add_argument(
+    "--redis-address",
+    default=None,
+    type=str,
+    help="The Redis address of the cluster.")
+parser.add_argument(
     "--seed",
     type=int,
     default=1,
@@ -173,7 +178,7 @@ if __name__ == "__main__":
     from ray import tune
     from ray.tune.schedulers import HyperBandScheduler
 
-    ray.init()
+    ray.init(redis_address=args.redis_address)
     sched = HyperBandScheduler(
         time_attr="training_iteration", reward_attr="neg_mean_loss")
     tune.run(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

If `source` and `target` are not provided for `rsync`, `ray rsync-up/rsync-down`
will automatically upload all file_mounts listed in the cluster yaml.

This PR is based off #4782.

## Related issue number


## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.