### PR TITLE
fix handling of non-integral timeout values in signal.receive

### DIFF
--- a/python/ray/experimental/signal.py
+++ b/python/ray/experimental/signal.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import logging
+
 from collections import defaultdict
 
 import ray
@@ -13,6 +15,7 @@ import ray.cloudpickle as cloudpickle
 # in node_manager.cc
 ACTOR_DIED_STR = "ACTOR_DIED_SIGNAL"
 
+logger = logging.getLogger(__name__)
 
 class Signal(object):
     """Base class for Ray signals."""
@@ -125,10 +128,16 @@ def receive(sources, timeout=None):
     for s in sources:
         task_id_to_sources[_get_task_id(s).hex()].append(s)
 
+    if timeout < 1e-3:
+        logger.warning("Timeout too small. Using 1ms minimum")
+        timeout = 1e-3
+
+    timeout_ms = int(1000 * timeout)
+
     # Construct the redis query.
     query = "XREAD BLOCK "
-    # Multiply by 1000x since timeout is in sec and redis expects ms.
-    query += str(1000 * timeout)
+    # redis expects ms.
+    query += str(timeout_ms)
     query += " STREAMS "
     query += " ".join([task_id for task_id in task_id_to_sources])
     query += " "

--- a/python/ray/experimental/signal.py
+++ b/python/ray/experimental/signal.py
@@ -17,6 +17,7 @@ ACTOR_DIED_STR = "ACTOR_DIED_SIGNAL"
 
 logger = logging.getLogger(__name__)
 
+
 class Signal(object):
     """Base class for Ray signals."""
     pass

--- a/python/ray/experimental/signal.py
+++ b/python/ray/experimental/signal.py
@@ -17,7 +17,6 @@ ACTOR_DIED_STR = "ACTOR_DIED_SIGNAL"
 
 logger = logging.getLogger(__name__)
 
-
 class Signal(object):
     """Base class for Ray signals."""
     pass
@@ -76,10 +75,8 @@ def send(signal):
         source_key = ray.worker.global_worker.current_task_id.hex()
 
     encoded_signal = ray.utils.binary_to_hex(cloudpickle.dumps(signal))
-    ray.worker.global_worker.redis_client.execute_command("XADD " +
-                                                          source_key +
-                                                          " * signal " +
-                                                          encoded_signal)
+    ray.worker.global_worker.redis_client.execute_command(
+        "XADD " + source_key + " * signal " + encoded_signal)
 
 
 def receive(sources, timeout=None):
@@ -171,8 +168,8 @@ def receive(sources, timeout=None):
                     # r[1] contains a list with elements (key, value), in our
                     # case we only have one key "signal" and the value is the
                     # signal.
-                    signal = cloudpickle.loads(ray.utils.hex_to_binary(
-                        r[1][1]))
+                    signal = cloudpickle.loads(
+                        ray.utils.hex_to_binary(r[1][1]))
                     results.append((s, signal))
 
     return results

--- a/python/ray/experimental/signal.py
+++ b/python/ray/experimental/signal.py
@@ -17,6 +17,7 @@ ACTOR_DIED_STR = "ACTOR_DIED_SIGNAL"
 
 logger = logging.getLogger(__name__)
 
+
 class Signal(object):
     """Base class for Ray signals."""
     pass
@@ -75,8 +76,10 @@ def send(signal):
         source_key = ray.worker.global_worker.current_task_id.hex()
 
     encoded_signal = ray.utils.binary_to_hex(cloudpickle.dumps(signal))
-    ray.worker.global_worker.redis_client.execute_command(
-        "XADD " + source_key + " * signal " + encoded_signal)
+    ray.worker.global_worker.redis_client.execute_command("XADD " +
+                                                          source_key +
+                                                          " * signal " +
+                                                          encoded_signal)
 
 
 def receive(sources, timeout=None):
@@ -168,8 +171,8 @@ def receive(sources, timeout=None):
                     # r[1] contains a list with elements (key, value), in our
                     # case we only have one key "signal" and the value is the
                     # signal.
-                    signal = cloudpickle.loads(
-                        ray.utils.hex_to_binary(r[1][1]))
+                    signal = cloudpickle.loads(ray.utils.hex_to_binary(
+                        r[1][1]))
                     results.append((s, signal))
 
     return results

--- a/python/ray/tests/test_signal.py
+++ b/python/ray/tests/test_signal.py
@@ -353,3 +353,35 @@ def test_serial_tasks_reading_same_signal(ray_start_regular):
     assert len(result_list) == 1
     result_list = ray.get(f.remote([a]))
     assert len(result_list) == 1
+
+
+def test_non_integral_receive_timeout(ray_start_regular):
+    @ray.remote
+    def send_signal(value):
+        signal.send(UserSignal(value))
+
+    a = send_signal.remote(0)
+
+    result_list = ray.experimental.signal.receive([a], timeout=0.1)
+
+    assert len(result_list) == 1
+
+
+def test_small_receive_timeout(ray_start_regular):
+    """ Test that receive handles timeout smaller than the 1ms min
+    """
+    # 0.1 ms
+    small_timeout = 1e-4
+
+    @ray.remote
+    def send_signal(value):
+        signal.send(UserSignal(value))
+
+    a = send_signal.remote(0)
+
+    # wait for a bit to give send_signal time to execute
+    time.sleep(1)
+
+    result_list = ray.experimental.signal.receive([a], timeout=small_timeout)
+
+    assert len(result_list) == 1

--- a/python/ray/tests/test_signal.py
+++ b/python/ray/tests/test_signal.py
@@ -361,6 +361,8 @@ def test_non_integral_receive_timeout(ray_start_regular):
         signal.send(UserSignal(value))
 
     a = send_signal.remote(0)
+    # make sure send_signal had a chance to execute
+    ray.get(a)
 
     result_list = ray.experimental.signal.receive([a], timeout=0.1)
 
@@ -378,9 +380,8 @@ def test_small_receive_timeout(ray_start_regular):
         signal.send(UserSignal(value))
 
     a = send_signal.remote(0)
-
-    # wait for a bit to give send_signal time to execute
-    time.sleep(1)
+    # make sure send_signal had a chance to execute
+    ray.get(a)
 
     result_list = ray.experimental.signal.receive([a], timeout=small_timeout)
 


### PR DESCRIPTION
This adds proper handling for non-integral values of the `timeout` arg of `ray.experimental.signal.receive`

For `timeout < 1e-3` (shorter than 1 ms), round up to 1ms and emit a warning.  

Closes #4674 


Needs linting and a test

