### PR TITLE
`ray stop` sends `SIGKILL` instead of `SIGTERM`

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -397,8 +397,8 @@ def stop():
     ]
 
     for process in processes_to_kill:
-        command = ("kill -9 $(ps aux | grep '" + process + "' | grep -v grep | " +
-                   "awk '{ print $2 }') 2> /dev/null")
+        command = ("kill -9 $(ps aux | grep '" + process +
+                   "' | grep -v grep | " + "awk '{ print $2 }') 2> /dev/null")
         subprocess.call([command], shell=True)
 
     # Find the PID of the jupyter process and kill it.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -397,7 +397,7 @@ def stop():
     ]
 
     for process in processes_to_kill:
-        command = ("kill $(ps aux | grep '" + process + "' | grep -v grep | " +
+        command = ("kill -9 $(ps aux | grep '" + process + "' | grep -v grep | " +
                    "awk '{ print $2 }') 2> /dev/null")
         subprocess.call([command], shell=True)
 


### PR DESCRIPTION
Should fix #5337 

The issue is that `ray stop` does not properly shutdown the ray services. The makes `ray up --restart-only` fail as both instances of ray services are live and talking to gcs on the same port. 

gRPC somehow does not shutdown properly when responding to SIGTERM.