### PR TITLE
Fix json.loads compatibility issue for Python 3.5

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -272,7 +272,7 @@ class NodeStats(threading.Thread):
 
         for x in p.listen():
             try:
-                D = json.loads(x["data"])
+                D = json.loads(ray.utils.decode(x["data"]))
                 with self._node_stats_lock:
                     self._node_stats[D["hostname"]] = D
             except Exception:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Before Python 3.6, the `json.loads` function could only accept `str` objects, not `bytes` objects. See the documentation at https://docs.python.org/3/library/json.html#json.loads for details.

## What do these changes do?

Decode the `bytes` messages coming from the Redis client into `str` objects in order to avoid the following type error in Python versions 3.0 to 3.5:

```
TypeError: the JSON object must be str, not 'bytes'
```

## Related issue number

N/A

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
