### PR TITLE
[rllib] For TF1.14, disable emulated multiple gpu devices in tests

### DIFF
--- a/python/ray/rllib/tests/test_optimizers.py
+++ b/python/ray/rllib/tests/test_optimizers.py
@@ -125,14 +125,14 @@ class AsyncSamplesOptimizerTest(unittest.TestCase):
     def testMultiGPU(self):
         local, remotes = self._make_evs()
         workers = WorkerSet._from_existing(local, remotes)
-        optimizer = AsyncSamplesOptimizer(workers, num_gpus=2, _fake_gpus=True)
+        optimizer = AsyncSamplesOptimizer(workers, num_gpus=1, _fake_gpus=True)
         self._wait_for(optimizer, 1000, 1000)
 
     def testMultiGPUParallelLoad(self):
         local, remotes = self._make_evs()
         workers = WorkerSet._from_existing(local, remotes)
         optimizer = AsyncSamplesOptimizer(
-            workers, num_gpus=2, num_data_loader_buffers=2, _fake_gpus=True)
+            workers, num_gpus=1, num_data_loader_buffers=1, _fake_gpus=True)
         self._wait_for(optimizer, 1000, 1000)
 
     def testMultiplePasses(self):
@@ -211,21 +211,21 @@ class AsyncSamplesOptimizerTest(unittest.TestCase):
                 num_data_loader_buffers=2, minibatch_buffer_size=4))
         optimizer = AsyncSamplesOptimizer(
             workers,
-            num_gpus=2,
+            num_gpus=1,
             train_batch_size=100,
             sample_batch_size=50,
             _fake_gpus=True)
         self._wait_for(optimizer, 1000, 1000)
         optimizer = AsyncSamplesOptimizer(
             workers,
-            num_gpus=2,
+            num_gpus=1,
             train_batch_size=100,
             sample_batch_size=25,
             _fake_gpus=True)
         self._wait_for(optimizer, 1000, 1000)
         optimizer = AsyncSamplesOptimizer(
             workers,
-            num_gpus=2,
+            num_gpus=1,
             train_batch_size=100,
             sample_batch_size=74,
             _fake_gpus=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This is a quick workaround for the test failures on TF 1.14 with:
```
InvalidArgumentError: Cannot colocate nodes node default_policy_1/tower_2/beta1_power/initial_value (defined at /home/travis/.local/lib/python2.7/site-packages/ray-0.8.0.dev1-py2.7-linux-x86_64.egg/ray/rllib/policy/tf_policy.py:336) placed on device Device assignments active during op 'default_policy_1/tower_2/beta1_power/initial_value' creation:
  with tf.device(/cpu:1): </home/travis/.local/lib/python2.7/site-packages/ray-0.8.0.dev1-py2.7-linux-x86_64.egg/ray/rllib/optimizers/multi_gpu_impl.py:270>  and node default_policy/fc1/bias/Initializer/zeros (defined at /home/travis/.local/lib/python2.7/site-packages/ray-0.8.0.dev1-py2.7-linux-x86_64.egg/ray/rllib/models/fcnet.py:37) placed on device Device assignments active during op 'default_policy/fc1/bias/Initializer/zeros' creation:
  with tf.device(None): </home/travis/miniconda/lib/python2.7/site-packages/tensorflow/python/ops/variables.py:1696> : Cannot merge devices with incompatible ids: '/job:localhost/replica:0/task:0/device:CPU:0' and '/device:CPU:1'
	 [[node default_policy_1/tower_2/beta1_power/initial_value (defined at /home/travis/.local/lib/python2.7/site-packages/ray-0.8.0.dev1-py2.7-linux-x86_64.egg/ray/rllib/policy/tf_policy.py:336) ]]Additional information about colocations:Node-device colocations active during op 'default_policy_1/tower_2/beta1_power/initial_value' creation:
  with tf.colocate_with(default_policy/fc1/bias): </home/travis/miniconda/lib/python2.7/site-packages/tensorflow/python/training/optimizer.py:821>
```

I've tested manually and multiple actual GPU devices work fine, just not the virtual CPU ones.


## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
