### PR TITLE
Properly short circuit core worker Get() on exception

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -223,6 +223,7 @@ cc_library(
         ":common_cc_proto",
         ":node_manager_fbs",
         ":ray_util",
+        "gcs_cc_proto",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
         "@plasma//:plasma_client",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -221,9 +221,9 @@ cc_library(
     copts = COPTS,
     deps = [
         ":common_cc_proto",
+        ":gcs_cc_proto",
         ":node_manager_fbs",
         ":ray_util",
-        "gcs_cc_proto",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
         "@plasma//:plasma_client",

--- a/src/ray/common/ray_object.cc
+++ b/src/ray/common/ray_object.cc
@@ -1,0 +1,22 @@
+#include "ray/common/ray_object.h"
+
+namespace ray {
+
+bool RayObject::IsException() {
+  if (metadata_ == nullptr) {
+    return false;
+  }
+  // TODO (kfstorm): metadata should be structured.
+  const std::string metadata(reinterpret_cast<const char *>(metadata_->Data()),
+                             metadata_->Size());
+  const auto error_type_descriptor = ray::rpc::ErrorType_descriptor();
+  for (int i = 0; i < error_type_descriptor->value_count(); i++) {
+    const auto error_type_number = error_type_descriptor->value(i)->number();
+    if (metadata == std::to_string(error_type_number)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace ray

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -2,6 +2,7 @@
 #define RAY_COMMON_RAY_OBJECT_H
 
 #include "ray/common/buffer.h"
+#include "ray/protobuf/gcs.pb.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -65,6 +66,9 @@ class RayObject {
   /// Whether this object has metadata.
   bool HasMetadata() const { return metadata_ != nullptr; }
 
+  /// Whether the object represents an exception.
+  bool IsException();
+
  private:
   std::shared_ptr<Buffer> data_;
   std::shared_ptr<Buffer> metadata_;
@@ -74,4 +78,4 @@ class RayObject {
 
 }  // namespace ray
 
-#endif  // RAY_COMMON_BUFFER_H
+#endif  // RAY_COMMON_RAY_OBJECT_H

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -30,7 +30,8 @@ Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
 Status CoreWorkerMemoryStoreProvider::Get(
     const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
     const TaskID &task_id,
-    std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results) {
+    std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results,
+    bool *got_exception) {
   const std::vector<ObjectID> id_vector(object_ids.begin(), object_ids.end());
   std::vector<std::shared_ptr<RayObject>> result_objects;
   RAY_RETURN_NOT_OK(
@@ -39,6 +40,9 @@ Status CoreWorkerMemoryStoreProvider::Get(
   for (size_t i = 0; i < id_vector.size(); i++) {
     if (result_objects[i] != nullptr) {
       (*results)[id_vector[i]] = result_objects[i];
+      if (result_objects[i]->IsException()) {
+        *got_exception = true;
+      }
     }
   }
   return Status::OK();

--- a/src/ray/core_worker/store_provider/memory_store_provider.h
+++ b/src/ray/core_worker/store_provider/memory_store_provider.h
@@ -25,7 +25,8 @@ class CoreWorkerMemoryStoreProvider : public CoreWorkerStoreProvider {
   /// See `CoreWorkerStoreProvider::Get` for semantics.
   Status Get(const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
              const TaskID &task_id,
-             std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results) override;
+             std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results,
+             bool *got_exception) override;
 
   /// See `CoreWorkerStoreProvider::Wait` for semantics.
   /// Note that `num_objects` must equal to number of items in `object_ids`.

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -26,7 +26,8 @@ class CoreWorkerPlasmaStoreProvider : public CoreWorkerStoreProvider {
   /// See `CoreWorkerStoreProvider::Get` for semantics.
   Status Get(const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
              const TaskID &task_id,
-             std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results) override;
+             std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results,
+             bool *got_exception) override;
 
   /// See `CoreWorkerStoreProvider::Wait` for semantics.
   Status Wait(const std::unordered_set<ObjectID> &object_ids, int num_objects,

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -52,7 +52,7 @@ class CoreWorkerPlasmaStoreProvider : public CoreWorkerStoreProvider {
   /// \param[out] results Map of objects to write results into. This method will only
   /// add to this map, not clear or remove from it, so the caller can pass in a non-empty
   /// map.
-  /// \param[out] got_exception Whether any of the fetched objects contained an
+  /// \param[out] got_exception Set to true if any of the fetched objects contained an
   /// exception.
   /// \return Status.
   Status FetchAndGetFromPlasmaStore(
@@ -60,12 +60,6 @@ class CoreWorkerPlasmaStoreProvider : public CoreWorkerStoreProvider {
       int64_t timeout_ms, bool fetch_only, const TaskID &task_id,
       std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results,
       bool *got_exception);
-
-  /// Whether the buffer represents an exception object.
-  ///
-  /// \param[in] object Object data.
-  /// \return Whether it represents an exception object.
-  static bool IsException(const RayObject &object);
 
   /// Print a warning if we've attempted too many times, but some objects are still
   /// unavailable.

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -32,11 +32,12 @@ class CoreWorkerStoreProvider {
   /// \param[in] task_id ID for the current task.
   /// \param[out] results Map of objects to write results into. Get will only add to this
   /// map, not clear or remove from it, so the caller can pass in a non-empty map.
-  /// \return Status.
-  virtual Status Get(
-      const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
-      const TaskID &task_id,
-      std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results) = 0;
+  /// \param[out] got_exception Set to true if any of the fetched results were an
+  /// exception. \return Status.
+  virtual Status Get(const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
+                     const TaskID &task_id,
+                     std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results,
+                     bool *got_exception) = 0;
 
   /// Wait for a list of objects to appear in the object store. Objects that appear will
   /// be added to the ready set.

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -518,10 +518,12 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
   ASSERT_TRUE(wait_results.count(nonexistent_id) == 0);
 
   // Test Get().
+  bool got_exception = false;
   std::unordered_map<ObjectID, std::shared_ptr<RayObject>> results;
   std::unordered_set<ObjectID> ids_set(ids.begin(), ids.end());
-  RAY_CHECK_OK(provider.Get(ids_set, -1, RandomTaskId(), &results));
+  RAY_CHECK_OK(provider.Get(ids_set, -1, RandomTaskId(), &results, &got_exception));
 
+  ASSERT_TRUE(!got_exception);
   ASSERT_EQ(results.size(), ids.size());
   for (size_t i = 0; i < ids.size(); i++) {
     const auto &expected = buffers[i];
@@ -542,7 +544,8 @@ void CoreWorkerTest::TestStoreProvider(StoreProviderType type) {
   RAY_CHECK_OK(provider.Delete(ids, true, false));
 
   usleep(200 * 1000);
-  RAY_CHECK_OK(provider.Get(ids_set, 0, RandomTaskId(), &results));
+  RAY_CHECK_OK(provider.Get(ids_set, 0, RandomTaskId(), &results, &got_exception));
+  ASSERT_TRUE(!got_exception);
   ASSERT_EQ(results.size(), 0);
 
   // Test Wait() with objects which will become ready later.

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -13,6 +13,7 @@
 #include "ray/raylet/raylet_client.h"
 #include "src/ray/protobuf/direct_actor.grpc.pb.h"
 #include "src/ray/protobuf/direct_actor.pb.h"
+#include "src/ray/protobuf/gcs.pb.h"
 #include "src/ray/util/test_util.h"
 
 #include <boost/asio.hpp>
@@ -825,6 +826,21 @@ TEST_F(SingleNodeTest, TestObjectInterface) {
     ASSERT_EQ(*results[i]->GetData(), *buffers[i].GetData());
     ASSERT_EQ(*results[i]->GetMetadata(), *buffers[i].GetMetadata());
   }
+
+  // Test Get() returns early when it encounters an error.
+  std::vector<ObjectID> ids_with_exception(ids.begin(), ids.end());
+  ids_with_exception.push_back(ObjectID::FromRandom());
+  std::vector<RayObject> buffers_with_exception(buffers.begin(), buffers.end());
+  std::string error_string = std::to_string(ray::rpc::TASK_EXECUTION_EXCEPTION);
+  char error_buffer[error_string.size()];
+  size_t len = error_string.copy(error_buffer, error_string.size(), 0);
+  buffers_with_exception.emplace_back(
+      nullptr, std::make_shared<LocalMemoryBuffer>(
+                   reinterpret_cast<uint8_t *>(error_buffer), len));
+
+  RAY_CHECK_OK(core_worker.Objects().Put(buffers_with_exception.back(),
+                                         ids_with_exception.back()));
+  RAY_CHECK_OK(core_worker.Objects().Get(ids_with_exception, -1, &results));
 
   // Test Wait().
   ObjectID non_existent_id = ObjectID::FromRandom();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We should be short circuiting calls to `Get()` in the core worker when we see an exception, but this wasn't propagated out of the plasma store provider (was causing some Java test errors).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
