### PR TITLE
[Java] `ObjectID::fromRandom` sets proper flags

### DIFF
--- a/java/api/src/main/java/org/ray/api/id/ObjectId.java
+++ b/java/api/src/main/java/org/ray/api/id/ObjectId.java
@@ -12,8 +12,6 @@ public class ObjectId extends BaseId implements Serializable {
 
   public static final int LENGTH = 20;
 
-  private static final int FLAGS_LENGTH = 2;
-
   /**
    * Create an ObjectId from a ByteBuffer.
    */
@@ -25,13 +23,13 @@ public class ObjectId extends BaseId implements Serializable {
    * Generate an ObjectId with random value.
    */
   public static ObjectId fromRandom() {
+    // This is tightly coupled with ObjectID definition in C++. If that changes,
+    // this must be changed as well.
+    // The following logic should be kept consistent with `ObjectID::FromRandom` in
+    // C++.
     byte[] b = new byte[LENGTH];
     new Random().nextBytes(b);
-    // Fill all bits of flags to zero to set the following flag values:
-    // Is task: false
-    // Object type: put
-    // Transport type: raylet
-    Arrays.fill(b, TaskId.LENGTH, TaskId.LENGTH + FLAGS_LENGTH, (byte) 0);
+    Arrays.fill(b, TaskId.LENGTH, LENGTH, (byte) 0);
     return new ObjectId(b);
   }
 

--- a/java/api/src/main/java/org/ray/api/id/ObjectId.java
+++ b/java/api/src/main/java/org/ray/api/id/ObjectId.java
@@ -12,7 +12,7 @@ public class ObjectId extends BaseId implements Serializable {
 
   public static final int LENGTH = 20;
 
-  public static final ObjectId NIL = genNil();
+  private static final int FLAGS_LENGTH = 2;
 
   /**
    * Create an ObjectId from a ByteBuffer.
@@ -22,20 +22,16 @@ public class ObjectId extends BaseId implements Serializable {
   }
 
   /**
-   * Generate a nil ObjectId.
-   */
-  private static ObjectId genNil() {
-    byte[] b = new byte[LENGTH];
-    Arrays.fill(b, (byte) 0xFF);
-    return new ObjectId(b);
-  }
-
-  /**
    * Generate an ObjectId with random value.
    */
   public static ObjectId fromRandom() {
     byte[] b = new byte[LENGTH];
     new Random().nextBytes(b);
+    // Fill all bits of flags to zero to set the following flag values:
+    // Is task: false
+    // Object type: put
+    // Transport type: raylet
+    Arrays.fill(b, TaskId.LENGTH, TaskId.LENGTH + FLAGS_LENGTH, (byte) 0);
     return new ObjectId(b);
   }
 

--- a/src/ray/core_worker/object_interface.cc
+++ b/src/ray/core_worker/object_interface.cc
@@ -28,7 +28,7 @@ void GroupObjectIdsByStoreProvider(
     // to whether it's from direct actor call before we can choose memory store provider.
     if (object_id.IsReturnObject() &&
         object_id.GetTransportType() ==
-            static_cast<int>(TaskTransportType::DIRECT_ACTOR)) {
+            static_cast<uint8_t>(TaskTransportType::DIRECT_ACTOR)) {
       type = StoreProviderType::MEMORY;
     }
 
@@ -51,13 +51,16 @@ CoreWorkerObjectInterface::CoreWorkerObjectInterface(
 Status CoreWorkerObjectInterface::Put(const RayObject &object, ObjectID *object_id) {
   ObjectID put_id = ObjectID::ForPut(worker_context_.GetCurrentTaskID(),
                                      worker_context_.GetNextPutIndex(),
-                                     /*transport_type=*/0);
+                                     static_cast<uint8_t>(TaskTransportType::RAYLET));
   *object_id = put_id;
   return Put(object, put_id);
 }
 
 Status CoreWorkerObjectInterface::Put(const RayObject &object,
                                       const ObjectID &object_id) {
+  RAY_CHECK(object_id.GetTransportType() ==
+            static_cast<uint8_t>(TaskTransportType::RAYLET))
+      << "Invalid transport type flag in object ID: " << object_id.GetTransportType();
   return store_providers_[StoreProviderType::PLASMA]->Put(object, object_id);
 }
 

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -153,7 +153,7 @@ Status CoreWorkerTaskInterface::SubmitTask(const RayFunction &function,
       TaskID::ForNormalTask(worker_context_.GetCurrentJobID(),
                             worker_context_.GetCurrentTaskID(), next_task_index);
   BuildCommonTaskSpec(builder, task_id, next_task_index, function, args,
-                      task_options.num_returns, task_options.resources, std::unordered_map<std::string, double>(),
+                      task_options.num_returns, task_options.resources, {},
                       TaskTransportType::RAYLET, return_ids);
   return task_submitters_[TaskTransportType::RAYLET]->SubmitTask(builder.Build());
 }
@@ -203,7 +203,7 @@ Status CoreWorkerTaskInterface::SubmitActorTask(ActorHandle &actor_handle,
       worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
       next_task_index, actor_handle.ActorID());
   BuildCommonTaskSpec(builder, actor_task_id, next_task_index, function, args,
-                      num_returns, task_options.resources, std::unordered_map<std::string, double>(), transport_type,
+                      num_returns, task_options.resources, {}, transport_type,
                       return_ids);
 
   std::unique_lock<std::mutex> guard(actor_handle.mutex_);

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -153,7 +153,7 @@ Status CoreWorkerTaskInterface::SubmitTask(const RayFunction &function,
       TaskID::ForNormalTask(worker_context_.GetCurrentJobID(),
                             worker_context_.GetCurrentTaskID(), next_task_index);
   BuildCommonTaskSpec(builder, task_id, next_task_index, function, args,
-                      task_options.num_returns, task_options.resources, {},
+                      task_options.num_returns, task_options.resources, std::unordered_map<std::string, double>(),
                       TaskTransportType::RAYLET, return_ids);
   return task_submitters_[TaskTransportType::RAYLET]->SubmitTask(builder.Build());
 }
@@ -203,7 +203,7 @@ Status CoreWorkerTaskInterface::SubmitActorTask(ActorHandle &actor_handle,
       worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
       next_task_index, actor_handle.ActorID());
   BuildCommonTaskSpec(builder, actor_task_id, next_task_index, function, args,
-                      num_returns, task_options.resources, {}, transport_type,
+                      num_returns, task_options.resources, std::unordered_map<std::string, double>(), transport_type,
                       return_ids);
 
   std::unique_lock<std::mutex> guard(actor_handle.mutex_);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Sometimes the Java test case `testPutWithDuplicateId` hangs at `Ray.get`. The root cause is that this test case puts an object with a random object ID, which is always stored in plasma store. However, The flags in object ID may indicate that it satisfies the condition of reading from the local memory store (enabled in #5452), but the object is not in local memory store.

https://github.com/ray-project/ray/blob/eab595777fcbcbef1b4e22937728b627dc94b791/src/ray/core_worker/object_interface.cc#L59-L62

https://github.com/ray-project/ray/blob/eab595777fcbcbef1b4e22937728b627dc94b791/src/ray/core_worker/object_interface.cc#L29-L33

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
