### PR TITLE
Deprecate old global state API.

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -1003,15 +1003,15 @@ class DeprecatedGlobalState(object):
     """A class used to print errors when the old global state API is used."""
 
     def object_table(self, object_id=None):
-        logger.warning(
-            "ray.global_state.object_table() is deprecated and will be "
-            "removed in a subsequent release. Use ray.objects() instead.")
+        raise DeprecationWarning(
+            "ray.global_state.object_table() is deprecated. Use ray.objects() "
+            "instead.")
         return ray.objects(object_id=object_id)
 
     def task_table(self, task_id=None):
-        logger.warning(
-            "ray.global_state.task_table() is deprecated and will be "
-            "removed in a subsequent release. Use ray.tasks() instead.")
+        raise DeprecationWarning(
+            "ray.global_state.task_table() is deprecated. Use ray.tasks() "
+            "instead.")
         return ray.tasks(task_id=task_id)
 
     def function_table(self, function_id=None):
@@ -1019,9 +1019,9 @@ class DeprecatedGlobalState(object):
             "ray.global_state.function_table() is deprecated.")
 
     def client_table(self):
-        logger.warning(
-            "ray.global_state.client_table() is deprecated and will be "
-            "removed in a subsequent release. Use ray.nodes() instead.")
+        raise DeprecationWarning(
+            "ray.global_state.client_table() is deprecated. Use ray.nodes() "
+            "instead.")
         return ray.nodes()
 
     def profile_table(self):
@@ -1029,39 +1029,36 @@ class DeprecatedGlobalState(object):
             "ray.global_state.profile_table() is deprecated.")
 
     def chrome_tracing_dump(self, filename=None):
-        logger.warning(
-            "ray.global_state.chrome_tracing_dump() is deprecated and will be "
-            "removed in a subsequent release. Use ray.timeline() instead.")
+        raise DeprecationWarning(
+            "ray.global_state.chrome_tracing_dump() is deprecated. Use "
+            "ray.timeline() instead.")
         return ray.timeline(filename=filename)
 
     def chrome_tracing_object_transfer_dump(self, filename=None):
-        logger.warning(
+        raise DeprecationWarning(
             "ray.global_state.chrome_tracing_object_transfer_dump() is "
-            "deprecated and will be removed in a subsequent release. Use "
-            "ray.object_transfer_timeline() instead.")
+            "deprecated. Use ray.object_transfer_timeline() instead.")
         return ray.object_transfer_timeline(filename=filename)
 
     def workers(self):
         raise DeprecationWarning("ray.global_state.workers() is deprecated.")
 
     def cluster_resources(self):
-        logger.warning(
-            "ray.global_state.cluster_resources() is deprecated and will be "
-            "removed in a subsequent release. Use ray.cluster_resources() "
-            "instead.")
+        raise DeprecationWarning(
+            "ray.global_state.cluster_resources() is deprecated. Use "
+            "ray.cluster_resources() instead.")
         return ray.cluster_resources()
 
     def available_resources(self):
-        logger.warning(
-            "ray.global_state.available_resources() is deprecated and will be "
-            "removed in a subsequent release. Use ray.available_resources() "
-            "instead.")
+        raise DeprecationWarning(
+            "ray.global_state.available_resources() is deprecated. Use "
+            "ray.available_resources() instead.")
         return ray.available_resources()
 
     def error_messages(self, all_jobs=False):
-        logger.warning(
-            "ray.global_state.error_messages() is deprecated and will be "
-            "removed in a subsequent release. Use ray.errors() instead.")
+        raise DeprecationWarning(
+            "ray.global_state.error_messages() is deprecated. Use "
+            "ray.errors() instead.")
         return ray.errors(all_jobs=all_jobs)
 
 

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -1006,13 +1006,11 @@ class DeprecatedGlobalState(object):
         raise DeprecationWarning(
             "ray.global_state.object_table() is deprecated. Use ray.objects() "
             "instead.")
-        return ray.objects(object_id=object_id)
 
     def task_table(self, task_id=None):
         raise DeprecationWarning(
             "ray.global_state.task_table() is deprecated. Use ray.tasks() "
             "instead.")
-        return ray.tasks(task_id=task_id)
 
     def function_table(self, function_id=None):
         raise DeprecationWarning(
@@ -1022,7 +1020,6 @@ class DeprecatedGlobalState(object):
         raise DeprecationWarning(
             "ray.global_state.client_table() is deprecated. Use ray.nodes() "
             "instead.")
-        return ray.nodes()
 
     def profile_table(self):
         raise DeprecationWarning(
@@ -1032,13 +1029,11 @@ class DeprecatedGlobalState(object):
         raise DeprecationWarning(
             "ray.global_state.chrome_tracing_dump() is deprecated. Use "
             "ray.timeline() instead.")
-        return ray.timeline(filename=filename)
 
     def chrome_tracing_object_transfer_dump(self, filename=None):
         raise DeprecationWarning(
             "ray.global_state.chrome_tracing_object_transfer_dump() is "
             "deprecated. Use ray.object_transfer_timeline() instead.")
-        return ray.object_transfer_timeline(filename=filename)
 
     def workers(self):
         raise DeprecationWarning("ray.global_state.workers() is deprecated.")
@@ -1047,19 +1042,16 @@ class DeprecatedGlobalState(object):
         raise DeprecationWarning(
             "ray.global_state.cluster_resources() is deprecated. Use "
             "ray.cluster_resources() instead.")
-        return ray.cluster_resources()
 
     def available_resources(self):
         raise DeprecationWarning(
             "ray.global_state.available_resources() is deprecated. Use "
             "ray.available_resources() instead.")
-        return ray.available_resources()
 
     def error_messages(self, all_jobs=False):
         raise DeprecationWarning(
             "ray.global_state.error_messages() is deprecated. Use "
             "ray.errors() instead.")
-        return ray.errors(all_jobs=all_jobs)
 
 
 state = GlobalState()


### PR DESCRIPTION
## Why are these changes needed?

In https://github.com/ray-project/ray/pull/4857, we reorganized the global state API. So far, we have been printing warnings saying that the old API will be deprecated, but still allowing the commands to succeed. This PR raises an exception telling the user what the correct command to use is. The next step after this has been around for a while will be to remove the deprecated APIs entirely.