### PR TITLE
Use bazel disk cache for all CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,6 @@ install:
   - if [ $RAY_CI_TUNE_AFFECTED != "1" ] && [ $RAY_CI_RLLIB_AFFECTED != "1" ] && [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
 
   - ./ci/suppress_output ./ci/travis/install-bazel.sh
-  - ./ci/suppress_output ./ci/travis/setup-bazel-cache.sh
   - ./ci/suppress_output ./ci/travis/install-dependencies.sh
   - export PATH="$HOME/miniconda/bin:$PATH"
   - ./ci/suppress_output ./ci/travis/install-ray.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       install:
         - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
         - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/suppress_output ./ci/travis/install-ray.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,10 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
-        # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray -v $HOME/ray-bazel-cache:/root/ray-bazel-cache -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+        - MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache"
+        # This command should be kept in sync with ray/python/README-building-wheels.md,
+        # except the `$MOUNT_BAZEL_CACHE` part.
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
       script:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
-        - MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache"
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache"
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
         - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
         # Mount bazel cache dir to the docker container.
-        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS='true'"
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
         - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
         # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray -v $HOME/ray-bazel-cache:/root/ray-bazel-cache -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
       script:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,8 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
+        - # Mount bazel cache dir to the docker container.
+        - mkdir -p $HOME/ray-bazel-cache
         - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache"
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,9 +112,8 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
-        - # Mount bazel cache dir to the docker container.
-        - mkdir -p $HOME/ray-bazel-cache
-        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache"
+        # Mount bazel cache dir to the docker container.
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS='true'"
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
         - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       install:
         - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
         - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./ci/suppress_output ./ci/travis/install-bazel.sh
+        - ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/suppress_output ./ci/travis/install-ray.sh

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -26,5 +26,4 @@ if [[ "$TRAVIS" == "true"  ]]; then
   # Use bazel disk cache if this script is running in Travis.
   mkdir -p $HOME/ray-bazel-cache
   echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
-  cat $HOME/.bazelrc
 fi

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -21,3 +21,9 @@ wget -O install.sh $URL
 chmod +x install.sh
 ./install.sh --user
 rm -f install.sh
+
+if [[ "$TRAVIS" == "TRAVIS"  ]]; then
+  # Use bazel disk cache if this script is running in Travis.
+  mkdir -p $HOME/ray-bazel-cache
+  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
+fi

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -24,8 +24,6 @@ rm -f install.sh
 
 if [[ "$TRAVIS" == "TRAVIS"  ]]; then
   # Use bazel disk cache if this script is running in Travis.
-  FILE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
-  BAZELRC="$FILE_DIR/../../.bazelrc"
   mkdir -p $HOME/ray-bazel-cache
-  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $BAZELRC
+  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
 fi

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -22,7 +22,7 @@ chmod +x install.sh
 ./install.sh --user
 rm -f install.sh
 
-if [[ "$TRAVIS" == "TRAVIS"  ]]; then
+if [[ "$TRAVIS" == "true"  ]]; then
   # Use bazel disk cache if this script is running in Travis.
   mkdir -p $HOME/ray-bazel-cache
   echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -26,4 +26,5 @@ if [[ "$TRAVIS" == "true"  ]]; then
   # Use bazel disk cache if this script is running in Travis.
   mkdir -p $HOME/ray-bazel-cache
   echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
+  cat $HOME/.bazelrc
 fi

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -24,6 +24,8 @@ rm -f install.sh
 
 if [[ "$TRAVIS" == "TRAVIS"  ]]; then
   # Use bazel disk cache if this script is running in Travis.
+  FILE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+  BAZELRC="$FILE_DIR/../../.bazelrc"
   mkdir -p $HOME/ray-bazel-cache
-  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
+  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $BAZELRC
 fi

--- a/ci/travis/setup-bazel-cache.sh
+++ b/ci/travis/setup-bazel-cache.sh
@@ -1,5 +1,0 @@
-set -x
-set -e
-
-mkdir -p $HOME/ray-bazel-cache
-echo "build --disk_cache=$HOME/ray-bazel-cache" >> .bazelrc


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Previously, bazel disk cache was only enabled for Python jobs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
