### PR TITLE
Fix race condition when creating actors

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1897,7 +1897,7 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
     RAY_CHECK_OK(gcs_client_->raylet_task_table().Lookup(
         JobID::Nil(), parent_task_id,
         /*success_callback=*/
-        [this, task_spec, resumed_from_checkpoint, port](
+        [this, task_spec, resumed_from_checkpoint, port, &worker, actor_id](
             ray::gcs::RedisGcsClient *client, const TaskID &parent_task_id,
             const TaskTableData &parent_task_data) {
           // This was an actor creation task. Convert the worker to an actor.
@@ -1915,8 +1915,8 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
                                           resumed_from_checkpoint, port);
         },
         /*failure_callback=*/
-        [this, task_spec, resumed_from_checkpoint, port](ray::gcs::RedisGcsClient *client,
-                                                         const TaskID &parent_task_id) {
+        [this, task_spec, resumed_from_checkpoint, port, &worker, actor_id](
+            ray::gcs::RedisGcsClient *client, const TaskID &parent_task_id) {
           // This was an actor creation task. Convert the worker to an actor.
           worker.AssignActorId(actor_id);
           // The parent task was not in the GCS task table. It should most likely be in

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1890,8 +1890,6 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
   }
 
   if (task_spec.IsActorCreationTask()) {
-    // This was an actor creation task. Convert the worker to an actor.
-    worker.AssignActorId(actor_id);
     // Lookup the parent actor id.
     auto parent_task_id = task_spec.ParentTaskId();
     RAY_CHECK(actor_handle_id.IsNil());
@@ -1902,6 +1900,8 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
         [this, task_spec, resumed_from_checkpoint, port](
             ray::gcs::RedisGcsClient *client, const TaskID &parent_task_id,
             const TaskTableData &parent_task_data) {
+          // This was an actor creation task. Convert the worker to an actor.
+          worker.AssignActorId(actor_id);
           // The task was in the GCS task table. Use the stored task spec to
           // get the parent actor id.
           Task parent_task(parent_task_data.task());
@@ -1917,6 +1917,8 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
         /*failure_callback=*/
         [this, task_spec, resumed_from_checkpoint, port](ray::gcs::RedisGcsClient *client,
                                                          const TaskID &parent_task_id) {
+          // This was an actor creation task. Convert the worker to an actor.
+          worker.AssignActorId(actor_id);
           // The parent task was not in the GCS task table. It should most likely be in
           // the
           // lineage cache.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR only assigns the actor id to the worker after we got the parent task spec from the GCS. This makes sure the actor cannot start processing tasks (and die!) before it has been finished creating.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
