### PR TITLE
Improve local_mode

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -72,7 +72,6 @@ from ray.state import (global_state, nodes, tasks, objects, timeline,
                        available_resources, errors)  # noqa: E402
 from ray.worker import (
     LOCAL_MODE,
-    PYTHON_MODE,
     SCRIPT_MODE,
     WORKER_MODE,
     connect,

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -551,14 +551,15 @@ class ActorHandle(object):
                     placement_resources={},
                     job_id=self._ray_actor_job_id,
                 )
-                # Update the actor counter and cursor to reflect the most recent
-                # invocation.
+                # Update the actor counter and cursor to reflect the most
+                # recent invocation.
                 self._ray_actor_counter += 1
                 # The last object returned is the dummy object that should be
-                # passed in to the next actor method. Do not return it to the user.
+                # passed in to the next actor method. Do not return it to the
+                # user.
                 self._ray_actor_cursor = object_ids.pop()
-                # We have notified the backend of the new actor handles to expect
-                # since the last task was submitted, so clear the list.
+                # We have notified the backend of the new actor handles to
+                # expect since the last task was submitted, so clear the list.
                 self._ray_new_actor_handles = []
 
         if len(object_ids) == 1:

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -30,9 +30,6 @@ def free(object_ids, local_only=False, delete_creating_tasks=False):
     """
     worker = ray.worker.get_global_worker()
 
-    if ray.worker._mode() == ray.worker.LOCAL_MODE:
-        return
-
     if isinstance(object_ids, ray.ObjectID):
         object_ids = [object_ids]
 
@@ -45,6 +42,10 @@ def free(object_ids, local_only=False, delete_creating_tasks=False):
         if not isinstance(object_id, ray.ObjectID):
             raise TypeError("Attempting to call `free` on the value {}, "
                             "which is not an ray.ObjectID.".format(object_id))
+
+    if ray.worker._mode() == ray.worker.LOCAL_MODE:
+        worker.local_mode_manager.free(object_ids)
+        return
 
     worker.check_connected()
     with profiling.profile("ray.free"):

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -6,7 +6,7 @@ import copy
 import traceback
 
 from pyarrow import PlasmaObjectExists
-from ray import ObjectID, ray_constants
+from ray import ObjectID
 from ray.utils import format_error_message
 from ray.exceptions import RayTaskError
 

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import copy
+import random
+import string
+import traceback
+
+import numpy as np
+
+from ray import ObjectID, ray_constants
+from ray.utils import format_error_message
+from ray.exceptions import RayTaskError
+
+
+def random_object_id():
+    return ObjectID(np.random.bytes(ray_constants.ID_SIZE))
+
+
+class LocalModeManager(object):
+    """A class used by the worker process to emulate remote operations when
+    running in local mode
+
+    Attributes:
+        object_store (dict): Local dictionary used to map ObjectIDs to objects.
+    """
+
+    def __init__(self):
+        """Initialize a LocalModeManager."""
+        self.object_store = {}
+
+    def execute(self, function, function_descriptor, args, num_return_vals):
+        """Synchronously executes a "remote" function or actor method.
+
+        Stores results in the local object store and returns ObjectIDs. Any
+        exceptions raised during function execution will be stored under all
+        ObjectIDs corresponding to the function and later raised by the worker.
+
+        Args:
+            function: The function to execute.
+            function_descriptor: Metadata about the function.
+            args: Arguments to the function. These will not be modified by
+                the function execution.
+            num_return_vals: Number of expected return values specified in the
+                function's decorator.
+
+        Returns:
+            The ObjectIDs corresponding to the function return values.
+        """
+        object_ids = [random_object_id() for _ in range(num_return_vals)]
+        try:
+            results = function(*copy.deepcopy(args))
+            if num_return_vals == 1:
+                self.object_store[object_ids[0]] = results
+            else:
+                for object_id, result in zip(object_ids, results):
+                    self.object_store[object_id] = result
+        except Exception:
+            function_name = function_descriptor.function_name
+            backtrace = format_error_message(traceback.format_exc())
+            task_error = RayTaskError(function_name, backtrace)
+            for object_id in object_ids:
+                self.object_store[object_id] = task_error
+
+        return object_ids
+
+    def put_object(self, object_id, value):
+        """Store an object in the local object store.
+
+        Args:
+            object_id: The ObjectID to store the value under. An existing value
+                for this ID will be overwritten if it exists.
+        """
+        self.object_store[object_id] = value
+
+    def get_object(self, object_ids):
+        """Fetch objects from the local object store.
+
+        Args:
+            object_ids: A list of ObjectIDs to fetch values for.
+
+        Raises:
+            KeyError if any of the ObjectIDs do not exist in the object store.
+        """
+        return [self.object_store[object_id] for object_id in object_ids]
+
+    def free(self, object_ids):
+        """Delete objects from the local object store.
+
+        Args:
+            object_ids: A list of ObjectIDs to delete.
+
+        Raises:
+            KeyError if any of the ObjectIDs do not exist in the object store.
+        """
+        for object_id in object_ids:
+            del self.object_store[object_id]

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -3,8 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import random
-import string
 import traceback
 
 from pyarrow import PlasmaObjectExists
@@ -91,9 +89,7 @@ class LocalModeManager(object):
 
         Args:
             object_ids: A list of ObjectIDs to delete.
-
-        Raises:
-            KeyError if any of the ObjectIDs do not exist in the object store.
         """
         for object_id in object_ids:
-            del self.object_store[object_id]
+            if object_id in self.object_store:
+                del self.object_store[object_id]

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -5,30 +5,38 @@ from __future__ import print_function
 import copy
 import traceback
 
-from pyarrow import PlasmaObjectExists
 from ray import ObjectID
 from ray.utils import format_error_message
 from ray.exceptions import RayTaskError
 
 
-class LocalModeManager(object):
-    """A class used by the worker process to emulate remote operations when
-    running in local mode
+class LocalModeObjectID(ObjectID):
+    """Wrapper class around ray.ObjectID used for local mode. Object values
+    are stored directly as a field of the LocalModeObjectID.
 
     Attributes:
-        object_store (dict): Local dictionary used to map ObjectIDs to objects.
+        value: Field that stores object values. If this field does not exist,
+            it equates to the object not existing in the object store. This is
+            necessary because None is a valid object value.
+    """
+    pass
+
+
+class LocalModeManager(object):
+    """A class used by the worker process to emulate remote operations when
+    running in local mode.
     """
 
     def __init__(self):
         """Initialize a LocalModeManager."""
-        self.object_store = {}
 
     def execute(self, function, function_descriptor, args, num_return_vals):
         """Synchronously executes a "remote" function or actor method.
 
-        Stores results in the local object store and returns ObjectIDs. Any
-        exceptions raised during function execution will be stored under all
-        ObjectIDs corresponding to the function and later raised by the worker.
+        Stores results directly in the generated and returned
+        LocalModeObjectIDs. Any exceptions raised during function execution
+        will be stored under all returned object IDs and later raised by the
+        worker.
 
         Args:
             function: The function to execute.
@@ -39,57 +47,85 @@ class LocalModeManager(object):
                 function's decorator.
 
         Returns:
-            The ObjectIDs corresponding to the function return values.
+            LocalModeObjectIDs corresponding to the function return values.
         """
-        object_ids = [ObjectID.from_random() for _ in range(num_return_vals)]
+        object_ids = [
+            LocalModeObjectID.from_random() for _ in range(num_return_vals)
+        ]
         try:
             results = function(*copy.deepcopy(args))
             if num_return_vals == 1:
-                self.object_store[object_ids[0]] = results
+                object_ids[0].value = results
             else:
                 for object_id, result in zip(object_ids, results):
-                    self.object_store[object_id] = result
+                    object_id.value = result
         except Exception:
             function_name = function_descriptor.function_name
             backtrace = format_error_message(traceback.format_exc())
             task_error = RayTaskError(function_name, backtrace)
             for object_id in object_ids:
-                self.object_store[object_id] = task_error
+                object_id.value = task_error
 
         return object_ids
 
-    def put_object(self, object_id, value):
-        """Store an object in the local object store.
+    def put_object(self, value):
+        """Store an object in the emulated object store.
+
+        Implemented by generating a LocalModeObjectID and storing the value
+        directly within it.
 
         Args:
-            object_id: The ObjectID to store the value under. An existing value
-                for this ID will be overwritten if it exists.
+            value: The value to store.
 
-        Raises:
-            pyarrow.PlasmaObjectExists if the ObjectID exists in the store.
+        Returns:
+            LocalModeObjectID corresponding to the value.
         """
-        if object_id in self.object_store:
-            raise PlasmaObjectExists()
-
-        self.object_store[object_id] = value
+        object_id = LocalModeObjectID.from_random()
+        object_id.value = value
+        return object_id
 
     def get_object(self, object_ids):
-        """Fetch objects from the local object store.
+        """Fetch objects from the emulated object store.
+
+        Accepts only LocalModeObjectIDs and reads values directly from them.
 
         Args:
-            object_ids: A list of ObjectIDs to fetch values for.
+            object_ids: A list of object IDs to fetch values for.
 
         Raises:
-            KeyError if any of the ObjectIDs do not exist in the object store.
+            TypeError if any of the object IDs are not LocalModeObjectIDs.
+            KeyError if any of the object IDs do not contain values.
         """
-        return [self.object_store[object_id] for object_id in object_ids]
+        results = []
+        for object_id in object_ids:
+            if not isinstance(object_id, LocalModeObjectID):
+                raise TypeError("Only LocalModeObjectIDs are supported" +
+                                "when running in LOCAL_MODE. Using " +
+                                "user-generated ObjectIDs will fail.")
+            if not hasattr(object_id, "value"):
+                raise KeyError("Value for {} not found".format(object_id))
+
+            results.append(object_id.value)
+
+        return results
 
     def free(self, object_ids):
-        """Delete objects from the local object store.
+        """Delete objects from the emulated object store.
+
+        Accepts only LocalModeObjectIDs and deletes their values directly.
 
         Args:
             object_ids: A list of ObjectIDs to delete.
+
+        Raises:
+            TypeError if any of the object IDs are not LocalModeObjectIDs.
         """
         for object_id in object_ids:
-            if object_id in self.object_store:
-                del self.object_store[object_id]
+            if not isinstance(object_id, LocalModeObjectID):
+                raise TypeError("Only LocalModeObjectIDs are supported" +
+                                "when running in LOCAL_MODE. Using " +
+                                "user-generated ObjectIDs will fail.")
+            try:
+                del object_id.value
+            except AttributeError:
+                pass

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -98,8 +98,8 @@ class LocalModeManager(object):
         results = []
         for object_id in object_ids:
             if not isinstance(object_id, LocalModeObjectID):
-                raise TypeError("Only LocalModeObjectIDs are supported" +
-                                "when running in LOCAL_MODE. Using " +
+                raise TypeError("Only LocalModeObjectIDs are supported "
+                                "when running in LOCAL_MODE. Using "
                                 "user-generated ObjectIDs will fail.")
             if not hasattr(object_id, "value"):
                 raise KeyError("Value for {} not found".format(object_id))
@@ -121,8 +121,8 @@ class LocalModeManager(object):
         """
         for object_id in object_ids:
             if not isinstance(object_id, LocalModeObjectID):
-                raise TypeError("Only LocalModeObjectIDs are supported" +
-                                "when running in LOCAL_MODE. Using " +
+                raise TypeError("Only LocalModeObjectIDs are supported "
+                                "when running in LOCAL_MODE. Using "
                                 "user-generated ObjectIDs will fail.")
             try:
                 del object_id.value

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -12,7 +12,7 @@ from ray.exceptions import RayTaskError
 
 class LocalModeObjectID(ObjectID):
     """Wrapper class around ray.ObjectID used for local mode.
-    
+
     Object values are stored directly as a field of the LocalModeObjectID.
 
     Attributes:

--- a/python/ray/local_mode_manager.py
+++ b/python/ray/local_mode_manager.py
@@ -11,8 +11,9 @@ from ray.exceptions import RayTaskError
 
 
 class LocalModeObjectID(ObjectID):
-    """Wrapper class around ray.ObjectID used for local mode. Object values
-    are stored directly as a field of the LocalModeObjectID.
+    """Wrapper class around ray.ObjectID used for local mode.
+    
+    Object values are stored directly as a field of the LocalModeObjectID.
 
     Attributes:
         value: Field that stores object values. If this field does not exist,
@@ -23,9 +24,7 @@ class LocalModeObjectID(ObjectID):
 
 
 class LocalModeManager(object):
-    """A class used by the worker process to emulate remote operations when
-    running in local mode.
-    """
+    """Used to emulate remote operations when running in local mode."""
 
     def __init__(self):
         """Initialize a LocalModeManager."""

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -280,15 +280,14 @@ def test_complex_serialization(ray_start_regular):
     TUPLE_OBJECTS = [(obj, ) for obj in BASE_OBJECTS]
     # The check that type(obj).__module__ != "numpy" should be unnecessary, but
     # otherwise this seems to fail on Mac OS X on Travis.
-    DICT_OBJECTS = (
-        [{
-            obj: obj
-        } for obj in PRIMITIVE_OBJECTS if
-         (obj.__hash__ is not None and type(obj).__module__ != "numpy")] + [{
-             0: obj
-         } for obj in BASE_OBJECTS] + [{
-             Foo(123): Foo(456)
-         }])
+    DICT_OBJECTS = ([{
+        obj: obj
+    } for obj in PRIMITIVE_OBJECTS if (
+        obj.__hash__ is not None and type(obj).__module__ != "numpy")] + [{
+            0: obj
+        } for obj in BASE_OBJECTS] + [{
+            Foo(123): Foo(456)
+        }])
 
     RAY_TEST_OBJECTS = (
         BASE_OBJECTS + LIST_OBJECTS + TUPLE_OBJECTS + DICT_OBJECTS)
@@ -1730,9 +1729,9 @@ def test_resource_constraints(shutdown_only):
     while True:
         if len(
                 set(
-                    ray.get(
-                        [get_worker_id.remote()
-                         for _ in range(num_workers)]))) == num_workers:
+                    ray.get([
+                        get_worker_id.remote() for _ in range(num_workers)
+                    ]))) == num_workers:
             break
 
     time_buffer = 2
@@ -1806,9 +1805,9 @@ def test_multi_resource_constraints(shutdown_only):
     while True:
         if len(
                 set(
-                    ray.get(
-                        [get_worker_id.remote()
-                         for _ in range(num_workers)]))) == num_workers:
+                    ray.get([
+                        get_worker_id.remote() for _ in range(num_workers)
+                    ]))) == num_workers:
             break
 
     @ray.remote(num_cpus=1, num_gpus=9)
@@ -3017,8 +3016,8 @@ def test_get_postprocess(ray_start_regular):
 
     ray.worker.global_worker._post_get_hooks.append(get_postprocessor)
 
-    assert ray.get([ray.put(i)
-                    for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]
+    assert ray.get(
+        [ray.put(i) for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]
 
 
 def test_export_after_shutdown(ray_start_regular):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1627,6 +1627,9 @@ def test_local_mode(shutdown_only):
     with pytest.raises(Exception):
         ray.get(k2)
 
+    # Should fail silently.
+    ray.internal.free([k1, k2])
+
     # Test actors in LOCAL_MODE.
 
     @ray.remote

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -280,14 +280,15 @@ def test_complex_serialization(ray_start_regular):
     TUPLE_OBJECTS = [(obj, ) for obj in BASE_OBJECTS]
     # The check that type(obj).__module__ != "numpy" should be unnecessary, but
     # otherwise this seems to fail on Mac OS X on Travis.
-    DICT_OBJECTS = ([{
-        obj: obj
-    } for obj in PRIMITIVE_OBJECTS if (
-        obj.__hash__ is not None and type(obj).__module__ != "numpy")] + [{
-            0: obj
-        } for obj in BASE_OBJECTS] + [{
-            Foo(123): Foo(456)
-        }])
+    DICT_OBJECTS = (
+        [{
+            obj: obj
+        } for obj in PRIMITIVE_OBJECTS if
+         (obj.__hash__ is not None and type(obj).__module__ != "numpy")] + [{
+             0: obj
+         } for obj in BASE_OBJECTS] + [{
+             Foo(123): Foo(456)
+         }])
 
     RAY_TEST_OBJECTS = (
         BASE_OBJECTS + LIST_OBJECTS + TUPLE_OBJECTS + DICT_OBJECTS)
@@ -1676,7 +1677,8 @@ def test_local_mode(shutdown_only):
 
     # Check that exceptions are deferred until ray.get().
 
-    exception_str = 'test_basic remote task exception'
+    exception_str = "test_basic remote task exception"
+
     @ray.remote
     def throws():
         raise Exception(exception_str)
@@ -1714,6 +1716,7 @@ def test_local_mode(shutdown_only):
     with pytest.raises(Exception, match=exception_str):
         ray.get(obj2)
 
+
 def test_resource_constraints(shutdown_only):
     num_workers = 20
     ray.init(num_cpus=10, num_gpus=2)
@@ -1727,9 +1730,9 @@ def test_resource_constraints(shutdown_only):
     while True:
         if len(
                 set(
-                    ray.get([
-                        get_worker_id.remote() for _ in range(num_workers)
-                    ]))) == num_workers:
+                    ray.get(
+                        [get_worker_id.remote()
+                         for _ in range(num_workers)]))) == num_workers:
             break
 
     time_buffer = 2
@@ -1803,9 +1806,9 @@ def test_multi_resource_constraints(shutdown_only):
     while True:
         if len(
                 set(
-                    ray.get([
-                        get_worker_id.remote() for _ in range(num_workers)
-                    ]))) == num_workers:
+                    ray.get(
+                        [get_worker_id.remote()
+                         for _ in range(num_workers)]))) == num_workers:
             break
 
     @ray.remote(num_cpus=1, num_gpus=9)
@@ -3014,8 +3017,8 @@ def test_get_postprocess(ray_start_regular):
 
     ray.worker.global_worker._post_get_hooks.append(get_postprocessor)
 
-    assert ray.get(
-        [ray.put(i) for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]
+    assert ray.get([ray.put(i)
+                    for i in [0, 1, 3, 5, -1, -3, 4]]) == [1, 3, 5, 4]
 
 
 def test_export_after_shutdown(ray_start_regular):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1611,6 +1611,22 @@ def test_local_mode(shutdown_only):
     assert ready == object_ids[:num_returns]
     assert remaining == object_ids[num_returns:]
 
+    # Check that ray.put() and ray.internal.free() work in local mode.
+
+    v1 = np.ones(10)
+    v2 = np.zeros(10)
+
+    k1 = ray.put(v1)
+    assert np.alltrue(v1 == ray.get(k1))
+    k2 = ray.put(v2)
+    assert np.alltrue(v2 == ray.get(k2))
+
+    ray.internal.free([k1, k2])
+    with pytest.raises(Exception):
+        ray.get(k1)
+    with pytest.raises(Exception):
+        ray.get(k2)
+
     # Test actors in LOCAL_MODE.
 
     @ray.remote


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Brings the behavior in local_mode closer in line with the default mode.
- Remote functions and methods now return `ObjectID`s instead of immediate values
- Exceptions raised by remote functions and methods will now be deferred until calling `ray.get()`

Note that there is currently no garbage collection in the emulated object store (local dictionary), so it will grow unboundedly until the worker exits. If this is a concern, we can cap its size or do LRU eviction, but I didn't want to add unnecessary complexity.


## Related issue number
#2822
Closes #1155, #2238, #4678
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
