### PR TITLE
Fix: ServerCallFactory's destructor not marked as virtual

### DIFF
--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -83,6 +83,8 @@ class ServerCallFactory {
   ///
   /// \return Pointer to the `ServerCall` object.
   virtual ServerCall *CreateCall() const = 0;
+
+  virtual ~ServerCallFactory() = default;
 };
 
 /// Represents the generic signature of a `FooServiceHandler::HandleBar()`


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?



## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
