### PR TITLE
Add regression test for actor load balancing

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -908,7 +908,7 @@ def test_actor_load_balancing(ray_start_cluster):
 @pytest.mark.skipif(
     pytest_timeout is None,
     reason="Timeout package not installed; skipping test that may hang.")
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_actor_lifetime_load_balancing(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -908,11 +908,11 @@ def test_actor_load_balancing(ray_start_cluster):
 @pytest.mark.skipif(
     pytest_timeout is None,
     reason="Timeout package not installed; skipping test that may hang.")
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(10)
 def test_actor_lifetime_load_balancing(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)
-    num_nodes = 4
+    num_nodes = 3
     for i in range(num_nodes):
         cluster.add_node(num_cpus=1)
     ray.init(redis_address=cluster.redis_address)


### PR DESCRIPTION
## What do these changes do?

Adds regression test for load-balancing actors when they request lifetime resources equal to the cluster capacity.

## Related issue number

Regression test for #5209.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
