### PR TITLE
make ActorStateAccessor thread safe

### DIFF
--- a/src/ray/gcs/actor_state_accessor.h
+++ b/src/ray/gcs/actor_state_accessor.h
@@ -28,7 +28,7 @@ class ActorStateAccessor {
   /// \param actor_id The ID of actor to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  /// TODO(micafan) Only need the latest data.So replace
+  /// TODO(micafan) Only need the latest data. So replace
   /// MultiItemCallback with OptionalItemCallback in next PR.
   Status AsyncGet(const ActorID &actor_id,
                   const MultiItemCallback<ActorTableData> &callback);

--- a/src/ray/gcs/actor_state_accessor.h
+++ b/src/ray/gcs/actor_state_accessor.h
@@ -1,6 +1,8 @@
 #ifndef RAY_GCS_ACTOR_STATE_ACCESSOR_H
 #define RAY_GCS_ACTOR_STATE_ACCESSOR_H
 
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
 #include "ray/common/id.h"
 #include "ray/gcs/callback.h"
 #include "ray/gcs/tables.h"
@@ -17,7 +19,7 @@ class RedisGcsClient;
 /// determined at submission time, and mutable fields which are determined at runtime).
 class ActorStateAccessor {
  public:
-  explicit ActorStateAccessor(RedisGcsClient &client_impl);
+  ActorStateAccessor(RedisGcsClient &client_impl, boost::asio::io_service &io_service);
 
   ~ActorStateAccessor() {}
 
@@ -26,6 +28,8 @@ class ActorStateAccessor {
   /// \param actor_id The ID of actor to look up in the GCS.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
+  /// TODO(micafan) Only need the latest data.So replace
+  /// MultiItemCallback with OptionalItemCallback in next PR.
   Status AsyncGet(const ActorID &actor_id,
                   const MultiItemCallback<ActorTableData> &callback);
 
@@ -61,7 +65,49 @@ class ActorStateAccessor {
                         const StatusCallback &done);
 
  private:
+  /// Get actor specification from GCS asynchronously.
+  ///
+  /// \param actor_id The ID of actor to look up in the GCS.
+  /// \param callback Callback that will be called after lookup finishes.
+  void DoAsyncGet(const ActorID &actor_id,
+                  const MultiItemCallback<ActorTableData> &callback);
+
+  /// Register an actor to GCS asynchronously.
+  ///
+  /// \param data_ptr The actor that will be registered to the GCS.
+  /// \param callback Callback that will be called after actor has been registered
+  /// to the GCS.
+  void DoAsyncRegister(const std::shared_ptr<ActorTableData> &data_ptr,
+                       const StatusCallback &callback);
+
+  /// Update dynamic states of actor in GCS asynchronously.
+  ///
+  /// \param actor_id ID of the actor to update.
+  /// \param data_ptr Data of the actor to update.
+  /// \param callback Callback that will be called after update finishes.
+  /// TODO(micafan) Don't expose the whole `ActorTableData` and only allow
+  /// updating dynamic states.
+  void DoAsyncUpdate(const ActorID &actor_id,
+                     const std::shared_ptr<ActorTableData> &data_ptr,
+                     const StatusCallback &callback);
+
+  /// Subscribe to any register operations of actors.
+  ///
+  /// \param subscribe Callback that will be called each time when an actor is registered
+  /// or updated.
+  /// \param done Callback that will be called when subscription is complete and we
+  /// are ready to receive notification.
+  /// \return Status
+  void DoAsyncSubscribe(const SubscribeCallback<ActorID, ActorTableData> &subscribe,
+                        const StatusCallback &done);
+
   RedisGcsClient &client_impl_;
+
+  // RedisContext and hiredis are not thread safe. Need to send the request
+  // to the background thread. Otherwise, an exception will be triggered
+  // in the case of multithreading (e.g.: core worker is multi-threaded).
+  // TODO(micafan): Remove io_service_ once GCS becomes a service.
+  boost::asio::io_service &io_service_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/actor_state_accessor_test.cc
+++ b/src/ray/gcs/actor_state_accessor_test.cc
@@ -43,7 +43,7 @@ class ActorStateAccessorTest : public ::testing::Test {
   void GenTestData() { GenActorData(); }
 
   void GenActorData() {
-    for (size_t i = 0; i < 2; ++i) {
+    for (size_t i = 0; i < 100; ++i) {
       std::shared_ptr<ActorTableData> actor = std::make_shared<ActorTableData>();
       ActorID actor_id = ActorID::FromRandom();
       actor->set_actor_id(actor_id.Binary());

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -135,7 +135,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   actor_checkpoint_id_table_.reset(new ActorCheckpointIdTable(shard_contexts_, this));
   resource_table_.reset(new DynamicResourceTable({primary_context_}, this));
 
-  actor_accessor_.reset(new ActorStateAccessor(*this));
+  actor_accessor_.reset(new ActorStateAccessor(*this, io_service));
 
   Status status = Attach(io_service);
   is_connected_ = status.ok();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -171,8 +171,14 @@ ray::Status NodeManager::RegisterGcs() {
     HandleActorStateTransition(actor_id, ActorRegistration(data));
   };
 
-  RAY_RETURN_NOT_OK(
-      gcs_client_->Actors().AsyncSubscribe(actor_notification_callback, nullptr));
+  auto subscribe_actor_callback = [](Status status) {
+    if (!status.ok()) {
+      RAY_LOG(FATAL) << "Failed to subscribe actors, status " << status;
+    }
+  };
+
+  RAY_RETURN_NOT_OK(gcs_client_->Actors().AsyncSubscribe(actor_notification_callback,
+                                                         subscribe_actor_callback));
 
   // Register a callback on the client table for new clients.
   auto node_manager_client_added = [this](gcs::RedisGcsClient *client, const UniqueID &id,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

hiredis is not thread-safe, that makes gcs's Interface include ActorStateAccessor is not thread safe. 

To fix this (for core worker), this PR make ActorStateAccessor thread safe by dispatch all actor request to gcs's backend thread.

(Another solution is lock RedisContext and RedisAsioClient to avoid writing conflicts, but it's not easy).

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
