### PR TITLE
Bump version string to 0.8.0.dev4

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -104,7 +104,7 @@ from ray.actor import method  # noqa: E402
 from ray.runtime_context import _get_runtime_context  # noqa: E402
 
 # Ray version string.
-__version__ = "0.7.4"
+__version__ = "0.8.0.dev4"
 
 __all__ = [
     "global_state",

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
   // Initialize stats.
   const ray::stats::TagsType global_tags = {
       {ray::stats::JobNameKey, "raylet"},
-      {ray::stats::VersionKey, "0.7.4"},
+      {ray::stats::VersionKey, "0.8.0.dev4"},
       {ray::stats::NodeAddressKey, node_ip_address}};
   ray::stats::Init(stat_address, global_tags, disable_stats, enable_stdout_exporter);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Set version string back to development version after the 0.7.4 release.

## What do these changes do?

Set version string to 0.8.0.dev4.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
