### PR TITLE
[docs] docs for running Tensorboard without sudo

### DIFF
--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -355,6 +355,12 @@ Then, after you run a experiment, you can visualize your experiment with TensorB
 
     $ tensorboard --logdir=~/ray_results/my_experiment
 
+If you are running Ray on a remote multi-user cluster where you do not have sudo access, you can run the following commands to make sure tensorboard is able to write to the tmp directory:
+
+.. code-block:: bash
+
+    $ export LOGDIR=~/ray_results/; export TMPDIR=/tmp/$USER; mkdir -p $TMPDIR; tensorboard --logdir $LOGDIR
+
 .. image:: ray-tune-tensorboard.png
 
 To use rllab's VisKit (you may have to install some dependencies), run:

--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -359,7 +359,7 @@ If you are running Ray on a remote multi-user cluster where you do not have sudo
 
 .. code-block:: bash
 
-    $ export LOGDIR=~/ray_results/; export TMPDIR=/tmp/$USER; mkdir -p $TMPDIR; tensorboard --logdir $LOGDIR
+    $ export TMPDIR=/tmp/$USER; mkdir -p $TMPDIR; tensorboard --logdir=~/ray_results
 
 .. image:: ray-tune-tensorboard.png
 


### PR DESCRIPTION
When we run Tensorboard to visualize the results of Ray outputs on multi-user clusters where we don't have sudo access, such as RISE clusters, a few commands need to first be run to make sure tensorboard can edit the tmp directory. This is a pretty common usecase so I figured we may as well put it in the documentation for Tune.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?



## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
