### PR TITLE
Add local_tf_session_args to unknown subkeys whitelist

### DIFF
--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -317,8 +317,8 @@ class Trainer(Trainable):
 
     _allow_unknown_configs = False
     _allow_unknown_subkeys = [
-        "tf_session_args", "local_tf_session_args", "env_config", "model", 
-        "optimizer", "multiagent", "custom_resources_per_worker", 
+        "tf_session_args", "local_tf_session_args", "env_config", "model",
+        "optimizer", "multiagent", "custom_resources_per_worker",
         "evaluation_config"
     ]
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -317,8 +317,9 @@ class Trainer(Trainable):
 
     _allow_unknown_configs = False
     _allow_unknown_subkeys = [
-        "tf_session_args", "env_config", "model", "optimizer", "multiagent",
-        "custom_resources_per_worker", "evaluation_config"
+        "tf_session_args", "local_tf_session_args", "env_config", "model", 
+        "optimizer", "multiagent", "custom_resources_per_worker", 
+        "evaluation_config"
     ]
 
     @PublicAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Since `tf_session_args` is included in the whitelist for unknown subkeys in the config, it would make sense to also include `local_tf_session_args`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
