### PR TITLE
Fix no cpus test

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -55,6 +55,7 @@ def _ray_start(**kwargs):
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
+
 # The following fixture will start ray with 1 cpu.
 @pytest.fixture
 def ray_start_no_cpu(request):

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -56,7 +56,7 @@ def _ray_start(**kwargs):
     ray.shutdown()
 
 
-# The following fixture will start ray with 1 cpu.
+# The following fixture will start ray with 0 cpu.
 @pytest.fixture
 def ray_start_no_cpu(request):
     param = getattr(request, "param", {})

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -55,6 +55,13 @@ def _ray_start(**kwargs):
     # The code after the yield will run as teardown code.
     ray.shutdown()
 
+# The following fixture will start ray with 1 cpu.
+@pytest.fixture
+def ray_start_no_cpu(request):
+    param = getattr(request, "param", {})
+    with _ray_start(num_cpus=0, **param) as res:
+        yield res
+
 
 # The following fixture will start ray with 1 cpu.
 @pytest.fixture

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -842,7 +842,7 @@ def test_remote_functions_not_scheduled_on_actors(ray_start_regular):
     assert actor_id not in resulting_ids
 
 
-def test_actors_on_nodes_with_no_cpus(ray_start_regular):
+def test_actors_on_nodes_with_no_cpus(ray_start_no_cpu):
     @ray.remote
     class Foo(object):
         def method(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Test test_actors_on_nodes_with_no_cpus  in python/ray/tests/test_actor.py always fails, change to start the test with no cpu and fix this test


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
