### PR TITLE
[autoscaler] Fix ssh control path length issue

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -6,6 +6,7 @@ try:  # py3
     from shlex import quote
 except ImportError:  # py2
     from pipes import quote
+import hashlib
 import logging
 import os
 import subprocess
@@ -23,7 +24,7 @@ logger = logging.getLogger(__name__)
 # How long to wait for a node to start, in seconds
 NODE_START_WAIT_S = 300
 SSH_CHECK_INTERVAL = 5
-CONTROL_PATH_MAX_LENGTH = 70
+CONTROL_HASH_MAX_LENGTH = 10
 
 
 def get_default_ssh_options(private_key, connect_timeout, ssh_control_path):
@@ -57,8 +58,9 @@ class NodeUpdater(object):
                  exit_on_update_fail=False,
                  use_internal_ip=False):
 
-        ssh_control_path = "/tmp/{}_ray_ssh_sockets/{}".format(
-            getuser(), cluster_name)[:CONTROL_PATH_MAX_LENGTH]
+        ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
+        ssh_control_path = "/tmp/{}_ray_ssh/{}".format(
+            getuser(), ssh_control_hash[:CONTROL_HASH_MAX_LENGTH])
 
         self.daemon = True
         self.process_runner = process_runner

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # How long to wait for a node to start, in seconds
 NODE_START_WAIT_S = 300
 SSH_CHECK_INTERVAL = 5
-CONTROL_HASH_MAX_LENGTH = 10
+HASH_MAX_LENGTH = 10
 
 
 def get_default_ssh_options(private_key, connect_timeout, ssh_control_path):
@@ -59,8 +59,10 @@ class NodeUpdater(object):
                  use_internal_ip=False):
 
         ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
+        ssh_user_hash = hashlib.md5(getuser()).hexdigest()
         ssh_control_path = "/tmp/{}_ray_ssh/{}".format(
-            getuser(), ssh_control_hash[:CONTROL_HASH_MAX_LENGTH])
+            ssh_user_hash[:HASH_MAX_LENGTH],
+            ssh_control_hash[:HASH_MAX_LENGTH])
 
         self.daemon = True
         self.process_runner = process_runner

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -59,7 +59,7 @@ class NodeUpdater(object):
                  use_internal_ip=False):
 
         ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
-        ssh_user_hash = hashlib.md5(getuser()).hexdigest()
+        ssh_user_hash = hashlib.md5(getuser().encode()).hexdigest()
         ssh_control_path = "/tmp/{}_ray_ssh/{}".format(
             ssh_user_hash[:HASH_MAX_LENGTH],
             ssh_control_hash[:HASH_MAX_LENGTH])

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -60,7 +60,7 @@ class NodeUpdater(object):
 
         ssh_control_hash = hashlib.md5(cluster_name.encode()).hexdigest()
         ssh_user_hash = hashlib.md5(getuser().encode()).hexdigest()
-        ssh_control_path = "/tmp/{}_ray_ssh/{}".format(
+        ssh_control_path = "/tmp/ray_ssh_{}/{}".format(
             ssh_user_hash[:HASH_MAX_LENGTH],
             ssh_control_hash[:HASH_MAX_LENGTH])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

While release testing for 0.7.4, I was running into https://github.com/ray-project/ray/issues/4745 again. This PR hashes the cluster dependent part of the control path and makes it fixed length so the error won't happen any more.

## What do these changes do?

Use the 10 first characters from an MD5 hash of the cluster dependent part of the control path instead of a truncated path.

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/4745

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
