### PR TITLE
Support multiple store providers in ObjectInterface

### DIFF
--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -18,7 +18,7 @@ void ObjectIdsByStoreProvider(
     auto type = StoreProviderType::PLASMA;
     // For raylet transport we always use plasma store provider, for direct actor call
     // there are a few cases:
-    // - objects manually added to store by`ray.put`: for these objects they always use
+    // - objects manually added to store by `ray.put`: for these objects they always use
     //   plasma store provider;
     // - task arguments: these objects are passed by value, and are not put into store;
     // - task return objects: these are put into memory store of the task submitter

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -8,7 +8,7 @@
 
 namespace ray {
 
-void GetObjectIdsPerStoreProvider(
+void ObjectIdsByStoreProvider(
     const std::vector<ObjectID> &object_ids,
     EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>> *results) {
   for (const auto &object_id : object_ids) {

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -3,8 +3,8 @@
 #include "ray/common/ray_config.h"
 #include "ray/core_worker/object_interface.h"
 #include "ray/core_worker/store_provider/local_plasma_provider.h"
-#include "ray/core_worker/store_provider/plasma_store_provider.h"
 #include "ray/core_worker/store_provider/memory_store_provider.h"
+#include "ray/core_worker/store_provider/plasma_store_provider.h"
 
 namespace ray {
 
@@ -68,8 +68,7 @@ Status CoreWorkerObjectInterface::Get(const std::vector<ObjectID> &ids,
 
   for (const auto &entry : object_ids_per_store_provider) {
     auto start_time = current_time_ms();
-    RAY_RETURN_NOT_OK(Get(entry.first, entry.second,
-                          current_timeout_ms, &objects));
+    RAY_RETURN_NOT_OK(Get(entry.first, entry.second, current_timeout_ms, &objects));
     int64_t duration = current_time_ms() - start_time;
     current_timeout_ms =
         (current_timeout_ms == -1)
@@ -104,9 +103,8 @@ Status CoreWorkerObjectInterface::Get(
   return Status::OK();
 }
 
-Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids,
-                                       int num_objects, int64_t timeout_ms,
-                                       std::vector<bool> *results) {
+Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num_objects,
+                                       int64_t timeout_ms, std::vector<bool> *results) {
   (*results).resize(ids.size(), false);
 
   if (num_objects <= 0 || num_objects > ids.size()) {
@@ -130,14 +128,14 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids,
       iter->second++;
     }
   }
-  
+
   auto current_timeout_ms = timeout_ms;
 
   for (const auto &entry : object_ids_per_store_provider) {
     std::unordered_set<ObjectID> objects;
     auto start_time = current_time_ms();
-    RAY_RETURN_NOT_OK(Wait(entry.first, entry.second, num_objects,
-                          current_timeout_ms, &objects));
+    RAY_RETURN_NOT_OK(
+        Wait(entry.first, entry.second, num_objects, current_timeout_ms, &objects));
     int64_t duration = current_time_ms() - start_time;
     current_timeout_ms =
         (current_timeout_ms == -1)
@@ -154,15 +152,13 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids,
     }
   }
 
-
-
   return Status::OK();
 }
 
 Status CoreWorkerObjectInterface::Wait(StoreProviderType type,
-            const std::unordered_set<ObjectID> &object_ids,
-            int num_objects, int64_t timeout_ms,
-            std::unordered_set<ObjectID> *results) {
+                                       const std::unordered_set<ObjectID> &object_ids,
+                                       int num_objects, int64_t timeout_ms,
+                                       std::unordered_set<ObjectID> *results) {
   std::vector<ObjectID> ids(object_ids.begin(), object_ids.end());
   if (!ids.empty()) {
     std::vector<bool> objects;
@@ -195,8 +191,7 @@ Status CoreWorkerObjectInterface::Delete(const std::vector<ObjectID> &object_ids
 
     std::vector<ObjectID> ids(entry.second.begin(), entry.second.end());
     RAY_RETURN_NOT_OK(store_providers_[type]->Delete(
-        ids, is_plasma ? local_only : false,
-        is_plasma ? delete_creating_tasks : false));
+        ids, is_plasma ? local_only : false, is_plasma ? delete_creating_tasks : false));
   }
 
   return Status::OK();

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -73,7 +73,8 @@ Status CoreWorkerObjectInterface::Get(const std::vector<ObjectID> &ids,
     RAY_RETURN_NOT_OK(Get(entry.first, entry.second, current_timeout_ms, &objects));
     if (current_timeout_ms > 0) {
       int64_t duration = current_time_ms() - start_time;
-      current_timeout_ms = std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
+      current_timeout_ms =
+          std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
     }
   }
 
@@ -126,19 +127,19 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num
     }
   }
 
-  auto wait_from_store_providers = [&ids, &object_ids_per_store_provider, &num_objects, &object_counts, results, this](
-      int64_t timeout) {
-
+  auto wait_from_store_providers = [&ids, &object_ids_per_store_provider, &num_objects,
+                                    &object_counts, results, this](int64_t timeout) {
     auto current_timeout_ms = timeout;
     for (const auto &entry : object_ids_per_store_provider) {
       std::unordered_set<ObjectID> objects;
       auto start_time = current_time_ms();
       int required_objects = std::min(static_cast<int>(entry.second.size()), num_objects);
-      RAY_RETURN_NOT_OK(
-          Wait(entry.first, entry.second, required_objects, current_timeout_ms, &objects));
+      RAY_RETURN_NOT_OK(Wait(entry.first, entry.second, required_objects,
+                             current_timeout_ms, &objects));
       if (current_timeout_ms > 0) {
         int64_t duration = current_time_ms() - start_time;
-        current_timeout_ms = std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
+        current_timeout_ms =
+            std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
       }
       for (const auto &entry : objects) {
         num_objects -= object_counts[entry];
@@ -159,8 +160,8 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num
   };
 
   // Wait from all the store providers with timeout set to 0. This is to avoid the case
-  // where we might use up the entire timeout on trying to get objects from one store provider
-  // before even trying another (which might have all of the objects available). 
+  // where we might use up the entire timeout on trying to get objects from one store
+  // provider before even trying another (which might have all of the objects available).
   RAY_RETURN_NOT_OK(wait_from_store_providers(0));
 
   if (num_objects > 0) {
@@ -168,7 +169,7 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num
     // if the required number of objects haven't been ready yet.
     RAY_RETURN_NOT_OK(wait_from_store_providers(timeout_ms));
   }
-  
+
   return Status::OK();
 }
 

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -77,7 +77,9 @@ Status CoreWorkerObjectInterface::Get(const std::vector<ObjectID> &ids,
   // since it uses a loop of `FetchOrReconstruct` and plasma `Get`, it's not
   // desirable if other store providers use up the timeout and leaves no time
   // for plasma provider to reconstruct the objects as necessary.
-  std::list<std::pair<StoreProviderType, std::reference_wrapper<std::unordered_set<ObjectID>>>> ids_per_provider;
+  std::list<
+      std::pair<StoreProviderType, std::reference_wrapper<std::unordered_set<ObjectID>>>>
+      ids_per_provider;
   for (auto &entry : object_ids_per_store_provider) {
     auto list_entry = std::make_pair(entry.first, std::ref(entry.second));
     if (entry.first == StoreProviderType::PLASMA) {
@@ -143,13 +145,15 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num
   // where we might use up the entire timeout on trying to get objects from one store
   // provider before even trying another (which might have all of the objects available).
   RAY_RETURN_NOT_OK(WaitFromMultipleStoreProviders(ids, object_ids_per_store_provider,
-                         /* timeout_ms= */ 0, &num_objects, results));
+                                                   /* timeout_ms= */ 0, &num_objects,
+                                                   results));
 
   if (num_objects > 0) {
     // Wait from all the store providers with the specified timeout
     // if the required number of objects haven't been ready yet.
     RAY_RETURN_NOT_OK(WaitFromMultipleStoreProviders(ids, object_ids_per_store_provider,
-                           /* timeout_ms= */ timeout_ms, &num_objects, results));
+                                                     /* timeout_ms= */ timeout_ms,
+                                                     &num_objects, results));
   }
 
   return Status::OK();

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -76,7 +76,8 @@ Status CoreWorkerObjectInterface::Get(const std::vector<ObjectID> &ids,
   // with a timeout of 0.
   for (const auto &entry : object_ids_per_store_provider) {
     auto start_time = current_time_ms();
-    RAY_RETURN_NOT_OK(GetFromStoreProvider(entry.first, entry.second, current_timeout_ms, &objects));
+    RAY_RETURN_NOT_OK(
+        GetFromStoreProvider(entry.first, entry.second, current_timeout_ms, &objects));
     if (current_timeout_ms > 0) {
       int64_t duration = current_time_ms() - start_time;
       current_timeout_ms =
@@ -127,66 +128,66 @@ Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, int num
   // where we might use up the entire timeout on trying to get objects from one store
   // provider before even trying another (which might have all of the objects available).
   RAY_RETURN_NOT_OK(Wait(ids, object_ids_per_store_provider,
-      /* timeout_ms= */0, &num_objects, results));
+                         /* timeout_ms= */ 0, &num_objects, results));
 
   if (num_objects > 0) {
     // Wait from all the store providers with the specified timeout
     // if the required number of objects haven't been ready yet.
     RAY_RETURN_NOT_OK(Wait(ids, object_ids_per_store_provider,
-        /* timeout_ms= */timeout_ms, &num_objects, results));
+                           /* timeout_ms= */ timeout_ms, &num_objects, results));
   }
 
   return Status::OK();
 }
 
-Status CoreWorkerObjectInterface::Wait(const std::vector<ObjectID> &ids, 
-    const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>> &ids_per_provider,
+Status CoreWorkerObjectInterface::Wait(
+    const std::vector<ObjectID> &ids,
+    const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>>
+        &ids_per_provider,
     int64_t timeout_ms, int *num_objects, std::vector<bool> *results) {
+  std::unordered_map<ObjectID, int> object_counts;
+  for (const auto &entry : ids) {
+    auto iter = object_counts.find(entry);
+    if (iter == object_counts.end()) {
+      object_counts.emplace(entry, 1);
+    } else {
+      iter->second++;
+    }
+  }
 
-    std::unordered_map<ObjectID, int> object_counts;
-    for (const auto &entry : ids) {
-      auto iter = object_counts.find(entry);
-      if (iter == object_counts.end()) {
-        object_counts.emplace(entry, 1);
-      } else {
-        iter->second++;
+  auto current_timeout_ms = timeout_ms;
+  for (const auto &entry : ids_per_provider) {
+    std::unordered_set<ObjectID> objects;
+    auto start_time = current_time_ms();
+    int required_objects = std::min(static_cast<int>(entry.second.size()), *num_objects);
+    RAY_RETURN_NOT_OK(WaitFromStoreProvider(entry.first, entry.second, required_objects,
+                                            current_timeout_ms, &objects));
+    if (current_timeout_ms > 0) {
+      int64_t duration = current_time_ms() - start_time;
+      current_timeout_ms =
+          std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
+    }
+    for (const auto &entry : objects) {
+      *num_objects -= object_counts[entry];
+    }
+
+    for (size_t i = 0; i < ids.size(); i++) {
+      if (objects.count(ids[i]) > 0) {
+        (*results)[i] = true;
       }
     }
 
-    auto current_timeout_ms = timeout_ms;
-    for (const auto &entry : ids_per_provider) {
-      std::unordered_set<ObjectID> objects;
-      auto start_time = current_time_ms();
-      int required_objects = std::min(static_cast<int>(entry.second.size()), *num_objects);
-      RAY_RETURN_NOT_OK(WaitFromStoreProvider(entry.first, entry.second, required_objects,
-                             current_timeout_ms, &objects));
-      if (current_timeout_ms > 0) {
-        int64_t duration = current_time_ms() - start_time;
-        current_timeout_ms =
-            std::max(static_cast<int64_t>(0), current_timeout_ms - duration);
-      }
-      for (const auto &entry : objects) {
-        *num_objects -= object_counts[entry];
-      }
-
-      for (size_t i = 0; i < ids.size(); i++) {
-        if (objects.count(ids[i]) > 0) {
-          (*results)[i] = true;
-        }
-      }
-
-      if (*num_objects <= 0) {
-        break;
-      }
+    if (*num_objects <= 0) {
+      break;
     }
+  }
 
-    return Status::OK();
-  };
+  return Status::OK();
+};
 
-Status CoreWorkerObjectInterface::WaitFromStoreProvider(StoreProviderType type,
-                                       const std::unordered_set<ObjectID> &object_ids,
-                                       int num_objects, int64_t timeout_ms,
-                                       std::unordered_set<ObjectID> *results) {
+Status CoreWorkerObjectInterface::WaitFromStoreProvider(
+    StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
+    int num_objects, int64_t timeout_ms, std::unordered_set<ObjectID> *results) {
   std::vector<ObjectID> ids(object_ids.begin(), object_ids.end());
   if (!ids.empty()) {
     std::vector<bool> objects;

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -69,6 +69,19 @@ class CoreWorkerObjectInterface {
                 bool delete_creating_tasks);
 
  private:
+  /// Helper function to get a list of objects from a different store providers.
+  ///
+  /// \param[in] object_ids IDs of the objects to get.
+  /// \param[in] ids_per_provider A map from store provider type to the set of
+  //             object ids for that store provider.
+  /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's -1.
+  /// \param[in/out] num_objects Number of objects that should appear before returning.
+  /// \param[out] results A bitset that indicates each object has appeared or not.
+  /// \return Status.
+  Status Wait(const std::vector<ObjectID> &object_ids, 
+    const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>> &ids_per_provider,
+    int64_t timeout_ms, int *num_objects, std::vector<bool> *results);
+
   /// Helper function to get a list of objects from a specific store provider.
   ///
   /// \param[in] type The type of store provider to use.
@@ -76,7 +89,7 @@ class CoreWorkerObjectInterface {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's -1.
   /// \param[out] results Result list of objects data.
   /// \return Status.
-  Status Get(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
+  Status GetFromStoreProvider(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
              int64_t timeout_ms,
              std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results);
 
@@ -88,7 +101,7 @@ class CoreWorkerObjectInterface {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status Wait(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
+  Status WaitFromStoreProvider(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
               int num_objects, int64_t timeout_ms, std::unordered_set<ObjectID> *results);
 
   /// Create a new store provider for the specified type on demand.

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -78,9 +78,10 @@ class CoreWorkerObjectInterface {
   /// \param[in/out] num_objects Number of objects that should appear before returning.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status Wait(const std::vector<ObjectID> &object_ids, 
-    const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>> &ids_per_provider,
-    int64_t timeout_ms, int *num_objects, std::vector<bool> *results);
+  Status Wait(const std::vector<ObjectID> &object_ids,
+              const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>>
+                  &ids_per_provider,
+              int64_t timeout_ms, int *num_objects, std::vector<bool> *results);
 
   /// Helper function to get a list of objects from a specific store provider.
   ///
@@ -89,9 +90,10 @@ class CoreWorkerObjectInterface {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's -1.
   /// \param[out] results Result list of objects data.
   /// \return Status.
-  Status GetFromStoreProvider(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
-             int64_t timeout_ms,
-             std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results);
+  Status GetFromStoreProvider(
+      StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
+      int64_t timeout_ms,
+      std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results);
 
   /// Helper function to wait a list of objects from a specific store provider.
   ///
@@ -101,8 +103,10 @@ class CoreWorkerObjectInterface {
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status WaitFromStoreProvider(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
-              int num_objects, int64_t timeout_ms, std::unordered_set<ObjectID> *results);
+  Status WaitFromStoreProvider(StoreProviderType type,
+                               const std::unordered_set<ObjectID> &object_ids,
+                               int num_objects, int64_t timeout_ms,
+                               std::unordered_set<ObjectID> *results);
 
   /// Create a new store provider for the specified type on demand.
   std::unique_ptr<CoreWorkerStoreProvider> CreateStoreProvider(

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -84,7 +84,7 @@ class CoreWorkerObjectInterface {
   ///
   /// \param[in] type The type of store provider to use.
   /// \param[in] object_ids IDs of the objects to wait for.
-  /// \param[in] num_objects Number of objects that should appear.
+  /// \param[in] num_objects Number of objects that should appear before returning.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -48,7 +48,8 @@ class CoreWorkerObjectInterface {
              std::vector<std::shared_ptr<RayObject>> *results);
 
   /// Wait for a list of objects to appear in the object store.
-  /// Duplicate object ids are supported, and `num_objects` includes duplicate ids in this case.
+  /// Duplicate object ids are supported, and `num_objects` includes duplicate ids in this
+  /// case.
   /// TODO(zhijunfu): it is probably more clear in semantics to just fail when there
   /// are duplicates, and require it to be handled at application level.
   ///

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -78,7 +78,7 @@ class CoreWorkerObjectInterface {
   /// \param[in/out] num_objects Number of objects that should appear before returning.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status Wait(const std::vector<ObjectID> &object_ids,
+  Status WaitFromMultipleStoreProviders(const std::vector<ObjectID> &object_ids,
               const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>>
                   &ids_per_provider,
               int64_t timeout_ms, int *num_objects, std::vector<bool> *results);

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -69,7 +69,7 @@ class CoreWorkerObjectInterface {
                 bool delete_creating_tasks);
 
  private:
-  /// Helper function to get a list of objects from a different store providers.
+  /// Helper function to get a list of objects from different store providers.
   ///
   /// \param[in] object_ids IDs of the objects to get.
   /// \param[in] ids_per_provider A map from store provider type to the set of

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -38,7 +38,7 @@ class CoreWorkerObjectInterface {
   /// \return Status.
   Status Put(const RayObject &object, const ObjectID &object_id);
 
-  /// Get a list of objects from the object store.
+  /// Get a list of objects from the object store. Duplicate object ids are supported.
   ///
   /// \param[in] ids IDs of the objects to get.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
@@ -48,6 +48,9 @@ class CoreWorkerObjectInterface {
              std::vector<std::shared_ptr<RayObject>> *results);
 
   /// Wait for a list of objects to appear in the object store.
+  /// Duplicate object ids are supported, and `num_objects` includes duplicate ids in this case.
+  /// TODO(zhijunfu): it is probably more clear in semantics to just fail when there
+  /// are duplicates, and require it to be handled at application level.
   ///
   /// \param[in] IDs of the objects to wait for.
   /// \param[in] num_objects Number of objects that should appear.

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -89,8 +89,7 @@ class CoreWorkerObjectInterface {
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
   Status Wait(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
-             int num_objects, int64_t timeout_ms,
-             std::unordered_set<ObjectID> *results);
+              int num_objects, int64_t timeout_ms, std::unordered_set<ObjectID> *results);
 
   /// Create a new store provider for the specified type on demand.
   std::unique_ptr<CoreWorkerStoreProvider> CreateStoreProvider(

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -78,10 +78,11 @@ class CoreWorkerObjectInterface {
   /// \param[in/out] num_objects Number of objects that should appear before returning.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
-  Status WaitFromMultipleStoreProviders(const std::vector<ObjectID> &object_ids,
-              const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>>
-                  &ids_per_provider,
-              int64_t timeout_ms, int *num_objects, std::vector<bool> *results);
+  Status WaitFromMultipleStoreProviders(
+      const std::vector<ObjectID> &object_ids,
+      const EnumUnorderedMap<StoreProviderType, std::unordered_set<ObjectID>>
+          &ids_per_provider,
+      int64_t timeout_ms, int *num_objects, std::vector<bool> *results);
 
   /// Helper function to get a list of objects from a specific store provider.
   ///

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -15,6 +15,7 @@ using rpc::RayletClient;
 
 class CoreWorker;
 class CoreWorkerStoreProvider;
+class CoreWorkerMemoryStore;
 
 /// The interface that contains all `CoreWorker` methods that are related to object store.
 class CoreWorkerObjectInterface {
@@ -49,7 +50,7 @@ class CoreWorkerObjectInterface {
   /// Wait for a list of objects to appear in the object store.
   ///
   /// \param[in] IDs of the objects to wait for.
-  /// \param[in] num_returns Number of objects that should appear.
+  /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[out] results A bitset that indicates each object has appeared or not.
   /// \return Status.
@@ -79,6 +80,18 @@ class CoreWorkerObjectInterface {
              int64_t timeout_ms,
              std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results);
 
+  /// Helper function to wait a list of objects from a specific store provider.
+  ///
+  /// \param[in] type The type of store provider to use.
+  /// \param[in] object_ids IDs of the objects to wait for.
+  /// \param[in] num_objects Number of objects that should appear.
+  /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
+  /// \param[out] results A bitset that indicates each object has appeared or not.
+  /// \return Status.
+  Status Wait(StoreProviderType type, const std::unordered_set<ObjectID> &object_ids,
+             int num_objects, int64_t timeout_ms,
+             std::unordered_set<ObjectID> *results);
+
   /// Create a new store provider for the specified type on demand.
   std::unique_ptr<CoreWorkerStoreProvider> CreateStoreProvider(
       StoreProviderType type) const;
@@ -93,6 +106,9 @@ class CoreWorkerObjectInterface {
 
   /// Store socket name.
   std::string store_socket_;
+
+  /// In-memory store for return objects. This is used for `MEMORY` store provider.
+  std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
 
   /// All the store providers supported.
   EnumUnorderedMap<StoreProviderType, std::unique_ptr<CoreWorkerStoreProvider>>

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -174,7 +174,7 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
       return Status::OK();
     }
 
-    if (object_ids.size() - remaining_ids.size() >= num_objects) {
+    if (object_ids.size() - remaining_ids.size() >= static_cast<size_t>(num_objects)) {
       // Already get enough objects.
       return Status::OK();
     }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -10,7 +10,8 @@ namespace ray {
 /// A class that represents a `Get` request.
 class GetRequest {
  public:
-  GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects, bool remove_after_get);
+  GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects,
+             bool remove_after_get);
 
   const std::unordered_set<ObjectID> &ObjectIds() const;
 
@@ -46,7 +47,8 @@ class GetRequest {
   std::condition_variable cv_;
 };
 
-GetRequest::GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects, bool remove_after_get)
+GetRequest::GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects,
+                       bool remove_after_get)
     : object_ids_(std::move(object_ids)),
       num_objects_(num_objects),
       remove_after_get_(remove_after_get),
@@ -134,8 +136,9 @@ Status CoreWorkerMemoryStore::Put(const ObjectID &object_id, const RayObject &ob
   return Status::OK();
 }
 
-Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids, int num_objects,
-                                  int64_t timeout_ms, bool remove_after_get,
+Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
+                                  int num_objects, int64_t timeout_ms,
+                                  bool remove_after_get,
                                   std::vector<std::shared_ptr<RayObject>> *results) {
   (*results).resize(object_ids.size(), nullptr);
 
@@ -179,8 +182,8 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids, int n
     int required_objects = num_objects - (object_ids.size() - remaining_ids.size());
 
     // Otherwise, create a GetRequest to track remaining objects.
-    get_request =
-        std::make_shared<GetRequest>(std::move(remaining_ids), required_objects, remove_after_get);
+    get_request = std::make_shared<GetRequest>(std::move(remaining_ids), required_objects,
+                                               remove_after_get);
     for (const auto &object_id : get_request->ObjectIds()) {
       object_get_requests_[object_id].push_back(get_request);
     }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -10,7 +10,7 @@ namespace ray {
 /// A class that represents a `Get` request.
 class GetRequest {
  public:
-  GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects,
+  GetRequest(std::unordered_set<ObjectID> object_ids, size_t num_objects,
              bool remove_after_get);
 
   const std::unordered_set<ObjectID> &ObjectIds() const;
@@ -36,7 +36,7 @@ class GetRequest {
   /// The object information for the objects in this request.
   std::unordered_map<ObjectID, std::shared_ptr<RayObject>> objects_;
   /// Number of objects required.
-  const int num_objects_;
+  const size_t num_objects_;
 
   // Whether the requested objects should be removed from store
   // after `get` returns.
@@ -47,7 +47,7 @@ class GetRequest {
   std::condition_variable cv_;
 };
 
-GetRequest::GetRequest(std::unordered_set<ObjectID> object_ids, int num_objects,
+GetRequest::GetRequest(std::unordered_set<ObjectID> object_ids, size_t num_objects,
                        bool remove_after_get)
     : object_ids_(std::move(object_ids)),
       num_objects_(num_objects),
@@ -179,7 +179,7 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
       return Status::OK();
     }
 
-    int required_objects = num_objects - (object_ids.size() - remaining_ids.size());
+    size_t required_objects = num_objects - (object_ids.size() - remaining_ids.size());
 
     // Otherwise, create a GetRequest to track remaining objects.
     get_request = std::make_shared<GetRequest>(std::move(remaining_ids), required_objects,

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -28,13 +28,14 @@ class CoreWorkerMemoryStore {
 
   /// Get a list of objects from the object store.
   ///
-  /// \param[in] object_ids IDs of the objects to get. Duplicates are allowed.
+  /// \param[in] object_ids IDs of the objects to get. Duplicates are not allowed.
+  /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[in] remove_after_get When to remove the objects from store after `Get`
   /// finishes.
   /// \param[out] results Result list of objects data.
   /// \return Status.
-  Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
+  Status Get(const std::vector<ObjectID> &object_ids, int num_objects, int64_t timeout_ms,
              bool remove_after_get, std::vector<std::shared_ptr<RayObject>> *results);
 
   /// Delete a list of objects from the object store.

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -24,21 +24,17 @@ Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
 Status CoreWorkerMemoryStoreProvider::Get(
     const std::vector<ObjectID> &object_ids, int64_t timeout_ms, const TaskID &task_id,
     std::vector<std::shared_ptr<RayObject>> *results) {
-  return store_->Get(object_ids, timeout_ms, true, results);
+  return store_->Get(object_ids, object_ids.size(), timeout_ms, true, results);
 }
 
 Status CoreWorkerMemoryStoreProvider::Wait(const std::vector<ObjectID> &object_ids,
                                            int num_objects, int64_t timeout_ms,
                                            const TaskID &task_id,
                                            std::vector<bool> *results) {
-  if (num_objects != static_cast<int>(object_ids.size())) {
-    return Status::Invalid("num_objects should equal to number of items in object_ids");
-  }
-
   (*results).resize(object_ids.size(), false);
 
   std::vector<std::shared_ptr<RayObject>> result_objects;
-  auto status = store_->Get(object_ids, timeout_ms, false, &result_objects);
+  auto status = store_->Get(object_ids, num_objects, timeout_ms, false, &result_objects);
   if (status.ok()) {
     RAY_CHECK(result_objects.size() == object_ids.size());
     for (size_t i = 0; i < object_ids.size(); i++) {

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -89,7 +89,7 @@ class CoreWorkerStoreProvider {
   /// Wait for a list of objects to appear in the object store.
   ///
   /// \param[in] IDs of the objects to wait for.
-  /// \param[in] num_objects Number of objects that should appear.
+  /// \param[in] num_objects Number of objects that should appear before returning.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[in] task_id ID for the current task.
   /// \param[out] results A bitset that indicates each object has appeared or not.

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -89,7 +89,7 @@ class CoreWorkerStoreProvider {
   /// Wait for a list of objects to appear in the object store.
   ///
   /// \param[in] IDs of the objects to wait for.
-  /// \param[in] num_returns Number of objects that should appear.
+  /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[in] task_id ID for the current task.
   /// \param[out] results A bitset that indicates each object has appeared or not.

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -106,11 +106,12 @@ CoreWorkerTaskInterface::CoreWorkerTaskInterface(
   task_submitters_.emplace(TaskTransportType::RAYLET,
                            std::unique_ptr<CoreWorkerRayletTaskSubmitter>(
                                new CoreWorkerRayletTaskSubmitter(raylet_client)));
-  task_submitters_.emplace(TaskTransportType::DIRECT_ACTOR,
-                           std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
-                               new CoreWorkerDirectActorTaskSubmitter(
-                                   io_service, gcs_client,
-                                   object_interface.CreateStoreProvider(StoreProviderType::MEMORY))));
+  task_submitters_.emplace(
+      TaskTransportType::DIRECT_ACTOR,
+      std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
+          new CoreWorkerDirectActorTaskSubmitter(
+              io_service, gcs_client,
+              object_interface.CreateStoreProvider(StoreProviderType::MEMORY))));
 }
 
 void CoreWorkerTaskInterface::BuildCommonTaskSpec(

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -109,7 +109,8 @@ CoreWorkerTaskInterface::CoreWorkerTaskInterface(
   task_submitters_.emplace(TaskTransportType::DIRECT_ACTOR,
                            std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
                                new CoreWorkerDirectActorTaskSubmitter(
-                                   io_service, gcs_client, object_interface)));
+                                   io_service, gcs_client,
+                                   object_interface.CreateStoreProvider(StoreProviderType::MEMORY))));
 }
 
 void CoreWorkerTaskInterface::BuildCommonTaskSpec(

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -568,10 +568,10 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
 
   // wait for the objects to appear.
   wait_results.clear();
-  RAY_CHECK_OK(provider.Wait(unready_ids, unready_ids.size(),  -1, RandomTaskId(), &wait_results));
+  RAY_CHECK_OK(
+      provider.Wait(unready_ids, unready_ids.size(), -1, RandomTaskId(), &wait_results));
   // wait for the thread to finish.
   async_thread.join();
-  
 }
 
 class ZeroNodeTest : public CoreWorkerTest {

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -550,7 +550,7 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
   ASSERT_TRUE(!results[0]);
   ASSERT_TRUE(!results[1]);
 
-  // Test Wait with objects which become ready later.
+  // Test Wait() with objects which will become ready later.
   std::vector<ObjectID> unready_ids(buffers.size());
   for (size_t i = 0; i < unready_ids.size(); i++) {
     unready_ids[i] = ObjectID::FromRandom();

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -499,7 +499,7 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
     RAY_CHECK_OK(provider.Put(buffers[i], ids[i]));
   }
 
-  // Test Wait().
+  // Test Wait() with duplicate object ids.
   std::vector<ObjectID> ids_with_duplicate;
   ids_with_duplicate.insert(ids_with_duplicate.end(), ids.begin(), ids.end());
   // add the same ids again to test `Get` with duplicate object ids.
@@ -511,6 +511,13 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
 
   std::vector<bool> wait_results;
   RAY_CHECK_OK(provider.Wait(wait_ids, 5, 100, RandomTaskId(), &wait_results));
+  ASSERT_EQ(wait_results.size(), 5);
+  ASSERT_EQ(wait_results, std::vector<bool>({true, true, true, true, false}));
+
+  // Test Wait() with duplicate object ids, and the required `num_objects`
+  // is less than size of `wait_ids`.
+  wait_results.clear();
+  RAY_CHECK_OK(provider.Wait(wait_ids, 4, 100, RandomTaskId(), &wait_results));
   ASSERT_EQ(wait_results.size(), 5);
   ASSERT_EQ(wait_results, std::vector<bool>({true, true, true, true, false}));
 

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -517,7 +517,7 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
   // Test Wait() with duplicate object ids, and the required `num_objects`
   // is less than size of `wait_ids`.
   wait_results.clear();
-  RAY_CHECK_OK(provider.Wait(wait_ids, 4, 100, RandomTaskId(), &wait_results));
+  RAY_CHECK_OK(provider.Wait(wait_ids, 4, -1, RandomTaskId(), &wait_results));
   ASSERT_EQ(wait_results.size(), 5);
   ASSERT_EQ(wait_results, std::vector<bool>({true, true, true, true, false}));
 
@@ -549,6 +549,29 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
   ASSERT_EQ(results.size(), 2);
   ASSERT_TRUE(!results[0]);
   ASSERT_TRUE(!results[1]);
+
+  // Test Wait with objects which become ready later.
+  std::vector<ObjectID> unready_ids(buffers.size());
+  for (size_t i = 0; i < unready_ids.size(); i++) {
+    unready_ids[i] = ObjectID::FromRandom();
+  }
+
+  auto thread_func = [&unready_ids, &provider, &buffers]() {
+    sleep(1);
+
+    for (size_t i = 0; i < unready_ids.size(); i++) {
+      RAY_CHECK_OK(provider.Put(buffers[i], unready_ids[i]));
+    }
+  };
+
+  std::thread async_thread(thread_func);
+
+  // wait for the objects to appear.
+  wait_results.clear();
+  RAY_CHECK_OK(provider.Wait(unready_ids, unready_ids.size(),  -1, RandomTaskId(), &wait_results));
+  // wait for the thread to finish.
+  async_thread.join();
+  
 }
 
 class ZeroNodeTest : public CoreWorkerTest {

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -22,7 +22,7 @@ CoreWorkerDirectActorTaskSubmitter::CoreWorkerDirectActorTaskSubmitter(
       gcs_client_(gcs_client),
       client_call_manager_(io_service),
       store_provider_(
-          object_interface.CreateStoreProvider(StoreProviderType::LOCAL_PLASMA)) {
+          object_interface.CreateStoreProvider(StoreProviderType::MEMORY)) {
   RAY_CHECK_OK(SubscribeActorUpdates());
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -21,8 +21,7 @@ CoreWorkerDirectActorTaskSubmitter::CoreWorkerDirectActorTaskSubmitter(
     : io_service_(io_service),
       gcs_client_(gcs_client),
       client_call_manager_(io_service),
-      store_provider_(
-          object_interface.CreateStoreProvider(StoreProviderType::MEMORY)) {
+      store_provider_(object_interface.CreateStoreProvider(StoreProviderType::MEMORY)) {
   RAY_CHECK_OK(SubscribeActorUpdates());
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -17,11 +17,11 @@ bool HasByReferenceArgs(const TaskSpecification &spec) {
 
 CoreWorkerDirectActorTaskSubmitter::CoreWorkerDirectActorTaskSubmitter(
     boost::asio::io_service &io_service, gcs::RedisGcsClient &gcs_client,
-    CoreWorkerObjectInterface &object_interface)
+    std::unique_ptr<CoreWorkerStoreProvider> store_provider)
     : io_service_(io_service),
       gcs_client_(gcs_client),
       client_call_manager_(io_service),
-      store_provider_(object_interface.CreateStoreProvider(StoreProviderType::MEMORY)) {
+      store_provider_(std::move(store_provider)) {
   RAY_CHECK_OK(SubscribeActorUpdates());
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -30,7 +30,7 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
  public:
   CoreWorkerDirectActorTaskSubmitter(boost::asio::io_service &io_service,
                                      gcs::RedisGcsClient &gcs_client,
-                                     CoreWorkerObjectInterface &object_interface);
+                                     std::unique_ptr<CoreWorkerStoreProvider> store_provider);
 
   /// Submit a task to an actor for execution.
   ///

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -28,9 +28,9 @@ struct ActorStateData {
 
 class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
  public:
-  CoreWorkerDirectActorTaskSubmitter(boost::asio::io_service &io_service,
-                                     gcs::RedisGcsClient &gcs_client,
-                                     std::unique_ptr<CoreWorkerStoreProvider> store_provider);
+  CoreWorkerDirectActorTaskSubmitter(
+      boost::asio::io_service &io_service, gcs::RedisGcsClient &gcs_client,
+      std::unique_ptr<CoreWorkerStoreProvider> store_provider);
 
   /// Submit a task to an actor for execution.
   ///


### PR DESCRIPTION
## What do these changes do?

This is to separate the support for multiple store providers from #5443 , which can be reviewed and merged independently.

## Related issue number

## Linter

- [Y] I've run `scripts/format.sh` to lint the changes in this PR.
