### PR TITLE
[Asyncio] Allow Async_API to init when loop is running

### DIFF
--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -13,6 +13,7 @@ async def _async_init():
     global handler, transport, protocol
     if handler is None:
         worker = ray.worker.global_worker
+        assert worker.connected, "Please call ray.init before async_api.init"
         loop = asyncio.get_event_loop()
         worker.plasma_client.subscribe()
         rsock = worker.plasma_client.get_notification_socket()

--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -1,7 +1,6 @@
 # Note: asyncio is only compatible with Python 3
 
 import asyncio
-import time
 
 import ray
 from ray.experimental.async_plasma import PlasmaProtocol, PlasmaEventHandler
@@ -23,6 +22,7 @@ async def _async_init():
         transport, protocol = await loop.create_connection(
             lambda: PlasmaProtocol(worker.plasma_client, handler), sock=rsock)
         logger.debug("AsyncPlasma Connection Created!")
+
 
 def init():
     """

--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -12,8 +12,8 @@ protocol = None
 async def _async_init():
     global handler, transport, protocol
     if handler is None:
+        assert ray.is_initialized(), "Please call ray.init before async_api.init"
         worker = ray.worker.global_worker
-        assert worker.connected, "Please call ray.init before async_api.init"
         loop = asyncio.get_event_loop()
         worker.plasma_client.subscribe()
         rsock = worker.plasma_client.get_notification_socket()

--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -1,8 +1,11 @@
 # Note: asyncio is only compatible with Python 3
 
 import asyncio
+import time
+
 import ray
 from ray.experimental.async_plasma import PlasmaProtocol, PlasmaEventHandler
+from ray.services import logger
 
 handler = None
 transport = None
@@ -19,7 +22,7 @@ async def _async_init():
         handler = PlasmaEventHandler(loop, worker)
         transport, protocol = await loop.create_connection(
             lambda: PlasmaProtocol(worker.plasma_client, handler), sock=rsock)
-
+        logger.debug("AsyncPlasma Connection Created!")
 
 def init():
     """
@@ -29,9 +32,7 @@ def init():
 
     loop = asyncio.get_event_loop()
     if loop.is_running():
-        raise Exception("You must initialize the Ray async API by calling "
-                        "async_api.init() or async_api.as_future(obj) before "
-                        "the event loop starts.")
+        asyncio.ensure_future(_async_init())
     else:
         asyncio.get_event_loop().run_until_complete(_async_init())
 

--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -12,7 +12,6 @@ protocol = None
 async def _async_init():
     global handler, transport, protocol
     if handler is None:
-        assert ray.is_initialized(), "Please call ray.init before async_api.init"
         worker = ray.worker.global_worker
         loop = asyncio.get_event_loop()
         worker.plasma_client.subscribe()
@@ -26,6 +25,8 @@ def init():
     """
     Initialize synchronously.
     """
+    assert ray.is_initialized(), "Please call ray.init before async_api.init"
+
     loop = asyncio.get_event_loop()
     if loop.is_running():
         raise Exception("You must initialize the Ray async API by calling "


### PR DESCRIPTION
Two changes were made:

- Make sure ray cluster is initialized before calling init()
- If the loop is already running `_async_init` is scheduled to run in current loop. 

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
