### PR TITLE
ignore object exists error for memory store provider

### DIFF
--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -74,6 +74,7 @@ enum class StatusCode : char {
   TypeError = 3,
   Invalid = 4,
   IOError = 5,
+  ObjectExists = 6,
   UnknownError = 9,
   NotImplemented = 10,
   RedisError = 11
@@ -132,6 +133,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::RedisError, msg);
   }
 
+  static Status ObjectExists(const std::string &msg) {
+    return Status(StatusCode::ObjectExists, msg);
+  }
+
   // Returns true iff the status indicates success.
   bool ok() const { return (state_ == NULL); }
 
@@ -143,6 +148,7 @@ class RAY_EXPORT Status {
   bool IsUnknownError() const { return code() == StatusCode::UnknownError; }
   bool IsNotImplemented() const { return code() == StatusCode::NotImplemented; }
   bool IsRedisError() const { return code() == StatusCode::RedisError; }
+  bool IsObjectExists() const { return code() == StatusCode::ObjectExists; }
 
   // Return a string representation of this status suitable for printing.
   // Returns the string "OK" for success.

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -111,7 +111,7 @@ Status CoreWorkerMemoryStore::Put(const ObjectID &object_id, const RayObject &ob
   std::unique_lock<std::mutex> lock(lock_);
   auto iter = objects_.find(object_id);
   if (iter != objects_.end()) {
-    return Status::KeyError(ObjectExistError());
+    return Status::ObjectExists("object already exists in the memory store");
   }
 
   auto object_entry =

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -111,7 +111,7 @@ Status CoreWorkerMemoryStore::Put(const ObjectID &object_id, const RayObject &ob
   std::unique_lock<std::mutex> lock(lock_);
   auto iter = objects_.find(object_id);
   if (iter != objects_.end()) {
-    return Status::KeyError("object already exists");
+    return Status::KeyError(ObjectExistError());
   }
 
   auto object_entry =

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -45,6 +45,10 @@ class CoreWorkerMemoryStore {
   void Delete(const std::vector<ObjectID> &object_ids);
 
  private:
+  static const std::string ObjectExistError() {
+    return "object already exists in the memory store";
+  }
+
   /// Map from object ID to `RayObject`.
   std::unordered_map<ObjectID, std::shared_ptr<RayObject>> objects_;
 
@@ -54,6 +58,8 @@ class CoreWorkerMemoryStore {
 
   /// Protect the two maps above.
   std::mutex lock_;
+
+  friend class CoreWorkerMemoryStoreProvider;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -45,10 +45,6 @@ class CoreWorkerMemoryStore {
   void Delete(const std::vector<ObjectID> &object_ids);
 
  private:
-  static const std::string ObjectExistError() {
-    return "object already exists in the memory store";
-  }
-
   /// Map from object ID to `RayObject`.
   std::unordered_map<ObjectID, std::shared_ptr<RayObject>> objects_;
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -54,8 +54,6 @@ class CoreWorkerMemoryStore {
 
   /// Protect the two maps above.
   std::mutex lock_;
-
-  friend class CoreWorkerMemoryStoreProvider;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -19,8 +19,7 @@ CoreWorkerMemoryStoreProvider::CoreWorkerMemoryStoreProvider(
 Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
                                           const ObjectID &object_id) {
   auto status = store_->Put(object_id, object);
-  if (status.IsKeyError() &&
-      status.message() == CoreWorkerMemoryStore::ObjectExistError()) {
+  if (status.IsObjectExists()) {
     // object already exists in store, treat it as ok.
     return Status::OK();
   } else {

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -20,7 +20,7 @@ Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
                                           const ObjectID &object_id) {
   auto status = store_->Put(object_id, object);
   if (status.IsObjectExists()) {
-    // object already exists in store, treat it as ok.
+    // Object already exists in store, treat it as ok.
     return Status::OK();
   } else {
     return status;

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -18,7 +18,14 @@ CoreWorkerMemoryStoreProvider::CoreWorkerMemoryStoreProvider(
 
 Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
                                           const ObjectID &object_id) {
-  return store_->Put(object_id, object);
+  auto status = store_->Put(object_id, object);
+  if (status.IsKeyError() &&
+      status.message() == CoreWorkerMemoryStore::ObjectExistError()) {
+    // object already exists in store, treat it as ok.
+    return Status::OK();
+  } else {
+    return status;
+  }
 }
 
 Status CoreWorkerMemoryStoreProvider::Get(


### PR DESCRIPTION
## Why are these changes needed?

It's reported that sometimes core worker test fails because we don't ignore the the object exists error for memory store provider. This PR fixes that issue.

https://travis-ci.com/ray-project/ray/jobs/229393241

## Related issue number


## Checks

- [Y] I've run `scripts/format.sh` to lint the changes in this PR.
- [Y] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
