### PR TITLE
configure learner queue timeout

### DIFF
--- a/python/ray/rllib/agents/impala/impala.py
+++ b/python/ray/rllib/agents/impala/impala.py
@@ -54,8 +54,9 @@ DEFAULT_CONFIG = with_common_config({
     "replay_buffer_num_slots": 0,
     # max queue size for train batches feeding into the learner
     "learner_queue_size": 16,
-    # wait for train batches to be available in minibatch buffer queue this many seconds
-    # this may need to be increased e.g. when training with a slow environment
+    # wait for train batches to be available in minibatch buffer queue
+    # this many seconds. This may need to be increased e.g. when training
+    # with a slow environment
     "learner_queue_timeout": 300,
     # level of queuing for sampling.
     "max_sample_requests_in_flight_per_worker": 2,

--- a/python/ray/rllib/agents/impala/impala.py
+++ b/python/ray/rllib/agents/impala/impala.py
@@ -130,6 +130,8 @@ def make_aggregators_and_optimizer(workers, config):
         num_sgd_iter=config["num_sgd_iter"],
         minibatch_buffer_size=config["minibatch_buffer_size"],
         num_aggregation_workers=config["num_aggregation_workers"],
+        learner_queue_size=config["learner_queue_size"],
+        learner_queue_timeout=config["learner_queue_timeout"],
         **config["optimizer"])
 
     if aggregators:

--- a/python/ray/rllib/agents/impala/impala.py
+++ b/python/ray/rllib/agents/impala/impala.py
@@ -54,6 +54,9 @@ DEFAULT_CONFIG = with_common_config({
     "replay_buffer_num_slots": 0,
     # max queue size for train batches feeding into the learner
     "learner_queue_size": 16,
+    # wait for train batches to be available in minibatch buffer queue this many seconds
+    # this may need to be increased e.g. when training with a slow environment
+    "learner_queue_timeout": 300,
     # level of queuing for sampling.
     "max_sample_requests_in_flight_per_worker": 2,
     # max number of workers to broadcast one set of weights to

--- a/python/ray/rllib/agents/ppo/appo.py
+++ b/python/ray/rllib/agents/ppo/appo.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = with_base_config(impala.DEFAULT_CONFIG, {
     "replay_proportion": 0.0,
     "replay_buffer_num_slots": 100,
     "learner_queue_size": 16,
+    "learner_queue_timeout": 300,
     "max_sample_requests_in_flight_per_worker": 2,
     "broadcast_interval": 1,
     "grad_clip": 40.0,

--- a/python/ray/rllib/optimizers/aso_learner.py
+++ b/python/ray/rllib/optimizers/aso_learner.py
@@ -33,7 +33,8 @@ class LearnerThread(threading.Thread):
         self.inqueue = queue.Queue(maxsize=learner_queue_size)
         self.outqueue = queue.Queue()
         self.minibatch_buffer = MinibatchBuffer(
-            self.inqueue, minibatch_buffer_size, num_sgd_iter, learner_queue_timeout)
+            self.inqueue, minibatch_buffer_size, num_sgd_iter,
+            learner_queue_timeout)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()
         self.load_timer = TimerStat()

--- a/python/ray/rllib/optimizers/aso_learner.py
+++ b/python/ray/rllib/optimizers/aso_learner.py
@@ -26,14 +26,14 @@ class LearnerThread(threading.Thread):
     """
 
     def __init__(self, local_worker, minibatch_buffer_size, num_sgd_iter,
-                 learner_queue_size):
+                 learner_queue_size, learner_queue_timeout):
         threading.Thread.__init__(self)
         self.learner_queue_size = WindowStat("size", 50)
         self.local_worker = local_worker
         self.inqueue = queue.Queue(maxsize=learner_queue_size)
         self.outqueue = queue.Queue()
         self.minibatch_buffer = MinibatchBuffer(
-            self.inqueue, minibatch_buffer_size, num_sgd_iter)
+            self.inqueue, minibatch_buffer_size, num_sgd_iter, learner_queue_timeout)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()
         self.load_timer = TimerStat()

--- a/python/ray/rllib/optimizers/aso_learner.py
+++ b/python/ray/rllib/optimizers/aso_learner.py
@@ -35,7 +35,7 @@ class LearnerThread(threading.Thread):
         self.minibatch_buffer = MinibatchBuffer(
             inqueue=self.inqueue,
             size=minibatch_buffer_size,
-            learner_queue_timeout=learner_queue_timeout,
+            timeout=learner_queue_timeout,
             num_passes=num_sgd_iter)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()

--- a/python/ray/rllib/optimizers/aso_learner.py
+++ b/python/ray/rllib/optimizers/aso_learner.py
@@ -33,8 +33,10 @@ class LearnerThread(threading.Thread):
         self.inqueue = queue.Queue(maxsize=learner_queue_size)
         self.outqueue = queue.Queue()
         self.minibatch_buffer = MinibatchBuffer(
-            self.inqueue, minibatch_buffer_size, num_sgd_iter,
-            learner_queue_timeout)
+            inqueue=self.inqueue,
+            size=minibatch_buffer_size,
+            learner_queue_timeout=learner_queue_timeout,
+            num_passes=num_sgd_iter)
         self.queue_timer = TimerStat()
         self.grad_timer = TimerStat()
         self.load_timer = TimerStat()

--- a/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
+++ b/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
@@ -43,7 +43,8 @@ class TFMultiGPULearner(LearnerThread):
                  num_data_load_threads=16,
                  _fake_gpus=False):
         LearnerThread.__init__(self, local_worker, minibatch_buffer_size,
-                               num_sgd_iter, learner_queue_size, learner_queue_timeout)
+                               num_sgd_iter, learner_queue_size,
+                               learner_queue_timeout)
         self.lr = lr
         self.train_batch_size = train_batch_size
         if not num_gpus:
@@ -100,7 +101,8 @@ class TFMultiGPULearner(LearnerThread):
             self.loader_thread.start()
 
         self.minibatch_buffer = MinibatchBuffer(
-            self.ready_optimizers, minibatch_buffer_size, learner_queue_timeout, num_sgd_iter)
+            self.ready_optimizers, minibatch_buffer_size,
+            learner_queue_timeout, num_sgd_iter)
 
     @override(LearnerThread)
     def step(self):

--- a/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
+++ b/python/ray/rllib/optimizers/aso_multi_gpu_learner.py
@@ -39,10 +39,11 @@ class TFMultiGPULearner(LearnerThread):
                  minibatch_buffer_size=1,
                  num_sgd_iter=1,
                  learner_queue_size=16,
+                 learner_queue_timeout=300,
                  num_data_load_threads=16,
                  _fake_gpus=False):
         LearnerThread.__init__(self, local_worker, minibatch_buffer_size,
-                               num_sgd_iter, learner_queue_size)
+                               num_sgd_iter, learner_queue_size, learner_queue_timeout)
         self.lr = lr
         self.train_batch_size = train_batch_size
         if not num_gpus:
@@ -99,7 +100,7 @@ class TFMultiGPULearner(LearnerThread):
             self.loader_thread.start()
 
         self.minibatch_buffer = MinibatchBuffer(
-            self.ready_optimizers, minibatch_buffer_size, num_sgd_iter)
+            self.ready_optimizers, minibatch_buffer_size, learner_queue_timeout, num_sgd_iter)
 
     @override(LearnerThread)
     def step(self):

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -42,6 +42,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                  num_sgd_iter=1,
                  minibatch_buffer_size=1,
                  learner_queue_size=16,
+                 learner_queue_timeout=300,
                  num_aggregation_workers=0,
                  _fake_gpus=False):
         PolicyOptimizer.__init__(self, workers)
@@ -69,11 +70,14 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                 minibatch_buffer_size=minibatch_buffer_size,
                 num_sgd_iter=num_sgd_iter,
                 learner_queue_size=learner_queue_size,
+                learner_queue_timeout=learner_queue_timeout,
                 _fake_gpus=_fake_gpus)
         else:
             self.learner = LearnerThread(self.workers.local_worker(),
-                                         minibatch_buffer_size, num_sgd_iter,
-                                         learner_queue_size)
+                                         minibatch_buffer_size=minibatch_buffer_size,
+                                         num_sgd_iter=num_sgd_iter,
+                                         learner_queue_size=learner_queue_size,
+                                         learner_queue_timeout=learner_queue_timeout)
         self.learner.start()
 
         # Stats

--- a/python/ray/rllib/optimizers/async_samples_optimizer.py
+++ b/python/ray/rllib/optimizers/async_samples_optimizer.py
@@ -73,11 +73,12 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                 learner_queue_timeout=learner_queue_timeout,
                 _fake_gpus=_fake_gpus)
         else:
-            self.learner = LearnerThread(self.workers.local_worker(),
-                                         minibatch_buffer_size=minibatch_buffer_size,
-                                         num_sgd_iter=num_sgd_iter,
-                                         learner_queue_size=learner_queue_size,
-                                         learner_queue_timeout=learner_queue_timeout)
+            self.learner = LearnerThread(
+                self.workers.local_worker(),
+                minibatch_buffer_size=minibatch_buffer_size,
+                num_sgd_iter=num_sgd_iter,
+                learner_queue_size=learner_queue_size,
+                learner_queue_timeout=learner_queue_timeout)
         self.learner.start()
 
         # Stats


### PR DESCRIPTION
## What do these changes do?

Makes learner queue timeout configurable for async samples optimizer.

## Related issue number

Closes #5260 

## Linter

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
