### PR TITLE
Require protobuf >= 3.8.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -150,7 +150,7 @@ requires = [
     "six >= 1.0.0",
     "flatbuffers",
     "faulthandler;python_version<'3.3'",
-    "protobuf",
+    "protobuf >= 3.8.0",
 ]
 
 setup(


### PR DESCRIPTION
Since 0.7.2, the generated protobuf files for python seem to require some features that are not present in protobuf-3.5.2. Upgrading to 3.8.0 fixed the crash on init for me.

```
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/pytorch_p36/bin/rllib", line 7, in <module>
    from ray.rllib.scripts import cli
  File "/home/ubuntu/anaconda3/envs/pytorch_p36/lib/python3.6/site-packages/ray/__init__.py", line 52, in <module>
    from ray._raylet import (
  File "python/ray/_raylet.pyx", line 39, in init ray._raylet
  File "/home/ubuntu/anaconda3/envs/pytorch_p36/lib/python3.6/site-packages/ray/utils.py", line 20, in <module>
    import ray.gcs_utils
  File "/home/ubuntu/anaconda3/envs/pytorch_p36/lib/python3.6/site-packages/ray/gcs_utils.py", line 7, in <module>
    from ray.core.generated.gcs_pb2 import (
  File "/home/ubuntu/anaconda3/envs/pytorch_p36/lib/python3.6/site-packages/ray/core/generated/gcs_pb2.py", line 24, in <module>
    serialized_pb=_b('\n\x1asrc/ray/protobuf/gcs.proto\x12\x07ray.rpc\"m\n\x08GcsEntry\x12\x37\n\x0b\x63hange_mode\x18\x01 \x01(\x0e\x32\x16.ray.rpc.GcsChangeModeR\nchangeMode\x12\x0e\n\x02id\x18\x02 \x01(\x0cR\x02id\x12\x18\n\x07\x65ntries\x18\x03 \x03(\x0cR\x07\x65ntries\"L\n\x0fObjectTableData\x12\x1f\n\x0bobject_size\x18\x01 \x01(\x04R\nobjectSize\x12\x18\n\x07manager\x18\x02 \x01(\x0cR\x07manager\"q\n\x16TaskReconstructionData\x12/\n\x13num_reconstructions\x18\x01 \x01(\x04R\x12numReconstructions\x12&\n\x0fnode_manager_id\x18\x02 \x01(\x0cR\rnodeManagerId\"#\n\rTaskTableData\x12\x12\n\x04task\x18\x01 \x01(\x0cR\x04task\"\x8d\x03\n\x0e\x41\x63torTableData\x12\x19\n\x08\x61\x63tor_id\x18\x01 \x01(\x0cR\x07\x61\x63torId\x12\x42\n\x1e\x61\x63tor_creation_dummy_object_id\x18\x02 \x01(\x0cR\x1a\x61\x63torCreationDummyObjectId\x12\x15\n\x06job_id\x18\x03 \x01(\x0cR\x05jobId\x12&\n\x0fnode_manager_id\x18\x04 \x01(\x0cR\rnodeManagerId\x12\x38\n\x05state\x18\x05 \x01(\x0e\x32\".ray.rpc.ActorTableData.ActorStateR\x05state\x12/\n\x13max_reconstructions\x18\x06 \x01(\x04R\x12maxReconstructions\x12;\n\x19remaining_reconstructions\x18\x07 \x01(\x04R\x18remainingReconstructions\"5\n\nActorState\x12\t\n\x05\x41LIVE\x10\x00\x12\x12\n\x0eRECONSTRUCTING\x10\x01\x12\x08\n\x04\x44\x45\x41\x44\x10\x02\"~\n\x0e\x45rrorTableData\x12\x15\n\x06job_id\x18\x01 \x01(\x0cR\x05jobId\x12\x12\n\x04type\x18\x02 \x01(\tR\x04type\x12#\n\rerror_message\x18\x03 \x01(\tR\x0c\x65rrorMessage\x12\x1c\n\ttimestamp\x18\x04 \x01(\x01R\ttimestamp\"\xdc\x02\n\x10ProfileTableData\x12%\n\x0e\x63omponent_type\x18\x01 \x01(\tR\rcomponentType\x12!\n\x0c\x63omponent_id\x18\x02 \x01(\x0cR\x0b\x63omponentId\x12&\n\x0fnode_ip_address\x18\x03 \x01(\tR\rnodeIpAddress\x12M\n\x0eprofile_events\x18\x04 \x03(\x0b\x32&.ray.rpc.ProfileTableData.ProfileEventR\rprofileEvents\x1a\x86\x01\n\x0cProfileEvent\x12\x1d\n\nevent_type\x18\x01 \x01(\tR\teventType\x12\x1d\n\nstart_time\x18\x02 \x01(\x01R\tstartTime\x12\x19\n\x08\x65nd_time\x18\x03 \x01(\x01R\x07\x65ndTime\x12\x1d\n\nextra_data\x18\x04 \x01(\tR\textraData\"_\n\x0bRayResource\x12#\n\rresource_name\x18\x01 \x01(\tR\x0cresourceName\x12+\n\x11resource_capacity\x18\x02 \x01(\x01R\x10resourceCapacity\"\xa4\x04\n\x0f\x43lientTableData\x12\x1b\n\tclient_id\x18\x01 \x01(\x0cR\x08\x63lientId\x12\x30\n\x14node_manager_address\x18\x02 \x01(\tR\x12nodeManagerAddress\x12,\n\x12raylet_socket_name\x18\x03 \x01(\tR\x10rayletSocketName\x12\x37\n\x18object_store_socket_name\x18\x04 \x01(\tR\x15objectStoreSocketName\x12*\n\x11node_manager_port\x18\x05 \x01(\x05R\x0fnodeManagerPort\x12.\n\x13object_manager_port\x18\x06 \x01(\x05R\x11objectManagerPort\x12\x41\n\nentry_type\x18\x07 \x01(\x0e\x32\".ray.rpc.ClientTableData.EntryTypeR\tentryType\x12\x32\n\x15resources_total_label\x18\x08 \x03(\tR\x13resourcesTotalLabel\x12\x38\n\x18resources_total_capacity\x18\t \x03(\x01R\x16resourcesTotalCapacity\"N\n\tEntryType\x12\r\n\tINSERTION\x10\x00\x12\x0c\n\x08\x44\x45LETION\x10\x01\x12\x14\n\x10RES_CREATEUPDATE\x10\x02\x12\x0e\n\nRES_DELETE\x10\x03\"\x83\x03\n\x12HeartbeatTableData\x12\x1b\n\tclient_id\x18\x01 \x01(\x0cR\x08\x63lientId\x12:\n\x19resources_available_label\x18\x02 \x03(\tR\x17resourcesAvailableLabel\x12@\n\x1cresources_available_capacity\x18\x03 \x03(\x01R\x1aresourcesAvailableCapacity\x12\x32\n\x15resources_total_label\x18\x04 \x03(\tR\x13resourcesTotalLabel\x12\x38\n\x18resources_total_capacity\x18\x05 \x03(\x01R\x16resourcesTotalCapacity\x12.\n\x13resource_load_label\x18\x06 \x03(\tR\x11resourceLoadLabel\x12\x34\n\x16resource_load_capacity\x18\x07 \x03(\x01R\x14resourceLoadCapacity\"L\n\x17HeartbeatBatchTableData\x12\x31\n\x05\x62\x61tch\x18\x01 \x03(\x0b\x32\x1b.ray.rpc.HeartbeatTableDataR\x05\x62\x61tch\"r\n\rTaskLeaseData\x12&\n\x0fnode_manager_id\x18\x01 \x01(\x0cR\rnodeManagerId\x12\x1f\n\x0b\x61\x63quired_at\x18\x02 \x01(\x04R\nacquiredAt\x12\x18\n\x07timeout\x18\x03 \x01(\x04R\x07timeout\">\n\x0cJobTableData\x12\x15\n\x06job_id\x18\x01 \x01(\x0cR\x05jobId\x12\x17\n\x07is_dead\x18\x02 \x01(\x08R\x06isDead\"\xd9\x02\n\x13\x41\x63torCheckpointData\x12\x19\n\x08\x61\x63tor_id\x18\x01 \x01(\x0cR\x07\x61\x63torId\x12\x31\n\x14\x65xecution_dependency\x18\x02 \x01(\x0cR\x13\x65xecutionDependency\x12\x1d\n\nhandle_ids\x18\x03 \x03(\x0cR\thandleIds\x12#\n\rtask_counters\x18\x04 \x03(\x04R\x0ctaskCounters\x12\x33\n\x15\x66rontier_dependencies\x18\x05 \x03(\x0cR\x14\x66rontierDependencies\x12\x38\n\x18unreleased_dummy_objects\x18\x06 \x03(\x0cR\x16unreleasedDummyObjects\x12\x41\n\x1dnum_dummy_object_dependencies\x18\x07 \x03(\rR\x1anumDummyObjectDependencies\"y\n\x15\x41\x63torCheckpointIdData\x12\x19\n\x08\x61\x63tor_id\x18\x01 \x01(\x0cR\x07\x61\x63torId\x12%\n\x0e\x63heckpoint_ids\x18\x02 \x03(\x0cR\rcheckpointIds\x12\x1e\n\ntimestamps\x18\x03 \x03(\x04R\ntimestamps*)\n\x08Language\x12\n\n\x06PYTHON\x10\x00\x12\x07\n\x03\x43PP\x10\x01\x12\x08\n\x04JAVA\x10\x02*\xc6\x02\n\x0bTablePrefix\x12\x14\n\x10TABLE_PREFIX_MIN\x10\x00\x12\n\n\x06UNUSED\x10\x01\x12\x08\n\x04TASK\x10\x02\x12\x0f\n\x0bRAYLET_TASK\x10\x03\x12\n\n\x06\x43LIENT\x10\x04\x12\n\n\x06OBJECT\x10\x05\x12\t\n\x05\x41\x43TOR\x10\x06\x12\x0c\n\x08\x46UNCTION\x10\x07\x12\x17\n\x13TASK_RECONSTRUCTION\x10\x08\x12\r\n\tHEARTBEAT\x10\t\x12\x13\n\x0fHEARTBEAT_BATCH\x10\n\x12\x0e\n\nERROR_INFO\x10\x0b\x12\x07\n\x03JOB\x10\x0c\x12\x0b\n\x07PROFILE\x10\r\x12\x0e\n\nTASK_LEASE\x10\x0e\x12\x14\n\x10\x41\x43TOR_CHECKPOINT\x10\x0f\x12\x17\n\x13\x41\x43TOR_CHECKPOINT_ID\x10\x10\x12\x11\n\rNODE_RESOURCE\x10\x11\x12\x14\n\x10TABLE_PREFIX_MAX\x10\x12*\xb4\x02\n\x0bTablePubsub\x12\x14\n\x10TABLE_PUBSUB_MIN\x10\x00\x12\x0e\n\nNO_PUBLISH\x10\x01\x12\x0f\n\x0bTASK_PUBSUB\x10\x02\x12\x16\n\x12RAYLET_TASK_PUBSUB\x10\x03\x12\x11\n\rCLIENT_PUBSUB\x10\x04\x12\x11\n\rOBJECT_PUBSUB\x10\x05\x12\x10\n\x0c\x41\x43TOR_PUBSUB\x10\x06\x12\x14\n\x10HEARTBEAT_PUBSUB\x10\x07\x12\x1a\n\x16HEARTBEAT_BATCH_PUBSUB\x10\x08\x12\x15\n\x11\x45RROR_INFO_PUBSUB\x10\t\x12\x15\n\x11TASK_LEASE_PUBSUB\x10\n\x12\x0e\n\nJOB_PUBSUB\x10\x0b\x12\x18\n\x14NODE_RESOURCE_PUBSUB\x10\x0c\x12\x14\n\x10TABLE_PUBSUB_MAX\x10\r*.\n\rGcsChangeMode\x12\x11\n\rAPPEND_OR_ADD\x10\x00\x12\n\n\x06REMOVE\x10\x01*J\n\tErrorType\x12\x0f\n\x0bWORKER_DIED\x10\x00\x12\x0e\n\nACTOR_DIED\x10\x01\x12\x1c\n\x18OBJECT_UNRECONSTRUCTABLE\x10\x02\x42\x1b\n\x19org.ray.runtime.generatedb\x06proto3')
```