### PR TITLE
Fixed: missing brackets when appending proc info on OutOfMemory

### DIFF
--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -43,7 +43,7 @@ class RayOutOfMemoryError(Exception):
         proc_stats = []
         for pid in pids:
             proc = psutil.Process(pid)
-            proc_stats.append(get_rss(proc.memory_info()), pid, proc.cmdline())
+            proc_stats.append((get_rss(proc.memory_info()), pid, proc.cmdline()))
         proc_str = "PID\tMEM\tCOMMAND"
         for rss, pid, cmdline in sorted(proc_stats, reverse=True)[:10]:
             proc_str += "\n{}\t{}GiB\t{}".format(

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -43,7 +43,8 @@ class RayOutOfMemoryError(Exception):
         proc_stats = []
         for pid in pids:
             proc = psutil.Process(pid)
-            proc_stats.append((get_rss(proc.memory_info()), pid, proc.cmdline()))
+            proc_stats.append((get_rss(proc.memory_info()), pid,
+                               proc.cmdline()))
         proc_str = "PID\tMEM\tCOMMAND"
         for rss, pid, cmdline in sorted(proc_stats, reverse=True)[:10]:
             proc_str += "\n{}\t{}GiB\t{}".format(


### PR DESCRIPTION
## Why are these changes needed?

proc_stats.append was missing the set of brackets when adding a tuple to the list, which resulted in runtime error instead of correct Out of Memory message display.

```
File "/lib/python3.7/site-packages/ray/memory_monitor.py", line 46, in get_message
    proc_stats.append(get_rss(proc.memory_info()), pid, proc.cmdline())
TypeError: append() takes exactly one argument (3 given)
```

## What do these changes do?

Bugfix

## Related issue number

-

## Linter

- [*] I've run `scripts/format.sh` to lint the changes in this PR.
