### PR TITLE
optimization about constructor of TaskSpecification/MessageWrapper/ResourceSet

### DIFF
--- a/python/ray/includes/task.pxd
+++ b/python/ray/includes/task.pxd
@@ -37,7 +37,7 @@ cdef extern from "ray/protobuf/gcs.pb.h" namespace "ray::rpc" nogil:
 
 cdef extern from "ray/common/task/task_spec.h" namespace "ray" nogil:
     cdef cppclass CTaskSpec "ray::TaskSpecification":
-        CTaskSpec(const RpcTaskSpec message)
+        CTaskSpec(const RpcTaskSpec &message)
         CTaskSpec(const c_string &serialized_binary)
         const RpcTaskSpec &GetMessage()
         c_string Serialize() const

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -19,7 +19,14 @@ class MessageWrapper {
   /// The input message will be **copied** into this object.
   ///
   /// \param message The protobuf message.
-  explicit MessageWrapper(const Message message)
+  explicit MessageWrapper(const Message &message)
+      : message_(std::make_shared<Message>(message)) {}
+
+  /// Construct from a protobuf message object.
+  /// The input message will be **moved** into this object.
+  ///
+  /// \param message The protobuf message.
+  explicit MessageWrapper(Message &&message)
       : message_(std::make_shared<Message>(std::move(message))) {}
 
   /// Construct from a protobuf message shared_ptr.

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -90,7 +90,7 @@ ResourceSet::ResourceSet(const std::unordered_map<std::string, double> &resource
 }
 
 ResourceSet::ResourceSet(const std::vector<std::string> &resource_labels,
-                         const std::vector<double> resource_capacity) {
+                         const std::vector<double> &resource_capacity) {
   RAY_CHECK(resource_labels.size() == resource_capacity.size());
   for (uint i = 0; i < resource_labels.size(); i++) {
     RAY_CHECK(resource_capacity[i] > 0);

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -77,7 +77,7 @@ class ResourceSet {
   /// \brief Constructs ResourceSet from two equal-length vectors with label and capacity
   /// specification.
   ResourceSet(const std::vector<std::string> &resource_labels,
-              const std::vector<double> resource_capacity);
+              const std::vector<double> &resource_capacity);
 
   /// \brief Empty ResourceSet destructor.
   ~ResourceSet();

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -27,7 +27,16 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// The input message will be **copied** into this object.
   ///
   /// \param message The protobuf message.
-  explicit TaskSpecification(rpc::TaskSpec message) : MessageWrapper(message) {
+  explicit TaskSpecification(const rpc::TaskSpec &message) : MessageWrapper(message) {
+    ComputeResources();
+  }
+
+  /// Construct from a protobuf message object.
+  /// The input message will be **moved** into this object.
+  ///
+  /// \param message The protobuf message.
+  explicit TaskSpecification(rpc::TaskSpec &&message)
+      : MessageWrapper(std::move(message)) {
     ComputeResources();
   }
 

--- a/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_WorkerContext.cc
@@ -50,7 +50,7 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_WorkerContext_nativeSetCurrentTask(
   task_spec_message.ParseFromArray(data, size);
   env->ReleaseByteArrayElements(taskSpec, data, JNI_ABORT);
 
-  ray::TaskSpecification spec(task_spec_message);
+  ray::TaskSpecification spec(std::move(task_spec_message));
   GetWorkerContextFromPointer(nativeWorkerContextFromPointer)->SetCurrentTask(spec);
 }
 

--- a/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
+++ b/src/ray/raylet/lib/java/org_ray_runtime_raylet_RayletClientImpl.cc
@@ -47,7 +47,7 @@ JNIEXPORT void JNICALL Java_org_ray_runtime_raylet_RayletClientImpl_nativeSubmit
   task_spec_message.ParseFromArray(data, size);
   env->ReleaseByteArrayElements(taskSpec, data, JNI_ABORT);
 
-  ray::TaskSpecification task_spec(task_spec_message);
+  ray::TaskSpecification task_spec(std::move(task_spec_message));
   auto status = raylet_client->SubmitTask(task_spec);
   THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, (void)0);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
optimization about constructor of MessageWrapper and ResourceSet
- The original usage of `MessageWrapper(const Message message)` inside `grpc_util.h` causes the `message` be copied twice as moving a `const Message` eventually calls the copy constructor
- The constructor of `ResourceSet` use `const std::vector<double> resource_capacity` as the input, which will lead to the  `resource_capacity` be copied twice too.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
