### PR TITLE
[core] Use int64_t instead of int to keep track of fractional resources

### DIFF
--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -18,7 +18,7 @@ FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity)
   RAY_CHECK(resource_quantity >= 0) << "Resource capacity, " << resource_quantity
                                     << ", should be nonnegative.";
 
-  resource_quantity_ = static_cast<int>(resource_quantity * kResourceConversionFactor);
+  resource_quantity_ = static_cast<int64_t>(resource_quantity * kResourceConversionFactor);
 }
 
 const FractionalResourceQuantity FractionalResourceQuantity::operator+(

--- a/src/ray/raylet/scheduling_resources.cc
+++ b/src/ray/raylet/scheduling_resources.cc
@@ -18,7 +18,8 @@ FractionalResourceQuantity::FractionalResourceQuantity(double resource_quantity)
   RAY_CHECK(resource_quantity >= 0) << "Resource capacity, " << resource_quantity
                                     << ", should be nonnegative.";
 
-  resource_quantity_ = static_cast<int64_t>(resource_quantity * kResourceConversionFactor);
+  resource_quantity_ =
+      static_cast<int64_t>(resource_quantity * kResourceConversionFactor);
 }
 
 const FractionalResourceQuantity FractionalResourceQuantity::operator+(

--- a/src/ray/raylet/scheduling_resources.h
+++ b/src/ray/raylet/scheduling_resources.h
@@ -58,7 +58,7 @@ class FractionalResourceQuantity {
  private:
   /// The resource quantity represented as 1/kResourceConversionFactor-th of a
   /// unit.
-  int resource_quantity_;
+  int64_t resource_quantity_;
 };
 
 /// \class ResourceSet


### PR DESCRIPTION
This was discovered when investigating https://github.com/ray-project/ray/issues/4657 and is what generated the integer underflow:

A signed int can be `2147483647` at max, and we measure `FractionalResourceQuantity` in multiples of 10000, so if as part of some accumulation (e.g. for resource bookkeeping in the queues with `SchedulingResources`) we get more than 214748 of a resource, the int will overflow.

This PR fixes the overflow by replacing the int with an int64. It fixes the crash in the original version of 
https://github.com/ray-project/ray/issues/4657.
