### PR TITLE
Lazily create summary writer for TF2 logger.

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -153,8 +153,11 @@ def tf2_compat_logger(config, logdir):
 
 
 class TF2Logger(Logger):
+    def _init(self):
+        self._file_writer = None
+
     def on_result(self, result):
-        if not hasattr(self, "_file_writer"):
+        if self._file_writer is None:
             from tensorflow.python.eager import context
             self._context = context
             self._file_writer = tf.summary.create_file_writer(self.logdir)
@@ -180,11 +183,11 @@ class TF2Logger(Logger):
         self._file_writer.flush()
 
     def flush(self):
-        if hasattr(self, "_file_writer"):
+        if self._file_writer is not None:
             self._file_writer.flush()
 
     def close(self):
-        if hasattr(self, "_file_writer"):
+        if self._file_writer is not None:
             self._file_writer.close()
 
 

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -153,10 +153,9 @@ def tf2_compat_logger(config, logdir):
 
 
 class TF2Logger(Logger):
-    def _init(self):
-        self._file_writer = tf.summary.create_file_writer(self.logdir)
-
     def on_result(self, result):
+        if not hasattr(self, "_file_writer"):
+            self._file_writer = tf.summary.create_file_writer(self.logdir)
         with tf.device("/CPU:0"):
             with self._file_writer.as_default():
                 step = result.get(
@@ -179,10 +178,12 @@ class TF2Logger(Logger):
         self._file_writer.flush()
 
     def flush(self):
-        self._file_writer.flush()
+        if hasattr(self, "_file_writer"):
+            self._file_writer.flush()
 
     def close(self):
-        self._file_writer.close()
+        if hasattr(self, "_file_writer"):
+            self._file_writer.close()
 
 
 def to_tf_values(result, path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

For tensorflow 2.0 with gpu support, the creation of summary writer will initialize visible gpu devices and other gpu-related settings, and then we cannot modify them anymore (see [this link](https://www.tensorflow.org/beta/guide/using_gpu)).

When sub-classing `Trainable`, we may need to declare gpu-related settings in `self._setup`. However, the settings will raise errors since `Trainable` invokes `self._setup` after logger creation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
