### PR TITLE
[tune] Disallow setting resources_per_trial when it is already configured

### DIFF
--- a/python/ray/rllib/agents/mock.py
+++ b/python/ray/rllib/agents/mock.py
@@ -20,6 +20,7 @@ class _MockTrainer(Trainer):
         "num_workers": 0,
     })
 
+    @classmethod
     def default_resource_request(cls, config):
         return None
 

--- a/python/ray/rllib/agents/mock.py
+++ b/python/ray/rllib/agents/mock.py
@@ -20,6 +20,9 @@ class _MockTrainer(Trainer):
         "num_workers": 0,
     })
 
+    def default_resource_request(cls, config):
+        return None
+
     def _init(self, config, env_creator):
         self.info = None
         self.restored = False

--- a/python/ray/rllib/examples/custom_train_fn.py
+++ b/python/ray/rllib/examples/custom_train_fn.py
@@ -40,13 +40,9 @@ def my_train_fn(config, reporter):
 
 if __name__ == "__main__":
     ray.init()
-    tune.run(
-        my_train_fn,
-        resources_per_trial={
-            "cpu": 1,
-        },
-        config={
-            "lr": 0.01,
-            "num_workers": 0,
-        },
-    )
+    config = {
+        "lr": 0.01,
+        "num_workers": 0,
+    }
+    resources = PPOTrainer.default_resource_request(config).to_json()
+    tune.run(my_train_fn, resources_per_trial=resources, config=config)

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -96,7 +96,7 @@ class Trainable(object):
         allocation, so the user does not need to.
         """
 
-        return Resources(cpu=1, gpu=0)
+        return None
 
     @classmethod
     def resource_help(cls, config):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -21,7 +21,6 @@ from ray.tune.result import (DEFAULT_RESULTS_DIR, TIME_THIS_ITER_S,
                              TIMESTEPS_THIS_ITER, DONE, TIMESTEPS_TOTAL,
                              EPISODES_THIS_ITER, EPISODES_TOTAL,
                              TRAINING_ITERATION, RESULT_DUPLICATE)
-from ray.tune.trial import Resources
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -281,19 +281,16 @@ class Trial(object):
         trainable_cls = self._get_trainable_cls()
         if trainable_cls and hasattr(trainable_cls,
                                      "default_resource_request"):
-            self.resources = trainable_cls.default_resource_request(
+            default_resources = trainable_cls.default_resource_request(
                 self.config)
-        else:
-            self.resources = None
-        if self.resources:
-            if resources:
+            if default_resources and resources:
                 raise ValueError(
                     "Resources for {} have been automatically set to {} "
                     "by its `default_resource_request()` method. Please "
                     "clear the `resources_per_trial` option.".format(
-                        trainable_cls, self.resources))
-        else:
-            self.resources = resources or Resources(cpu=1, gpu=0)
+                        trainable_cls, default_resources))
+            resources = default_resources
+        self.resources = resources or Resources(cpu=1, gpu=0)
         self.stopping_criterion = stopping_criterion or {}
         self.upload_dir = upload_dir
         self.loggers = loggers

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -279,7 +279,12 @@ class Trial(object):
         self.local_dir = local_dir  # This remains unexpanded for syncing.
         self.experiment_tag = experiment_tag
         trainable_cls = self._get_trainable_cls()
-        self.resources = trainable_cls.default_resource_request(self.config)
+        if trainable_cls and hasattr(trainable_cls,
+                                     "default_resource_request"):
+            self.resources = trainable_cls.default_resource_request(
+                self.config)
+        else:
+            self.resources = None
         if self.resources:
             if resources:
                 raise ValueError(

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -293,7 +293,7 @@ class Trial(object):
                     "clear the `resources_per_trial` option.".format(
                         trainable_cls, self.resources))
         else:
-            self.resources = Resources(cpu=1, gpu=0)
+            self.resources = resources or Resources(cpu=1, gpu=0)
         self.stopping_criterion = stopping_criterion or {}
         self.upload_dir = upload_dir
         self.loggers = loggers

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -283,13 +283,14 @@ class Trial(object):
                                      "default_resource_request"):
             default_resources = trainable_cls.default_resource_request(
                 self.config)
-            if default_resources and resources:
-                raise ValueError(
-                    "Resources for {} have been automatically set to {} "
-                    "by its `default_resource_request()` method. Please "
-                    "clear the `resources_per_trial` option.".format(
-                        trainable_cls, default_resources))
-            resources = default_resources
+            if default_resources:
+                if resources:
+                    raise ValueError(
+                        "Resources for {} have been automatically set to {} "
+                        "by its `default_resource_request()` method. Please "
+                        "clear the `resources_per_trial` option.".format(
+                            trainable_cls, default_resources))
+                resources = default_resources
         self.resources = resources or Resources(cpu=1, gpu=0)
         self.stopping_criterion = stopping_criterion or {}
         self.upload_dir = upload_dir

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -275,9 +275,17 @@ class Trial(object):
         self.config = config or {}
         self.local_dir = local_dir  # This remains unexpanded for syncing.
         self.experiment_tag = experiment_tag
-        self.resources = (
-            resources
-            or self._get_trainable_cls().default_resource_request(self.config))
+        trainable_cls = self._get_trainable_cls()
+        self.resources = trainable_cls.default_resource_request(self.config)
+        if self.resources:
+            if resources:
+                raise ValueError(
+                    "Resources for {} have been automatically set to {} "
+                    "by its `default_resource_request()` method. Please "
+                    "clear the `resources_per_trial` option.".format(
+                        trainable_cls, self.resources))
+        else:
+            self.resources = Resources(cpu=1, gpu=0)
         self.stopping_criterion = stopping_criterion or {}
         self.upload_dir = upload_dir
         self.loggers = loggers

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -139,6 +139,9 @@ class Resources(
         return Resources(cpu, gpu, extra_cpu, extra_gpu, new_custom_res,
                          extra_custom_res)
 
+    def to_json(self):
+        return resources_to_json(self)
+
 
 def json_to_resources(data):
     if data is None or data == "null":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Raise an error if the user tries to set resources_per_trial in RLlib.

## Related issue number

https://groups.google.com/forum/#!topic/ray-dev/coaz8dgHyYw

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
