### PR TITLE
Improve memory check

### DIFF
--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -62,13 +62,13 @@ class MemoryMonitor(object):
         # If the error threshold env is set, overwrite the threshold with it.
         try:
             self.error_threshold = float(
-                os.getenv("RAY_MEMORY_MONITOR_ERROR_THRESHOLD")
-            )
+                os.getenv("RAY_MEMORY_MONITOR_ERROR_THRESHOLD"))
         except (ValueError, TypeError):
             self.error_threshold = error_threshold
         # Try to read the cgroup memory limit if it is available.
         try:
-            with open("/sys/fs/cgroup/memory/memory.limit_in_bytes", "rb") as f:
+            with open("/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                      "rb") as f:
                 self.cgroup_memory_limit_gb = int(f.read()) / 1e9
         except IOError:
             self.cgroup_memory_limit_gb = sys.maxsize / 1e9
@@ -91,7 +91,8 @@ class MemoryMonitor(object):
             used_gb = total_gb - psutil.virtual_memory().available / 1e9
             if self.cgroup_memory_limit_gb < total_gb:
                 total_gb = self.cgroup_memory_limit_gb
-                with open("/sys/fs/cgroup/memory/memory.usage_in_bytes", "rb") as f:
+                with open("/sys/fs/cgroup/memory/memory.usage_in_bytes",
+                          "rb") as f:
                     used_gb = int(f.read()) / 1e9
             if used_gb > total_gb * self.error_threshold:
                 raise RayOutOfMemoryError(

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -52,6 +52,13 @@ class MemoryMonitor(object):
 
     This presents a much cleaner error message to users than what would happen
     if we actually ran out of memory.
+
+    The monitor tries to use the cgroup memory limit and usage if it is set
+    and available so that it is more reasonable inside containers. Otherwise,
+    it uses `psutil` to check the memory usage.
+
+    The environment variable `RAY_MEMORY_MONITOR_ERROR_THRESHOLD` can be used
+    to overwrite the default error_threshold setting.
     """
 
     def __init__(self, error_threshold=0.95, check_interval=1):
@@ -59,7 +66,6 @@ class MemoryMonitor(object):
         # throttle this check at most once a second or so.
         self.check_interval = check_interval
         self.last_checked = time.time()
-        # If the error threshold env is set, overwrite the threshold with it. 
         try:
             self.error_threshold = float(
                 os.getenv("RAY_MEMORY_MONITOR_ERROR_THRESHOLD"))

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import logging
 import os
+import sys
 import time
 
 try:
@@ -58,7 +59,19 @@ class MemoryMonitor(object):
         # throttle this check at most once a second or so.
         self.check_interval = check_interval
         self.last_checked = time.time()
-        self.error_threshold = error_threshold
+        # If the error threshold env is set, overwrite the threshold with it.
+        try:
+            self.error_threshold = float(
+                os.getenv("RAY_MEMORY_MONITOR_ERROR_THRESHOLD")
+            )
+        except (ValueError, TypeError):
+            self.error_threshold = error_threshold
+        # Try to read the cgroup memory limit if it is available.
+        try:
+            with open("/sys/fs/cgroup/memory/memory.limit_in_bytes", "rb") as f:
+                self.cgroup_memory_limit_gb = int(f.read()) / 1e9
+        except IOError:
+            self.cgroup_memory_limit_gb = sys.maxsize / 1e9
         if not psutil:
             print("WARNING: Not monitoring node memory since `psutil` is not "
                   "installed. Install this with `pip install psutil` "
@@ -76,6 +89,10 @@ class MemoryMonitor(object):
             self.last_checked = time.time()
             total_gb = psutil.virtual_memory().total / 1e9
             used_gb = total_gb - psutil.virtual_memory().available / 1e9
+            if self.cgroup_memory_limit_gb < total_gb:
+                total_gb = self.cgroup_memory_limit_gb
+                with open("/sys/fs/cgroup/memory/memory.usage_in_bytes", "rb") as f:
+                    used_gb = int(f.read()) / 1e9
             if used_gb > total_gb * self.error_threshold:
                 raise RayOutOfMemoryError(
                     RayOutOfMemoryError.get_message(used_gb, total_gb,

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -59,7 +59,7 @@ class MemoryMonitor(object):
         # throttle this check at most once a second or so.
         self.check_interval = check_interval
         self.last_checked = time.time()
-        # If the error threshold env is set, overwrite the threshold with it.
+        # If the error threshold env is set, overwrite the threshold with it. 
         try:
             self.error_threshold = float(
                 os.getenv("RAY_MEMORY_MONITOR_ERROR_THRESHOLD"))


### PR DESCRIPTION
###  What do these changes do?
The fixed 95% memory error threshold is not flexible inside containers since it now only reads the virtual memory on the host. This change does the following: 
- Use the cgroup memory limit and usage if it is set and available so that it is more reasonable inside a container with resources limits. 
- Add a `RAY_MEMORY_MONITOR_ERROR_THRESHOLD` env var to allow manual control of the threshold.

## Related issue number
#5211

## Linter
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
