### PR TITLE
fix CallbackReply resize

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -113,7 +113,7 @@ void CallbackReply::ReadAsStringArray(std::vector<std::string> *array) const {
     RAY_CHECK(!is_pubsub_reply) << "Subpub reply cannot be read as a string array.";
   }
 
-  array->resize(array_size);
+  array->reserve(array_size);
   for (size_t i = 0; i < array_size; ++i) {
     auto *entry = redis_reply_->element[i];
     RAY_CHECK(REDIS_REPLY_STRING == entry->type) << "Unexcepted type: " << entry->type;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Vector resize will change the end of the vector. Use reserve instead of resize.

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
