### PR TITLE
Clean up some tables in GCS when driver exits.

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -33,7 +33,7 @@ def _parse_client_table(redis_client):
     NIL_CLIENT_ID = ray.ObjectID.nil().binary()
     message = redis_client.execute_command("RAY.TABLE_LOOKUP",
                                            ray.gcs_utils.TablePrefix.CLIENT,
-                                           "", NIL_CLIENT_ID)
+                                           "", ray.ObjectID.nil().binary(), NIL_CLIENT_ID)
 
     # Handle the case where no clients are returned. This should only
     # occur potentially immediately after the cluster is started.
@@ -245,6 +245,7 @@ class GlobalState(object):
         # Return information about a single object ID.
         message = self._execute_command(object_id, "RAY.TABLE_LOOKUP",
                                         ray.gcs_utils.TablePrefix.OBJECT, "",
+                                        ray.ObjectID.nil().binary(),
                                         object_id.binary())
         if message is None:
             return {}
@@ -304,7 +305,7 @@ class GlobalState(object):
         assert isinstance(task_id, ray.TaskID)
         message = self._execute_command(task_id, "RAY.TABLE_LOOKUP",
                                         ray.gcs_utils.TablePrefix.RAYLET_TASK,
-                                        "", task_id.binary())
+                                        "", ray.ObjectID.nil().binary(), task_id.binary())
         if message is None:
             return {}
         gcs_entries = ray.gcs_utils.GcsTableEntry.GetRootAsGcsTableEntry(
@@ -426,7 +427,7 @@ class GlobalState(object):
         # events and should also support returning a window of events.
         message = self._execute_command(batch_id, "RAY.TABLE_LOOKUP",
                                         ray.gcs_utils.TablePrefix.PROFILE, "",
-                                        batch_id.binary())
+                                        ray.ObjectID.nil().binary(), batch_id.binary())
 
         if message is None:
             return []
@@ -865,7 +866,7 @@ class GlobalState(object):
         assert isinstance(driver_id, ray.DriverID)
         message = self.redis_client.execute_command(
             "RAY.TABLE_LOOKUP", ray.gcs_utils.TablePrefix.ERROR_INFO, "",
-            driver_id.binary())
+            ray.ObjectID.nil().binary(), driver_id.binary())
 
         # If there are no errors, return early.
         if message is None:
@@ -930,6 +931,7 @@ class GlobalState(object):
             "RAY.TABLE_LOOKUP",
             ray.gcs_utils.TablePrefix.ACTOR_CHECKPOINT_ID,
             "",
+            ray.ObjectID.nil().binary(),
             actor_id.binary(),
         )
         if message is None:

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -96,7 +96,7 @@ def push_error_to_driver_through_redis(redis_client,
     redis_client.execute_command("RAY.TABLE_APPEND",
                                  ray.gcs_utils.TablePrefix.ERROR_INFO,
                                  ray.gcs_utils.TablePubsub.ERROR_INFO,
-                                 driver_id.binary(), error_data)
+                                 driver_id.binary, driver_id.binary(), error_data)
 
 
 def is_cython(obj):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1884,6 +1884,7 @@ def connect(node,
                                          "RAY.TABLE_ADD",
                                          ray.gcs_utils.TablePrefix.RAYLET_TASK,
                                          ray.gcs_utils.TablePubsub.RAYLET_TASK,
+                                         driver_task.driver_id().binary(),
                                          driver_task.task_id().binary(),
                                          driver_task._serialized_raylet_task())
 

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -36,4 +36,11 @@ constexpr char kObjectTablePrefix[] = "ObjectTable";
 /// Prefix for the task table keys in redis.
 constexpr char kTaskTablePrefix[] = "TaskTable";
 
+/// Prefix for the index of actor table.
+constexpr char kActorIndexPrefix[] = "INDEX_ACTOR_";
+/// Prefix for the index of raylet task table.
+constexpr char kRayletTaskIndexPrefix[] = "INDEX_RAYLET_TASK_";
+/// Prefix for the index of object table.
+constexpr char kObjectIndexPrefix[] = "INDEX_OBJECT_";
+
 #endif  // RAY_CONSTANTS_H_

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -113,7 +113,7 @@ void CallbackReply::ReadAsStringArray(std::vector<std::string> *array) const {
         strcmp(entry->str, "subscribe") == 0 || strcmp(entry->str, "message") == 0;
     RAY_CHECK(!is_pubsub_reply) << "Subpub reply cannot be read as a string array.";
   }
-  // array->reverse(array_size);
+
   for (size_t i = 0; i < array_size; ++i) {
     auto *entry = redis_reply_->element[i];
     RAY_CHECK(REDIS_REPLY_STRING == entry->type) << "Unexcepted type: " << entry->type;
@@ -274,10 +274,10 @@ Status RedisContext::RunArgvAsyncWithCallback(const std::vector<std::string> &ar
   }
   int status = redisAsyncCommandArgv(async_context_, reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
       reinterpret_cast<void *>(callback_index), args.size(), argv.data(), argc.data());
-//  std::string a("ACTOR");
-//  Status status = redisAsyncCommandArgv(async_context_, &GlobalRedisCallback,
-//                                               reinterpret_cast<void *>(callback_index),
-//                                               2, "SMEMBERS %b", a.c_str(), a.size());
+
+  if (status == REDIS_ERR) {
+    return Status::RedisError(std::string(async_context_->errstr));
+  }
   return Status::OK();
 }
 

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -517,6 +517,9 @@ int Set_DoWrite(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool is
         REPLY_AND_RETURN_IF_FALSE(RedisModule_DeleteKey(key) == REDISMODULE_OK,
                                   "ERR Failed to delete empty set.");
       }
+
+      // Update the index.
+      RAY_IGNORE_EXPR(UpdateTableIndex(ctx, prefix_str, driver_id_str, id, /*is_add=*/false));
     }
     return REDISMODULE_OK;
   } else {

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -104,7 +104,6 @@ Status ParseTablePrefix(const RedisModuleString *table_prefix_str, TablePrefix *
   }
 }
 
-/// TODO(qwang): Add more
 /// Update index for tables.
 Status UpdateTableIndex(RedisModuleCtx *ctx,
                         RedisModuleString *prefix_enum,
@@ -116,12 +115,8 @@ Status UpdateTableIndex(RedisModuleCtx *ctx,
     return Status::RedisError("Failed to parse table prefix.");
   }
 
-//  if (prefix == TablePrefix::OBJECT) {
-//    GetDriverIdOfObject(ctx, id);
-//  }
-
   if (prefix != TablePrefix::ACTOR && prefix != TablePrefix::RAYLET_TASK && prefix != TablePrefix::OBJECT) {
-    RAY_LOG(DEBUG) << "Ignore this update index since the prefix is not ACTOR, and it's " << EnumNameTablePrefix(prefix);
+    RAY_LOG(DEBUG) << "The table("<< EnumNameTablePrefix(prefix) <<") needn't to be updated index.";
     return Status::OK();
   }
 
@@ -129,8 +124,6 @@ Status UpdateTableIndex(RedisModuleCtx *ctx,
   RedisModuleCallReply *reply =
     RedisModule_Call(ctx, is_add ? "SADD" : "SREM", "ss", key_str, id);
   if (RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ERROR) {
-    //*changed = RedisModule_CallReplyInteger(reply) > 0;
-    //TODO(qwang): Should we remove empty set here?
     return Status::RedisError("Failed to update index.");
   } else {
     return Status::OK();
@@ -460,7 +453,6 @@ int ChainTableAppend_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 #endif
 
 int Set_DoPublish(RedisModuleCtx *ctx, RedisModuleString **argv, bool is_add) {
-  // TODO(qwang): Check argc
   RedisModuleString *pubsub_channel_str = argv[2];
   RedisModuleString *id = argv[4];
   RedisModuleString *data = argv[5];
@@ -479,7 +471,6 @@ int Set_DoPublish(RedisModuleCtx *ctx, RedisModuleString **argv, bool is_add) {
   }
 }
 
-// TODO(qwang): extra the common code.
 int Set_DoWrite(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool is_add,
                 bool *changed) {
   if (argc != 6) {

--- a/src/ray/gcs/redis_module/ray_redis_module.cc
+++ b/src/ray/gcs/redis_module/ray_redis_module.cc
@@ -732,6 +732,7 @@ int TableDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return RedisModule_WrongArity(ctx);
   }
   RedisModuleString *prefix_str = argv[1];
+  RedisModuleString *driver_id_str = argv[3];
   RedisModuleString *data = argv[5];
 
   size_t len = 0;
@@ -746,6 +747,7 @@ int TableDelete_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   for (size_t i = 0; i < ids_to_delete; ++i) {
     RedisModuleString *id_data =
         RedisModule_CreateString(ctx, data_ptr + i * id_length, id_length);
+    RAY_IGNORE_EXPR(UpdateTableIndex(ctx, prefix_str, driver_id_str, id_data, /*is_add=*/false));
     RAY_IGNORE_EXPR(DeleteKeyHelper(ctx, prefix_str, id_data));
   }
   return RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -4,7 +4,6 @@
 #include "ray/common/ray_config.h"
 #include "ray/gcs/client.h"
 #include "ray/util/util.h"
-#include "ray/constants.h"
 
 namespace {
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -460,6 +460,9 @@ class ObjectTable : public Set<ObjectID, ObjectTableData> {
     prefix_ = TablePrefix::OBJECT;
   };
 
+  using GetAllObjectsCallback =  std::function<void (const std::vector<ObjectID> &)>;
+  Status GetAllObjectIdsByDriverId(const DriverID &driver_id, GetAllObjectsCallback callback);
+
   virtual ~ObjectTable(){};
 };
 
@@ -529,6 +532,9 @@ class ActorTable : public Log<ActorID, ActorTableData> {
     pubsub_channel_ = TablePubsub::ACTOR;
     prefix_ = TablePrefix::ACTOR;
   }
+
+  using GetAllActorsCallback =  std::function<void (const std::vector<ActorID> &)>;
+  Status GetAllActorIdsByDriverId(const DriverID &driver_id, GetAllActorsCallback callback);
 };
 
 class TaskReconstructionLog : public Log<TaskID, TaskReconstructionData> {
@@ -610,6 +616,10 @@ class TaskTable : public Table<TaskID, ray::protocol::Task> {
       : TaskTable(contexts, client) {
     command_type_ = command_type;
   };
+
+  using GetAllTasksCallback =  std::function<void (const std::vector<TaskID> &)>;
+  Status GetAllTaskIdsByDriverId(const DriverID &driver_id, GetAllTasksCallback callback);
+
 };
 
 }  // namespace raylet

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -199,6 +199,15 @@ class Log : public LogInterface<ID, Data>, virtual public PubsubInterface<ID> {
   /// \return Void.
   void Delete(const DriverID &driver_id, const std::vector<ID> &ids);
 
+  using GetAllIdsCallback = std::function<void (const std::vector<ID> &)>;
+
+  /// Get all ids of this table by driver.
+  ///
+  /// \param driver_id The ID of this driver.
+  /// \param callback The callback that processes the data of ids.
+  /// \return Status
+  Status GetAllIdsByDriver(const DriverID &driver_id, GetAllIdsCallback callback);
+
   /// Returns debug string for class.
   ///
   /// \return string.
@@ -349,6 +358,15 @@ class Table : private Log<ID, Data>,
     Log<ID, Data>::Delete(driver_id, ids);
   }
 
+  using GetAllIdsCallback = std::function<void (const std::vector<ID> &)>;
+
+  /// Get all ids of this table by driver.
+  ///
+  /// \param driver_id The ID of this driver.
+  /// \param callback The callback that processes the data of ids.
+  /// \return Status
+  Status GetAllIdsByDriver(const DriverID &driver_id, GetAllIdsCallback callback);
+
   /// Returns debug string for class.
   ///
   /// \return string.
@@ -434,6 +452,15 @@ class Set : private Log<ID, Data>,
     return Log<ID, Data>::Subscribe(driver_id, client_id, subscribe, done);
   }
 
+  using GetAllIdsCallback = std::function<void (const std::vector<ID> &)>;
+
+  /// Get all ids of this table by driver.
+  ///
+  /// \param driver_id The ID of this driver.
+  /// \param callback The callback that processes the data of ids.
+  /// \return Status
+  Status GetAllIdsByDriver(const DriverID &driver_id, GetAllIdsCallback callback);
+
   /// Returns debug string for class.
   ///
   /// \return string.
@@ -459,9 +486,6 @@ class ObjectTable : public Set<ObjectID, ObjectTableData> {
     pubsub_channel_ = TablePubsub::OBJECT;
     prefix_ = TablePrefix::OBJECT;
   };
-
-  using GetAllObjectsCallback =  std::function<void (const std::vector<ObjectID> &)>;
-  Status GetAllObjectIdsByDriverId(const DriverID &driver_id, GetAllObjectsCallback callback);
 
   virtual ~ObjectTable(){};
 };
@@ -533,8 +557,6 @@ class ActorTable : public Log<ActorID, ActorTableData> {
     prefix_ = TablePrefix::ACTOR;
   }
 
-  using GetAllActorsCallback =  std::function<void (const std::vector<ActorID> &)>;
-  Status GetAllActorIdsByDriverId(const DriverID &driver_id, GetAllActorsCallback callback);
 };
 
 class TaskReconstructionLog : public Log<TaskID, TaskReconstructionData> {
@@ -616,9 +638,6 @@ class TaskTable : public Table<TaskID, ray::protocol::Task> {
       : TaskTable(contexts, client) {
     command_type_ = command_type;
   };
-
-  using GetAllTasksCallback =  std::function<void (const std::vector<TaskID> &)>;
-  Status GetAllTaskIdsByDriverId(const DriverID &driver_id, GetAllTasksCallback callback);
 
 };
 

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -124,6 +124,10 @@ class ObjectDirectoryInterface {
   ///
   /// \return string.
   virtual std::string DebugString() const = 0;
+
+  virtual void BindTaskIdToDriver(const TaskID &task_id, const DriverID &driver_id) = 0;
+
+  virtual void CleanTaskBinding(const TaskID &task_id) = 0;
 };
 
 /// Ray ObjectDirectory declaration.
@@ -171,6 +175,10 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   /// ObjectDirectory should not be copied.
   RAY_DISALLOW_COPY_AND_ASSIGN(ObjectDirectory);
 
+  void BindTaskIdToDriver(const TaskID &task_id, const DriverID &driver_id) override;
+
+  void CleanTaskBinding(const TaskID &task_id) override;
+
  private:
   /// Callbacks associated with a call to GetLocations.
   struct LocationListenerState {
@@ -192,6 +200,9 @@ class ObjectDirectory : public ObjectDirectoryInterface {
   std::shared_ptr<gcs::AsyncGcsClient> gcs_client_;
   /// Info about subscribers to object locations.
   std::unordered_map<ObjectID, LocationListenerState> listeners_;
+  /// Map from task ID to driver ID. Used to bind object to driver.
+  /// This will help to keep GCS TPS lower.
+  std::unordered_map<TaskID, DriverID> task_driver_binding_;
 };
 
 }  // namespace ray

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -275,10 +275,8 @@ void NodeManager::HandleDriverTableUpdate(
       // alive because of the delay in killing workers.
       CleanUpTasksForDeadDriver(driver_id);
 
-      // Clean up GCS
+      // Clean up data from GCS.
       CleanUpGcsData(driver_id);
-
-      // TODO(qwang): Clean up other data cached in node_manager, object manager.
     }
   }
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -750,7 +750,7 @@ void NodeManager::CleanUpGcsData(const DriverID &driver_id) {
     auto cb = [driver_id, this](const std::vector <ActorID> &ids) {
       this->gcs_client_->actor_table().Delete(driver_id, ids);
     };
-    gcs_client_->actor_table().GetAllActorIdsByDriverId(driver_id, std::move(cb));
+    gcs_client_->actor_table().GetAllIdsByDriver(driver_id, std::move(cb));
   }
 
   {
@@ -758,7 +758,7 @@ void NodeManager::CleanUpGcsData(const DriverID &driver_id) {
     auto cb = [driver_id, this] (const std::vector<TaskID> &ids) {
       this->gcs_client_->raylet_task_table().Delete(driver_id, ids);
     };
-    gcs_client_->raylet_task_table().GetAllTaskIdsByDriverId(driver_id, std::move(cb));
+    gcs_client_->raylet_task_table().GetAllIdsByDriver(driver_id, std::move(cb));
   }
 
   {
@@ -768,7 +768,7 @@ void NodeManager::CleanUpGcsData(const DriverID &driver_id) {
       // Note that this also can removed the objects from GCS.
       object_manager_.FreeObjects(ids, false);
     };
-    gcs_client_->object_table().GetAllObjectIdsByDriverId(driver_id, std::move(cb));
+    gcs_client_->object_table().GetAllIdsByDriver(driver_id, std::move(cb));
   }
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -328,6 +328,12 @@ class NodeManager {
   /// \return Void.
   void CleanUpTasksForDeadDriver(const DriverID &driver_id);
 
+  /// Clean up the data in Gcs when a driver dies.
+  ///
+  /// \param driver_id The driver that died.
+  /// \retrurn Void.
+  void CleanUpGcsData(const DriverID &driver_id);
+
   /// Handle an object becoming local. This updates any local accounting, but
   /// does not write to any global accounting in the GCS.
   ///

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -3,6 +3,7 @@
 
 #include <boost/system/error_code.hpp>
 #include <chrono>
+#include <algorithm>
 
 #include "ray/common/status.h"
 
@@ -77,5 +78,21 @@ class InitShutdownRAII {
  private:
   ShutdownFunc shutdown_;
 };
+
+template <typename T>
+using BatchCallType = std::function<void (const std::vector<T> &)>;
+
+/// Do batch call on a set of items.
+///
+/// \param items The items that we will do batch call on.
+/// \param batch_size The size of a batch.
+/// \param batch_call The function that we will do on a batch of items.
+template <typename T>
+void DoBatchCall(const std::vector<T> &items, size_t batch_size, BatchCallType<T> batch_call) {
+  for (int i = 0; i < items.size(); i += batch_size) {
+    const size_t end_index = std::min(i + batch_size, items.size());
+    batch_call(std::vector<T>(items.begin() + i, items.begin() + end_index));
+  }
+}
 
 #endif  // RAY_UTIL_UTIL_H


### PR DESCRIPTION
## What do these changes do?
This PR aims to clean up task table, object table and actor table when a driver exits. Otherwise, if we run many drivers on a cluster which is a long running cluster, the redis will often be OOM.

We added indexes for the tables per redis instance. 

For task table, we added a k-v pair which index the `driver_id` to all `task_id`s of the driver to every redis instance.

We clean up the task table and actor table by `Log::Delete()` method, and clean up the object table by `ObjectManager::FreeObjects()`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
