### PR TITLE
[projects] Only set git repo in the config if .git exists

### DIFF
--- a/python/ray/projects/projects.py
+++ b/python/ray/projects/projects.py
@@ -93,6 +93,9 @@ class ProjectDefinition:
 
         return command_to_run
 
+    def git_repo(self):
+        return self.config.get("repo", None)
+
 
 def find_root(directory):
     """Find root directory of the ray project.

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -101,12 +101,13 @@ def create(project_name, cluster_yaml, requirements):
         requirements = REQUIREMENTS_TXT
 
     repo = None
-    try:
-        repo = subprocess.check_output(
-            "git remote get-url origin".split(" ")).strip()
-        logger.info("Setting repo URL to %s", repo)
-    except subprocess.CalledProcessError:
-        pass
+    if os.path.exists(".git"):
+        try:
+            repo = subprocess.check_output(
+                "git remote get-url origin".split(" ")).strip()
+            logger.info("Setting repo URL to %s", repo)
+        except subprocess.CalledProcessError:
+            pass
 
     with open(PROJECT_TEMPLATE) as f:
         project_template = f.read()


### PR DESCRIPTION
## Why are these changes needed?

Previously, when creating a project, it would default to setting the git repo URL in the project config as long as a git command succeeded. However, the git command can also succeed when the project directory is a subdirectory inside a git repo, and the project directory may not even be tracked by git. This modifies the command so that the git repo URL is only set if `.git` is in the directory where the command is called.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
