### PR TITLE
[grpc] refactor rpc server to support multiple io services

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -32,17 +32,6 @@ import ray.tests.utils
 
 logger = logging.getLogger(__name__)
 
-def test_forward(ray_start_cluster):
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
-    ray.init(redis_address=cluster.redis_address)
-    cluster.add_node(num_cpus=1, resources={"RemoteResource": 10})
-
-    @ray.remote(resources={"RemoteResource": 1})
-    def f():
-        return 1
-
-    ray.get([f.remote() for _ in range(10)])
 
 def test_simple_serialization(ray_start_regular):
     primitive_objects = [
@@ -3003,3 +2992,16 @@ def test_export_after_shutdown(ray_start_regular):
         ray.get(actor_handle.method.remote())
 
     ray.get(export_definitions_from_worker.remote(f, Actor))
+
+
+def test_forward(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    ray.init(redis_address=cluster.redis_address)
+    cluster.add_node(num_cpus=1, resources={"RemoteResource": 10})
+
+    @ray.remote(resources={"RemoteResource": 1})
+    def f():
+        return 1
+
+    ray.get([f.remote() for _ in range(10)])

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2992,16 +2992,3 @@ def test_export_after_shutdown(ray_start_regular):
         ray.get(actor_handle.method.remote())
 
     ray.get(export_definitions_from_worker.remote(f, Actor))
-
-
-def test_forward(ray_start_cluster):
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
-    ray.init(redis_address=cluster.redis_address)
-    cluster.add_node(num_cpus=1, resources={"RemoteResource": 10})
-
-    @ray.remote(resources={"RemoteResource": 1})
-    def f():
-        return 1
-
-    ray.get([f.remote() for _ in range(10)])

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -32,6 +32,17 @@ import ray.tests.utils
 
 logger = logging.getLogger(__name__)
 
+def test_forward(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    ray.init(redis_address=cluster.redis_address)
+    cluster.add_node(num_cpus=1, resources={"RemoteResource": 10})
+
+    @ray.remote(resources={"RemoteResource": 1})
+    def f():
+        return 1
+
+    ray.get([f.remote() for _ in range(10)])
 
 def test_simple_serialization(ray_start_regular):
     primitive_objects = [

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -100,7 +100,8 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
                      gcs_client_->raylet_task_table(), gcs_client_->raylet_task_table(),
                      config.max_lineage_size),
       actor_registry_(),
-      node_manager_server_(config.node_manager_port, io_service, *this),
+      node_manager_server_("NodeManager", config.node_manager_port),
+      node_manager_service_(io_service, *this),
       client_call_manager_(io_service) {
   RAY_CHECK(heartbeat_period_.count() > 0);
   // Initialize the resource map with own cluster resource configuration.
@@ -118,6 +119,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
 
   RAY_ARROW_CHECK_OK(store_client_.Connect(config.store_socket_name.c_str()));
   // Run the node manger rpc server.
+  node_manager_server_.RegisterService(node_manager_service_);
   node_manager_server_.Run();
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -509,7 +509,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   rpc::GrpcServer node_manager_server_;
 
   /// The RPC service.
-  rpc::NodeManagerGrpcService node_manager_service_;  
+  rpc::NodeManagerGrpcService node_manager_service_;
 
   /// The `ClientCallManager` object that is shared by all `NodeManagerClient`s.
   rpc::ClientCallManager client_call_manager_;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -506,7 +506,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   std::unordered_map<ActorID, ActorCheckpointID> checkpoint_id_to_restore_;
 
   /// The RPC server.
-  rpc::NodeManagerServer node_manager_server_;
+  rpc::GrpcServer node_manager_server_;
+
+  /// The RPC service.
+  rpc::NodeManagerGrpcService node_manager_service_;  
 
   /// The `ClientCallManager` object that is shared by all `NodeManagerClient`s.
   rpc::ClientCallManager client_call_manager_;

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -55,7 +55,7 @@ void GrpcServer::PollEventsFromCompletionQueue() {
         // incoming request.
         server_call->GetFactory().CreateCall();
         server_call->SetState(ServerCallState::PROCESSING);
-        server_call->GetIOService().post([server_call] { server_call->HandleRequest(); });
+        server_call->HandleRequest();
         break;
       case ServerCallState::SENDING_REPLY:
         // The reply has been sent, this call can be deleted now.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -35,7 +35,6 @@ void GrpcServer::Run() {
 
 void GrpcServer::RegisterService(GrpcService &service) {
   services_.emplace_back(service.GetGrpcService());
-
   service.InitServerCallFactories(cq_, &server_call_factories_and_concurrencies_);
 }
 

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -1,4 +1,5 @@
 #include "ray/rpc/grpc_server.h"
+#include <grpcpp/impl/service_type.h>
 
 namespace ray {
 namespace rpc {
@@ -9,8 +10,10 @@ void GrpcServer::Run() {
   grpc::ServerBuilder builder;
   // TODO(hchen): Add options for authentication.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &port_);
-  // Allow subclasses to register concrete services.
-  RegisterServices(builder);
+  // Register all the services to this server.
+  for (auto &entry : services_) {
+    builder.RegisterService(&entry.get());
+  }
   // Get hold of the completion queue used for the asynchronous communication
   // with the gRPC runtime.
   cq_ = builder.AddCompletionQueue();
@@ -18,8 +21,7 @@ void GrpcServer::Run() {
   server_ = builder.BuildAndStart();
   RAY_LOG(DEBUG) << name_ << " server started, listening on port " << port_ << ".";
 
-  // Allow subclasses to initialize the server call factories.
-  InitServerCallFactories(&server_call_factories_and_concurrencies_);
+  // Create calls for all the server call factories.
   for (auto &entry : server_call_factories_and_concurrencies_) {
     for (int i = 0; i < entry.second; i++) {
       // Create and request calls from the factory.
@@ -29,6 +31,12 @@ void GrpcServer::Run() {
   // Start a thread that polls incoming requests.
   std::thread polling_thread(&GrpcServer::PollEventsFromCompletionQueue, this);
   polling_thread.detach();
+}
+
+void GrpcServer::RegisterService(GrpcService &service) {
+  services_.emplace_back(service.GetGrpcService());
+
+  service.InitServerCallFactories(cq_, &server_call_factories_and_concurrencies_);
 }
 
 void GrpcServer::PollEventsFromCompletionQueue() {
@@ -48,7 +56,7 @@ void GrpcServer::PollEventsFromCompletionQueue() {
         // incoming request.
         server_call->GetFactory().CreateCall();
         server_call->SetState(ServerCallState::PROCESSING);
-        main_service_.post([server_call] { server_call->HandleRequest(); });
+        server_call->GetIOService().post([server_call] { server_call->HandleRequest(); });
         break;
       case ServerCallState::SENDING_REPLY:
         // The reply has been sent, this call can be deleted now.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -12,7 +12,9 @@
 namespace ray {
 namespace rpc {
 
-/// Base class that represents an abstract gRPC server.
+class GrpcService;
+
+/// Class that represents an gRPC server.
 ///
 /// A `GrpcServer` listens on a specific port. It owns
 /// 1) a `ServerCompletionQueue` that is used for polling events from gRPC,
@@ -30,9 +32,8 @@ class GrpcServer {
   ///  will be chosen.
   /// \param[in] main_service The main event loop, to which service handler functions
   /// will be posted.
-  GrpcServer(const std::string &name, const uint32_t port,
-             boost::asio::io_service &main_service)
-      : name_(name), port_(port), main_service_(main_service) {}
+  GrpcServer(const std::string &name, const uint32_t port)
+      : name_(name), port_(port) {}
 
   /// Destruct this gRPC server.
   ~GrpcServer() {
@@ -46,36 +47,24 @@ class GrpcServer {
   /// Get the port of this gRPC server.
   int GetPort() const { return port_; }
 
- protected:
-  /// Subclasses should implement this method and register one or multiple gRPC services
-  /// to the given `ServerBuilder`.
+  /// Register a grpc service.
   ///
-  /// \param[in] builder The `ServerBuilder` instance to register services to.
-  virtual void RegisterServices(grpc::ServerBuilder &builder) = 0;
+  /// \param[in] builder The `GrpcService` to register to this server.
+  void RegisterService(GrpcService &service);
 
-  /// Subclasses should implement this method to initialize the `ServerCallFactory`
-  /// instances, as well as specify maximum number of concurrent requests that gRPC
-  /// server can "accept" (not "handle"). Each factory will be used to create
-  /// `accept_concurrency` `ServerCall` objects, each of which will be used to accept and
-  /// handle an incoming request.
-  ///
-  /// \param[out] server_call_factories_and_concurrencies The `ServerCallFactory` objects,
-  /// and the maximum number of concurrent requests that gRPC server can accept.
-  virtual void InitServerCallFactories(
-      std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
-          *server_call_factories_and_concurrencies) = 0;
+ protected:
 
   /// This function runs in a background thread. It keeps polling events from the
   /// `ServerCompletionQueue`, and dispaches the event to the `ServiceHandler` instances
   /// via the `ServerCall` objects.
   void PollEventsFromCompletionQueue();
 
-  /// The main event loop, to which the service handler functions will be posted.
-  boost::asio::io_service &main_service_;
   /// Name of this server, used for logging and debugging purpose.
   const std::string name_;
   /// Port of this server.
   int port_;
+  /// The `grpc::Service` objects which should be registered to `ServerBuilder`.
+  std::vector<std::reference_wrapper<grpc::Service>> services_;
   /// The `ServerCallFactory` objects, and the maximum number of concurrent requests that
   /// gRPC server can accept.
   std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
@@ -84,6 +73,50 @@ class GrpcServer {
   std::unique_ptr<grpc::ServerCompletionQueue> cq_;
   /// The `Server` object.
   std::unique_ptr<grpc::Server> server_;
+};
+
+
+/// Base class that represents an abstract gRPC service.
+///
+/// Subclass should implement `InitServerCallFactories` to decide
+/// which kinds of requests this server should accept.
+class GrpcService {
+ public:
+  /// Constructor.
+  ///
+  /// \param[in] name Name of this server, used for logging and debugging purpose.
+  /// \param[in] port The port to bind this server to. If it's 0, a random available port
+  ///  will be chosen.
+  /// \param[in] main_service The main event loop, to which service handler functions
+  /// will be posted.
+  GrpcService(boost::asio::io_service &main_service)
+      : main_service_(main_service) {}
+
+  /// Destruct this gRPC service.
+  ~GrpcService() {}
+
+ protected:
+  /// TODO
+  virtual grpc::Service &GetGrpcService() = 0;
+
+  /// Subclasses should implement this method to initialize the `ServerCallFactory`
+  /// instances, as well as specify maximum number of concurrent requests that gRPC
+  /// server can "accept" (not "handle"). Each factory will be used to create
+  /// `accept_concurrency` `ServerCall` objects, each of which will be used to accept and
+  /// handle an incoming request.
+  ///
+  /// \param[out] service The `grpc::Service` object.
+  /// \param[out] server_call_factories_and_concurrencies The `ServerCallFactory` objects,
+  /// and the maximum number of concurrent requests that gRPC server can accept.
+  virtual void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
+          *server_call_factories_and_concurrencies) = 0;
+
+  /// The main event loop, to which the service handler functions will be posted.
+  boost::asio::io_service &main_service_;
+
+  friend class GrpcServer;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -30,8 +30,6 @@ class GrpcServer {
   /// \param[in] name Name of this server, used for logging and debugging purpose.
   /// \param[in] port The port to bind this server to. If it's 0, a random available port
   ///  will be chosen.
-  /// \param[in] main_service The main event loop, to which service handler functions
-  /// will be posted.
   GrpcServer(const std::string &name, const uint32_t port) : name_(name), port_(port) {}
 
   /// Destruct this gRPC server.
@@ -46,9 +44,11 @@ class GrpcServer {
   /// Get the port of this gRPC server.
   int GetPort() const { return port_; }
 
-  /// Register a grpc service.
+  /// Register a grpc service. Multiple services can be registered to the same server.
+  /// Note that the `service` registered must remain valid for the lifetime of the
+  /// `GrpcServer`, as it holds the underlying `grpc::Service`.
   ///
-  /// \param[in] builder The `GrpcService` to register to this server.
+  /// \param[in] service A `GrpcService` to register to this server.
   void RegisterService(GrpcService &service);
 
  protected:
@@ -76,14 +76,11 @@ class GrpcServer {
 /// Base class that represents an abstract gRPC service.
 ///
 /// Subclass should implement `InitServerCallFactories` to decide
-/// which kinds of requests this server should accept.
+/// which kinds of requests this service should accept.
 class GrpcService {
  public:
   /// Constructor.
   ///
-  /// \param[in] name Name of this server, used for logging and debugging purpose.
-  /// \param[in] port The port to bind this server to. If it's 0, a random available port
-  ///  will be chosen.
   /// \param[in] main_service The main event loop, to which service handler functions
   /// will be posted.
   GrpcService(boost::asio::io_service &main_service) : main_service_(main_service) {}
@@ -92,7 +89,8 @@ class GrpcService {
   ~GrpcService() {}
 
  protected:
-  /// TODO
+  /// Return the underlying grpc::Service object for this class.
+  /// This is passed to `GrpcServer` to be registered to grpc `ServerBuilder`.
   virtual grpc::Service &GetGrpcService() = 0;
 
   /// Subclasses should implement this method to initialize the `ServerCallFactory`
@@ -101,7 +99,7 @@ class GrpcService {
   /// `accept_concurrency` `ServerCall` objects, each of which will be used to accept and
   /// handle an incoming request.
   ///
-  /// \param[out] service The `grpc::Service` object.
+  /// \param[in] cq The grpc completion queue.
   /// \param[out] server_call_factories_and_concurrencies The `ServerCallFactory` objects,
   /// and the maximum number of concurrent requests that gRPC server can accept.
   virtual void InitServerCallFactories(

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -32,8 +32,7 @@ class GrpcServer {
   ///  will be chosen.
   /// \param[in] main_service The main event loop, to which service handler functions
   /// will be posted.
-  GrpcServer(const std::string &name, const uint32_t port)
-      : name_(name), port_(port) {}
+  GrpcServer(const std::string &name, const uint32_t port) : name_(name), port_(port) {}
 
   /// Destruct this gRPC server.
   ~GrpcServer() {
@@ -53,7 +52,6 @@ class GrpcServer {
   void RegisterService(GrpcService &service);
 
  protected:
-
   /// This function runs in a background thread. It keeps polling events from the
   /// `ServerCompletionQueue`, and dispaches the event to the `ServiceHandler` instances
   /// via the `ServerCall` objects.
@@ -75,7 +73,6 @@ class GrpcServer {
   std::unique_ptr<grpc::Server> server_;
 };
 
-
 /// Base class that represents an abstract gRPC service.
 ///
 /// Subclass should implement `InitServerCallFactories` to decide
@@ -89,8 +86,7 @@ class GrpcService {
   ///  will be chosen.
   /// \param[in] main_service The main event loop, to which service handler functions
   /// will be posted.
-  GrpcService(boost::asio::io_service &main_service)
-      : main_service_(main_service) {}
+  GrpcService(boost::asio::io_service &main_service) : main_service_(main_service) {}
 
   /// Destruct this gRPC service.
   ~GrpcService() {}

--- a/src/ray/rpc/node_manager_server.h
+++ b/src/ray/rpc/node_manager_server.h
@@ -25,7 +25,6 @@ class NodeManagerServiceHandler {
                                  RequestDoneCallback done_callback) = 0;
 };
 
-
 /// The `GrpcService` for `NodeManagerService`.
 class NodeManagerGrpcService : public GrpcService {
  public:
@@ -35,22 +34,22 @@ class NodeManagerGrpcService : public GrpcService {
   /// \param[in] handler The service handler that actually handle the requests.
   NodeManagerGrpcService(boost::asio::io_service &io_service,
                          NodeManagerServiceHandler &service_handler)
-      : GrpcService(io_service),
-        service_handler_(service_handler) {};
- 
+      : GrpcService(io_service), service_handler_(service_handler){};
+
  protected:
   grpc::Service &GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
-          *server_call_factories_and_concurrencies) override {  
+          *server_call_factories_and_concurrencies) override {
     // Initialize the factory for `ForwardTask` requests.
     std::unique_ptr<ServerCallFactory> forward_task_call_factory(
         new ServerCallFactoryImpl<NodeManagerService, NodeManagerServiceHandler,
                                   ForwardTaskRequest, ForwardTaskReply>(
             service_, &NodeManagerService::AsyncService::RequestForwardTask,
-            service_handler_, &NodeManagerServiceHandler::HandleForwardTask, cq, main_service_));
+            service_handler_, &NodeManagerServiceHandler::HandleForwardTask, cq,
+            main_service_));
 
     // Set `ForwardTask`'s accept concurrency to 100.
     server_call_factories_and_concurrencies->emplace_back(
@@ -62,7 +61,7 @@ class NodeManagerGrpcService : public GrpcService {
   NodeManagerService::AsyncService service_;
 
   /// The service handler that actually handle the requests.
-  NodeManagerServiceHandler &service_handler_; 
+  NodeManagerServiceHandler &service_handler_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/node_manager_server.h
+++ b/src/ray/rpc/node_manager_server.h
@@ -25,33 +25,32 @@ class NodeManagerServiceHandler {
                                  RequestDoneCallback done_callback) = 0;
 };
 
-/// The `GrpcServer` for `NodeManagerService`.
-class NodeManagerServer : public GrpcServer {
+
+/// The `GrpcService` for `NodeManagerService`.
+class NodeManagerGrpcService : public GrpcService {
  public:
   /// Constructor.
   ///
-  /// \param[in] port See super class.
-  /// \param[in] main_service See super class.
+  /// \param[in] io_service See super class.
   /// \param[in] handler The service handler that actually handle the requests.
-  NodeManagerServer(const uint32_t port, boost::asio::io_service &main_service,
-                    NodeManagerServiceHandler &service_handler)
-      : GrpcServer("NodeManager", port, main_service),
-        service_handler_(service_handler){};
-
-  void RegisterServices(grpc::ServerBuilder &builder) override {
-    /// Register `NodeManagerService`.
-    builder.RegisterService(&service_);
-  }
+  NodeManagerGrpcService(boost::asio::io_service &io_service,
+                         NodeManagerServiceHandler &service_handler)
+      : GrpcService(io_service),
+        service_handler_(service_handler) {};
+ 
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
 
   void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
-          *server_call_factories_and_concurrencies) override {
+          *server_call_factories_and_concurrencies) override {  
     // Initialize the factory for `ForwardTask` requests.
     std::unique_ptr<ServerCallFactory> forward_task_call_factory(
         new ServerCallFactoryImpl<NodeManagerService, NodeManagerServiceHandler,
                                   ForwardTaskRequest, ForwardTaskReply>(
             service_, &NodeManagerService::AsyncService::RequestForwardTask,
-            service_handler_, &NodeManagerServiceHandler::HandleForwardTask, cq_));
+            service_handler_, &NodeManagerServiceHandler::HandleForwardTask, cq, main_service_));
 
     // Set `ForwardTask`'s accept concurrency to 100.
     server_call_factories_and_concurrencies->emplace_back(
@@ -61,8 +60,9 @@ class NodeManagerServer : public GrpcServer {
  private:
   /// The grpc async service object.
   NodeManagerService::AsyncService service_;
+
   /// The service handler that actually handle the requests.
-  NodeManagerServiceHandler &service_handler_;
+  NodeManagerServiceHandler &service_handler_; 
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -58,6 +58,9 @@ class ServerCall {
 
   /// Get the factory that created this `ServerCall`.
   virtual const ServerCallFactory &GetFactory() const = 0;
+
+  /// Get io service.
+  virtual boost::asio::io_service &GetIOService() = 0;
 };
 
 /// The factory that creates a particular kind of `ServerCall` objects.
@@ -94,14 +97,17 @@ class ServerCallImpl : public ServerCall {
   /// \param[in] factory The factory which created this call.
   /// \param[in] service_handler The service handler that handles the request.
   /// \param[in] handle_request_function Pointer to the service handler function.
+  /// \param[in] io_service The event loop.  
   ServerCallImpl(
       const ServerCallFactory &factory, ServiceHandler &service_handler,
-      HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function)
+      HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
+      boost::asio::io_service &io_service)
       : state_(ServerCallState::PENDING),
         factory_(factory),
         service_handler_(service_handler),
         handle_request_function_(handle_request_function),
-        response_writer_(&context_) {}
+        response_writer_(&context_),
+        io_service_(io_service) {}
 
   ServerCallState GetState() const override { return state_; }
 
@@ -110,15 +116,17 @@ class ServerCallImpl : public ServerCall {
   void HandleRequest() override {
     state_ = ServerCallState::PROCESSING;
     (service_handler_.*handle_request_function_)(request_, &reply_,
-                                                 [this](Status status) {
-                                                   // When the handler is done with the
-                                                   // request, tell gRPC to finish this
-                                                   // request.
-                                                   SendReply(status);
-                                                 });
+                                                [this](Status status) {
+                                                  // When the handler is done with the
+                                                  // request, tell gRPC to finish this
+                                                  // request.
+                                                  SendReply(status);
+                                                });
   }
 
   const ServerCallFactory &GetFactory() const override { return factory_; }
+
+  boost::asio::io_service &GetIOService() override { return io_service_; }
 
  private:
   /// Tell gRPC to finish this request.
@@ -145,6 +153,9 @@ class ServerCallImpl : public ServerCall {
 
   /// The reponse writer.
   grpc::ServerAsyncResponseWriter<Reply> response_writer_;
+
+  /// The event loop.
+  boost::asio::io_service &io_service_;
 
   /// The request message.
   Request request_;
@@ -185,23 +196,26 @@ class ServerCallFactoryImpl : public ServerCallFactory {
   /// \param[in] service_handler The service handler that handles the request.
   /// \param[in] handle_request_function Pointer to the service handler function.
   /// \param[in] cq The `CompletionQueue`.
+  /// \param[in] io_service The event loop.
   ServerCallFactoryImpl(
       AsyncService &service,
       RequestCallFunction<GrpcService, Request, Reply> request_call_function,
       ServiceHandler &service_handler,
       HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
-      const std::unique_ptr<grpc::ServerCompletionQueue> &cq)
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      boost::asio::io_service &io_service)
       : service_(service),
         request_call_function_(request_call_function),
         service_handler_(service_handler),
         handle_request_function_(handle_request_function),
-        cq_(cq) {}
+        cq_(cq),
+        io_service_(io_service) {}
 
   ServerCall *CreateCall() const override {
     // Create a new `ServerCall`. This object will eventually be deleted by
     // `GrpcServer::PollEventsFromCompletionQueue`.
     auto call = new ServerCallImpl<ServiceHandler, Request, Reply>(
-        *this, service_handler_, handle_request_function_);
+        *this, service_handler_, handle_request_function_, io_service_);
     /// Request gRPC runtime to starting accepting this kind of request, using the call as
     /// the tag.
     (service_.*request_call_function_)(&call->context_, &call->request_,
@@ -225,6 +239,9 @@ class ServerCallFactoryImpl : public ServerCallFactory {
 
   /// The `CompletionQueue`.
   const std::unique_ptr<grpc::ServerCompletionQueue> &cq_;
+
+  /// The event loop.
+  boost::asio::io_service &io_service_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -97,7 +97,7 @@ class ServerCallImpl : public ServerCall {
   /// \param[in] factory The factory which created this call.
   /// \param[in] service_handler The service handler that handles the request.
   /// \param[in] handle_request_function Pointer to the service handler function.
-  /// \param[in] io_service The event loop.  
+  /// \param[in] io_service The event loop.
   ServerCallImpl(
       const ServerCallFactory &factory, ServiceHandler &service_handler,
       HandleRequestFunction<ServiceHandler, Request, Reply> handle_request_function,
@@ -116,12 +116,12 @@ class ServerCallImpl : public ServerCall {
   void HandleRequest() override {
     state_ = ServerCallState::PROCESSING;
     (service_handler_.*handle_request_function_)(request_, &reply_,
-                                                [this](Status status) {
-                                                  // When the handler is done with the
-                                                  // request, tell gRPC to finish this
-                                                  // request.
-                                                  SendReply(status);
-                                                });
+                                                 [this](Status status) {
+                                                   // When the handler is done with the
+                                                   // request, tell gRPC to finish this
+                                                   // request.
+                                                   SendReply(status);
+                                                 });
   }
 
   const ServerCallFactory &GetFactory() const override { return factory_; }


### PR DESCRIPTION
## What do these changes do?

Support multiple services for a single grpc server
- add a `GrpcService` abstraction in addition to `GrpcServer`
- allow different rpc services for a single rpc server, they can use different `IO services` while sharing a single port, which is needed to support direct actor call.

## Related issue number

#5029 

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
