### PR TITLE
optimize BaseID::FromBinary and BaseID::hex

### DIFF
--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -100,7 +100,7 @@ inline std::vector<ID> IdVectorFromProtobuf(
   auto str_vec = VectorFromProtobuf(pb_repeated);
   std::vector<ID> ret;
   std::transform(str_vec.begin(), str_vec.end(), std::back_inserter(ret),
-                 &ID::FromBinary);
+                 static_cast<ID (*)(const std::string &)>(&ID::FromBinary));
   return ret;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
- Add `BaseID::FromBinary` to construct ID from raw data pointer and size, which reduces the number of memory copies in some case.
- Optimize `BaseID::hex` implementation (about 1.6 to 1.7 times performance improvement)


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
