### PR TITLE
[sgd] Add non-distributed PyTorch runner

### DIFF
--- a/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class DistributedPyTorchRunner(PyTorchRunner):
-    """Manages a distributed PyTorch model replica"""
+    """Manages a distributed PyTorch model replica."""
 
     def __init__(self,
                  model_creator,
@@ -103,13 +103,13 @@ class DistributedPyTorchRunner(PyTorchRunner):
             sampler=self.validation_sampler)
 
     def step(self):
-        """Runs a training epoch and updates the model parameters"""
+        """Runs a training epoch and updates the model parameters."""
         logger.debug("Starting step")
         self.train_sampler.set_epoch(self.epoch)
         return super(DistributedPyTorchRunner, self).step()
 
     def get_state(self):
-        """Returns the state of the runner"""
+        """Returns the state of the runner."""
         return {
             "epoch": self.epoch,
             "model": self.model.module.state_dict(),
@@ -118,12 +118,13 @@ class DistributedPyTorchRunner(PyTorchRunner):
         }
 
     def set_state(self, state):
-        """Sets the state of the model"""
+        """Sets the state of the model."""
         # TODO: restore timer stats
         self.model.module.load_state_dict(state["model"])
         self.optimizer.load_state_dict(state["optimizer"])
         self.epoch = state["stats"]["epoch"]
 
     def shutdown(self):
-        """Attempts to shut down the worker"""
+        """Attempts to shut down the worker."""
+        super(DistributedPyTorchRunner, self).shutdown()
         dist.destroy_process_group()

--- a/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
 import os
 import torch.distributed as dist
@@ -21,16 +25,13 @@ class DistributedPyTorchRunner(PyTorchRunner):
         """Initializes the runner.
 
         Args:
-            model_creator (dict -> torch.nn.Module): creates the model using
-                the config.
-            data_creator (dict -> Dataset, Dataset): creates the training and
-                validation data sets using the config.
+            model_creator (dict -> torch.nn.Module): see pytorch_trainer.py.
+            data_creator (dict -> Dataset, Dataset):  see pytorch_trainer.py.
             optimizer_creator (torch.nn.Module, dict -> loss, optimizer):
-                creates the loss and optimizer using the model and the config.
-            config (dict): configuration passed to 'model_creator',
-                'data_creator', and 'optimizer_creator'.
-            batch_size (int): batch size used in an update.
-            backend (string): backend used by distributed PyTorch.
+                see pytorch_trainer.py.
+            config (dict):  see pytorch_trainer.py.
+            batch_size (int): batch size used by one replica for an update.
+            backend (string):  see pytorch_trainer.py.
         """
         super(DistributedPyTorchRunner, self).__init__(
             model_creator, data_creator, optimizer_creator, config, batch_size)

--- a/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/distributed_pytorch_runner.py
@@ -1,0 +1,129 @@
+import logging
+import os
+import torch.distributed as dist
+import torch.utils.data
+
+from ray.experimental.sgd.pytorch.pytorch_runner import PyTorchRunner
+
+logger = logging.getLogger(__name__)
+
+
+class DistributedPyTorchRunner(PyTorchRunner):
+    """Manages a distributed PyTorch model replica"""
+
+    def __init__(self,
+                 model_creator,
+                 data_creator,
+                 optimizer_creator,
+                 config=None,
+                 batch_size=16,
+                 backend="gloo"):
+        """Initializes the runner.
+
+        Args:
+            model_creator (dict -> torch.nn.Module): creates the model using
+                the config.
+            data_creator (dict -> Dataset, Dataset): creates the training and
+                validation data sets using the config.
+            optimizer_creator (torch.nn.Module, dict -> loss, optimizer):
+                creates the loss and optimizer using the model and the config.
+            config (dict): configuration passed to 'model_creator',
+                'data_creator', and 'optimizer_creator'.
+            batch_size (int): batch size used in an update.
+            backend (string): backend used by distributed PyTorch.
+        """
+        super(DistributedPyTorchRunner, self).__init__(
+            model_creator, data_creator, optimizer_creator, config, batch_size)
+        self.backend = backend
+
+    def setup(self, url, world_rank, world_size):
+        """Connects to the distributed PyTorch backend and initializes the model.
+
+        Args:
+            url (str): the URL used to connect to distributed PyTorch.
+            world_rank (int): the index of the runner.
+            world_size (int): the total number of runners.
+        """
+        self._setup_distributed_pytorch(url, world_rank, world_size)
+        self._setup_training()
+
+    def _setup_distributed_pytorch(self, url, world_rank, world_size):
+        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+        with self._timers["setup_proc"]:
+            self.world_rank = world_rank
+            logger.debug(
+                "Connecting to {} world_rank: {} world_size: {}".format(
+                    url, world_rank, world_size))
+            logger.debug("using {}".format(self.backend))
+            dist.init_process_group(
+                backend=self.backend,
+                init_method=url,
+                rank=world_rank,
+                world_size=world_size)
+
+    def _setup_training(self):
+        logger.debug("Creating model")
+        self.model = self.model_creator(self.config)
+        if torch.cuda.is_available():
+            self.model = torch.nn.parallel.DistributedDataParallel(
+                self.model.cuda())
+        else:
+            self.model = torch.nn.parallel.DistributedDataParallelCPU(
+                self.model)
+
+        logger.debug("Creating optimizer")
+        self.criterion, self.optimizer = self.optimizer_creator(
+            self.model, self.config)
+        if torch.cuda.is_available():
+            self.criterion = self.criterion.cuda()
+
+        logger.debug("Creating dataset")
+        self.training_set, self.validation_set = self.data_creator(self.config)
+
+        # TODO: make num_workers configurable
+        self.train_sampler = torch.utils.data.distributed.DistributedSampler(
+            self.training_set)
+        self.train_loader = torch.utils.data.DataLoader(
+            self.training_set,
+            batch_size=self.batch_size,
+            shuffle=(self.train_sampler is None),
+            num_workers=2,
+            pin_memory=False,
+            sampler=self.train_sampler)
+
+        self.validation_sampler = (
+            torch.utils.data.distributed.DistributedSampler(
+                self.validation_set))
+        self.validation_loader = torch.utils.data.DataLoader(
+            self.validation_set,
+            batch_size=self.batch_size,
+            shuffle=(self.validation_sampler is None),
+            num_workers=2,
+            pin_memory=False,
+            sampler=self.validation_sampler)
+
+    def step(self):
+        """Runs a training epoch and updates the model parameters"""
+        logger.debug("Starting step")
+        self.train_sampler.set_epoch(self.epoch)
+        return super(DistributedPyTorchRunner, self).step()
+
+    def get_state(self):
+        """Returns the state of the runner"""
+        return {
+            "epoch": self.epoch,
+            "model": self.model.module.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+            "stats": self.stats()
+        }
+
+    def set_state(self, state):
+        """Sets the state of the model"""
+        # TODO: restore timer stats
+        self.model.module.load_state_dict(state["model"])
+        self.optimizer.load_state_dict(state["optimizer"])
+        self.epoch = state["stats"]["epoch"]
+
+    def shutdown(self):
+        """Attempts to shut down the worker"""
+        dist.destroy_process_group()

--- a/python/ray/experimental/sgd/pytorch/pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_runner.py
@@ -24,15 +24,12 @@ class PyTorchRunner(object):
         """Initializes the runner.
 
         Args:
-            model_creator (dict -> torch.nn.Module): creates the model using
-                the config.
-            data_creator (dict -> Dataset, Dataset): creates the training and
-                validation data sets using the config.
+            model_creator (dict -> torch.nn.Module): see pytorch_trainer.py.
+            data_creator (dict -> Dataset, Dataset): see pytorch_trainer.py.
             optimizer_creator (torch.nn.Module, dict -> loss, optimizer):
-                creates the loss and optimizer using the model and the config.
-            config (dict): configuration passed to 'model_creator',
-                'data_creator', and 'optimizer_creator'.
-            batch_size (int): batch size used in an update.
+                see pytorch_trainer.py.
+            config (dict): see pytorch_trainer.py.
+            batch_size (int): see pytorch_trainer.py.
         """
 
         self.model_creator = model_creator

--- a/python/ray/experimental/sgd/pytorch/pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_runner.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class PyTorchRunner(object):
-    """Manages a PyTorch model for training"""
+    """Manages a PyTorch model for training."""
 
     def __init__(self,
                  model_creator,
@@ -52,7 +52,7 @@ class PyTorchRunner(object):
         }
 
     def setup(self):
-        """Initializes the model"""
+        """Initializes the model."""
         logger.debug("Creating model")
         self.model = self.model_creator(self.config)
         if torch.cuda.is_available():
@@ -81,15 +81,15 @@ class PyTorchRunner(object):
             pin_memory=False)
 
     def get_node_ip(self):
-        """Returns the IP address of the current node"""
+        """Returns the IP address of the current node."""
         return ray.services.get_node_ip_address()
 
     def find_free_port(self):
-        """Finds a fee port on the curent node"""
+        """Finds a free port on the current node."""
         return utils.find_free_port()
 
     def step(self):
-        """Runs a training epoch and updates the model parameters"""
+        """Runs a training epoch and updates the model parameters."""
         logger.debug("Begin Training Epoch {}".format(self.epoch + 1))
         with self._timers["training"]:
             train_stats = utils.train(self.train_loader, self.model,
@@ -102,7 +102,7 @@ class PyTorchRunner(object):
         return train_stats
 
     def validate(self):
-        """Evaluates the model on the validation data set"""
+        """Evaluates the model on the validation data set."""
         with self._timers["validation"]:
             validation_stats = utils.validate(self.validation_loader,
                                               self.model, self.criterion)
@@ -111,7 +111,7 @@ class PyTorchRunner(object):
         return validation_stats
 
     def stats(self):
-        """Returns a dictionary of statistics collected"""
+        """Returns a dictionary of statistics collected."""
         stats = {"epoch": self.epoch}
         for k, t in self._timers.items():
             stats[k + "_time_mean"] = t.mean
@@ -120,7 +120,7 @@ class PyTorchRunner(object):
         return stats
 
     def get_state(self):
-        """Returns the state of the runner"""
+        """Returns the state of the runner."""
         return {
             "epoch": self.epoch,
             "model": self.model.state_dict(),
@@ -129,12 +129,20 @@ class PyTorchRunner(object):
         }
 
     def set_state(self, state):
-        """Sets the state of the model"""
+        """Sets the state of the model."""
         # TODO: restore timer stats
         self.model.load_state_dict(state["model"])
         self.optimizer.load_state_dict(state["optimizer"])
         self.epoch = state["stats"]["epoch"]
 
     def shutdown(self):
-        """Attempts to shut down the worker"""
-        pass
+        """Attempts to shut down the worker."""
+        del self.validation_loader
+        del self.validation_set
+        del self.train_loader
+        del self.training_set
+        del self.criterion
+        del self.optimizer
+        del self.model
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()

--- a/python/ray/experimental/sgd/pytorch/pytorch_runner.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_runner.py
@@ -84,6 +84,10 @@ class PyTorchRunner(object):
         """Returns the IP address of the current node"""
         return ray.services.get_node_ip_address()
 
+    def find_free_port(self):
+        """Finds a fee port on the curent node"""
+        return utils.find_free_port()
+
     def step(self):
         """Runs a training epoch and updates the model parameters"""
         logger.debug("Begin Training Epoch {}".format(self.epoch + 1))

--- a/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
@@ -55,8 +55,9 @@ class PyTorchTrainer(object):
         # TODO: add support for callbacks
         if num_replicas > 1 and not dist.is_available():
             raise Exception(
-                ("Distributed PyTorch is not supported on macOS. For more "
-                 "information, see "
+                ("Distributed PyTorch is not supported on macOS. "
+                 "To run without distributed PyTorch, set 'num_replicas=1'. "
+                 "For more information, see "
                  "https://github.com/pytorch/examples/issues/467."))
 
         self.model_creator = model_creator

--- a/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
@@ -104,7 +104,7 @@ class PyTorchTrainer(object):
         ]
 
         ip = ray.get(self.workers[0].get_node_ip.remote())
-        port = utils.find_free_port()
+        port = ray.get(self.workers[0].find_free_port.remote())
         address = "tcp://{ip}:{port}".format(ip=ip, port=port)
 
         # Get setup tasks in order to throw errors on failure

--- a/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import sys
 import torch
+import torch.distributed as dist
 import logging
 
 import ray
@@ -53,7 +53,7 @@ class PyTorchTrainer(object):
         """
         # TODO: add support for mixed precision
         # TODO: add support for callbacks
-        if sys.platform == "darwin":
+        if num_replicas > 1 and not dist.is_available():
             raise Exception(
                 ("Distributed PyTorch is not supported on macOS. For more "
                  "information, see "

--- a/python/ray/experimental/sgd/pytorch/utils.py
+++ b/python/ray/experimental/sgd/pytorch/utils.py
@@ -238,3 +238,8 @@ def sgd_mse_optimizer(model, config):
     criterion = nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)
     return criterion, optimizer
+
+
+def clean_state_dict(state_dict):
+    """Removes the 'module.' prefix added by PyTorch"""
+    return {k.replace("module.", ""): v for k, v in state_dict.items()}

--- a/python/ray/experimental/sgd/pytorch/utils.py
+++ b/python/ray/experimental/sgd/pytorch/utils.py
@@ -196,7 +196,7 @@ def find_free_port():
 
 
 class AverageMeter(object):
-    """Computes and stores the average and current value"""
+    """Computes and stores the average and current value."""
 
     def __init__(self):
         self.reset()
@@ -238,8 +238,3 @@ def sgd_mse_optimizer(model, config):
     criterion = nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)
     return criterion, optimizer
-
-
-def clean_state_dict(state_dict):
-    """Removes the 'module.' prefix added by PyTorch"""
-    return {k.replace("module.", ""): v for k, v in state_dict.items()}

--- a/python/ray/experimental/sgd/tests/test_pytorch.py
+++ b/python/ray/experimental/sgd/tests/test_pytorch.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 
 import os
 import pytest
-import sys
 import tempfile
 import torch
+import torch.distributed as dist
 
 from ray.tests.conftest import ray_start_2_cpus  # noqa: F401
 from ray.experimental.sgd.pytorch import PyTorchTrainer, Resources
@@ -15,9 +15,8 @@ from ray.experimental.sgd.tests.pytorch_utils import (
     model_creator, optimizer_creator, data_creator)
 
 
-# Distributed PyTorch doesn't work with macOS, so test with only 1 replica
 @pytest.mark.parametrize(  # noqa: F811
-    "num_replicas", [1] if sys.platform == "darwin" else [1, 2])
+    "num_replicas", [1, 2] if dist.is_available() else [1])
 def test_train(ray_start_2_cpus, num_replicas):  # noqa: F811
     trainer = PyTorchTrainer(
         model_creator,
@@ -38,9 +37,8 @@ def test_train(ray_start_2_cpus, num_replicas):  # noqa: F811
     assert validation_loss2 <= validation_loss1
 
 
-# Distributed PyTorch doesn't work with macOS, so test with only 1 replica
 @pytest.mark.parametrize(  # noqa: F811
-    "num_replicas", [1] if sys.platform == "darwin" else [1, 2])
+    "num_replicas", [1, 2] if dist.is_available() else [1])
 def test_save_and_restore(ray_start_2_cpus, num_replicas):  # noqa: F811
     trainer1 = PyTorchTrainer(
         model_creator,

--- a/python/ray/experimental/sgd/tests/test_pytorch.py
+++ b/python/ray/experimental/sgd/tests/test_pytorch.py
@@ -15,14 +15,15 @@ from ray.experimental.sgd.tests.pytorch_utils import (
     model_creator, optimizer_creator, data_creator)
 
 
-@pytest.mark.skipif(  # noqa: F811
-    sys.platform == "darwin", reason="Doesn't work on macOS.")
-def test_train(ray_start_2_cpus):  # noqa: F811
+# Distributed PyTorch doesn't work with macOS, so test with only 1 replica
+@pytest.mark.parametrize(  # noqa: F811
+    "num_replicas", [1] if sys.platform == "darwin" else [1, 2])
+def test_train(ray_start_2_cpus, num_replicas):  # noqa: F811
     trainer = PyTorchTrainer(
         model_creator,
         data_creator,
         optimizer_creator,
-        num_replicas=2,
+        num_replicas=num_replicas,
         resources_per_replica=Resources(num_cpus=1))
     train_loss1 = trainer.train()["train_loss"]
     validation_loss1 = trainer.validate()["validation_loss"]
@@ -37,14 +38,15 @@ def test_train(ray_start_2_cpus):  # noqa: F811
     assert validation_loss2 <= validation_loss1
 
 
-@pytest.mark.skipif(  # noqa: F811
-    sys.platform == "darwin", reason="Doesn't work on macOS.")
-def test_save_and_restore(ray_start_2_cpus):  # noqa: F811
+# Distributed PyTorch doesn't work with macOS, so test with only 1 replica
+@pytest.mark.parametrize(  # noqa: F811
+    "num_replicas", [1] if sys.platform == "darwin" else [1, 2])
+def test_save_and_restore(ray_start_2_cpus, num_replicas):  # noqa: F811
     trainer1 = PyTorchTrainer(
         model_creator,
         data_creator,
         optimizer_creator,
-        num_replicas=2,
+        num_replicas=num_replicas,
         resources_per_replica=Resources(num_cpus=1))
     trainer1.train()
 
@@ -59,7 +61,7 @@ def test_save_and_restore(ray_start_2_cpus):  # noqa: F811
         model_creator,
         data_creator,
         optimizer_creator,
-        num_replicas=2,
+        num_replicas=num_replicas,
         resources_per_replica=Resources(num_cpus=1))
     trainer2.restore(filename)
 


### PR DESCRIPTION
Updates `PyTorchTrainer` to use distributed PyTorch only if `num_replicas > 1`. This should allow use on OSX despite pytorch/examples#467 as long as `num_replicas=1`.

#### Introduces the following concepts:
- `PyTorchRunner`: manages a single PyTorch model for training. Used when `num_replicas=1`. Can not be used for distributed training.
- `DistrbutedPyTorchRunner`: manages a distributed PyTorch model replica. Code is almost identical as before.

#### Minor changes
- Use `model.module.state_dict()` and `model.module.load_state_dict(state_dict)` for distributed data parallel models as [described in the documentation](https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-torch-nn-dataparallel-models) instead of changing state dict keys.
- Use `dist.is_available()` instead of checking `sys.platform` for throwing macOS-specific errors.