### PR TITLE
Starting of ray head and worker is synchronized on GCS_READY flag in gcs

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -697,6 +697,11 @@ def start_redis(node_ip_address,
         shard_client.execute_command("MEMBER.CONNECT_TO_MASTER",
                                      node_ip_address, port)
 
+        # indicate that all relevant options have been written into primary
+        # redis-server by the head node so that workers know whether they
+        # should start to read them from redis.
+        primary_redis_client.set("GCS_READY", 1)
+
     return redis_address, redis_shards, processes
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
This PR solve the problem of workers missing configs set by header in gcs when head and worker start concurrently.
The solution is to set a GCS_READY flag in GCS, which both head and workers synchronize on.

## Related issue number
Closes #4266

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
