### PR TITLE
Replace ReturnIds with NumReturns in TaskInfo to reduce the size

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/AbstractRayRuntime.java
@@ -390,7 +390,7 @@ public abstract class AbstractRayRuntime implements RayRuntime {
         actor.increaseTaskCounter(),
         actor.getNewActorHandles().toArray(new UniqueId[0]),
         ArgumentsBuilder.wrap(args, language == TaskLanguage.PYTHON),
-        returnIds,
+        numReturns,
         resources,
         language,
         functionDescriptor

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -178,7 +178,7 @@ public class RayletClientImpl implements RayletClient {
       }
     }
     // Deserialize return ids
-    ObjectId[] returnIds = IdUtil.getObjectIdsFromByteBuffer(info.returnsAsByteBuffer());
+    int numReturns = info.numReturns();
 
     // Deserialize required resources;
     Map<String, Double> resources = new HashMap<>();
@@ -193,7 +193,7 @@ public class RayletClientImpl implements RayletClient {
     );
     return new TaskSpec(driverId, taskId, parentTaskId, parentCounter, actorCreationId,
         maxActorReconstructions, actorId, actorHandleId, actorCounter, newActorHandles,
-        args, returnIds, resources, TaskLanguage.JAVA, functionDescriptor);
+        args, numReturns, resources, TaskLanguage.JAVA, functionDescriptor);
   }
 
   private static ByteBuffer convertTaskSpecToFlatbuffer(TaskSpec task) {

--- a/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
+++ b/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java
@@ -154,6 +154,7 @@ public class RayletClientImpl implements RayletClient {
     UniqueId actorId = UniqueId.fromByteBuffer(info.actorIdAsByteBuffer());
     UniqueId actorHandleId = UniqueId.fromByteBuffer(info.actorHandleIdAsByteBuffer());
     int actorCounter = info.actorCounter();
+    int numReturns = info.numReturns();
 
     // Deserialize new actor handles
     UniqueId[] newActorHandles = IdUtil.getUniqueIdsFromByteBuffer(
@@ -177,8 +178,6 @@ public class RayletClientImpl implements RayletClient {
         args[i] = FunctionArg.passByValue(data);
       }
     }
-    // Deserialize return ids
-    int numReturns = info.numReturns();
 
     // Deserialize required resources;
     Map<String, Double> resources = new HashMap<>();
@@ -211,6 +210,7 @@ public class RayletClientImpl implements RayletClient {
     final int actorIdOffset = fbb.createString(task.actorId.toByteBuffer());
     final int actorHandleIdOffset = fbb.createString(task.actorHandleId.toByteBuffer());
     final int actorCounter = task.actorCounter;
+    final int numReturnsOffset = task.numReturns;
 
     // Serialize the new actor handles.
     int newActorHandlesOffset
@@ -233,9 +233,6 @@ public class RayletClientImpl implements RayletClient {
       argsOffsets[i] = Arg.createArg(fbb, objectIdOffset, dataOffset);
     }
     int argsOffset = fbb.createVectorOfTables(argsOffsets);
-
-    // Serialize returns
-    int returnsOffset = fbb.createString(IdUtil.concatIds(task.returnIds));
 
     // Serialize required resources
     // The required_resources vector indicates the quantities of the different
@@ -292,7 +289,7 @@ public class RayletClientImpl implements RayletClient {
         actorCounter,
         newActorHandlesOffset,
         argsOffset,
-        returnsOffset,
+        numReturnsOffset,
         requiredResourcesOffset,
         requiredPlacementResourcesOffset,
         language,

--- a/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
+++ b/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
@@ -106,6 +106,10 @@ public class TaskSpec {
     this.newActorHandles = newActorHandles;
     this.args = args;
     this.numReturns = numReturns;
+    returnIds = new ObjectId[numReturns];
+    for (int i = 0; i < numReturns; ++i) {
+      returnIds[i] = IdUtil.computeReturnId(taskId, i + 1);
+    }
     this.resources = resources;
     this.language = language;
     if (language == TaskLanguage.JAVA) {
@@ -119,10 +123,6 @@ public class TaskSpec {
     }
     this.functionDescriptor = functionDescriptor;
     this.executionDependencies = new ArrayList<>();
-    returnIds = new ObjectId[numReturns];
-    for (int i = 0; i < numReturns; ++i) {
-      returnIds[i] = IdUtil.computeReturnId(taskId, i + 1);
-    }
   }
 
   public JavaFunctionDescriptor getJavaFunctionDescriptor() {

--- a/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
+++ b/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
@@ -11,6 +11,7 @@ import org.ray.api.id.UniqueId;
 import org.ray.runtime.functionmanager.FunctionDescriptor;
 import org.ray.runtime.functionmanager.JavaFunctionDescriptor;
 import org.ray.runtime.functionmanager.PyFunctionDescriptor;
+import org.ray.runtime.util.IdUtil;
 
 /**
  * Represents necessary information of a task for scheduling and executing.
@@ -50,7 +51,10 @@ public class TaskSpec {
   // Task arguments.
   public final FunctionArg[] args;
 
-  // return ids
+  // number of return objects.
+  public final int numReturns;
+
+  // returns ids.
   public final ObjectId[] returnIds;
 
   // The task's resource demands.
@@ -86,7 +90,7 @@ public class TaskSpec {
       int actorCounter,
       UniqueId[] newActorHandles,
       FunctionArg[] args,
-      ObjectId[] returnIds,
+      int numReturns,
       Map<String, Double> resources,
       TaskLanguage language,
       FunctionDescriptor functionDescriptor) {
@@ -101,7 +105,7 @@ public class TaskSpec {
     this.actorCounter = actorCounter;
     this.newActorHandles = newActorHandles;
     this.args = args;
-    this.returnIds = returnIds;
+    this.numReturns = numReturns;
     this.resources = resources;
     this.language = language;
     if (language == TaskLanguage.JAVA) {
@@ -115,6 +119,10 @@ public class TaskSpec {
     }
     this.functionDescriptor = functionDescriptor;
     this.executionDependencies = new ArrayList<>();
+    returnIds = new ObjectId[numReturns];
+    for (int i = 0; i < numReturns; ++i) {
+      returnIds[i] = IdUtil.computeReturnId(taskId, i);
+    }
   }
 
   public JavaFunctionDescriptor getJavaFunctionDescriptor() {
@@ -145,7 +153,7 @@ public class TaskSpec {
         ", actorCounter=" + actorCounter +
         ", newActorHandles=" + Arrays.toString(newActorHandles) +
         ", args=" + Arrays.toString(args) +
-        ", returnIds=" + Arrays.toString(returnIds) +
+        ", numReturns=" + numReturns +
         ", resources=" + resources +
         ", language=" + language +
         ", functionDescriptor=" + functionDescriptor +

--- a/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
+++ b/java/runtime/src/main/java/org/ray/runtime/task/TaskSpec.java
@@ -121,7 +121,7 @@ public class TaskSpec {
     this.executionDependencies = new ArrayList<>();
     returnIds = new ObjectId[numReturns];
     for (int i = 0; i < numReturns; ++i) {
-      returnIds[i] = IdUtil.computeReturnId(taskId, i);
+      returnIds[i] = IdUtil.computeReturnId(taskId, i + 1);
     }
   }
 

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -89,9 +89,8 @@ table TaskInfo {
   new_actor_handles: string;
   // Task arguments.
   args: [Arg];
-  // Object IDs of return values. This is a long string that concatenate
-  // all of the return object IDs of this task.
-  returns: string;
+  // Number of return objects.
+  num_returns: int;
   // The required_resources vector indicates the quantities of the different
   // resources required by this task.
   required_resources: [ResourcePair];

--- a/src/ray/raylet/task_test.cc
+++ b/src/ray/raylet/task_test.cc
@@ -68,8 +68,8 @@ TEST(TaskSpecTest, TaskInfoSize) {
         to_flatbuf(fbb, TaskID::from_random()), 0, to_flatbuf(fbb, ActorID::nil()),
         to_flatbuf(fbb, ObjectID::nil()), 0, to_flatbuf(fbb, ActorID::nil()),
         to_flatbuf(fbb, ActorHandleID::nil()), 0,
-        ids_to_flatbuf(fbb, std::vector<ObjectID>()), fbb.CreateVector(arguments),
-        1, map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}), Language::PYTHON,
+        ids_to_flatbuf(fbb, std::vector<ObjectID>()), fbb.CreateVector(arguments), 1,
+        map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}), Language::PYTHON,
         string_vec_to_flatbuf(fbb, {"PackageName", "ClassName", "FunctionName"}));
     fbb.Finish(spec);
     RAY_LOG(ERROR) << "Ordinary task info size: " << fbb.GetSize();
@@ -90,8 +90,8 @@ TEST(TaskSpecTest, TaskInfoSize) {
         to_flatbuf(fbb, ActorHandleID::from_random()), 20,
         ids_to_flatbuf(fbb, std::vector<ObjectID>(
                                 {ObjectID::from_random(), ObjectID::from_random()})),
-        fbb.CreateVector(arguments),
-        2, map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}), Language::PYTHON,
+        fbb.CreateVector(arguments), 2, map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}),
+        Language::PYTHON,
         string_vec_to_flatbuf(fbb, {"PackageName", "ClassName", "FunctionName"}));
     fbb.Finish(spec);
     RAY_LOG(ERROR) << "Actor task info size: " << fbb.GetSize();

--- a/src/ray/raylet/task_test.cc
+++ b/src/ray/raylet/task_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 
+#include "ray/common/common_protocol.h"
 #include "ray/raylet/task_spec.h"
 
 namespace ray {
@@ -45,6 +46,56 @@ TEST(IdPropertyTest, TestIdProperty) {
   ASSERT_TRUE(TaskID::nil().is_nil());
   ASSERT_TRUE(ObjectID().is_nil());
   ASSERT_TRUE(ObjectID::nil().is_nil());
+}
+
+TEST(TaskSpecTest, TaskInfoSize) {
+  std::vector<ObjectID> references = {ObjectID::from_random(), ObjectID::from_random()};
+  auto arguments_1 = std::make_shared<TaskArgumentByReference>(references);
+  std::string one_arg("This is an value argument.");
+  auto arguments_2 = std::make_shared<TaskArgumentByValue>(
+      reinterpret_cast<const uint8_t *>(one_arg.c_str()), one_arg.size());
+  std::vector<std::shared_ptr<TaskArgument>> task_arguments({arguments_1, arguments_2});
+  auto task_id = TaskID::from_random();
+  {
+    flatbuffers::FlatBufferBuilder fbb;
+    std::vector<flatbuffers::Offset<Arg>> arguments;
+    for (auto &argument : task_arguments) {
+      arguments.push_back(argument->ToFlatbuffer(fbb));
+    }
+    // General task.
+    auto spec = CreateTaskInfo(
+        fbb, to_flatbuf(fbb, DriverID::from_random()), to_flatbuf(fbb, task_id),
+        to_flatbuf(fbb, TaskID::from_random()), 0, to_flatbuf(fbb, ActorID::nil()),
+        to_flatbuf(fbb, ObjectID::nil()), 0, to_flatbuf(fbb, ActorID::nil()),
+        to_flatbuf(fbb, ActorHandleID::nil()), 0,
+        ids_to_flatbuf(fbb, std::vector<ObjectID>()), fbb.CreateVector(arguments),
+        1, map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}), Language::PYTHON,
+        string_vec_to_flatbuf(fbb, {"PackageName", "ClassName", "FunctionName"}));
+    fbb.Finish(spec);
+    RAY_LOG(ERROR) << "Ordinary task info size: " << fbb.GetSize();
+  }
+
+  {
+    flatbuffers::FlatBufferBuilder fbb;
+    std::vector<flatbuffers::Offset<Arg>> arguments;
+    for (auto &argument : task_arguments) {
+      arguments.push_back(argument->ToFlatbuffer(fbb));
+    }
+    // General task.
+    auto spec = CreateTaskInfo(
+        fbb, to_flatbuf(fbb, DriverID::from_random()), to_flatbuf(fbb, task_id),
+        to_flatbuf(fbb, TaskID::from_random()), 10,
+        to_flatbuf(fbb, ActorID::from_random()), to_flatbuf(fbb, ObjectID::from_random()),
+        10000000, to_flatbuf(fbb, ActorID::from_random()),
+        to_flatbuf(fbb, ActorHandleID::from_random()), 20,
+        ids_to_flatbuf(fbb, std::vector<ObjectID>(
+                                {ObjectID::from_random(), ObjectID::from_random()})),
+        fbb.CreateVector(arguments),
+        2, map_to_flatbuf(fbb, {}), map_to_flatbuf(fbb, {}), Language::PYTHON,
+        string_vec_to_flatbuf(fbb, {"PackageName", "ClassName", "FunctionName"}));
+    fbb.Finish(spec);
+    RAY_LOG(ERROR) << "Actor task info size: " << fbb.GetSize();
+  }
 }
 
 }  // namespace raylet


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Because the return ids can be calculated from TaskId, we can replace `ReturnIds` with `NumReturns` to make TaskInfo smaller. TaskInfo is used in submitting task in the critical path. Smaller ones will benefit the efficiency.

From the added test:
- General TaskInfo size (1 return object): 536->508, 28 bytes smaller.
- Actor TaskInfo size (1 return object with a dummy object): 608->560, 48 bytes smaller.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
