### PR TITLE
[rllib] Qmix off by 1 in double Q calculation

### DIFF
--- a/rllib/agents/qmix/qmix_policy.py
+++ b/rllib/agents/qmix/qmix_policy.py
@@ -177,7 +177,7 @@ class QMixTorchPolicy(Policy):
         agent_obs_space = obs_space.original_space.spaces[0]
         if isinstance(agent_obs_space, Dict):
             space_keys = set(agent_obs_space.spaces.keys())
-            if space_keys != {"obs", "action_mask"}:
+            if not {"obs", "action_mask"}.issubset(space_keys):
                 raise ValueError(
                     "Dict obs space for agent must have keyset "
                     "['obs', 'action_mask'], got {}".format(space_keys))

--- a/rllib/agents/qmix/qmix_policy.py
+++ b/rllib/agents/qmix/qmix_policy.py
@@ -60,8 +60,6 @@ class QMixLoss(nn.Module):
             next_action_mask: Tensor of shape [B, T, n_agents, n_actions]
         """
 
-        B, T = obs.size(0), obs.size(1)
-
         # Calculate estimated Q-Values
         mac_out = _unroll_mac(self.model, obs)
 
@@ -452,13 +450,10 @@ def _unroll_mac(model, obs_tensor):
     n_agents = obs_tensor.size(2)
 
     mac_out = []
-    h = [
-        s.expand([B, n_agents, -1])
-        for s in model.get_initial_state()
-    ]
+    h = [s.expand([B, n_agents, -1]) for s in model.get_initial_state()]
     for t in range(T):
         q, h = _mac(model, obs_tensor[:, t], h)
         mac_out.append(q)
-    mac_out = th.stack(mac_out, dim=1) # Concat over time
+    mac_out = th.stack(mac_out, dim=1)  # Concat over time
 
     return mac_out

--- a/rllib/agents/qmix/qmix_policy.py
+++ b/rllib/agents/qmix/qmix_policy.py
@@ -77,7 +77,7 @@ class QMixLoss(nn.Module):
         # Max over target Q-Values
         if self.double_q:
             # Double Q learning computes the target Q values by selecting the
-            # t+1 timestep action according to the "live" neural network and
+            # t+1 timestep action according to the "policy" neural network and
             # then estimating the Q-value of that action with the "target"
             # neural network
 
@@ -88,11 +88,11 @@ class QMixLoss(nn.Module):
             # mask out unallowed actions
             mac_out_tp1[ignore_action_tp1] = -np.inf
 
-            # obtain best actions at t+1 according to live NN
+            # obtain best actions at t+1 according to policy NN
             cur_max_actions = mac_out_tp1.max(dim=3, keepdim=True)[1]
 
-            # use the target network to estimate the Q-values of live network's
-            # selected actions
+            # use the target network to estimate the Q-values of policy
+            # network's selected actions
             target_max_qvals = th.gather(target_mac_out, 3,
                                          cur_max_actions).squeeze(3)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This solves a couple of issues with Qmix including a bug in its implementation of double Q learning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
