### PR TITLE
Fix edge case in autoscaler with poor bin packing

### DIFF
--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -156,17 +156,30 @@ class LoadMetricsTest(unittest.TestCase):
         lm.update("1.1.1.1", {"CPU": 2}, {"CPU": 1}, {"CPU": 1})
         self.assertEqual(lm.approx_workers_used(), 1.0)
 
-        # Both nodes count as busy since there is a queue on one. This covers
-        # the edge case with a small head and large worker, and the worker is
-        # busy but the head node cannot schedule tasks.
+        # Both nodes count as busy since there is a queue on one.
+        lm.update("2.2.2.2", {"CPU": 2}, {"CPU": 2}, {})
+        self.assertEqual(lm.approx_workers_used(), 2.0)
+        lm.update("2.2.2.2", {"CPU": 2}, {"CPU": 0}, {})
+        self.assertEqual(lm.approx_workers_used(), 2.0)
         lm.update("2.2.2.2", {"CPU": 2}, {"CPU": 1}, {})
         self.assertEqual(lm.approx_workers_used(), 2.0)
 
-        # no queue anymore, so we're back to exact accounting
+        # No queue anymore, so we're back to exact accounting.
         lm.update("1.1.1.1", {"CPU": 2}, {"CPU": 0}, {})
         self.assertEqual(lm.approx_workers_used(), 1.5)
         lm.update("2.2.2.2", {"CPU": 2}, {"CPU": 1}, {"GPU": 1})
         self.assertEqual(lm.approx_workers_used(), 2.0)
+
+        lm.update("3.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        lm.update("4.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        lm.update("5.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        lm.update("6.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        lm.update("7.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        lm.update("8.3.3.3", {"CPU": 2}, {"CPU": 1}, {})
+        self.assertEqual(lm.approx_workers_used(), 8.0)
+
+        lm.update("2.2.2.2", {"CPU": 2}, {"CPU": 1}, {})  # no queue anymore
+        self.assertEqual(lm.approx_workers_used(), 4.5)
 
     def testPruneByNodeIp(self):
         lm = LoadMetrics()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When the cluster is backlogged, bump the "estimated busy nodes" count by the number of nonidle nodes + 1. This takes into account the case where the head node cannot accept tasks and hence is idle, or more generally, when nodes don't register as fully utilized due to poor bin packing, but there are tasks in a backlog somewhere in the cluster.

One side effect is that we are slightly more aggressive at scaling up, but this is probably ok.

## Related issue number

Closes https://github.com/ray-project/ray/issues/5696

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
