### PR TITLE
[Projects] Add "session execute"

### DIFF
--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -233,7 +233,7 @@ class SessionRunner(object):
         else:
             try:
                 return self.project_definition.get_command_to_run(
-                        command=command, args=args)
+                    command=command, args=args)
             except ValueError as e:
                 raise click.ClickException(e)
 
@@ -306,7 +306,7 @@ def session_start(command, args, shell):
         steps += [("Running command", lambda: runner.execute_command(cmd))]
 
     for i, (prompt, function) in enumerate(steps):
-        logger.info("[{}/{}] {}".format(i+1, len(steps), prompt))
+        logger.info("[{}/{}] {}".format(i + 1, len(steps), prompt))
         function()
 
 

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -167,7 +167,7 @@ def stop():
         override_cluster_name=None)
 
 
-def run_start_session(args, num_steps):
+def run_session_start(args, num_steps):
     project_definition = load_project_or_throw()
 
     # Check for features we don't support right now
@@ -207,7 +207,7 @@ def run_start_session(args, num_steps):
         cwd=project_definition.working_directory())
 
 
-def run_execute_session(command, args, shell):
+def run_session_execute(command, args, shell):
     project_definition = load_project_or_throw()
 
     if shell:
@@ -248,6 +248,7 @@ def session_start(command, args, shell):
 
 
 @session_cli.command(
+    name="execute",
     context_settings=dict(ignore_unknown_options=True, ),
     help="Execute a command in a session")
 @click.argument("command", required=False)
@@ -258,7 +259,7 @@ def session_start(command, args, shell):
         "If set, run the command as a raw shell command instead of looking up "
         "the command in the project config"),
     is_flag=True)
-def execute(command, args, shell):
+def session_execute(command, args, shell):
     run_session_execute(command, args, shell)
 
 

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -295,19 +295,24 @@ def stop():
     is_flag=True)
 def session_start(command, args, shell):
     runner = SessionRunner()
-    steps = [
-        ("Creating cluster", lambda: runner.create_cluster()),
-        ("Syncing the project", lambda: runner.sync_files()),
-        ("Setting up environment", lambda: runner.setup_environment()),
-    ]
     if shell or command:
-        # Run this before the cluster is started to validate the command.
+        # Get the actual command to run.
         cmd = runner.format_command(command, args, shell)
-        steps += [("Running command", lambda: runner.execute_command(cmd))]
+        num_steps = 4
+    else:
+        num_steps = 3
 
-    for i, (prompt, function) in enumerate(steps):
-        logger.info("[{}/{}] {}".format(i + 1, len(steps), prompt))
-        function()
+    logger.info("[1/{}] Creating cluster".format(num_steps))
+    runner.create_cluster()
+    logger.info("[2/{}] Syncing the project".format(num_steps))
+    runner.sync_files()
+    logger.info("[3/{}] Setting up environment".format(num_steps))
+    runner.setup_environment()
+
+    if shell or command:
+        # Run the actual command.
+        logger.info("[4/4] Running command")
+        runner.execute_command(cmd)
 
 
 @session_cli.command(

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -214,7 +214,8 @@ class SessionRunner(object):
 
             # Create a temporary requirements_txt in the head node.
             remote_requirements_txt = (
-                "/tmp/" + "ray_project_requirements_txt_{}".format(time.time()))
+                "/tmp/" + "ray_project_requirements_txt_{}".format(
+                    time.time()))
 
             rsync(
                 self.project_definition.cluster_yaml,
@@ -229,7 +230,6 @@ class SessionRunner(object):
         if "shell" in project_environment:
             for cmd in project_environment["shell"]:
                 self.execute_command(cmd)
-
 
     def execute_command(self, cmd):
         """Execute a shell command in the session.

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -168,8 +168,9 @@ class SessionRunner(object):
             self.command_to_run = command
         else:
             try:
-                self.command_to_run = self.project_definition.get_command_to_run(
-                    command=command, args=args)
+                self.command_to_run = (
+                    self.project_definition.get_command_to_run(
+                        command=command, args=args))
             except ValueError as e:
                 raise click.ClickException(e)
 
@@ -179,9 +180,7 @@ class SessionRunner(object):
                        or "dockerimage" in project_environment)
         if need_docker:
             raise click.ClickException(
-                "Docker support in session is currently not implemented. "
-                "Please file an feature request at"
-                "https://github.com/ray-project/ray/issues")
+                "Docker support in session is currently not implemented.")
 
     def create_cluster(self):
         """Create a cluster that will run the session."""
@@ -218,7 +217,7 @@ class SessionRunner(object):
                     time.time()))
 
             rsync(
-                self.project_definition.cluster_yaml,
+                self.project_definition.cluster_yaml(),
                 source=requirements_txt,
                 target=remote_requirements_txt,
                 override_cluster_name=None,

--- a/python/ray/tests/test_projects.py
+++ b/python/ray/tests/test_projects.py
@@ -12,7 +12,7 @@ import sys
 
 from contextlib import contextmanager
 
-from ray.projects.scripts import start
+from ray.projects.scripts import session_start
 import ray
 
 if sys.version_info >= (3, 3):
@@ -101,7 +101,7 @@ def run_test_project(project_dir, command, args):
 
 def test_session_start_default_project():
     result, mock_calls, test_dir = run_test_project(
-        "session-tests/project-pass", start, [])
+        "session-tests/project-pass", session_start, ["default"])
 
     loaded_project = ray.projects.ProjectDefinition(test_dir)
     assert result.exit_code == 0
@@ -144,8 +144,8 @@ def test_session_start_default_project():
 
 
 def test_session_start_docker_fail():
-    result, _, _ = run_test_project("session-tests/with-docker-fail", start,
-                                    [])
+    result, _, _ = run_test_project("session-tests/with-docker-fail",
+                                    session_start, [])
 
     assert result.exit_code == 1
     assert ("Docker support in session is currently "
@@ -153,8 +153,8 @@ def test_session_start_docker_fail():
 
 
 def test_session_invalid_config_errored():
-    result, _, _ = run_test_project("session-tests/invalid-config-fail", start,
-                                    [])
+    result, _, _ = run_test_project("session-tests/invalid-config-fail",
+                                    session_start, [])
 
     assert result.exit_code == 1
     assert "validation failed" in result.output
@@ -164,7 +164,7 @@ def test_session_invalid_config_errored():
 
 def test_session_create_command():
     result, mock_calls, test_dir = run_test_project(
-        "session-tests/commands-test", start,
+        "session-tests/commands-test", session_start,
         ["first", "--a", "1", "--b", "2"])
 
     # Verify the project can be loaded.

--- a/python/ray/tests/test_projects.py
+++ b/python/ray/tests/test_projects.py
@@ -12,7 +12,7 @@ import sys
 
 from contextlib import contextmanager
 
-from ray.projects.scripts import session_start
+from ray.projects.scripts import session_start, session_execute
 import ray
 
 if sys.version_info >= (3, 3):
@@ -139,6 +139,29 @@ def test_session_start_default_project():
         commands_executed = [
             cmd for cmd in commands_executed if "pip install -r" not in cmd
         ]
+
+    assert expected_commands == commands_executed
+
+
+def test_session_execute_default_project():
+    result, mock_calls, test_dir = run_test_project(
+        "session-tests/project-pass", session_execute, ["default"])
+
+    loaded_project = ray.projects.ProjectDefinition(test_dir)
+    assert result.exit_code == 0
+
+    assert mock_calls["rsync"].call_count == 0
+    assert mock_calls["create_or_update_cluster"].call_count == 0
+
+    exec_cluster_call = mock_calls["exec_cluster"]
+    commands_executed = []
+    for _, kwargs in exec_cluster_call.call_args_list:
+        commands_executed.append(kwargs["cmd"].replace(
+            "cd {}; ".format(loaded_project.working_directory()), ""))
+
+    expected_commands = [
+        command["command"] for command in loaded_project.config["commands"]
+    ]
 
     assert expected_commands == commands_executed
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR introduces a new `session execute` command which allows running commands in an already created session.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
