### PR TITLE
Fix a crash when unknown worker registering to raylet.

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -164,7 +164,10 @@ void WorkerPool::RegisterWorker(const std::shared_ptr<Worker> &worker) {
   state.registered_workers.insert(std::move(worker));
 
   auto it = state.starting_worker_processes.find(pid);
-  RAY_CHECK(it != state.starting_worker_processes.end());
+  if (it == state.starting_worker_processes.end()) {
+    RAY_LOG(WARNING) << "Received a register request from an unknown worker " << pid;
+    return;
+  }
   it->second--;
   if (it->second == 0) {
     state.starting_worker_processes.erase(it);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
This change aims to avoid crash from raylet when a worker from last cluster registers to this cluster.  


<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
