### PR TITLE
Fix memory leak in rpc ServerCall and ClientCall

### DIFF
--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -30,6 +30,8 @@ class ClientCall {
   /// The callback to be called by `ClientCallManager` when the reply of this request is
   /// received.
   virtual void OnReplyReceived() = 0;
+
+  virtual ~ClientCall() = default;
 };
 
 class ClientCallManager;
@@ -142,7 +144,7 @@ class ClientCallManager {
     bool ok = false;
     // Keep reading events from the `CompletionQueue` until it's shutdown.
     while (cq_.Next(&got_tag, &ok)) {
-      ClientCall *call = reinterpret_cast<ClientCall *>(got_tag);
+      auto *call = reinterpret_cast<ClientCall *>(got_tag);
       if (ok) {
         // Post the callback to the main event loop.
         main_service_.post([call]() {

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -43,7 +43,7 @@ void GrpcServer::PollEventsFromCompletionQueue() {
   bool ok;
   // Keep reading events from the `CompletionQueue` until it's shutdown.
   while (cq_->Next(&tag, &ok)) {
-    ServerCall *server_call = static_cast<ServerCall *>(tag);
+    auto *server_call = static_cast<ServerCall *>(tag);
     // `ok == false` indicates that the server has been shut down.
     // We should delete the call object in this case.
     bool delete_call = !ok;

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -58,6 +58,8 @@ class ServerCall {
 
   /// Get the factory that created this `ServerCall`.
   virtual const ServerCallFactory &GetFactory() const = 0;
+
+  virtual ~ServerCall() = default;;
 };
 
 /// The factory that creates a particular kind of `ServerCall` objects.

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -59,7 +59,8 @@ class ServerCall {
   /// Get the factory that created this `ServerCall`.
   virtual const ServerCallFactory &GetFactory() const = 0;
 
-  virtual ~ServerCall() = default;;
+  virtual ~ServerCall() = default;
+  ;
 };
 
 /// The factory that creates a particular kind of `ServerCall` objects.

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -60,7 +60,6 @@ class ServerCall {
   virtual const ServerCallFactory &GetFactory() const = 0;
 
   virtual ~ServerCall() = default;
-  ;
 };
 
 /// The factory that creates a particular kind of `ServerCall` objects.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

`ServerCall` and `ClientCall`'s destructors weren't defined as virtual functions, causing the sub classes not being properly deleted.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
