### PR TITLE
[rllib] Fix output API when lz4 not installed

### DIFF
--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -19,7 +19,7 @@ from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.offline.io_context import IOContext
 from ray.rllib.offline.output_writer import OutputWriter
 from ray.rllib.utils.annotations import override, PublicAPI
-from ray.rllib.utils.compression import pack
+from ray.rllib.utils.compression import pack, compression_supported
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class JsonWriter(OutputWriter):
 
 
 def _to_jsonable(v, compress):
-    if compress:
+    if compress and compression_supported():
         return str(pack(v))
     elif isinstance(v, np.ndarray):
         return v.tolist()

--- a/rllib/utils/compression.py
+++ b/rllib/utils/compression.py
@@ -24,6 +24,11 @@ except ImportError:
 
 
 @DeveloperAPI
+def compression_supported():
+    return LZ4_ENABLED
+
+
+@DeveloperAPI
 def pack(data):
     if LZ4_ENABLED:
         data = pyarrow.serialize(data).to_buffer().to_pybytes()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

The problem is that if lz4 was not enabled, the array gets encoded as .__str__().

## Related issue number

Closes https://github.com/ray-project/ray/issues/5398

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
