### PR TITLE
bump version to 0.7.2

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -97,7 +97,7 @@ from ray.actor import method  # noqa: E402
 from ray.runtime_context import _get_runtime_context  # noqa: E402
 
 # Ray version string.
-__version__ = "0.8.0.dev1"
+__version__ = "0.7.2"
 
 __all__ = [
     "global_state",


### PR DESCRIPTION
There will be a followup PR bumping version to `0.8.0.dev2`

Part 1/11 in #5067