### PR TITLE
autoscaler/monitor: Kill workers on exception

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -10,6 +10,7 @@ import math
 import os
 import subprocess
 import threading
+import traceback
 import time
 from collections import defaultdict
 
@@ -660,6 +661,20 @@ class StandardAutoscaler(object):
 
         return "{}/{} target nodes{}".format(
             len(nodes), self.target_num_workers(), suffix)
+
+    def kill_workers(self):
+        logger.error("StandardAutoscaler: kill_workers triggered")
+
+        while True:
+            try:
+                nodes = self.workers()
+                if nodes:
+                    self.provider.terminate_nodes(nodes)
+                logger.error("StandardAutoscaler: terminated {} node(s)".format(len(nodes)))
+            except Exception:
+                traceback.print_exc()
+
+            time.sleep(10)
 
 
 def typename(v):

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -293,7 +293,7 @@ class Monitor(object):
 
         self.gcs_flush_policy.record_flush()
 
-    def run(self):
+    def _run(self):
         """Run the monitor.
 
         This function loops forever, checking for messages about dead database
@@ -325,9 +325,13 @@ class Monitor(object):
             # messages.
             time.sleep(ray._config.heartbeat_timeout_milliseconds() * 1e-3)
 
-        # TODO(rkn): This infinite loop should be inside of a try/except block,
-        # and if an exception is thrown we should push an error message to all
-        # drivers.
+    def run(self):
+        try:
+            self._run()
+        except Exception:
+            if self.autoscaler:
+                self.autoscaler.kill_workers()
+            raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At the moment, if the autoscaler crashes, it will leave workers alive.

I don't think that makes sense. We've ended up in situations whereby the monitor crashes due to a number of errors and then leaves 100 workers up which could cost us hundreds of dollars on AWS.

I have tested this change with a random `raise Exception` in the autoscaler loop and it works fine.