### PR TITLE
[rllib] Validate that entropy coeff is not an integer

### DIFF
--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -126,6 +126,10 @@ def warn_about_bad_reward_scales(trainer, result):
 
 
 def validate_config(config):
+    if isinstance(config["entropy_coeff"], int):
+        raise ValueError(
+            "Entropy coefficient {} must be float.".format(
+                config["entropy_coeff"]))
     if config["entropy_coeff"] < 0:
         raise DeprecationWarning("entropy_coeff must be >= 0")
     if config["sgd_minibatch_size"] > config["train_batch_size"]:

--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -126,12 +126,10 @@ def warn_about_bad_reward_scales(trainer, result):
 
 
 def validate_config(config):
-    if isinstance(config["entropy_coeff"], int):
-        raise ValueError(
-            "Entropy coefficient {} must be float.".format(
-                config["entropy_coeff"]))
     if config["entropy_coeff"] < 0:
         raise DeprecationWarning("entropy_coeff must be >= 0")
+    if isinstance(config["entropy_coeff"], int):
+        config["entropy_coeff"] = float(config["entropy_coeff"])
     if config["sgd_minibatch_size"] > config["train_batch_size"]:
         raise ValueError(
             "Minibatch size {} must be <= train batch size {}.".format(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Passing an integer value for entropy coeff such as 0 raises an error somewhere inside the TF policy graph.

<!-- Please give a short summary of the change and the problem this solves. -->

This casts int values of entropy coeff to floats. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #5686 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
