### PR TITLE
[tune] Fixed bug with joining experiment_path twice.

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -66,7 +66,7 @@ class ExperimentAnalysis(object):
                 "No experiment state found in {}!".format(experiment_path))
         experiment_filename = max(
             list(experiment_state_paths))  # if more than one, pick latest
-        with open(os.path.join(experiment_path, experiment_filename)) as f:
+        with open(experiment_filename) as f:
             self._experiment_state = json.load(f)
 
         if "checkpoints" not in self._experiment_state:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Fixes constructor for ExperimentAnalysis, which currently joins `experiment_path` using `os.path.join` once more than necessary. Path joining is already done in Lines 62-63, so it doesn't need to be done in Line 69.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
