### PR TITLE
[Flaky Test] Fix queue actor init in setup_queue_actor fixture

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1779,7 +1779,11 @@ def setup_queue_actor():
         def read(self):
             return self.queue
 
-    yield Queue.remote()
+    queue = Queue.remote()
+    # Make sure queue actor is initialized.
+    ray.get(queue.read.remote())
+
+    yield queue
 
     # The code after the yield will run as teardown code.
     ray.shutdown()
@@ -1787,8 +1791,6 @@ def setup_queue_actor():
 
 def test_fork(setup_queue_actor):
     queue = setup_queue_actor
-    # Make sure queue actor is initialized.
-    ray.get(queue.read.remote())
 
     @ray.remote
     def fork(queue, key, item):


### PR DESCRIPTION
Fix all tests require `setup_queue_actor`. This can also fix test_nest_fork as well. 