### PR TITLE
Call ray.put in ray.init() to speed up first object store access.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2043,6 +2043,13 @@ def connect(node,
         worker.current_job_id,
     )
 
+    # Put something in the plasma store so that subsequent plasma store
+    # accesses will be faster. Currently the first access is always slow, and
+    # we don't want the user to experience this.
+    temporary_object_id = ray.ObjectID(np.random.bytes(20))
+    worker.put_object(temporary_object_id, 1)
+    ray.internal.free([temporary_object_id])
+
     # Start the import thread
     worker.import_thread = import_thread.ImportThread(worker, mode,
                                                       worker.threads_stopped)


### PR DESCRIPTION
One problem that users often run into is that the first time they do something with Ray it is very slow. The second time is much faster. This applies to the first usage of any worker and not just the driver. The reason is that the first time a driver or worker accesses the object store (e.g., by calling `ray.put` or by completing a task), it takes about half a second (presumably to memory map the a large file).

Note that instead of calling `ray.put`, I tried just calling `plasma_client.put` instead. However, that only sped things up by a factor of 2.

```python
import ray

ray.init()

%time ray.get(ray.put(1))
```

**Before this PR:** The timed line takes 500+ milliseconds.
**Using plasma_client.put instead of ray.put:** The timed line takes 250+ milliseconds (I'm not 100% sure why).
**After this PR:** The timed line takes 700 microseconds.

Note that `ray.init()` gets slower in this PR.

It's important that this happens on workers as well as the driver.