### PR TITLE
Upload wheels on Travis to branchname/commit_id.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ deploy:
     acl: public_read
     region: us-west-2
     local_dir: .whl
-    upload-dir: $TRAVIS_COMMIT
+    upload-dir: "$TRAVIS_BRANCH/$TRAVIS_COMMIT"
     skip_cleanup: true
     on:
       repo: ray-project/ray


### PR DESCRIPTION
I noticed that if we cherry-pick a commit from one branch to another (in particular, from the master branch to a release branch), then the commit has the same commit ID on both branches, and so the wheels built from the two branches will override each other in S3 (but the actual wheels will differ since the branches are different). We can fix this by prefixing the commit ID with the branch name.

So instead of

https://ray-wheels.s3-us-west-2.amazonaws.com/002531b199aaeb40d267b4ac50dbc7ae7689da1b/ray-0.6.2-cp27-cp27m-macosx_10_6_intel.whl

it would be

https://ray-wheels.s3-us-west-2.amazonaws.com/master/002531b199aaeb40d267b4ac50dbc7ae7689da1b/ray-0.6.2-cp27-cp27m-macosx_10_6_intel.whl