### PR TITLE
Add linting pre-push hook

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,7 +18,9 @@ To contribute a patch:
    harder to merge in a large change with a lot of disjoint features.
 2. Submit the patch as a GitHub pull request against the master branch.
 3. Make sure that your code passes the unit tests.
-4. Add new unit tests for your code.
+4. Make sure that your code passes the linter. Run setup_hooks.sh to create
+   a git hook that will run the linter before you push your changes.
+5. Add new unit tests for your code.
 
 .. _`ray-dev@googlegroups.com`: https://groups.google.com/forum/#!forum/ray-dev
 .. _`GitHub Issues`: https://github.com/ray-project/ray/issues

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "Linting changes as part of pre-push hook"
+echo ""
+echo "ci/travis/format.sh:"
+ci/travis/format.sh
+
+lint_exit_status=$?
+if [ $lint_exit_status -ne 0 ]; then
+	echo ""
+	echo "Linting changes failed."
+	echo "Please make sure 'ci/travis/format.sh'"\
+		"runs with no errors before pushing."
+	echo "If you want to ignore this and push anyways,"\
+		"re-run with '--no-verify'."
+	exit 1
+fi
+exit 0

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ln -s $PWD/hooks/pre-push $PWD/.git/hooks/pre-push


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Adds a pre-push hook that runs `ci/travis/format.sh` before pushing changes. Prints out a message explaining how to circumvent if the linter fails.

Note that we can't actually do this completely automatically because it is a security vulnerability (git doesn't want repository maintainers to be able to run arbitrary client-side code). There are some tools that make this more automated (e.g., for npm project maintainers), but for this simple use case I think it's better to just do it ourselves with a script that symlinks the hook to the local `.git/hooks` directory.

I'm open to suggestions if anyone has a better idea for where to instruct contributors to install the hook or where we can do it automatically (maybe as part of the build process).

## Related issue number
5152
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
