### PR TITLE
Fix crash because of the reference to deleted variable in grpc server call

### DIFF
--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -143,7 +143,7 @@ class ServerCallImpl : public ServerCall {
         [this](Status status, std::function<void()> success,
                std::function<void()> failure) {
           // These two callbacks must be set before `SendReply`, because `SendReply`
-          // is aysnc and this callback might be deleted right after `SendReply`.
+          // is aysnc and this `ServerCall` might be deleted right after `SendReply`.
           send_reply_success_callback_ = std::move(success);
           send_reply_failure_callback_ = std::move(failure);
 

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -142,6 +142,8 @@ class ServerCallImpl : public ServerCall {
         request_, &reply_,
         [this](Status status, std::function<void()> success,
                std::function<void()> failure) {
+          // These two callbacks must be set before `SendReply`, because `SendReply`
+          // is aysnc and this callback might be deleted right after `SendReply`.
           send_reply_success_callback_ = std::move(success);
           send_reply_failure_callback_ = std::move(failure);
 

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -142,12 +142,13 @@ class ServerCallImpl : public ServerCall {
         request_, &reply_,
         [this](Status status, std::function<void()> success,
                std::function<void()> failure) {
-          // When the handler is done with the
-          // request, tell gRPC to finish this
-          // request.
-          SendReply(status);
           send_reply_success_callback_ = std::move(success);
           send_reply_failure_callback_ = std::move(failure);
+
+          // When the handler is done with the request, tell gRPC to finish this request.
+          // Must send reply at the bottom of this callback, once we invoke this funciton,
+          // this server call might be deleted
+          SendReply(status);
         });
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
We found that sending reply would crash in server_call (send_reply_success_callback_ = std::move(success)). It crashes here because of the reference to send_reply_succes_callback_ which might have been deleted after we invoke asynchronous SendReply function. This pr fixes this. 


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
