### PR TITLE
 fixed inconsistent action placeholder of MARWIL

### DIFF
--- a/python/ray/rllib/agents/marwil/marwil_policy.py
+++ b/python/ray/rllib/agents/marwil/marwil_policy.py
@@ -110,7 +110,7 @@ class MARWILPolicy(MARWILPostprocessing, TFPolicy):
         self.output_actions = action_dist.sample()
 
         # Training inputs
-        self.act_t = tf.placeholder(tf.int32, [None], name="action")
+        self.act_t = ModelCatalog.get_action_placeholder(action_space)
         self.cum_rew_t = tf.placeholder(tf.float32, [None], name="reward")
 
         # v network evaluation


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Made the action placeholders for both inference and training consistent with the action space.


## Related issue number
#5205
<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
