### PR TITLE
fix log monitor read error

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -78,6 +78,15 @@ class LogMonitor(object):
         self.closed_file_infos = []
         self.can_open_more_files = True
 
+    def file_should_monitor(filename):
+        """Check whether the file should be monitored.
+
+        Currently, we only monitor worker log file.
+        """
+        return (filename.startswith("worker")
+                    and (filename.endswith("out")
+                        or filename.endswith("err")))
+
     def close_all_files(self):
         """Close all open files (so that we can open more)."""
         while len(self.open_file_infos) > 0:
@@ -93,7 +102,9 @@ class LogMonitor(object):
 
         for log_filename in log_filenames:
             full_path = os.path.join(self.logs_dir, log_filename)
-            if full_path not in self.log_filenames:
+            filename = full_path.split("/")[-1]
+            if (file_should_monitor(filename)
+                    and full_path not in self.log_filenames):
                 self.log_filenames.add(full_path)
                 self.closed_file_infos.append(
                     LogFileInfo(
@@ -172,20 +183,20 @@ class LogMonitor(object):
             lines_to_publish = []
             max_num_lines_to_read = 100
             for _ in range(max_num_lines_to_read):
-                next_line = file_info.file_handle.readline()
-                if next_line == "":
-                    break
-                if next_line[-1] == "\n":
-                    next_line = next_line[:-1]
-                lines_to_publish.append(next_line)
+                try:
+                    next_line = file_info.file_handle.readline()
+                    if next_line == "":
+                        break
+                    if next_line[-1] == "\n":
+                        next_line = next_line[:-1]
+                    lines_to_publish.append(next_line)
+                except:
+                    logger.error("Error: Reading file: {}, position: {} "
+                                 "failed.".format(file_info.full_path,
+                                 file_info.file_info.file_handle.tell()))
+                    raise
 
-            # Publish the lines if this is a worker process.
-            filename = file_info.filename.split("/")[-1]
-            is_worker = (filename.startswith("worker")
-                         and (filename.endswith("out")
-                              or filename.endswith("err")))
-
-            if is_worker and file_info.file_position == 0:
+            if file_info.file_position == 0:
                 if (len(lines_to_publish) > 0 and
                         lines_to_publish[0].startswith("Ray worker pid: ")):
                     file_info.worker_pid = int(
@@ -195,7 +206,7 @@ class LogMonitor(object):
             # Record the current position in the file.
             file_info.file_position = file_info.file_handle.tell()
 
-            if len(lines_to_publish) > 0 and is_worker:
+            if len(lines_to_publish) > 0:
                 self.redis_client.publish(
                     ray.gcs_utils.LOG_FILE_CHANNEL,
                     json.dumps({

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -84,8 +84,7 @@ class LogMonitor(object):
         Currently, we only monitor worker log file.
         """
         return (filename.startswith("worker")
-                    and (filename.endswith("out")
-                        or filename.endswith("err")))
+                and (filename.endswith("out") or filename.endswith("err")))
 
     def close_all_files(self):
         """Close all open files (so that we can open more)."""
@@ -192,8 +191,9 @@ class LogMonitor(object):
                     lines_to_publish.append(next_line)
                 except:
                     logger.error("Error: Reading file: {}, position: {} "
-                                 "failed.".format(file_info.full_path,
-                                 file_info.file_info.file_handle.tell()))
+                                 "failed.".format(
+                                     file_info.full_path,
+                                     file_info.file_info.file_handle.tell()))
                     raise
 
             if file_info.file_position == 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Currently, we will encounter some errors when monitoring all the file under logs. And we also just need the worker logfile from the code. In this patch, we only read those file which matches a worker log file format.


## Related issue number

<!-- For example: "Closes #1234" -->
Closes #5220

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
