### PR TITLE
Improved KeyboardInterrupt Exception Handling

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -36,6 +36,7 @@ from ray.includes.unique_ids cimport (
 )
 from ray.includes.task cimport CTaskSpec
 from ray.includes.ray_config cimport RayConfig
+from ray.exceptions import RayletError
 from ray.utils import decode
 
 cimport cpython
@@ -57,7 +58,7 @@ cdef int check_status(const CRayStatus& status) nogil except -1:
 
     with gil:
         message = status.message().decode()
-        raise Exception(message)
+        raise RayletError(message)
 
 
 cdef c_vector[CObjectID] ObjectIDsToVector(object_ids):

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -77,6 +77,19 @@ class RayActorError(RayError):
         return "The actor died unexpectedly before finishing this task."
 
 
+class RayletError(RayError):
+    """Indicates that the Raylet client has errored.
+
+    This exception can be thrown when the raylet is killed.
+    """
+
+    def __init__(self, client_exc):
+        self.client_exc = client_exc
+
+    def __str__(self):
+        return "The Raylet died with this message: {}".format(self.client_exc)
+
+
 class UnreconstructableError(RayError):
     """Indicates that an object is lost and cannot be reconstructed.
 

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import redis
 import threading
 import traceback
 
@@ -10,6 +11,10 @@ from ray import ray_constants
 from ray import cloudpickle as pickle
 from ray import profiling
 from ray import utils
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ImportThread(object):
@@ -80,6 +85,8 @@ class ImportThread(object):
                     num_imported += 1
                     key = self.redis_client.lindex("Exports", i)
                     self._process_key(key)
+        except (OSError, redis.exceptions.ConnectionError) as e:
+            logger.error("ImportThread: {}".format(e))
         finally:
             # Close the pubsub client to avoid leaking file descriptors.
             import_pubsub_client.close()

--- a/python/ray/tune/examples/mnist_pytorch.py
+++ b/python/ray/tune/examples/mnist_pytorch.py
@@ -112,6 +112,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.ray_redis_address:
         ray.init(redis_address=args.ray_redis_address)
+    datasets.MNIST("~/data", train=True, download=True)
     sched = AsyncHyperBandScheduler(
         time_attr="training_iteration", metric="mean_accuracy")
     tune.run(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1522,8 +1522,9 @@ def custom_excepthook(type, value, tb):
     if global_worker.mode == SCRIPT_MODE:
         error_message = "".join(traceback.format_tb(tb))
         try:
-            global_worker.redis_client.hmset(b"Drivers:" + global_worker.worker_id,
-                                             {"exception": error_message})
+            global_worker.redis_client.hmset(
+                b"Drivers:" + global_worker.worker_id,
+                {"exception": error_message})
         except (ConnectionRefusedError, redis.exceptions.ConnectionError):
             logger.warning("Could not push exception to redis.")
     # Call the normal excepthook.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -12,6 +12,7 @@ import json
 import logging
 import numpy as np
 import os
+import redis
 import signal
 from six.moves import queue
 import sys
@@ -1520,8 +1521,11 @@ def custom_excepthook(type, value, tb):
     # If this is a driver, push the exception to redis.
     if global_worker.mode == SCRIPT_MODE:
         error_message = "".join(traceback.format_tb(tb))
-        global_worker.redis_client.hmset(b"Drivers:" + global_worker.worker_id,
-                                         {"exception": error_message})
+        try:
+            global_worker.redis_client.hmset(b"Drivers:" + global_worker.worker_id,
+                                             {"exception": error_message})
+        except (ConnectionRefusedError, redis.exceptions.ConnectionError):
+            logger.warning("Could not push exception to redis.")
     # Call the normal excepthook.
     normal_excepthook(type, value, tb)
 
@@ -1583,6 +1587,8 @@ def print_logs(redis_client, threads_stopped):
                     "The driver may not be able to keep up with the "
                     "stdout/stderr of the workers. To avoid forwarding logs "
                     "to the driver, use 'ray.init(log_to_driver=False)'.")
+    except (OSError, redis.exceptions.ConnectionError) as e:
+        logger.error("print_logs: {}".format(e))
     finally:
         # Close the pubsub client to avoid leaking file descriptors.
         pubsub_client.close()
@@ -1681,6 +1687,8 @@ def listen_error_messages_raylet(worker, task_error_queue, threads_stopped):
                 task_error_queue.put((error_message, time.time()))
             else:
                 logger.error(error_message)
+    except (OSError, redis.exceptions.ConnectionError) as e:
+        logger.error("listen_error_messages_raylet: {}".format(e))
     finally:
         # Close the pubsub client to avoid leaking file descriptors.
         worker.error_message_pubsub_client.close()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

Using keyboard interrupts and other standard interrupts often causes Ray
to scream. This is pretty annoying especially for application-level developers. This PR aims to clean up the error stack trace. 
**Below shows a standard stack trace - this PR provides a reduction from 115 lines to 22 lines.**


Previously, looked like:

```console
^CTraceback (most recent call last):
  File "/home/ubuntu/ray/python/ray/worker.py", line 2339, in wait
    worker.current_task_id,
  File "python/ray/_raylet.pyx", line 270, in ray._raylet.RayletClient.wait
  File "python/ray/_raylet.pyx", line 60, in ray._raylet.check_status
Exception: [RayletClient] Raylet connection closed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "mnist_pytorch.py", line 133, in <module>
    "use_gpu": int(args.cuda)
  File "/home/ubuntu/ray/python/ray/tune/tune.py", line 244, in run
    runner.step()
  File "/home/ubuntu/ray/python/ray/tune/trial_runner.py", line 325, in step
    self._process_events()  # blocking
  File "/home/ubuntu/ray/python/ray/tune/trial_runner.py", line 489, in _process_events
    trial = self.trial_executor.get_next_available_trial()  # blocking
  File "/home/ubuntu/ray/python/ray/tune/ray_trial_executor.py", line 318, in get_next_available_trial
    [result_id], _ = ray.wait(shuffled_results)
  File "/home/ubuntu/ray/python/ray/worker.py", line 2339, in wait
    worker.current_task_id,
KeyboardInterrupt
Exception in thread ray_listen_error_messages:
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 185, in _read_from_socket
    raise socket.error(SERVER_CLOSED_CONNECTION_ERROR)
OSError: Connection closed by server.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/ray/python/ray/worker.py", line 1663, in listen_error_messages_raylet
    msg = worker.error_message_pubsub_client.get_message()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3135, in get_message
    response = self.parse_response(block=False, timeout=timeout)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3036, in parse_response
    return self._execute(connection, connection.read_response)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3013, in _execute
    return command(*args)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 637, in read_response
    response = self._parser.read_response()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 290, in read_response
    response = self._buffer.readline()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 224, in readline
    self._read_from_socket()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 199, in _read_from_socket
    (e.args,))
redis.exceptions.ConnectionError: Error while reading from socket: ('Connection closed by server.',)

Exception in thread ray_import_thread:
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 185, in _read_from_socket
    raise socket.error(SERVER_CLOSED_CONNECTION_ERROR)
OSError: Connection closed by server.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/ray/python/ray/import_thread.py", line 69, in _run
    msg = import_pubsub_client.get_message()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3135, in get_message
    response = self.parse_response(block=False, timeout=timeout)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3036, in parse_response
    return self._execute(connection, connection.read_response)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3013, in _execute
    return command(*args)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 637, in read_response
    response = self._parser.read_response()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 290, in read_response
    response = self._buffer.readline()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 224, in readline
    self._read_from_socket()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 199, in _read_from_socket
    (e.args,))
redis.exceptions.ConnectionError: Error while reading from socket: ('Connection closed by server.',)

Exception in thread ray_print_logs:
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 185, in _read_from_socket
    raise socket.error(SERVER_CLOSED_CONNECTION_ERROR)
OSError: Connection closed by server.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/ubuntu/anaconda3/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/ubuntu/ray/python/ray/worker.py", line 1561, in print_logs
    msg = pubsub_client.get_message()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3135, in get_message
    response = self.parse_response(block=False, timeout=timeout)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3036, in parse_response
    return self._execute(connection, connection.read_response)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/client.py", line 3013, in _execute
    return command(*args)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 637, in read_response
    response = self._parser.read_response()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 290, in read_response
    response = self._buffer.readline()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 224, in readline
    self._read_from_socket()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/redis/connection.py", line 199, in _read_from_socket
    (e.args,))
redis.exceptions.ConnectionError: Error while reading from socket: ('Connection closed by server.',)
```

This now looks like:

```console
^C2019-07-21 21:42:02,264	ERROR worker.py:1692 -- listen_error_messages_raylet: Error while reading from socket: ('Connection closed by server.',)
2019-07-21 21:42:02,268	ERROR worker.py:1592 -- print_logs: Error while reading from socket: ('Connection closed by server.',)
2019-07-21 21:42:02,269	ERROR import_thread.py:89 -- ImportThread: Error while reading from socket: ('Connection closed by server.',)
2019-07-21 21:42:02,362	WARNING worker.py:1529 -- Could not push exception to redis.
Traceback (most recent call last):
  File "mnist_pytorch.py", line 134, in <module>
    "use_gpu": int(args.cuda)
  File "/home/ubuntu/ray/python/ray/tune/tune.py", line 244, in run
    runner.step()
  File "/home/ubuntu/ray/python/ray/tune/trial_runner.py", line 325, in step
    self._process_events()  # blocking
  File "/home/ubuntu/ray/python/ray/tune/trial_runner.py", line 489, in _process_events
    trial = self.trial_executor.get_next_available_trial()  # blocking
  File "/home/ubuntu/ray/python/ray/tune/ray_trial_executor.py", line 321, in get_next_available_trial
    [result_id], _ = ray.wait(shuffled_results)
  File "/home/ubuntu/ray/python/ray/worker.py", line 2348, in wait
    worker.current_task_id,
  File "python/ray/_raylet.pyx", line 271, in ray._raylet.RayletClient.wait
  File "python/ray/_raylet.pyx", line 61, in ray._raylet.check_status
  File "/home/ubuntu/ray/python/ray/exceptions.py", line 86, in __init__
    def __init__(self, client_exc):
KeyboardInterrupt
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.