### PR TITLE
[rllib] Port remainder of algorithms to build_trainer() pattern

### DIFF
--- a/doc/source/rllib-package-ref.rst
+++ b/doc/source/rllib-package-ref.rst
@@ -1,25 +1,11 @@
 RLlib Package Reference
 =======================
 
-ray.rllib.agents
-----------------
+ray.rllib.policy
+-------------
 
-.. automodule:: ray.rllib.agents
+.. automodule:: ray.rllib.policy
     :members:
-    
-.. autoclass:: ray.rllib.agents.a3c.A2CTrainer
-.. autoclass:: ray.rllib.agents.a3c.A3CTrainer
-.. autoclass:: ray.rllib.agents.ddpg.ApexDDPGTrainer
-.. autoclass:: ray.rllib.agents.ddpg.DDPGTrainer
-.. autoclass:: ray.rllib.agents.dqn.ApexTrainer
-.. autoclass:: ray.rllib.agents.dqn.DQNTrainer
-.. autoclass:: ray.rllib.agents.es.ESTrainer
-.. autoclass:: ray.rllib.agents.pg.PGTrainer
-.. autoclass:: ray.rllib.agents.impala.ImpalaTrainer
-.. autoclass:: ray.rllib.agents.ppo.APPOTrainer
-.. autoclass:: ray.rllib.agents.ppo.PPOTrainer
-.. autoclass:: ray.rllib.agents.marwil.MARWILTrainer
-
 
 ray.rllib.env
 -------------

--- a/doc/source/rllib-package-ref.rst
+++ b/doc/source/rllib-package-ref.rst
@@ -2,7 +2,7 @@ RLlib Package Reference
 =======================
 
 ray.rllib.policy
--------------
+----------------
 
 .. automodule:: ray.rllib.policy
     :members:

--- a/python/ray/rllib/agents/ddpg/apex.py
+++ b/python/ray/rllib/agents/ddpg/apex.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ray.rllib.agents.dqn.apex import update_target_based_on_num_steps_trained
+from ray.rllib.agents.dqn.apex import APEX_TRAINER_PROPERTIES
 from ray.rllib.agents.ddpg.ddpg import DDPGTrainer, \
     DEFAULT_CONFIG as DDPG_CONFIG
 from ray.rllib.utils import merge_dicts
@@ -10,7 +10,6 @@ from ray.rllib.utils import merge_dicts
 APEX_DDPG_DEFAULT_CONFIG = merge_dicts(
     DDPG_CONFIG,  # see also the options in ddpg.py, which are also supported
     {
-        "optimizer_class": "AsyncReplayOptimizer",
         "optimizer": merge_dicts(
             DDPG_CONFIG["optimizer"], {
                 "max_weight_sync_delay": 400,
@@ -35,4 +34,4 @@ APEX_DDPG_DEFAULT_CONFIG = merge_dicts(
 ApexDDPGTrainer = DDPGTrainer.with_updates(
     name="APEX_DDPG",
     default_config=APEX_DDPG_DEFAULT_CONFIG,
-    after_optimizer_step=update_target_based_on_num_steps_trained)
+    **APEX_TRAINER_PROPERTIES)

--- a/python/ray/rllib/agents/ddpg/apex.py
+++ b/python/ray/rllib/agents/ddpg/apex.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from ray.rllib.agents.dqn.apex import update_target_based_on_num_steps_trained
 from ray.rllib.agents.ddpg.ddpg import DDPGTrainer, \
     DEFAULT_CONFIG as DDPG_CONFIG
-from ray.rllib.utils.annotations import override
 from ray.rllib.utils import merge_dicts
 
 APEX_DDPG_DEFAULT_CONFIG = merge_dicts(
@@ -32,23 +32,7 @@ APEX_DDPG_DEFAULT_CONFIG = merge_dicts(
     },
 )
 
-
-class ApexDDPGTrainer(DDPGTrainer):
-    """DDPG variant that uses the Ape-X distributed policy optimizer.
-
-    By default, this is configured for a large single node (32 cores). For
-    running in a large cluster, increase the `num_workers` config var.
-    """
-
-    _name = "APEX_DDPG"
-    _default_config = APEX_DDPG_DEFAULT_CONFIG
-
-    @override(DDPGTrainer)
-    def update_target_if_needed(self):
-        # Ape-X updates based on num steps trained, not sampled
-        if self.optimizer.num_steps_trained - self.last_target_update_ts > \
-                self.config["target_network_update_freq"]:
-            self.workers.local_worker().foreach_trainable_policy(
-                lambda p, _: p.update_target())
-            self.last_target_update_ts = self.optimizer.num_steps_trained
-            self.num_target_updates += 1
+ApexDDPGTrainer = DDPGTrainer.with_updates(
+    name="APEX_DDPG",
+    default_config=APEX_DDPG_DEFAULT_CONFIG,
+    after_optimizer_step=update_target_based_on_num_steps_trained)

--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -3,9 +3,9 @@ from __future__ import division
 from __future__ import print_function
 
 from ray.rllib.agents.trainer import with_common_config
-from ray.rllib.agents.dqn.dqn import DQNTrainer
+from ray.rllib.agents.dqn.dqn import GenericOffPolicyTrainer, \
+    update_worker_explorations
 from ray.rllib.agents.ddpg.ddpg_policy import DDPGTFPolicy
-from ray.rllib.utils.annotations import override
 from ray.rllib.utils.schedules import ConstantSchedule, LinearSchedule
 
 # yapf: disable
@@ -97,6 +97,11 @@ DEFAULT_CONFIG = with_common_config({
     # optimization on initial policy parameters. Note that this will be
     # disabled when the action noise scale is set to 0 (e.g during evaluation).
     "pure_exploration_steps": 1000,
+    # Extra configuration that disables exploration.
+    "evaluation_config": {
+        "exploration_fraction": 0,
+        "exploration_final_eps": 0,
+    },
 
     # === Replay buffer ===
     # Size of the replay buffer. Note that if async_updates is set, then
@@ -108,6 +113,11 @@ DEFAULT_CONFIG = with_common_config({
     "prioritized_replay_alpha": 0.6,
     # Beta parameter for sampling from prioritized replay buffer.
     "prioritized_replay_beta": 0.4,
+    # Fraction of entire training period over which the beta parameter is
+    # annealed
+    "beta_annealing_fraction": 0.2,
+    # Final value of beta
+    "final_prioritized_replay_beta": 0.4,
     # Epsilon to add to the TD errors when updating priorities.
     "prioritized_replay_eps": 1e-6,
     # Whether to LZ4 compress observations
@@ -159,47 +169,56 @@ DEFAULT_CONFIG = with_common_config({
 # yapf: enable
 
 
-class DDPGTrainer(DQNTrainer):
-    """DDPG implementation in TensorFlow."""
-    _name = "DDPG"
-    _default_config = DEFAULT_CONFIG
-    _policy = DDPGTFPolicy
-
-    @override(DQNTrainer)
-    def _train(self):
-        pure_expl_steps = self.config["pure_exploration_steps"]
-        if pure_expl_steps:
-            # tell workers whether they should do pure exploration
-            only_explore = self.global_timestep < pure_expl_steps
-            self.workers.local_worker().foreach_trainable_policy(
-                lambda p, _: p.set_pure_exploration_phase(only_explore))
-            for e in self.workers.remote_workers():
-                e.foreach_trainable_policy.remote(
-                    lambda p, _: p.set_pure_exploration_phase(only_explore))
-        return super(DDPGTrainer, self)._train()
-
-    @override(DQNTrainer)
-    def _make_exploration_schedule(self, worker_index):
-        # Override DQN's schedule to take into account
-        # `exploration_ou_noise_scale`
-        if self.config["per_worker_exploration"]:
-            assert self.config["num_workers"] > 1, \
-                "This requires multiple workers"
-            if worker_index >= 0:
-                # FIXME: what do magic constants mean? (0.4, 7)
-                max_index = float(self.config["num_workers"] - 1)
-                exponent = 1 + worker_index / max_index * 7
-                return ConstantSchedule(0.4**exponent)
-            else:
-                # local ev should have zero exploration so that eval rollouts
-                # run properly
-                return ConstantSchedule(0.0)
-        elif self.config["exploration_should_anneal"]:
-            return LinearSchedule(
-                schedule_timesteps=int(self.config["exploration_fraction"] *
-                                       self.config["schedule_max_timesteps"]),
-                initial_p=1.0,
-                final_p=self.config["exploration_final_scale"])
+def make_exploration_schedule(config, worker_index):
+    # Modification of DQN's schedule to take into account
+    # `exploration_ou_noise_scale`
+    if config["per_worker_exploration"]:
+        assert config["num_workers"] > 1, "This requires multiple workers"
+        if worker_index >= 0:
+            # FIXME: what do magic constants mean? (0.4, 7)
+            max_index = float(config["num_workers"] - 1)
+            exponent = 1 + worker_index / max_index * 7
+            return ConstantSchedule(0.4**exponent)
         else:
-            # *always* add exploration noise
-            return ConstantSchedule(1.0)
+            # local ev should have zero exploration so that eval rollouts
+            # run properly
+            return ConstantSchedule(0.0)
+    elif config["exploration_should_anneal"]:
+        return LinearSchedule(
+            schedule_timesteps=int(config["exploration_fraction"] *
+                                   config["schedule_max_timesteps"]),
+            initial_p=1.0,
+            final_p=config["exploration_final_scale"])
+    else:
+        # *always* add exploration noise
+        return ConstantSchedule(1.0)
+
+
+def setup_ddpg_exploration(trainer):
+    trainer.exploration0 = make_exploration_schedule(trainer.config, -1)
+    trainer.explorations = [
+        make_exploration_schedule(trainer.config, i)
+        for i in range(trainer.config["num_workers"])
+    ]
+
+
+def add_pure_exploration_phase(trainer):
+    global_timestep = trainer.optimizer.num_steps_sampled
+    pure_expl_steps = trainer.config["pure_exploration_steps"]
+    if pure_expl_steps:
+        # tell workers whether they should do pure exploration
+        only_explore = global_timestep < pure_expl_steps
+        trainer.workers.local_worker().foreach_trainable_policy(
+            lambda p, _: p.set_pure_exploration_phase(only_explore))
+        for e in trainer.workers.remote_workers():
+            e.foreach_trainable_policy.remote(
+                lambda p, _: p.set_pure_exploration_phase(only_explore))
+    update_worker_explorations(trainer)
+
+
+DDPGTrainer = GenericOffPolicyTrainer.with_updates(
+    name="DDPG",
+    default_config=DEFAULT_CONFIG,
+    default_policy=DDPGTFPolicy,
+    before_init=setup_ddpg_exploration,
+    before_train_step=add_pure_exploration_phase)

--- a/python/ray/rllib/agents/ddpg/ddpg.py
+++ b/python/ray/rllib/agents/ddpg/ddpg.py
@@ -156,8 +156,6 @@ DEFAULT_CONFIG = with_common_config({
     # to increase if your environment is particularly slow to sample, or if
     # you're using the Async or Ape-X optimizers.
     "num_workers": 0,
-    # Optimizer class to use.
-    "optimizer_class": "SyncReplayOptimizer",
     # Whether to use a distribution of epsilons across workers for exploration.
     "per_worker_exploration": False,
     # Whether to compute priorities on workers.

--- a/python/ray/rllib/agents/ddpg/td3.py
+++ b/python/ray/rllib/agents/ddpg/td3.py
@@ -1,3 +1,9 @@
+"""A more stable successor to TD3.
+
+By default, this uses a near-identical configuration to that reported in the
+TD3 paper.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -36,7 +42,6 @@ TD3_DEFAULT_CONFIG = merge_dicts(
         "train_batch_size": 100,
         "use_huber": False,
         "target_network_update_freq": 0,
-        "optimizer_class": "SyncReplayOptimizer",
         "num_workers": 0,
         "num_gpus_per_worker": 0,
         "per_worker_exploration": False,
@@ -48,10 +53,5 @@ TD3_DEFAULT_CONFIG = merge_dicts(
     },
 )
 
-
-class TD3Trainer(DDPGTrainer):
-    """A more stable successor to TD3. By default, this uses a near-identical
-    configuration to that reported in the TD3 paper."""
-
-    _name = "TD3"
-    _default_config = TD3_DEFAULT_CONFIG
+TD3Trainer = DDPGTrainer.with_updates(
+    name="TD3", default_config=TD3_DEFAULT_CONFIG)

--- a/python/ray/rllib/agents/dqn/apex.py
+++ b/python/ray/rllib/agents/dqn/apex.py
@@ -43,17 +43,20 @@ def defer_make_workers(trainer, env_creator, policy, config):
 
 def make_async_optimizer(workers, config):
     assert len(workers.remote_workers()) == 0
+    extra_config = config["optimizer"].copy()
+    for key in [
+            "prioritized_replay", "prioritized_replay_alpha",
+            "prioritized_replay_beta", "prioritized_replay_eps"
+    ]:
+        if key in config:
+            extra_config[key] = config[key]
     opt = AsyncReplayOptimizer(
         workers,
         learning_starts=config["learning_starts"],
         buffer_size=config["buffer_size"],
-        prioritized_replay=config["prioritized_replay"],
-        prioritized_replay_alpha=config["prioritized_replay_alpha"],
-        prioritized_replay_beta=config["prioritized_replay_beta"],
-        prioritized_replay_eps=config["prioritized_replay_eps"],
         train_batch_size=config["train_batch_size"],
         sample_batch_size=config["sample_batch_size"],
-        **config["optimizer"])
+        **extra_config)
     workers.add_workers(config["num_workers"])
     opt._set_workers(workers.remote_workers())
     return opt

--- a/python/ray/rllib/agents/dqn/dqn.py
+++ b/python/ray/rllib/agents/dqn/dqn.py
@@ -140,6 +140,12 @@ def make_optimizer(workers, config):
 
 
 def check_config_and_setup_param_noise(config):
+    """Update the config based on settings.
+
+    Rewrites sample_batch_size to take into account n_step truncation, and also
+    adds the necessary callbacks to support parameter space noise exploration.
+    """
+
     # Update effective batch size to include n-step
     adjusted_batch_size = max(config["sample_batch_size"],
                               config.get("n_step", 1))

--- a/python/ray/rllib/agents/dqn/dqn.py
+++ b/python/ray/rllib/agents/dqn/dqn.py
@@ -43,6 +43,9 @@ DEFAULT_CONFIG = with_common_config({
     # 1.0 to exploration_fraction over this number of timesteps scaled by
     # exploration_fraction
     "schedule_max_timesteps": 100000,
+    # Minimum env steps to optimize for per train call. This value does
+    # not affect learning, only the length of iterations.
+    "timesteps_per_iteration": 1000,
     # Fraction of entire training period over which the exploration rate is
     # annealed
     "exploration_fraction": 0.1,

--- a/python/ray/rllib/agents/dqn/dqn.py
+++ b/python/ray/rllib/agents/dqn/dqn.py
@@ -3,26 +3,16 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-import time
 
 from ray import tune
-from ray.rllib import optimizers
-from ray.rllib.agents.trainer import Trainer, with_common_config
+from ray.rllib.agents.trainer import with_common_config
+from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.agents.dqn.dqn_policy import DQNTFPolicy
-from ray.rllib.evaluation.metrics import collect_metrics
+from ray.rllib.optimizers import AsyncReplayOptimizer, SyncReplayOptimizer
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
-from ray.rllib.utils.annotations import override
 from ray.rllib.utils.schedules import ConstantSchedule, LinearSchedule
 
 logger = logging.getLogger(__name__)
-
-OPTIMIZER_SHARED_CONFIGS = [
-    "buffer_size", "prioritized_replay", "prioritized_replay_alpha",
-    "prioritized_replay_beta", "schedule_max_timesteps",
-    "beta_annealing_fraction", "final_prioritized_replay_beta",
-    "prioritized_replay_eps", "sample_batch_size", "train_batch_size",
-    "learning_starts"
-]
 
 # yapf: disable
 # __sphinx_doc_begin__
@@ -53,8 +43,6 @@ DEFAULT_CONFIG = with_common_config({
     # 1.0 to exploration_fraction over this number of timesteps scaled by
     # exploration_fraction
     "schedule_max_timesteps": 100000,
-    # Number of env steps to optimize for before returning
-    "timesteps_per_iteration": 1000,
     # Fraction of entire training period over which the exploration rate is
     # annealed
     "exploration_fraction": 0.1,
@@ -128,161 +116,117 @@ DEFAULT_CONFIG = with_common_config({
 # yapf: enable
 
 
-class DQNTrainer(Trainer):
-    """DQN implementation in TensorFlow."""
+def make_workers(trainer, env_creator, policy, config):
+    if config["optimizer_class"] == "AsyncReplayOptimizer":
+        # Hack to workaround https://github.com/ray-project/ray/issues/2541
+        # The workers will be creatd later, after the optimizer is created
+        num_workers = 0
+    else:
+        num_workers = config["num_workers"]
+    return trainer._make_workers(env_creator, policy, config, num_workers)
 
-    _name = "DQN"
-    _default_config = DEFAULT_CONFIG
-    _policy = DQNTFPolicy
-    _optimizer_shared_configs = OPTIMIZER_SHARED_CONFIGS
 
-    @override(Trainer)
-    def _init(self, config, env_creator):
-        self._validate_config()
+def make_optimizer(workers, config):
+    if config["optimizer_class"] == "SyncReplayOptimizer":
+        return SyncReplayOptimizer(
+            workers,
+            learning_starts=config["learning_starts"],
+            buffer_size=config["buffer_size"],
+            prioritized_replay=config["prioritized_replay"],
+            prioritized_replay_alpha=config["prioritized_replay_alpha"],
+            prioritized_replay_beta=config["prioritized_replay_beta"],
+            schedule_max_timesteps=config["schedule_max_timesteps"],
+            beta_annealing_fraction=config["beta_annealing_fraction"],
+            final_prioritized_replay_beta=config[
+                "final_prioritized_replay_beta"],
+            prioritized_replay_eps=config["prioritized_replay_eps"],
+            train_batch_size=config["train_batch_size"],
+            sample_batch_size=config["sample_batch_size"],
+            **config["optimizer"])
+    elif config["optimizer_class"] == "AsyncReplayOptimizer":
+        assert len(workers.remote_workers()) == 0
+        opt = AsyncReplayOptimizer(
+            workers,
+            learning_starts=config["learning_starts"],
+            buffer_size=config["buffer_size"],
+            prioritized_replay=config["prioritized_replay"],
+            prioritized_replay_alpha=config["prioritized_replay_alpha"],
+            prioritized_replay_beta=config["prioritized_replay_beta"],
+            prioritized_replay_eps=config["prioritized_replay_eps"],
+            train_batch_size=config["train_batch_size"],
+            sample_batch_size=config["sample_batch_size"],
+            **config["optimizer"])
+        workers.add_workers(config["num_workers"])
+        opt._set_workers(workers.remote_workers())
+        return opt
+    else:
+        raise ValueError(
+            "Optimizer class must be one of `SyncReplayOptimizer` or "
+            "`AsyncReplayOptimizer`.")
 
-        # Update effective batch size to include n-step
-        adjusted_batch_size = max(config["sample_batch_size"],
-                                  config.get("n_step", 1))
-        config["sample_batch_size"] = adjusted_batch_size
 
+def check_config_and_setup_param_noise(config):
+    # Update effective batch size to include n-step
+    adjusted_batch_size = max(config["sample_batch_size"],
+                              config.get("n_step", 1))
+    config["sample_batch_size"] = adjusted_batch_size
+
+    if config["parameter_noise"]:
+        if config["batch_mode"] != "complete_episodes":
+            raise ValueError("Exploration with parameter space noise requires "
+                             "batch_mode to be complete_episodes.")
+        if config.get("noisy", False):
+            raise ValueError(
+                "Exploration with parameter space noise and noisy network "
+                "cannot be used at the same time.")
+        if config["callbacks"]["on_episode_start"]:
+            start_callback = config["callbacks"]["on_episode_start"]
+        else:
+            start_callback = None
+
+        def on_episode_start(info):
+            # as a callback function to sample and pose parameter space
+            # noise on the parameters of network
+            policies = info["policy"]
+            for pi in policies.values():
+                pi.add_parameter_noise()
+            if start_callback:
+                start_callback(info)
+
+        config["callbacks"]["on_episode_start"] = tune.function(
+            on_episode_start)
+        if config["callbacks"]["on_episode_end"]:
+            end_callback = config["callbacks"]["on_episode_end"]
+        else:
+            end_callback = None
+
+        def on_episode_end(info):
+            # as a callback function to monitor the distance
+            # between noisy policy and original policy
+            policies = info["policy"]
+            episode = info["episode"]
+            episode.custom_metrics["policy_distance"] = policies[
+                DEFAULT_POLICY_ID].pi_distance
+            if end_callback:
+                end_callback(info)
+
+        config["callbacks"]["on_episode_end"] = tune.function(on_episode_end)
+
+
+def get_initial_state(config):
+    return {
+        "last_target_update_ts": 0,
+        "num_target_updates": 0,
+    }
+
+
+class ExplorationScheduleMixin(object):
+    def __init__(self):
         self.exploration0 = self._make_exploration_schedule(-1)
         self.explorations = [
             self._make_exploration_schedule(i)
-            for i in range(config["num_workers"])
+            for i in range(self.config["num_workers"])
         ]
-
-        for k in self._optimizer_shared_configs:
-            if self._name != "DQN" and k in [
-                    "schedule_max_timesteps", "beta_annealing_fraction",
-                    "final_prioritized_replay_beta"
-            ]:
-                # only Rainbow needs annealing prioritized_replay_beta
-                continue
-            if k not in config["optimizer"]:
-                config["optimizer"][k] = config[k]
-
-        if config.get("parameter_noise", False):
-            if config["callbacks"]["on_episode_start"]:
-                start_callback = config["callbacks"]["on_episode_start"]
-            else:
-                start_callback = None
-
-            def on_episode_start(info):
-                # as a callback function to sample and pose parameter space
-                # noise on the parameters of network
-                policies = info["policy"]
-                for pi in policies.values():
-                    pi.add_parameter_noise()
-                if start_callback:
-                    start_callback(info)
-
-            config["callbacks"]["on_episode_start"] = tune.function(
-                on_episode_start)
-            if config["callbacks"]["on_episode_end"]:
-                end_callback = config["callbacks"]["on_episode_end"]
-            else:
-                end_callback = None
-
-            def on_episode_end(info):
-                # as a callback function to monitor the distance
-                # between noisy policy and original policy
-                policies = info["policy"]
-                episode = info["episode"]
-                episode.custom_metrics["policy_distance"] = policies[
-                    DEFAULT_POLICY_ID].pi_distance
-                if end_callback:
-                    end_callback(info)
-
-            config["callbacks"]["on_episode_end"] = tune.function(
-                on_episode_end)
-
-        if config["optimizer_class"] != "AsyncReplayOptimizer":
-            self.workers = self._make_workers(
-                env_creator,
-                self._policy,
-                config,
-                num_workers=self.config["num_workers"])
-            workers_needed = 0
-        else:
-            # Hack to workaround https://github.com/ray-project/ray/issues/2541
-            self.workers = self._make_workers(
-                env_creator, self._policy, config, num_workers=0)
-            workers_needed = self.config["num_workers"]
-
-        self.optimizer = getattr(optimizers, config["optimizer_class"])(
-            self.workers, **config["optimizer"])
-
-        # Create the remote workers *after* the replay actors
-        if workers_needed > 0:
-            self.workers.add_workers(workers_needed)
-            self.optimizer._set_workers(self.workers.remote_workers())
-
-        self.last_target_update_ts = 0
-        self.num_target_updates = 0
-
-    @override(Trainer)
-    def _train(self):
-        start_timestep = self.global_timestep
-
-        # Update worker explorations
-        exp_vals = [self.exploration0.value(self.global_timestep)]
-        self.workers.local_worker().foreach_trainable_policy(
-            lambda p, _: p.set_epsilon(exp_vals[0]))
-        for i, e in enumerate(self.workers.remote_workers()):
-            exp_val = self.explorations[i].value(self.global_timestep)
-            e.foreach_trainable_policy.remote(
-                lambda p, _: p.set_epsilon(exp_val))
-            exp_vals.append(exp_val)
-
-        # Do optimization steps
-        start = time.time()
-        while (self.global_timestep - start_timestep <
-               self.config["timesteps_per_iteration"]
-               ) or time.time() - start < self.config["min_iter_time_s"]:
-            self.optimizer.step()
-            self.update_target_if_needed()
-
-        if self.config["per_worker_exploration"]:
-            # Only collect metrics from the third of workers with lowest eps
-            result = self.collect_metrics(
-                selected_workers=self.workers.remote_workers()[
-                    -len(self.workers.remote_workers()) // 3:])
-        else:
-            result = self.collect_metrics()
-
-        result.update(
-            timesteps_this_iter=self.global_timestep - start_timestep,
-            info=dict({
-                "min_exploration": min(exp_vals),
-                "max_exploration": max(exp_vals),
-                "num_target_updates": self.num_target_updates,
-            }, **self.optimizer.stats()))
-
-        return result
-
-    def update_target_if_needed(self):
-        if self.global_timestep - self.last_target_update_ts > \
-                self.config["target_network_update_freq"]:
-            self.workers.local_worker().foreach_trainable_policy(
-                lambda p, _: p.update_target())
-            self.last_target_update_ts = self.global_timestep
-            self.num_target_updates += 1
-
-    @property
-    def global_timestep(self):
-        return self.optimizer.num_steps_sampled
-
-    def _evaluate(self):
-        logger.info("Evaluating current policy for {} episodes".format(
-            self.config["evaluation_num_episodes"]))
-        self.evaluation_workers.local_worker().restore(
-            self.workers.local_worker().save())
-        self.evaluation_workers.local_worker().foreach_policy(
-            lambda p, _: p.set_epsilon(0))
-        for _ in range(self.config["evaluation_num_episodes"]):
-            self.evaluation_workers.local_worker().sample()
-        metrics = collect_metrics(self.evaluation_workers.local_worker())
-        return {"evaluation": metrics}
 
     def _make_exploration_schedule(self, worker_index):
         # Use either a different `eps` per worker, or a linear schedule.
@@ -304,26 +248,68 @@ class DQNTrainer(Trainer):
             initial_p=1.0,
             final_p=self.config["exploration_final_eps"])
 
-    def __getstate__(self):
-        state = Trainer.__getstate__(self)
-        state.update({
-            "num_target_updates": self.num_target_updates,
-            "last_target_update_ts": self.last_target_update_ts,
-        })
-        return state
 
-    def __setstate__(self, state):
-        Trainer.__setstate__(self, state)
-        self.num_target_updates = state["num_target_updates"]
-        self.last_target_update_ts = state["last_target_update_ts"]
+def update_worker_explorations(trainer):
+    global_timestep = trainer.optimizer.num_steps_sampled
+    exp_vals = [trainer.exploration0.value(global_timestep)]
+    trainer.workers.local_worker().foreach_trainable_policy(
+        lambda p, _: p.set_epsilon(exp_vals[0]))
+    for i, e in enumerate(trainer.workers.remote_workers()):
+        exp_val = trainer.explorations[i].value(global_timestep)
+        e.foreach_trainable_policy.remote(lambda p, _: p.set_epsilon(exp_val))
+        exp_vals.append(exp_val)
+    trainer.train_start_timestep = global_timestep
+    trainer.cur_exp_vals = exp_vals
 
-    def _validate_config(self):
-        if self.config.get("parameter_noise", False):
-            if self.config["batch_mode"] != "complete_episodes":
-                raise ValueError(
-                    "Exploration with parameter space noise requires "
-                    "batch_mode to be complete_episodes.")
-            if self.config.get("noisy", False):
-                raise ValueError(
-                    "Exploration with parameter space noise and noisy network "
-                    "cannot be used at the same time.")
+
+def add_trainer_metrics(trainer, result):
+    global_timestep = trainer.optimizer.num_steps_sampled
+    result.update(
+        timesteps_this_iter=global_timestep - trainer.train_start_timestep,
+        info=dict({
+            "min_exploration": min(trainer.cur_exp_vals),
+            "max_exploration": max(trainer.cur_exp_vals),
+            "num_target_updates": trainer.state["num_target_updates"],
+        }, **trainer.optimizer.stats()))
+
+
+def update_target_if_needed(trainer, fetches):
+    global_timestep = trainer.optimizer.num_steps_sampled
+    if global_timestep - trainer.state["last_target_update_ts"] > \
+            trainer.config["target_network_update_freq"]:
+        trainer.workers.local_worker().foreach_trainable_policy(
+            lambda p, _: p.update_target())
+        trainer.state["last_target_update_ts"] = global_timestep
+        trainer.state["num_target_updates"] += 1
+
+
+def collect_metrics(trainer):
+    if trainer.config["per_worker_exploration"]:
+        # Only collect metrics from the third of workers with lowest eps
+        result = trainer.collect_metrics(
+            selected_workers=trainer.workers.remote_workers()[
+                -len(trainer.workers.remote_workers()) // 3:])
+    else:
+        result = trainer.collect_metrics()
+    return result
+
+
+def disable_exploration(trainer):
+    trainer.evaluation_workers.local_worker().foreach_policy(
+        lambda p, _: p.set_epsilon(0))
+
+
+DQNTrainer = build_trainer(
+    name="DQN",
+    default_policy=DQNTFPolicy,
+    default_config=DEFAULT_CONFIG,
+    make_workers=make_workers,
+    make_policy_optimizer=make_optimizer,
+    validate_config=check_config_and_setup_param_noise,
+    get_initial_state=get_initial_state,
+    before_train_step=update_worker_explorations,
+    after_optimizer_step=update_target_if_needed,
+    after_train_result=add_trainer_metrics,
+    before_evaluate_fn=disable_exploration,
+    collect_metrics_fn=collect_metrics,
+    mixins=[ExplorationScheduleMixin])

--- a/python/ray/rllib/agents/ppo/appo.py
+++ b/python/ray/rllib/agents/ppo/appo.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from ray.rllib.agents.ppo.appo_policy import AsyncPPOTFPolicy
 from ray.rllib.agents.trainer import with_base_config
 from ray.rllib.agents import impala
-from ray.rllib.utils.annotations import override
 
 # yapf: disable
 # __sphinx_doc_begin__
@@ -51,14 +50,8 @@ DEFAULT_CONFIG = with_base_config(impala.DEFAULT_CONFIG, {
 # __sphinx_doc_end__
 # yapf: enable
 
-
-class APPOTrainer(impala.ImpalaTrainer):
-    """PPO surrogate loss with IMPALA-architecture."""
-
-    _name = "APPO"
-    _default_config = DEFAULT_CONFIG
-    _policy = AsyncPPOTFPolicy
-
-    @override(impala.ImpalaTrainer)
-    def _get_policy(self):
-        return AsyncPPOTFPolicy
+APPOTrainer = impala.ImpalaTrainer.with_updates(
+    name="APPO",
+    default_config=DEFAULT_CONFIG,
+    default_policy=AsyncPPOTFPolicy,
+    get_policy_class=lambda _: AsyncPPOTFPolicy)

--- a/python/ray/rllib/agents/qmix/apex.py
+++ b/python/ray/rllib/agents/qmix/apex.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 from ray.rllib.agents.qmix.qmix import QMixTrainer, \
     DEFAULT_CONFIG as QMIX_CONFIG
-from ray.rllib.utils.annotations import override
 from ray.rllib.utils import merge_dicts
 
 APEX_QMIX_DEFAULT_CONFIG = merge_dicts(
@@ -45,7 +44,7 @@ class ApexQMixTrainer(QMixTrainer):
     _name = "APEX_QMIX"
     _default_config = APEX_QMIX_DEFAULT_CONFIG
 
-    @override(QMixTrainer)
+    #    @override(QMixTrainer)
     def update_target_if_needed(self):
         # Ape-X updates based on num steps trained, not sampled
         if self.optimizer.num_steps_trained - self.last_target_update_ts > \

--- a/python/ray/rllib/agents/qmix/apex.py
+++ b/python/ray/rllib/agents/qmix/apex.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from ray.rllib.agents.dqn.apex import APEX_TRAINER_PROPERTIES
 from ray.rllib.agents.qmix.qmix import QMixTrainer, \
     DEFAULT_CONFIG as QMIX_CONFIG
 from ray.rllib.utils import merge_dicts
@@ -11,7 +12,6 @@ from ray.rllib.utils import merge_dicts
 APEX_QMIX_DEFAULT_CONFIG = merge_dicts(
     QMIX_CONFIG,  # see also the options in qmix.py, which are also supported
     {
-        "optimizer_class": "AsyncReplayOptimizer",
         "optimizer": merge_dicts(
             QMIX_CONFIG["optimizer"],
             {
@@ -33,23 +33,7 @@ APEX_QMIX_DEFAULT_CONFIG = merge_dicts(
     },
 )
 
-
-class ApexQMixTrainer(QMixTrainer):
-    """QMIX variant that uses the Ape-X distributed policy optimizer.
-
-    By default, this is configured for a large single node (32 cores). For
-    running in a large cluster, increase the `num_workers` config var.
-    """
-
-    _name = "APEX_QMIX"
-    _default_config = APEX_QMIX_DEFAULT_CONFIG
-
-    #    @override(QMixTrainer)
-    def update_target_if_needed(self):
-        # Ape-X updates based on num steps trained, not sampled
-        if self.optimizer.num_steps_trained - self.last_target_update_ts > \
-                self.config["target_network_update_freq"]:
-            self.workers.local_worker().foreach_trainable_policy(
-                lambda p, _: p.update_target())
-            self.last_target_update_ts = self.optimizer.num_steps_trained
-            self.num_target_updates += 1
+ApexQMixTrainer = QMixTrainer.with_updates(
+    name="APEX_QMIX",
+    default_config=APEX_QMIX_DEFAULT_CONFIG,
+    **APEX_TRAINER_PROPERTIES)

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -186,6 +186,9 @@ COMMON_CONFIG = {
     "remote_env_batch_wait_ms": 0,
     # Minimum time per iteration
     "min_iter_time_s": 0,
+    # Number of env steps to optimize for per train call. This value does
+    # not affect learning, only the length of iterations.
+    "timesteps_per_iteration": 1000,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:
@@ -499,6 +502,7 @@ class Trainer(Trainable):
 
         logger.info("Evaluating current policy for {} episodes".format(
             self.config["evaluation_num_episodes"]))
+        self._before_evaluate()
         self.evaluation_workers.local_worker().restore(
             self.workers.local_worker().save())
         for _ in range(self.config["evaluation_num_episodes"]):
@@ -506,6 +510,11 @@ class Trainer(Trainable):
 
         metrics = collect_metrics(self.evaluation_workers.local_worker())
         return {"evaluation": metrics}
+
+    @DeveloperAPI
+    def _before_evaluate(self):
+        """Pre-evaluation callback."""
+        pass
 
     @PublicAPI
     def compute_action(self,

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -186,9 +186,9 @@ COMMON_CONFIG = {
     "remote_env_batch_wait_ms": 0,
     # Minimum time per iteration
     "min_iter_time_s": 0,
-    # Number of env steps to optimize for per train call. This value does
+    # Minimum env steps to optimize for per train call. This value does
     # not affect learning, only the length of iterations.
-    "timesteps_per_iteration": 1000,
+    "timesteps_per_iteration": 0,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:

--- a/python/ray/rllib/agents/trainer_template.py
+++ b/python/ray/rllib/agents/trainer_template.py
@@ -160,6 +160,12 @@ def build_trainer(name,
 
     @staticmethod
     def with_updates(**overrides):
+        """Build a copy of this trainer with the specified overrides.
+
+        Arguments:
+            overrides (dict): use this to override any of the arguments
+                originally passed to build_trainer() for this policy.
+        """
         return build_trainer(**dict(original_kwargs, **overrides))
 
     trainer_cls.with_updates = with_updates

--- a/python/ray/rllib/agents/trainer_template.py
+++ b/python/ray/rllib/agents/trainer_template.py
@@ -91,6 +91,8 @@ def build_trainer(name,
                 validate_config(config)
             if get_initial_state:
                 self.state = get_initial_state(self)
+            else:
+                self.state = {}
             if get_policy_class is None:
                 policy = default_policy
             else:

--- a/python/ray/rllib/policy/tf_policy_template.py
+++ b/python/ray/rllib/policy/tf_policy_template.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from ray.rllib.policy.dynamic_tf_policy import DynamicTFPolicy
 from ray.rllib.policy.policy import Policy, LEARNER_STATS_KEY
 from ray.rllib.policy.tf_policy import TFPolicy
+from ray.rllib.utils import add_mixins
 from ray.rllib.utils.annotations import override, DeveloperAPI
 
 
@@ -89,13 +90,7 @@ def build_tf_policy(name,
     """
 
     original_kwargs = locals().copy()
-    base = DynamicTFPolicy
-    while mixins:
-
-        class new_base(mixins.pop(), base):
-            pass
-
-        base = new_base
+    base = add_mixins(DynamicTFPolicy, mixins)
 
     class policy_cls(base):
         def __init__(self,

--- a/python/ray/rllib/policy/torch_policy_template.py
+++ b/python/ray/rllib/policy/torch_policy_template.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.rllib.models.catalog import ModelCatalog
+from ray.rllib.utils import add_mixins
 from ray.rllib.utils.annotations import override, DeveloperAPI
 
 
@@ -56,13 +57,7 @@ def build_torch_policy(name,
     """
 
     original_kwargs = locals().copy()
-    base = TorchPolicy
-    while mixins:
-
-        class new_base(mixins.pop(), base):
-            pass
-
-        base = new_base
+    base = add_mixins(TorchPolicy, mixins)
 
     class policy_cls(base):
         def __init__(self, obs_space, action_space, config):

--- a/python/ray/rllib/utils/__init__.py
+++ b/python/ray/rllib/utils/__init__.py
@@ -30,7 +30,7 @@ def renamed_class(cls, old_name):
 def add_mixins(base, mixins):
     """Returns a new class with mixins applied in priority order."""
 
-    mixins = (mixins or []).copy()
+    mixins = list(mixins or [])
 
     while mixins:
 

--- a/python/ray/rllib/utils/__init__.py
+++ b/python/ray/rllib/utils/__init__.py
@@ -27,6 +27,21 @@ def renamed_class(cls, old_name):
     return DeprecationWrapper
 
 
+def add_mixins(base, mixins):
+    """Returns a new class with mixins applied in priority order."""
+
+    mixins = (mixins or []).copy()
+
+    while mixins:
+
+        class new_base(mixins.pop(), base):
+            pass
+
+        base = new_base
+
+    return base
+
+
 def renamed_agent(cls):
     """Helper class for renaming Agent => Trainer with a warning."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Ports DQN, DDPG, QMIX, APEX variants, IMPALA, APPO, MARWIL to use the build_trainer() pattern for their trainers.

We still have to port the policies for some of these algorithms, but that can be done in a separate PR.

## Related issue number

https://github.com/ray-project/ray/issues/4788

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
