### PR TITLE
Fix releasing CPUs incorrectly when actor creation task blocked.

### DIFF
--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -591,16 +591,17 @@ def test_release_cpus_when_actor_creation_task_blocking(shutdown_only):
     assert 100 == ray.get(a.get_num.remote())
 
     def wait_until(condition, timeout_ms):
-        TIMEOUT_DURATION_MS = 100
+        SLEEP_DURATION_MS = 100
         time_elapsed = 0
         while time_elapsed <= timeout_ms:
             if condition():
                 return True
-            time_elapsed += TIMEOUT_DURATION_MS
+            time.sleep(SLEEP_DURATION_MS)
+            time_elapsed += SLEEP_DURATION_MS
         return False
 
-    def assert_available_resource():
+    def assert_available_resources():
         return 1 == ray.available_resources()["CPU"]
 
-    result = wait_until(assert_available_resource, 1000)
+    result = wait_until(assert_available_resources, 1000)
     assert result is True

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -592,11 +592,11 @@ def test_release_cpus_when_actor_creation_task_blocking(shutdown_only):
 
     def wait_until(condition, timeout_ms):
         TIMEOUT_DURATION_MS = 100
-        time_elaspe = 0
-        while time_elaspe < timeout_ms:
+        time_elapsed = 0
+        while time_elapsed <= timeout_ms:
             if condition():
                 return True
-            time_elaspe += TIMEOUT_DURATION_MS
+            time_elapsed += TIMEOUT_DURATION_MS
         return False
 
     def assert_available_resource():

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -576,8 +576,7 @@ def test_release_cpus_when_actor_creation_task_blocking(shutdown_only):
 
     @ray.remote(num_cpus=1)
     def get_100():
-        import time
-        time.sleep(2)
+        time.sleep(1)
         return 100
 
     @ray.remote(num_cpus=1)
@@ -590,4 +589,18 @@ def test_release_cpus_when_actor_creation_task_blocking(shutdown_only):
 
     a = A.remote()
     assert 100 == ray.get(a.get_num.remote())
-    assert 1 == ray.available_resources()["CPU"]
+
+    def wait_until(condition, timeout_ms):
+        TIMEOUT_DURATION_MS = 100
+        time_elaspe = 0
+        while time_elaspe < timeout_ms:
+            if condition():
+                return True
+            time_elaspe += TIMEOUT_DURATION_MS
+        return False
+
+    def assert_available_resource():
+        return 1 == ray.available_resources()["CPU"]
+
+    result = wait_until(assert_available_resource, 1000)
+    assert result is True

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1577,7 +1577,6 @@ void NodeManager::HandleTaskBlocked(const WorkerID &worker_id,
       local_queues_.QueueTasks({task}, TaskState::RUNNING);
       // Get the CPU resources required by the running task.
       // Release the CPU resources.
-      RAY_LOG(INFO) << ">>>>>>>>>>>>>>>>>>>>here here.";
       auto const cpu_resource_ids = worker->ReleaseTaskCpuResources();
       local_available_resources_.Release(cpu_resource_ids);
       cluster_resource_map_[gcs_client_->client_table().GetLocalClientId()].Release(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1576,14 +1576,12 @@ void NodeManager::HandleTaskBlocked(const WorkerID &worker_id,
       RAY_CHECK(local_queues_.RemoveTask(current_task_id, &task));
       local_queues_.QueueTasks({task}, TaskState::RUNNING);
       // Get the CPU resources required by the running task.
-      const auto required_resources = task.GetTaskSpecification().GetRequiredResources();
-      const ResourceSet cpu_resources = required_resources.GetNumCpus();
-
       // Release the CPU resources.
+      RAY_LOG(INFO) << ">>>>>>>>>>>>>>>>>>>>here here.";
       auto const cpu_resource_ids = worker->ReleaseTaskCpuResources();
       local_available_resources_.Release(cpu_resource_ids);
       cluster_resource_map_[gcs_client_->client_table().GetLocalClientId()].Release(
-          cpu_resources);
+          cpu_resource_ids.ToResourceSet());
       worker->MarkBlocked();
 
       // Try dispatching tasks since we may have released some resources.


### PR DESCRIPTION
The following test can't pass before this PR:
```python
    ray.init(num_cpus=2)

     @ray.remote(num_cpus=1)
    def get_100():
        import time
        time.sleep(2)
        return 100

     @ray.remote(num_cpus=1)
    class A(object):
        def __init__(self):
            self.num = ray.get(get_100.remote())

         def get_num(self):
            return self.num

     a = A.remote()
    assert 100 == ray.get(a.get_num.remote())
    assert 1 == ray.available_resources()["CPU"]
```