### PR TITLE
Fix O(n^2) behavior in the log_monitor

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -96,7 +96,14 @@ class LogMonitor(object):
                 # by it.
                 target = os.path.join(
                     self.logs_dir, "old", os.path.basename(file_info.filename))
-                shutil.move(file_info.filename, target)
+                try:
+                    shutil.move(file_info.filename, target)
+                except (IOError, OSError) as e:
+                    if e.errno == errno.ENOENT:
+                        logger.warning("Warning: The file {} was not "
+                                       "found.".format(file_info.filename))
+                    else:
+                        raise e
             else:
                 self.closed_file_infos.append(file_info)
         self.can_open_more_files = True

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -85,6 +85,12 @@ class LogMonitor(object):
             file_info = self.open_file_infos.pop(0)
             file_info.file_handle.close()
             file_info.file_handle = None
+            try:
+                # Test if the worker process is still alive
+                os.kill(file_info.worker_pid, 0)
+            except:
+                
+            if
             self.closed_file_infos.append(file_info)
         self.can_open_more_files = True
 

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -96,12 +96,7 @@ class LogMonitor(object):
                 # by it.
                 target = os.path.join(
                     self.logs_dir, "old", os.path.basename(file_info.filename))
-                try:
-                    shutil.move(file_info.filename, target)
-                except IOError:
-                    # Create the target directory if it doesn't exist yet.
-                    os.makedirs(os.path.dirname(target))
-                    shutil.move(file_info.filename, target)
+                shutil.move(file_info.filename, target)
             else:
                 self.closed_file_infos.append(file_info)
         self.can_open_more_files = True

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -94,8 +94,8 @@ class LogMonitor(object):
                 # The process is not alive any more, so move the log file
                 # out of the log directory so glob.glob will not be slowed
                 # by it.
-                target = os.path.join(
-                    self.logs_dir, "old", os.path.basename(file_info.filename))
+                target = os.path.join(self.logs_dir, "old",
+                                      os.path.basename(file_info.filename))
                 try:
                     shutil.move(file_info.filename, target)
                 except (IOError, OSError) as e:

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -90,7 +90,7 @@ class LogMonitor(object):
                 # Test if the worker process that generated the log file
                 # is still alive.
                 os.kill(file_info.worker_pid, 0)
-            except os.OSError:
+            except OSError:
                 # The process is not alive any more, so move the log file
                 # out of the log directory so glob.glob will not be slowed
                 # by it.

--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -94,12 +94,13 @@ class LogMonitor(object):
                 # The process is not alive any more, so move the log file
                 # out of the log directory so glob.glob will not be slowed
                 # by it.
-                target = os.path.join(self.logs_dir, "old")
+                target = os.path.join(
+                    self.logs_dir, "old", os.path.basename(file_info.filename))
                 try:
                     shutil.move(file_info.filename, target)
                 except IOError:
                     # Create the target directory if it doesn't exist yet.
-                    os.makedirs(target)
+                    os.makedirs(os.path.dirname(target))
                     shutil.move(file_info.filename, target)
             else:
                 self.closed_file_infos.append(file_info)

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -180,6 +180,8 @@ class Node(object):
         # Create a directory to be used for process log files.
         self._logs_dir = os.path.join(self._session_dir, "logs")
         try_to_create_directory(self._logs_dir, warn_if_exist=False)
+        old_logs_dir = os.path.join(self._logs_dir, "old")
+        try_to_create_directory(old_logs_dir, warn_if_exist=False)
 
     def get_resource_spec(self):
         """Resolve and return the current resource spec for the node."""

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -3155,7 +3155,9 @@ def test_move_log_files_to_old(shutdown_only):
             print("function f finished")
 
     # First create a temporary actor.
-    actors = [Actor.remote() for i in range(ray_constants.LOG_MONITOR_MAX_OPEN_FILES)]
+    actors = [
+        Actor.remote() for i in range(ray_constants.LOG_MONITOR_MAX_OPEN_FILES)
+    ]
     ray.get([a.f.remote() for a in actors])
 
     # Now kill the actors so the files get moved to logs/old/.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -3143,7 +3143,7 @@ def test_invalid_unicode_in_worker_log(shutdown_only):
     assert ray.services.remaining_processes_alive()
 
 
-# @pytest.mark.skip(reason="This test is too expensive to run.")
+@pytest.mark.skip(reason="This test is too expensive to run.")
 def test_move_log_files_to_old(shutdown_only):
     info = ray.init(num_cpus=1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, the log monitor can get choked if there are too many logfiles around. If the log directory is too large, the `glob.glob` call in https://github.com/ray-project/ray/blob/ddfababb8286430b75a5c0edaeaece9db8319f88/python/ray/log_monitor.py#L94 can take a large amount of time, and it will be called in each iteration of the log monitor loop. Typically this happens if there are many log files from dead actors. In this PR, we move log files from dead actors to a subdirectory, so `glob.glob` keeps being fast.

## Related issue number

Fixes https://github.com/ray-project/ray/issues/5320
<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
