### PR TITLE
[rllib] optimizer state not restored properly

### DIFF
--- a/python/ray/rllib/agents/trainer_template.py
+++ b/python/ray/rllib/agents/trainer_template.py
@@ -151,12 +151,12 @@ def build_trainer(name,
 
         def __getstate__(self):
             state = Trainer.__getstate__(self)
-            state.update(self.state)
+            state["trainer_state"] = self.state.copy()
             return state
 
         def __setstate__(self, state):
             Trainer.__setstate__(self, state)
-            self.state = state
+            self.state = state["trainer_state"].copy()
 
     @staticmethod
     def with_updates(**overrides):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

We inadvertently restored the wrong dict to self.state in the trainer, which caused the issue reported in 5246.

## Related issue number

Fixes https://github.com/ray-project/ray/issues/5246

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
