### PR TITLE
Fix 5667 - Changing use of sun NotImplementedException to apache NotImplementedException

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/context/LocalModeWorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/context/LocalModeWorkerContext.java
@@ -8,7 +8,7 @@ import org.ray.api.id.UniqueId;
 import org.ray.runtime.generated.Common.TaskSpec;
 import org.ray.runtime.generated.Common.TaskType;
 import org.ray.runtime.task.LocalModeTaskSubmitter;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Worker context for local mode.
@@ -24,7 +24,7 @@ public class LocalModeWorkerContext implements WorkerContext {
 
   @Override
   public UniqueId getCurrentWorkerId() {
-    throw new NotImplementedException();
+    throw new NotImplementedException("getCurrentWorkerId() not (yet) implemented.");
   }
 
   @Override

--- a/java/runtime/src/main/java/org/ray/runtime/context/LocalModeWorkerContext.java
+++ b/java/runtime/src/main/java/org/ray/runtime/context/LocalModeWorkerContext.java
@@ -5,6 +5,7 @@ import org.ray.api.id.ActorId;
 import org.ray.api.id.JobId;
 import org.ray.api.id.TaskId;
 import org.ray.api.id.UniqueId;
+import org.ray.runtime.config.RunMode;
 import org.ray.runtime.generated.Common.TaskSpec;
 import org.ray.runtime.generated.Common.TaskType;
 import org.ray.runtime.task.LocalModeTaskSubmitter;
@@ -24,7 +25,7 @@ public class LocalModeWorkerContext implements WorkerContext {
 
   @Override
   public UniqueId getCurrentWorkerId() {
-    throw new NotImplementedException("getCurrentWorkerId() not (yet) implemented.");
+    throw new NotImplementedException("Not supported in "+ RunMode.SINGLE_PROCESS +" mode.");
   }
 
   @Override


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

See https://github.com/ray-project/ray/issues/5667

Basically, the use of sun.reflect.generics.reflectiveObjects.NotImplementedException creates a dependency to sun proprietary Class. It might be better suited to switch to another Class. In LocalModeRayletClient.java, it seems the apache lang version is preferred: org.apache.commons.lang3.NotImplementedException

## Related issue number

Closes #5667

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
        => can't run it without installing yapf@0.23.0 which seems impossible now with brew
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
        => NA
