### PR TITLE
Refactor redis callback handling

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -20,7 +20,8 @@ namespace {
 
 /// A helper function to call the callback and delete it from the callback
 /// manager if necessary.
-void ProcessCallback(int64_t callback_index, const ray::gcs::CallbackReply &callback_reply) {
+void ProcessCallback(int64_t callback_index,
+                     const ray::gcs::CallbackReply &callback_reply) {
   RAY_CHECK(callback_index >= 0) << "The callback index must be greater than 0, "
                                  << "but it actually is " << callback_index;
   auto callback_item = ray::gcs::RedisCallbackManager::instance().get(callback_index);
@@ -52,9 +53,7 @@ CallbackReply::CallbackReply(redisReply *redisReply) {
   this->redis_reply_ = redisReply;
 }
 
-bool CallbackReply::IsNil() const {
-  return REDIS_REPLY_NIL == redis_reply_->type;
-}
+bool CallbackReply::IsNil() const { return REDIS_REPLY_NIL == redis_reply_->type; }
 
 uint64_t CallbackReply::ReadAsInteger() const {
   RAY_CHECK(REDIS_REPLY_INTEGER == redis_reply_->type)
@@ -65,8 +64,7 @@ uint64_t CallbackReply::ReadAsInteger() const {
 }
 
 std::string CallbackReply::ReadAsString() const {
-  if (REDIS_REPLY_NIL == redis_reply_->type ||
-      REDIS_REPLY_STATUS == redis_reply_->type) {
+  if (REDIS_REPLY_NIL == redis_reply_->type || REDIS_REPLY_STATUS == redis_reply_->type) {
     return "";
   }
 
@@ -77,19 +75,19 @@ std::string CallbackReply::ReadAsString() const {
 
 Status CallbackReply::ReadAsStatus() const {
   RAY_CHECK(REDIS_REPLY_STATUS == redis_reply_->type)
-    << "Unexpected type:" << redis_reply_->type;
+      << "Unexpected type:" << redis_reply_->type;
 
-    const std::string status_str(redis_reply_->str, redis_reply_->len);
-    if ("OK" == status_str) {
-      return Status::OK();
-    }
+  const std::string status_str(redis_reply_->str, redis_reply_->len);
+  if ("OK" == status_str) {
+    return Status::OK();
+  }
 
-    return Status::RedisError(status_str);
+  return Status::RedisError(status_str);
 }
 
 std::string CallbackReply::ReadAsPubsubData() const {
   RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply_->type)
-      << "Unexcepted type:" << redis_reply_->type;;
+      << "Unexcepted type:" << redis_reply_->type;
 
   std::string data = "";
   // Parse the published message.
@@ -116,8 +114,8 @@ std::vector<std::string> CallbackReply::ReadAsStringArray() const {
 
   if (array_size > 0) {
     auto *entry = redis_reply_->element[0];
-    const bool is_pubsub_reply
-        = strcmp(entry->str, "subscribe") == 0 || strcmp(entry->str, "message") == 0;
+    const bool is_pubsub_reply =
+        strcmp(entry->str, "subscribe") == 0 || strcmp(entry->str, "message") == 0;
     RAY_CHECK(!is_pubsub_reply) << "Subpub reply cannot be read as a string array.";
   }
 

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -48,18 +48,16 @@ namespace gcs {
 
 CallbackReply::CallbackReply(redisReply *redisReply) {
   RAY_CHECK(nullptr != redisReply);
-  RAY_CHECK(redisReply->type != REDIS_REPLY_ERROR)
-      << "Got an error in redis reply:" << redisReply->str;
+  RAY_CHECK(redisReply->type != REDIS_REPLY_ERROR) << "Got an error in redis reply:"
+                                                   << redisReply->str;
   this->redis_reply_ = redisReply;
 }
 
 bool CallbackReply::IsNil() const { return REDIS_REPLY_NIL == redis_reply_->type; }
 
 uint64_t CallbackReply::ReadAsInteger() const {
-  RAY_CHECK(REDIS_REPLY_INTEGER == redis_reply_->type)
-      << "Unexpected type:" << redis_reply_->type;
-
-  RAY_CHECK(REDIS_REPLY_INTEGER == redis_reply_->type);
+  RAY_CHECK(REDIS_REPLY_INTEGER == redis_reply_->type) << "Unexpected type:"
+                                                       << redis_reply_->type;
   return static_cast<uint64_t>(redis_reply_->integer);
 }
 
@@ -68,15 +66,14 @@ std::string CallbackReply::ReadAsString() const {
     return "";
   }
 
-  RAY_CHECK(REDIS_REPLY_STRING == redis_reply_->type)
-      << "Unexpected type:" << redis_reply_->type;
+  RAY_CHECK(REDIS_REPLY_STRING == redis_reply_->type) << "Unexpected type:"
+                                                      << redis_reply_->type;
   return std::string(redis_reply_->str, redis_reply_->len);
 }
 
 Status CallbackReply::ReadAsStatus() const {
-  RAY_CHECK(REDIS_REPLY_STATUS == redis_reply_->type)
-      << "Unexpected type:" << redis_reply_->type;
-
+  RAY_CHECK(REDIS_REPLY_STATUS == redis_reply_->type) << "Unexpected type:"
+                                                      << redis_reply_->type;
   const std::string status_str(redis_reply_->str, redis_reply_->len);
   if ("OK" == status_str) {
     return Status::OK();
@@ -86,8 +83,8 @@ Status CallbackReply::ReadAsStatus() const {
 }
 
 std::string CallbackReply::ReadAsPubsubData() const {
-  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply_->type)
-      << "Unexcepted type:" << redis_reply_->type;
+  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply_->type) << "Unexpected type:"
+                                                     << redis_reply_->type;
 
   std::string data = "";
   // Parse the published message.

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -34,7 +34,7 @@ class CallbackReply {
   bool IsNil() const;
 
   /// Read this reply data as an integer.
-  uint64_t ReadAsInteger() const;
+  int64_t ReadAsInteger() const;
 
   /// Read this reply data as a string.
   ///
@@ -49,7 +49,10 @@ class CallbackReply {
   std::string ReadAsPubsubData() const;
 
   /// Read this reply data as a string array.
-  std::vector<std::string> ReadAsStringArray() const;
+  ///
+  /// \param array Since the return-value may be large,
+  /// make it as an output parameter.
+  void ReadAsStringArray(std::vector<std::string> *array) const;
 
  private:
   redisReply *redis_reply_;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -24,9 +24,31 @@ struct aeEventLoop;
 namespace ray {
 
 namespace gcs {
+
+/// A simple reply wrapper for redis reply.
+class CallbackReply {
+ public:
+  explicit CallbackReply(redisReply *redis_reply);
+
+  bool IsNil() const;
+
+  uint64_t ReadAsInteger() const;
+
+  std::string ReadAsString() const;
+
+  Status ReadAsStatus() const;
+
+  std::string ReadAsPubsubData() const;
+
+  std::vector<std::string> ReadAsStringArray() const;
+
+ private:
+  redisReply *redis_reply_;
+};
+
 /// Every callback should take in a vector of the results from the Redis
 /// operation.
-using RedisCallback = std::function<void(const std::string &)>;
+using RedisCallback = std::function<void(const CallbackReply &)>;
 
 void GlobalRedisCallback(void *c, void *r, void *privdata);
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -30,16 +30,25 @@ class CallbackReply {
  public:
   explicit CallbackReply(redisReply *redis_reply);
 
+  /// Whether this reply is `nil` type reply.
   bool IsNil() const;
 
+  /// Read this reply data as an integer.
   uint64_t ReadAsInteger() const;
 
+  /// Read this reply data as a string.
+  ///
+  /// Note that this will return an empty string if
+  /// the type of this reply is `nil` or `status`.
   std::string ReadAsString() const;
 
+  /// Read this reply data as a status.
   Status ReadAsStatus() const;
 
+  /// Read this reply data as a pub-sub data.
   std::string ReadAsPubsubData() const;
 
+  /// Read this reply data as a string array.
   std::vector<std::string> ReadAsStringArray() const;
 
  private:

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -351,7 +351,7 @@ int TableAppend_DoWrite(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     // The requested index did not match the current length of the log. Return
     // an error message as a string.
     static const char *reply = "ERR entry exists";
-    RedisModule_ReplyWithStringBuffer(ctx, reply, strlen(reply));
+    RedisModule_ReplyWithSimpleString(ctx, reply);
     return REDISMODULE_ERR;
   }
 }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -44,7 +44,8 @@ Status Log<ID, Data>::Append(const DriverID &driver_id, const ID &id,
   auto callback = [this, id, dataT, done](const CallbackReply &reply) {
     const auto status = reply.ReadAsStatus();
     // Failed to append the entry.
-    RAY_CHECK(status.ok()) << "Failed to execute command TABLE_APPEND:" << status.ToString();
+    RAY_CHECK(status.ok()) << "Failed to execute command TABLE_APPEND:"
+                           << status.ToString();
     if (done != nullptr) {
       (done)(client_, id, *dataT);
     }
@@ -527,8 +528,8 @@ void ClientTable::HandleNotification(AsyncGcsClient *client,
 
 void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientTableDataT &data) {
   auto connected_client_id = ClientID::from_binary(data.client_id);
-  RAY_CHECK(client_id_ == connected_client_id) << connected_client_id << " "
-                                               << client_id_;
+  RAY_CHECK(client_id_ == connected_client_id)
+      << connected_client_id << " " << client_id_;
 }
 
 const ClientID &ClientTable::GetLocalClientId() const { return client_id_; }
@@ -557,8 +558,8 @@ Status ClientTable::Connect(const ClientTableDataT &local_client) {
 
     // Callback for a notification from the client table.
     auto notification_callback = [this](
-        AsyncGcsClient *client, const UniqueID &log_key,
-        const std::vector<ClientTableDataT> &notifications) {
+                                     AsyncGcsClient *client, const UniqueID &log_key,
+                                     const std::vector<ClientTableDataT> &notifications) {
       RAY_CHECK(log_key == client_log_key_);
       std::unordered_map<std::string, ClientTableDataT> connected_nodes;
       std::unordered_map<std::string, ClientTableDataT> disconnected_nodes;
@@ -650,8 +651,8 @@ Status ActorCheckpointIdTable::AddCheckpointId(const DriverID &driver_id,
                                                const ActorID &actor_id,
                                                const ActorCheckpointID &checkpoint_id) {
   auto lookup_callback = [this, checkpoint_id, driver_id, actor_id](
-      ray::gcs::AsyncGcsClient *client, const UniqueID &id,
-      const ActorCheckpointIdDataT &data) {
+                             ray::gcs::AsyncGcsClient *client, const UniqueID &id,
+                             const ActorCheckpointIdDataT &data) {
     std::shared_ptr<ActorCheckpointIdDataT> copy =
         std::make_shared<ActorCheckpointIdDataT>(data);
     copy->timestamps.push_back(current_sys_time_ms());
@@ -670,7 +671,7 @@ Status ActorCheckpointIdTable::AddCheckpointId(const DriverID &driver_id,
     RAY_CHECK_OK(Add(driver_id, actor_id, copy, nullptr));
   };
   auto failure_callback = [this, checkpoint_id, driver_id, actor_id](
-      ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
+                              ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
     std::shared_ptr<ActorCheckpointIdDataT> data =
         std::make_shared<ActorCheckpointIdDataT>();
     data->actor_id = id.binary();

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -528,8 +528,8 @@ void ClientTable::HandleNotification(AsyncGcsClient *client,
 
 void ClientTable::HandleConnected(AsyncGcsClient *client, const ClientTableDataT &data) {
   auto connected_client_id = ClientID::from_binary(data.client_id);
-  RAY_CHECK(client_id_ == connected_client_id)
-      << connected_client_id << " " << client_id_;
+  RAY_CHECK(client_id_ == connected_client_id) << connected_client_id << " "
+                                               << client_id_;
 }
 
 const ClientID &ClientTable::GetLocalClientId() const { return client_id_; }
@@ -558,8 +558,8 @@ Status ClientTable::Connect(const ClientTableDataT &local_client) {
 
     // Callback for a notification from the client table.
     auto notification_callback = [this](
-                                     AsyncGcsClient *client, const UniqueID &log_key,
-                                     const std::vector<ClientTableDataT> &notifications) {
+        AsyncGcsClient *client, const UniqueID &log_key,
+        const std::vector<ClientTableDataT> &notifications) {
       RAY_CHECK(log_key == client_log_key_);
       std::unordered_map<std::string, ClientTableDataT> connected_nodes;
       std::unordered_map<std::string, ClientTableDataT> disconnected_nodes;
@@ -651,8 +651,8 @@ Status ActorCheckpointIdTable::AddCheckpointId(const DriverID &driver_id,
                                                const ActorID &actor_id,
                                                const ActorCheckpointID &checkpoint_id) {
   auto lookup_callback = [this, checkpoint_id, driver_id, actor_id](
-                             ray::gcs::AsyncGcsClient *client, const UniqueID &id,
-                             const ActorCheckpointIdDataT &data) {
+      ray::gcs::AsyncGcsClient *client, const UniqueID &id,
+      const ActorCheckpointIdDataT &data) {
     std::shared_ptr<ActorCheckpointIdDataT> copy =
         std::make_shared<ActorCheckpointIdDataT>(data);
     copy->timestamps.push_back(current_sys_time_ms());
@@ -671,7 +671,7 @@ Status ActorCheckpointIdTable::AddCheckpointId(const DriverID &driver_id,
     RAY_CHECK_OK(Add(driver_id, actor_id, copy, nullptr));
   };
   auto failure_callback = [this, checkpoint_id, driver_id, actor_id](
-                              ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
+      ray::gcs::AsyncGcsClient *client, const UniqueID &id) {
     std::shared_ptr<ActorCheckpointIdDataT> data =
         std::make_shared<ActorCheckpointIdDataT>();
     data->actor_id = id.binary();

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -64,8 +64,8 @@ Status Log<ID, Data>::AppendAt(const DriverID &driver_id, const ID &id,
                                const WriteCallback &failure, int log_length) {
   num_appends_++;
   auto callback = [this, id, dataT, done, failure](const CallbackReply &reply) {
-    const auto data = reply.ReadAsString();
-    if (data.empty()) {
+    const auto status = reply.ReadAsStatus();
+    if (status.ok()) {
       if (done != nullptr) {
         (done)(client_, id, *dataT);
       }
@@ -88,10 +88,10 @@ Status Log<ID, Data>::Lookup(const DriverID &driver_id, const ID &id,
                              const Callback &lookup) {
   num_lookups_++;
   auto callback = [this, id, lookup](const CallbackReply &reply) {
-    const auto data = reply.ReadAsString();
     if (lookup != nullptr) {
       std::vector<DataT> results;
-      if (!data.empty()) {
+      if (!reply.IsNil()) {
+        const auto data = reply.ReadAsString();
         auto root = flatbuffers::GetRoot<GcsTableEntry>(data.data());
         RAY_CHECK(from_flatbuf<ID>(*root->id()) == id);
         for (size_t i = 0; i < root->entries()->size(); i++) {
@@ -237,7 +237,6 @@ Status Table<ID, Data>::Add(const DriverID &driver_id, const ID &id,
                             std::shared_ptr<DataT> &dataT, const WriteCallback &done) {
   num_adds_++;
   auto callback = [this, id, dataT, done](const CallbackReply &reply) {
-    RAY_IGNORE_EXPR(reply);
     if (done != nullptr) {
       (done)(client_, id, *dataT);
     }
@@ -303,7 +302,6 @@ Status Set<ID, Data>::Add(const DriverID &driver_id, const ID &id,
                           std::shared_ptr<DataT> &dataT, const WriteCallback &done) {
   num_adds_++;
   auto callback = [this, id, dataT, done](const CallbackReply &reply) {
-    RAY_IGNORE_EXPR(reply);
     if (done != nullptr) {
       (done)(client_, id, *dataT);
     }
@@ -321,7 +319,6 @@ Status Set<ID, Data>::Remove(const DriverID &driver_id, const ID &id,
                              std::shared_ptr<DataT> &dataT, const WriteCallback &done) {
   num_removes_++;
   auto callback = [this, id, dataT, done](const CallbackReply &reply) {
-    RAY_IGNORE_EXPR(reply);
     if (done != nullptr) {
       (done)(client_, id, *dataT);
     }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -45,7 +45,6 @@ Status Log<ID, Data>::Append(const DriverID &driver_id, const ID &id,
     const auto status = reply.ReadAsStatus();
     // Failed to append the entry.
     RAY_CHECK(status.ok()) << "Failed to execute command TABLE_APPEND:" << status.ToString();
-
     if (done != nullptr) {
       (done)(client_, id, *dataT);
     }

--- a/src/ray/status.h
+++ b/src/ray/status.h
@@ -121,7 +121,7 @@ class RAY_EXPORT Status {
     return Status(StatusCode::RedisError, msg);
   }
 
-  // Returns true if the status indicates success.
+  // Returns true iff the status indicates success.
   bool ok() const { return (state_ == NULL); }
 
   bool IsOutOfMemory() const { return code() == StatusCode::OutOfMemory; }

--- a/src/ray/status.h
+++ b/src/ray/status.h
@@ -121,7 +121,7 @@ class RAY_EXPORT Status {
     return Status(StatusCode::RedisError, msg);
   }
 
-  // Returns true iff the status indicates success.
+  // Returns true if the status indicates success.
   bool ok() const { return (state_ == NULL); }
 
   bool IsOutOfMemory() const { return code() == StatusCode::OutOfMemory; }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Before this change, we pass all replies data of redis as strings, it's not  convenient for us to parse other type of the replies like array.

I think it's useful to do this change since we'll use other types of the redis callback.


## Related issue number
This closes #4770
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
