### PR TITLE
Replace ImmutableMap.of() with new HashMap<>() in GcsClient.java

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/gcs/GcsClient.java
@@ -1,7 +1,6 @@
 package org.ray.runtime.gcs;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,12 +75,12 @@ public class GcsClient {
       if (data.getIsInsertion()) {
         //Code path of node insertion.
         NodeInfo nodeInfo = new NodeInfo(
-            clientId, data.getNodeManagerAddress(), true, ImmutableMap.of());
+            clientId, data.getNodeManagerAddress(), true, new HashMap<>());
         clients.put(clientId, nodeInfo);
       } else {
         // Code path of node deletion.
         NodeInfo nodeInfo = new NodeInfo(clientId, clients.get(clientId).nodeAddress,
-            false, ImmutableMap.of());
+            false, new HashMap<>());
         clients.put(clientId, nodeInfo);
       }
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Since the resource data is filled after the map is created, we can't use an empty ImmutableMap here. It's a bug introduced in #5050.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.