### PR TITLE
[flaky test] Fix test_calling_start_ray_head

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -77,7 +77,7 @@ class Node(object):
             def clean_up_children(*args, **kwargs):
                 logger.info("Cleaning up children and exiting...")
                 self.kill_all_processes(check_alive=False, allow_graceful=True)
-                signal.signal(signal.SIGTERM, lambda: sys.exit(1))
+                signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
                 try:
                     # SIGTERM our process group as a last resort in case there
                     # were processes that we spawned but didn't add to the list

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -194,7 +194,7 @@ class Node(object):
 
         # Register the a handler to be called if we get a SIGTERM.
         # In this case, we want to exit with an error code (1) after
-        # cleaning up chlid processes.
+        # cleaning up child processes.
         def sigterm_handler():
             return clean_up_children(lambda *args, **kwargs: sys.exit(1))
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -75,7 +75,6 @@ class Node(object):
                                  "cannot both be true.")
 
             def clean_up_children(*args, **kwargs):
-                logger.info("Cleaning up children and exiting...")
                 self.kill_all_processes(check_alive=False, allow_graceful=True)
                 signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
                 try:
@@ -86,8 +85,8 @@ class Node(object):
                     # sending it to ourselves.
                     os.killpg(0, signal.SIGTERM)
                 except OSError as e:
-                    logger.warning("killpg failed, processes may not have "
-                                   "been cleaned up properly: {}.".format(e))
+                    print("killpg failed, processes may not have "
+                          "been cleaned up properly: {}.".format(e))
 
             atexit.register(clean_up_children)
             signal.signal(signal.SIGINT, clean_up_children)

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -61,6 +61,13 @@ class Node(object):
             connect_only (bool): If true, connect to the node without starting
                 new processes.
         """
+        # Make ourselves a process group session leader to ensure we can clean
+        # up child processes later without killing a process that started us.
+        try:
+            os.setpgrp()
+        except OSError as e:
+            logger.warning("setpgrp failed, processes may not be "
+                           "cleaned up properly: {}.".format(e))
 
         if shutdown_at_exit:
             if connect_only:
@@ -69,6 +76,17 @@ class Node(object):
 
             def clean_up_children(*args, **kwargs):
                 self.kill_all_processes(check_alive=False, allow_graceful=True)
+                signal.signal(signal.SIGTERM, lambda *args: sys.exit(1))
+                try:
+                    # SIGTERM our process group as a last resort in case there
+                    # were processes that we spawned but didn't add to the list
+                    # (could happen if interrupted just after spawning them).
+                    # We could send SIGKILL here to be sure, but we're also
+                    # sending it to ourselves.
+                    os.killpg(0, signal.SIGTERM)
+                except OSError as e:
+                    print("killpg failed, processes may not have "
+                          "been cleaned up properly: {}.".format(e))
 
             atexit.register(clean_up_children)
             signal.signal(signal.SIGTERM, clean_up_children)

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -89,7 +89,6 @@ class Node(object):
                           "been cleaned up properly: {}.".format(e))
 
             atexit.register(clean_up_children)
-            signal.signal(signal.SIGINT, clean_up_children)
             signal.signal(signal.SIGTERM, clean_up_children)
 
         self.head = head

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -9,8 +9,13 @@ import time
 
 import ray
 from ray.utils import _random_string
-from ray.tests.utils import (run_string_as_driver,
-                             run_string_as_driver_nonblocking)
+from ray.tests.utils import (
+    run_string_as_driver,
+    run_string_as_driver_nonblocking,
+    wait_for_children_of_pid,
+    wait_for_children_of_pid_to_exit,
+    kill_process_by_name,
+)
 
 
 def test_error_isolation(call_ray_start):
@@ -267,7 +272,7 @@ print("success")
 
 
 def test_calling_start_ray_head():
-    # Test that we can call start-ray.sh with various command line
+    # Test that we can call ray start with various command line
     # parameters. TODO(rkn): This test only tests the --head code path. We
     # should also test the non-head node code path.
 
@@ -327,62 +332,28 @@ def test_calling_start_ray_head():
             ["ray", "start", "--head", "--redis-address", "127.0.0.1:6379"])
     subprocess.check_output(["ray", "stop"])
 
-    # Test --block. Killing any child process should cause the command to exit.
+    # Test --block. Killing a child process should cause the command to exit.
     blocked = subprocess.Popen(["ray", "start", "--head", "--block"])
-    blocked.poll()
 
-    # Wait for up to 10s for the ray command to spawn a child process.
-    for _ in range(10):
-        try:
-            subprocess.check_output(["pgrep", "-P", str(blocked.pid)])
-            break
-        except subprocess.CalledProcessError:
-            time.sleep(1)
-    else:
-        assert False, "ray start didn't spawn children within 10s of starting"
+    wait_for_children_of_pid(blocked.pid, num_children=7, timeout=30)
 
     blocked.poll()
     assert blocked.returncode is None
 
-    # Kill all child processes of the ray command and check that it exits.
-    subprocess.check_output(["pkill", "-P", str(blocked.pid)])
-    for _ in range(10):
-        time.sleep(1)
-        blocked.poll()
-        if blocked.returncode is not None:
-            break
-    else:
-        assert False, "ray start didn't exit within 10s of child process dying"
-
-    assert blocked.returncode != 0
+    kill_process_by_name("raylet")
+    wait_for_children_of_pid_to_exit(blocked.pid, timeout=120)
+    blocked.wait()
 
     # Test --block. Killing the command should clean up all child processes.
     blocked = subprocess.Popen(["ray", "start", "--head", "--block"])
     blocked.poll()
     assert blocked.returncode is None
 
-    # Wait for up to 10s for the ray command to spawn a child process.
-    for _ in range(10):
-        try:
-            subprocess.check_output(["pgrep", "-P", str(blocked.pid)])
-            break
-        except subprocess.CalledProcessError:
-            time.sleep(1)
-    else:
-        assert False, "ray start didn't spawn children within 10s of starting"
+    wait_for_children_of_pid(blocked.pid, num_children=7, timeout=30)
 
     blocked.terminate()
-
-    # Check that the child processes are cleaned up within 10s.
-    for _ in range(10):
-        try:
-            subprocess.check_output(
-                ["pgrep", "-P", str(blocked.pid), "raylet"])
-        except subprocess.CalledProcessError:
-            # pgrep didn't find anything, so the child processes are dead.
-            break
-    else:
-        assert False, "ray start didn't kill children within 10s of exiting."
+    wait_for_children_of_pid_to_exit(blocked.pid, timeout=120)
+    blocked.wait()
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -343,6 +343,7 @@ def test_calling_start_ray_head():
     kill_process_by_name("raylet")
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=120)
     blocked.wait()
+    assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
     # Test --block. Killing the command should clean up all child processes.
     blocked = subprocess.Popen(["ray", "start", "--head", "--block"])
@@ -354,6 +355,7 @@ def test_calling_start_ray_head():
     blocked.terminate()
     wait_for_children_of_pid_to_exit(blocked.pid, timeout=120)
     blocked.wait()
+    assert blocked.returncode != 0, "ray start shouldn't return 0 on bad exit"
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -57,9 +57,9 @@ def wait_for_children_of_pid_to_exit(pid, timeout=20):
 
     _, alive = psutil.wait_procs(children, timeout=timeout)
     if len(alive) > 0:
-        print([_.pid for _ in alive])
-        raise Exception("Timed out while waiting for process children to exit "
-                        "({} left alive).".format(len(alive)))
+        raise Exception("Timed out while waiting for process children to exit."
+                        " Children still alive: {}.".format(
+                            [p.name() for p in alive]))
 
 
 def kill_process_by_name(name, SIGKILL=False):

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import fnmatch
 import os
+import psutil
 import subprocess
 import sys
 import tempfile
@@ -35,6 +36,39 @@ def wait_for_pid_to_exit(pid, timeout=20):
             return
         time.sleep(0.1)
     raise Exception("Timed out while waiting for process to exit.")
+
+
+def wait_for_children_of_pid(pid, num_children=1, timeout=20):
+    p = psutil.Process(pid)
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        num_alive = len(p.children(recursive=False))
+        if num_alive >= num_children:
+            return
+        time.sleep(0.1)
+    raise Exception("Timed out while waiting for process children to start "
+                    "({}/{} started).".format(num_alive, num_children))
+
+
+def wait_for_children_of_pid_to_exit(pid, timeout=20):
+    children = psutil.Process(pid).children()
+    if len(children) == 0:
+        return
+
+    _, alive = psutil.wait_procs(children, timeout=timeout)
+    if len(alive) > 0:
+        print([_.pid for _ in alive])
+        raise Exception("Timed out while waiting for process children to exit "
+                        "({} left alive).".format(len(alive)))
+
+
+def kill_process_by_name(name, SIGKILL=False):
+    for p in psutil.process_iter(attrs=["name"]):
+        if p.info["name"] == name:
+            if SIGKILL:
+                p.kill()
+            else:
+                p.terminate()
 
 
 def run_string_as_driver(driver_script):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_calling_start_ray_head` is failing intermittently on travis.

This change uses process groups in `node.py` to `SIGTERM` spawned processes even in the case that we spawn a process and then are interrupted before adding it to the processes list. It also makes the test itself more reliable by waiting for child processes to start up before killing the raylet.

This might still not be perfect as spawning and killing processes seems to occasionally take a *very* long time on travis, but should be significantly better at least.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
