### PR TITLE
[stability] Make task result for RemoveTask optional

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2188,10 +2188,11 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
                 // Remove the RESUBMITTED task from the SWAP queue.
                 Task task;
                 TaskState state;
-                RAY_CHECK(local_queues_.RemoveTask(task_id, &task, &state));
-                RAY_CHECK(state == TaskState::SWAP);
-                // Submit the task again.
-                SubmitTask(task, Lineage());
+                if (local_queues_.RemoveTask(task_id, &task, &state)) {
+                  RAY_CHECK(state == TaskState::SWAP);
+                  // Submit the task again.
+                  SubmitTask(task, Lineage());
+                }
               });
           // Temporarily move the RESUBMITTED task to the SWAP queue while the
           // timer is active.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -549,9 +549,9 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
   std::unordered_set<TaskID> local_task_ids;
   for (const auto &task_id : decision) {
     // (See design_docs/task_states.rst for the state transition diagram.)
+    Task task;
     TaskState state;
-    const auto task = local_queues_.RemoveTask(task_id, &state);
-    if (!task) {
+    if (!local_queues_.RemoveTask(task_id, &task, &state)) {
       return;
     }
     // Since we are spilling back from the ready and waiting queues, we need
@@ -563,7 +563,7 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
     }
     // Attempt to forward the task. If this fails to forward the task,
     // the task will be resubmit locally.
-    ForwardTaskOrResubmit(task.get(), client_id);
+    ForwardTaskOrResubmit(task, client_id);
   }
 }
 
@@ -983,9 +983,9 @@ void NodeManager::ProcessDisconnectClientMessage(
       // If the worker was an actor, the task was already cleaned up in
       // `HandleDisconnectedActor`.
       if (actor_id.IsNil()) {
-        const auto &task = local_queues_.RemoveTask(task_id);
-        RAY_CHECK(task);
-        TreatTaskAsFailed(task.get(), ErrorType::WORKER_DIED);
+        Task task;
+        RAY_CHECK(local_queues_.RemoveTask(task_id, &task));
+        TreatTaskAsFailed(task, ErrorType::WORKER_DIED);
       }
 
       if (!intentional_disconnect) {
@@ -1321,11 +1321,11 @@ void NodeManager::ScheduleTasks(
     } else {
       // TODO(atumanov): need a better interface for task exit on forward.
       // (See design_docs/task_states.rst for the state transition diagram.)
-      const auto task = local_queues_.RemoveTask(task_id);
-      // Attempt to forward the task. If this fails to forward the task,
-      // the task will be resubmit locally.
-      if (task) {
-        ForwardTaskOrResubmit(task.get(), client_id);
+      Task task;
+      if (local_queues_.RemoveTask(task_id, &task)) {
+        // Attempt to forward the task. If this fails to forward the task,
+        // the task will be resubmit locally.
+        ForwardTaskOrResubmit(task, client_id);
       }
     }
   }
@@ -1612,9 +1612,8 @@ void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection>
     // worker as blocked. This temporarily releases any resources that the
     // worker holds while it is blocked.
     if (!worker->IsBlocked() && current_task_id == worker->GetAssignedTaskId()) {
-      const auto optional_task = local_queues_.RemoveTask(current_task_id);
-      RAY_CHECK(optional_task);
-      const auto task = optional_task.get();
+      Task task;
+      RAY_CHECK(local_queues_.RemoveTask(current_task_id, &task));
       local_queues_.QueueTasks({task}, TaskState::RUNNING);
       // Get the CPU resources required by the running task.
       const auto required_resources = task.GetTaskSpecification().GetRequiredResources();
@@ -1663,9 +1662,8 @@ void NodeManager::HandleTaskUnblocked(
     // the worker.
     if (worker->IsBlocked() && current_task_id == worker->GetAssignedTaskId()) {
       // (See design_docs/task_states.rst for the state transition diagram.)
-      const auto optional_task = local_queues_.RemoveTask(current_task_id);
-      RAY_CHECK(optional_task);
-      const auto task = optional_task.get();
+      Task task;
+      RAY_CHECK(local_queues_.RemoveTask(current_task_id, &task));
       local_queues_.QueueTasks({task}, TaskState::RUNNING);
       // Get the CPU resources required by the running task.
       const auto required_resources = task.GetTaskSpecification().GetRequiredResources();
@@ -1783,12 +1781,11 @@ bool NodeManager::AssignTask(const Task &task) {
       static_cast<int64_t>(protocol::MessageType::ExecuteTask), fbb.GetSize(),
       fbb.GetBufferPointer(), [this, worker, task_id](ray::Status status) {
         // Remove the ASSIGNED task from the SWAP queue.
+        Task assigned_task;
         TaskState state;
-        auto optional_assigned_task = local_queues_.RemoveTask(task_id, &state);
-        if (!optional_assigned_task) {
+        if (!local_queues_.RemoveTask(task_id, &assigned_task, &state)) {
           return;
         }
-        auto assigned_task = optional_assigned_task.get();
 
         RAY_CHECK(state == TaskState::SWAP);
 
@@ -1861,9 +1858,8 @@ void NodeManager::FinishAssignedTask(Worker &worker) {
   RAY_LOG(DEBUG) << "Finished task " << task_id;
 
   // (See design_docs/task_states.rst for the state transition diagram.)
-  const auto optional_task = local_queues_.RemoveTask(task_id);
-  RAY_CHECK(optional_task);
-  const auto task = optional_task.get();
+  Task task;
+  RAY_CHECK(local_queues_.RemoveTask(task_id, &task));
 
   // Release task's resources. The worker's lifetime resources are still held.
   auto const &task_resources = worker.GetTaskResourceIds();
@@ -2190,10 +2186,9 @@ void NodeManager::ForwardTaskOrResubmit(const Task &task,
                 RAY_LOG(INFO) << "Resubmitting task " << task_id
                               << " because ForwardTask failed.";
                 // Remove the RESUBMITTED task from the SWAP queue.
+                Task task;
                 TaskState state;
-                const auto optional_task = local_queues_.RemoveTask(task_id, &state);
-                RAY_CHECK(optional_task);
-                const auto task = optional_task.get();
+                RAY_CHECK(local_queues_.RemoveTask(task_id, &task, &state));
                 RAY_CHECK(state == TaskState::SWAP);
                 // Submit the task again.
                 SubmitTask(task, Lineage());
@@ -2267,12 +2262,11 @@ void NodeManager::ForwardTask(
   client->ForwardTask(request, [this, on_error, task_id, node_id](
                                    Status status, const rpc::ForwardTaskReply &reply) {
     // Remove the FORWARDING task from the SWAP queue.
+    Task task;
     TaskState state;
-    const auto optional_task = local_queues_.RemoveTask(task_id, &state);
-    if (!optional_task) {
+    if (!local_queues_.RemoveTask(task_id, &task, &state)) {
       return;
     }
-    const auto task = optional_task.get();
     RAY_CHECK(state == TaskState::SWAP);
 
     if (status.ok()) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -984,8 +984,9 @@ void NodeManager::ProcessDisconnectClientMessage(
       // `HandleDisconnectedActor`.
       if (actor_id.IsNil()) {
         Task task;
-        RAY_CHECK(local_queues_.RemoveTask(task_id, &task));
-        TreatTaskAsFailed(task, ErrorType::WORKER_DIED);
+        if (local_queues_.RemoveTask(task_id, &task)) {
+          TreatTaskAsFailed(task, ErrorType::WORKER_DIED);
+        }
       }
 
       if (!intentional_disconnect) {

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -247,7 +247,8 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   return removed_tasks;
 }
 
-boost::optional<Task> SchedulingQueue::RemoveTask(const TaskID &task_id, TaskState *removed_task_state) {
+boost::optional<Task> SchedulingQueue::RemoveTask(const TaskID &task_id,
+                                                  TaskState *removed_task_state) {
   std::vector<Task> removed_tasks;
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
@@ -278,8 +279,9 @@ boost::optional<Task> SchedulingQueue::RemoveTask(const TaskID &task_id, TaskSta
     RAY_CHECK(task.GetTaskSpecification().TaskId() == task_id);
     return task;
   }
-  RAY_LOG(DEBUG) << "Task " << task_id << " that is to be removed "
-                 " could not be found any more. Probably its driver was removed.";
+  RAY_LOG(DEBUG) << "Task " << task_id
+                 << " that is to be removed could not be found any more."
+                 << " Probably its driver was removed.";
   return boost::optional<Task>();
 }
 

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -248,7 +248,7 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
 }
 
 bool SchedulingQueue::RemoveTask(const TaskID &task_id,
-                                 Task *task,
+                                 Task *removed_task,
                                  TaskState *removed_task_state) {
   std::vector<Task> removed_tasks;
   std::unordered_set<TaskID> task_id_set = {task_id};
@@ -276,8 +276,8 @@ bool SchedulingQueue::RemoveTask(const TaskID &task_id,
 
   // Make sure we got the removed task.
   if (removed_tasks.size() == 1) {
-    *task = removed_tasks.front();
-    RAY_CHECK(task->GetTaskSpecification().TaskId() == task_id);
+    *removed_task = removed_tasks.front();
+    RAY_CHECK(removed_task->GetTaskSpecification().TaskId() == task_id);
     return true;
   }
   RAY_LOG(DEBUG) << "Task " << task_id

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -247,8 +247,7 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   return removed_tasks;
 }
 
-bool SchedulingQueue::RemoveTask(const TaskID &task_id,
-                                 Task *removed_task,
+bool SchedulingQueue::RemoveTask(const TaskID &task_id, Task *removed_task,
                                  TaskState *removed_task_state) {
   std::vector<Task> removed_tasks;
   std::unordered_set<TaskID> task_id_set = {task_id};

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -247,8 +247,9 @@ std::vector<Task> SchedulingQueue::RemoveTasks(std::unordered_set<TaskID> &task_
   return removed_tasks;
 }
 
-boost::optional<Task> SchedulingQueue::RemoveTask(const TaskID &task_id,
-                                                  TaskState *removed_task_state) {
+bool SchedulingQueue::RemoveTask(const TaskID &task_id,
+                                 Task *task,
+                                 TaskState *removed_task_state) {
   std::vector<Task> removed_tasks;
   std::unordered_set<TaskID> task_id_set = {task_id};
   // Try to find the task to remove in the queues.
@@ -275,14 +276,14 @@ boost::optional<Task> SchedulingQueue::RemoveTask(const TaskID &task_id,
 
   // Make sure we got the removed task.
   if (removed_tasks.size() == 1) {
-    const auto &task = removed_tasks.front();
-    RAY_CHECK(task.GetTaskSpecification().TaskId() == task_id);
-    return task;
+    *task = removed_tasks.front();
+    RAY_CHECK(task->GetTaskSpecification().TaskId() == task_id);
+    return true;
   }
   RAY_LOG(DEBUG) << "Task " << task_id
                  << " that is to be removed could not be found any more."
                  << " Probably its driver was removed.";
-  return boost::optional<Task>();
+  return false;
 }
 
 void SchedulingQueue::MoveTasks(std::unordered_set<TaskID> &task_ids, TaskState src_state,

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -227,13 +227,13 @@ class SchedulingQueue {
   ///
   /// \param task_id The task ID to remove from the queue. The corresponding
   /// task must be contained in the queue.
-  /// \param task The removed task will be written here.
+  /// \param task The removed task will be written here, if any.
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
   /// \return true if the task was removed, false if it is not in the queue.
   bool RemoveTask(const TaskID &task_id,
-                  Task *task,
-                  TaskState *task_state = nullptr);
+                  Task *removed_task,
+                  TaskState *removed_task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.
   ///

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -232,7 +232,8 @@ class SchedulingQueue {
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
   /// \return The task that was removed, if any.
-  boost::optional<Task> RemoveTask(const TaskID &task_id, TaskState *task_state = nullptr);
+  boost::optional<Task> RemoveTask(const TaskID &task_id,
+                                   TaskState *task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.
   ///

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -231,8 +231,7 @@ class SchedulingQueue {
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
   /// \return true if the task was removed, false if it is not in the queue.
-  bool RemoveTask(const TaskID &task_id,
-                  Task *removed_task,
+  bool RemoveTask(const TaskID &task_id, Task *removed_task,
                   TaskState *removed_task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -7,8 +7,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include "ray/raylet/task.h"
 #include "ray/util/logging.h"
 #include "ray/util/ordered_set.h"

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -229,11 +229,13 @@ class SchedulingQueue {
   ///
   /// \param task_id The task ID to remove from the queue. The corresponding
   /// task must be contained in the queue.
+  /// \param task The removed task will be written here.
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
-  /// \return The task that was removed, if any.
-  boost::optional<Task> RemoveTask(const TaskID &task_id,
-                                   TaskState *task_state = nullptr);
+  /// \return true if the task was removed, false if it is not in the queue.
+  bool RemoveTask(const TaskID &task_id,
+                  Task *task,
+                  TaskState *task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.
   ///

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -7,6 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <boost/optional.hpp>
+
 #include "ray/raylet/task.h"
 #include "ray/util/logging.h"
 #include "ray/util/ordered_set.h"
@@ -229,8 +231,8 @@ class SchedulingQueue {
   /// task must be contained in the queue.
   /// \param task_state If this is not nullptr, then the state of the removed
   /// task will be written here.
-  /// \return The task that was removed.
-  Task RemoveTask(const TaskID &task_id, TaskState *task_state = nullptr);
+  /// \return The task that was removed, if any.
+  boost::optional<Task> RemoveTask(const TaskID &task_id, TaskState *task_state = nullptr);
 
   /// Remove a driver task ID. This is an empty task used to represent a driver.
   ///

--- a/src/ray/raylet/task.h
+++ b/src/ray/raylet/task.h
@@ -21,6 +21,10 @@ namespace raylet {
 /// time.
 class Task {
  public:
+  /// Construct an empty task. This should only be used to pass a task
+  /// as an out parameter to a function or method.
+  Task() {}
+
   /// Construct a `Task` object from a protobuf message.
   ///
   /// \param message The protobuf message.

--- a/src/ray/raylet/task_execution_spec.h
+++ b/src/ray/raylet/task_execution_spec.h
@@ -17,6 +17,10 @@ using rpc::MessageWrapper;
 /// Wrapper class of protobuf `TaskExecutionSpec`, see `common.proto` for details.
 class TaskExecutionSpecification : public MessageWrapper<rpc::TaskExecutionSpec> {
  public:
+  /// Construct an emtpy task execution specification. This should not be used
+  /// directly.
+  TaskExecutionSpecification() {}
+
   /// Construct from a protobuf message object.
   /// The input message will be **copied** into this object.
   ///

--- a/src/ray/raylet/task_spec.h
+++ b/src/ray/raylet/task_spec.h
@@ -26,6 +26,9 @@ using rpc::TaskType;
 /// Wrapper class of protobuf `TaskSpec`, see `common.proto` for details.
 class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
  public:
+  /// Construct an empty task specification. This should not be used directly.
+  TaskSpecification() {}
+
   /// Construct from a protobuf message object.
   /// The input message will be **copied** into this object.
   ///

--- a/src/ray/rpc/message_wrapper.h
+++ b/src/ray/rpc/message_wrapper.h
@@ -11,6 +11,9 @@ namespace rpc {
 template <class Message>
 class MessageWrapper {
  public:
+  /// Construct an empty message wrapper. This should not be used directly.
+  MessageWrapper() {}
+
   /// Construct from a protobuf message object.
   /// The input message will be **copied** into this object.
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This fixes the long-running stress test https://github.com/ray-project/ray/blob/master/ci/long_running_tests/workloads/many_drivers.py. It fixes a race condition where Task information is removed when a driver is disconnected but then still further used.

The current hypothesis is that this concerns only the SWAP queue, so there are still some checks left in. If other queues are also affected, we might need to make them non-fatal too.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
