### PR TITLE
`ray stop` kills processes more carefully

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -411,12 +411,13 @@ def stop():
     processes_to_kill = [
         # The first element is the substring to filter.
         # The second element, if True, is to filter ps results by command name
-        # (only the executable name); if False, is to filter ps results by
-        # command with all its arguments. See STANDARD FORMAT SPECIFIERS
-        # section of http://man7.org/linux/man-pages/man1/ps.1.html about comm
-        # and args. This can help avoid killing non-ray processes.
+        # (only the first 15 charactors of the executable name);
+        # if False, is to filter ps results by command with all its arguments.
+        # See STANDARD FORMAT SPECIFIERS section of
+        # http://man7.org/linux/man-pages/man1/ps.1.html
+        # about comm and args. This can help avoid killing non-ray processes.
         ["raylet", True],
-        ["plasma_store_server", True],
+        ["plasma_store", True],
         ["raylet_monitor", True],
         ["monitor.py", False],
         ["redis-server", True],
@@ -432,6 +433,12 @@ def stop():
         filter = process[0]
         if process[1]:
             format = "pid,comm"
+            # According to https://superuser.com/questions/567648/ps-comm-format-always-cuts-the-process-name,  # noqa: E501
+            # comm only prints the first 15 characters of the executable name.
+            if len(filter) > 15:
+                raise ValueError("The filter string should not be more than" +
+                                 " 15 characters. Actual length: " +
+                                 str(len(filter)) + ". Filter: " + filter)
         else:
             format = "pid,args"
         command = ("kill -9 $(ps ax -o " + format + " | grep '" + filter +

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -409,32 +409,31 @@ def stop():
     # Note that raylet needs to exit before object store, otherwise
     # it cannot exit gracefully.
     processes_to_kill = [
-        # The first element is to filter ps results by command name (only the
-        # executable name). The second element is to filter ps results by
+        # The first element is the substring to filter.
+        # The second element, if True, is to filter ps results by command name
+        # (only the executable name); if False, is to filter ps results by
         # command with all its arguments. See STANDARD FORMAT SPECIFIERS
         # section of http://man7.org/linux/man-pages/man1/ps.1.html about comm
-        # and args. The two levels of filters can help avoid killing non-ray
-        # processes.
-        ["raylet", None],
-        ["plasma_store_server", None],
-        ["raylet_monitor", None],
-        [None, "monitor.py"],
-        ["redis-server", None],
-        [None, "default_worker.py"],  # Python worker.
-        [" ray_", None],  # Python worker.
-        [None, "org.ray.runtime.runner.worker.DefaultWorker"],  # Java worker.
-        [None, "log_monitor.py"],
-        [None, "reporter.py"],
-        [None, "dashboard.py"],
+        # and args. This can help avoid killing non-ray processes.
+        ["raylet", True],
+        ["plasma_store_server", True],
+        ["raylet_monitor", True],
+        ["monitor.py", False],
+        ["redis-server", True],
+        ["default_worker.py", False],  # Python worker.
+        [" ray_", True],  # Python worker.
+        ["org.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
+        ["log_monitor.py", False],
+        ["reporter.py", False],
+        ["dashboard.py", False],
     ]
 
     for process in processes_to_kill:
-        if process[0]:
+        filter = process[0]
+        if process[1]:
             format = "pid,comm"
-            filter = process[0]
         else:
             format = "pid,args"
-            filter = process[1]
         command = ("kill -9 $(ps ax -o " + format + " | grep '" + filter +
                    "' | grep -v grep | " + "awk '{ print $1 }') 2> /dev/null")
         subprocess.call([command], shell=True)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -409,22 +409,34 @@ def stop():
     # Note that raylet needs to exit before object store, otherwise
     # it cannot exit gracefully.
     processes_to_kill = [
-        "raylet",
-        "plasma_store_server",
-        "raylet_monitor",
-        "monitor.py",
-        "redis-server",
-        "default_worker.py",  # Python worker.
-        " ray_",  # Python worker.
-        "org.ray.runtime.runner.worker.DefaultWorker",  # Java worker.
-        "log_monitor.py",
-        "reporter.py",
-        "dashboard.py",
+        # The first element is to filter ps results by command name (only the
+        # executable name). The second element is to filter ps results by
+        # command with all its arguments. See STANDARD FORMAT SPECIFIERS
+        # section of http://man7.org/linux/man-pages/man1/ps.1.html about comm
+        # and args. The two levels of filters can help avoid killing non-ray
+        # processes.
+        ["raylet", None],
+        ["plasma_store_server", None],
+        ["raylet_monitor", None],
+        [None, "monitor.py"],
+        ["redis-server", None],
+        [None, "default_worker.py"],  # Python worker.
+        [" ray_", None],  # Python worker.
+        [None, "org.ray.runtime.runner.worker.DefaultWorker"],  # Java worker.
+        [None, "log_monitor.py"],
+        [None, "reporter.py"],
+        [None, "dashboard.py"],
     ]
 
     for process in processes_to_kill:
-        command = ("kill -9 $(ps aux | grep '" + process +
-                   "' | grep -v grep | " + "awk '{ print $2 }') 2> /dev/null")
+        if process[0]:
+            format = "pid,comm"
+            filter = process[0]
+        else:
+            format = "pid,args"
+            filter = process[1]
+        command = ("kill -9 $(ps ax -o " + format + " | grep '" + filter +
+                   "' | grep -v grep | " + "awk '{ print $1 }') 2> /dev/null")
         subprocess.call([command], shell=True)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Sometimes `ray stop` accidentally kill processes don't belong to the ray cluster. 

e.g. if I modify `java/test.sh` to add a new JVM parameter `-Dray.raylet.config.foo=bar`, then the java test will be killed at the end of the first `BaseMultiLanguageTest` test case, due to `ray stop` kills all process with command line matches `raylet`.

## What do these changes do?

For some processes, we grep results with `ps ax -o pid,comm` (which only prints the pid and the executable name) to make sure command line parameters are excluded from the match. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
