### PR TITLE
Bug fix while determining ip address in reporter.py

### DIFF
--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -68,6 +68,8 @@ def determine_ip_address():
         ]
         return addrs[0]
     except IndexError: # no interface starting with "e"
+        logger.warning('IndexError from determine_ip_address: no IP address name starting with "e", \
+            using socket.gethostbyname(socket.gethostname()) instead!')
         return socket.gethostbyname(socket.gethostname())
 
 

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -9,6 +9,7 @@ import os
 import traceback
 import time
 import datetime
+import socket
 from socket import AddressFamily
 
 try:

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -67,7 +67,7 @@ def determine_ip_address():
             for x in v if x.family == AddressFamily.AF_INET
         ]
         return addrs[0]
-    except IndexError: # no interface starting with "e"
+    except IndexError:  # no interface starting with "e"
         logger.warning('IndexError from determine_ip_address: no IP address name starting with "e", \
             using socket.gethostbyname(socket.gethostname()) instead!')
         return socket.gethostbyname(socket.gethostname())

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -57,6 +57,7 @@ def running_worker(s):
 
     return True
 
+class DetermineIPAdressError(RuntimeError): pass
 
 def determine_ip_address():
     """Return the first IP address for an ethernet interface on the system."""
@@ -66,21 +67,15 @@ def determine_ip_address():
             for x in v if x.family == AddressFamily.AF_INET
         ]
         return addrs[0]
+    except IndexError: # no interface starting with "e"
+        addrs_kind = "ipogif0"
+        addrs = [
+            x.address for k, v in psutil.net_if_addrs().items() if k == addrs_kind
+                      for x in v if x.family == socket.AddressFamily.AF_INET
+        ]
+        return addrs[0]
     except IndexError:
-        import subprocess
-        p = subprocess.run(
-                '/sbin/ifconfig',
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                shell=True,
-                encoding='utf-8',
-                check=True,
-                )
-        stdout = p.stdout.strip()
-        lines = stdout.split('\n')
-        for i, line in enumerate(lines):
-            if 'ipogif0' in line:
-                return lines[i+1].split()[1].split(':')[1]
+        raise DetermineIPAddressError('Can\'t find any ip address starting by "e" or of kind "ipogif0"...')
 
 
 def to_posix_time(dt):

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -57,7 +57,7 @@ def running_worker(s):
 
     return True
 
-class DetermineIPAdressError(RuntimeError): pass
+class DetermineIPAddressError(RuntimeError): pass
 
 def determine_ip_address():
     """Return the first IP address for an ethernet interface on the system."""

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -78,7 +78,7 @@ def determine_ip_address():
                 )
         stdout = p.stdout.strip()
         lines = stdout.split('\n')
-        for i, line in enumerate(line):
+        for i, line in enumerate(lines):
             if 'ipogif0' in line:
                 return lines[i+1].split()[1].split(':')[1]
 

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -60,11 +60,27 @@ def running_worker(s):
 
 def determine_ip_address():
     """Return the first IP address for an ethernet interface on the system."""
-    addrs = [
-        x.address for k, v in psutil.net_if_addrs().items() if k[0] == "e"
-        for x in v if x.family == AddressFamily.AF_INET
-    ]
-    return addrs[0]
+    try:
+        addrs = [
+            x.address for k, v in psutil.net_if_addrs().items() if k[0] == "e"
+            for x in v if x.family == AddressFamily.AF_INET
+        ]
+        return addrs[0]
+    except IndexError:
+        import subprocess
+        p = subprocess.run(
+                '/sbin/ifconfig',
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+                encoding='utf-8',
+                check=True,
+                )
+        stdout = p.stdout.strip()
+        lines = stdout.split('\n')
+        for i, line in enumerate(line):
+            if 'ipogif0' in line:
+                return lines[i+1].split()[1].split(':')[1]
 
 
 def to_posix_time(dt):

--- a/python/ray/reporter.py
+++ b/python/ray/reporter.py
@@ -57,7 +57,6 @@ def running_worker(s):
 
     return True
 
-class DetermineIPAddressError(RuntimeError): pass
 
 def determine_ip_address():
     """Return the first IP address for an ethernet interface on the system."""
@@ -68,14 +67,7 @@ def determine_ip_address():
         ]
         return addrs[0]
     except IndexError: # no interface starting with "e"
-        addrs_kind = "ipogif0"
-        addrs = [
-            x.address for k, v in psutil.net_if_addrs().items() if k == addrs_kind
-                      for x in v if x.family == socket.AddressFamily.AF_INET
-        ]
-        return addrs[0]
-    except IndexError:
-        raise DetermineIPAddressError('Can\'t find any ip address starting by "e" or of kind "ipogif0"...')
+        return socket.gethostbyname(socket.gethostname())
 
 
 def to_posix_time(dt):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

These change are returning the ip address using the socket lib instead of looking at their names. On some system an IP address of kind Ethernet doesn't start by "e". This change should not change de previous behaviour which remains the default one.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
