### PR TITLE
Fix bug in passing large arguments to tasks.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -96,7 +96,7 @@ def compute_task_id(ObjectID object_id):
     return TaskID(object_id.native().TaskId().Binary())
 
 
-cdef c_bool is_simple_value(value, int *num_elements_contained):
+cdef c_bool is_simple_value(value, int64_t *num_elements_contained):
     num_elements_contained[0] += 1
 
     if num_elements_contained[0] >= RayConfig.instance().num_elements_limit():
@@ -170,7 +170,7 @@ def check_simple_value(value):
         True if the value should be send by value, False otherwise.
     """
 
-    cdef int num_elements_contained = 0
+    cdef int64_t num_elements_contained = 0
     return is_simple_value(value, &num_elements_contained)
 
 


### PR DESCRIPTION
The issue was brought up in https://stackoverflow.com/questions/57194396/exception-ignored-in-ray-raylet-is-simple-value-overflowerror-value-too-larg.

The following fails before this fix.

```python
import numpy as np
import ray

ray.init(object_store_memory=10**10)

@ray.remote
def f(x):
    pass

f.remote(np.zeros(10**9))
```

It fails with

```
OverflowError                             Traceback (most recent call last)
OverflowError: value too large to convert to int
Exception ignored in: 'ray._raylet.is_simple_value'
OverflowError: value too large to convert to int
```