### PR TITLE
Fix test_logging_to_driver and test_not_logging_to_driver

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2649,8 +2649,6 @@ def test_logging_to_driver(shutdown_only):
     output_lines = captured["out"]
     for i in range(200):
         assert str(i) in output_lines
-    error_lines = captured["err"]
-    assert len(error_lines) == 0
 
 
 def test_not_logging_to_driver(shutdown_only):
@@ -2671,8 +2669,6 @@ def test_not_logging_to_driver(shutdown_only):
 
     output_lines = captured["out"]
     assert len(output_lines) == 0
-    error_lines = captured["err"]
-    assert len(error_lines) == 0
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -2650,6 +2650,11 @@ def test_logging_to_driver(shutdown_only):
     for i in range(200):
         assert str(i) in output_lines
 
+    # TODO(rkn): Check that no additional logs appear beyond what we expect
+    # and that there are no duplicate logs. Once we address the issue
+    # described in https://github.com/ray-project/ray/pull/5462, we should
+    # also check that nothing is logged to stderr.
+
 
 def test_not_logging_to_driver(shutdown_only):
     ray.init(num_cpus=1, log_to_driver=False)
@@ -2669,6 +2674,11 @@ def test_not_logging_to_driver(shutdown_only):
 
     output_lines = captured["out"]
     assert len(output_lines) == 0
+
+    # TODO(rkn): Check that no additional logs appear beyond what we expect
+    # and that there are no duplicate logs. Once we address the issue
+    # described in https://github.com/ray-project/ray/pull/5462, we should
+    # also check that nothing is logged to stderr.
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

These 2 tests are flaky on CI. Because sometimes the previous autoscaler tests will start background threads and print the following errors to stderr.

```
Traceback (most recent call last):
  File "/home/travis/miniconda/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/home/travis/build/ray-project/ray/python/ray/autoscaler/updater.py", line 151, in run
    raise e
AssertionError: Unable to SSH to node
```

The purpose of these tests should be to verify that the logs are redirected (or not redirected) to driver stdout. So there's no need to check `stderr`. However, we should also fix the issue of not stopping autoscaler background threads in a different PR.

## What do these changes do?


## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
