### PR TITLE
Fix log files being opened as unicode files

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -144,7 +144,7 @@ class LogMonitor(object):
             # file.
             if file_size > file_info.size_when_last_opened:
                 try:
-                    f = open(file_info.filename, "r")
+                    f = open(file_info.filename, "rb")
                 except (IOError, OSError) as e:
                     if e.errno == errno.ENOENT:
                         logger.warning("Warning: The file {} was not "

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -179,9 +179,9 @@ class LogMonitor(object):
             for _ in range(max_num_lines_to_read):
                 try:
                     next_line = file_info.file_handle.readline()
-                    if next_line == "":
+                    if next_line == b"":
                         break
-                    if next_line[-1] == "\n":
+                    if next_line[-1] == b"\n":
                         next_line = next_line[:-1]
                     lines_to_publish.append(next_line)
                 except Exception:
@@ -193,9 +193,9 @@ class LogMonitor(object):
 
             if file_info.file_position == 0:
                 if (len(lines_to_publish) > 0 and
-                        lines_to_publish[0].startswith("Ray worker pid: ")):
+                        lines_to_publish[0].startswith(b"Ray worker pid: ")):
                     file_info.worker_pid = int(
-                        lines_to_publish[0].split(" ")[-1])
+                        lines_to_publish[0].split(b" ")[-1])
                     lines_to_publish = lines_to_publish[1:]
                 elif "/raylet" in file_info.filename:
                     file_info.worker_pid = "raylet"
@@ -209,7 +209,7 @@ class LogMonitor(object):
                     json.dumps({
                         "ip": self.ip,
                         "pid": file_info.worker_pid,
-                        "lines": lines_to_publish
+                        "lines": [line.decode() for line in lines_to_publish]
                     }))
                 anything_published = True
 

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -178,7 +178,11 @@ class LogMonitor(object):
             max_num_lines_to_read = 100
             for _ in range(max_num_lines_to_read):
                 try:
-                    next_line = file_info.file_handle.readline().decode()
+                    next_line = file_info.file_handle.readline()
+                    # Replace any characters not in UTF-8 with
+                    # a replacement character, see
+                    # https://stackoverflow.com/a/38565489/10891801
+                    next_line = next_line.decode("utf-8", "replace")
                     if next_line == "":
                         break
                     if next_line[-1] == "\n":

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -178,10 +178,10 @@ class LogMonitor(object):
             max_num_lines_to_read = 100
             for _ in range(max_num_lines_to_read):
                 try:
-                    next_line = file_info.file_handle.readline()
-                    if next_line == b"":
+                    next_line = file_info.file_handle.readline().decode()
+                    if next_line == "":
                         break
-                    if next_line[-1] == b"\n":
+                    if next_line[-1] == "\n":
                         next_line = next_line[:-1]
                     lines_to_publish.append(next_line)
                 except Exception:
@@ -193,9 +193,9 @@ class LogMonitor(object):
 
             if file_info.file_position == 0:
                 if (len(lines_to_publish) > 0 and
-                        lines_to_publish[0].startswith(b"Ray worker pid: ")):
+                        lines_to_publish[0].startswith("Ray worker pid: ")):
                     file_info.worker_pid = int(
-                        lines_to_publish[0].split(b" ")[-1])
+                        lines_to_publish[0].split(" ")[-1])
                     lines_to_publish = lines_to_publish[1:]
                 elif "/raylet" in file_info.filename:
                     file_info.worker_pid = "raylet"
@@ -209,7 +209,7 @@ class LogMonitor(object):
                     json.dumps({
                         "ip": self.ip,
                         "pid": file_info.worker_pid,
-                        "lines": [line.decode() for line in lines_to_publish]
+                        "lines": lines_to_publish
                     }))
                 anything_published = True
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -3130,9 +3130,9 @@ def test_invalid_unicode_in_worker_log(shutdown_only):
             break
 
     with open(log_file_paths[0], "wb") as f:
-        f.write(b'\xe5abc\nline2\nline3\n')
-        f.write(b'\xe5abc\nline2\nline3\n')
-        f.write(b'\xe5abc\nline2\nline3\n')
+        f.write(b"\xe5abc\nline2\nline3\n")
+        f.write(b"\xe5abc\nline2\nline3\n")
+        f.write(b"\xe5abc\nline2\nline3\n")
         f.flush()
 
     # Wait till the log monitor reads the file.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import collections
 from concurrent.futures import ThreadPoolExecutor
+import glob
 import json
 import logging
 from multiprocessing import Process
@@ -3113,3 +3114,29 @@ def test_export_after_shutdown(ray_start_regular):
         ray.get(actor_handle.method.remote())
 
     ray.get(export_definitions_from_worker.remote(f, Actor))
+
+
+def test_invalid_unicode_in_worker_log(shutdown_only):
+    info = ray.init(num_cpus=1)
+
+    logs_dir = os.path.join(info["session_dir"], "logs")
+
+    # Wait till first worker log file is created.
+    while True:
+        log_file_paths = glob.glob("{}/worker*.out".format(logs_dir))
+        if len(log_file_paths) == 0:
+            time.sleep(0.2)
+        else:
+            break
+
+    with open(log_file_paths[0], "wb") as f:
+        f.write(b'\xe5abc\nline2\nline3\n')
+        f.write(b'\xe5abc\nline2\nline3\n')
+        f.write(b'\xe5abc\nline2\nline3\n')
+        f.flush()
+
+    # Wait till the log monitor reads the file.
+    time.sleep(1.0)
+
+    # Make sure that nothing has died.
+    assert ray.services.remaining_processes_alive()


### PR DESCRIPTION
Currently, log files are opened as unicode files, which can cause problems if they contain bytes that are non-valid unicode characters. This PR opens the file as binary files and then decodes the bytes with a special decoder that replaces non-valid unicode characters with a special replacement character (https://stackoverflow.com/a/38565489/10891801).

This fixes https://github.com/ray-project/ray/issues/4382