### PR TITLE
Fix travis error in direct_actor_transport.cc

### DIFF
--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -290,7 +290,7 @@ void CoreWorkerDirectActorTaskReceiver::HandlePushTask(
 
         send_reply_callback(status, nullptr, nullptr);
       },
-      [this, send_reply_callback]() {
+      [send_reply_callback]() {
         send_reply_callback(Status::Invalid("client cancelled rpc"), nullptr, nullptr);
       });
 }


### PR DESCRIPTION
Fixes
```
src/ray/core_worker/transport/direct_actor_transport.cc:293:8: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
      [this, send_reply_callback]() {
       ^
1 error generated.
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
