### PR TITLE
[rllib] [RFC] Deprecate Python 2 / RLlib

### DIFF
--- a/python/ray/rllib/__init__.py
+++ b/python/ray/rllib/__init__.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
+import sys
 
 # Note: do not introduce unnecessary library dependencies here, e.g. gym.
 # This file is imported from the tune module in order to register RLlib agents.
@@ -29,6 +30,11 @@ def _setup_logger():
         ))
     logger.addHandler(handler)
     logger.propagate = False
+
+    if sys.version_info[0] < 3:
+        logger.warn(
+            "RLlib Python 2 support is deprecated, and will be removed "
+            "in a future release.")
 
 
 def _register_all():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This deprecates Python 2 for RLlib (just RLlib, not ray core). Currently less than 10% of pip installs are for Python 2.

The main advantage of moving to Python 3 is the addition of type annotations.