### PR TITLE
[tune] Pretty print params json in logger.py

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -95,7 +95,12 @@ class JsonLogger(Logger):
         self.config = config
         config_out = os.path.join(self.logdir, "params.json")
         with open(config_out, "w") as f:
-            json.dump(self.config, f, cls=_SafeFallbackEncoder)
+            json.dump(
+                self.config,
+                f,
+                indent=2,
+                sort_keys=True,
+                cls=_SafeFallbackEncoder)
         config_pkl = os.path.join(self.logdir, "params.pkl")
         with open(config_pkl, "wb") as f:
             cloudpickle.dump(self.config, f)


### PR DESCRIPTION
## What do these changes do?
Adds back the pretty printing for logger.pys json dumps. This was removed in #4362. If it was removed on purpose, then disregard this.

## Linter
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
