### PR TITLE
WIP: Migrate process starting code from "services.py" to "node.py"

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -2,17 +2,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import atexit
+import binascii
 import collections
 import datetime
 import errno
 import json
 import os
 import logging
-import signal
+import multiprocessing
+import redis
 import sys
 import tempfile
-import threading
 import time
 
 import ray
@@ -27,17 +27,56 @@ logger = logging.getLogger(__name__)
 
 PY3 = sys.version_info.major >= 3
 
+# Location of the redis server and module.
+RAY_HOME = os.path.join(os.path.dirname(__file__), "../..")
+
+REDIS_EXECUTABLE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/ray/thirdparty/redis/src/redis-server")
+REDIS_MODULE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/ray/gcs/redis_module/libray_redis_module.so")
+
+# Location of the credis server and modules.
+# credis will be enabled if the environment variable RAY_USE_NEW_GCS is set.
+CREDIS_EXECUTABLE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/credis/redis/src/redis-server")
+CREDIS_MASTER_MODULE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/credis/build/src/libmaster.so")
+CREDIS_MEMBER_MODULE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/credis/build/src/libmember.so")
+
+# Location of the plasma object store executable.
+PLASMA_STORE_EXECUTABLE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/plasma/plasma_store_server")
+
+RAYLET_MONITOR_EXECUTABLE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "core/src/ray/raylet/raylet_monitor")
+
+# Location of the raylet executables.
+RAYLET_EXECUTABLE = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), "core/src/ray/raylet/raylet")
+
+RUN_PLASMA_STORE_PROFILER = False
+RUN_PLASMA_STORE_VALGRIND = True
+# True if processes are run in the valgrind profiler.
+RUN_RAYLET_PROFILER = False
+
+DEFAULT_JAVA_WORKER_OPTIONS = "-classpath {}".format(
+    os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "../../../build/java/*"))
+
 
 class Node(object):
     """An encapsulation of the Ray processes on a single node.
 
     This class is responsible for starting Ray processes and killing them,
     and it also controls the temp file policy.
-
-    Attributes:
-        all_processes (dict): A mapping from process type (str) to a list of
-            ProcessInfo objects. All lists have length one except for the Redis
-            server list, which has multiple.
     """
 
     def __init__(self,
@@ -63,7 +102,32 @@ class Node(object):
             raise ValueError("'shutdown_at_exit' and 'connect_only' cannot "
                              "be both true.")
         self.head = head
-        self.all_processes = {}
+        self._process_control = ray.services.ProcessControl(shutdown_at_exit)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_REDIS_SERVER, unique=False)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_MONITOR, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_RAYLET_MONITOR, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_LOG_MONITOR, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_REPORTER, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_DASHBOARD, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_PLASMA_STORE, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_RAYLET, unique=True)
+        self._process_control.register_process_type(
+            ray_constants.PROCESS_TYPE_WORKER, unique=False)
+        # Kill the raylet first. This is important for suppressing errors at
+        # shutdown because we give the raylet a chance to exit gracefully and
+        # clean up its child worker processes. If we were to kill the plasma
+        # store (or Redis) first, that could cause the raylet to exit
+        # ungracefully, leading to more verbose output from the workers.
+        self._process_control.set_teardown_order([
+            ray_constants.PROCESS_TYPE_RAYLET])
 
         # Try to get node IP address with the parameters.
         if ray_params.node_ip_address:
@@ -77,15 +141,24 @@ class Node(object):
 
         ray_params.update_if_absent(
             include_log_monitor=True,
+            redirect_worker_output=True,
             resources={},
             include_webui=False,
             temp_dir="/tmp/ray",
+            # If the object manager port is None, then use 0 to cause
+            # the object manager to choose its own port.
+            object_manager_port=0,
+            # If the node manager port is None, then use 0 to cause the
+            # node manager to choose its own port.
+            node_manager_port=0,
+            java_worker_options=DEFAULT_JAVA_WORKER_OPTIONS,
             worker_path=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "workers/default_worker.py"))
 
         self._ray_params = ray_params
         self._redis_address = ray_params.redis_address
+        self._redis_shards = []
         self._config = (json.loads(ray_params._internal_config)
                         if ray_params._internal_config else None)
 
@@ -148,10 +221,6 @@ class Node(object):
 
         if not connect_only:
             self.start_ray_processes()
-
-        if shutdown_at_exit:
-            atexit.register(lambda: self.kill_all_processes(
-                check_alive=False, allow_graceful=True))
 
     def _init_temp(self, redis_client):
         # Create an dictionary to store temp file index.
@@ -334,89 +403,393 @@ class Node(object):
             prefix=default_prefix, directory_name=self._sockets_dir)
 
     def start_redis(self):
-        """Start the Redis servers."""
-        assert self._redis_address is None
-        redis_log_files = [self.new_log_files("redis")]
-        for i in range(self._ray_params.num_redis_shards):
-            redis_log_files.append(self.new_log_files("redis-shard_" + str(i)))
+        """Start the Redis global state store."""
+        num_redis_shards = self._ray_params.num_redis_shards
+        redis_shard_ports = self._ray_params.redis_shard_ports
+        if redis_shard_ports is None:
+            redis_shard_ports = num_redis_shards * [None]
+        elif len(redis_shard_ports) != num_redis_shards:
+            raise Exception(
+                "The number of Redis shard ports does not match the "
+                "number of Redis shards.")
 
-        (self._redis_address, redis_shards,
-         process_infos) = ray.services.start_redis(
-             self._node_ip_address,
-             redis_log_files,
-             port=self._ray_params.redis_port,
-             redis_shard_ports=self._ray_params.redis_shard_ports,
-             num_redis_shards=self._ray_params.num_redis_shards,
-             redis_max_clients=self._ray_params.redis_max_clients,
-             redirect_worker_output=True,
-             password=self._ray_params.redis_password,
-             include_java=self._ray_params.include_java,
-             redis_max_memory=self._ray_params.redis_max_memory)
-        assert (
-            ray_constants.PROCESS_TYPE_REDIS_SERVER not in self.all_processes)
-        self.all_processes[ray_constants.PROCESS_TYPE_REDIS_SERVER] = (
-            process_infos)
+        use_credis = ("RAY_USE_NEW_GCS" in os.environ)
+        if use_credis:
+            if self.redis_password is not None:
+                # TODO(pschafhalter) remove this once credis supports
+                # authenticating Redis ports
+                raise Exception("Setting the `redis_password` argument is not "
+                                "supported in credis. To run Ray with "
+                                "password-protected Redis ports, ensure that "
+                                "the environment variable"
+                                "`RAY_USE_NEW_GCS=off`.")
+            assert num_redis_shards == 1, (
+                "For now, RAY_USE_NEW_GCS supports 1 shard, and credis "
+                "supports 1-node chain for that shard only.")
+
+        if use_credis:
+            redis_executable = CREDIS_EXECUTABLE
+            # TODO(suquark): We need credis here because some symbols need
+            # to be imported from credis dynamically through dlopen when Ray
+            # is built with RAY_USE_NEW_GCS=on. We should remove them later
+            # for the primary shard.
+            # See src/ray/gcs/redis_module/ray_redis_module.cc
+            redis_modules = [CREDIS_MASTER_MODULE, REDIS_MODULE]
+        else:
+            redis_executable = REDIS_EXECUTABLE
+            redis_modules = [REDIS_MODULE]
+
+        redis_stdout_file, redis_stderr_file = self.new_log_files("redis")
+        # Start the primary Redis shard.
+        port = self._start_redis_instance(
+            redis_executable,
+            modules=redis_modules,
+            port=self._ray_params.redis_port,
+            password=self.redis_password,
+            redis_max_clients=self._ray_params.redis_max_clients,
+            # Below we use None to indicate no limit on the memory of the
+            # primary Redis shard.
+            redis_max_memory=None,
+            stdout_file=redis_stdout_file,
+            stderr_file=redis_stderr_file)
+        self._redis_address = ray.services.address(self._node_ip_address, port)
+
+        # Register the number of Redis shards in the primary shard, so that clients
+        # know how many redis shards to expect under RedisShards.
+        primary_redis_client = self.create_redis_client()
+        primary_redis_client.set("NumRedisShards", str(num_redis_shards))
+
+        # Put the redirect_worker_output bool in the Redis shard so that workers
+        # can access it and know whether or not to redirect their output.
+        primary_redis_client.set("RedirectOutput", 1
+        if self._ray_params.redirect_worker_output else 0)
+
+        # put the include_java bool to primary redis-server, so that other nodes
+        # can access it and know whether or not to enable cross-languages.
+        primary_redis_client.set("INCLUDE_JAVA", 1
+        if self._ray_params.include_java else 0)
+
+        # Store version information in the primary Redis shard.
+        ray.services._put_version_info_in_redis(primary_redis_client)
+
+        # Calculate the redis memory.
+        redis_max_memory = self._ray_params.redis_max_memory
+        system_memory = ray.utils.get_system_memory()
+        if redis_max_memory is None:
+            redis_max_memory = min(
+                ray_constants.DEFAULT_REDIS_MAX_MEMORY_BYTES,
+                max(
+                    int(system_memory * 0.2),
+                    ray_constants.REDIS_MINIMUM_MEMORY_BYTES))
+        if redis_max_memory < ray_constants.REDIS_MINIMUM_MEMORY_BYTES:
+            raise ValueError(
+                "Attempting to cap Redis memory usage at {} bytes, "
+                "but the minimum allowed is {} bytes.".format(
+                    redis_max_memory,
+                    ray_constants.REDIS_MINIMUM_MEMORY_BYTES))
+
+        # Start other Redis shards. Each Redis shard logs to a separate file,
+        # prefixed by "redis-<shard number>".
+        redis_shards = []
+        for i in range(num_redis_shards):
+            redis_stdout_file, redis_stderr_file = self.new_log_files(
+                "redis-shard_" + str(i))
+            if use_credis:
+                redis_executable = CREDIS_EXECUTABLE
+                # It is important to load the credis module
+                # BEFORE the ray module, as the latter contains an extern
+                # declaration that the former supplies.
+                redis_modules = [CREDIS_MEMBER_MODULE, REDIS_MODULE]
+            else:
+                redis_executable = REDIS_EXECUTABLE
+                redis_modules = [REDIS_MODULE]
+
+            redis_shard_port = self._start_redis_instance(
+                redis_executable,
+                modules=redis_modules,
+                port=redis_shard_ports[i],
+                password=self.redis_password,
+                redis_max_clients=self._ray_params.redis_max_clients,
+                redis_max_memory=redis_max_memory,
+                stdout_file=redis_stdout_file,
+                stderr_file=redis_stderr_file)
+
+            shard_address = ray.services.address(
+                self._node_ip_address, redis_shard_port)
+            redis_shards.append(shard_address)
+            # Store redis shard information in the primary redis shard.
+            primary_redis_client.rpush("RedisShards", shard_address)
+
+        self._redis_shards = redis_shards
+
+        if use_credis:
+            # Configure the chain state. The way it is intended to work is
+            # the following:
+            #
+            # PRIMARY_SHARD
+            #
+            # SHARD_1 (master replica) -> SHARD_1 (member replica)
+            #                                        -> SHARD_1 (member replica)
+            #
+            # SHARD_2 (master replica) -> SHARD_2 (member replica)
+            #                                        -> SHARD_2 (member replica)
+            # ...
+            #
+            #
+            # If we have credis members in future, their modules should be:
+            # [CREDIS_MEMBER_MODULE, REDIS_MODULE],
+            # and they will be initialized by
+            # execute_command("MEMBER.CONNECT_TO_MASTER", node_ip_address, port)
+            #
+            # Currently we have num_redis_shards == 1, so only one chain will be
+            # created, and the chain only contains master.
+
+            # TODO(suquark): Currently, this is not correct because we are
+            # using the master replica as the primary shard. This should be
+            # fixed later. I had tried to fix it but failed because of heartbeat
+            # issues.
+            shard_client = redis.StrictRedis(
+                host=self._node_ip_address,
+                port=redis_shard_port,
+                password=self.redis_password)
+            primary_redis_client.execute_command("MASTER.ADD",
+                                                 self._node_ip_address,
+                                                 redis_shard_port)
+            shard_client.execute_command("MEMBER.CONNECT_TO_MASTER",
+                                         self._node_ip_address, port)
+
+    def _start_redis_instance(self,
+                              executable,
+                              modules,
+                              port=None,
+                              redis_max_clients=None,
+                              num_retries=20,
+                              stdout_file=None,
+                              stderr_file=None,
+                              password=None,
+                              redis_max_memory=None):
+        """Start a single Redis server.
+
+        Notes:
+            If "port" is not None, then we will only use this port and try
+            only once. Otherwise, random ports will be used and the maximum
+            retries count is "num_retries".
+
+        Args:
+            executable (str): Full path of the redis-server executable.
+            modules (list of str): A list of pathnames, pointing to the redis
+                module(s) that will be loaded in this redis server.
+            port (int): If provided, start a Redis server with this port.
+            redis_max_clients: If this is provided, Ray will attempt to configure
+                Redis with this maxclients number.
+            num_retries (int): The number of times to attempt to start Redis. If a
+                port is provided, this defaults to 1.
+            stdout_file: A file handle opened for writing to redirect stdout to. If
+                no redirection should happen, then this should be None.
+            stderr_file: A file handle opened for writing to redirect stderr to. If
+                no redirection should happen, then this should be None.
+            password (str): Prevents external clients without the password
+                from connecting to Redis if provided.
+            redis_max_memory: The max amount of memory (in bytes) to allow redis
+                to use, or None for no limit. Once the limit is exceeded, redis
+                will start LRU eviction of entries.
+
+        Returns:
+            A tuple of the port used by Redis and ProcessInfo for the process that
+                was started. If a port is passed in, then the returned port value
+                is the same.
+
+        Raises:
+            Exception: An exception is raised if Redis could not be started.
+        """
+        assert os.path.isfile(executable)
+        for module in modules:
+            assert os.path.isfile(module)
+        counter = 0
+        if port is not None:
+            # If a port is specified, then try only once to connect.
+            # This ensures that we will use the given port.
+            num_retries = 1
+        else:
+            port = ray.services.new_port()
+
+        load_module_args = []
+        for module in modules:
+            load_module_args += ["--loadmodule", module]
+
+        while counter < num_retries:
+            if counter > 0:
+                logger.warning("Redis failed to start, retrying now.")
+
+            # Construct the command to start the Redis server.
+            command = [executable]
+            if password:
+                command += ["--requirepass", password]
+            command += (
+                    ["--port", str(port), "--loglevel",
+                     "warning"] + load_module_args)
+            process_info = self._process_control.start_ray_process(
+                command,
+                ray_constants.PROCESS_TYPE_REDIS_SERVER,
+                stdout_file=stdout_file,
+                stderr_file=stderr_file)
+            time.sleep(0.1)
+            # Check if Redis successfully started (or at least if it the executable
+            # did not exit within 0.1 seconds).
+            if process_info.process.poll() is None:
+                break
+            port = ray.services.new_port()
+            counter += 1
+        if counter == num_retries:
+            raise Exception(
+                "Couldn't start Redis. Check log files: {} {}".format(
+                    stdout_file.name, stderr_file.name))
+
+        ray.services.setup_redis_instance(port, password, redis_max_memory,
+                                          redis_max_clients)
+
+        return port
 
     def start_log_monitor(self):
         """Start the log monitor."""
         stdout_file, stderr_file = self.new_log_files("log_monitor")
-        process_info = ray.services.start_log_monitor(
-            self.redis_address,
-            self._logs_dir,
-            stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            redis_password=self._ray_params.redis_password)
-        assert ray_constants.PROCESS_TYPE_LOG_MONITOR not in self.all_processes
-        self.all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] = [
-            process_info
+        log_monitor_filepath = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "log_monitor.py")
+        command = [
+            sys.executable, "-u", log_monitor_filepath,
+            "--redis-address={}".format(self._redis_address),
+            "--logs-dir={}".format(self._logs_dir)
         ]
+        if self.redis_password:
+            command += ["--redis-password", self.redis_password]
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_LOG_MONITOR,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file)
 
     def start_reporter(self):
         """Start the reporter."""
         stdout_file, stderr_file = self.new_log_files("reporter", True)
-        process_info = ray.services.start_reporter(
-            self.redis_address,
+        reporter_filepath = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "reporter.py")
+        command = [
+            sys.executable, "-u", reporter_filepath,
+            "--redis-address={}".format(self._redis_address)
+        ]
+        redis_password = self._ray_params.redis_password or ""
+        if redis_password:
+            command += ["--redis-password", redis_password]
+
+        try:
+            import psutil  # noqa: F401
+        except ImportError:
+            logger.warning(
+                "Failed to start the reporter. The reporter requires "
+                "'pip install psutil'.")
+            return None
+
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_REPORTER,
             stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            redis_password=self._ray_params.redis_password)
-        assert ray_constants.PROCESS_TYPE_REPORTER not in self.all_processes
-        if process_info is not None:
-            self.all_processes[ray_constants.PROCESS_TYPE_REPORTER] = [
-                process_info
-            ]
+            stderr_file=stderr_file)
 
     def start_dashboard(self):
         """Start the dashboard."""
+        if not PY3:
+            return None
         stdout_file, stderr_file = self.new_log_files("dashboard", True)
-        self._webui_url, process_info = ray.services.start_dashboard(
-            self.redis_address,
-            self._temp_dir,
+        port = ray.utils.get_next_available_socket(8080)
+        token = ray.utils.decode(binascii.hexlify(os.urandom(24)))
+
+        dashboard_filepath = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "dashboard/dashboard.py")
+        command = [
+            sys.executable,
+            "-u",
+            dashboard_filepath,
+            "--redis-address={}".format(self._redis_address),
+            "--http-port={}".format(port),
+            "--token={}".format(token),
+            "--temp-dir={}".format(self._temp_dir),
+        ]
+        if self.redis_password:
+            command += ["--redis-password", self.redis_password]
+
+        try:
+            import aiohttp  # noqa: F401
+            import psutil  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "Failed to start the dashboard. The dashboard requires "
+                "Python 3 as well as 'pip install aiohttp psutil'.")
+
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_DASHBOARD,
             stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            redis_password=self._ray_params.redis_password)
-        assert ray_constants.PROCESS_TYPE_DASHBOARD not in self.all_processes
-        if process_info is not None:
-            self.all_processes[ray_constants.PROCESS_TYPE_DASHBOARD] = [
-                process_info
-            ]
-            redis_client = self.create_redis_client()
-            redis_client.hmset("webui", {"url": self._webui_url})
+            stderr_file=stderr_file)
+        dashboard_url = "http://{}:{}/?token={}".format(
+            self._node_ip_address, port, token)
+        print("\n" + "=" * 70)
+        print("View the dashboard at {}".format(dashboard_url))
+        print("=" * 70 + "\n")
+        self._webui_url = dashboard_url
+        redis_client = self.create_redis_client()
+        redis_client.hmset("webui", {"url": self._webui_url})
 
     def start_plasma_store(self):
         """Start the plasma store."""
         stdout_file, stderr_file = self.new_log_files("plasma_store")
-        process_info = ray.services.start_plasma_store(
-            stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            object_store_memory=self._ray_params.object_store_memory,
-            plasma_directory=self._ray_params.plasma_directory,
-            huge_pages=self._ray_params.huge_pages,
-            plasma_store_socket_name=self._plasma_store_socket_name)
-        assert (
-            ray_constants.PROCESS_TYPE_PLASMA_STORE not in self.all_processes)
-        self.all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] = [
-            process_info
+        object_store_memory = self._ray_params.object_store_memory
+        plasma_directory = self._ray_params.plasma_directory
+        huge_pages = self._ray_params.huge_pages
+        plasma_store_socket_name = self._plasma_store_socket_name
+
+        object_store_memory, plasma_directory = (
+            ray.services.determine_plasma_store_config(
+                object_store_memory, plasma_directory, huge_pages))
+
+        # Print the object store memory using two decimal places.
+        object_store_memory_str = (object_store_memory / 10**7) / 10**2
+        logger.info("Starting the Plasma object store with {} GB memory "
+                    "using {}.".format(
+            round(object_store_memory_str, 2), plasma_directory))
+
+        if RUN_PLASMA_STORE_VALGRIND and RUN_PLASMA_STORE_PROFILER:
+            raise Exception(
+                "Cannot use valgrind and profiler at the same time.")
+
+        if huge_pages and not (sys.platform == "linux"
+                               or sys.platform == "linux2"):
+            raise Exception("The huge_pages argument is only supported on "
+                            "Linux.")
+
+        if huge_pages and plasma_directory is None:
+            raise Exception("If huge_pages is True, then the "
+                            "plasma_directory argument must be provided.")
+
+        if not isinstance(object_store_memory, int):
+            raise Exception("plasma_store_memory should be an integer.")
+
+        command = [
+            PLASMA_STORE_EXECUTABLE, "-s", plasma_store_socket_name, "-m",
+            str(object_store_memory)
         ]
+        if plasma_directory is not None:
+            command += ["-d", plasma_directory]
+        if huge_pages:
+            command += ["-h"]
+        # Start the Plasma store.
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_PLASMA_STORE,
+            use_valgrind=RUN_PLASMA_STORE_VALGRIND,
+            use_valgrind_profiler=RUN_PLASMA_STORE_PROFILER,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file)
 
     def start_raylet(self, use_valgrind=False, use_profiler=False):
         """Start the raylet.
@@ -428,31 +801,66 @@ class Node(object):
                 valgrind profiler.
         """
         stdout_file, stderr_file = self.new_log_files("raylet")
-        process_info = ray.services.start_raylet(
-            self._redis_address,
-            self._node_ip_address,
-            self._raylet_socket_name,
-            self._plasma_store_socket_name,
-            self._ray_params.worker_path,
-            self._temp_dir,
-            self._session_dir,
-            self._ray_params.num_cpus,
-            self._ray_params.num_gpus,
-            self._ray_params.resources,
-            self._ray_params.object_manager_port,
-            self._ray_params.node_manager_port,
-            self._ray_params.redis_password,
+        if use_valgrind and use_profiler:
+            raise Exception(
+                "Cannot use valgrind and profiler at the same time.")
+
+        num_cpus = self._ray_params.num_cpus
+        num_gpus = self._ray_params.num_gpus
+        cpu_count = multiprocessing.cpu_count()
+
+        num_initial_workers = (num_cpus if num_cpus is not None else cpu_count)
+
+        static_resources = ray.services.check_and_update_resources(
+            num_cpus, num_gpus, self._ray_params.resources)
+
+        # Limit the number of workers that can be started in parallel by the
+        # raylet. However, make sure it is at least 1.
+        num_cpus_static = static_resources.get("CPU", 0)
+        maximum_startup_concurrency = max(1, min(cpu_count, num_cpus_static))
+
+        # Format the resource argument in a form like 'CPU,1.0,GPU,0,Custom,3'.
+        resource_argument = ",".join(
+            ["{},{}".format(*kv) for kv in static_resources.items()])
+
+        python_worker_command = self._start_python_worker_command()
+        if self._ray_params.include_java:
+            java_worker_command = self._start_java_worker_command()
+        else:
+            java_worker_command = ""
+
+        gcs_ip_address, gcs_port = self._redis_address.split(":")
+
+        command = [
+            RAYLET_EXECUTABLE,
+            "--raylet_socket_name={}".format(self._raylet_socket_name),
+            "--store_socket_name={}".format(self._plasma_store_socket_name),
+            "--object_manager_port={}".format(
+                self._ray_params.object_manager_port),
+            "--node_manager_port={}".format(
+                self._ray_params.node_manager_port),
+            "--node_ip_address={}".format(self._node_ip_address),
+            "--redis_address={}".format(gcs_ip_address),
+            "--redis_port={}".format(gcs_port),
+            "--num_initial_workers={}".format(num_initial_workers),
+            "--maximum_startup_concurrency={}".format(
+                maximum_startup_concurrency),
+            "--static_resource_list={}".format(resource_argument),
+            "--config_list={}".format(self._get_config_list()),
+            "--python_worker_command={}".format(python_worker_command),
+            "--java_worker_command={}".format(java_worker_command),
+            "--redis_password={}".format(self.redis_password or ""),
+            "--temp_dir={}".format(self._temp_dir),
+        ]
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_RAYLET,
             use_valgrind=use_valgrind,
-            use_profiler=use_profiler,
+            use_gdb=False,
+            use_valgrind_profiler=use_profiler,
+            use_perftools_profiler=("RAYLET_PERFTOOLS_PATH" in os.environ),
             stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            config=self._config,
-            include_java=self._ray_params.include_java,
-            java_worker_options=self._ray_params.java_worker_options,
-            load_code_from_local=self._ray_params.load_code_from_local,
-        )
-        assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
-        self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]
+            stderr_file=stderr_file)
 
     def new_worker_redirected_log_file(self, worker_id):
         """Create new logging files for workers to redirect its output."""
@@ -460,36 +868,108 @@ class Node(object):
             "worker-" + ray.utils.binary_to_hex(worker_id), True))
         return worker_stdout_file, worker_stderr_file
 
-    def start_worker(self):
-        """Start a worker process."""
-        raise NotImplementedError
+    def _start_python_worker_command(self):
+        """Get the command to start the worker."""
+        command = [
+            sys.executable, "-u", self._ray_params.worker_path,
+            "--node-ip-address=" + self._node_ip_address,
+            "--object-store-name=" + self._plasma_store_socket_name,
+            "--raylet-name=" + self._raylet_socket_name,
+            "--redis-address=" + self._redis_address,
+            "--temp-dir=" + self._temp_dir
+        ]
+        if self.redis_password:
+            command += ["--redis_password={}".format(self.redis_password)]
+        if self.load_code_from_local:
+            command += ["--load-code-from-local"]
+        return command
+
+    def start_python_worker(self):
+        """Start a Python worker process."""
+        command = self._start_python_worker_command()
+        self._process_control.start_ray_process(
+            command, ray_constants.PROCESS_TYPE_WORKER)
+
+    def _start_java_worker_command(self):
+        """"""
+        assert self._ray_params.java_worker_options is not None
+        java_worker_options = self._ray_params.java_worker_options
+        command = [
+            "java", "-Dray.home={}".format(RAY_HOME),
+            "-Dray.log-dir={}".format(self._logs_dir),
+
+        ]
+        if self._redis_address is not None:
+            command.append(
+                "-Dray.redis.address={}".format(self._redis_address))
+
+        if self._plasma_store_socket_name is not None:
+            command.append("-Dray.object-store.socket-name={}".format(
+                self._plasma_store_socket_name))
+
+        if self._raylet_socket_name is not None:
+            command.append("-Dray.raylet.socket-name={}".format(
+                self._raylet_socket_name))
+
+        if self.redis_password is not None:
+            command.append("-Dray.redis.password={}".format(
+                self.redis_password))
+
+        if java_worker_options:
+            # Put `java_worker_options` in the last, so it can overwrite the
+            # above options.
+            command.append(java_worker_options)
+        command.append("org.ray.runtime.runner.worker.DefaultWorker")
+        return command
+
+    def start_java_worker(self):
+        """Start a Java worker process."""
+        command = self._start_java_worker_command()
+        self._process_control.start_ray_process(
+            command, ray_constants.PROCESS_TYPE_WORKER)
 
     def start_monitor(self):
         """Start the monitor."""
         stdout_file, stderr_file = self.new_log_files("monitor")
-        process_info = ray.services.start_monitor(
-            self._redis_address,
+        monitor_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "monitor.py")
+        command = [
+            sys.executable, "-u", monitor_path,
+            "--redis-address=" + str(self._redis_address)
+        ]
+        if self._ray_params.autoscaling_config:
+            command.append("--autoscaling-config=" + str(
+                self._ray_params.autoscaling_config))
+        if self._ray_params.redis_password:
+            command.append(
+                "--redis-password=" + self._ray_params.redis_password)
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_MONITOR,
             stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            autoscaling_config=self._ray_params.autoscaling_config,
-            redis_password=self._ray_params.redis_password)
-        assert ray_constants.PROCESS_TYPE_MONITOR not in self.all_processes
-        self.all_processes[ray_constants.PROCESS_TYPE_MONITOR] = [process_info]
+            stderr_file=stderr_file)
+
+    def _get_config_list(self):
+        config = self._config or {}
+        return ",".join(["{},{}".format(*kv) for kv in config.items()])
 
     def start_raylet_monitor(self):
-        """Start the raylet monitor."""
+        """Start the raylet monitor to monitor the other processes."""
         stdout_file, stderr_file = self.new_log_files("raylet_monitor")
-        process_info = ray.services.start_raylet_monitor(
-            self._redis_address,
-            stdout_file=stdout_file,
-            stderr_file=stderr_file,
-            redis_password=self._ray_params.redis_password,
-            config=self._config)
-        assert (ray_constants.PROCESS_TYPE_RAYLET_MONITOR not in
-                self.all_processes)
-        self.all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR] = [
-            process_info
+        gcs_ip_address, gcs_port = self._redis_address.split(":")
+        command = [
+            RAYLET_MONITOR_EXECUTABLE,
+            "--redis_address={}".format(gcs_ip_address),
+            "--redis_port={}".format(gcs_port),
+            "--config_list={}".format(self._get_config_list()),
         ]
+        if self.redis_password:
+            command += ["--redis_password={}".format(self.redis_password)]
+        self._process_control.start_ray_process(
+            command,
+            ray_constants.PROCESS_TYPE_RAYLET_MONITOR,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file)
 
     def start_head_processes(self):
         """Start head processes on the node."""
@@ -512,100 +992,12 @@ class Node(object):
                 self._logs_dir))
 
         self.start_plasma_store()
-        self.start_raylet()
+        self.start_raylet(use_valgrind=RUN_RAYLET_PROFILER)
         if PY3:
             self.start_reporter()
 
         if self._ray_params.include_log_monitor:
             self.start_log_monitor()
-
-    def _kill_process_type(self,
-                           process_type,
-                           allow_graceful=False,
-                           check_alive=True,
-                           wait=False):
-        """Kill a process of a given type.
-
-        If the process type is PROCESS_TYPE_REDIS_SERVER, then we will kill all
-        of the Redis servers.
-
-        If the process was started in valgrind, then we will raise an exception
-        if the process has a non-zero exit code.
-
-        Args:
-            process_type: The type of the process to kill.
-            allow_graceful (bool): Send a SIGTERM first and give the process
-                time to exit gracefully. If that doesn't work, then use
-                SIGKILL. We usually want to do this outside of tests.
-            check_alive (bool): If true, then we expect the process to be alive
-                and will raise an exception if the process is already dead.
-            wait (bool): If true, then this method will not return until the
-                process in question has exited.
-
-        Raises:
-            This process raises an exception in the following cases:
-                1. The process had already died and check_alive is true.
-                2. The process had been started in valgrind and had a non-zero
-                   exit code.
-        """
-        process_infos = self.all_processes[process_type]
-        if process_type != ray_constants.PROCESS_TYPE_REDIS_SERVER:
-            assert len(process_infos) == 1
-        for process_info in process_infos:
-            process = process_info.process
-            # Handle the case where the process has already exited.
-            if process.poll() is not None:
-                if check_alive:
-                    raise Exception("Attempting to kill a process of type "
-                                    "'{}', but this process is already dead."
-                                    .format(process_type))
-                else:
-                    continue
-
-            if process_info.use_valgrind:
-                process.terminate()
-                process.wait()
-                if process.returncode != 0:
-                    message = ("Valgrind detected some errors in process of "
-                               "type {}. Error code {}.".format(
-                                   process_type, process.returncode))
-                    if process_info.stdout_file is not None:
-                        with open(process_info.stdout_file, "r") as f:
-                            message += "\nPROCESS STDOUT:\n" + f.read()
-                    if process_info.stderr_file is not None:
-                        with open(process_info.stderr_file, "r") as f:
-                            message += "\nPROCESS STDERR:\n" + f.read()
-                    raise Exception(message)
-                continue
-
-            if process_info.use_valgrind_profiler:
-                # Give process signal to write profiler data.
-                os.kill(process.pid, signal.SIGINT)
-                # Wait for profiling data to be written.
-                time.sleep(0.1)
-
-            if allow_graceful:
-                # Allow the process one second to exit gracefully.
-                process.terminate()
-                timer = threading.Timer(1, lambda process: process.kill(),
-                                        [process])
-                try:
-                    timer.start()
-                    process.wait()
-                finally:
-                    timer.cancel()
-
-                if process.poll() is not None:
-                    continue
-
-            # If the process did not exit within one second, force kill it.
-            process.kill()
-            # The reason we usually don't call process.wait() here is that
-            # there's some chance we'd end up waiting a really long time.
-            if wait:
-                process.wait()
-
-        del self.all_processes[process_type]
 
     def kill_redis(self, check_alive=True):
         """Kill the Redis servers.
@@ -614,7 +1006,7 @@ class Node(object):
             check_alive (bool): Raise an exception if any of the processes
                 were already dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_REDIS_SERVER, check_alive=check_alive)
 
     def kill_plasma_store(self, check_alive=True):
@@ -624,7 +1016,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_PLASMA_STORE, check_alive=check_alive)
 
     def kill_raylet(self, check_alive=True):
@@ -634,7 +1026,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_RAYLET, check_alive=check_alive)
 
     def kill_log_monitor(self, check_alive=True):
@@ -644,7 +1036,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_LOG_MONITOR, check_alive=check_alive)
 
     def kill_reporter(self, check_alive=True):
@@ -656,7 +1048,7 @@ class Node(object):
         """
         # reporter is started only in PY3.
         if PY3:
-            self._kill_process_type(
+            self._process_control.kill_process_type(
                 ray_constants.PROCESS_TYPE_REPORTER, check_alive=check_alive)
 
     def kill_dashboard(self, check_alive=True):
@@ -666,7 +1058,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_DASHBOARD, check_alive=check_alive)
 
     def kill_monitor(self, check_alive=True):
@@ -676,7 +1068,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_MONITOR, check_alive=check_alive)
 
     def kill_raylet_monitor(self, check_alive=True):
@@ -686,7 +1078,7 @@ class Node(object):
             check_alive (bool): Raise an exception if the process was already
                 dead.
         """
-        self._kill_process_type(
+        self._process_control.kill_process_type(
             ray_constants.PROCESS_TYPE_RAYLET_MONITOR, check_alive=check_alive)
 
     def kill_all_processes(self, check_alive=True, allow_graceful=False):
@@ -699,24 +1091,7 @@ class Node(object):
             check_alive (bool): Raise an exception if any of the processes were
                 already dead.
         """
-        # Kill the raylet first. This is important for suppressing errors at
-        # shutdown because we give the raylet a chance to exit gracefully and
-        # clean up its child worker processes. If we were to kill the plasma
-        # store (or Redis) first, that could cause the raylet to exit
-        # ungracefully, leading to more verbose output from the workers.
-        if ray_constants.PROCESS_TYPE_RAYLET in self.all_processes:
-            self._kill_process_type(
-                ray_constants.PROCESS_TYPE_RAYLET,
-                check_alive=check_alive,
-                allow_graceful=allow_graceful)
-
-        # We call "list" to copy the keys because we are modifying the
-        # dictionary while iterating over it.
-        for process_type in list(self.all_processes.keys()):
-            self._kill_process_type(
-                process_type,
-                check_alive=check_alive,
-                allow_graceful=allow_graceful)
+        self._process_control.kill_all_processes(check_alive, allow_graceful)
 
     def live_processes(self):
         """Return a list of the live processes.
@@ -724,12 +1099,7 @@ class Node(object):
         Returns:
             A list of the live processes.
         """
-        result = []
-        for process_type, process_infos in self.all_processes.items():
-            for process_info in process_infos:
-                if process_info.process.poll() is None:
-                    result.append((process_type, process_info.process))
-        return result
+        return self._process_control.live_processes()
 
     def dead_processes(self):
         """Return a list of the dead processes.
@@ -741,12 +1111,7 @@ class Node(object):
             A list of the dead processes ignoring the ones that have been
                 explicitly killed.
         """
-        result = []
-        for process_type, process_infos in self.all_processes.items():
-            for process_info in process_infos:
-                if process_info.process.poll() is not None:
-                    result.append((process_type, process_info.process))
-        return result
+        return self._process_control.dead_processes()
 
     def any_processes_alive(self):
         """Return true if any processes are still alive.
@@ -754,7 +1119,7 @@ class Node(object):
         Returns:
             True if any process is still alive.
         """
-        return any(self.live_processes())
+        return self._process_control.any_processes_alive()
 
     def remaining_processes_alive(self):
         """Return true if all remaining processes are still alive.
@@ -765,7 +1130,7 @@ class Node(object):
         Returns:
             True if any process that wasn't explicitly killed is still alive.
         """
-        return not any(self.dead_processes())
+        return self._process_control.remaining_processes_alive()
 
 
 class LocalNode(object):

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import binascii
+import atexit
 import collections
 import json
 import logging
@@ -10,9 +10,11 @@ import multiprocessing
 import os
 import random
 import resource
+import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 import redis
 
@@ -20,47 +22,6 @@ import pyarrow
 # Ray modules
 import ray
 import ray.ray_constants as ray_constants
-
-# True if processes are run in the valgrind profiler.
-RUN_RAYLET_PROFILER = False
-RUN_PLASMA_STORE_PROFILER = False
-
-# Location of the redis server and module.
-RAY_HOME = os.path.join(os.path.dirname(__file__), "../..")
-REDIS_EXECUTABLE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/ray/thirdparty/redis/src/redis-server")
-REDIS_MODULE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/ray/gcs/redis_module/libray_redis_module.so")
-
-# Location of the credis server and modules.
-# credis will be enabled if the environment variable RAY_USE_NEW_GCS is set.
-CREDIS_EXECUTABLE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/credis/redis/src/redis-server")
-CREDIS_MASTER_MODULE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/credis/build/src/libmaster.so")
-CREDIS_MEMBER_MODULE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/credis/build/src/libmember.so")
-
-# Location of the plasma object store executable.
-PLASMA_STORE_EXECUTABLE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/plasma/plasma_store_server")
-
-# Location of the raylet executables.
-RAYLET_MONITOR_EXECUTABLE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)),
-    "core/src/ray/raylet/raylet_monitor")
-RAYLET_EXECUTABLE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "core/src/ray/raylet/raylet")
-
-DEFAULT_JAVA_WORKER_OPTIONS = "-classpath {}".format(
-    os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), "../../../build/java/*"))
 
 # Logger for this module. It should be configured at the entry point
 # into the program using Ray. Ray provides a default configuration at
@@ -71,6 +32,8 @@ ProcessInfo = collections.namedtuple("ProcessInfo", [
     "process", "stdout_file", "stderr_file", "use_valgrind", "use_gdb",
     "use_valgrind_profiler", "use_perftools_profiler", "use_tmux"
 ])
+
+ProcessProperty = collections.namedtuple("ProcessProperty", ["unique"])
 
 
 def address(ip_address, port):
@@ -242,140 +205,338 @@ def create_redis_client(redis_address, password=None):
         host=redis_ip_address, port=int(redis_port), password=password)
 
 
-def start_ray_process(command,
-                      process_type,
-                      env_updates=None,
-                      cwd=None,
-                      use_valgrind=False,
-                      use_gdb=False,
-                      use_valgrind_profiler=False,
-                      use_perftools_profiler=False,
-                      use_tmux=False,
-                      stdout_file=None,
-                      stderr_file=None):
-    """Start one of the Ray processes.
+class ProcessControl(object):
+    def __init__(self, shutdown_at_exit=True):
+        self._processes = collections.defaultdict(lambda :[])
+        self._process_types = {}
+        self._teardown_order = []
+        if shutdown_at_exit:
+            atexit.register(lambda: self.kill_all_processes(
+                check_alive=False, allow_graceful=True))
 
-    TODO(rkn): We need to figure out how these commands interact. For example,
-    it may only make sense to start a process in gdb if we also start it in
-    tmux. Similarly, certain combinations probably don't make sense, like
-    simultaneously running the process in valgrind and the profiler.
+    def set_teardown_order(self, order):
+        self._teardown_order = order
 
-    Args:
-        command (List[str]): The command to use to start the Ray process.
-        process_type (str): The type of the process that is being started
-            (e.g., "raylet").
-        env_updates (dict): A dictionary of additional environment variables to
-            run the command with (in addition to the caller's environment
-            variables).
-        cwd (str): The directory to run the process in.
-        use_valgrind (bool): True if we should start the process in valgrind.
-        use_gdb (bool): True if we should start the process in gdb.
-        use_valgrind_profiler (bool): True if we should start the process in
-            the valgrind profiler.
-        use_perftools_profiler (bool): True if we should profile the process
-            using perftools.
-        use_tmux (bool): True if we should start the process in tmux.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
+    def register_process_type(self, process_type, unique=False):
+        """Register a process type so that it can be managed"""
+        self._process_types[process_type] = ProcessProperty(unique=unique)
 
-    Returns:
-        Information about the process that was started including a handle to
-            the process that was started.
-    """
-    # Detect which flags are set through environment variables.
-    valgrind_env_var = "RAY_{}_VALGRIND".format(process_type.upper())
-    if os.environ.get(valgrind_env_var) == "1":
-        logger.info("Detected environment variable '%s'.", valgrind_env_var)
-        use_valgrind = True
-    valgrind_profiler_env_var = "RAY_{}_VALGRIND_PROFILER".format(
-        process_type.upper())
-    if os.environ.get(valgrind_profiler_env_var) == "1":
-        logger.info("Detected environment variable '%s'.",
-                    valgrind_profiler_env_var)
-        use_valgrind_profiler = True
-    perftools_profiler_env_var = "RAY_{}_PERFTOOLS_PROFILER".format(
-        process_type.upper())
-    if os.environ.get(perftools_profiler_env_var) == "1":
-        logger.info("Detected environment variable '%s'.",
-                    perftools_profiler_env_var)
-        use_perftools_profiler = True
-    tmux_env_var = "RAY_{}_TMUX".format(process_type.upper())
-    if os.environ.get(tmux_env_var) == "1":
-        logger.info("Detected environment variable '%s'.", tmux_env_var)
-        use_tmux = True
-    gdb_env_var = "RAY_{}_GDB".format(process_type.upper())
-    if os.environ.get(gdb_env_var) == "1":
-        logger.info("Detected environment variable '%s'.", gdb_env_var)
-        use_gdb = True
+    def add_process(self, process_type, process_info):
+        # We could also use a defaultdict for this.
+        self._processes[process_type].append(process_info)
 
-    if sum(
-        [use_gdb, use_valgrind, use_valgrind_profiler, use_perftools_profiler
-         ]) > 1:
-        raise ValueError(
-            "At most one of the 'use_gdb', 'use_valgrind', "
-            "'use_valgrind_profiler', and 'use_perftools_profiler' flags can "
-            "be used at a time.")
-    if env_updates is None:
-        env_updates = {}
-    if not isinstance(env_updates, dict):
-        raise ValueError("The 'env_updates' argument must be a dictionary.")
+    def exists_process_type(self, process_type):
+        return len(self._processes[process_type]) > 0
 
-    modified_env = os.environ.copy()
-    modified_env.update(env_updates)
+    def start_ray_process(self,
+                          command,
+                          process_type,
+                          env_updates=None,
+                          cwd=None,
+                          use_valgrind=False,
+                          use_gdb=False,
+                          use_valgrind_profiler=False,
+                          use_perftools_profiler=False,
+                          use_tmux=False,
+                          stdout_file=None,
+                          stderr_file=None):
+        """Start one of the Ray processes.
 
-    if use_gdb:
-        if not use_tmux:
+        TODO(rkn): We need to figure out how these commands interact. For example,
+        it may only make sense to start a process in gdb if we also start it in
+        tmux. Similarly, certain combinations probably don't make sense, like
+        simultaneously running the process in valgrind and the profiler.
+
+        Args:
+            command (List[str]): The command to use to start the Ray process.
+            process_type (str): The type of the process that is being started
+                (e.g., "raylet").
+            env_updates (dict): A dictionary of additional environment variables to
+                run the command with (in addition to the caller's environment
+                variables).
+            cwd (str): The directory to run the process in.
+            use_valgrind (bool): True if we should start the process in valgrind.
+            use_gdb (bool): True if we should start the process in gdb.
+            use_valgrind_profiler (bool): True if we should start the process in
+                the valgrind profiler.
+            use_perftools_profiler (bool): True if we should profile the process
+                using perftools.
+            use_tmux (bool): True if we should start the process in tmux.
+            stdout_file: A file handle opened for writing to redirect stdout to. If
+                no redirection should happen, then this should be None.
+            stderr_file: A file handle opened for writing to redirect stderr to. If
+                no redirection should happen, then this should be None.
+
+        Returns:
+            Information about the process that was started including a handle to
+                the process that was started.
+        """
+        if process_type not in self._process_types:
+            raise Exception("Unexcepted process type {}.".format(process_type))
+        if self._process_types[process_type].unique:
+            if len(self._processes[process_type]) > 0:
+                raise Exception("There has been a process instance.")
+        # Detect which flags are set through environment variables.
+        valgrind_env_var = "RAY_{}_VALGRIND".format(process_type.upper())
+        if os.environ.get(valgrind_env_var) == "1":
+            logger.info("Detected environment variable '%s'.",
+                        valgrind_env_var)
+            use_valgrind = True
+        valgrind_profiler_env_var = "RAY_{}_VALGRIND_PROFILER".format(
+            process_type.upper())
+        if os.environ.get(valgrind_profiler_env_var) == "1":
+            logger.info("Detected environment variable '%s'.",
+                        valgrind_profiler_env_var)
+            use_valgrind_profiler = True
+        perftools_profiler_env_var = "RAY_{}_PERFTOOLS_PROFILER".format(
+            process_type.upper())
+        if os.environ.get(perftools_profiler_env_var) == "1":
+            logger.info("Detected environment variable '%s'.",
+                        perftools_profiler_env_var)
+            use_perftools_profiler = True
+        tmux_env_var = "RAY_{}_TMUX".format(process_type.upper())
+        if os.environ.get(tmux_env_var) == "1":
+            logger.info("Detected environment variable '%s'.", tmux_env_var)
+            use_tmux = True
+        gdb_env_var = "RAY_{}_GDB".format(process_type.upper())
+        if os.environ.get(gdb_env_var) == "1":
+            logger.info("Detected environment variable '%s'.", gdb_env_var)
+            use_gdb = True
+
+        if sum(
+                [use_gdb, use_valgrind, use_valgrind_profiler,
+                 use_perftools_profiler
+                 ]) > 1:
             raise ValueError(
-                "If 'use_gdb' is true, then 'use_tmux' must be true as well.")
+                "At most one of the 'use_gdb', 'use_valgrind', "
+                "'use_valgrind_profiler', and 'use_perftools_profiler' flags can "
+                "be used at a time.")
+        if env_updates is None:
+            env_updates = {}
+        if not isinstance(env_updates, dict):
+            raise ValueError(
+                "The 'env_updates' argument must be a dictionary.")
 
-        # TODO(suquark): Any better temp file creation here?
-        gdb_init_path = "/tmp/ray/gdb_init_{}_{}".format(
-            process_type, time.time())
-        ray_process_path = command[0]
-        ray_process_args = command[1:]
-        run_args = " ".join(["'{}'".format(arg) for arg in ray_process_args])
-        with open(gdb_init_path, "w") as gdb_init_file:
-            gdb_init_file.write("run {}".format(run_args))
-        command = ["gdb", ray_process_path, "-x", gdb_init_path]
+        modified_env = os.environ.copy()
+        modified_env.update(env_updates)
 
-    if use_valgrind:
-        command = [
-            "valgrind", "--track-origins=yes", "--leak-check=full",
-            "--show-leak-kinds=all", "--leak-check-heuristics=stdstring",
-            "--error-exitcode=1"
-        ] + command
+        if use_gdb:
+            if not use_tmux:
+                raise ValueError(
+                    "If 'use_gdb' is true, then 'use_tmux' must be true as well.")
 
-    if use_valgrind_profiler:
-        command = ["valgrind", "--tool=callgrind"] + command
+            # TODO(suquark): Any better temp file creation here?
+            gdb_init_path = "/tmp/ray/gdb_init_{}_{}".format(
+                process_type, time.time())
+            ray_process_path = command[0]
+            ray_process_args = command[1:]
+            run_args = " ".join(
+                ["'{}'".format(arg) for arg in ray_process_args])
+            with open(gdb_init_path, "w") as gdb_init_file:
+                gdb_init_file.write("run {}".format(run_args))
+            command = ["gdb", ray_process_path, "-x", gdb_init_path]
 
-    if use_perftools_profiler:
-        modified_env["LD_PRELOAD"] = os.environ["PERFTOOLS_PATH"]
-        modified_env["CPUPROFILE"] = os.environ["PERFTOOLS_LOGFILE"]
+        if use_valgrind:
+            command = [
+                          "valgrind", "--track-origins=yes",
+                          "--leak-check=full",
+                          "--show-leak-kinds=all",
+                          "--leak-check-heuristics=stdstring",
+                          "--error-exitcode=1"
+                      ] + command
 
-    if use_tmux:
-        # The command has to be created exactly as below to ensure that it
-        # works on all versions of tmux. (Tested with tmux 1.8-5, travis'
-        # version, and tmux 2.1)
-        command = ["tmux", "new-session", "-d", "{}".format(" ".join(command))]
+        if use_valgrind_profiler:
+            command = ["valgrind", "--tool=callgrind"] + command
 
-    process = subprocess.Popen(
-        command,
-        env=modified_env,
-        cwd=cwd,
-        stdout=stdout_file,
-        stderr=stderr_file)
+        if use_perftools_profiler:
+            modified_env["LD_PRELOAD"] = os.environ["PERFTOOLS_PATH"]
+            modified_env["CPUPROFILE"] = os.environ["PERFTOOLS_LOGFILE"]
 
-    return ProcessInfo(
-        process=process,
-        stdout_file=stdout_file.name if stdout_file is not None else None,
-        stderr_file=stderr_file.name if stderr_file is not None else None,
-        use_valgrind=use_valgrind,
-        use_gdb=use_gdb,
-        use_valgrind_profiler=use_valgrind_profiler,
-        use_perftools_profiler=use_perftools_profiler,
-        use_tmux=use_tmux)
+        if use_tmux:
+            # The command has to be created exactly as below to ensure that it
+            # works on all versions of tmux. (Tested with tmux 1.8-5, travis'
+            # version, and tmux 2.1)
+            command = ["tmux", "new-session", "-d",
+                       "{}".format(" ".join(command))]
+
+        process = subprocess.Popen(
+            command,
+            env=modified_env,
+            cwd=cwd,
+            stdout=stdout_file,
+            stderr=stderr_file)
+
+        process_info = ProcessInfo(
+            process=process,
+            stdout_file=stdout_file.name if stdout_file is not None else None,
+            stderr_file=stderr_file.name if stderr_file is not None else None,
+            use_valgrind=use_valgrind,
+            use_gdb=use_gdb,
+            use_valgrind_profiler=use_valgrind_profiler,
+            use_perftools_profiler=use_perftools_profiler,
+            use_tmux=use_tmux)
+        self._processes[process_type].append(process_info)
+        return process_info
+
+    def kill_process_type(self,
+                          process_type,
+                          allow_graceful=False,
+                          check_alive=True,
+                          wait=False):
+        """Kill a process of a given type.
+
+        If the process type is PROCESS_TYPE_REDIS_SERVER, then we will kill all
+        of the Redis servers.
+
+        If the process was started in valgrind, then we will raise an exception
+        if the process has a non-zero exit code.
+
+        Args:
+            process_type: The type of the process to kill.
+            allow_graceful (bool): Send a SIGTERM first and give the process
+                time to exit gracefully. If that doesn't work, then use
+                SIGKILL. We usually want to do this outside of tests.
+            check_alive (bool): If true, then we expect the process to be alive
+                and will raise an exception if the process is already dead.
+            wait (bool): If true, then this method will not return until the
+                process in question has exited.
+
+        Raises:
+            This process raises an exception in the following cases:
+                1. The process had already died and check_alive is true.
+                2. The process had been started in valgrind and had a non-zero
+                   exit code.
+        """
+        process_infos = self._processes[process_type]
+        for process_info in process_infos:
+            process = process_info.process
+            # Handle the case where the process has already exited.
+            if process.poll() is not None:
+                if check_alive:
+                    raise Exception("Attempting to kill a process of type "
+                                    "'{}', but this process is already dead."
+                                    .format(process_type))
+                else:
+                    continue
+
+            if process_info.use_valgrind:
+                process.terminate()
+                process.wait()
+                if process.returncode != 0:
+                    message = ("Valgrind detected some errors in process of "
+                               "type {}. Error code {}.".format(
+                                   process_type, process.returncode))
+                    if process_info.stdout_file is not None:
+                        with open(process_info.stdout_file, "r") as f:
+                            message += "\nPROCESS STDOUT:\n" + f.read()
+                    if process_info.stderr_file is not None:
+                        with open(process_info.stderr_file, "r") as f:
+                            message += "\nPROCESS STDERR:\n" + f.read()
+                    raise Exception(message)
+                continue
+
+            if process_info.use_valgrind_profiler:
+                # Give process signal to write profiler data.
+                os.kill(process.pid, signal.SIGINT)
+                # Wait for profiling data to be written.
+                time.sleep(0.1)
+
+            if allow_graceful:
+                # Allow the process one second to exit gracefully.
+                process.terminate()
+                timer = threading.Timer(1, lambda process: process.kill(),
+                                        [process])
+                try:
+                    timer.start()
+                    process.wait()
+                finally:
+                    timer.cancel()
+
+                if process.poll() is not None:
+                    continue
+
+            # If the process did not exit within one second, force kill it.
+            process.kill()
+            # The reason we usually don't call process.wait() here is that
+            # there's some chance we'd end up waiting a really long time.
+            if wait:
+                process.wait()
+
+        del self._processes[process_type]
+
+    def kill_all_processes(self, check_alive=True, allow_graceful=False):
+        """Kill all of the processes.
+
+        Note that This is slower than necessary because it calls kill, wait,
+        kill, wait, ... instead of kill, kill, ..., wait, wait, ...
+
+        Args:
+            check_alive (bool): Raise an exception if any of the processes were
+                already dead.
+        """
+        for process_type in self._teardown_order:
+            if process_type in self._processes:
+                self.kill_process_type(
+                    process_type,
+                    check_alive=check_alive,
+                    allow_graceful=allow_graceful)
+
+        # We call "list" to copy the keys because we are modifying the
+        # dictionary while iterating over it.
+        for process_type in list(self._processes.keys()):
+            self.kill_process_type(
+                process_type,
+                check_alive=check_alive,
+                allow_graceful=allow_graceful)
+
+    def live_processes(self):
+        """Return a list of the live processes.
+
+        Returns:
+            A list of the live processes.
+        """
+        result = []
+        for process_type, process_infos in self._processes.items():
+            for process_info in process_infos:
+                if process_info.process.poll() is None:
+                    result.append((process_type, process_info.process))
+        return result
+
+    def dead_processes(self):
+        """Return a list of the dead processes.
+
+        Note that this ignores processes that have been explicitly killed,
+        e.g., via a command like node.kill_raylet().
+
+        Returns:
+            A list of the dead processes ignoring the ones that have been
+                explicitly killed.
+        """
+        result = []
+        for process_type, process_infos in self._processes.items():
+            for process_info in process_infos:
+                if process_info.process.poll() is not None:
+                    result.append((process_type, process_info.process))
+        return result
+
+    def any_processes_alive(self):
+        """Return true if any processes are still alive.
+
+        Returns:
+            True if any process is still alive.
+        """
+        return any(self.live_processes())
+
+    def remaining_processes_alive(self):
+        """Return true if all remaining processes are still alive.
+
+        Note that this ignores processes that have been explicitly killed,
+        e.g., via a command like node.kill_raylet().
+
+        Returns:
+            True if any process that wasn't explicitly killed is still alive.
+        """
+        return not any(self.dead_processes())
 
 
 def wait_for_redis_to_start(redis_ip_address,
@@ -498,292 +659,9 @@ def check_version_info(redis_client):
             logger.warning(error_message)
 
 
-def start_redis(node_ip_address,
-                redirect_files,
-                port=None,
-                redis_shard_ports=None,
-                num_redis_shards=1,
-                redis_max_clients=None,
-                redirect_worker_output=False,
-                password=None,
-                use_credis=None,
-                redis_max_memory=None,
-                include_java=False):
-    """Start the Redis global state store.
-
-    Args:
-        node_ip_address: The IP address of the current node. This is only used
-            for recording the log filenames in Redis.
-        redirect_files: The list of (stdout, stderr) file pairs.
-        port (int): If provided, the primary Redis shard will be started on
-            this port.
-        redis_shard_ports: A list of the ports to use for the non-primary Redis
-            shards.
-        num_redis_shards (int): If provided, the number of Redis shards to
-            start, in addition to the primary one. The default value is one
-            shard.
-        redis_max_clients: If this is provided, Ray will attempt to configure
-            Redis with this maxclients number.
-        redirect_worker_output (bool): True if worker output should be
-            redirected to a file and false otherwise. Workers will have access
-            to this value when they start up.
-        password (str): Prevents external clients without the password
-            from connecting to Redis if provided.
-        use_credis: If True, additionally load the chain-replicated libraries
-            into the redis servers.  Defaults to None, which means its value is
-            set by the presence of "RAY_USE_NEW_GCS" in os.environ.
-        redis_max_memory: The max amount of memory (in bytes) to allow each
-            redis shard to use. Once the limit is exceeded, redis will start
-            LRU eviction of entries. This only applies to the sharded redis
-            tables (task, object, and profile tables). By default, this is
-            capped at 10GB but can be set higher.
-        include_java (bool): If True, the raylet backend can also support
-            Java worker.
-
-    Returns:
-        A tuple of the address for the primary Redis shard, a list of
-            addresses for the remaining shards, and the processes that were
-            started.
-    """
-
-    if len(redirect_files) != 1 + num_redis_shards:
-        raise ValueError("The number of redirect file pairs should be equal "
-                         "to the number of redis shards (including the "
-                         "primary shard) we will start.")
-    if redis_shard_ports is None:
-        redis_shard_ports = num_redis_shards * [None]
-    elif len(redis_shard_ports) != num_redis_shards:
-        raise Exception("The number of Redis shard ports does not match the "
-                        "number of Redis shards.")
-
-    processes = []
-
-    if use_credis is None:
-        use_credis = ("RAY_USE_NEW_GCS" in os.environ)
-    if use_credis:
-        if password is not None:
-            # TODO(pschafhalter) remove this once credis supports
-            # authenticating Redis ports
-            raise Exception("Setting the `redis_password` argument is not "
-                            "supported in credis. To run Ray with "
-                            "password-protected Redis ports, ensure that "
-                            "the environment variable `RAY_USE_NEW_GCS=off`.")
-        assert num_redis_shards == 1, (
-            "For now, RAY_USE_NEW_GCS supports 1 shard, and credis "
-            "supports 1-node chain for that shard only.")
-
-    if use_credis:
-        redis_executable = CREDIS_EXECUTABLE
-        # TODO(suquark): We need credis here because some symbols need to be
-        # imported from credis dynamically through dlopen when Ray is built
-        # with RAY_USE_NEW_GCS=on. We should remove them later for the primary
-        # shard.
-        # See src/ray/gcs/redis_module/ray_redis_module.cc
-        redis_modules = [CREDIS_MASTER_MODULE, REDIS_MODULE]
-    else:
-        redis_executable = REDIS_EXECUTABLE
-        redis_modules = [REDIS_MODULE]
-
-    redis_stdout_file, redis_stderr_file = redirect_files[0]
-    # Start the primary Redis shard.
-    port, p = _start_redis_instance(
-        redis_executable,
-        modules=redis_modules,
-        port=port,
-        password=password,
-        redis_max_clients=redis_max_clients,
-        # Below we use None to indicate no limit on the memory of the
-        # primary Redis shard.
-        redis_max_memory=None,
-        stdout_file=redis_stdout_file,
-        stderr_file=redis_stderr_file)
-    processes.append(p)
-    redis_address = address(node_ip_address, port)
-
-    # Register the number of Redis shards in the primary shard, so that clients
-    # know how many redis shards to expect under RedisShards.
-    primary_redis_client = redis.StrictRedis(
-        host=node_ip_address, port=port, password=password)
-    primary_redis_client.set("NumRedisShards", str(num_redis_shards))
-
-    # Put the redirect_worker_output bool in the Redis shard so that workers
-    # can access it and know whether or not to redirect their output.
-    primary_redis_client.set("RedirectOutput", 1
-                             if redirect_worker_output else 0)
-
-    # put the include_java bool to primary redis-server, so that other nodes
-    # can access it and know whether or not to enable cross-languages.
-    primary_redis_client.set("INCLUDE_JAVA", 1 if include_java else 0)
-
-    # Store version information in the primary Redis shard.
-    _put_version_info_in_redis(primary_redis_client)
-
-    # Calculate the redis memory.
-    system_memory = ray.utils.get_system_memory()
-    if redis_max_memory is None:
-        redis_max_memory = min(
-            ray_constants.DEFAULT_REDIS_MAX_MEMORY_BYTES,
-            max(
-                int(system_memory * 0.2),
-                ray_constants.REDIS_MINIMUM_MEMORY_BYTES))
-    if redis_max_memory < ray_constants.REDIS_MINIMUM_MEMORY_BYTES:
-        raise ValueError("Attempting to cap Redis memory usage at {} bytes, "
-                         "but the minimum allowed is {} bytes.".format(
-                             redis_max_memory,
-                             ray_constants.REDIS_MINIMUM_MEMORY_BYTES))
-
-    # Start other Redis shards. Each Redis shard logs to a separate file,
-    # prefixed by "redis-<shard number>".
-    redis_shards = []
-    for i in range(num_redis_shards):
-        redis_stdout_file, redis_stderr_file = redirect_files[i + 1]
-        if use_credis:
-            redis_executable = CREDIS_EXECUTABLE
-            # It is important to load the credis module BEFORE the ray module,
-            # as the latter contains an extern declaration that the former
-            # supplies.
-            redis_modules = [CREDIS_MEMBER_MODULE, REDIS_MODULE]
-        else:
-            redis_executable = REDIS_EXECUTABLE
-            redis_modules = [REDIS_MODULE]
-
-        redis_shard_port, p = _start_redis_instance(
-            redis_executable,
-            modules=redis_modules,
-            port=redis_shard_ports[i],
-            password=password,
-            redis_max_clients=redis_max_clients,
-            redis_max_memory=redis_max_memory,
-            stdout_file=redis_stdout_file,
-            stderr_file=redis_stderr_file)
-        processes.append(p)
-
-        shard_address = address(node_ip_address, redis_shard_port)
-        redis_shards.append(shard_address)
-        # Store redis shard information in the primary redis shard.
-        primary_redis_client.rpush("RedisShards", shard_address)
-
-    if use_credis:
-        # Configure the chain state. The way it is intended to work is
-        # the following:
-        #
-        # PRIMARY_SHARD
-        #
-        # SHARD_1 (master replica) -> SHARD_1 (member replica)
-        #                                        -> SHARD_1 (member replica)
-        #
-        # SHARD_2 (master replica) -> SHARD_2 (member replica)
-        #                                        -> SHARD_2 (member replica)
-        # ...
-        #
-        #
-        # If we have credis members in future, their modules should be:
-        # [CREDIS_MEMBER_MODULE, REDIS_MODULE], and they will be initialized by
-        # execute_command("MEMBER.CONNECT_TO_MASTER", node_ip_address, port)
-        #
-        # Currently we have num_redis_shards == 1, so only one chain will be
-        # created, and the chain only contains master.
-
-        # TODO(suquark): Currently, this is not correct because we are
-        # using the master replica as the primary shard. This should be
-        # fixed later. I had tried to fix it but failed because of heartbeat
-        # issues.
-        primary_client = redis.StrictRedis(
-            host=node_ip_address, port=port, password=password)
-        shard_client = redis.StrictRedis(
-            host=node_ip_address, port=redis_shard_port, password=password)
-        primary_client.execute_command("MASTER.ADD", node_ip_address,
-                                       redis_shard_port)
-        shard_client.execute_command("MEMBER.CONNECT_TO_MASTER",
-                                     node_ip_address, port)
-
-    return redis_address, redis_shards, processes
-
-
-def _start_redis_instance(executable,
-                          modules,
-                          port=None,
-                          redis_max_clients=None,
-                          num_retries=20,
-                          stdout_file=None,
-                          stderr_file=None,
-                          password=None,
-                          redis_max_memory=None):
-    """Start a single Redis server.
-
-    Notes:
-        If "port" is not None, then we will only use this port and try
-        only once. Otherwise, random ports will be used and the maximum
-        retries count is "num_retries".
-
-    Args:
-        executable (str): Full path of the redis-server executable.
-        modules (list of str): A list of pathnames, pointing to the redis
-            module(s) that will be loaded in this redis server.
-        port (int): If provided, start a Redis server with this port.
-        redis_max_clients: If this is provided, Ray will attempt to configure
-            Redis with this maxclients number.
-        num_retries (int): The number of times to attempt to start Redis. If a
-            port is provided, this defaults to 1.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        password (str): Prevents external clients without the password
-            from connecting to Redis if provided.
-        redis_max_memory: The max amount of memory (in bytes) to allow redis
-            to use, or None for no limit. Once the limit is exceeded, redis
-            will start LRU eviction of entries.
-
-    Returns:
-        A tuple of the port used by Redis and ProcessInfo for the process that
-            was started. If a port is passed in, then the returned port value
-            is the same.
-
-    Raises:
-        Exception: An exception is raised if Redis could not be started.
-    """
-    assert os.path.isfile(executable)
-    for module in modules:
-        assert os.path.isfile(module)
-    counter = 0
-    if port is not None:
-        # If a port is specified, then try only once to connect.
-        # This ensures that we will use the given port.
-        num_retries = 1
-    else:
-        port = new_port()
-
-    load_module_args = []
-    for module in modules:
-        load_module_args += ["--loadmodule", module]
-
-    while counter < num_retries:
-        if counter > 0:
-            logger.warning("Redis failed to start, retrying now.")
-
-        # Construct the command to start the Redis server.
-        command = [executable]
-        if password:
-            command += ["--requirepass", password]
-        command += (
-            ["--port", str(port), "--loglevel", "warning"] + load_module_args)
-        process_info = start_ray_process(
-            command,
-            ray_constants.PROCESS_TYPE_REDIS_SERVER,
-            stdout_file=stdout_file,
-            stderr_file=stderr_file)
-        time.sleep(0.1)
-        # Check if Redis successfully started (or at least if it the executable
-        # did not exit within 0.1 seconds).
-        if process_info.process.poll() is None:
-            break
-        port = new_port()
-        counter += 1
-    if counter == num_retries:
-        raise Exception("Couldn't start Redis. Check log files: {} {}".format(
-            stdout_file.name, stderr_file.name))
-
+def setup_redis_instance(port, password,
+                         redis_max_memory=None,
+                         redis_max_clients=None):
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(
         host="127.0.0.1", port=port, password=password)
@@ -838,153 +716,6 @@ def _start_redis_instance(executable,
                             " ".join(cur_config_list))
     # Put a time stamp in Redis to indicate when it was started.
     redis_client.set("redis_start_time", time.time())
-    return port, process_info
-
-
-def start_log_monitor(redis_address,
-                      logs_dir,
-                      stdout_file=None,
-                      stderr_file=None,
-                      redis_password=None):
-    """Start a log monitor process.
-
-    Args:
-        redis_address (str): The address of the Redis instance.
-        logs_dir (str): The directory of logging files.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        redis_password (str): The password of the redis server.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    log_monitor_filepath = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "log_monitor.py")
-    command = [
-        sys.executable, "-u", log_monitor_filepath,
-        "--redis-address={}".format(redis_address),
-        "--logs-dir={}".format(logs_dir)
-    ]
-    if redis_password:
-        command += ["--redis-password", redis_password]
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_LOG_MONITOR,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
-
-
-def start_reporter(redis_address,
-                   stdout_file=None,
-                   stderr_file=None,
-                   redis_password=None):
-    """Start a reporter process.
-
-    Args:
-        redis_address (str): The address of the Redis instance.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        redis_password (str): The password of the redis server.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    reporter_filepath = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "reporter.py")
-    command = [
-        sys.executable, "-u", reporter_filepath,
-        "--redis-address={}".format(redis_address)
-    ]
-    if redis_password:
-        command += ["--redis-password", redis_password]
-
-    try:
-        import psutil  # noqa: F401
-    except ImportError:
-        logger.warning("Failed to start the reporter. The reporter requires "
-                       "'pip install psutil'.")
-        return None
-
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_REPORTER,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
-
-
-def start_dashboard(redis_address,
-                    temp_dir,
-                    stdout_file=None,
-                    stderr_file=None,
-                    redis_password=None):
-    """Start a dashboard process.
-
-    Args:
-        redis_address (str): The address of the Redis instance.
-        temp_dir (str): The temporary directory used for log files and
-            information for this Ray session.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        redis_password (str): The password of the redis server.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    port = 8080
-    while True:
-        try:
-            port_test_socket = socket.socket()
-            port_test_socket.bind(("127.0.0.1", port))
-            port_test_socket.close()
-            break
-        except socket.error:
-            port += 1
-
-    token = ray.utils.decode(binascii.hexlify(os.urandom(24)))
-
-    dashboard_filepath = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "dashboard/dashboard.py")
-    command = [
-        sys.executable,
-        "-u",
-        dashboard_filepath,
-        "--redis-address={}".format(redis_address),
-        "--http-port={}".format(port),
-        "--token={}".format(token),
-        "--temp-dir={}".format(temp_dir),
-    ]
-    if redis_password:
-        command += ["--redis-password", redis_password]
-
-    if sys.version_info <= (3, 0):
-        return None, None
-    try:
-        import aiohttp  # noqa: F401
-        import psutil  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "Failed to start the dashboard. The dashboard requires Python 3 "
-            "as well as 'pip install aiohttp psutil'.")
-
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_DASHBOARD,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    dashboard_url = "http://{}:{}/?token={}".format(
-        ray.services.get_node_ip_address(), port, token)
-    print("\n" + "=" * 70)
-    print("View the dashboard at {}".format(dashboard_url))
-    print("=" * 70 + "\n")
-    return dashboard_url, process_info
 
 
 def check_and_update_resources(num_cpus, num_gpus, resources):
@@ -1055,206 +786,6 @@ def check_and_update_resources(num_cpus, num_gpus, resources):
                 ray_constants.MAX_RESOURCE_QUANTITY))
 
     return resources
-
-
-def start_raylet(redis_address,
-                 node_ip_address,
-                 raylet_name,
-                 plasma_store_name,
-                 worker_path,
-                 temp_dir,
-                 session_dir,
-                 num_cpus=None,
-                 num_gpus=None,
-                 resources=None,
-                 object_manager_port=None,
-                 node_manager_port=None,
-                 redis_password=None,
-                 use_valgrind=False,
-                 use_profiler=False,
-                 stdout_file=None,
-                 stderr_file=None,
-                 config=None,
-                 include_java=False,
-                 java_worker_options=None,
-                 load_code_from_local=False):
-    """Start a raylet, which is a combined local scheduler and object manager.
-
-    Args:
-        redis_address (str): The address of the primary Redis server.
-        node_ip_address (str): The IP address of this node.
-        raylet_name (str): The name of the raylet socket to create.
-        plasma_store_name (str): The name of the plasma store socket to connect
-             to.
-        worker_path (str): The path of the Python file that new worker
-            processes will execute.
-        temp_dir (str): The path of the temporary directory Ray will use.
-        session_dir (str): The path of this session.
-        num_cpus: The CPUs allocated for this raylet.
-        num_gpus: The GPUs allocated for this raylet.
-        resources: The custom resources allocated for this raylet.
-        object_manager_port: The port to use for the object manager. If this is
-            None, then the object manager will choose its own port.
-        node_manager_port: The port to use for the node manager. If this is
-            None, then the node manager will choose its own port.
-        redis_password: The password to use when connecting to Redis.
-        use_valgrind (bool): True if the raylet should be started inside
-            of valgrind. If this is True, use_profiler must be False.
-        use_profiler (bool): True if the raylet should be started inside
-            a profiler. If this is True, use_valgrind must be False.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        config (dict|None): Optional Raylet configuration that will
-            override defaults in RayConfig.
-        include_java (bool): If True, the raylet backend can also support
-            Java worker.
-        java_worker_options (str): The command options for Java worker.
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    config = config or {}
-    config_str = ",".join(["{},{}".format(*kv) for kv in config.items()])
-
-    if use_valgrind and use_profiler:
-        raise Exception("Cannot use valgrind and profiler at the same time.")
-
-    num_initial_workers = (num_cpus if num_cpus is not None else
-                           multiprocessing.cpu_count())
-
-    static_resources = check_and_update_resources(num_cpus, num_gpus,
-                                                  resources)
-
-    # Limit the number of workers that can be started in parallel by the
-    # raylet. However, make sure it is at least 1.
-    num_cpus_static = static_resources.get("CPU", 0)
-    maximum_startup_concurrency = max(
-        1, min(multiprocessing.cpu_count(), num_cpus_static))
-
-    # Format the resource argument in a form like 'CPU,1.0,GPU,0,Custom,3'.
-    resource_argument = ",".join(
-        ["{},{}".format(*kv) for kv in static_resources.items()])
-
-    gcs_ip_address, gcs_port = redis_address.split(":")
-
-    if include_java is True:
-        java_worker_options = (java_worker_options
-                               or DEFAULT_JAVA_WORKER_OPTIONS)
-        java_worker_command = build_java_worker_command(
-            java_worker_options,
-            redis_address,
-            plasma_store_name,
-            raylet_name,
-            redis_password,
-            session_dir,
-        )
-    else:
-        java_worker_command = ""
-
-    # Create the command that the Raylet will use to start workers.
-    start_worker_command = ("{} {} "
-                            "--node-ip-address={} "
-                            "--object-store-name={} "
-                            "--raylet-name={} "
-                            "--redis-address={} "
-                            "--temp-dir={}".format(
-                                sys.executable, worker_path, node_ip_address,
-                                plasma_store_name, raylet_name, redis_address,
-                                temp_dir))
-    if redis_password:
-        start_worker_command += " --redis-password {}".format(redis_password)
-
-    # If the object manager port is None, then use 0 to cause the object
-    # manager to choose its own port.
-    if object_manager_port is None:
-        object_manager_port = 0
-    # If the node manager port is None, then use 0 to cause the node manager
-    # to choose its own port.
-    if node_manager_port is None:
-        node_manager_port = 0
-
-    if load_code_from_local:
-        start_worker_command += " --load-code-from-local "
-
-    command = [
-        RAYLET_EXECUTABLE,
-        "--raylet_socket_name={}".format(raylet_name),
-        "--store_socket_name={}".format(plasma_store_name),
-        "--object_manager_port={}".format(object_manager_port),
-        "--node_manager_port={}".format(node_manager_port),
-        "--node_ip_address={}".format(node_ip_address),
-        "--redis_address={}".format(gcs_ip_address),
-        "--redis_port={}".format(gcs_port),
-        "--num_initial_workers={}".format(num_initial_workers),
-        "--maximum_startup_concurrency={}".format(maximum_startup_concurrency),
-        "--static_resource_list={}".format(resource_argument),
-        "--config_list={}".format(config_str),
-        "--python_worker_command={}".format(start_worker_command),
-        "--java_worker_command={}".format(java_worker_command),
-        "--redis_password={}".format(redis_password or ""),
-        "--temp_dir={}".format(temp_dir),
-    ]
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_RAYLET,
-        use_valgrind=use_valgrind,
-        use_gdb=False,
-        use_valgrind_profiler=use_profiler,
-        use_perftools_profiler=("RAYLET_PERFTOOLS_PATH" in os.environ),
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-
-    return process_info
-
-
-def build_java_worker_command(
-        java_worker_options,
-        redis_address,
-        plasma_store_name,
-        raylet_name,
-        redis_password,
-        session_dir,
-):
-    """This method assembles the command used to start a Java worker.
-
-    Args:
-        java_worker_options (str): The command options for Java worker.
-        redis_address (str): Redis address of GCS.
-        plasma_store_name (str): The name of the plasma store socket to connect
-           to.
-        raylet_name (str): The name of the raylet socket to create.
-        redis_password (str): The password of connect to redis.
-        session_dir (str): The path of this session.
-    Returns:
-        The command string for starting Java worker.
-    """
-    assert java_worker_options is not None
-
-    command = "java ".format(java_worker_options)
-    if redis_address is not None:
-        command += "-Dray.redis.address={} ".format(redis_address)
-
-    if plasma_store_name is not None:
-        command += (
-            "-Dray.object-store.socket-name={} ".format(plasma_store_name))
-
-    if raylet_name is not None:
-        command += "-Dray.raylet.socket-name={} ".format(raylet_name)
-
-    if redis_password is not None:
-        command += "-Dray.redis.password={} ".format(redis_password)
-
-    command += "-Dray.home={} ".format(RAY_HOME)
-    command += "-Dray.log-dir={} ".format(os.path.join(session_dir, "logs"))
-
-    if java_worker_options:
-        # Put `java_worker_options` in the last, so it can overwrite the
-        # above options.
-        command += java_worker_options + " "
-    command += "org.ray.runtime.runner.worker.DefaultWorker"
-
-    return command
 
 
 def determine_plasma_store_config(object_store_memory=None,
@@ -1335,238 +866,11 @@ def determine_plasma_store_config(object_store_memory=None,
             "The file {} does not exist or is not a directory.".format(
                 plasma_directory))
 
-    return object_store_memory, plasma_directory
-
-
-def _start_plasma_store(plasma_store_memory,
-                        use_valgrind=False,
-                        use_profiler=False,
-                        stdout_file=None,
-                        stderr_file=None,
-                        plasma_directory=None,
-                        huge_pages=False,
-                        socket_name=None):
-    """Start a plasma store process.
-
-    Args:
-        plasma_store_memory (int): The amount of memory in bytes to start the
-            plasma store with.
-        use_valgrind (bool): True if the plasma store should be started inside
-            of valgrind. If this is True, use_profiler must be False.
-        use_profiler (bool): True if the plasma store should be started inside
-            a profiler. If this is True, use_valgrind must be False.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        plasma_directory: A directory where the Plasma memory mapped files will
-            be created.
-        huge_pages: a boolean flag indicating whether to start the
-            Object Store with hugetlbfs support. Requires plasma_directory.
-        socket_name (str): If provided, it will specify the socket
-            name used by the plasma store.
-
-    Return:
-        A tuple of the name of the plasma store socket and ProcessInfo for the
-            plasma store process.
-    """
-    if use_valgrind and use_profiler:
-        raise Exception("Cannot use valgrind and profiler at the same time.")
-
-    if huge_pages and not (sys.platform == "linux"
-                           or sys.platform == "linux2"):
-        raise Exception("The huge_pages argument is only supported on "
-                        "Linux.")
-
-    if huge_pages and plasma_directory is None:
-        raise Exception("If huge_pages is True, then the "
-                        "plasma_directory argument must be provided.")
-
-    if not isinstance(plasma_store_memory, int):
-        raise Exception("plasma_store_memory should be an integer.")
-
-    command = [
-        PLASMA_STORE_EXECUTABLE, "-s", socket_name, "-m",
-        str(plasma_store_memory)
-    ]
-    if plasma_directory is not None:
-        command += ["-d", plasma_directory]
-    if huge_pages:
-        command += ["-h"]
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_PLASMA_STORE,
-        use_valgrind=use_valgrind,
-        use_valgrind_profiler=use_profiler,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
-
-
-def start_plasma_store(stdout_file=None,
-                       stderr_file=None,
-                       object_store_memory=None,
-                       plasma_directory=None,
-                       huge_pages=False,
-                       plasma_store_socket_name=None):
-    """This method starts an object store process.
-
-    Args:
-        stdout_file: A file handle opened for writing to redirect stdout
-            to. If no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr
-            to. If no redirection should happen, then this should be None.
-        object_store_memory: The amount of memory (in bytes) to start the
-            object store with.
-        plasma_directory: A directory where the Plasma memory mapped files will
-            be created.
-        huge_pages: Boolean flag indicating whether to start the Object
-            Store with hugetlbfs support. Requires plasma_directory.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    object_store_memory, plasma_directory = determine_plasma_store_config(
-        object_store_memory, plasma_directory, huge_pages)
-
     if object_store_memory < ray_constants.OBJECT_STORE_MINIMUM_MEMORY_BYTES:
-        raise ValueError("Attempting to cap object store memory usage at {} "
-                         "bytes, but the minimum allowed is {} bytes.".format(
-                             object_store_memory,
-                             ray_constants.OBJECT_STORE_MINIMUM_MEMORY_BYTES))
+        raise ValueError(
+            "Attempting to cap object store memory usage at {} "
+            "bytes, but the minimum allowed is {} bytes.".format(
+                object_store_memory,
+                ray_constants.OBJECT_STORE_MINIMUM_MEMORY_BYTES))
 
-    # Print the object store memory using two decimal places.
-    object_store_memory_str = (object_store_memory / 10**7) / 10**2
-    logger.info("Starting the Plasma object store with {} GB memory "
-                "using {}.".format(
-                    round(object_store_memory_str, 2), plasma_directory))
-    # Start the Plasma store.
-    process_info = _start_plasma_store(
-        object_store_memory,
-        use_profiler=RUN_PLASMA_STORE_PROFILER,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file,
-        plasma_directory=plasma_directory,
-        huge_pages=huge_pages,
-        socket_name=plasma_store_socket_name)
-
-    return process_info
-
-
-def start_worker(node_ip_address,
-                 object_store_name,
-                 raylet_name,
-                 redis_address,
-                 worker_path,
-                 temp_dir,
-                 stdout_file=None,
-                 stderr_file=None):
-    """This method starts a worker process.
-
-    Args:
-        node_ip_address (str): The IP address of the node that this worker is
-            running on.
-        object_store_name (str): The socket name of the object store.
-        raylet_name (str): The socket name of the raylet server.
-        redis_address (str): The address that the Redis server is listening on.
-        worker_path (str): The path of the source code which the worker process
-            will run.
-        temp_dir (str): The path of the temp dir.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    command = [
-        sys.executable, "-u", worker_path,
-        "--node-ip-address=" + node_ip_address,
-        "--object-store-name=" + object_store_name,
-        "--raylet-name=" + raylet_name,
-        "--redis-address=" + str(redis_address), "--temp-dir=" + temp_dir
-    ]
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_WORKER,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
-
-
-def start_monitor(redis_address,
-                  stdout_file=None,
-                  stderr_file=None,
-                  autoscaling_config=None,
-                  redis_password=None):
-    """Run a process to monitor the other processes.
-
-    Args:
-        redis_address (str): The address that the Redis server is listening on.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        autoscaling_config: path to autoscaling config file.
-        redis_password (str): The password of the redis server.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    monitor_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "monitor.py")
-    command = [
-        sys.executable, "-u", monitor_path,
-        "--redis-address=" + str(redis_address)
-    ]
-    if autoscaling_config:
-        command.append("--autoscaling-config=" + str(autoscaling_config))
-    if redis_password:
-        command.append("--redis-password=" + redis_password)
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_MONITOR,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
-
-
-def start_raylet_monitor(redis_address,
-                         stdout_file=None,
-                         stderr_file=None,
-                         redis_password=None,
-                         config=None):
-    """Run a process to monitor the other processes.
-
-    Args:
-        redis_address (str): The address that the Redis server is listening on.
-        stdout_file: A file handle opened for writing to redirect stdout to. If
-            no redirection should happen, then this should be None.
-        stderr_file: A file handle opened for writing to redirect stderr to. If
-            no redirection should happen, then this should be None.
-        redis_password (str): The password of the redis server.
-        config (dict|None): Optional configuration that will
-            override defaults in RayConfig.
-
-    Returns:
-        ProcessInfo for the process that was started.
-    """
-    gcs_ip_address, gcs_port = redis_address.split(":")
-    redis_password = redis_password or ""
-    config = config or {}
-    config_str = ",".join(["{},{}".format(*kv) for kv in config.items()])
-    command = [
-        RAYLET_MONITOR_EXECUTABLE,
-        "--redis_address={}".format(gcs_ip_address),
-        "--redis_port={}".format(gcs_port),
-        "--config_list={}".format(config_str),
-    ]
-    if redis_password:
-        command += ["--redis_password={}".format(redis_password)]
-    process_info = start_ray_process(
-        command,
-        ray_constants.PROCESS_TYPE_RAYLET_MONITOR,
-        stdout_file=stdout_file,
-        stderr_file=stderr_file)
-    return process_info
+    return object_store_memory, plasma_directory

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -11,6 +11,7 @@ import logging
 import numpy as np
 import os
 import six
+import socket
 import subprocess
 import sys
 import threading
@@ -542,3 +543,15 @@ def try_to_create_directory(directory_path, warn_if_exist=True):
     # Change the log directory permissions so others can use it. This is
     # important when multiple people are using the same machine.
     try_make_directory_shared(directory_path)
+
+
+def get_next_available_socket(start_address):
+    port = start_address
+    while True:
+        try:
+            port_test_socket = socket.socket()
+            port_test_socket.bind(("127.0.0.1", port))
+            port_test_socket.close()
+            break
+        except socket.error:
+            port += 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This PR migrates process starting code from `services.py` to `node.py` to eliminate redundant argument passing & documents (~400 lines are reduced). Some code has been reorganized to make the interface more unified for different languages. (e.g. `_start_java_worker_command` & `_start_python_worker_command`)

This PR also moves code involves process controlling from `node.py` to `services.py` to form the `ProcessControl` class. This class provides full interfaces to control process lifetime, which could be useful for code reuse (e.g. we could give up the concept of "head node" later, so this class will be useful for something like global services).

Other small fixes (found when refactoring the code):

1. `RUN_RAYLET_PROFILER` was defined but never used.
2. We check if we have started a process after we call `start_ray_process`. Fixed in `ProcessControl` class.

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
