### PR TITLE
Keep parameter space noise consistent with action space noise (Fix 5173)

### DIFF
--- a/python/ray/rllib/agents/ddpg/ddpg_policy.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy.py
@@ -58,7 +58,8 @@ class DDPGPostprocessing(object):
             distance_in_action_space = np.sqrt(
                 np.mean(np.square(clean_actions - noisy_actions)))
             self.pi_distance = distance_in_action_space
-            if distance_in_action_space < self.config["exploration_ou_sigma"]:
+            if distance_in_action_space < self.config["exploration_ou_sigma"] * self.cur_noise_scale:
+                # multiplying the sampled OU noise by current noise scale is equivalent to multiplying the sigma of OU by current noise scale
                 self.parameter_noise_sigma_val *= 1.01
             else:
                 self.parameter_noise_sigma_val /= 1.01

--- a/python/ray/rllib/agents/ddpg/ddpg_policy.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy.py
@@ -58,8 +58,10 @@ class DDPGPostprocessing(object):
             distance_in_action_space = np.sqrt(
                 np.mean(np.square(clean_actions - noisy_actions)))
             self.pi_distance = distance_in_action_space
-            if distance_in_action_space < self.config["exploration_ou_sigma"] * self.cur_noise_scale:
-                # multiplying the sampled OU noise by current noise scale is equivalent to multiplying the sigma of OU by current noise scale
+            if distance_in_action_space < \
+                self.config["exploration_ou_sigma"] * self.cur_noise_scale:
+                # multiplying the sampled OU noise by noise scale is 
+                # equivalent to multiplying the sigma of OU by noise scale
                 self.parameter_noise_sigma_val *= 1.01
             else:
                 self.parameter_noise_sigma_val /= 1.01

--- a/python/ray/rllib/agents/ddpg/ddpg_policy.py
+++ b/python/ray/rllib/agents/ddpg/ddpg_policy.py
@@ -59,8 +59,8 @@ class DDPGPostprocessing(object):
                 np.mean(np.square(clean_actions - noisy_actions)))
             self.pi_distance = distance_in_action_space
             if distance_in_action_space < \
-                self.config["exploration_ou_sigma"] * self.cur_noise_scale:
-                # multiplying the sampled OU noise by noise scale is 
+                    self.config["exploration_ou_sigma"] * self.cur_noise_scale:
+                # multiplying the sampled OU noise by noise scale is
                 # equivalent to multiplying the sigma of OU by noise scale
                 self.parameter_noise_sigma_val *= 1.01
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Adjust the sigma of parameter space Gaussian noise according to the sigma of OU noise multiplied by `noise_scale`. Thus, we are able to keep consistent with the actually intended action space noise.


## Related issue number

<!-- For example: "Closes #1234" -->
#5173

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
