### PR TITLE
[stability] Fix node_failures.py crashes

### DIFF
--- a/ci/long_running_tests/workloads/node_failures.py
+++ b/ci/long_running_tests/workloads/node_failures.py
@@ -49,7 +49,7 @@ while True:
     for _ in range(100):
         previous_ids = [f.remote(previous_id) for previous_id in previous_ids]
 
-    ray.wait(previous_ids, num_returns=len(previous_ids))
+    ray.get(previous_ids)
 
     for _ in range(100):
         previous_ids = [f.remote(previous_id) for previous_id in previous_ids]

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -166,7 +166,10 @@ void ObjectManager::TryPull(const ObjectID &object_id) {
   auto &client_vector = it->second.client_locations;
 
   // The timer should never fire if there are no expected client locations.
-  RAY_CHECK(!client_vector.empty());
+  if (client_vector.empty()) {
+    return;
+  }
+
   RAY_CHECK(local_objects_.count(object_id) == 0);
   // Make sure that there is at least one client which is not the local client.
   // TODO(rkn): It may actually be possible for this check to fail.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This fixes the crash in `node_failures.py`. Before the fix in the object manager, it crashed with
```
F0708 01:05:21.352319 30813 object_manager.cc:169]  Check failed: !client_vector.empty() 
*** Check failure stack trace: ***
*** Aborted at 1562547921 (unix time) try "date -d @1562547921" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x3e80000785d) received by PID 30813 (TID 0x7f54bea807c0) from PID 30813; stack trace: ***
    @     0x7f54be66a390 (unknown)
    @     0x7f54bd81b428 gsignal
    @     0x7f54bd81d02a abort
    @           0x677fc9 google::logging_fail()
    @           0x679cfa google::LogMessage::Fail()
    @           0x67b003 google::LogMessage::SendToLog()
    @           0x679a22 google::LogMessage::Flush()
    @           0x679c11 google::LogMessage::~LogMessage()
    @           0x6774a2 ray::RayLog::~RayLog()
    @           0x4a23fe ray::ObjectManager::TryPull()
    @           0x4a28fd _ZN5boost4asio6detail12wait_handlerIZN3ray13ObjectManager7TryPullERKNS3_8ObjectIDEEUlRKNS_6system10error_codeEE0_E11do_completeEPvPNS1_19scheduler_operationESB_m
    @           0x42880d boost::asio::detail::scheduler::run()
    @           0x40f824 main
    @     0x7f54bd806830 __libc_start_main
    @           0x423371 (unknown)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
