### PR TITLE
[sgd] hotfix example failure

### DIFF
--- a/python/ray/experimental/sgd/examples/train_example.py
+++ b/python/ray/experimental/sgd/examples/train_example.py
@@ -37,4 +37,4 @@ if __name__ == "__main__":
 
     import ray
     ray.init(redis_address=args.redis_address)
-    train_example(num_replicas=2, use_gpus=args.use_gpu)
+    train_example(num_replicas=2, use_gpu=args.use_gpu)

--- a/python/ray/experimental/sgd/examples/train_example.py
+++ b/python/ray/experimental/sgd/examples/train_example.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--redis-address",
-        required=True,
+        required=False,
         type=str,
         help="the address to use for Redis")
     parser.add_argument(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
```
ccf24c74f16db424ba024ffd887c3b6d2428d5f0b7e54f29c439321d52b9a13a python /ray/python/ray/experimental/sgd/examples/train_example.py

real	0m2.553s
user	0m0.048s
sys	0m0.028s
WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
usage: train_example.py [-h] --redis-address REDIS_ADDRESS [--use-gpu]
train_example.py: error: the following arguments are required: --redis-address
FAILED 2
```

Fixes the Jenkins test.


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.