### PR TITLE
[rllib] fix arguments of distribution class example

### DIFF
--- a/rllib/examples/custom_torch_policy.py
+++ b/rllib/examples/custom_torch_policy.py
@@ -18,7 +18,7 @@ def policy_gradient_loss(policy, batch_tensors):
     logits, _ = policy.model({
         SampleBatch.CUR_OBS: batch_tensors[SampleBatch.CUR_OBS]
     })
-    action_dist = policy.dist_class(logits, policy.model)
+    action_dist = policy.dist_class(logits)
     log_probs = action_dist.logp(batch_tensors[SampleBatch.ACTIONS])
     return -batch_tensors[SampleBatch.REWARDS].dot(log_probs)
 


### PR DESCRIPTION
Fixed the example code.
