### PR TITLE
Rename `GetNextTaskIndex` to `NextAndGetTaskIndex` in core worker

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/WorkerContext.java
@@ -73,14 +73,14 @@ public class WorkerContext {
    * Increment the put index and return the new value.
    */
   public int nextPutIndex() {
-    return nativeGetNextPutIndex(nativeWorkerContextPointer);
+    return nativeNextAndGetPutIndex(nativeWorkerContextPointer);
   }
 
   /**
    * Increment the task index and return the new value.
    */
   public int nextTaskIndex() {
-    return nativeGetNextTaskIndex(nativeWorkerContextPointer);
+    return nativeNextAndGetTaskIndex(nativeWorkerContextPointer);
   }
 
   /**
@@ -131,9 +131,9 @@ public class WorkerContext {
 
   private static native byte[] nativeGetCurrentWorkerId(long nativeWorkerContextPointer);
 
-  private static native int nativeGetNextTaskIndex(long nativeWorkerContextPointer);
+  private static native int nativeNextAndGetTaskIndex(long nativeWorkerContextPointer);
 
-  private static native int nativeGetNextPutIndex(long nativeWorkerContextPointer);
+  private static native int nativeNextAndGetPutIndex(long nativeWorkerContextPointer);
 
   private static native void nativeDestroy(long nativeWorkerContextPointer);
 }

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -8,9 +8,13 @@ struct WorkerThreadContext {
   WorkerThreadContext()
       : current_task_id_(TaskID::FromRandom()), task_index_(0), put_index_(0) {}
 
-  int GetNextTaskIndex() { return ++task_index_; }
+  int GetNextTaskIndex() const { return 1 + task_index_; }
 
-  int GetNextPutIndex() { return ++put_index_; }
+  int NextAndGetTaskIndex() const { return ++task_index_; }
+
+  int GetNextPutIndex() const { return 1 + put_index_; }
+
+  int NextAndGetTaskIndex() const { return ++put_index_; }
 
   const TaskID &GetCurrentTaskID() const { return current_task_id_; }
 
@@ -62,9 +66,13 @@ const WorkerType WorkerContext::GetWorkerType() const { return worker_type_; }
 
 const WorkerID &WorkerContext::GetWorkerID() const { return worker_id_; }
 
-int WorkerContext::GetNextTaskIndex() { return GetThreadContext().GetNextTaskIndex(); }
+int WorkerContext::GetNextTaskIndex() const { return GetThreadContext().GetNextTaskIndex(); }
 
-int WorkerContext::GetNextPutIndex() { return GetThreadContext().GetNextPutIndex(); }
+int NextAndGetTaskIndex() { return GetThreadContext().NextAndGetTaskIndex(); }
+
+int WorkerContext::GetNextPutIndex() const { return GetThreadContext().GetNextPutIndex(); }
+
+int NextAndGetPutIndex() { return GetThreadContext().NextAndGetPutIndex(); }
 
 const JobID &WorkerContext::GetCurrentJobID() const { return current_job_id_; }
 

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -24,9 +24,18 @@ class WorkerContext {
 
   std::shared_ptr<const TaskSpecification> GetCurrentTask() const;
 
-  int GetNextTaskIndex();
+  /// \return The next index of the task which will be submitted by current task.
+  /// It also means the number of tasks submitted by current task in this context.
+  int GetNextTaskIndex() const;
 
-  int GetNextPutIndex();
+  /// Increase the task index and then return the result.
+  int NextAndGetTaskIndex();
+
+  /// \return The number of objects putted by current task in this context.
+  int GetNextPutIndex() const;
+
+  /// Increase the put index and then return the result.
+  int NextAndGetPutIndex();
 
  private:
   /// Type of the worker.

--- a/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.cc
@@ -101,22 +101,22 @@ JNIEXPORT jbyteArray JNICALL Java_org_ray_runtime_WorkerContext_nativeGetCurrent
 
 /*
  * Class:     org_ray_runtime_WorkerContext
- * Method:    nativeGetNextTaskIndex
+ * Method:    nativeNextAndGetTaskIndex
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeGetNextTaskIndex(
+JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeNextAndGetTaskIndex(
     JNIEnv *env, jclass, jlong nativeWorkerContextFromPointer) {
-  return GetWorkerContextFromPointer(nativeWorkerContextFromPointer)->GetNextTaskIndex();
+  return GetWorkerContextFromPointer(nativeWorkerContextFromPointer)->NextAndGetTaskIndex();
 }
 
 /*
  * Class:     org_ray_runtime_WorkerContext
- * Method:    nativeGetNextPutIndex
+ * Method:    nativeNextAndPutIndex
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeGetNextPutIndex(
+JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeNextAndPutIndex(
     JNIEnv *env, jclass, jlong nativeWorkerContextFromPointer) {
-  return GetWorkerContextFromPointer(nativeWorkerContextFromPointer)->GetNextPutIndex();
+  return GetWorkerContextFromPointer(nativeWorkerContextFromPointer)->NextAndPutIndex();
 }
 
 /*

--- a/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.h
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.h
@@ -57,19 +57,19 @@ Java_org_ray_runtime_WorkerContext_nativeGetCurrentWorkerId(JNIEnv *, jclass, jl
 
 /*
  * Class:     org_ray_runtime_WorkerContext
- * Method:    nativeGetNextTaskIndex
+ * Method:    nativeNextAndGetTaskIndex
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeGetNextTaskIndex(JNIEnv *,
-                                                                                 jclass,
-                                                                                 jlong);
+JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeNextAndGetTaskIndex(JNIEnv *,
+                                                                                    jclass,
+                                                                                    jlong);
 
 /*
  * Class:     org_ray_runtime_WorkerContext
- * Method:    nativeGetNextPutIndex
+ * Method:    nativeNextAndPutIndex
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeGetNextPutIndex(JNIEnv *,
+JNIEXPORT jint JNICALL Java_org_ray_runtime_WorkerContext_nativeNextAndPutIndex(JNIEnv *,
                                                                                 jclass,
                                                                                 jlong);
 

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -17,7 +17,7 @@ CoreWorkerObjectInterface::CoreWorkerObjectInterface(
 
 Status CoreWorkerObjectInterface::Put(const RayObject &object, ObjectID *object_id) {
   ObjectID put_id = ObjectID::ForPut(worker_context_.GetCurrentTaskID(),
-                                     worker_context_.GetNextPutIndex());
+                                     worker_context_.NextAndGetPutIndex());
   *object_id = put_id;
   return Put(object, put_id);
 }

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -114,7 +114,7 @@ void CoreWorkerTaskInterface::BuildCommonTaskSpec(
     const std::unordered_map<std::string, double> &required_resources,
     const std::unordered_map<std::string, double> &required_placement_resources,
     std::vector<ObjectID> *return_ids) {
-  auto next_task_index = worker_context_.GetNextTaskIndex();
+  auto next_task_index = worker_context_.NextAndGetTaskIndex();
   // Build common task spec.
   builder.SetCommonTaskSpec(
       function.language, function.function_descriptor, worker_context_.GetCurrentJobID(),

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -584,24 +584,28 @@ TEST_F(ZeroNodeTest, TestWorkerContext) {
 
   WorkerContext context(WorkerType::WORKER, job_id);
   ASSERT_TRUE(context.GetCurrentTaskID().IsNil());
+  ASSERT_EQ(context.NextAndGetTaskIndex(), 1);
   ASSERT_EQ(context.GetNextTaskIndex(), 1);
+  ASSERT_EQ(context.NextAndGetTaskIndex(), 2);
   ASSERT_EQ(context.GetNextTaskIndex(), 2);
+  ASSERT_EQ(context.NextAndGetPutIndex(), 1);
   ASSERT_EQ(context.GetNextPutIndex(), 1);
+  ASSERT_EQ(context.NextAndGetPutIndex(), 2);
   ASSERT_EQ(context.GetNextPutIndex(), 2);
 
   auto thread_func = [&context]() {
     // Verify that task_index, put_index are thread-local.
     ASSERT_TRUE(!context.GetCurrentTaskID().IsNil());
-    ASSERT_EQ(context.GetNextTaskIndex(), 1);
-    ASSERT_EQ(context.GetNextPutIndex(), 1);
+    ASSERT_EQ(context.NextAndGetPutIndex(), 1);
+    ASSERT_EQ(context.NextAndGetPutIndex(), 1);
   };
 
   std::thread async_thread(thread_func);
   async_thread.join();
 
   // Verify that these fields are thread-local.
-  ASSERT_EQ(context.GetNextTaskIndex(), 3);
-  ASSERT_EQ(context.GetNextPutIndex(), 3);
+  ASSERT_EQ(context.NextAndGetPutIndex(), 3);
+  ASSERT_EQ(context.NextAndGetPutIndex(), 3);
 }
 
 TEST_F(ZeroNodeTest, TestActorHandle) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
In core worker context, `GetNextTaskIndex()` method increases the `task_index_`. I'd like to change the behavior to `Not do increase, and just return the value` to resolve the issue when we need only get the task_index somewhere, like https://github.com/ray-project/ray/pull/5286.

In this PR,
`GetNextTaskIndex()` is declared as `const`, and add another method `NextAndGetTaskIndex()` to increase the value.

`put_index` is the similar.


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
