### PR TITLE
[revert] Disable monitor error logging to stdout

### DIFF
--- a/python/ray/log_monitor.py
+++ b/python/ray/log_monitor.py
@@ -115,8 +115,7 @@ class LogMonitor(object):
         log_file_paths = glob.glob("{}/worker*[.out|.err]".format(
             self.logs_dir))
         # segfaults and other serious errors are logged here
-        raylet_err_paths = (glob.glob("{}/raylet*.err".format(self.logs_dir)) +
-                            glob.glob("{}/monitor*.err".format(self.logs_dir)))
+        raylet_err_paths = glob.glob("{}/raylet*.err".format(self.logs_dir))
         for file_path in log_file_paths + raylet_err_paths:
             if os.path.isfile(
                     file_path) and file_path not in self.log_filenames:


### PR DESCRIPTION
This turns out to be pretty obnoxious since all python logs go to stderr. We could probably force the configuration to not do this, but this is the quick revert.