### PR TITLE
scripts/format.sh: Check upstream with `git remote`

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -17,8 +17,8 @@ builtin cd "$(dirname "${BASH_SOURCE:-$0}")"
 ROOT="$(git rev-parse --show-toplevel)"
 builtin cd "$ROOT" || exit 1
 
-# Add the upstream branch if it doesn't exist
-if ! [[ -e "$ROOT/.git/refs/remotes/upstream" ]]; then
+# Add the upstream remote if it doesn't exist
+if ! git remote -v | grep -q upstream; then
     git remote add 'upstream' 'https://github.com/ray-project/ray.git'
 fi
 


### PR DESCRIPTION
The previous approach check `.git` directory. However, in the case of `git work-tree`, the `.git` is a file that points to the real git repo location. So `ls $ROOT/.git` no longer works. 

