### PR TITLE
[rllib] Add preprocessing example to offline documentation

### DIFF
--- a/python/ray/rllib/examples/saving_experiences.py
+++ b/python/ray/rllib/examples/saving_experiences.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import gym
 import numpy as np
 
+from ray.rllib.models.preprocessors import get_preprocessor
 from ray.rllib.evaluation.sample_batch_builder import SampleBatchBuilder
 from ray.rllib.offline.json_writer import JsonWriter
 
@@ -17,6 +18,12 @@ if __name__ == "__main__":
     # You normally wouldn't want to manually create sample batches if a
     # simulator is available, but let's do it anyways for example purposes:
     env = gym.make("CartPole-v0")
+
+    # RLlib uses preprocessors to implement transforms such as one-hot encoding
+    # and flattening of tuple and dict observations. For CartPole a no-op
+    # preprocessor is used, but this may be relevant for more complex envs.
+    prep = get_preprocessor(env.observation_space)(env.observation_space)
+    print("The preprocessor is", prep)
 
     for eps_id in range(100):
         obs = env.reset()
@@ -31,7 +38,7 @@ if __name__ == "__main__":
                 t=t,
                 eps_id=eps_id,
                 agent_index=0,
-                obs=obs,
+                obs=prep.transform(obs),
                 actions=action,
                 action_prob=1.0,  # put the true action probability here
                 rewards=rew,
@@ -39,7 +46,7 @@ if __name__ == "__main__":
                 prev_rewards=prev_reward,
                 dones=done,
                 infos=info,
-                new_obs=new_obs)
+                new_obs=prep.transform(new_obs))
             obs = new_obs
             prev_action = action
             prev_reward = rew


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

In the example, show how to use preprocessors.

## Related issue number

Resolves https://groups.google.com/forum/#!msg/ray-dev/8Hh4K_tu8X4/FTlAubDdBwAJ

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
