### PR TITLE
[tune] Fix CLI test

### DIFF
--- a/python/ray/tune/tests/test_commands.py
+++ b/python/ray/tune/tests/test_commands.py
@@ -33,7 +33,7 @@ class Capturing():
 
 @pytest.fixture
 def start_ray():
-    ray.init()
+    ray.init(log_to_driver=False)
     _register_all()
     yield
     ray.shutdown()


### PR DESCRIPTION
## What do these changes do?

`test_commands` was failing frequently because TF would output a warning
message and the message would be piped to driver STDOUT. 

This PR fixes that by turning off `log_to_driver`.


## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.