### PR TITLE
Refactor RayObject for single-copy put in Python

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -347,6 +347,7 @@ cc_library(
         # should only depend on `raylet_client`, instead of the whole `raylet_lib`.
         ":raylet_lib",
         ":worker_rpc",
+        "@plasma//:arrow",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -347,7 +347,6 @@ cc_library(
         # should only depend on `raylet_client`, instead of the whole `raylet_lib`.
         ":raylet_lib",
         ":worker_rpc",
-        "@plasma//:arrow",
     ],
 )
 

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -7,6 +7,7 @@ cc_library(
     srcs = [
         "cpp/src/arrow/buffer.cc",
         "cpp/src/arrow/io/interfaces.cc",
+        "cpp/src/arrow/io/memory.cc",
         "cpp/src/arrow/memory_pool.cc",
         "cpp/src/arrow/status.cc",
         "cpp/src/arrow/util/io-util.cc",
@@ -18,7 +19,10 @@ cc_library(
     hdrs = [
         "cpp/src/arrow/buffer.h",
         "cpp/src/arrow/io/interfaces.h",
+        "cpp/src/arrow/io/memory.h",
         "cpp/src/arrow/memory_pool.h",
+        "cpp/src/arrow/python/serialize.h",
+	"cpp/src/arrow/python/visibility.h",
         "cpp/src/arrow/status.h",
         "cpp/src/arrow/util/bit-util.h",
         "cpp/src/arrow/util/io-util.h",
@@ -40,6 +44,7 @@ cc_library(
     ],
     copts = COPTS,
     strip_include_prefix = "cpp/src",
+    visibility = ["//visibility:public"],
     deps = [
         "@boost//:filesystem",
         "@com_github_google_glog//:glog",

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -22,7 +22,7 @@ cc_library(
         "cpp/src/arrow/io/memory.h",
         "cpp/src/arrow/memory_pool.h",
         "cpp/src/arrow/python/serialize.h",
-	"cpp/src/arrow/python/visibility.h",
+        "cpp/src/arrow/python/visibility.h",
         "cpp/src/arrow/status.h",
         "cpp/src/arrow/util/bit-util.h",
         "cpp/src/arrow/util/io-util.h",

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -44,7 +44,6 @@ cc_library(
     ],
     copts = COPTS,
     strip_include_prefix = "cpp/src",
-    visibility = ["//visibility:public"],
     deps = [
         "@boost//:filesystem",
         "@com_github_google_glog//:glog",

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -20,7 +20,7 @@ class Buffer {
   /// Size of this buffer.
   virtual size_t Size() const = 0;
 
-  virtual ~Buffer() {};
+  virtual ~Buffer(){};
 
   bool operator==(const Buffer &rhs) const {
     return this->Data() == rhs.Data() && this->Size() == rhs.Size();

--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -20,7 +20,7 @@ class Buffer {
   /// Size of this buffer.
   virtual size_t Size() const = 0;
 
-  virtual ~Buffer(){};
+  virtual ~Buffer() {};
 
   bool operator==(const Buffer &rhs) const {
     return this->Data() == rhs.Data() && this->Size() == rhs.Size();

--- a/src/ray/core_worker/core_worker_test.cc
+++ b/src/ray/core_worker/core_worker_test.cc
@@ -147,8 +147,7 @@ class CoreWorkerTest : public ::testing::Test {
 
       ASSERT_EQ(results.size(), 1);
       ASSERT_EQ(results[0]->Data()->Size(), buffer1->Size());
-      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()),
-                0);
+      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()), 0);
     }
 
     // Test pass by reference.
@@ -175,8 +174,7 @@ class CoreWorkerTest : public ::testing::Test {
 
       ASSERT_EQ(results.size(), 1);
       ASSERT_EQ(results[0]->Data()->Size(), buffer1->Size());
-      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()),
-                0);
+      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()), 0);
     }
   }
 
@@ -229,8 +227,7 @@ class CoreWorkerTest : public ::testing::Test {
 
       ASSERT_EQ(results.size(), 1);
       ASSERT_EQ(results[0]->Data()->Size(), buffer1->Size() + buffer2->Size());
-      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()),
-                0);
+      ASSERT_EQ(memcmp(results[0]->Data()->Data(), buffer1->Data(), buffer1->Size()), 0);
       ASSERT_EQ(memcmp(results[0]->Data()->Data() + buffer1->Size(), buffer2->Data(),
                        buffer2->Size()),
                 0);
@@ -411,7 +408,8 @@ TEST_F(TwoNodeTest, TestObjectInterfaceCrossNodes) {
   std::vector<ObjectID> ids(buffers.size());
   for (size_t i = 0; i < ids.size(); i++) {
     RAY_CHECK_OK(worker1.Objects().Put(
-        BufferedRayObject(std::make_shared<LocalMemoryBuffer>(buffers[i]), nullptr), &ids[i]));
+        BufferedRayObject(std::make_shared<LocalMemoryBuffer>(buffers[i]), nullptr),
+        &ids[i]));
   }
 
   // Test Get() from remote node.

--- a/src/ray/core_worker/core_worker_test.cc
+++ b/src/ray/core_worker/core_worker_test.cc
@@ -34,7 +34,7 @@ bool CompareObjectData(std::shared_ptr<RayObject> object, std::shared_ptr<Buffer
   }
 
   uint8_t mem[object->DataSize()];
-  auto tmp_buffer = std::make_shared<LocalMemoryBuffer>(mem, object->DataSize());
+  std::shared_ptr<LocalMemoryBuffer> tmp_buffer(new LocalMemoryBuffer(mem, object->DataSize()));
   if (!object->WriteDataTo(tmp_buffer).ok()) {
     return false;
   }

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -151,7 +151,8 @@ inline ReturnT ReadJavaNativeRayObject(
                                    reinterpret_cast<uint8_t *>(metadata), metadata_size)
                              : nullptr;
 
-  auto native_obj = std::make_shared<ray::RayObject>(data_buffer, metadata_buffer);
+  auto native_obj =
+      std::make_shared<ray::BufferedRayObject>(data_buffer, metadata_buffer);
   auto result = reader(native_obj);
 
   if (data) {

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -170,8 +170,8 @@ inline jobject ToJavaNativeRayObject(JNIEnv *env,
   if (!rayObject) {
     return nullptr;
   }
-  auto java_data = NativeBufferToJavaByteArray(env, rayObject->GetData());
-  auto java_metadata = NativeBufferToJavaByteArray(env, rayObject->GetMetadata());
+  auto java_data = NativeBufferToJavaByteArray(env, rayObject->Data());
+  auto java_metadata = NativeBufferToJavaByteArray(env, rayObject->Metadata());
   auto java_obj = env->NewObject(java_native_ray_object_class,
                                  java_native_ray_object_init, java_data, java_metadata);
   return java_obj;

--- a/src/ray/core_worker/mock_worker.cc
+++ b/src/ray/core_worker/mock_worker.cc
@@ -46,6 +46,7 @@ class MockWorker {
     for (const auto &arg : args) {
       auto tmp_buffer = std::make_shared<LocalMemoryBuffer>(buffer+curr, arg->GetDataSize());
       RAY_RETURN_NOT_OK(arg->WriteDataTo(tmp_buffer));
+      curr += arg->GetDataSize();
     }
 
     auto return_value = RayObject(

--- a/src/ray/core_worker/mock_worker.cc
+++ b/src/ray/core_worker/mock_worker.cc
@@ -38,15 +38,15 @@ class MockWorker {
     // Merge all the content from input args.
     int total_size = 0;
     for (const auto &arg : args) {
-      total_size += arg->GetDataSize();
+      total_size += arg->DataSize();
     }
 
     uint8_t buffer[total_size];
     int curr = 0;
     for (const auto &arg : args) {
-      auto tmp_buffer = std::make_shared<LocalMemoryBuffer>(buffer+curr, arg->GetDataSize());
+      auto tmp_buffer = std::make_shared<LocalMemoryBuffer>(buffer+curr, arg->DataSize());
       RAY_RETURN_NOT_OK(arg->WriteDataTo(tmp_buffer));
-      curr += arg->GetDataSize();
+      curr += arg->DataSize();
     }
 
     auto return_value = RayObject(

--- a/src/ray/core_worker/mock_worker.cc
+++ b/src/ray/core_worker/mock_worker.cc
@@ -44,13 +44,14 @@ class MockWorker {
     uint8_t buffer[total_size];
     int curr = 0;
     for (const auto &arg : args) {
-      auto tmp_buffer = std::make_shared<LocalMemoryBuffer>(buffer+curr, arg->DataSize());
+      auto tmp_buffer =
+          std::make_shared<LocalMemoryBuffer>(buffer + curr, arg->DataSize());
       RAY_RETURN_NOT_OK(arg->WriteDataTo(tmp_buffer));
       curr += arg->DataSize();
     }
 
-    auto return_value = RayObject(
-        std::make_shared<LocalMemoryBuffer>(buffer, total_size), nullptr);
+    auto return_value =
+        RayObject(std::make_shared<LocalMemoryBuffer>(buffer, total_size), nullptr);
 
     // Write the merged content to each of return ids.
     for (int i = 0; i < num_returns; i++) {

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -7,11 +7,18 @@
 namespace ray {
 
 Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
+  if (data_->Size() > buffer->Size()) {
+    return Status::Invalid(kBufferTooSmallErrMsg);
+  }
   memcpy(buffer->Data(), data_->Data(), data_->Size());
   return Status::OK();
 }
 
 Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
+  if (object_size_ > buffer->Size()) {
+    return Status::Invalid(kBufferTooSmallErrMsg);
+  }
+
   auto arrow_buffer =
       std::make_shared<arrow::MutableBuffer>(buffer->Data(), buffer->Size());
   arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -6,15 +6,16 @@
 
 namespace ray {
 
-Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
+Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
   memcpy(buffer->Data(), data_->Data(), data_->Size());
   return Status::OK();
 }
 
-Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
-  arrow::MutableBuffer arrow_buffer(buffer->Data(), buffer->Size());
-  arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);
-  RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(buffer_writer));
+Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
+  auto arrow_buffer = std::make_shared<arrow::ResizableBuffer>(buffer->Data(), buffer->Size());
+  arrow::io::BufferOutputStream buffer_stream(arrow_buffer);
+  //arrow::io::OutputStream output_stream(arrow_buffer);
+  RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(&buffer_stream));
   return Status::OK();
 }
 

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -1,12 +1,8 @@
+#include "arrow/buffer.h"
+#include "arrow/io/memory.h"
+
 #include "ray/core_worker/store_provider/store_provider.h"
 #include "ray/common/status.h"
-
-namespace arrow {
-  class MutableBuffer;
-namespace io {
-  class FixedSizeBufferWriter;
-}
-}
 
 namespace ray {
 
@@ -15,10 +11,10 @@ Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
   return Status::OK();
 }
 
-Status PyRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
+Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
   arrow::MutableBuffer arrow_buffer(buffer->Data(), buffer->Size());
   arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);
-  RAY_ARROW_RETURN_NOT_OK(data_->WriteTo(buffer_writer));
+  RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(buffer_writer));
   return Status::OK();
 }
 

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -1,0 +1,25 @@
+#include "ray/core_worker/store_provider/store_provider.h"
+#include "ray/common/status.h"
+
+namespace arrow {
+  class MutableBuffer;
+namespace io {
+  class FixedSizeBufferWriter;
+}
+}
+
+namespace ray {
+
+Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
+  memcpy(buffer->Data(), data_->Data(), data_->Size());
+  return Status::OK();
+}
+
+Status PyRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
+  arrow::MutableBuffer arrow_buffer(buffer->Data(), buffer->Size());
+  arrow::FixedSizeBufferWriter buffer_writer(arrow_buffer);
+  RAY_ARROW_RETURN_NOT_OK(data_->WriteTo(buffer_writer));
+  return Status::OK();
+}
+
+} // namespace ray

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -17,7 +17,7 @@ Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
 
 Status PyRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) {
   arrow::MutableBuffer arrow_buffer(buffer->Data(), buffer->Size());
-  arrow::FixedSizeBufferWriter buffer_writer(arrow_buffer);
+  arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);
   RAY_ARROW_RETURN_NOT_OK(data_->WriteTo(buffer_writer));
   return Status::OK();
 }

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -18,4 +18,12 @@ Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
   return Status::OK();
 }
 
+const std::shared_ptr<Buffer>& PyArrowRayObject::Data() {
+  if (data_ == nullptr) {
+    data_ = std::make_shared<LocalMemoryBuffer>(new uint8_t[object_size_], object_size_);
+    auto status = this->WriteDataTo(data_);
+  }
+  return data_;
+}
+
 } // namespace ray

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -1,8 +1,8 @@
 #include "arrow/buffer.h"
 #include "arrow/io/memory.h"
 
-#include "ray/core_worker/store_provider/store_provider.h"
 #include "ray/common/status.h"
+#include "ray/core_worker/store_provider/store_provider.h"
 
 namespace ray {
 
@@ -12,13 +12,14 @@ Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
 }
 
 Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
-  auto arrow_buffer = std::make_shared<arrow::MutableBuffer>(buffer->Data(), buffer->Size());
+  auto arrow_buffer =
+      std::make_shared<arrow::MutableBuffer>(buffer->Data(), buffer->Size());
   arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);
   RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(&buffer_writer));
   return Status::OK();
 }
 
-const std::shared_ptr<Buffer>& PyArrowRayObject::Data() {
+const std::shared_ptr<Buffer> &PyArrowRayObject::Data() {
   if (data_ == nullptr) {
     data_ = std::make_shared<LocalMemoryBuffer>(new uint8_t[object_size_], object_size_);
     auto status = this->WriteDataTo(data_);
@@ -26,4 +27,4 @@ const std::shared_ptr<Buffer>& PyArrowRayObject::Data() {
   return data_;
 }
 
-} // namespace ray
+}  // namespace ray

--- a/src/ray/core_worker/store_provider/store_provider.cc
+++ b/src/ray/core_worker/store_provider/store_provider.cc
@@ -12,10 +12,9 @@ Status BufferedRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
 }
 
 Status PyArrowRayObject::WriteDataTo(std::shared_ptr<Buffer> buffer) const {
-  auto arrow_buffer = std::make_shared<arrow::ResizableBuffer>(buffer->Data(), buffer->Size());
-  arrow::io::BufferOutputStream buffer_stream(arrow_buffer);
-  //arrow::io::OutputStream output_stream(arrow_buffer);
-  RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(&buffer_stream));
+  auto arrow_buffer = std::make_shared<arrow::MutableBuffer>(buffer->Data(), buffer->Size());
+  arrow::io::FixedSizeBufferWriter buffer_writer(arrow_buffer);
+  RAY_ARROW_RETURN_NOT_OK(object_->WriteTo(&buffer_writer));
   return Status::OK();
 }
 

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -15,8 +15,7 @@ namespace ray {
 /// differently by implementations in order to avoid copying large data.
 class RayObject {
  public:
-  RayObject(const std::shared_ptr<Buffer> &metadata)
-      : metadata_(metadata) {}
+  RayObject(const std::shared_ptr<Buffer> &metadata) : metadata_(metadata) {}
 
   virtual ~RayObject() {}
 
@@ -36,7 +35,7 @@ class RayObject {
 class BufferedRayObject : public RayObject {
  public:
   BufferedRayObject(const std::shared_ptr<Buffer> &metadata,
-		const std::shared_ptr<Buffer> &data)
+                    const std::shared_ptr<Buffer> &data)
       : RayObject(metadata), data_(data) {}
 
   const std::shared_ptr<Buffer> &Data() override { return data_; };
@@ -58,8 +57,8 @@ class BufferedRayObject : public RayObject {
 class PyArrowRayObject : public RayObject {
  public:
   PyArrowRayObject(const std::shared_ptr<Buffer> &metadata,
-		const std::shared_ptr<arrow::py::SerializedPyObject> &object,
-		size_t object_size)
+                   const std::shared_ptr<arrow::py::SerializedPyObject> &object,
+                   size_t object_size)
       : RayObject(metadata), object_(object), object_size_(object_size) {}
 
   ~PyArrowRayObject() {

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -10,6 +10,8 @@
 
 namespace ray {
 
+const std::string kBufferTooSmallErrMsg = "Target buffer smaller than object data.";
+
 /// RayObjects consist of data and metadata. Metadata is always passed
 /// in as a buffer because it is small, but data can be handled
 /// differently by implementations in order to avoid copying large data.

--- a/src/ray/core_worker/task_execution.cc
+++ b/src/ray/core_worker/task_execution.cc
@@ -84,7 +84,7 @@ Status CoreWorkerTaskExecutionInterface::BuildArgsForExecutor(
       indices.push_back(i);
     } else {
       // pass by value.
-      (*args)[i] = std::make_shared<RayObject>(
+      (*args)[i] = std::make_shared<BufferedRayObject>(
           std::make_shared<LocalMemoryBuffer>(const_cast<uint8_t *>(task.ArgVal(i)),
                                               task.ArgValLength(i)),
           nullptr);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Refactors the `RayObject` interface to allow for multiple implementations (e.g., for Java, Python, etc.) that can either copy data into a buffer and then into an object store or write directly from application program memory to avoid a copy.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
