### PR TITLE
[rllib] Allow Torch policies access to full action input dict in extra_action_out_fn

### DIFF
--- a/doc/source/rllib-concepts.rst
+++ b/doc/source/rllib-concepts.rst
@@ -393,7 +393,7 @@ Defining a policy in PyTorch is quite similar to that for TensorFlow (and the pr
 
 .. code-block:: python
 
-    def model_value_predictions(policy, model_out):
+    def model_value_predictions(policy, input_dict, state_batches, model_out):
         return {SampleBatch.VF_PREDS: model_out[2].cpu().numpy()}
 
 ``postprocess_fn`` and ``mixins``: Similar to the PPO example, we need access to the value function during postprocessing (i.e., ``add_advantages`` below calls ``policy._value()``. The value function is exposed through a mixin class that defines the method:

--- a/python/ray/rllib/agents/a3c/a3c_torch_policy.py
+++ b/python/ray/rllib/agents/a3c/a3c_torch_policy.py
@@ -53,7 +53,7 @@ def add_advantages(policy,
                               policy.config["lambda"])
 
 
-def model_value_predictions(policy, model_out):
+def model_value_predictions(policy, input_dict, state_batches, model_out):
     return {SampleBatch.VF_PREDS: model_out[2].cpu().numpy()}
 
 

--- a/python/ray/rllib/policy/torch_policy_template.py
+++ b/python/ray/rllib/policy/torch_policy_template.py
@@ -108,11 +108,13 @@ def build_torch_policy(name,
                 return TorchPolicy.extra_grad_process(self)
 
         @override(TorchPolicy)
-        def extra_action_out(self, model_out):
+        def extra_action_out(self, input_dict, state_batches, model_out):
             if extra_action_out_fn:
-                return extra_action_out_fn(self, model_out)
+                return extra_action_out_fn(self, input_dict, state_batches,
+                                           model_out)
             else:
-                return TorchPolicy.extra_action_out(self, model_out)
+                return TorchPolicy.extra_action_out(self, input_dict,
+                                                    state_batches, model_out)
 
         @override(TorchPolicy)
         def optimizer(self):

--- a/python/ray/rllib/utils/tracking_dict.py
+++ b/python/ray/rllib/utils/tracking_dict.py
@@ -30,3 +30,8 @@ class UsageTrackingDict(dict):
                 self.intercepted_values[key] = self.get_interceptor(value)
             value = self.intercepted_values[key]
         return value
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, key, value)
+        if key in self.intercepted_values:
+            self.intercepted_values[key] = value


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Unlike in the TF graph, the extra_action_out fn needs all possible inputs explicitly passed to it. Before this change it could only access the model outputs and could not compute arbitrary extra values.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
