### PR TITLE
[Java] Fix getCurrentActorId in multi-threading scenario.

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
+++ b/java/test/src/main/java/org/ray/api/test/MultiThreadingTest.java
@@ -46,15 +46,15 @@ public class MultiThreadingTest extends BaseTest {
   @RayRemote
   public static class ActorIdTester {
 
+    private final ActorId actorId;
+
     public ActorIdTester() {
-      Assert.assertNotEquals(Ray.getRuntimeContext().getCurrentActorId(), ActorId.NIL);
+      actorId = Ray.getRuntimeContext().getCurrentActorId();
+      Assert.assertNotEquals(actorId, ActorId.NIL);
     }
 
     @RayRemote
-    public ActorId getCurrentActorId(boolean async) {
-      if (!async) {
-        return Ray.getRuntimeContext().getCurrentActorId();
-      }
+    public ActorId getCurrentActorId() {
       final ActorId[] result = new ActorId[1];
       Thread thread = new Thread(() -> {
         result[0] = Ray.getRuntimeContext().getCurrentActorId();
@@ -65,6 +65,7 @@ public class MultiThreadingTest extends BaseTest {
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
+      Assert.assertEquals(result[0], actorId);
       return result[0];
     }
   }
@@ -136,9 +137,7 @@ public class MultiThreadingTest extends BaseTest {
   public void testGetCurrentActorId() {
     TestUtils.skipTestUnderSingleProcess();
     RayActor<ActorIdTester> actorIdTester = Ray.createActor(ActorIdTester::new);
-    ActorId actorId = Ray.call(ActorIdTester::getCurrentActorId, actorIdTester, false).get();
-    Assert.assertEquals(actorId, actorIdTester.getId());
-    actorId = Ray.call(ActorIdTester::getCurrentActorId, actorIdTester, true).get();
+    ActorId actorId = Ray.call(ActorIdTester::getCurrentActorId, actorIdTester).get();
     Assert.assertEquals(actorId, actorIdTester.getId());
   }
 

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -40,6 +40,9 @@ class WorkerContext {
   /// Job ID for this worker.
   JobID current_job_id_;
 
+  /// ID of current actor.
+  ActorID current_actor_id_;
+
  private:
   static WorkerThreadContext &GetThreadContext();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Calling `getCurrentActorId` in non-main thread results in `NIL`. This is a bug introduced in #5370. 

## What do these changes do?

Fix the bug by moving `current_actor_id_` from `WorkerThreadContext` to `WorkerContext`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
