### PR TITLE
[Java] Destroy native core worker before killing ray processes

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/org/ray/runtime/RayNativeRuntime.java
@@ -131,12 +131,12 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
 
   @Override
   public void shutdown() {
-    if (null != manager) {
-      manager.cleanup();
-    }
     if (nativeCoreWorkerPointer != 0) {
       nativeDestroyCoreWorker(nativeCoreWorkerPointer);
       nativeCoreWorkerPointer = 0;
+    }
+    if (null != manager) {
+      manager.cleanup();
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, we can see error messages like below when running Java tests. This is because raylet and other processes are killed before destroying core worker. This PR helps fix these annoying error messages.

```
E0823 21:09:12.196899 121937920 raylet_client.cc:134] IOError: [RayletClient] Connection closed unexpectedly. [RayletClient] Failed to disconnect from raylet.
```

## What do these changes do?

In `RayNativeRuntime`, put `runManager.cleanup()` after core worker destruction.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
