### PR TITLE
 remove redundant scaler of l2 reg

### DIFF
--- a/python/ray/rllib/agents/ddpg/ddpg_policy.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy.py
@@ -228,12 +228,10 @@ class DDPGTFPolicy(DDPGPostprocessing, TFPolicy):
         if config["l2_reg"] is not None:
             for var in self.policy_vars:
                 if "bias" not in var.name:
-                    self.actor_loss += (
-                        config["l2_reg"] * tf.nn.l2_loss(var))
+                    self.actor_loss += (config["l2_reg"] * tf.nn.l2_loss(var))
             for var in self.q_func_vars:
                 if "bias" not in var.name:
-                    self.critic_loss += (
-                        config["l2_reg"] * tf.nn.l2_loss(var))
+                    self.critic_loss += (config["l2_reg"] * tf.nn.l2_loss(var))
             if self.config["twin_q"]:
                 for var in self.twin_q_func_vars:
                     if "bias" not in var.name:

--- a/python/ray/rllib/agents/ddpg/ddpg_policy.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy.py
@@ -229,16 +229,16 @@ class DDPGTFPolicy(DDPGPostprocessing, TFPolicy):
             for var in self.policy_vars:
                 if "bias" not in var.name:
                     self.actor_loss += (
-                        config["l2_reg"] * 0.5 * tf.nn.l2_loss(var))
+                        config["l2_reg"] * tf.nn.l2_loss(var))
             for var in self.q_func_vars:
                 if "bias" not in var.name:
                     self.critic_loss += (
-                        config["l2_reg"] * 0.5 * tf.nn.l2_loss(var))
+                        config["l2_reg"] * tf.nn.l2_loss(var))
             if self.config["twin_q"]:
                 for var in self.twin_q_func_vars:
                     if "bias" not in var.name:
                         self.critic_loss += (
-                            config["l2_reg"] * 0.5 * tf.nn.l2_loss(var))
+                            config["l2_reg"] * tf.nn.l2_loss(var))
 
         # update_target_fn will be called periodically to copy Q network to
         # target Q network


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
remove redundant scaler (0.5) of l2 regularization from ddpg_policy.py


## Related issue number
#5047 
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
