### PR TITLE
Enable seeding actors for reproducible experiments

### DIFF
--- a/ci/jenkins_tests/run_rllib_tests.sh
+++ b/ci/jenkins_tests/run_rllib_tests.sh
@@ -288,6 +288,9 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
 
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     /ray/ci/suppress_output python /ray/python/ray/rllib/tests/test_local.py
+    
+docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
+    /ray/ci/suppress_output python /ray/python/ray/rllib/tests/test_reproducibility.py
 
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     /ray/ci/suppress_output python /ray/python/ray/rllib/tests/test_dependency.py

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -196,7 +196,7 @@ COMMON_CONFIG = {
     # This argument, in conjunction with worker_index, sets the random seed of
     # each worker, so that identically configured trials will have identical
     # results. This makes experiments reproducible.
-    "seed": 123,
+    "seed": None,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -193,9 +193,10 @@ COMMON_CONFIG = {
     # Minimum env steps to optimize for per train call. This value does
     # not affect learning, only the length of iterations.
     "timesteps_per_iteration": 0,
-    # If set to the same integer, identically configured trials will have
-    # identical random behavior. This makes experiments reproducible.
-    "seed": None,
+    # This argument, in conjunction with worker_index, sets the random seed of
+    # each worker, so that identically configured trials will have identical
+    # results. This makes experiments reproducible.
+    "seed": 123,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:
@@ -432,9 +433,6 @@ class Trainer(Trainable):
         if self.config.get("log_level"):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 
-        # Get the seed for creating workers
-        self._seed = self.config.get("seed", None)
-
         def get_scope():
             if tf:
                 return tf.Graph().as_default()
@@ -487,8 +485,7 @@ class Trainer(Trainable):
             policy,
             config,
             num_workers=num_workers,
-            logdir=self.logdir,
-            seed=self._seed)
+            logdir=self.logdir)
 
     @DeveloperAPI
     def _init(self, config, env_creator):

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -195,7 +195,7 @@ COMMON_CONFIG = {
     "timesteps_per_iteration": 0,
     # If set to the same integer, identically configured trials will have
     # identical random behavior. This makes experiments reproducible.
-    "reproducible_seed": None,
+    "seed": None,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:
@@ -433,7 +433,7 @@ class Trainer(Trainable):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 
         # Get the seed for creating workers
-        self._reproducible_seed = self.config.get("reproducible_seed", None)
+        self._seed = self.config.get("seed", None)
 
         def get_scope():
             if tf:
@@ -488,7 +488,7 @@ class Trainer(Trainable):
             config,
             num_workers=num_workers,
             logdir=self.logdir,
-            reproducible_seed=self._reproducible_seed)
+            seed=self._seed)
 
     @DeveloperAPI
     def _init(self, config, env_creator):

--- a/python/ray/rllib/agents/trainer.py
+++ b/python/ray/rllib/agents/trainer.py
@@ -193,6 +193,9 @@ COMMON_CONFIG = {
     # Minimum env steps to optimize for per train call. This value does
     # not affect learning, only the length of iterations.
     "timesteps_per_iteration": 0,
+    # If set to the same integer, identically configured trials will have
+    # identical random behavior. This makes experiments reproducible.
+    "reproducible_seed": None,
 
     # === Offline Datasets ===
     # Specify how to generate experiences:
@@ -429,6 +432,9 @@ class Trainer(Trainable):
         if self.config.get("log_level"):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 
+        # Get the seed for creating workers
+        self._reproducible_seed = self.config.get("reproducible_seed", None)
+
         def get_scope():
             if tf:
                 return tf.Graph().as_default()
@@ -481,7 +487,8 @@ class Trainer(Trainable):
             policy,
             config,
             num_workers=num_workers,
-            logdir=self.logdir)
+            logdir=self.logdir,
+            reproducible_seed=self._reproducible_seed)
 
     @DeveloperAPI
     def _init(self, config, env_creator):

--- a/python/ray/rllib/evaluation/rollout_worker.py
+++ b/python/ray/rllib/evaluation/rollout_worker.py
@@ -219,7 +219,7 @@ class RolloutWorker(EvaluatorInterface):
             soft_horizon (bool): Calculate rewards but don't reset the
                 environment when the horizon is hit.
             seed (int): Set the seed of both np and tf to this value to
-                to ensure each remote worker has unique explration behavior.
+                to ensure each remote worker has unique exploration behavior.
             _fake_sampler (bool): Use a fake (inf speed) sampler for testing.
         """
 
@@ -298,8 +298,9 @@ class RolloutWorker(EvaluatorInterface):
         policy_dict = _validate_and_canonicalize(policy, self.env)
         self.policies_to_train = policies_to_train or list(policy_dict.keys())
         # set numpy and python seed
-        np.random.seed(seed)
-        random.seed(seed)
+        if seed is not None:
+            np.random.seed(seed)
+            random.seed(seed)
         if _has_tensorflow_graph(policy_dict):
             if (ray.is_initialized()
                     and ray.worker._mode() != ray.worker.LOCAL_MODE
@@ -318,7 +319,8 @@ class RolloutWorker(EvaluatorInterface):
                             gpu_options=tf.GPUOptions(allow_growth=True)))
                 with self.tf_sess.as_default():
                     # set graph-level seed
-                    tf.set_random_seed(seed)
+                    if seed is not None:
+                        tf.set_random_seed(seed)
                     self.policy_map, self.preprocessors = \
                         self._build_policy_map(policy_dict, policy_config)
         else:

--- a/python/ray/rllib/evaluation/rollout_worker.py
+++ b/python/ray/rllib/evaluation/rollout_worker.py
@@ -31,6 +31,7 @@ from ray.rllib.utils.debug import disable_log_once_globally, log_once, \
 from ray.rllib.utils.filter import get_filter
 from ray.rllib.utils.tf_run_builder import TFRunBuilder
 from ray.rllib.utils import try_import_tf
+from ray.rllib.utils.seed import seed as seed_all
 
 tf = try_import_tf()
 logger = logging.getLogger(__name__)
@@ -314,7 +315,7 @@ class RolloutWorker(EvaluatorInterface):
                 with self.tf_sess.as_default():
                     if seed is not None:
                         # ensure each worker has unique exploration behavior
-                        tf.set_random_seed(seed)
+                        seed_all(seed, seed, seed)
                     self.policy_map, self.preprocessors = \
                         self._build_policy_map(policy_dict, policy_config)
         else:

--- a/python/ray/rllib/evaluation/rollout_worker.py
+++ b/python/ray/rllib/evaluation/rollout_worker.py
@@ -130,7 +130,8 @@ class RolloutWorker(EvaluatorInterface):
                  remote_worker_envs=False,
                  remote_env_batch_wait_ms=0,
                  soft_horizon=False,
-                 _fake_sampler=False):
+                 _fake_sampler=False,
+                 seed=None):
         """Initialize a rollout worker.
 
         Arguments:
@@ -216,6 +217,8 @@ class RolloutWorker(EvaluatorInterface):
             soft_horizon (bool): Calculate rewards but don't reset the
                 environment when the horizon is hit.
             _fake_sampler (bool): Use a fake (inf speed) sampler for testing.
+            seed (int): If not None, set the graph-level seed to this value
+                to ensure each remote worker has unique explration behavior.
         """
 
         global _global_worker
@@ -309,6 +312,9 @@ class RolloutWorker(EvaluatorInterface):
                         config=tf.ConfigProto(
                             gpu_options=tf.GPUOptions(allow_growth=True)))
                 with self.tf_sess.as_default():
+                    if seed is not None:
+                        # ensure each worker has unique exploration behavior
+                        tf.set_random_seed(seed)
                     self.policy_map, self.preprocessors = \
                         self._build_policy_map(policy_dict, policy_config)
         else:

--- a/python/ray/rllib/evaluation/worker_set.py
+++ b/python/ray/rllib/evaluation/worker_set.py
@@ -32,8 +32,7 @@ class WorkerSet(object):
                  trainer_config=None,
                  num_workers=0,
                  logdir=None,
-                 _setup=True,
-                 seed=None):
+                 _setup=True):
         """Create a new WorkerSet and initialize its workers.
 
         Arguments:
@@ -44,8 +43,6 @@ class WorkerSet(object):
             num_workers (int): Number of remote rollout workers to create.
             logdir (str): Optional logging directory for workers.
             _setup (bool): Whether to setup workers. This is only for testing.
-            seed (int): If not None, used in conjunction with worker_index to
-                seed each worker.
         """
 
         if not trainer_config:
@@ -57,7 +54,6 @@ class WorkerSet(object):
         self._remote_config = trainer_config
         self._num_workers = num_workers
         self._logdir = logdir
-        self._seed = seed or int(time.time())
 
         if _setup:
             self._local_config = merge_dicts(
@@ -66,8 +62,7 @@ class WorkerSet(object):
 
             # Always create a local worker
             self._local_worker = self._make_worker(
-                RolloutWorker, env_creator, policy, 0, self._local_config,
-                self._seed)
+                RolloutWorker, env_creator, policy, 0, self._local_config)
 
             # Create a number of remote workers
             self._remote_workers = []
@@ -91,8 +86,7 @@ class WorkerSet(object):
         cls = RolloutWorker.as_remote(**remote_args).remote
         self._remote_workers.extend([
             self._make_worker(cls, self._env_creator, self._policy, i + 1,
-                              self._remote_config, self._seed + i + 1)
-            for i in range(num_workers)
+                              self._remote_config) for i in range(num_workers)
         ])
 
     def reset(self, new_remote_workers):
@@ -141,8 +135,7 @@ class WorkerSet(object):
                      env_creator,
                      policy,
                      worker_index,
-                     config,
-                     seed=None):
+                     config):
         def session_creator():
             logger.debug("Creating TF session {}".format(
                 config["tf_session_args"]))
@@ -224,5 +217,5 @@ class WorkerSet(object):
             remote_worker_envs=config["remote_worker_envs"],
             remote_env_batch_wait_ms=config["remote_env_batch_wait_ms"],
             soft_horizon=config["soft_horizon"],
-            _fake_sampler=config.get("_fake_sampler", False),
-            seed=seed)
+            seed=config["seed"]+worker_index,
+            _fake_sampler=config.get("_fake_sampler", False))

--- a/python/ray/rllib/evaluation/worker_set.py
+++ b/python/ray/rllib/evaluation/worker_set.py
@@ -33,7 +33,7 @@ class WorkerSet(object):
                  num_workers=0,
                  logdir=None,
                  _setup=True,
-                 reproducible_seed=None):
+                 seed=None):
         """Create a new WorkerSet and initialize its workers.
 
         Arguments:
@@ -44,8 +44,8 @@ class WorkerSet(object):
             num_workers (int): Number of remote rollout workers to create.
             logdir (str): Optional logging directory for workers.
             _setup (bool): Whether to setup workers. This is only for testing.
-            reproducible_seed (int): If not None, used in conjunction with
-                worker_index to seed each worker.
+            seed (int): If not None, used in conjunction with worker_index to
+                seed each worker.
         """
 
         if not trainer_config:
@@ -57,7 +57,7 @@ class WorkerSet(object):
         self._remote_config = trainer_config
         self._num_workers = num_workers
         self._logdir = logdir
-        self._reproducible_seed = reproducible_seed or int(time.time())
+        self._seed = seed or int(time.time())
 
         if _setup:
             self._local_config = merge_dicts(
@@ -67,7 +67,7 @@ class WorkerSet(object):
             # Always create a local worker
             self._local_worker = self._make_worker(
                 RolloutWorker, env_creator, policy, 0, self._local_config,
-                self._reproducible_seed)
+                self._seed)
 
             # Create a number of remote workers
             self._remote_workers = []
@@ -91,8 +91,7 @@ class WorkerSet(object):
         cls = RolloutWorker.as_remote(**remote_args).remote
         self._remote_workers.extend([
             self._make_worker(cls, self._env_creator, self._policy, i + 1,
-                              self._remote_config,
-                              self._reproducible_seed + i + 1)
+                              self._remote_config, self._seed + i + 1)
             for i in range(num_workers)
         ])
 

--- a/python/ray/rllib/evaluation/worker_set.py
+++ b/python/ray/rllib/evaluation/worker_set.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 import logging
 from types import FunctionType
 
@@ -130,12 +129,7 @@ class WorkerSet(object):
         workers._remote_workers = remote_workers or []
         return workers
 
-    def _make_worker(self,
-                     cls,
-                     env_creator,
-                     policy,
-                     worker_index,
-                     config):
+    def _make_worker(self, cls, env_creator, policy, worker_index, config):
         def session_creator():
             logger.debug("Creating TF session {}".format(
                 config["tf_session_args"]))
@@ -217,5 +211,5 @@ class WorkerSet(object):
             remote_worker_envs=config["remote_worker_envs"],
             remote_env_batch_wait_ms=config["remote_env_batch_wait_ms"],
             soft_horizon=config["soft_horizon"],
-            seed=config["seed"]+worker_index,
+            seed=config["seed"] + worker_index,
             _fake_sampler=config.get("_fake_sampler", False))

--- a/python/ray/rllib/evaluation/worker_set.py
+++ b/python/ray/rllib/evaluation/worker_set.py
@@ -92,7 +92,8 @@ class WorkerSet(object):
         self._remote_workers.extend([
             self._make_worker(cls, self._env_creator, self._policy, i + 1,
                               self._remote_config,
-                              self._reproducible_seed+i+1) for i in range(num_workers)
+                              self._reproducible_seed + i + 1)
+            for i in range(num_workers)
         ])
 
     def reset(self, new_remote_workers):
@@ -136,7 +137,12 @@ class WorkerSet(object):
         workers._remote_workers = remote_workers or []
         return workers
 
-    def _make_worker(self, cls, env_creator, policy, worker_index, config,
+    def _make_worker(self,
+                     cls,
+                     env_creator,
+                     policy,
+                     worker_index,
+                     config,
                      seed=None):
         def session_creator():
             logger.debug("Creating TF session {}".format(

--- a/python/ray/rllib/evaluation/worker_set.py
+++ b/python/ray/rllib/evaluation/worker_set.py
@@ -211,5 +211,6 @@ class WorkerSet(object):
             remote_worker_envs=config["remote_worker_envs"],
             remote_env_batch_wait_ms=config["remote_env_batch_wait_ms"],
             soft_horizon=config["soft_horizon"],
-            seed=config["seed"] + worker_index,
+            seed=(config["seed"] + worker_index)
+            if config["seed"] is not None else None,
             _fake_sampler=config.get("_fake_sampler", False))

--- a/python/ray/rllib/tests/test_reproducibility.py
+++ b/python/ray/rllib/tests/test_reproducibility.py
@@ -6,7 +6,6 @@ import unittest
 
 import ray
 from ray.rllib.agents.dqn import DQNTrainer
-from ray.rllib.agents.dqn.dqn_policy import _adjust_nstep
 from ray.tune.registry import register_env
 import numpy as np
 import gym
@@ -17,7 +16,7 @@ class TestReproducibility(unittest.TestCase):
         class PickLargest(gym.Env):
             def __init__(self):
                 self.observation_space = gym.spaces.Box(
-                    low=float("-inf"), high=float("inf"), shape=(4,))
+                    low=float("-inf"), high=float("inf"), shape=(4, ))
                 self.action_space = gym.spaces.Discrete(4)
                 np.random.seed(1234)
 
@@ -38,9 +37,7 @@ class TestReproducibility(unittest.TestCase):
             register_env("PickLargest", env_creator)
             agent = DQNTrainer(
                 env="PickLargest",
-                config={
-                    "seed": 666 if trial in [0, 1] else 999
-                })
+                config={"seed": 666 if trial in [0, 1] else 999})
 
             trajectory = list()
             for _ in range(8):
@@ -65,7 +62,7 @@ class TestReproducibility(unittest.TestCase):
         for v1, v2 in zip(trajs[1], trajs[2]):
             if v1 != v2:
                 diff_cnt += 1
-        self.assertTrue(diff_cnt>8)
+        self.assertTrue(diff_cnt > 8)
 
 
 if __name__ == "__main__":

--- a/python/ray/rllib/tests/test_reproducibility.py
+++ b/python/ray/rllib/tests/test_reproducibility.py
@@ -18,7 +18,6 @@ class TestReproducibility(unittest.TestCase):
                 self.observation_space = gym.spaces.Box(
                     low=float("-inf"), high=float("inf"), shape=(4, ))
                 self.action_space = gym.spaces.Discrete(4)
-                np.random.seed(1234)
 
             def reset(self, **kwargs):
                 self.obs = np.random.randn(4)

--- a/python/ray/rllib/tests/test_reproducibility.py
+++ b/python/ray/rllib/tests/test_reproducibility.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+import ray
+from ray.rllib.agents.dqn import DQNTrainer
+from ray.rllib.agents.dqn.dqn_policy import _adjust_nstep
+from ray.tune.registry import register_env
+import numpy as np
+import gym
+
+
+class TestReproducibility(unittest.TestCase):
+    def testReproducingTrajectory(self):
+        class PickLargest(gym.Env):
+            def __init__(self):
+                self.observation_space = gym.spaces.Box(
+                    low=float("-inf"), high=float("inf"), shape=(4,))
+                self.action_space = gym.spaces.Discrete(4)
+                np.random.seed(1234)
+
+            def reset(self, **kwargs):
+                self.obs = np.random.randn(4)
+                return self.obs
+
+            def step(self, action):
+                reward = self.obs[action]
+                return self.obs, reward, True, {}
+
+        def env_creator(env_config):
+            return PickLargest()
+
+        trajs = list()
+        for trial in range(3):
+            ray.init()
+            register_env("PickLargest", env_creator)
+            agent = DQNTrainer(
+                env="PickLargest",
+                config={
+                    "seed": 666 if trial in [0, 1] else 999
+                })
+
+            trajectory = list()
+            for _ in range(8):
+                r = agent.train()
+                trajectory.append(r["episode_reward_max"])
+                trajectory.append(r["episode_reward_min"])
+            trajs.append(trajectory)
+
+            ray.shutdown()
+
+        # trial0 and trial1 use same seed and thus
+        # expect identical trajectories.
+        all_same = True
+        for v0, v1 in zip(trajs[0], trajs[1]):
+            if v0 != v1:
+                all_same = False
+        self.assertTrue(all_same)
+
+        # trial1 and trial2 use different seeds and thus
+        # most rewards tend to be different.
+        diff_cnt = 0
+        for v1, v2 in zip(trajs[1], trajs[2]):
+            if v1 != v2:
+                diff_cnt += 1
+        self.assertTrue(diff_cnt>8)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Added `reproducible_seed` for `Trainer` config. Use this value to seed workers (i.e., actors) in conjunction with worker_index, so that exploration behaviors can be repeated/reproduced.


## Related issue number
#5194 
<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
