### PR TITLE
[Projects] Fix project templates in wheel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -803,6 +803,9 @@ filegroup(
         "python/ray/internal/*.py",
         "python/ray/projects/*.py",
         "python/ray/projects/schema.json",
+        "python/ray/projects/template/cluster_template.yaml",
+        "python/ray/projects/template/project_template.yaml",
+        "python/ray/projects/template/requirements.txt",
         "python/ray/workers/default_worker.py",
     ]),
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, the project templates are not deployed as parts of the Ray wheels. This PR fixes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
