### PR TITLE
Inherit Function Docstrings and other metedata

### DIFF
--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -79,6 +79,7 @@ class RemoteFunction(object):
         @wraps(function)
         def _remote_proxy(*args, **kwargs):
             return self._remote(args=args, kwargs=kwargs)
+
         self.remote = _remote_proxy
 
     def __call__(self, *args, **kwargs):

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import copy
 import logging
+from functools import wraps
 
 from ray.function_manager import FunctionDescriptor
 import ray.signature
@@ -74,14 +75,16 @@ class RemoteFunction(object):
 
         self._last_driver_id_exported_for = None
 
+        # Override task.remote's signature and docstring
+        @wraps(function)
+        def _remote_proxy(*args, **kwargs):
+            return self._remote(args=args, kwargs=kwargs)
+        self.remote = _remote_proxy
+
     def __call__(self, *args, **kwargs):
         raise Exception("Remote functions cannot be called directly. Instead "
                         "of running '{}()', try '{}.remote()'.".format(
                             self._function_name, self._function_name))
-
-    def remote(self, *args, **kwargs):
-        """This runs immediately when a remote function is called."""
-        return self._remote(args=args, kwargs=kwargs)
 
     def _submit(self,
                 args=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
When user use `@ray.remote` decorate, the docstring and signature of original function is loss. This tiny PR makes it possible for users to see the signature and docstring for a ray remote task.


### Before
![image](https://user-images.githubusercontent.com/21118851/59530105-986d0c00-8e97-11e9-9df2-063c4f7251cc.png)


### After
![image](https://user-images.githubusercontent.com/21118851/59530136-ac187280-8e97-11e9-80a1-9f1cf08942d8.png)

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.


## Discussion
I can't apply the same mechanism to inherit docstrings or signature for actors. Because ActorHandle only has actor_id not the original class. I'm happy to discuss here how to retrieve the original class from ActorHandle.  
