### PR TITLE
[WIP] Handle request order for gRPC

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
-# Bazel build
-# C/C++ documentation: https://docs.bazel.build/versions/master/be/c-cpp.html
+#Bazel build
+#C / C++ documentation : https:  // docs.bazel.build/versions/master/be/c-cpp.html
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@build_stack_rules_proto//python:python_proto_compile.bzl", "python_proto_compile")
@@ -9,7 +9,19 @@ load("@//bazel:cython_library.bzl", "pyx_library")
 
 COPTS = ["-DRAY_USE_GLOG"]
 
-# === Begin of protobuf definitions ===
+#== = Begin of protobuf definitions == =
+
+#A protobuf file used only for testing.
+proto_library(
+    name = "test_proto",
+    srcs = ["src/ray/protobuf/test.proto"],
+)
+
+cc_proto_library(
+    name = "test_cc_proto",
+    deps = [":test_proto"],
+    testonly=True,
+)
 
 proto_library(
     name = "common_proto",
@@ -112,11 +124,35 @@ cc_proto_library(
     deps = ["direct_actor_proto"],
 )
 
-# === End of protobuf definitions ===
+#== = End of protobuf definitions == =
 
-# === Begin of rpc definitions ===
+#== = Begin of rpc definitions == =
 
-# GRPC common lib.
+cc_grpc_library(
+    name = "test_cc_grpc",
+    srcs = [":test_proto"],
+    grpc_only = True,
+    deps = [":test_cc_proto"],
+    testonly=True,
+)
+
+cc_test(
+    name = "rpc_test",
+    srcs = [
+        "src/ray/rpc/test/rpc_test.cc",
+    ],
+    copts = COPTS,
+    deps = [
+        ":grpc_common_lib",
+        ":ray_common",
+        ":test_cc_grpc",
+        "@boost//:asio",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+#GRPC common lib.
 cc_library(
     name = "grpc_common_lib",
     srcs = glob([
@@ -134,7 +170,7 @@ cc_library(
     ],
 )
 
-# Node manager gRPC lib.
+#Node manager gRPC lib.
 cc_grpc_library(
     name = "node_manager_cc_grpc",
     srcs = [":node_manager_proto"],
@@ -142,7 +178,7 @@ cc_grpc_library(
     deps = [":node_manager_cc_proto"],
 )
 
-# Node manager server and client.
+#Node manager server and client.
 cc_library(
     name = "node_manager_rpc",
     hdrs = glob([
@@ -158,7 +194,7 @@ cc_library(
     ],
 )
 
-# Object manager gRPC lib.
+#Object manager gRPC lib.
 cc_grpc_library(
     name = "object_manager_cc_grpc",
     srcs = [":object_manager_proto"],
@@ -166,7 +202,7 @@ cc_grpc_library(
     deps = [":object_manager_cc_proto"],
 )
 
-# Object manager rpc server and client.
+#Object manager rpc server and client.
 cc_library(
     name = "object_manager_rpc",
     hdrs = glob([
@@ -182,7 +218,7 @@ cc_library(
     ],
 )
 
-# Raylet gRPC lib.
+#Raylet gRPC lib.
 cc_grpc_library(
     name = "raylet_cc_grpc",
     srcs = [":raylet_proto"],
@@ -190,7 +226,7 @@ cc_grpc_library(
     deps = [":raylet_cc_proto"],
 )
 
-# Raylet rpc server and client.
+#Raylet rpc server and client.
 cc_library(
     name = "raylet_rpc",
     srcs = glob([
@@ -210,7 +246,7 @@ cc_library(
     ],
 )
 
-# Worker gRPC lib.
+#Worker gRPC lib.
 cc_grpc_library(
     name = "worker_cc_grpc",
     srcs = [":worker_proto"],
@@ -218,7 +254,7 @@ cc_grpc_library(
     deps = [":worker_cc_proto"],
 )
 
-# direct actor gRPC lib.
+#direct actor gRPC lib.
 cc_grpc_library(
     name = "direct_actor_cc_grpc",
     srcs = [":direct_actor_proto"],
@@ -226,7 +262,7 @@ cc_grpc_library(
     deps = [":direct_actor_cc_proto"],
 )
 
-# worker server and client.
+#worker server and client.
 cc_library(
     name = "worker_rpc",
     hdrs = glob([
@@ -243,7 +279,7 @@ cc_library(
     ],
 )
 
-# === End of rpc definitions ===
+#== = End of rpc definitions == =
 
 cc_library(
     name = "ray_common",
@@ -406,8 +442,8 @@ cc_library(
         ":core_worker_cc_proto",
         ":ray_common",
         ":ray_util",
-        # TODO(hchen): After `raylet_client` is migrated to gRPC, `core_worker_lib`
-        # should only depend on `raylet_client`, instead of the whole `raylet_lib`.
+#TODO(hchen) : After `raylet_client` is migrated to gRPC, `core_worker_lib`
+#should only depend on `raylet_client`, instead of the whole `raylet_lib`.
         ":raylet_lib",
         ":worker_rpc",
         ":gcs",
@@ -887,8 +923,8 @@ genrule(
         for f in $(locations //:all_py_proto); do
             cp -f $$f $$WORK_DIR/python/ray/core/generated/;
         done &&
-        # NOTE(hchen): Protobuf doesn't allow specifying Python package name. So we use this `sed`
-        # command to change the import path in the generated file.
+#NOTE(hchen) : Protobuf doesn't allow specifying Python package name. So we use this `sed`
+#command to change the import path in the generated file.
         sed -i -E 's/from src.ray.protobuf/from ./' $$WORK_DIR/python/ray/core/generated/gcs_pb2.py &&
         echo $$WORK_DIR > $@
     """,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
-#Bazel build
-#C / C++ documentation : https:  // docs.bazel.build/versions/master/be/c-cpp.html
+# Bazel build
+# C/C++ documentation: https://docs.bazel.build/versions/master/be/c-cpp.html
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@build_stack_rules_proto//python:python_proto_compile.bzl", "python_proto_compile")
@@ -9,12 +9,12 @@ load("@//bazel:cython_library.bzl", "pyx_library")
 
 COPTS = ["-DRAY_USE_GLOG"]
 
-#== = Begin of protobuf definitions == =
+# === Begin of protobuf definitions ===
 
-#A protobuf file used only for testing.
+# A protobuf file used only for testing.
 proto_library(
-    name = "test_proto",
-    srcs = ["src/ray/protobuf/test.proto"],
+   name = "test_proto",
+   srcs = ["src/ray/protobuf/test.proto"],
 )
 
 cc_proto_library(
@@ -124,9 +124,9 @@ cc_proto_library(
     deps = ["direct_actor_proto"],
 )
 
-#== = End of protobuf definitions == =
+# === End of protobuf definitions ===
 
-#== = Begin of rpc definitions == =
+# === Begin of rpc definitions ===
 
 cc_grpc_library(
     name = "test_cc_grpc",
@@ -152,7 +152,7 @@ cc_test(
     ],
 )
 
-#GRPC common lib.
+# GRPC common lib.
 cc_library(
     name = "grpc_common_lib",
     srcs = glob([
@@ -170,7 +170,7 @@ cc_library(
     ],
 )
 
-#Node manager gRPC lib.
+# Node manager gRPC lib.
 cc_grpc_library(
     name = "node_manager_cc_grpc",
     srcs = [":node_manager_proto"],
@@ -178,7 +178,7 @@ cc_grpc_library(
     deps = [":node_manager_cc_proto"],
 )
 
-#Node manager server and client.
+# Node manager server and client.
 cc_library(
     name = "node_manager_rpc",
     hdrs = glob([
@@ -194,7 +194,7 @@ cc_library(
     ],
 )
 
-#Object manager gRPC lib.
+# Object manager gRPC lib.
 cc_grpc_library(
     name = "object_manager_cc_grpc",
     srcs = [":object_manager_proto"],
@@ -202,7 +202,7 @@ cc_grpc_library(
     deps = [":object_manager_cc_proto"],
 )
 
-#Object manager rpc server and client.
+# Object manager rpc server and client.
 cc_library(
     name = "object_manager_rpc",
     hdrs = glob([
@@ -218,7 +218,7 @@ cc_library(
     ],
 )
 
-#Raylet gRPC lib.
+# Raylet gRPC lib.
 cc_grpc_library(
     name = "raylet_cc_grpc",
     srcs = [":raylet_proto"],
@@ -226,7 +226,7 @@ cc_grpc_library(
     deps = [":raylet_cc_proto"],
 )
 
-#Raylet rpc server and client.
+# Raylet rpc server and client.
 cc_library(
     name = "raylet_rpc",
     srcs = glob([
@@ -246,7 +246,7 @@ cc_library(
     ],
 )
 
-#Worker gRPC lib.
+# Worker gRPC lib.
 cc_grpc_library(
     name = "worker_cc_grpc",
     srcs = [":worker_proto"],
@@ -254,7 +254,7 @@ cc_grpc_library(
     deps = [":worker_cc_proto"],
 )
 
-#direct actor gRPC lib.
+# direct actor gRPC lib.
 cc_grpc_library(
     name = "direct_actor_cc_grpc",
     srcs = [":direct_actor_proto"],
@@ -262,7 +262,7 @@ cc_grpc_library(
     deps = [":direct_actor_cc_proto"],
 )
 
-#worker server and client.
+# worker server and client.
 cc_library(
     name = "worker_rpc",
     hdrs = glob([
@@ -279,7 +279,7 @@ cc_library(
     ],
 )
 
-#== = End of rpc definitions == =
+# === End of rpc definitions ===
 
 cc_library(
     name = "ray_common",
@@ -442,8 +442,8 @@ cc_library(
         ":core_worker_cc_proto",
         ":ray_common",
         ":ray_util",
-#TODO(hchen) : After `raylet_client` is migrated to gRPC, `core_worker_lib`
-#should only depend on `raylet_client`, instead of the whole `raylet_lib`.
+        # TODO(hchen): After `raylet_client` is migrated to gRPC, `core_worker_lib`
+        # should only depend on `raylet_client`, instead of the whole `raylet_lib`.
         ":raylet_lib",
         ":worker_rpc",
         ":gcs",
@@ -923,8 +923,8 @@ genrule(
         for f in $(locations //:all_py_proto); do
             cp -f $$f $$WORK_DIR/python/ray/core/generated/;
         done &&
-#NOTE(hchen) : Protobuf doesn't allow specifying Python package name. So we use this `sed`
-#command to change the import path in the generated file.
+        # NOTE(hchen): Protobuf doesn't allow specifying Python package name. So we use this `sed`
+        # command to change the import path in the generated file.
         sed -i -E 's/from src.ray.protobuf/from ./' $$WORK_DIR/python/ray/core/generated/gcs_pb2.py &&
         echo $$WORK_DIR > $@
     """,

--- a/src/ray/protobuf/test.proto
+++ b/src/ray/protobuf/test.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package ray.rpc;
+
+/// This file is only used for grpc test.
+
+message EchoRequest {
+  string request_message = 1;
+}
+
+message EchoReply {
+  string reply_message = 1;
+}
+
+service TestService {
+  rpc Echo(EchoRequest) returns (EchoReply);
+}

--- a/src/ray/protobuf/test.proto
+++ b/src/ray/protobuf/test.proto
@@ -2,16 +2,17 @@ syntax = "proto3";
 
 package ray.rpc;
 
-/// This file is only used for grpc test.
+/// This file is only used for rpc test.
 
-message EchoRequest {
-  string request_message = 1;
+message HelloRequest {
+  string who = 1;
+  uint64 index = 2;
 }
 
-message EchoReply {
-  string reply_message = 1;
+message HelloReply {
+  string message = 1;
 }
 
 service TestService {
-  rpc Echo(EchoRequest) returns (EchoReply);
+  rpc Hello(HelloRequest) returns (HelloReply);
 }

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -152,8 +152,12 @@ class ClientCallManager {
   std::shared_ptr<ClientCall> CreateCall(
       typename GrpcService::Stub &stub,
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
-      const Request &request, const ClientCallback<Reply> &callback) {
+      const Request &request, const ClientCallback<Reply> &callback,
+      const std::unordered_map<std::string, std::string> &meta = {}) {
     auto call = std::make_shared<ClientCallImpl<Reply>>(callback);
+    for (const auto &meta_entry : meta) {
+      call->context_.AddMetadata(meta_entry.first, meta_entry.second);
+    }
     // Send request.
     call->response_reader_ =
         (stub.*prepare_async_function)(&call->context_, request, &cq_);

--- a/src/ray/rpc/constants.h
+++ b/src/ray/rpc/constants.h
@@ -1,0 +1,12 @@
+#ifndef RAY_RPC_CONSTANTS_H
+#define RAY_RPC_CONSTANTS_H
+
+#include <string>
+
+/// Metadata key for client id.
+const std::string CLIENT_ID_META_KEY = "client_id";
+
+/// Metadata key for request index.
+const std::string REQUEST_INDEX_META_KEY = "request_index";
+
+#endif

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -1,7 +1,10 @@
 #ifndef RAY_RPC_GRPC_CLIENT_H
 #define RAY_RPC_GRPC_CLIENT_H
 
+#include <map>
 #include <grpcpp/grpcpp.h>
+
+#include "ray/common/id.h"
 
 namespace ray {
 namespace rpc {
@@ -9,16 +12,16 @@ namespace rpc {
 template <typename GrpcService>
 class GrpcClient {
  protected:
-  GrpcClient(bool keep_request_order)
+  explicit GrpcClient(bool keep_request_order)
       : keep_request_order_(keep_request_order),
-        client_id_(UniqueID::FromRandom().Binary()),
+        client_id_(UniqueID::FromRandom().Hex()),
         current_request_index_(0) {}
 
   std::unordered_map<std::string, std::string> GetMetaForNextRequest() {
     std::unordered_map<std::string, std::string> ret;
-    ret["CLIENT_ID"] = client_id_;
+    ret["client_id"] = client_id_;
     if (keep_request_order_) {
-      ret["REQUEST_INDEX"] = current_request_index_++;
+      ret["request_index"] = current_request_index_++;
     }
     return ret;
   }

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -1,10 +1,11 @@
 #ifndef RAY_RPC_GRPC_CLIENT_H
 #define RAY_RPC_GRPC_CLIENT_H
 
-#include <map>
 #include <grpcpp/grpcpp.h>
+#include <map>
 
 #include "ray/common/id.h"
+#include "ray/rpc/constants.h"
 
 namespace ray {
 namespace rpc {
@@ -12,16 +13,22 @@ namespace rpc {
 template <typename GrpcService>
 class GrpcClient {
  protected:
-  explicit GrpcClient(bool keep_request_order)
-      : keep_request_order_(keep_request_order),
+  /// Constructor.
+  ///
+  /// \param[in] strict_request_order Whether the server should handle requests from this
+  /// client in the same order as they were sent.
+  explicit GrpcClient(bool strict_request_order)
+      : strict_request_order_(strict_request_order),
         client_id_(UniqueID::FromRandom().Hex()),
         current_request_index_(0) {}
 
+  /// Get metadata for the next request to send.
   std::unordered_map<std::string, std::string> GetMetaForNextRequest() {
     std::unordered_map<std::string, std::string> ret;
-    ret["client_id"] = client_id_;
-    if (keep_request_order_) {
-      ret["request_index"] = current_request_index_++;
+    ret[CLIENT_ID_META_KEY] = client_id_;
+    if (strict_request_order_) {
+      // Add request index to the meta if `strict_request_order` is enabled.
+      ret[REQUEST_INDEX_META_KEY] = std::to_string(current_request_index_++);
     }
     return ret;
   }
@@ -29,7 +36,7 @@ class GrpcClient {
   /// The gRPC-generated stub.
   std::unique_ptr<typename GrpcService::Stub> stub_;
 
-  bool keep_request_order_;
+  bool strict_request_order_;
 
   std::string client_id_;
 

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -1,0 +1,39 @@
+#ifndef RAY_RPC_GRPC_CLIENT_H
+#define RAY_RPC_GRPC_CLIENT_H
+
+#include <grpcpp/grpcpp.h>
+
+namespace ray {
+namespace rpc {
+
+template <typename GrpcService>
+class GrpcClient {
+ protected:
+  GrpcClient(bool keep_request_order)
+      : keep_request_order_(keep_request_order),
+        client_id_(UniqueID::FromRandom().Binary()),
+        current_request_index_(0) {}
+
+  std::unordered_map<std::string, std::string> GetMetaForNextRequest() {
+    std::unordered_map<std::string, std::string> ret;
+    ret["CLIENT_ID"] = client_id_;
+    if (keep_request_order_) {
+      ret["REQUEST_INDEX"] = current_request_index_++;
+    }
+    return ret;
+  }
+
+  /// The gRPC-generated stub.
+  std::unique_ptr<typename GrpcService::Stub> stub_;
+
+  bool keep_request_order_;
+
+  std::string client_id_;
+
+  uint64_t current_request_index_;
+};
+
+}  // namespace rpc
+}  // namespace ray
+
+#endif

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -20,7 +20,7 @@ class GrpcClient {
   explicit GrpcClient(bool strict_request_order)
       : strict_request_order_(strict_request_order),
         client_id_(UniqueID::FromRandom().Hex()),
-        current_request_index_(0) {}
+        next_request_index_(0) {}
 
   /// Get metadata for the next request to send.
   std::unordered_map<std::string, std::string> GetMetaForNextRequest() {
@@ -28,7 +28,7 @@ class GrpcClient {
     ret[CLIENT_ID_META_KEY] = client_id_;
     if (strict_request_order_) {
       // Add request index to the meta if `strict_request_order` is enabled.
-      ret[REQUEST_INDEX_META_KEY] = std::to_string(current_request_index_++);
+      ret[REQUEST_INDEX_META_KEY] = std::to_string(next_request_index_++);
     }
     return ret;
   }
@@ -36,11 +36,15 @@ class GrpcClient {
   /// The gRPC-generated stub.
   std::unique_ptr<typename GrpcService::Stub> stub_;
 
+  /// Whether the server should handle requests from this
+  /// client in the same order as they were sent.
   bool strict_request_order_;
 
+  /// Id of this client.
   std::string client_id_;
 
-  uint64_t current_request_index_;
+  /// Index for the next request.
+  uint64_t next_request_index_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -95,13 +95,13 @@ void GrpcServer::PollEventsFromCompletionQueue() {
 }
 
 void GrpcServer::HandleReceivedRequest(ServerCall *server_call) {
-  auto request_index_str = server_call->GetClientMeta("REQUEST_INDEX");
+  auto request_index_str = server_call->GetClientMeta("request_index");
   if (request_index_str.empty()) {
     // If this request doesn't have `request_index`, it means that we don't need to guarantee
     // request order. So we can immediately handle this request.
     server_call->HandleRequest();
   } else {
-    auto client_id = server_call->GetClientMeta("CLIENT_ID");
+    auto client_id = server_call->GetClientMeta("client_id");
     RAY_CHECK(!client_id.empty());
     auto request_index = std::stoull(request_index_str);
     auto &pending_requests = pending_requests_by_client_id_[client_id];

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -76,6 +76,8 @@ class GrpcServer {
   /// via the `ServerCall` objects.
   void PollEventsFromCompletionQueue();
 
+  void HandleReceivedRequest(ServerCall *server_call);
+
   /// Name of this server, used for logging and debugging purpose.
   const std::string name_;
   /// Port of this server.
@@ -96,6 +98,13 @@ class GrpcServer {
   std::unique_ptr<grpc::Server> server_;
   /// The polling thread used to check the completion queue.
   std::thread polling_thread_;
+
+  ///
+  struct PendingRequests {
+    uint64_t next_request_index_to_handle = 0;
+    std::unordered_map<uint64_t, ServerCall *> buffer;
+  };
+  std::unordered_map<std::string, PendingRequests> pending_requests_by_client_id_;
 };
 
 /// Base class that represents an abstract gRPC service.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -45,9 +45,7 @@ class GrpcServer {
 
   /// Destruct this gRPC server.
   ~GrpcServer() {
-    RAY_LOG(INFO) << "Shutting down";
     Shutdown();
-    RAY_LOG(INFO) << "Shutdown";
   }
 
   /// Initialize and run this server.
@@ -125,7 +123,7 @@ class GrpcService {
       : main_service_(main_service) {}
 
   /// Destruct this gRPC service.
-  ~GrpcService() = default;
+  virtual ~GrpcService() = default;
 
  protected:
   /// Return the underlying grpc::Service object for this class.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -44,7 +44,11 @@ class GrpcServer {
   }
 
   /// Destruct this gRPC server.
-  ~GrpcServer() { Shutdown(); }
+  ~GrpcServer() {
+    RAY_LOG(INFO) << "Shutting down";
+    Shutdown();
+    RAY_LOG(INFO) << "Shutdown";
+  }
 
   /// Initialize and run this server.
   void Run();

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -44,9 +44,7 @@ class GrpcServer {
   }
 
   /// Destruct this gRPC server.
-  ~GrpcServer() {
-    Shutdown();
-  }
+  ~GrpcServer() { Shutdown(); }
 
   /// Initialize and run this server.
   void Run();
@@ -78,6 +76,7 @@ class GrpcServer {
   /// via the `ServerCall` objects.
   void PollEventsFromCompletionQueue();
 
+  /// Handle a new received request.
   void HandleReceivedRequest(ServerCall *server_call);
 
   /// Name of this server, used for logging and debugging purpose.
@@ -101,11 +100,14 @@ class GrpcServer {
   /// The polling thread used to check the completion queue.
   std::thread polling_thread_;
 
-  ///
+  /// Buffered out-of-order requests.
   struct PendingRequests {
+    /// Next expected request index.
     uint64_t next_request_index_to_handle = 0;
+    /// Mapping from the index to the buffered request.
     std::unordered_map<uint64_t, ServerCall *> buffer;
   };
+  /// Buffer out-of-order requests per client.
   std::unordered_map<std::string, PendingRequests> pending_requests_by_client_id_;
 };
 

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -69,6 +69,8 @@ class ServerCall {
   // Invoked when sending reply fails.
   virtual void OnReplyFailed() = 0;
 
+  virtual std::string GetClientMeta(const std::string &key) = 0;
+
   /// Virtual destruct function to make sure subclass would destruct properly.
   virtual ~ServerCall() = default;
 };
@@ -171,6 +173,15 @@ class ServerCallImpl : public ServerCall {
     if (send_reply_failure_callback_ && !io_service_.stopped()) {
       auto callback = std::move(send_reply_failure_callback_);
       io_service_.post([callback]() { callback(); });
+    }
+  }
+
+  std::string GetClientMeta(const std::string &key) override {
+    auto it = context_.client_metadata().find(key);
+    if (it == context_.client_metadata().end()) {
+      return "";
+    } else {
+      return std::string(it->second.data(), it->second.size());
     }
   }
 

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -69,6 +69,7 @@ class ServerCall {
   // Invoked when sending reply fails.
   virtual void OnReplyFailed() = 0;
 
+  // Get metadata sent by the client for the given key.
   virtual std::string GetClientMeta(const std::string &key) = 0;
 
   /// Virtual destruct function to make sure subclass would destruct properly.

--- a/src/ray/rpc/test/rpc_test.cc
+++ b/src/ray/rpc/test/rpc_test.cc
@@ -6,6 +6,7 @@
 #include "ray/rpc/client_call.h"
 #include "ray/rpc/grpc_client.h"
 #include "ray/rpc/grpc_server.h"
+#include "ray/util/test_util.h"
 #include "src/ray/protobuf/test.grpc.pb.h"
 
 namespace ray {
@@ -20,21 +21,23 @@ class TestClient : public GrpcClient<TestService> {
   /// \param[in] address Address of the test server.
   /// \param[in] port Port of the test server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
+  /// \param[in] strict_request_order Whether the server should handle requests from this
+  /// client in the same order as they were sent.
   TestClient(const std::string &address, const int port,
-             ClientCallManager &client_call_manager, bool keep_request_order)
-      : GrpcClient(keep_request_order), client_call_manager_(client_call_manager) {
+             ClientCallManager &client_call_manager, bool strict_request_order)
+      : GrpcClient(strict_request_order), client_call_manager_(client_call_manager) {
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
         address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
     stub_ = TestService::NewStub(channel);
   };
 
-  /// Send an echo request.
+  /// Send a Hello request.
   ///
   /// \param[in] request The request message.
   /// \param[in] callback The callback function that handles reply.
-  Status Echo(const EchoRequest &request, const ClientCallback<EchoReply> &callback) {
-    auto call = client_call_manager_.CreateCall<TestService, EchoRequest, EchoReply>(
-        *stub_, &TestService::Stub::PrepareAsyncEcho, request, callback,
+  Status Hello(const HelloRequest &request, const ClientCallback<HelloReply> &callback) {
+    auto call = client_call_manager_.CreateCall<TestService, HelloRequest, HelloReply>(
+        *stub_, &TestService::Stub::PrepareAsyncHello, request, callback,
         GetMetaForNextRequest());
     return call->GetStatus();
   }
@@ -46,10 +49,10 @@ class TestClient : public GrpcClient<TestService> {
 
 class TestServiceHandler {
  public:
-  /// Handle a `Echo` request.
-  virtual void HandleEcho(const EchoRequest &request, EchoReply *reply,
-                          SendReplyCallback send_reply_callback) = 0;
-  virtual ~TestServiceHandler() = 0;
+  /// Handle a `Hello` request.
+  virtual void HandleHello(const HelloRequest &request, HelloReply *reply,
+                           SendReplyCallback send_reply_callback) = 0;
+  virtual ~TestServiceHandler() = default;
 };
 
 /// The `GrpcService` for `TestService`.
@@ -70,13 +73,13 @@ class TestGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
           *server_call_factories_and_concurrencies) override {
-    // Initialize the factory for `Echo` requests.
-    std::unique_ptr<ServerCallFactory> echo_call_factory(
-        new ServerCallFactoryImpl<TestService, TestServiceHandler, EchoRequest,
-                                  EchoReply>(
-            service_, &TestService::AsyncService::RequestEcho, service_handler_,
-            &TestServiceHandler::HandleEcho, cq, main_service_));
-    server_call_factories_and_concurrencies->emplace_back(std::move(echo_call_factory),
+    // Initialize the factory for `Hello` requests.
+    std::unique_ptr<ServerCallFactory> Hello_call_factory(
+        new ServerCallFactoryImpl<TestService, TestServiceHandler, HelloRequest,
+                                  HelloReply>(
+            service_, &TestService::AsyncService::RequestHello, service_handler_,
+            &TestServiceHandler::HandleHello, cq, main_service_));
+    server_call_factories_and_concurrencies->emplace_back(std::move(Hello_call_factory),
                                                           10);
   }
 
@@ -90,21 +93,35 @@ class TestGrpcService : public GrpcService {
 
 class TestServer : public TestServiceHandler {
  public:
-  explicit TestServer(boost::asio::io_service &io_service)
-      : test_server_("TestServer", 0), test_grpc_service_(io_service, *this) {
+  /// Constructor.
+  ///
+  /// \param io_service `io_service` used for the `GrpcServer`.
+  /// \param strict_request_order Whether the server should handle the requests in the
+  /// same order as they were sent from the client.
+  explicit TestServer(boost::asio::io_service &io_service, bool strict_request_order)
+      : test_server_("TestServer", 0),
+        test_grpc_service_(io_service, *this),
+        strict_request_order_(strict_request_order) {
     test_server_.RegisterService(test_grpc_service_);
     test_server_.Run();
   }
 
-  void HandleEcho(const EchoRequest &request, EchoReply *reply,
-                  SendReplyCallback send_reply_callback) override {
-    RAY_LOG(DEBUG) << "Server received a request from the client, msg: "
-                   << request.request_message();
-    reply->set_reply_message(request.request_message());
+  void HandleHello(const HelloRequest &request, HelloReply *reply,
+                   SendReplyCallback send_reply_callback) override {
+    const auto &client = request.who();
+    reply->set_message("Hello, " + client);
+
+    if (strict_request_order_) {
+      auto index = request.index();
+      ASSERT_TRUE(index == last_received_request_index[client] + 1);
+      last_received_request_index[client] += 1;
+    }
+
     auto success_callback = [] { RAY_LOG(DEBUG) << "Reply sent to the client."; };
     auto failure_callback = [] {
       RAY_LOG(FATAL) << "Failed to send reply to the client.";
     };
+
     send_reply_callback(Status::OK(), success_callback, failure_callback);
   }
 
@@ -113,6 +130,9 @@ class TestServer : public TestServiceHandler {
  private:
   GrpcServer test_server_;
   TestGrpcService test_grpc_service_;
+  bool strict_request_order_;
+  // Index of the last received request per client.
+  std::unordered_map<std::string, int64_t> last_received_request_index;
 };
 
 class RpcTest : public ::testing::Test {
@@ -120,7 +140,7 @@ class RpcTest : public ::testing::Test {
   RpcTest()
       : client_work_(client_service_),
         server_work_(server_service_),
-        client_call_manager_(new ClientCallManager(client_service_)) {}
+        client_call_manager_(client_service_) {}
 
   void SetUp() override {
     client_thread_.reset(new std::thread([this] { client_service_.run(); }));
@@ -128,81 +148,109 @@ class RpcTest : public ::testing::Test {
   }
 
   void TearDown() override {
-//    RAY_LOG(INFO) << "Tear down";
-//    client_service_.stop();
-//    client_thread_->join();
-//    client_thread_.reset();
-//    RAY_LOG(INFO) << "Tear down 1";
-//
-//    server_service_.stop();
-//    server_thread_->join();
-//    server_thread_.reset();
-//    RAY_LOG(INFO) << "Tear down 2";
+    client_service_.stop();
+    client_thread_->join();
+    client_thread_.reset();
+
+    server_service_.stop();
+    server_thread_->join();
+    server_thread_.reset();
   }
 
-  std::unique_ptr<TestServer> CreateServer() {
-    return std::unique_ptr<TestServer>(new TestServer(server_service_));
+  /// Create a server.
+  ///
+  /// \param strict_request_order Whether the server should handle the requests in the
+  /// same order as they were sent from the client.
+  std::unique_ptr<TestServer> CreateServer(bool strict_request_order) {
+    return std::unique_ptr<TestServer>(
+        new TestServer(server_service_, strict_request_order));
   }
 
-  std::unique_ptr<TestClient> CreateClient(int port, bool keep_request_order) {
-    return std::unique_ptr<TestClient>(
-        new TestClient("127.0.0.1", port, *client_call_manager_, keep_request_order));
+  /// Create a client.
+  ///
+  /// \param[in] server_port Port of the server.
+  /// \param[in] strict_request_order Whether the server should handle requests from this
+  /// client in the same order as they were sent.
+  std::unique_ptr<TestClient> CreateClient(int server_port, bool strict_request_order) {
+    return std::unique_ptr<TestClient>(new TestClient(
+        "127.0.0.1", server_port, client_call_manager_, strict_request_order));
   }
 
-// protected:
+ protected:
+  // `io_service` for the clients.
   boost::asio::io_service client_service_;
+  // A `io_service::work` to keep `client_service_` running.
   boost::asio::io_service::work client_work_;
+  // The thread in which `client_service_` is running.
   std::unique_ptr<std::thread> client_thread_;
 
+  // `io_service` for the servers.
   boost::asio::io_service server_service_;
+  // A `io_service::work` to keep `server_service_` running.
   boost::asio::io_service::work server_work_;
+  // The thread in which `server_service_` is running.
   std::unique_ptr<std::thread> server_thread_;
 
-  std::unique_ptr<ClientCallManager> client_call_manager_;
+  // The `ClientCallManager` shared by all clients.
+  ClientCallManager client_call_manager_;
 };
 
+/// Test sending unary requests.
+///
+/// \param[in] rpc_test The `RpcTest` object.
+/// \param[in] num_servers Number of servers to create.
+/// \param[in] num_clients Number of clients per server to create.
+/// \param[in] num_requests Number of requests to send per client.
+/// \param[in] strict_request_order Whether the server should handle requests from this
+/// client in the same order as they were sent.
 void TestUnaryRequests(RpcTest &rpc_test, int num_servers, int num_clients,
-                       int num_requests) {
+                       int num_requests, bool strict_request_order) {
   std::vector<std::unique_ptr<TestServer>> servers;
   std::vector<std::unique_ptr<TestClient>> clients;
+
+  // Create servers and clients.
   for (int i = 0; i < num_servers; i++) {
-    servers.emplace_back(rpc_test.CreateServer());
+    servers.emplace_back(rpc_test.CreateServer(strict_request_order));
     for (int j = 0; j < num_clients; j++) {
-      clients.emplace_back(rpc_test.CreateClient(servers.back()->GetPort(), false));
+      clients.emplace_back(rpc_test.CreateClient(servers.back()->GetPort(), strict_request_order));
     }
   }
 
-//  int num_replies = 0;
+  // Number of pending replies.
+  std::atomic<int> pending_replies(num_servers * num_clients * num_requests);
 
-//  for (const auto &client : clients) {
-//    for (int i = 0; i < num_requests; i++) {
-//      EchoRequest request;
-//      request.set_request_message(std::to_string(i));
-//      auto status = client->Echo(
-//          request, [&num_replies, i](const Status &status, const EchoReply &reply) {
-//            RAY_CHECK_OK(status);
-//            num_replies++;
-//            ASSERT_EQ(reply.reply_message(), std::to_string(i));
-//          });
-//      RAY_CHECK_OK(status);
-//    }
-//  }
-//  std::this_thread::sleep_for(std::chrono::microseconds(2000));
-  RAY_LOG(INFO) << "Tear down";
-  rpc_test.client_service_.stop();
-  rpc_test.client_thread_->join();
-  rpc_test.client_thread_.reset();
-  RAY_LOG(INFO) << "Tear down 1";
-
-  rpc_test.server_service_.stop();
-  rpc_test.server_thread_->join();
-  rpc_test.server_thread_.reset();
-  RAY_LOG(INFO) << "Tear down 2";
-  rpc_test.client_call_manager_.reset(nullptr);
-  RAY_LOG(INFO) << "END";
+  for (int i = 0; i < clients.size(); i++) {
+    const auto &client = clients[i];
+    std::string client_name = "client_" + std::to_string(i);
+    for (int j = 0; j < num_requests; j++) {
+      HelloRequest request;
+      request.set_who(client_name);
+      request.set_index(j);
+      auto status = client->Hello(
+          request, [&pending_replies, client_name](const Status &status, const HelloReply &reply) {
+            ASSERT_TRUE(status.ok());
+            pending_replies -= 1;
+            ASSERT_EQ(reply.message(), "Hello, " + client_name);
+          });
+      ASSERT_TRUE(status.ok());
+    }
+  }
+  // Wait until all replies are received.
+  WaitForCondition([&pending_replies]() { return pending_replies == 0; }, 5000);
 }
 
-TEST_F(RpcTest, TestUnaryRequests) { TestUnaryRequests(*this, 2, 1, 100); }
+// Test sending unary requests from one client to one server.
+TEST_F(RpcTest, TestUnaryRequests) { TestUnaryRequests(*this, 1, 1, 100, false); }
+
+// Test sending unary requests from multiple clients to multiple servers.
+TEST_F(RpcTest, TestUnaryRequestsWithManyClientsAndServers) {
+  TestUnaryRequests(*this, 5, 5, 100, false);
+}
+
+// Test the `strict_request_order` option in `GrpcClient`.
+TEST_F(RpcTest, TestStrictRequestOrder) {
+  TestUnaryRequests(*this, 1, 10, 100, true);
+}
 
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/rpc/test/rpc_test.cc
+++ b/src/ray/rpc/test/rpc_test.cc
@@ -1,0 +1,213 @@
+#include <grpcpp/grpcpp.h>
+#include <gtest/gtest.h>
+#include <boost/asio.hpp>
+
+#include "ray/common/status.h"
+#include "ray/rpc/client_call.h"
+#include "ray/rpc/grpc_client.h"
+#include "ray/rpc/grpc_server.h"
+#include "src/ray/protobuf/test.grpc.pb.h"
+
+namespace ray {
+namespace rpc {
+
+using ray::Status;
+
+class TestClient : public GrpcClient<TestService> {
+ public:
+  /// Constructor.
+  ///
+  /// \param[in] address Address of the test server.
+  /// \param[in] port Port of the test server.
+  /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
+  TestClient(const std::string &address, const int port,
+             ClientCallManager &client_call_manager, bool keep_request_order)
+      : GrpcClient(keep_request_order), client_call_manager_(client_call_manager) {
+    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
+        address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
+    stub_ = TestService::NewStub(channel);
+  };
+
+  /// Send an echo request.
+  ///
+  /// \param[in] request The request message.
+  /// \param[in] callback The callback function that handles reply.
+  Status Echo(const EchoRequest &request, const ClientCallback<EchoReply> &callback) {
+    auto call = client_call_manager_.CreateCall<TestService, EchoRequest, EchoReply>(
+        *stub_, &TestService::Stub::PrepareAsyncEcho, request, callback,
+        GetMetaForNextRequest());
+    return call->GetStatus();
+  }
+
+ private:
+  /// The `ClientCallManager` used for managing requests.
+  ClientCallManager &client_call_manager_;
+};
+
+class TestServiceHandler {
+ public:
+  /// Handle a `Echo` request.
+  virtual void HandleEcho(const EchoRequest &request, EchoReply *reply,
+                          SendReplyCallback send_reply_callback) = 0;
+  virtual ~TestServiceHandler() = 0;
+};
+
+/// The `GrpcService` for `TestService`.
+class TestGrpcService : public GrpcService {
+ public:
+  /// Constructor.
+  ///
+  /// \param[in] io_service See super class.
+  /// \param[in] handler The service handler that actually handle the requests.
+  TestGrpcService(boost::asio::io_service &io_service,
+                  TestServiceHandler &service_handler)
+      : GrpcService(io_service), service_handler_(service_handler){};
+
+ protected:
+  grpc::Service &GetGrpcService() override { return service_; }
+
+  void InitServerCallFactories(
+      const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
+      std::vector<std::pair<std::unique_ptr<ServerCallFactory>, int>>
+          *server_call_factories_and_concurrencies) override {
+    // Initialize the factory for `Echo` requests.
+    std::unique_ptr<ServerCallFactory> echo_call_factory(
+        new ServerCallFactoryImpl<TestService, TestServiceHandler, EchoRequest,
+                                  EchoReply>(
+            service_, &TestService::AsyncService::RequestEcho, service_handler_,
+            &TestServiceHandler::HandleEcho, cq, main_service_));
+    server_call_factories_and_concurrencies->emplace_back(std::move(echo_call_factory),
+                                                          10);
+  }
+
+ private:
+  /// The grpc async service object.
+  TestService::AsyncService service_;
+
+  /// The service handler that actually handle the requests.
+  TestServiceHandler &service_handler_;
+};
+
+class TestServer : public TestServiceHandler {
+ public:
+  explicit TestServer(boost::asio::io_service &io_service)
+      : test_server_("TestServer", 0), test_grpc_service_(io_service, *this) {
+    test_server_.RegisterService(test_grpc_service_);
+    test_server_.Run();
+  }
+
+  void HandleEcho(const EchoRequest &request, EchoReply *reply,
+                  SendReplyCallback send_reply_callback) override {
+    RAY_LOG(DEBUG) << "Server received a request from the client, msg: "
+                   << request.request_message();
+    reply->set_reply_message(request.request_message());
+    auto success_callback = [] { RAY_LOG(DEBUG) << "Reply sent to the client."; };
+    auto failure_callback = [] {
+      RAY_LOG(FATAL) << "Failed to send reply to the client.";
+    };
+    send_reply_callback(Status::OK(), success_callback, failure_callback);
+  }
+
+  int GetPort() { return test_server_.GetPort(); }
+
+ private:
+  GrpcServer test_server_;
+  TestGrpcService test_grpc_service_;
+};
+
+class RpcTest : public ::testing::Test {
+ public:
+  RpcTest()
+      : client_work_(client_service_),
+        server_work_(server_service_),
+        client_call_manager_(new ClientCallManager(client_service_)) {}
+
+  void SetUp() override {
+    client_thread_.reset(new std::thread([this] { client_service_.run(); }));
+    server_thread_.reset(new std::thread([this] { server_service_.run(); }));
+  }
+
+  void TearDown() override {
+//    RAY_LOG(INFO) << "Tear down";
+//    client_service_.stop();
+//    client_thread_->join();
+//    client_thread_.reset();
+//    RAY_LOG(INFO) << "Tear down 1";
+//
+//    server_service_.stop();
+//    server_thread_->join();
+//    server_thread_.reset();
+//    RAY_LOG(INFO) << "Tear down 2";
+  }
+
+  std::unique_ptr<TestServer> CreateServer() {
+    return std::unique_ptr<TestServer>(new TestServer(server_service_));
+  }
+
+  std::unique_ptr<TestClient> CreateClient(int port, bool keep_request_order) {
+    return std::unique_ptr<TestClient>(
+        new TestClient("127.0.0.1", port, *client_call_manager_, keep_request_order));
+  }
+
+// protected:
+  boost::asio::io_service client_service_;
+  boost::asio::io_service::work client_work_;
+  std::unique_ptr<std::thread> client_thread_;
+
+  boost::asio::io_service server_service_;
+  boost::asio::io_service::work server_work_;
+  std::unique_ptr<std::thread> server_thread_;
+
+  std::unique_ptr<ClientCallManager> client_call_manager_;
+};
+
+void TestUnaryRequests(RpcTest &rpc_test, int num_servers, int num_clients,
+                       int num_requests) {
+  std::vector<std::unique_ptr<TestServer>> servers;
+  std::vector<std::unique_ptr<TestClient>> clients;
+  for (int i = 0; i < num_servers; i++) {
+    servers.emplace_back(rpc_test.CreateServer());
+    for (int j = 0; j < num_clients; j++) {
+      clients.emplace_back(rpc_test.CreateClient(servers.back()->GetPort(), false));
+    }
+  }
+
+//  int num_replies = 0;
+
+//  for (const auto &client : clients) {
+//    for (int i = 0; i < num_requests; i++) {
+//      EchoRequest request;
+//      request.set_request_message(std::to_string(i));
+//      auto status = client->Echo(
+//          request, [&num_replies, i](const Status &status, const EchoReply &reply) {
+//            RAY_CHECK_OK(status);
+//            num_replies++;
+//            ASSERT_EQ(reply.reply_message(), std::to_string(i));
+//          });
+//      RAY_CHECK_OK(status);
+//    }
+//  }
+//  std::this_thread::sleep_for(std::chrono::microseconds(2000));
+  RAY_LOG(INFO) << "Tear down";
+  rpc_test.client_service_.stop();
+  rpc_test.client_thread_->join();
+  rpc_test.client_thread_.reset();
+  RAY_LOG(INFO) << "Tear down 1";
+
+  rpc_test.server_service_.stop();
+  rpc_test.server_thread_->join();
+  rpc_test.server_thread_.reset();
+  RAY_LOG(INFO) << "Tear down 2";
+  rpc_test.client_call_manager_.reset(nullptr);
+  RAY_LOG(INFO) << "END";
+}
+
+TEST_F(RpcTest, TestUnaryRequests) { TestUnaryRequests(*this, 2, 1, 100); }
+
+}  // namespace rpc
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/rpc/worker/direct_actor_client.h
+++ b/src/ray/rpc/worker/direct_actor_client.h
@@ -16,7 +16,7 @@ namespace ray {
 namespace rpc {
 
 /// Client used for communicating with a direct actor server.
-class DirectActorClient : public GetRpcClient<DirectActorService> {
+class DirectActorClient : public GrpcClient<DirectActorService> {
  public:
   /// Constructor.
   ///

--- a/src/ray/util/test_util.h
+++ b/src/ray/util/test_util.h
@@ -12,7 +12,7 @@ namespace ray {
 /// \param[in] condition The condition to wait for.
 /// \param[in] timeout_ms Timeout in milliseconds to wait for for.
 /// \return Whether the condition is met.
-bool WaitForCondition(std::function<bool()> condition, int timeout_ms) {
+bool WaitForCondition(const std::function<bool()>& condition, int timeout_ms) {
   int wait_time = 0;
   while (true) {
     if (condition()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?

gRPC may receive client requests in a different order as they were sent. This is problematic in some scenarios. This PR resolves this issue by buffering and sorting requests. A `strict_request_order` option is added to grpc client.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
