### PR TITLE
[tune] tune.run keep_checkpoints_num 

### DIFF
--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -49,6 +49,7 @@ def run(run_or_experiment,
         sync_to_driver=None,
         checkpoint_freq=0,
         checkpoint_at_end=False,
+        keep_checkpoints_num=None,
         export_formats=None,
         max_failures=3,
         restore=None,
@@ -113,6 +114,8 @@ def run(run_or_experiment,
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
+        keep_checkpoints_num (int): Number of checkpoints to keep. A value of
+            `None` keeps all checkpoints. Default value to `None`
         export_formats (list): List of formats that exported at the end of
             the experiment. Default is None.
         max_failures (int): Try to recover a trial from its last
@@ -195,6 +198,7 @@ def run(run_or_experiment,
             loggers=loggers,
             checkpoint_freq=checkpoint_freq,
             checkpoint_at_end=checkpoint_at_end,
+            keep_checkpoints_num=keep_checkpoints_num,
             export_formats=export_formats,
             max_failures=max_failures,
             restore=restore,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -50,6 +50,7 @@ def run(run_or_experiment,
         checkpoint_freq=0,
         checkpoint_at_end=False,
         keep_checkpoints_num=None,
+        checkpoint_score_attr=None,
         export_formats=None,
         max_failures=3,
         restore=None,
@@ -115,7 +116,12 @@ def run(run_or_experiment,
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
         keep_checkpoints_num (int): Number of checkpoints to keep. A value of
-            `None` keeps all checkpoints. Default value to `None`
+            `None` keeps all checkpoints. Defaults to `None`. If set, need
+            to provide `checkpoint_score_attr`.
+        checkpoint_score_attr (str): Specifies by which attribute to rank the
+            best checkpoint. Default is increasing order. If attribute starts
+            with `min-` it will rank attribute in decreasing order, i.e.
+            `min-validation_loss`.
         export_formats (list): List of formats that exported at the end of
             the experiment. Default is None.
         max_failures (int): Try to recover a trial from its last
@@ -199,6 +205,7 @@ def run(run_or_experiment,
             checkpoint_freq=checkpoint_freq,
             checkpoint_at_end=checkpoint_at_end,
             keep_checkpoints_num=keep_checkpoints_num,
+            checkpoint_score_attr=checkpoint_score_attr,
             export_formats=export_formats,
             max_failures=max_failures,
             restore=restore,


### PR DESCRIPTION
## What do these changes do?
It adds the missing `keep_checkpoints_num` to tune arguments.


## Related issue number
Closes #5105 