### PR TITLE
Fix a typo in kubernetes yaml

### DIFF
--- a/kubernetes/submit.yaml
+++ b/kubernetes/submit.yaml
@@ -86,7 +86,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoreDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 type: ray


### PR DESCRIPTION
## What do these changes do?
Just fix a typo in kubernetes yaml.

## Related ~issue~ PR number
https://github.com/ray-project/ray/pull/4582

## Linter
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
