### PR TITLE
[tune] Fix Travis Blocking

### DIFF
--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -150,10 +150,5 @@ class SerialTuneRelativeLocalDirTest(unittest.TestCase):
         self._restore(exp_name, local_dir, local_dir)
 
 
-class ParallelTuneRelativeLocalDirTest(SerialTuneRelativeLocalDirTest):
-    local_mode = False
-    prefix = "Parallel"
-
-
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
Travis tests block right now on `test_tune_save_restore`. This should
fix that.


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.