### PR TITLE
Fix test_object_broadcast on linux

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -52,11 +52,11 @@ def test_object_broadcast(ray_start_cluster_with_resource):
     def f(x):
         return
 
-    x = np.zeros(150 * 1024 * 1024, dtype=np.uint8)
+    x = np.zeros(10 * 1024 * 1024, dtype=np.uint8)
 
     @ray.remote
     def create_object():
-        return np.zeros(150 * 1024 * 1024, dtype=np.uint8)
+        return np.zeros(10 * 1024 * 1024, dtype=np.uint8)
 
     object_ids = []
 


### PR DESCRIPTION
The size was accidentally increased to 150MB, exceeding the /dev/shm size on linux travis.

Closes https://github.com/ray-project/ray/issues/5536