### PR TITLE
Fix Java MultithreadingTest

### DIFF
--- a/java/test/src/main/java/org/ray/api/TestUtils.java
+++ b/java/test/src/main/java/org/ray/api/TestUtils.java
@@ -51,7 +51,12 @@ public class TestUtils {
   }
 
   /**
-   * Warm up the cluster.
+   * Warm up the cluster to make sure there's at least one idle worker.
+   *
+   * This is needed before calling `wait`. Because, in Travis CI, starting a new worker
+   * process could be slower than the wait timeout.
+   * TODO(hchen): We should consider supporting always reversing a certain number of
+   * idle workers in Raylet's worker pool.
    */
   public static void warmUpCluster() {
     RayObject<String> obj = Ray.call(TestUtils::hi);

--- a/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
+++ b/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
@@ -81,10 +81,11 @@ public class MultiThreadingTest extends BaseTest {
       Assert.assertEquals(arg, (int) Ray.get(obj.getId()));
     }, LOOP_COUNTER);
 
+    TestUtils.warmUpCluster();
     // Test wait for one object in multi threads.
     RayObject<Integer> obj = Ray.call(MultiThreadingTest::echo, 100);
     runTestCaseInMultipleThreads(() -> {
-      WaitResult<Integer> result = Ray.wait(ImmutableList.of(obj), 1, 2000);
+      WaitResult<Integer> result = Ray.wait(ImmutableList.of(obj), 1, 1000);
       Assert.assertEquals(1, result.getReady().size());
     }, 1);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

I tried fixing this test at #5170 by increasing the timeout. But it still fails occasionally. 
This PR fixes this again by warming up the worker pool. Should make this test much less sensitive to time.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
