### PR TITLE
Add retries in dynamic resource test cases

### DIFF
--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -216,7 +216,7 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
             node_res_condition = resource_condition(res_name, res_capacity,
                                                     node_resource_getter)
             was_successful = retry_until(node_res_condition,
-                                        TIMEOUT_RESOURCE_UPDATE)
+                                         TIMEOUT_RESOURCE_UPDATE)
             resources_created.append(was_successful)
         success = all(resources_created)
     assert success

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -43,6 +43,7 @@ def resource_condition(resource_name,
 
     return lambda: condition(resource_name, expected_capacity, resource_getter)
 
+
 def node_resource_getter_generator(target_node_id):
     def node_resource_getter(target_node_id):
         target_node = next(
@@ -51,6 +52,7 @@ def node_resource_getter_generator(target_node_id):
         return resources
 
     return lambda: node_resource_getter(target_node_id)
+
 
 def test_dynamic_res_creation(ray_start_regular):
     # This test creates a resource locally (without specifying the client_id)


### PR DESCRIPTION
## Why are these changes needed?

Some of the dynamic resource test cases fail intermittently with `KeyError` when querying `ray.available_resources()` or `ray.available_resources()`. I believe this happens in rare cases when there are delays in GCS updates/heartbeat propagation and the test ends up querying the resource state before it has been updated.

As a fix, this PR adds a retry-timeout mechanism which retries the assertion condition until a short timeout elapses. 

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
