### PR TITLE
reformat observation as tuple

### DIFF
--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -193,7 +193,7 @@ class TupleFlatteningPreprocessor(Preprocessor):
 
     @override(Preprocessor)
     def transform(self, observation):
-        self.check_shape(observation)
+        self.check_shape(tuple(observation))
         array = np.zeros(self.shape)
         self.write(observation, array, 0)
         return array


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
TupleFlatteningPreprocessor.transform(..., observation) gets an observation of type **np.ndarray**, and sends it to self.check_shape(observation) that **expects a tuple** (since TupleFlatteningPreprocessor is only used when the env.observation_space is a gym.spaces.Tuple). To fix that, I added an explicit cast into a tuple before sending to self.check_shape()


## Related issue number
"Closes #4952 "

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
