### PR TITLE
Unblock ci test because of crash in linux grpc reply handler function

### DIFF
--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -146,8 +146,12 @@ class ServerCallImpl : public ServerCall {
           // request, tell gRPC to finish this
           // request.
           SendReply(status);
-          // send_reply_success_callback_ = std::move(success);
-          // send_reply_failure_callback_ = std::move(failure);
+          if (success) {
+            send_reply_success_callback_ = std::move(success);
+          }
+          if (failure) {
+            send_reply_failure_callback_ = std::move(failure);
+          }
         });
   }
 

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -146,8 +146,8 @@ class ServerCallImpl : public ServerCall {
           // request, tell gRPC to finish this
           // request.
           SendReply(status);
-          send_reply_success_callback_ = std::move(success);
-          send_reply_failure_callback_ = std::move(failure);
+          // send_reply_success_callback_ = std::move(success);
+          // send_reply_failure_callback_ = std::move(failure);
         });
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Grpc reply handler will crash in linux system in server call, unblock the test and fix this after figuring out the root cause.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
