### PR TITLE
[rllib] Move some inline defs to avoid deserialization errors

### DIFF
--- a/python/ray/rllib/evaluation/metrics.py
+++ b/python/ray/rllib/evaluation/metrics.py
@@ -7,6 +7,7 @@ import numpy as np
 import collections
 
 import ray
+from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.offline.off_policy_estimator import OffPolicyEstimate
 from ray.rllib.policy.policy import LEARNER_STATS_KEY
@@ -14,11 +15,6 @@ from ray.rllib.utils.annotations import DeveloperAPI
 from ray.rllib.utils.memory import ray_get_and_free
 
 logger = logging.getLogger(__name__)
-
-RolloutMetrics = collections.namedtuple("RolloutMetrics", [
-    "episode_length", "episode_reward", "agent_rewards", "custom_metrics",
-    "perf_stats"
-])
 
 
 @DeveloperAPI

--- a/python/ray/rllib/evaluation/rollout_metrics.py
+++ b/python/ray/rllib/evaluation/rollout_metrics.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+# Define this in its own file, see #5125
+RolloutMetrics = collections.namedtuple("RolloutMetrics", [
+    "episode_length", "episode_reward", "agent_rewards", "custom_metrics",
+    "perf_stats"
+])

--- a/python/ray/rllib/evaluation/rollout_worker.py
+++ b/python/ray/rllib/evaluation/rollout_worker.py
@@ -277,13 +277,13 @@ class RolloutWorker(EvaluatorInterface):
                     dim=model_config.get("dim"),
                     framestack=model_config.get("framestack"))
                 if monitor_path:
-                    env = _monitor(env, monitor_path)
+                    env = gym.wrappers.Monitor(env, monitor_path, resume=True)
                 return env
         else:
 
             def wrap(env):
                 if monitor_path:
-                    env = _monitor(env, monitor_path)
+                    env = gym.wrappers.Monitor(env, monitor_path, resume=True)
                 return env
 
         self.env = wrap(self.env)
@@ -796,10 +796,6 @@ def _validate_env(env):
             "ExternalEnv, VectorEnv, or BaseEnv. The provided env creator "
             "function returned {} ({}).".format(env, type(env)))
     return env
-
-
-def _monitor(env, path):
-    return gym.wrappers.Monitor(env, path, resume=True)
 
 
 def _has_tensorflow_graph(policy_dict):

--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -10,7 +10,7 @@ import threading
 import time
 
 from ray.rllib.evaluation.episode import MultiAgentEpisode, _flatten_action
-from ray.rllib.evaluation.metrics import RolloutMetrics
+from ray.rllib.evaluation.rollout_metrics import RolloutMetrics
 from ray.rllib.evaluation.sample_batch_builder import \
     MultiAgentSampleBatchBuilder
 from ray.rllib.policy.tf_policy import TFPolicy


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

I'm still not sure why the definition order of these classes matter, or why the protobuf refactoring PR causes it to matter. However, this PR does empirically fix the IMPALA crashes when remote_worker_envs=True and the number of workers is overloaded on the machine.

## Related issue number

Closes https://github.com/ray-project/ray/issues/5125

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
