### PR TITLE
[tune] Add a first implementation of reset_logger for PBT

### DIFF
--- a/python/ray/tune/examples/pbt_tf2.py
+++ b/python/ray/tune/examples/pbt_tf2.py
@@ -1,0 +1,190 @@
+import os
+import random
+import tensorflow as tf
+import ray
+
+from ray.tune import schedulers
+from ray.tune import Trainable
+from ray import tune
+from ray.tune.logger import Logger
+from ray.tune.result import TRAINING_ITERATION, TIME_TOTAL_S, TIMESTEPS_TOTAL
+
+ray.init(local_mode=False)
+
+config = {
+    'seed': 1,
+    'verbose': False,
+    'model': {
+        'h_size': 256,
+        'nb_h_layer': 3,
+        'activation': 'leakyrelu',
+    },
+    'training': {
+        'batch_size': 64,
+        'lr': tune.sample_from(lambda spec: random.uniform(5e-4, 5e-2)),
+        'optimizer': 'adam',
+        'reg_param': tune.sample_from(lambda spec: random.uniform(1e-2, 5e1)),
+    },
+    'eval': {
+        'batch_size': 256,
+    },
+    'tune': {
+        'resources_per_trial': {
+            'cpu': 1,
+            'gpu': 0,
+        },
+        "stop": {
+            TRAINING_ITERATION: 32,
+        },
+        'local_dir': os.path.dirname(os.path.realpath(__file__)) + '/pbt',
+        'num_samples': 16,
+        'checkpoint_freq': 0,
+        'checkpoint_at_end': True,
+        'verbose': 1,
+    },
+}
+
+tune_scheduler_config = {
+    'time_attr': TRAINING_ITERATION,
+    'metric': 'loss',
+    'mode': 'min',
+    'perturbation_interval': 4,
+    'quantile_fraction': .5,
+    'resample_probability': .25,  # par param: 25% new, 75% (50% *1.2, 50% *.8)
+    'hyperparam_mutations': {
+        'training': {
+            'lr': lambda: random.uniform(5e-4, 1e-1),
+            'reg_param': lambda: random.uniform(1e-2, 5e1),
+        }
+    }
+}
+
+
+class PBTTrain(Trainable):
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    def _setup(self, config):
+        self.model = tf.keras.models.Sequential([
+            tf.keras.layers.Dense(
+                16, batch_input_shape=[256, 1], activation='relu'),
+            tf.keras.layers.Dense(16, activation='tanh'),
+            tf.keras.layers.Dense(1),
+        ])
+
+        self.lr = tf.Variable(config['training']['lr'])
+        self.reg_param = tf.Variable(config['training']['reg_param'])
+        self.optim = tf.keras.optimizers.SGD(self.lr)
+
+        self.ckpt = tf.train.Checkpoint(
+            model=self.model,
+            lr=self.lr,
+            reg_param=self.reg_param,
+        )
+
+        self.new_config = None
+
+    def _train(self):
+        for i in range(100):
+            input = tf.random.normal([256, 1])
+            y_true = input**2
+
+            with tf.GradientTape() as tape:
+                output = self.model(input)
+                reg = 0.
+                for w in self.model.trainable_weights:
+                    reg += tf.reduce_mean(w)
+                reg /= len(self.model.trainable_weights)
+                loss = tf.reduce_mean(
+                    tf.square(output - y_true)) + self.reg_param * reg
+
+            grads = tape.gradient(loss, self.model.trainable_weights)
+            self.optim.apply_gradients(
+                zip(grads, self.model.trainable_weights))
+
+        # Eval
+        loss = 0.
+        for i in range(100):
+            input = tf.random.normal([256, 1])
+            y_true = input**2
+
+            output = self.model(input)
+
+            loss += tf.reduce_mean(tf.square(output - y_true))
+        loss /= 10
+
+        tune_dict = {
+            'loss': loss.numpy(),
+            'lr': self.lr.numpy(),
+            'reg_param': self.reg_param.numpy(),
+        }
+
+        return tune_dict
+
+    def _save(self, checkpoint_dir):
+        save_path_prefix = self.ckpt.write(
+            os.path.join(checkpoint_dir, 'ckpt'))
+
+        # This is needed to comply with tune framework
+        open(save_path_prefix, 'a').close()
+
+        return save_path_prefix
+
+    def _restore(self, save_path_prefix):
+        self.ckpt.restore(save_path_prefix)
+
+        if self.new_config is not None:
+            for key, val in self.new_config.items():
+                self[key].assign(val)
+
+            self.new_config = None
+
+        return
+
+    def reset_config(self, new_config):
+        self.new_config = {
+            'lr': new_config['training']['lr'],
+            'reg_param': new_config['training']['reg_param'],
+        }
+
+        return True
+
+
+class TF2Logger(Logger):
+    def _init(self):
+        self._file_writer = tf.summary.create_file_writer(self.logdir)
+
+    def on_result(self, result):
+        with tf.device('/CPU:0'):
+            with self._file_writer.as_default():
+                step = result.get(
+                    TIMESTEPS_TOTAL) or result[TRAINING_ITERATION]
+
+                tmp = result.copy()
+                for k in [
+                        "config", "pid", "timestamp", TIME_TOTAL_S,
+                        TRAINING_ITERATION
+                ]:
+                    if k in tmp:
+                        del tmp[k]  # not useful to log these
+
+                for attr, value in tmp.items():
+                    if type(value) in [int, float]:
+                        tf.summary.scalar(attr, value, step=step)
+        self._file_writer.flush()
+
+    def flush(self):
+        self._file_writer.flush()
+
+    def close(self):
+        self._file_writer.close()
+
+
+scheduler = schedulers.PopulationBasedTraining(**tune_scheduler_config)
+
+trial_list = tune.run(
+    PBTTrain,
+    config=config,
+    scheduler=scheduler,
+    loggers=[TF2Logger],
+    **config['tune'])

--- a/python/ray/tune/examples/pbt_tf2.py
+++ b/python/ray/tune/examples/pbt_tf2.py
@@ -127,10 +127,10 @@ if __name__ == "__main__":
                 'gpu': 0,
             },
             "stop": {
-                TRAINING_ITERATION: 50,
+                TRAINING_ITERATION: 25,
             },
             'local_dir': os.path.dirname(os.path.realpath(__file__)) + '/pbt',
-            'num_samples': 16,
+            'num_samples': 8,
             'checkpoint_freq': 0,
             'checkpoint_at_end': True,
             'verbose': 1,
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         'time_attr': TRAINING_ITERATION,
         'metric': 'loss',
         'mode': 'min',
-        'perturbation_interval': 10,
+        'perturbation_interval': 5,
         'quantile_fraction': .5,
         'resample_probability': .25,  # par param: 25% new, 75% (50% *1.2, 50% *.8)
         'hyperparam_mutations': {

--- a/python/ray/tune/examples/pbt_tf2.py
+++ b/python/ray/tune/examples/pbt_tf2.py
@@ -1,7 +1,7 @@
 import os
 import random
-import tensorflow as tf
 import ray
+import numpy as np
 
 from ray.tune import schedulers
 from ray.tune import Trainable
@@ -9,74 +9,26 @@ from ray import tune
 from ray.tune.logger import Logger
 from ray.tune.result import TRAINING_ITERATION, TIME_TOTAL_S, TIMESTEPS_TOTAL
 
-ray.init(local_mode=False)
-
-config = {
-    'seed': 1,
-    'verbose': False,
-    'model': {
-        'h_size': 256,
-        'nb_h_layer': 3,
-        'activation': 'leakyrelu',
-    },
-    'training': {
-        'batch_size': 64,
-        'lr': tune.sample_from(lambda spec: random.uniform(5e-4, 5e-2)),
-        'optimizer': 'adam',
-        'reg_param': tune.sample_from(lambda spec: random.uniform(1e-2, 5e1)),
-    },
-    'eval': {
-        'batch_size': 256,
-    },
-    'tune': {
-        'resources_per_trial': {
-            'cpu': 1,
-            'gpu': 0,
-        },
-        "stop": {
-            TRAINING_ITERATION: 32,
-        },
-        'local_dir': os.path.dirname(os.path.realpath(__file__)) + '/pbt',
-        'num_samples': 16,
-        'checkpoint_freq': 0,
-        'checkpoint_at_end': True,
-        'verbose': 1,
-    },
-}
-
-tune_scheduler_config = {
-    'time_attr': TRAINING_ITERATION,
-    'metric': 'loss',
-    'mode': 'min',
-    'perturbation_interval': 4,
-    'quantile_fraction': .5,
-    'resample_probability': .25,  # par param: 25% new, 75% (50% *1.2, 50% *.8)
-    'hyperparam_mutations': {
-        'training': {
-            'lr': lambda: random.uniform(5e-4, 1e-1),
-            'reg_param': lambda: random.uniform(1e-2, 5e1),
-        }
-    }
-}
-
 
 class PBTTrain(Trainable):
+    tf = __import__('tensorflow')
+
     def __getitem__(self, item):
         return getattr(self, item)
 
     def _setup(self, config):
-        self.model = tf.keras.models.Sequential([
-            tf.keras.layers.Dense(
+        self.model = self.tf.keras.models.Sequential([
+            self.tf.keras.layers.Dense(
                 16, batch_input_shape=[256, 1], activation='relu'),
-            tf.keras.layers.Dense(16, activation='tanh'),
-            tf.keras.layers.Dense(1),
+            self.tf.keras.layers.Dense(16, activation='tanh'),
+            self.tf.keras.layers.Dense(1),
         ])
 
-        self.lr = tf.Variable(config['training']['lr'])
-        self.reg_param = tf.Variable(config['training']['reg_param'])
-        self.optim = tf.keras.optimizers.SGD(self.lr)
+        self.lr = self.tf.Variable(config['training']['lr'])
+        self.reg_param = self.tf.Variable(config['training']['reg_param'])
+        self.optim = self.tf.keras.optimizers.SGD(self.lr)
 
-        self.ckpt = tf.train.Checkpoint(
+        self.ckpt = self.tf.train.Checkpoint(
             model=self.model,
             lr=self.lr,
             reg_param=self.reg_param,
@@ -86,17 +38,17 @@ class PBTTrain(Trainable):
 
     def _train(self):
         for i in range(100):
-            input = tf.random.normal([256, 1])
-            y_true = input**2
+            x = self.tf.random.normal([256, 1])
+            y_true = x**2
 
-            with tf.GradientTape() as tape:
-                output = self.model(input)
+            with self.tf.GradientTape() as tape:
+                output = self.model(x)
                 reg = 0.
                 for w in self.model.trainable_weights:
-                    reg += tf.reduce_mean(w)
+                    reg += self.tf.reduce_mean(w)
                 reg /= len(self.model.trainable_weights)
-                loss = tf.reduce_mean(
-                    tf.square(output - y_true)) + self.reg_param * reg
+                loss = self.tf.reduce_mean(
+                    self.tf.square(output - y_true)) + self.reg_param * reg
 
             grads = tape.gradient(loss, self.model.trainable_weights)
             self.optim.apply_gradients(
@@ -105,18 +57,20 @@ class PBTTrain(Trainable):
         # Eval
         loss = 0.
         for i in range(100):
-            input = tf.random.normal([256, 1])
-            y_true = input**2
+            x = self.tf.random.normal([256, 1])
+            y_true = x**2
 
-            output = self.model(input)
+            output = self.model(x)
 
-            loss += tf.reduce_mean(tf.square(output - y_true))
+            loss += self.tf.reduce_mean(self.tf.square(output - y_true))
         loss /= 10
 
+        loss_val = loss.numpy()
         tune_dict = {
-            'loss': loss.numpy(),
+            'loss': loss_val,
             'lr': self.lr.numpy(),
             'reg_param': self.reg_param.numpy(),
+            'done': np.isnan(loss_val)
         }
 
         return tune_dict
@@ -124,9 +78,6 @@ class PBTTrain(Trainable):
     def _save(self, checkpoint_dir):
         save_path_prefix = self.ckpt.write(
             os.path.join(checkpoint_dir, 'ckpt'))
-
-        # This is needed to comply with tune framework
-        open(save_path_prefix, 'a').close()
 
         return save_path_prefix
 
@@ -150,41 +101,61 @@ class PBTTrain(Trainable):
         return True
 
 
-class TF2Logger(Logger):
-    def _init(self):
-        self._file_writer = tf.summary.create_file_writer(self.logdir)
+if __name__ == "__main__":
+    ray.init(local_mode=False)
 
-    def on_result(self, result):
-        with tf.device('/CPU:0'):
-            with self._file_writer.as_default():
-                step = result.get(
-                    TIMESTEPS_TOTAL) or result[TRAINING_ITERATION]
+    config = {
+        'seed': 1,
+        'verbose': False,
+        'model': {
+            'h_size': 256,
+            'nb_h_layer': 3,
+            'activation': 'leakyrelu',
+        },
+        'training': {
+            'batch_size': 64,
+            'lr': tune.sample_from(lambda spec: random.uniform(5e-4, 5e-2)),
+            'optimizer': 'adam',
+            'reg_param': tune.sample_from(lambda spec: random.uniform(1e-2, 2e1)),
+        },
+        'eval': {
+            'batch_size': 256,
+        },
+        'tune': {
+            'resources_per_trial': {
+                'cpu': 1,
+                'gpu': 0,
+            },
+            "stop": {
+                TRAINING_ITERATION: 50,
+            },
+            'local_dir': os.path.dirname(os.path.realpath(__file__)) + '/pbt',
+            'num_samples': 16,
+            'checkpoint_freq': 0,
+            'checkpoint_at_end': True,
+            'verbose': 1,
+        },
+    }
 
-                tmp = result.copy()
-                for k in [
-                        "config", "pid", "timestamp", TIME_TOTAL_S,
-                        TRAINING_ITERATION
-                ]:
-                    if k in tmp:
-                        del tmp[k]  # not useful to log these
+    tune_scheduler_config = {
+        'time_attr': TRAINING_ITERATION,
+        'metric': 'loss',
+        'mode': 'min',
+        'perturbation_interval': 10,
+        'quantile_fraction': .5,
+        'resample_probability': .25,  # par param: 25% new, 75% (50% *1.2, 50% *.8)
+        'hyperparam_mutations': {
+            'training': {
+                'lr': lambda: random.uniform(5e-4, 1e-1),
+                'reg_param': lambda: random.uniform(1e-2, 5e1),
+            }
+        }
+    }
+    scheduler = schedulers.PopulationBasedTraining(**tune_scheduler_config)
 
-                for attr, value in tmp.items():
-                    if type(value) in [int, float]:
-                        tf.summary.scalar(attr, value, step=step)
-        self._file_writer.flush()
-
-    def flush(self):
-        self._file_writer.flush()
-
-    def close(self):
-        self._file_writer.close()
-
-
-scheduler = schedulers.PopulationBasedTraining(**tune_scheduler_config)
-
-trial_list = tune.run(
-    PBTTrain,
-    config=config,
-    scheduler=scheduler,
-    loggers=[TF2Logger],
-    **config['tune'])
+    trial_list = tune.run(
+        PBTTrain,
+        config=config,
+        scheduler=scheduler, 
+        **config['tune']
+    )

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -286,7 +286,6 @@ class RayTrialExecutor(TrialExecutor):
         trial.config = new_config
         if reset_logger is True:
             trial.reset_logger()
-            new_config['logdir'] = trial.logdir
 
         trainable = trial.runner
         with warn_if_slow("reset_config"):

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -265,7 +265,11 @@ class RayTrialExecutor(TrialExecutor):
             self._paused[trial_future[0]] = trial
         super(RayTrialExecutor, self).pause_trial(trial)
 
-    def reset_trial(self, trial, new_config, new_experiment_tag):
+    def reset_trial(self,
+                    trial,
+                    new_config,
+                    new_experiment_tag,
+                    reset_logger=False):
         """Tries to invoke `Trainable.reset_config()` to reset trial.
 
         Args:
@@ -280,6 +284,10 @@ class RayTrialExecutor(TrialExecutor):
         """
         trial.experiment_tag = new_experiment_tag
         trial.config = new_config
+        if reset_logger is True:
+            trial.reset_logger()
+            new_config['logdir'] = trial.logdir
+
         trainable = trial.runner
         with warn_if_slow("reset_config"):
             reset_val = ray.get(trainable.reset_config.remote(new_config))

--- a/python/ray/tune/schedulers/hb_bohb.py
+++ b/python/ray/tune/schedulers/hb_bohb.py
@@ -7,6 +7,7 @@ import logging
 from ray.tune.schedulers.trial_scheduler import TrialScheduler
 from ray.tune.schedulers.hyperband import HyperBandScheduler, Bracket
 from ray.tune.trial import Trial
+from ray.tune.util import flatten_dict
 
 logger = logging.getLogger(__name__)
 
@@ -74,14 +75,16 @@ class HyperBandForBOHB(HyperBandScheduler):
         The current running trial will not be handled,
         as the trialrunner will be given control to handle it."""
 
-        result["hyperband_info"] = {}
+        flat_result = flatten_dict(result)
+
+        flat_result["hyperband_info"] = {}
         bracket, _ = self._trial_info[trial]
-        bracket.update_trial_stats(trial, result)
+        bracket.update_trial_stats(trial, flat_result)
 
         if bracket.continue_trial(trial):
             return TrialScheduler.CONTINUE
 
-        result["hyperband_info"]["budget"] = bracket._cumul_r
+        flat_result["hyperband_info"]["budget"] = bracket._cumul_r
 
         # MAIN CHANGE HERE!
         statuses = [(t, t.status) for t in bracket._live_trials]

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -9,6 +9,7 @@ import logging
 from ray.tune.schedulers.trial_scheduler import FIFOScheduler, TrialScheduler
 from ray.tune.trial import Trial
 from ray.tune.error import TuneError
+from ray.tune.util import flatten_dict
 
 logger = logging.getLogger(__name__)
 
@@ -172,8 +173,9 @@ class HyperBandScheduler(FIFOScheduler):
         The current running trial will not be handled,
         as the trialrunner will be given control to handle it."""
 
+        flat_result = flatten_dict(result)
         bracket, _ = self._trial_info[trial]
-        bracket.update_trial_stats(trial, result)
+        bracket.update_trial_stats(trial, flat_result)
 
         if bracket.continue_trial(trial):
             return TrialScheduler.CONTINUE

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -315,13 +315,13 @@ class PopulationBasedTraining(FIFOScheduler):
 
         new_tag = make_experiment_tag(trial_state.orig_tag, new_config,
                                       self._hyperparam_mutations)
-        trial.reset_logger()
-        new_config["new_logdir"] = trial.logdir
+
         reset_successful = trial_executor.reset_trial(
             trial, new_config, new_tag, reset_logger=True)
         if reset_successful:
             trial_executor.restore(
                 trial, Checkpoint.from_object(new_state.last_checkpoint))
+            trial.result_logger.on_result(new_state.last_result)
         else:
             trial_executor.stop_trial(trial, stop_logger=False)
             trial.config = new_config

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -91,7 +91,7 @@ def make_experiment_tag(orig_tag, config, mutations):
     resolved_vars = {}
     for k in mutations.keys():
         resolved_vars[("config", k)] = config[k]
-    return "{}@perturbed[{}]".format(orig_tag, format_vars(resolved_vars))
+    return "{}@perturbed~{}".format(orig_tag, format_vars(resolved_vars))
 
 
 class PopulationBasedTraining(FIFOScheduler):

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -72,17 +72,7 @@ class Trainable(object):
         self.config = config or {}
         log_sys_usage = self.config.get("log_sys_usage", False)
 
-        if logger_creator:
-            self._result_logger = logger_creator(self.config)
-            self._logdir = self._result_logger.logdir
-        else:
-            logdir_prefix = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
-            if not os.path.exists(DEFAULT_RESULTS_DIR):
-                os.makedirs(DEFAULT_RESULTS_DIR)
-            self._logdir = tempfile.mkdtemp(
-                prefix=logdir_prefix, dir=DEFAULT_RESULTS_DIR)
-            self._result_logger = UnifiedLogger(
-                self.config, self._logdir, loggers=None)
+        self.create_logger(logger_creator)
 
         self._iteration = 0
         self._time_total = 0.0
@@ -131,6 +121,20 @@ class Trainable(object):
         logger.warning("Getting current IP.")
         self._local_ip = ray.services.get_node_ip_address()
         return self._local_ip
+
+    def create_logger(self, logger_creator):
+        if logger_creator:
+            self._result_logger = logger_creator(self.config)
+            self._logdir = self._result_logger.logdir
+        else:
+            logdir_prefix = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+            if not os.path.exists(DEFAULT_RESULTS_DIR):
+                os.makedirs(DEFAULT_RESULTS_DIR)
+            self._logdir = tempfile.mkdtemp(
+                prefix=logdir_prefix, dir=DEFAULT_RESULTS_DIR)
+            self._result_logger = UnifiedLogger(
+                self.config, self._logdir, loggers=None)
+        
 
     def train(self):
         """Runs one logical iteration of training.

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -261,6 +261,13 @@ class Trial(object):
         if self.result_logger:
             self.result_logger.sync_results_to_new_location(worker_ip)
 
+    def reset_logger(self):
+        """Reset logger"""
+
+        self.close_logger()
+        self.logdir = None
+        self.init_logger()
+
     def close_logger(self):
         """Close logger."""
 
@@ -387,7 +394,6 @@ class Trial(object):
             self.last_debug = time.time()
         self.last_result = result
         self.last_update_time = time.time()
-        self.result_logger.on_result(self.last_result)
 
     def compare_checkpoints(self, attr_mean):
         """Compares two checkpoints based on the attribute attr_mean param.

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -405,6 +405,7 @@ class Trial(object):
             self.last_debug = time.time()
         self.last_result = result
         self.last_update_time = time.time()
+        # self.result_logger.on_result(result)
 
     def compare_checkpoints(self, attr_mean):
         """Compares two checkpoints based on the attribute attr_mean param.

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -519,14 +519,14 @@ class TrialRunner(object):
             flat_result = flatten_dict(result)
             if trial.should_stop(flat_result):
                 # Hook into scheduler
-                self._scheduler_alg.on_trial_complete(self, trial, flat_result)
+                self._scheduler_alg.on_trial_complete(self, trial, result)
                 self._search_alg.on_trial_complete(
                     trial.trial_id, result=flat_result)
                 decision = TrialScheduler.STOP
             else:
                 with warn_if_slow("scheduler.on_trial_result"):
                     decision = self._scheduler_alg.on_trial_result(
-                        self, trial, flat_result, result)
+                        self, trial, result)
                 with warn_if_slow("search_alg.on_trial_result"):
                     self._search_alg.on_trial_result(trial.trial_id,
                                                      flat_result)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -516,6 +516,9 @@ class TrialRunner(object):
 
             self._total_time += result.get(TIME_THIS_ITER_S, 0)
 
+            if not is_duplicate:
+                trial.result_logger.on_result(result)
+
             flat_result = flatten_dict(result)
             if trial.should_stop(flat_result):
                 # Hook into scheduler

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -516,9 +516,6 @@ class TrialRunner(object):
 
             self._total_time += result.get(TIME_THIS_ITER_S, 0)
 
-            if not is_duplicate:
-                trial.result_logger.on_result(result)
-
             flat_result = flatten_dict(result)
             if trial.should_stop(flat_result):
                 # Hook into scheduler
@@ -529,7 +526,7 @@ class TrialRunner(object):
             else:
                 with warn_if_slow("scheduler.on_trial_result"):
                     decision = self._scheduler_alg.on_trial_result(
-                        self, trial, flat_result)
+                        self, trial, flat_result, result)
                 with warn_if_slow("search_alg.on_trial_result"):
                     self._search_alg.on_trial_result(trial.trial_id,
                                                      flat_result)


### PR DESCRIPTION
## What do these changes do?
Those changes are related to the discussion: #5312 
It implements a consistent way to create subfolders when using PBT and ensure a forward flow of metrics logged

## Related issue number

Closes #5312 

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
