### PR TITLE
Leave `ray.wait` calls open until the task or actor exits

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -2708,7 +2708,7 @@ def test_ray_wait_dead_actor(ray_start_cluster):
     # Evict the result from the dead node.
     ray.internal.free([remote_ping_id], local_only=True)
     # Create an actor on the local node that will call ray.wait in a loop.
-    head_node_resource = 'HEAD_NODE'
+    head_node_resource = "HEAD_NODE"
     ray.experimental.set_resource(head_node_resource, 1)
 
     @ray.remote(num_cpus=0, resources={head_node_resource: 1})

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -2656,7 +2656,7 @@ def test_decorated_method(ray_start_regular):
 @pytest.mark.skipif(
     pytest_timeout is None,
     reason="Timeout package not installed; skipping test that may hang.")
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 1,
@@ -2680,6 +2680,8 @@ def test_ray_wait_dead_actor(ray_start_cluster):
     ray.get([actor.ping.remote() for actor in actors])
 
     ping_ids = [actor.ping.remote() for actor in actors]
+    ray.get(ping_ids)
+    ray.internal.free(ping_ids, local_only=True)
     cluster.remove_node(worker_node)
 
     unready = ping_ids[:]
@@ -2689,3 +2691,4 @@ def test_ray_wait_dead_actor(ray_start_cluster):
 
     with pytest.raises(ray.exceptions.RayActorError):
         ray.get(ping_ids)
+    # TODO(swang): Write another test that calls ray.wait in separate tasks.

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -2656,14 +2656,17 @@ def test_decorated_method(ray_start_regular):
 @pytest.mark.skipif(
     pytest_timeout is None,
     reason="Timeout package not installed; skipping test that may hang.")
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
+@pytest.mark.parametrize(
+    "ray_start_cluster", [{
+        "num_cpus": 1,
+        "num_nodes": 2,
+    }], indirect=True)
 def test_ray_wait_dead_actor(ray_start_cluster):
     """Tests that methods completed by dead actors are returned as ready"""
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=0)
-    node = cluster.add_node(num_cpus=1)
-    ray.init(redis_address=cluster.redis_address)
-    print(len(ray.state.state.client_table()), "clients")
+    worker_node = cluster.list_all_nodes()[-1]
+    num_nodes = len(cluster.list_all_nodes())
 
     @ray.remote(num_cpus=1)
     class Actor(object):
@@ -2673,16 +2676,16 @@ def test_ray_wait_dead_actor(ray_start_cluster):
         def ping(self):
             time.sleep(1)
 
-    actor = Actor.remote()
-    ray.get(actor.ping.remote())
+    actors = [Actor.remote() for _ in range(num_nodes)]
+    ray.get([actor.ping.remote() for actor in actors])
 
-    ping_id = actor.ping.remote()
-    cluster.remove_node(node)
+    ping_ids = [actor.ping.remote() for actor in actors]
+    cluster.remove_node(worker_node)
 
-    ready = []
-    while not ready:
-        ready, _ = ray.wait([ping_id], timeout=0.01)
+    unready = ping_ids[:]
+    while unready:
+        _, unready = ray.wait(unready, timeout=0.01)
         time.sleep(1)
 
     with pytest.raises(ray.exceptions.RayActorError):
-        ray.get(ping_id)
+        ray.get(ping_ids)

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -2689,7 +2689,8 @@ def test_ray_wait_dead_actor(ray_start_cluster):
     remote_node = cluster.list_all_nodes()[-1]
     remote_ping_id = None
     for i, actor in enumerate(actors):
-        if ray.get(actor.local_plasma.remote()) == remote_node.plasma_store_socket_name:
+        if ray.get(actor.local_plasma.remote()
+                   ) == remote_node.plasma_store_socket_name:
             remote_ping_id = ping_ids[i]
     ray.internal.free([remote_ping_id], local_only=True)
     cluster.remove_node(remote_node)
@@ -2709,6 +2710,7 @@ def test_ray_wait_dead_actor(ray_start_cluster):
     # Create an actor on the local node that will call ray.wait in a loop.
     head_node_resource = 'HEAD_NODE'
     ray.experimental.set_resource(head_node_resource, 1)
+
     @ray.remote(num_cpus=0, resources={head_node_resource: 1})
     class ParentActor(object):
         def __init__(self, ping_ids):

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -411,7 +411,7 @@ def test_driver_exiting_when_worker_blocked(call_ray_start):
     ray.init(redis_address=redis_address)
 
     # Define a driver that creates two tasks, one that runs forever and the
-    # other blocked on the first.
+    # other blocked on the first in a `ray.get`.
     driver_script = """
 import time
 import ray
@@ -422,6 +422,30 @@ def f():
 @ray.remote
 def g():
     ray.get(f.remote())
+g.remote()
+time.sleep(1)
+print("success")
+""".format(redis_address)
+
+    # Create some drivers and let them exit and make sure everything is
+    # still alive.
+    for _ in range(3):
+        out = run_string_as_driver(driver_script)
+        # Make sure the first driver ran to completion.
+        assert "success" in out
+
+    # Define a driver that creates two tasks, one that runs forever and the
+    # other blocked on the first in a `ray.wait`.
+    driver_script = """
+import time
+import ray
+ray.init(redis_address="{}")
+@ray.remote
+def f():
+    time.sleep(10**6)
+@ray.remote
+def g():
+    ray.wait([f.remote()])
 g.remote()
 time.sleep(1)
 print("success")
@@ -446,6 +470,31 @@ ray.init(redis_address="{}")
 def g(x):
     return
 g.remote(ray.ObjectID(ray.utils.hex_to_binary("{}")))
+time.sleep(1)
+print("success")
+""".format(redis_address, nonexistent_id_hex)
+
+    # Create some drivers and let them exit and make sure everything is
+    # still alive.
+    for _ in range(3):
+        out = run_string_as_driver(driver_script)
+        # Simulate the nonexistent dependency becoming available.
+        ray.worker.global_worker.put_object(
+            ray.ObjectID(nonexistent_id_bytes), None)
+        # Make sure the first driver ran to completion.
+        assert "success" in out
+
+    nonexistent_id_bytes = _random_string()
+    nonexistent_id_hex = ray.utils.binary_to_hex(nonexistent_id_bytes)
+    # Define a driver that calls `ray.wait` on a nonexistent object.
+    driver_script = """
+import time
+import ray
+ray.init(redis_address="{}")
+@ray.remote
+def g():
+    ray.wait(ray.ObjectID(ray.utils.hex_to_binary("{}")))
+g.remote()
 time.sleep(1)
 print("success")
 """.format(redis_address, nonexistent_id_hex)

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -162,11 +162,8 @@ class ClientConnection : public ServerConnection<T> {
     return std::static_pointer_cast<ClientConnection<T>>(shared_from_this());
   }
 
-  /// \return The ClientID of the remote client.
-  const ClientID &GetClientId() const;
-
-  /// \param client_id The ClientID of the remote client.
-  void SetClientID(const ClientID &client_id);
+  /// Register the client.
+  void Register();
 
   /// Listen for and process messages from the client connection. Once a
   /// message has been fully received, the client manager's
@@ -198,8 +195,8 @@ class ClientConnection : public ServerConnection<T> {
   /// \return Information of remote endpoint.
   std::string RemoteEndpointInfo();
 
-  /// The ClientID of the remote client.
-  ClientID client_id_;
+  /// Whether the client has sent us a registration message yet.
+  bool registered_;
   /// The handler for a message from the client.
   MessageHandler<T> message_handler_;
   /// A label used for debug messages.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -822,15 +822,10 @@ void NodeManager::ProcessClientMessage(
 
 void NodeManager::ProcessRegisterClientRequestMessage(
     const std::shared_ptr<LocalClientConnection> &client, const uint8_t *message_data) {
+  client->Register();
   auto message = flatbuffers::GetRoot<protocol::RegisterClientRequest>(message_data);
-  auto client_id = from_flatbuf<ClientID>(*message->worker_id());
-  client->SetClientID(client_id);
   Language language = static_cast<Language>(message->language());
-  // TODO: Set the WorkerID according to the core worker client.
-  WorkerID worker_id = WorkerID::FromRandom();
-  if (message->is_worker()) {
-    worker_id = from_flatbuf<WorkerID>(*message->worker_id());
-  }
+  WorkerID worker_id = from_flatbuf<WorkerID>(*message->worker_id());
   auto worker = std::make_shared<Worker>(worker_id, message->worker_pid(), language,
                                          message->port(), client, client_call_manager_);
   if (message->is_worker()) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -323,11 +323,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param client The client that is executing the unblocked task.
   /// \param current_task_id The task that is unblocked.
-  /// \param ray_get Whether the task was blocked in a `ray.get` call, as
-  /// opposed to a `ray.wait` call.
   /// \return Void.
   void HandleTaskUnblocked(const std::shared_ptr<LocalClientConnection> &client,
-                           const TaskID &current_task_id, bool ray_get);
+                           const TaskID &current_task_id);
 
   /// Kill a worker.
   ///

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -308,10 +308,12 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \param client The client that is executing the blocked task.
   /// \param required_object_ids The IDs that the client is blocked waiting for.
   /// \param current_task_id The task that is blocked.
+  /// \param ray_get Whether the task is blocked in a `ray.get` call, as
+  /// opposed to a `ray.wait` call.
   /// \return Void.
   void HandleTaskBlocked(const std::shared_ptr<LocalClientConnection> &client,
                          const std::vector<ObjectID> &required_object_ids,
-                         const TaskID &current_task_id);
+                         const TaskID &current_task_id, bool ray_get);
 
   /// Handle a task that is unblocked. This could be a task assigned to a
   /// worker, an out-of-band task (e.g., a thread created by the application),
@@ -321,9 +323,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   ///
   /// \param client The client that is executing the unblocked task.
   /// \param current_task_id The task that is unblocked.
+  /// \param ray_get Whether the task was blocked in a `ray.get` call, as
+  /// opposed to a `ray.wait` call.
   /// \return Void.
   void HandleTaskUnblocked(const std::shared_ptr<LocalClientConnection> &client,
-                           const TaskID &current_task_id);
+                           const TaskID &current_task_id, bool ray_get);
 
   /// Kill a worker.
   ///

--- a/src/ray/raylet/reconstruction_policy.cc
+++ b/src/ray/raylet/reconstruction_policy.cc
@@ -171,6 +171,7 @@ void ReconstructionPolicy::HandleTaskLeaseNotification(const TaskID &task_id,
 }
 
 void ReconstructionPolicy::ListenAndMaybeReconstruct(const ObjectID &object_id) {
+  RAY_LOG(DEBUG) << "Listening and maybe reconstructing object " << object_id;
   TaskID task_id = object_id.TaskId();
   auto it = listening_tasks_.find(task_id);
   // Add this object to the list of objects created by the same task.
@@ -185,6 +186,7 @@ void ReconstructionPolicy::ListenAndMaybeReconstruct(const ObjectID &object_id) 
 }
 
 void ReconstructionPolicy::Cancel(const ObjectID &object_id) {
+  RAY_LOG(DEBUG) << "Reconstruction for object " << object_id << " canceled";
   TaskID task_id = object_id.TaskId();
   auto it = listening_tasks_.find(task_id);
   if (it == listening_tasks_.end()) {

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -194,8 +194,7 @@ void TaskDependencyManager::SubscribeWaitDependencies(
   }
 }
 
-void TaskDependencyManager::UnsubscribeWaitDependencies(
-    const WorkerID &worker_id) {
+void TaskDependencyManager::UnsubscribeWaitDependencies(const WorkerID &worker_id) {
   // Remove the task from the table of subscribed tasks.
   auto it = worker_dependencies_.find(worker_id);
   if (it == worker_dependencies_.end()) {

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -86,12 +86,12 @@ std::vector<TaskID> TaskDependencyManager::HandleObjectLocal(
   if (creating_task_entry != required_tasks_.end()) {
     auto object_entry = creating_task_entry->second.find(object_id);
     if (object_entry != creating_task_entry->second.end()) {
-      for (auto &dependent_task_id : object_entry->second) {
+      for (auto &dependent_task_id : object_entry->second.dependent_tasks) {
         auto &task_entry = task_dependencies_[dependent_task_id];
-        task_entry.num_missing_dependencies--;
+        task_entry.num_missing_get_dependencies--;
         // If the dependent task now has all of its arguments ready, it's ready
         // to run.
-        if (task_entry.num_missing_dependencies == 0) {
+        if (task_entry.num_missing_get_dependencies == 0) {
           ready_task_ids.push_back(dependent_task_id);
         }
       }
@@ -118,18 +118,18 @@ std::vector<TaskID> TaskDependencyManager::HandleObjectMissing(
   if (creating_task_entry != required_tasks_.end()) {
     auto object_entry = creating_task_entry->second.find(object_id);
     if (object_entry != creating_task_entry->second.end()) {
-      for (auto &dependent_task_id : object_entry->second) {
+      for (auto &dependent_task_id : object_entry->second.dependent_tasks) {
         auto &task_entry = task_dependencies_[dependent_task_id];
         // If the dependent task had all of its arguments ready, it was ready to
         // run but must be switched to waiting since one of its arguments is now
         // missing.
-        if (task_entry.num_missing_dependencies == 0) {
+        if (task_entry.num_missing_get_dependencies == 0) {
           waiting_task_ids.push_back(dependent_task_id);
           // During normal execution we should be able to include the check
           // RAY_CHECK(pending_tasks_.count(dependent_task_id) == 1);
           // However, this invariant will not hold during unit test execution.
         }
-        task_entry.num_missing_dependencies++;
+        task_entry.num_missing_get_dependencies++;
       }
     }
   }
@@ -140,24 +140,24 @@ std::vector<TaskID> TaskDependencyManager::HandleObjectMissing(
   return waiting_task_ids;
 }
 
-bool TaskDependencyManager::SubscribeDependencies(
+bool TaskDependencyManager::SubscribeGetDependencies(
     const TaskID &task_id, const std::vector<ObjectID> &required_objects) {
   auto &task_entry = task_dependencies_[task_id];
 
   // Record the task's dependencies.
   for (const auto &object_id : required_objects) {
-    auto inserted = task_entry.object_dependencies.insert(object_id);
+    auto inserted = task_entry.get_dependencies.insert(object_id);
     if (inserted.second) {
       // Get the ID of the task that creates the dependency.
       TaskID creating_task_id = object_id.TaskId();
       // Determine whether the dependency can be fulfilled by the local node.
       if (local_objects_.count(object_id) == 0) {
         // The object is not local.
-        task_entry.num_missing_dependencies++;
+        task_entry.num_missing_get_dependencies++;
       }
       // Add the subscribed task to the mapping from object ID to list of
       // dependent tasks.
-      required_tasks_[creating_task_id][object_id].push_back(task_id);
+      required_tasks_[creating_task_id][object_id].dependent_tasks.insert(task_id);
     }
   }
 
@@ -168,33 +168,55 @@ bool TaskDependencyManager::SubscribeDependencies(
   }
 
   // Return whether all dependencies are local.
-  return (task_entry.num_missing_dependencies == 0);
+  return (task_entry.num_missing_get_dependencies == 0);
 }
 
-bool TaskDependencyManager::UnsubscribeDependencies(const TaskID &task_id) {
-  // Remove the task from the table of subscribed tasks.
-  auto it = task_dependencies_.find(task_id);
-  if (it == task_dependencies_.end()) {
-    return false;
+void TaskDependencyManager::SubscribeWaitDependencies(
+    const WorkerID &worker_id, const std::vector<ObjectID> &required_objects) {
+  auto &worker_entry = worker_dependencies_[worker_id];
+
+  // Record the task's dependencies.
+  for (const auto &object_id : required_objects) {
+    auto inserted = worker_entry.insert(object_id);
+    if (inserted.second) {
+      // Get the ID of the task that creates the dependency.
+      TaskID creating_task_id = object_id.TaskId();
+      // Add the subscribed task to the mapping from object ID to list of
+      // dependent tasks.
+      required_tasks_[creating_task_id][object_id].dependent_workers.insert(worker_id);
+    }
   }
 
-  const TaskDependencies task_entry = std::move(it->second);
-  task_dependencies_.erase(it);
+  // These dependencies are required by the given task. Try to make them local
+  // if necessary.
+  for (const auto &object_id : required_objects) {
+    HandleRemoteDependencyRequired(object_id);
+  }
+}
+
+void TaskDependencyManager::UnsubscribeWaitDependencies(
+    const WorkerID &worker_id) {
+  // Remove the task from the table of subscribed tasks.
+  auto it = worker_dependencies_.find(worker_id);
+  if (it == worker_dependencies_.end()) {
+    return;
+  }
+
+  const WorkerDependencies worker_entry = std::move(it->second);
+  worker_dependencies_.erase(it);
 
   // Remove the task's dependencies.
-  for (const auto &object_id : task_entry.object_dependencies) {
+  for (const auto &object_id : worker_entry) {
     // Remove the task from the list of tasks that are dependent on this
     // object.
     // Get the ID of the task that creates the dependency.
     TaskID creating_task_id = object_id.TaskId();
     auto creating_task_entry = required_tasks_.find(creating_task_id);
-    std::vector<TaskID> &dependent_tasks = creating_task_entry->second[object_id];
-    auto it = std::find(dependent_tasks.begin(), dependent_tasks.end(), task_id);
-    RAY_CHECK(it != dependent_tasks.end());
-    dependent_tasks.erase(it);
+    auto &dependent_workers = creating_task_entry->second[object_id].dependent_workers;
+    RAY_CHECK(dependent_workers.erase(worker_id) > 0);
     // If the unsubscribed task was the only task dependent on the object, then
     // erase the object entry.
-    if (dependent_tasks.empty()) {
+    if (creating_task_entry->second[object_id].Empty()) {
       creating_task_entry->second.erase(object_id);
       // Remove the task that creates this object if there are no more object
       // dependencies created by the task.
@@ -206,7 +228,45 @@ bool TaskDependencyManager::UnsubscribeDependencies(const TaskID &task_id) {
 
   // These dependencies are no longer required by the given task. Cancel any
   // in-progress operations to make them local.
-  for (const auto &object_id : task_entry.object_dependencies) {
+  for (const auto &object_id : worker_entry) {
+    HandleRemoteDependencyCanceled(object_id);
+  }
+}
+
+bool TaskDependencyManager::UnsubscribeGetDependencies(const TaskID &task_id) {
+  // Remove the task from the table of subscribed tasks.
+  auto it = task_dependencies_.find(task_id);
+  if (it == task_dependencies_.end()) {
+    return false;
+  }
+
+  const TaskDependencies task_entry = std::move(it->second);
+  task_dependencies_.erase(it);
+
+  // Remove the task's dependencies.
+  for (const auto &object_id : task_entry.get_dependencies) {
+    // Remove the task from the list of tasks that are dependent on this
+    // object.
+    // Get the ID of the task that creates the dependency.
+    TaskID creating_task_id = object_id.TaskId();
+    auto creating_task_entry = required_tasks_.find(creating_task_id);
+    auto &dependent_tasks = creating_task_entry->second[object_id].dependent_tasks;
+    RAY_CHECK(dependent_tasks.erase(task_id) > 0);
+    // If the unsubscribed task was the only task dependent on the object, then
+    // erase the object entry.
+    if (creating_task_entry->second[object_id].Empty()) {
+      creating_task_entry->second.erase(object_id);
+      // Remove the task that creates this object if there are no more object
+      // dependencies created by the task.
+      if (creating_task_entry->second.empty()) {
+        required_tasks_.erase(creating_task_entry);
+      }
+    }
+  }
+
+  // These dependencies are no longer required by the given task. Cancel any
+  // in-progress operations to make them local.
+  for (const auto &object_id : task_entry.get_dependencies) {
     HandleRemoteDependencyCanceled(object_id);
   }
 
@@ -313,8 +373,8 @@ void TaskDependencyManager::RemoveTasksAndRelatedObjects(
     auto task_it = task_dependencies_.find(*it);
     if (task_it != task_dependencies_.end()) {
       // Add the objects that this task was subscribed to.
-      required_objects.insert(task_it->second.object_dependencies.begin(),
-                              task_it->second.object_dependencies.end());
+      required_objects.insert(task_it->second.get_dependencies.begin(),
+                              task_it->second.get_dependencies.end());
     }
     // The task no longer depends on anything.
     task_dependencies_.erase(*it);

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -417,7 +417,7 @@ void TaskDependencyManager::RemoveTasksAndRelatedObjects(
   // them.
   for (const auto &task_id : task_ids) {
     RAY_CHECK(required_tasks_.find(task_id) == required_tasks_.end())
-        << "RemoveTasksAndRelatedObjects was called on" << task_id
+        << "RemoveTasksAndRelatedObjects was called on " << task_id
         << ", but another task depends on it that was not included in the argument";
   }
 }

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -64,10 +64,11 @@ class TaskDependencyManager {
   /// Subscribe to object depedencies required by the worker. This should be called for
   /// ray.wait calls during task execution.
   ///
-  /// The TaskDependencyManager will track these dependencies until the dependencies are
-  /// local, or until UnsubscribeWaitDependencies is called with the same worker ID,
-  /// whichever occurs first. If any dependencies are remote, then they will be requested.
-  /// This method may be called multiple times per worker on the same objects.
+  /// The TaskDependencyManager will track all remote dependencies until the
+  /// dependencies are local, or until UnsubscribeWaitDependencies is called
+  /// with the same worker ID, whichever occurs first. Remote dependencies will
+  /// be requested.  This method may be called multiple times per worker on the
+  /// same objects.
   ///
   /// \param worker_id The ID of the worker that called `ray.wait`.
   /// \param required_objects The objects required by the worker.

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -43,8 +43,11 @@ class TaskDependencyManager {
   bool CheckObjectLocal(const ObjectID &object_id) const;
 
   /// Subscribe to object depedencies required by the task and check whether
-  /// all dependencies are fulfilled. This will track this task's dependencies
-  /// until UnsubscribeDependencies is called on the same task ID. If any
+  /// all dependencies are fulfilled. This should be called for task arguments and
+  /// `ray.get` calls during task execution.
+  ///
+  /// The TaskDependencyManager will track the task's dependencies
+  /// until UnsubscribeGetDependencies is called on the same task ID. If any
   /// dependencies are remote, then they will be requested. When the last
   /// remote dependency later appears locally via a call to HandleObjectLocal,
   /// the subscribed task will be returned by the HandleObjectLocal call,
@@ -55,16 +58,38 @@ class TaskDependencyManager {
   /// \param required_objects The objects required by the task.
   /// \return Whether all of the given dependencies for the given task are
   /// local.
-  bool SubscribeDependencies(const TaskID &task_id,
-                             const std::vector<ObjectID> &required_objects);
+  bool SubscribeGetDependencies(const TaskID &task_id,
+                                const std::vector<ObjectID> &required_objects);
 
-  /// Unsubscribe from the object dependencies required by this task. If the
-  /// objects were remote and are no longer required by any subscribed task,
-  /// then they will be canceled.
+  /// Subscribe to object depedencies required by the worker. This should be called for
+  /// ray.wait calls during task execution.
   ///
-  /// \param task_id The ID of the task whose dependencies to unsubscribe from.
+  /// The TaskDependencyManager will track these dependencies until the dependencies are
+  /// local, or until UnsubscribeWaitDependencies is called with the same worker ID,
+  /// whichever occurs first. If any dependencies are remote, then they will be requested.
+  /// This method may be called multiple times per worker on the same objects.
+  ///
+  /// \param worker_id The ID of the worker that called `ray.wait`.
+  /// \param required_objects The objects required by the worker.
+  /// \return Void.
+  void SubscribeWaitDependencies(const WorkerID &worker_id,
+                                 const std::vector<ObjectID> &required_objects);
+
+  /// Unsubscribe from the object dependencies required by this task through the task
+  /// arguments or `ray.get`. If the objects were remote and are no longer required by any
+  /// subscribed task, then they will be canceled.
+  ///
+  /// \param task_id The ID of the task whose dependencies we should unsubscribe from.
   /// \return Whether the task was subscribed before.
-  bool UnsubscribeDependencies(const TaskID &task_id);
+  bool UnsubscribeGetDependencies(const TaskID &task_id);
+
+  /// Unsubscribe from the object dependencies required by this worker through `ray.wait`.
+  /// If the objects were remote and are no longer required by any subscribed task, then
+  /// they will be canceled.
+  ///
+  /// \param worker_id The ID of the worker whose dependencies we should unsubscribe from.
+  /// \return The objects that the worker was waiting on.
+  void UnsubscribeWaitDependencies(const WorkerID &worker_id);
 
   /// Mark that the given task is pending execution. Any objects that it creates
   /// are now considered to be pending creation. If there are any subscribed
@@ -125,17 +150,33 @@ class TaskDependencyManager {
   void RecordMetrics() const;
 
  private:
-  using ObjectDependencyMap = std::unordered_map<ray::ObjectID, std::vector<ray::TaskID>>;
+  struct ObjectDependencies {
+    /// The tasks that depend on this object, either because the object is a task argument
+    /// or because the task called `ray.get` on the object.
+    std::unordered_set<TaskID> dependent_tasks;
+    /// The workers that depend on this object because they called `ray.wait` on the
+    /// object.
+    std::unordered_set<WorkerID> dependent_workers;
+
+    bool Empty() const { return dependent_tasks.empty() && dependent_workers.empty(); }
+  };
 
   /// A struct to represent the object dependencies of a task.
   struct TaskDependencies {
-    /// The objects that the task is dependent on. These must be local before
-    /// the task is ready to execute.
-    std::unordered_set<ObjectID> object_dependencies;
+    /// The objects that the task depends on. These are either the arguments to
+    /// the task or objects that the task calls `ray.get` on. These must be
+    /// local before the task is ready to execute. Objects are removed from
+    /// this set once UnsubscribeGetDependencies is called.
+    std::unordered_set<ObjectID> get_dependencies;
     /// The number of object arguments that are not available locally. This
     /// must be zero before the task is ready to execute.
-    int64_t num_missing_dependencies;
+    int64_t num_missing_get_dependencies;
   };
+
+  /// The objects that the worker is fetching. These are objects that a task that executed
+  /// or is executing on the worker called `ray.wait` on that are not yet local. An object
+  /// will be automatically removed from this set once it becomes local.
+  using WorkerDependencies = std::unordered_set<ObjectID>;
 
   struct PendingTask {
     PendingTask(int64_t initial_lease_period_ms, boost::asio::io_service &io_service)
@@ -188,13 +229,16 @@ class TaskDependencyManager {
   /// The storage system for the task lease table.
   gcs::TableInterface<TaskID, TaskLeaseData> &task_lease_table_;
   /// A mapping from task ID of each subscribed task to its list of object
-  /// dependencies.
+  /// dependencies, either task arguments or objects passed into `ray.get`.
   std::unordered_map<ray::TaskID, TaskDependencies> task_dependencies_;
+  /// A mapping from worker ID to each object that the worker called `ray.wait` on.
+  std::unordered_map<ray::WorkerID, WorkerDependencies> worker_dependencies_;
   /// All tasks whose outputs are required by a subscribed task. This is a
   /// mapping from task ID to information about the objects that the task
   /// creates, either by return value or by `ray.put`. For each object, we
   /// store the IDs of the subscribed tasks that are dependent on the object.
-  std::unordered_map<ray::TaskID, ObjectDependencyMap> required_tasks_;
+  std::unordered_map<ray::TaskID, std::unordered_map<ObjectID, ObjectDependencies>>
+      required_tasks_;
   /// Objects that are required by a subscribed task, are not local, and are
   /// not created by a pending task. For these objects, there are pending
   /// operations to make the object available.

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -10,10 +10,11 @@ namespace ray {
 namespace raylet {
 
 /// A constructor responsible for initializing the state of a worker.
-Worker::Worker(pid_t pid, const Language &language, int port,
+Worker::Worker(const WorkerID &worker_id, pid_t pid, const Language &language, int port,
                std::shared_ptr<LocalClientConnection> connection,
                rpc::ClientCallManager &client_call_manager)
-    : pid_(pid),
+    : worker_id_(worker_id),
+      pid_(pid),
       language_(language),
       port_(port),
       connection_(connection),
@@ -35,6 +36,8 @@ void Worker::MarkBlocked() { blocked_ = true; }
 void Worker::MarkUnblocked() { blocked_ = false; }
 
 bool Worker::IsBlocked() const { return blocked_; }
+
+WorkerID Worker::WorkerId() const { return worker_id_; }
 
 pid_t Worker::Pid() const { return pid_; }
 

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -20,7 +20,7 @@ namespace raylet {
 class Worker {
  public:
   /// A constructor that initializes a worker object.
-  Worker(pid_t pid, const Language &language, int port,
+  Worker(const WorkerID &worker_id, pid_t pid, const Language &language, int port,
          std::shared_ptr<LocalClientConnection> connection,
          rpc::ClientCallManager &client_call_manager);
   /// A destructor responsible for freeing all worker state.
@@ -30,6 +30,8 @@ class Worker {
   void MarkBlocked();
   void MarkUnblocked();
   bool IsBlocked() const;
+  /// Return the worker's ID.
+  WorkerID WorkerId() const;
   /// Return the worker's PID.
   pid_t Pid() const;
   Language GetLanguage() const;
@@ -61,6 +63,8 @@ class Worker {
                   const std::function<void(Status)> finish_assign_callback);
 
  private:
+  /// The worker's ID.
+  WorkerID worker_id_;
   /// The worker's PID.
   pid_t pid_;
   /// The language type of this worker.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -89,8 +89,8 @@ class WorkerPoolTest : public ::testing::Test {
     auto client =
         LocalClientConnection::Create(client_handler, message_handler, std::move(socket),
                                       "worker", {}, error_message_type_);
-    return std::shared_ptr<Worker>(
-        new Worker(pid, language, -1, client, client_call_manager_));
+    return std::shared_ptr<Worker>(new Worker(WorkerID::FromRandom(), pid, language, -1,
+                                              client, client_call_manager_));
   }
 
   void SetWorkerCommands(const WorkerCommandMap &worker_commands) {


### PR DESCRIPTION
## What do these changes do?

Previously, `ray.wait` calls would get canceled as soon as the call was able to return to the client, once the `timeout` or `num_returns` parameters was satisfied. This changes the behavior so that the raylet will continue to try and satisfy `ray.wait` calls even after control has been returned to the client. The call will be canceled when the object is local or when the task or actor that made the call exits, whichever occurs first.

This means that objects that the frontend requests through `ray.wait` that are not yet ready will be polled in the background until they become ready. This should reduce the number of calls that we have to make to `Pull` the object from remote object managers.

## Related issue number

Fixes #3715. Replaces #4153.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
