### PR TITLE
Submit task asynchronously from raylet client

### DIFF
--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import os
 import signal
 import sys
@@ -311,8 +312,12 @@ def check_components_alive(cluster, component_type, check_component_alive):
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 8,
-        "num_nodes": 4
-    }], indirect=True)
+        "num_nodes": 4,
+        "_internal_config": json.dumps({
+            "num_heartbeats_timeout": 100
+        }),
+    }],
+    indirect=True)
 def test_raylet_failed(ray_start_cluster):
     cluster = ray_start_cluster
     # Kill all raylets on worker nodes.
@@ -329,8 +334,12 @@ def test_raylet_failed(ray_start_cluster):
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_cpus": 8,
-        "num_nodes": 2
-    }], indirect=True)
+        "num_nodes": 2,
+        "_internal_config": json.dumps({
+            "num_heartbeats_timeout": 100
+        }),
+    }],
+    indirect=True)
 def test_plasma_store_failed(ray_start_cluster):
     cluster = ray_start_cluster
     # Kill all plasma stores on worker nodes.

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -337,6 +337,13 @@ void TaskDependencyManager::AcquireTaskLease(const TaskID &task_id) {
     return;
   }
 
+  // Check that we were able to renew the task lease before the previous one
+  // expired.
+  if (now_ms > it->second.expires_at) {
+    RAY_LOG(WARNING) << "Task " << task_id << " lease to renew has already expired by "
+                     << (it->second.expires_at - now_ms) << "ms";
+  }
+
   auto task_lease_data = std::make_shared<TaskLeaseData>();
   task_lease_data->set_node_manager_id(client_id_.Hex());
   task_lease_data->set_acquired_at(current_sys_time_ms());

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -337,13 +337,6 @@ void TaskDependencyManager::AcquireTaskLease(const TaskID &task_id) {
     return;
   }
 
-  // Check that we were able to renew the task lease before the previous one
-  // expired.
-  if (now_ms > it->second.expires_at) {
-    RAY_LOG(WARNING) << "Task " << task_id << " lease to renew has already expired by "
-                     << (it->second.expires_at - now_ms) << "ms";
-  }
-
   auto task_lease_data = std::make_shared<TaskLeaseData>();
   task_lease_data->set_node_manager_id(client_id_.Hex());
   task_lease_data->set_acquired_at(current_sys_time_ms());

--- a/src/ray/rpc/raylet/raylet_client.cc
+++ b/src/ray/rpc/raylet/raylet_client.cc
@@ -77,10 +77,18 @@ ray::Status RayletClient::SubmitTask(const ray::TaskSpecification &task_spec) {
   SubmitTaskRequest submit_task_request;
   submit_task_request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
 
-  grpc::ClientContext context;
-  SubmitTaskReply reply;
-  auto status = stub_->SubmitTask(&context, submit_task_request, &reply);
-  return GrpcStatusToRayStatus(status);
+  auto callback = [this](const Status &status, const SubmitTaskReply &reply) {
+    if (!status.ok() && is_connected_) {
+      is_connected_ = false;
+      RAY_LOG(INFO) << "Failed to send SubmitTaskRequest, msg: " << status.message();
+    }
+  };
+
+  auto call =
+      client_call_manager_.CreateCall<RayletService, SubmitTaskRequest, SubmitTaskReply>(
+          *stub_, &RayletService::Stub::PrepareAsyncSubmitTask, submit_task_request,
+          callback);
+  return call->GetStatus();
 }
 
 ray::Status RayletClient::GetTask(std::unique_ptr<ray::TaskSpecification> *task_spec) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

- Change task submission from sync to async.
- Mitigate 2 flaky tests caused by submitting tasks too fast. 

## Performance

script: https://gist.github.com/simon-mo/ae92d1f8e37e696738fe346f53a9e64d

before
```
count    10000.000000
mean         0.420324
std          0.235060
min          0.262766
25%          0.359584
50%          0.389354
75%          0.444090
max         11.620947
dtype: float64
```

now:
```
count    10000.000000
mean         0.161857
std          0.136520
min          0.080047
25%          0.140904
50%          0.147249
75%          0.155751
max         10.838463
dtype: float64
```

## Related issue number

Fixes #5310

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
