### PR TITLE
[HOTFIX] Revert "[autoscaler] Clean up error messages on setup failure (#5210)"

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -379,7 +379,7 @@ def exec_cluster(config_file, cmd, docker, screen, tmux, stop, start,
             cmd,
             screen,
             tmux,
-            expect_error=True,
+            expect_error=stop,
             port_forward=port_forward)
 
         if tmux or screen:

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -291,20 +291,12 @@ class NodeUpdater(object):
                 "-L", "{}:localhost:{}".format(port_forward, port_forward)
             ]
 
-        final_cmd = ssh + ssh_opt + get_default_ssh_options(
-            self.ssh_private_key, connect_timeout, self.ssh_control_path) + [
-                "{}@{}".format(self.ssh_user, self.ssh_ip), cmd
-            ]
-
-        try:
-            self.get_caller(expect_error)(
-                final_cmd,
-                stdout=redirect or sys.stdout,
-                stderr=redirect or sys.stderr)
-        except subprocess.CalledProcessError:
-            logger.error("Command failed: \n\n  {}\n".format(
-                " ".join(final_cmd)))
-            sys.exit(1)
+        self.get_caller(expect_error)(
+            ssh + ssh_opt + get_default_ssh_options(
+                self.ssh_private_key, connect_timeout, self.ssh_control_path) +
+            ["{}@{}".format(self.ssh_user, self.ssh_ip), cmd],
+            stdout=redirect or sys.stdout,
+            stderr=redirect or sys.stderr)
 
 
 class NodeUpdaterThread(NodeUpdater, Thread):


### PR DESCRIPTION
This reverts commit 7fc15dbf7fa0769eecbe1692ed3a97b5c8b918dd.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

This reverts the commit that breaks cluster setup. This is a release blocking issue for 0.7.3.

## Related issue number

https://github.com/ray-project/ray/pull/5210
## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
