### PR TITLE
[Java] Fix bug of `BaseID` in multi-threading case.

### DIFF
--- a/java/api/src/main/java/org/ray/api/id/BaseId.java
+++ b/java/api/src/main/java/org/ray/api/id/BaseId.java
@@ -39,7 +39,7 @@ public abstract class BaseId implements Serializable {
   /**
    * @return True if this id is nil.
    */
-  public boolean isNil() {
+  public synchronized boolean isNil() {
     if (isNilCache == null) {
       isNilCache = true;
       for (int i = 0; i < size(); ++i) {
@@ -59,7 +59,7 @@ public abstract class BaseId implements Serializable {
   public abstract int size();
 
   @Override
-  public int hashCode() {
+  public synchronized int hashCode() {
     // Lazy evaluation.
     if (hashCodeCache == 0) {
       hashCodeCache = Arrays.hashCode(id);

--- a/java/api/src/main/java/org/ray/api/id/BaseId.java
+++ b/java/api/src/main/java/org/ray/api/id/BaseId.java
@@ -39,15 +39,16 @@ public abstract class BaseId implements Serializable {
   /**
    * @return True if this id is nil.
    */
-  public synchronized boolean isNil() {
+  public boolean isNil() {
     if (isNilCache == null) {
-      isNilCache = true;
+      boolean localIsNil = true;
       for (int i = 0; i < size(); ++i) {
         if (id[i] != (byte) 0xff) {
-          isNilCache = false;
+          localIsNil = false;
           break;
         }
       }
+    isNilCache = localIsNil;
     }
     return isNilCache;
   }
@@ -59,7 +60,7 @@ public abstract class BaseId implements Serializable {
   public abstract int size();
 
   @Override
-  public synchronized int hashCode() {
+  public int hashCode() {
     // Lazy evaluation.
     if (hashCodeCache == 0) {
       hashCodeCache = Arrays.hashCode(id);


### PR DESCRIPTION
The CI always fail at the case `testInWorker` because of the failure at this check https://github.com/ray-project/ray/blob/master/java/runtime/src/main/java/org/ray/runtime/raylet/RayletClientImpl.java#L86.

The reason for this is that  multiple threads  hold the same `driver_id`. Once [this line]( https://github.com/ray-project/ray/blob/master/java/api/src/main/java/org/ray/api/id/BaseId.java#L44) has been performed in one thread, another thread(called `ThreadB`) went into `isNil()` method immediately, then it returned `true` in `ThreadB`.