### PR TITLE
Scale bazel HTTP timeout by 5x

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,4 @@ build --per_file_copt='\\.pb\\.cc$@-w'
 build --per_file_copt='external*@-w'
 # This workaround is needed due to https://github.com/bazelbuild/bazel/issues/4341
 build --per_file_copt="external/com_github_grpc_grpc/.*@-DGRPC_BAZEL_BUILD"
+build --http_timeout_scaling=5.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We have been seeing some failures on travis for `./ci/travis/install-ray.sh' due to timeouts when downloading dependencies. Example: https://travis-ci.com/ray-project/ray/jobs/226412123

## What do these changes do?

Scales the bazel http timeouts by 5x. This should be a behavior change in the majority of cases when downloads are successful, but will prevent failures when things are running more slowly than usual e.g., due to congestion on travis.

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
