### PR TITLE
Drop duplicated string format in java command

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1231,7 +1231,7 @@ def build_java_worker_command(
     """
     assert java_worker_options is not None
 
-    command = "java ".format(java_worker_options)
+    command = "java "
     if redis_address is not None:
         command += "-Dray.redis.address={} ".format(redis_address)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This string format is unnecessary. `java_worker_options` has been appended to the commandline later.
