### PR TITLE
[rllib] Give error if sample_async is used with pytorch for A3C

### DIFF
--- a/python/ray/rllib/agents/a3c/a3c.py
+++ b/python/ray/rllib/agents/a3c/a3c.py
@@ -48,6 +48,10 @@ def get_policy_class(config):
 def validate_config(config):
     if config["entropy_coeff"] < 0:
         raise DeprecationWarning("entropy_coeff must be >= 0")
+    if config["sample_async"] and config["use_pytorch"]:
+        raise ValueError(
+            "The sample_async option is not supported with use_pytorch: "
+            "Multithreading can be lead to crashes if used with pytorch.")
 
 
 def make_async_optimizer(workers, config):

--- a/python/ray/rllib/agents/a3c/a3c.py
+++ b/python/ray/rllib/agents/a3c/a3c.py
@@ -30,7 +30,7 @@ DEFAULT_CONFIG = with_common_config({
     "min_iter_time_s": 5,
     # Workers sample async. Note that this increases the effective
     # sample_batch_size by up to 5x due to async buffering of batches.
-    "sample_async": True,
+    "sample_async": False,
 })
 # __sphinx_doc_end__
 # yapf: enable

--- a/python/ray/rllib/agents/a3c/a3c.py
+++ b/python/ray/rllib/agents/a3c/a3c.py
@@ -30,7 +30,7 @@ DEFAULT_CONFIG = with_common_config({
     "min_iter_time_s": 5,
     # Workers sample async. Note that this increases the effective
     # sample_batch_size by up to 5x due to async buffering of batches.
-    "sample_async": False,
+    "sample_async": True,
 })
 # __sphinx_doc_end__
 # yapf: enable


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This gives an error if sample_async is used with use_pytorch for the A3C agent, as that can lead to random crashes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
