### PR TITLE
Fix Java CI failure

### DIFF
--- a/java/api/src/main/java/org/ray/api/id/BaseId.java
+++ b/java/api/src/main/java/org/ray/api/id/BaseId.java
@@ -48,7 +48,7 @@ public abstract class BaseId implements Serializable {
           break;
         }
       }
-    isNilCache = localIsNil;
+      isNilCache = localIsNil;
     }
     return isNilCache;
   }

--- a/java/test/src/main/java/org/ray/api/TestUtils.java
+++ b/java/test/src/main/java/org/ray/api/TestUtils.java
@@ -1,7 +1,6 @@
 package org.ray.api;
 
 import java.util.function.Supplier;
-
 import org.ray.api.annotation.RayRemote;
 import org.ray.runtime.AbstractRayRuntime;
 import org.ray.runtime.config.RunMode;

--- a/java/test/src/main/java/org/ray/api/TestUtils.java
+++ b/java/test/src/main/java/org/ray/api/TestUtils.java
@@ -1,8 +1,11 @@
 package org.ray.api;
 
 import java.util.function.Supplier;
+
+import org.ray.api.annotation.RayRemote;
 import org.ray.runtime.AbstractRayRuntime;
 import org.ray.runtime.config.RunMode;
+import org.testng.Assert;
 import org.testng.SkipException;
 
 public class TestUtils {
@@ -41,5 +44,18 @@ public class TestUtils {
       }
     }
     return false;
+  }
+
+  @RayRemote
+  private static String hi() {
+    return "hi";
+  }
+
+  /**
+   * Warm up the cluster.
+   */
+  public static void warmUpCluster() {
+    RayObject<String> obj = Ray.call(TestUtils::hi);
+    Assert.assertEquals(obj.get(), "hi");
   }
 }

--- a/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
+++ b/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
@@ -31,15 +31,15 @@ public class DynamicResourceTest extends BaseTest {
 
     Ray.setResource("A", 10.0);
 
-    // Assert node info.
-    List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
-    Assert.assertEquals(nodes.size(), 1);
-    Assert.assertEquals(nodes.get(0).resources.get("A"), 10.0);
-
     // Assert ray call result.
     result = Ray.wait(ImmutableList.of(obj), 1, 1000);
     Assert.assertEquals(result.getReady().size(), 1);
     Assert.assertEquals(Ray.get(obj.getId()), "hi");
+
+    // Assert node info.
+    List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
+    Assert.assertEquals(nodes.size(), 1);
+    Assert.assertEquals(nodes.get(0).resources.get("A"), 10.0);
   }
 
 }

--- a/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
+++ b/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
@@ -3,6 +3,8 @@ package org.ray.api.test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.TestUtils;
@@ -21,7 +23,7 @@ public class DynamicResourceTest extends BaseTest {
   }
 
   @Test
-  public void testSetResource() {
+  public void testSetResource() throws InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
     CallOptions op1 =
         new CallOptions.Builder().setResources(ImmutableMap.of("A", 10.0)).createCallOptions();
@@ -36,6 +38,7 @@ public class DynamicResourceTest extends BaseTest {
     Assert.assertEquals(result.getReady().size(), 1);
     Assert.assertEquals(Ray.get(obj.getId()), "hi");
 
+    TimeUnit.SECONDS.sleep(1);
     // Assert node info.
     List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
     Assert.assertEquals(nodes.size(), 1);

--- a/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
+++ b/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
 import org.ray.api.TestUtils;

--- a/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
+++ b/java/test/src/main/java/org/ray/api/test/DynamicResourceTest.java
@@ -31,17 +31,21 @@ public class DynamicResourceTest extends BaseTest {
     Assert.assertEquals(result.getReady().size(), 0);
 
     Ray.setResource("A", 10.0);
+    boolean resourceReady = TestUtils.waitForCondition(()-> {
+      List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
+      if(nodes.size() != 1) {
+        return false;
+      }
+      return (0 == Double.compare(10.0, nodes.get(0).resources.get("A")));
+    }, 2000);
+
+    Assert.assertTrue(resourceReady);
 
     // Assert ray call result.
     result = Ray.wait(ImmutableList.of(obj), 1, 1000);
     Assert.assertEquals(result.getReady().size(), 1);
     Assert.assertEquals(Ray.get(obj.getId()), "hi");
 
-    TimeUnit.SECONDS.sleep(1);
-    // Assert node info.
-    List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
-    Assert.assertEquals(nodes.size(), 1);
-    Assert.assertEquals(nodes.get(0).resources.get("A"), 10.0);
   }
 
 }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -54,7 +54,7 @@ public class WaitTest extends BaseTest {
 
   @Test
   public void testWaitInWorker() {
-    // Call a task in advance to warm up the cluster to avoid too slow to start workers.
+    // Call a task in advance to warm up the cluster to avoid being too slow to start workers.
     warmUpCluster();
 
     RayObject<Object> res = Ray.call(WaitTest::waitInWorker);

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -54,6 +54,9 @@ public class WaitTest extends BaseTest {
 
   @Test
   public void testWaitInWorker() {
+    // Call a task in advance to warm up the cluster to avoid too slow to start workers.
+    warmUpCluster();
+
     RayObject<Object> res = Ray.call(WaitTest::waitInWorker);
     res.get();
   }
@@ -70,5 +73,10 @@ public class WaitTest extends BaseTest {
     } catch (NullPointerException e) {
       Assert.assertTrue(true);
     }
+  }
+
+  private void warmUpCluster() {
+    RayObject<String> obj = Ray.call(WaitTest::hi);
+    Assert.assertEquals(obj.get(), "hi");
   }
 }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.ray.api.Ray;
 import org.ray.api.RayObject;
+import org.ray.api.TestUtils;
 import org.ray.api.WaitResult;
 import org.ray.api.annotation.RayRemote;
 import org.testng.Assert;
@@ -29,7 +30,7 @@ public class WaitTest extends BaseTest {
 
   private static void testWait() {
     // Call a task in advance to warm up the cluster to avoid being too slow to start workers.
-    warmUpCluster();
+    TestUtils.warmUpCluster();
 
     RayObject<String> obj1 = Ray.call(WaitTest::hi);
     RayObject<String> obj2 = Ray.call(WaitTest::delayedHi);
@@ -75,8 +76,4 @@ public class WaitTest extends BaseTest {
     }
   }
 
-  public static void warmUpCluster() {
-    RayObject<String> obj = Ray.call(WaitTest::hi);
-    Assert.assertEquals(obj.get(), "hi");
-  }
 }

--- a/java/test/src/main/java/org/ray/api/test/WaitTest.java
+++ b/java/test/src/main/java/org/ray/api/test/WaitTest.java
@@ -28,6 +28,9 @@ public class WaitTest extends BaseTest {
   }
 
   private static void testWait() {
+    // Call a task in advance to warm up the cluster to avoid being too slow to start workers.
+    warmUpCluster();
+
     RayObject<String> obj1 = Ray.call(WaitTest::hi);
     RayObject<String> obj2 = Ray.call(WaitTest::delayedHi);
 
@@ -54,9 +57,6 @@ public class WaitTest extends BaseTest {
 
   @Test
   public void testWaitInWorker() {
-    // Call a task in advance to warm up the cluster to avoid being too slow to start workers.
-    warmUpCluster();
-
     RayObject<Object> res = Ray.call(WaitTest::waitInWorker);
     res.get();
   }
@@ -75,7 +75,7 @@ public class WaitTest extends BaseTest {
     }
   }
 
-  private void warmUpCluster() {
+  public static void warmUpCluster() {
     RayObject<String> obj = Ray.call(WaitTest::hi);
     Assert.assertEquals(obj.get(), "hi");
   }


### PR DESCRIPTION

1. Fix dynamic resource test.
2. Fix wait test.