### PR TITLE
[rllib] Make RLLib handle zero-length observation arrays

### DIFF
--- a/python/ray/rllib/utils/debug.py
+++ b/python/ray/rllib/utils/debug.py
@@ -88,8 +88,8 @@ def _summarize(obj):
             return _StringValue(
                 "np.ndarray({}, dtype={}, min={}, max={}, mean={})".format(
                     obj.shape, obj.dtype, round(float(np.min(obj)), 3),
-                    round(float(np.max(obj)), 3),
-                    round(float(np.mean(obj)), 3)))
+                    round(float(np.max(obj)), 3), round(
+                        float(np.mean(obj)), 3)))
     elif isinstance(obj, MultiAgentBatch):
         return {
             "type": "MultiAgentBatch",

--- a/python/ray/rllib/utils/debug.py
+++ b/python/ray/rllib/utils/debug.py
@@ -78,15 +78,18 @@ def _summarize(obj):
     elif isinstance(obj, tuple):
         return tuple(_summarize(x) for x in obj)
     elif isinstance(obj, np.ndarray):
-        if obj.dtype == np.object:
+        if obj.size == 0:
+            return _StringValue("np.ndarray({}, dtype={})".format(
+                obj.shape, obj.dtype))
+        elif obj.dtype == np.object:
             return _StringValue("np.ndarray({}, dtype={}, head={})".format(
                 obj.shape, obj.dtype, _summarize(obj[0])))
         else:
             return _StringValue(
                 "np.ndarray({}, dtype={}, min={}, max={}, mean={})".format(
                     obj.shape, obj.dtype, round(float(np.min(obj)), 3),
-                    round(float(np.max(obj)), 3), round(
-                        float(np.mean(obj)), 3)))
+                    round(float(np.max(obj)), 3),
+                    round(float(np.mean(obj)), 3)))
     elif isinstance(obj, MultiAgentBatch):
         return {
             "type": "MultiAgentBatch",

--- a/python/ray/rllib/utils/memory.py
+++ b/python/ray/rllib/utils/memory.py
@@ -56,7 +56,11 @@ def aligned_array(size, dtype, align=64):
     empty = np.empty(n + (align - 1), dtype=np.uint8)
     data_align = empty.ctypes.data % align
     offset = 0 if data_align == 0 else (align - data_align)
-    output = empty[offset:offset + n].view(dtype)
+    if n == 0:
+        # stop np from optimising out empty slice reference
+        output = empty[offset:offset + 1][0:0].view(dtype)
+    else:
+        output = empty[offset:offset + n].view(dtype)
 
     assert len(output) == size, len(output)
     assert output.ctypes.data % align == 0, output.ctypes.data


### PR DESCRIPTION
## What do these changes do?

Make `ray.rllib.utlis.debug._summarize` handle zero-length arrays correctly. Also fix `aligned_arrays` to handle zero-length arrays.

## Related issue number

Fixes #5207

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.