### PR TITLE
Refine RegisterClientRequest message to make it clearer.

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -85,7 +85,7 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
   return h;
 }
 
-TaskID TaskID::ComputeDriverTaskID(const ClientID &driver_id) {
+TaskID TaskID::ComputeDriverTaskId(const ClientID &driver_id) {
   std::string driver_id_str = driver_id.Binary();
   driver_id_str.resize(Size());
   return TaskID::FromBinary(driver_id_str);

--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -85,7 +85,7 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
   return h;
 }
 
-TaskID TaskID::GetDriverTaskID(const WorkerID &driver_id) {
+TaskID TaskID::ComputeDriverTaskID(const ClientID &driver_id) {
   std::string driver_id_str = driver_id.Binary();
   driver_id_str.resize(Size());
   return TaskID::FromBinary(driver_id_str);

--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -85,7 +85,7 @@ uint64_t MurmurHash64A(const void *key, int len, unsigned int seed) {
   return h;
 }
 
-TaskID TaskID::ComputeDriverTaskId(const ClientID &driver_id) {
+TaskID TaskID::ComputeDriverTaskId(const WorkerID &driver_id) {
   std::string driver_id_str = driver_id.Binary();
   driver_id_str.resize(Size());
   return TaskID::FromBinary(driver_id_str);

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -72,7 +72,7 @@ class TaskID : public BaseID<TaskID> {
  public:
   TaskID() : BaseID() {}
   static size_t Size() { return kTaskIDSize; }
-  static TaskID ComputeDriverTaskId(const ClientID &driver_id);
+  static TaskID ComputeDriverTaskId(const WorkerID &driver_id);
 
  private:
   uint8_t id_[kTaskIDSize];

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -17,7 +17,7 @@
 
 namespace ray {
 
-class WorkerID;
+class ClientID;
 class UniqueID;
 
 // Declaration.
@@ -72,7 +72,7 @@ class TaskID : public BaseID<TaskID> {
  public:
   TaskID() : BaseID() {}
   static size_t Size() { return kTaskIDSize; }
-  static TaskID GetDriverTaskID(const WorkerID &driver_id);
+  static TaskID ComputeDriverTaskID(const ClientID &driver_id);
 
  private:
   uint8_t id_[kTaskIDSize];

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -17,7 +17,7 @@
 
 namespace ray {
 
-class ClientID;
+class WorkerID;
 class UniqueID;
 
 // Declaration.

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -72,7 +72,7 @@ class TaskID : public BaseID<TaskID> {
  public:
   TaskID() : BaseID() {}
   static size_t Size() { return kTaskIDSize; }
-  static TaskID ComputeDriverTaskID(const ClientID &driver_id);
+  static TaskID ComputeDriverTaskId(const ClientID &driver_id);
 
  private:
   uint8_t id_[kTaskIDSize];

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -134,7 +134,7 @@ table RegisterClientRequest {
   worker_id: string;
   // The process ID of this worker.
   worker_pid: long;
-  // The job ID.
+  // The job ID only if this request is from a driver.
   job_id: string;
   // Language of this worker.
   language: Language;

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -134,7 +134,7 @@ table RegisterClientRequest {
   worker_id: string;
   // The process ID of this worker.
   worker_pid: long;
-  // The job ID only if this request is from a driver.
+  // The job ID if the client is a driver, otherwise it should be NIL.
   job_id: string;
   // Language of this worker.
   language: Language;

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -134,9 +134,10 @@ table RegisterClientRequest {
   client_id: string;
   // The process ID of this worker.
   worker_pid: long;
-  // The driver ID. This is non-nil if the client is a driver.
-  // TODO(qwang): rename this to driver_task_id.
-  driver_id: string;
+  // The job ID.
+  job_id: string;
+  //
+  driver_task_id: string;
   // Language of this worker.
   language: Language;
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -136,8 +136,6 @@ table RegisterClientRequest {
   worker_pid: long;
   // The job ID.
   job_id: string;
-  //
-  driver_task_id: string;
   // Language of this worker.
   language: Language;
 }

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -131,7 +131,7 @@ table RegisterClientRequest {
   // True if the client is a worker and false if the client is a driver.
   is_worker: bool;
   // The ID of the worker or driver.
-  client_id: string;
+  worker_id: string;
   // The process ID of this worker.
   worker_pid: long;
   // The job ID.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -853,7 +853,7 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     DispatchTasks(local_queues_.GetReadyTasksWithResources());
   } else {
     // Register the new driver.
-    const ClientID driver_id = from_flatbuf<ClientID>(*message->client_id());
+    const WorkerID driver_id = from_flatbuf<WorkerID>(*message->worker_id());
     // Compute a dummy driver task id from a given driver.
     const TaskID driver_task_id = TaskID::ComputeDriverTaskId(driver_id);
     worker->AssignTaskId(driver_task_id);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -844,7 +844,7 @@ void NodeManager::ProcessClientMessage(
 void NodeManager::ProcessRegisterClientRequestMessage(
     const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data) {
   auto message = flatbuffers::GetRoot<protocol::RegisterClientRequest>(message_data);
-  client->SetClientID(from_flatbuf<ClientID>(*message->client_id()));
+  client->SetClientID(from_flatbuf<ClientID>(*message->worker_id()));
   auto worker =
       std::make_shared<Worker>(message->worker_pid(), message->language(), client);
   if (message->is_worker()) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -856,11 +856,9 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     // message is actually the ID of the driver task, while client_id represents the
     // real driver ID, which can associate all the tasks/actors for a given driver,
     // which is set to the worker ID.
-    // TODO(qwang): Use driver_task_id instead here.
-    const WorkerID driver_id = from_flatbuf<WorkerID>(*message->driver_id());
-    TaskID driver_task_id = TaskID::GetDriverTaskID(driver_id);
+    const TaskID driver_task_id = from_flatbuf<TaskID>(*message->driver_task_id());
     worker->AssignTaskId(driver_task_id);
-    worker->AssignJobId(from_flatbuf<JobID>(*message->client_id()));
+    worker->AssignJobId(from_flatbuf<JobID>(*message->job_id()));
     worker_pool_.RegisterDriver(std::move(worker));
     local_queues_.AddDriverTaskId(driver_task_id);
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -856,7 +856,8 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     // message is actually the ID of the driver task, while client_id represents the
     // real driver ID, which can associate all the tasks/actors for a given driver,
     // which is set to the worker ID.
-    const TaskID driver_task_id = from_flatbuf<TaskID>(*message->driver_task_id());
+    const ClientID driver_id = from_flatbuf<ClientID>(*message->client_id());
+    const TaskID driver_task_id = TaskID::ComputeDriverTaskId(driver_id);
     worker->AssignTaskId(driver_task_id);
     worker->AssignJobId(from_flatbuf<JobID>(*message->job_id()));
     worker_pool_.RegisterDriver(std::move(worker));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -852,11 +852,9 @@ void NodeManager::ProcessRegisterClientRequestMessage(
     worker_pool_.RegisterWorker(std::move(worker));
     DispatchTasks(local_queues_.GetReadyTasksWithResources());
   } else {
-    // Register the new driver. Note that here the driver_id in RegisterClientRequest
-    // message is actually the ID of the driver task, while client_id represents the
-    // real driver ID, which can associate all the tasks/actors for a given driver,
-    // which is set to the worker ID.
+    // Register the new driver.
     const ClientID driver_id = from_flatbuf<ClientID>(*message->client_id());
+    // Compute a dummy driver task id from a given driver.
     const TaskID driver_task_id = TaskID::ComputeDriverTaskId(driver_id);
     worker->AssignTaskId(driver_task_id);
     worker->AssignJobId(from_flatbuf<JobID>(*message->job_id()));

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -206,11 +206,12 @@ RayletClient::RayletClient(const std::string &raylet_socket, const ClientID &cli
     : client_id_(client_id), is_worker_(is_worker), job_id_(job_id), language_(language) {
   // For C++14, we could use std::make_unique
   conn_ = std::unique_ptr<RayletConnection>(new RayletConnection(raylet_socket, -1, -1));
+  const auto driver_task_id = TaskID::ComputeDriverTaskID(client_id);
 
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateRegisterClientRequest(
       fbb, is_worker, to_flatbuf(fbb, client_id), getpid(), to_flatbuf(fbb, job_id),
-      language);
+      to_flatbuf(fbb, driver_task_id), language);
   fbb.Finish(message);
   // Register the process ID with the raylet.
   // NOTE(swang): If raylet exits and we are registered as a worker, we will get killed.

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -206,12 +206,11 @@ RayletClient::RayletClient(const std::string &raylet_socket, const ClientID &cli
     : client_id_(client_id), is_worker_(is_worker), job_id_(job_id), language_(language) {
   // For C++14, we could use std::make_unique
   conn_ = std::unique_ptr<RayletConnection>(new RayletConnection(raylet_socket, -1, -1));
-  const auto driver_task_id = TaskID::ComputeDriverTaskID(client_id);
 
   flatbuffers::FlatBufferBuilder fbb;
   auto message = ray::protocol::CreateRegisterClientRequest(
       fbb, is_worker, to_flatbuf(fbb, client_id), getpid(), to_flatbuf(fbb, job_id),
-      to_flatbuf(fbb, driver_task_id), language);
+      language);
   fbb.Finish(message);
   // Register the process ID with the raylet.
   // NOTE(swang): If raylet exits and we are registered as a worker, we will get killed.


### PR DESCRIPTION
Refine `RegisterClientRequest` to make the handler in node_manager clearer.