### PR TITLE
[hotfix] fix backward compat with older yaml libraries

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -508,7 +508,7 @@ class StandardAutoscaler(object):
     def reload_config(self, errors_fatal=False):
         try:
             with open(self.config_path) as f:
-                new_config = yaml.load(f.read(), Loader=yaml.FullLoader)
+                new_config = yaml.safe_load(f.read())
             validate_config(new_config)
             new_launch_hash = hash_launch_conf(new_config["worker_nodes"],
                                                new_config["auth"])

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -35,7 +35,7 @@ def create_or_update_cluster(config_file, override_min_workers,
                              override_max_workers, no_restart, restart_only,
                              yes, override_cluster_name):
     """Create or updates an autoscaling Ray cluster from a config json."""
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_min_workers is not None:
         config["min_workers"] = override_min_workers
     if override_max_workers is not None:
@@ -73,7 +73,7 @@ def _bootstrap_config(config):
 def teardown_cluster(config_file, yes, workers_only, override_cluster_name):
     """Destroys all nodes of a Ray cluster described by a config json."""
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
     validate_config(config)
@@ -119,7 +119,7 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name):
 def kill_node(config_file, yes, override_cluster_name):
     """Kills a random Raylet worker."""
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
     config = _bootstrap_config(config)
@@ -326,7 +326,7 @@ def exec_cluster(config_file, cmd, docker, screen, tmux, stop, start,
     """
     assert not (screen and tmux), "Can specify only one of `screen` or `tmux`."
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
     config = _bootstrap_config(config)
@@ -426,7 +426,7 @@ def rsync(config_file, source, target, override_cluster_name, down):
     assert bool(source) == bool(target), (
         "Must either provide both or neither source and target.")
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
     config = _bootstrap_config(config)
@@ -463,7 +463,7 @@ def rsync(config_file, source, target, override_cluster_name, down):
 def get_head_node_ip(config_file, override_cluster_name):
     """Returns head node IP for given configuration file if exists."""
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
 
@@ -483,7 +483,7 @@ def get_head_node_ip(config_file, override_cluster_name):
 def get_worker_node_ips(config_file, override_cluster_name):
     """Returns worker node IPs for given configuration file."""
 
-    config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
+    config = yaml.safe_load(open(config_file).read())
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -112,7 +112,7 @@ def get_default_config(provider_config):
             provider_config["type"]))
     path_to_default = load_config()
     with open(path_to_default) as f:
-        defaults = yaml.load(f, Loader=yaml.FullLoader)
+        defaults = yaml.safe_load(f)
 
     return defaults
 

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -133,7 +133,7 @@ class Dashboard(object):
             try:
                 with open(
                         Path("~/ray_bootstrap_config.yaml").expanduser()) as f:
-                    cfg = yaml.load(f, Loader=yaml.FullLoader)
+                    cfg = yaml.safe_load(f)
             except Exception:
                 return await json_response(error="No config")
 

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -109,7 +109,7 @@ def create_parser(parser_creator=None):
 def run(args, parser):
     if args.config_file:
         with open(args.config_file) as f:
-            experiments = yaml.load(f, Loader=yaml.FullLoader)
+            experiments = yaml.safe_load(f)
     else:
         # Note: keep this in sync with tune/config_parser.py
         experiments = {

--- a/python/ray/tune/TuneClient.ipynb
+++ b/python/ray/tune/TuneClient.ipynb
@@ -36,7 +36,7 @@
     "import yaml\n",
     "\n",
     "with open(\"../rllib/tuned_examples/hyperband-cartpole.yaml\") as f:\n",
-    "    d = yaml.load(f, Loader=yaml.FullLoader)"
+    "    d = yaml.safe_load(f)"
    ]
   },
   {


### PR DESCRIPTION
Older versions of pyyaml don't have `loader` as an attribute, so it is not possible to use this without breaking rllib/tune.