### PR TITLE
[tune] PBT perturbing after first iteration

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -268,8 +268,8 @@ class PopulationBasedTraining(FIFOScheduler):
             "pbt_policy_" + trial_to_clone_id + ".txt")
         policy = [
             trial_name, trial_to_clone_name,
-            trial.last_result[TRAINING_ITERATION],
-            trial_to_clone.last_result[TRAINING_ITERATION],
+            trial.last_result.get(TRAINING_ITERATION, 0),
+            trial_to_clone.last_result.get(TRAINING_ITERATION, 0),
             trial_to_clone.config, new_config
         ]
         # Log to global file.

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -12,6 +12,7 @@ import tempfile
 import shutil
 import ray
 
+from ray.tune.result import TRAINING_ITERATION
 from ray.tune.schedulers import (HyperBandScheduler, AsyncHyperBandScheduler,
                                  PopulationBasedTraining, MedianStoppingRule,
                                  TrialScheduler)
@@ -938,7 +939,7 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         for i, trial in enumerate(trials):
             trial.local_dir = tmpdir
-            trial.last_result = {}
+            trial.last_result = {TRAINING_ITERATION: i}
         pbt.on_trial_result(runner, trials[0], result(15, -100))
         pbt.on_trial_result(runner, trials[0], result(20, -100))
         pbt.on_trial_result(runner, trials[2], result(20, 40))

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -622,10 +622,14 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         ray.shutdown()
         _register_all()  # re-register the evicted objects
 
-    def basicSetup(self, resample_prob=0.0, explore=None, log_config=False):
+    def basicSetup(self,
+                   resample_prob=0.0,
+                   explore=None,
+                   perturbation_interval=10,
+                   log_config=False):
         pbt = PopulationBasedTraining(
             time_attr="training_iteration",
-            perturbation_interval=10,
+            perturbation_interval=perturbation_interval,
             resample_probability=resample_prob,
             quantile_fraction=0.25,
             hyperparam_mutations={
@@ -958,6 +962,14 @@ class PopulationBasedTestingSuite(unittest.TestCase):
             TrialScheduler.CONTINUE)
         self.assertEqual(trials[0].config["id_factor"], 42)
         self.assertEqual(trials[0].config["float_factor"], 43)
+
+    def testFastIteration(self):
+        pbt, runner = self.basicSetup(
+            resample_prob=0.0, perturbation_interval=1)
+        trials = runner.get_trials()
+        self.assertEqual(
+            pbt.on_trial_result(runner, trials[0], result(20, -100)),
+            TrialScheduler.CONTINUE)
 
 
 class AsyncHyperBandSuite(unittest.TestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Occasionally, with the above described config PBT attempts to perturb
config before trial.last_result is populated. This results in KeyError
and the worker dies.j


## Related issue number

Closes #5041.

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.