### PR TITLE
Fix bug in which actor classes are not exported multiple times.

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -43,6 +43,9 @@ class RemoteFunction(object):
             return the resulting ObjectIDs. For an example, see
             "test_decorated_function" in "python/ray/tests/test_basic.py".
         _function_signature: The function signature.
+        _last_export_session: The index of the last session in which the remote
+            function was exported. This is used to determine if we need to
+            export the remote function again.
     """
 
     def __init__(self, function, num_cpus, num_gpus, resources,
@@ -68,7 +71,6 @@ class RemoteFunction(object):
 
         # Export the function.
         worker = ray.worker.get_global_worker()
-        # In which session this function was exported last time.
         self._last_export_session = worker._session_index
         worker.function_actor_manager.export(self)
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2942,3 +2942,29 @@ def test_get_postprocess(ray_start_regular):
 
     assert ray.get(
         [ray.put(i) for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]
+
+
+def test_export_after_shutdown(ray_start_regular):
+    # This test checks that we can use actor and remote function definitions
+    # across multiple Ray sessions.
+
+    @ray.remote
+    def f():
+        pass
+
+    @ray.remote
+    class Actor(object):
+        def method(self):
+            pass
+
+    ray.get(f.remote())
+    a = Actor.remote()
+    ray.get(a.method.remote())
+
+    ray.shutdown()
+
+    # Start Ray and use the remote function and actor again.
+    ray.init(num_cpus=1)
+    ray.get(f.remote())
+    a = Actor.remote()
+    ray.get(a.method.remote())


### PR DESCRIPTION
This allows actor class definitions to be reused between multiple Ray sessions (and adds a test). This was done for remote functions but not actors in #4195.