### PR TITLE
Fix Redis Test

### DIFF
--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -38,7 +38,7 @@ class TestRedisPassword(object):
         # Check that Redis connections require a password
         redis_client = redis.StrictRedis(
             host=redis_ip, port=redis_port, password=None)
-        with pytest.raises(redis.ResponseError):
+        with pytest.raises(redis.exceptions.AuthenticationError):
             redis_client.ping()
 
         # Check that we can connect to Redis using the provided password

--- a/python/setup.py
+++ b/python/setup.py
@@ -143,7 +143,7 @@ requires = [
     "colorama",
     "pytest",
     "pyyaml",
-    "redis",
+    "redis>=3.3.2",
     # NOTE: Don't upgrade the version of six! Doing so causes installation
     # problems. See https://github.com/ray-project/ray/issues/4169.
     "six >= 1.0.0",


### PR DESCRIPTION
Catch a different error in redis init test. Our current master are failing because of this. 


```
____________________ TestRedisPassword.test_redis_password _____________________
self = <ray.tests.test_ray_init.TestRedisPassword object at 0x7f4e0bc35518>
password = '657c7eab2a0fbe90ec43fbb0cfe32351c37468c5a2b57113cfbd706eb95f9ff57247b38b09bb6330ac8d318059d535ba700b621c26216e2b9aff0...e4aaec9a148cc4022b85f94ca2f98e05fcbfe62f3713d804a911131aa0db606c16891a95ac5a6964ad30d342cef7e7da6653c8d706cfb5812f0f72'
shutdown_only = None
    @pytest.mark.skipif(
        os.environ.get("RAY_USE_NEW_GCS") == "on",
        reason="New GCS API doesn't support Redis authentication yet.")
    def test_redis_password(self, password, shutdown_only):
        @ray.remote
        def f():
            return 1
    
        info = ray.init(redis_password=password)
        redis_address = info["redis_address"]
        redis_ip, redis_port = redis_address.split(":")
    
        # Check that we can run a task
        object_id = f.remote()
        ray.get(object_id)
    
        # Check that Redis connections require a password
        redis_client = redis.StrictRedis(
            host=redis_ip, port=redis_port, password=None)
        with pytest.raises(redis.ResponseError):
>           redis_client.ping()
python/ray/tests/test_ray_init.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../.local/lib/python3.6/site-packages/redis-3.3.0-py3.6.egg/redis/client.py:1106: in ping
    return self.execute_command('PING')
../../../.local/lib/python3.6/site-packages/redis-3.3.0-py3.6.egg/redis/client.py:839: in execute_command
    return self.parse_response(conn, command_name, **options)
../../../.local/lib/python3.6/site-packages/redis-3.3.0-py3.6.egg/redis/client.py:853: in parse_response
    response = connection.read_response()
../../../.local/lib/python3.6/site-packages/redis-3.3.0-py3.6.egg/redis/connection.py:671: in read_response
    response = self._parser.read_response()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <redis.connection.PythonParser object at 0x7f4ddca88cf8>
    def read_response(self):
        response = self._buffer.readline()
        if not response:
            raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
    
        byte, response = byte_to_chr(response[0]), response[1:]
    
        if byte not in ('-', '+', ':', '$', '*'):
            raise InvalidResponse("Protocol Error: %s, %s" %
                                  (str(byte), str(response)))
    
        # server returned an error
        if byte == '-':
            response = nativestr(response)
            error = self.parse_error(response)
            # if the error is a ConnectionError, raise immediately so the user
            # is notified
            if isinstance(error, ConnectionError):
>               raise error
E               redis.exceptions.AuthenticationError: Authentication required.


```