### PR TITLE
Properly test Python wheels.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - export PATH="$HOME/miniconda/bin:$PATH"
         - cd doc
         - pip install -q -r requirements-doc.txt
-        - pip install yapf==0.23.0
+        - pip install -q yapf==0.23.0
         - sphinx-build -W -b html -d _build/doctrees source _build/html
         - cd ..
         # Run Python linting, ignore dict vs {} (C408), others are defaults

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -59,8 +59,7 @@ elif [[ "$LINT" == "1" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   # Install Python linting tools.
-  pip install -q flake8==3.7.7 flake8-comprehensions
-  pip install flake8-quotes==2.0.0
+  pip install -q flake8==3.7.7 flake8-comprehensions flake8-quotes==2.0.0
 elif [[ "$LINUX_WHEELS" == "1" ]]; then
   sudo apt-get install docker
   sudo usermod -a -G docker travis

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -40,7 +40,7 @@ if [[ "$platform" == "linux" ]]; then
   $PIP_CMD install -q "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)")")
   $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Now test Python 3.6.
@@ -59,7 +59,7 @@ if [[ "$platform" == "linux" ]]; then
   $PIP_CMD install -q "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)" | tail -n1)")
   $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Check that the other wheels are present.
@@ -96,7 +96,7 @@ elif [[ "$platform" == "macosx" ]]; then
     $PIP_CMD install -q "$PYTHON_WHEEL"
 
     # Run a simple test script to make sure that the wheel works.
-    INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")
+    INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)" | tail -n1)")
     $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
   done
 else

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -57,11 +57,10 @@ if [[ "$platform" == "linux" ]]; then
   PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '36')
 
   # Install the wheel.
-  $PIP_CMD install psutil setproctitle
   $PIP_CMD install "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")
   $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Check that the other wheels are present.
@@ -95,11 +94,10 @@ elif [[ "$platform" == "macosx" ]]; then
     PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
 
     # Install the wheel.
-    $PIP_CMD install psutil setproctitle
     $PIP_CMD install "$PYTHON_WHEEL"
 
     # Run a simple test script to make sure that the wheel works.
-    INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
+    INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")
     $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
   done
 else

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -21,7 +21,7 @@ else
   exit 1
 fi
 
-TEST_SCRIPT=$ROOT_DIR/../../python/ray/tests/test_microbenchmarks.py
+TEST_SCRIPT="tests/test_microbenchmarks.py"
 
 if [[ "$platform" == "linux" ]]; then
   # First test Python 2.7.
@@ -37,7 +37,8 @@ if [[ "$platform" == "linux" ]]; then
   $HOME/miniconda2/bin/pip install $PYTHON_WHEEL
 
   # Run a simple test script to make sure that the wheel works.
-  $HOME/miniconda2/bin/python $TEST_SCRIPT
+  INSTALLED_RAY_DIRECTORY=$(dirname $(python -c "import ray; print(ray.__file__)"))
+  $HOME/miniconda2/bin/python -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Now test Python 3.6.
 
@@ -52,7 +53,8 @@ if [[ "$platform" == "linux" ]]; then
   $HOME/miniconda3/bin/pip install $PYTHON_WHEEL
 
   # Run a simple test script to make sure that the wheel works.
-  $HOME/miniconda3/bin/python $TEST_SCRIPT
+  INSTALLED_RAY_DIRECTORY=$(dirname $(python -c "import ray; print(ray.__file__)"))
+  $HOME/miniconda3/bin/python -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Check that the other wheels are present.
   NUMBER_OF_WHEELS=$(ls -1q $ROOT_DIR/../../.whl/*.whl | wc -l)
@@ -88,7 +90,8 @@ elif [[ "$platform" == "macosx" ]]; then
     $PIP_CMD install $PYTHON_WHEEL
 
     # Run a simple test script to make sure that the wheel works.
-    $PYTHON_EXE $TEST_SCRIPT
+    INSTALLED_RAY_DIRECTORY=$(dirname $($PYTHON_EXE -c "import ray; print(ray.__file__)"))
+    $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
   done
 else
   echo "Unrecognized environment."

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -40,7 +40,7 @@ if [[ "$platform" == "linux" ]]; then
   $PIP_CMD install -q "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)")")
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)" | tail -n1)")
   $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Now test Python 3.6.

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -28,39 +28,45 @@ if [[ "$platform" == "linux" ]]; then
 
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda2-4.5.4-Linux-x86_64.sh -O miniconda2.sh
-  bash miniconda2.sh -b -p $HOME/miniconda2
+  bash miniconda2.sh -b -p "$HOME/miniconda2"
+
+  PYTHON_EXE=$HOME/miniconda2/bin/python
+  PIP_CMD=$HOME/miniconda2/bin/pip
 
   # Find the right wheel by grepping for the Python version.
-  PYTHON_WHEEL=$(find $ROOT_DIR/../../.whl -type f -maxdepth 1 -print | grep -m1 '27')
+  PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '27')
 
   # Install the wheel.
-  $HOME/miniconda2/bin/pip install $PYTHON_WHEEL
+  $PIP_CMD install "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname $(python -c "import ray; print(ray.__file__)"))
-  $HOME/miniconda2/bin/python -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
+  $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Now test Python 3.6.
 
   # Install miniconda.
   wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O miniconda3.sh
-  bash miniconda3.sh -b -p $HOME/miniconda3
+  bash miniconda3.sh -b -p "$HOME/miniconda3"
+
+  PYTHON_EXE=$HOME/miniconda3/bin/python
+  PIP_CMD=$HOME/miniconda3/bin/pip
 
   # Find the right wheel by grepping for the Python version.
-  PYTHON_WHEEL=$(find $ROOT_DIR/../../.whl -type f -maxdepth 1 -print | grep -m1 '36')
+  PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '36')
 
   # Install the wheel.
-  $HOME/miniconda3/bin/pip install $PYTHON_WHEEL
+  $PIP_CMD install "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
-  INSTALLED_RAY_DIRECTORY=$(dirname $(python -c "import ray; print(ray.__file__)"))
-  $HOME/miniconda3/bin/python -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
+  INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
+  $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Check that the other wheels are present.
-  NUMBER_OF_WHEELS=$(ls -1q $ROOT_DIR/../../.whl/*.whl | wc -l)
+  NUMBER_OF_WHEELS=$(ls -1q "$ROOT_DIR/../../.whl/*.whl" | wc -l)
   if [[ "$NUMBER_OF_WHEELS" != "4" ]]; then
     echo "Wrong number of wheels found."
-    ls -l $ROOT_DIR/../.whl/
+    ls -l "$ROOT_DIR/../.whl/"
     exit 2
   fi
 
@@ -81,16 +87,16 @@ elif [[ "$platform" == "macosx" ]]; then
     PY_WHEEL_VERSION=${PY_WHEEL_VERSIONS[i]}
 
     PYTHON_EXE=$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM
-    PIP_CMD="$(dirname $PYTHON_EXE)/pip$PY_MM"
+    PIP_CMD="$(dirname "$PYTHON_EXE")/pip$PY_MM"
 
     # Find the appropriate wheel by grepping for the Python version.
-    PYTHON_WHEEL=$(find $ROOT_DIR/../../.whl -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
+    PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
 
     # Install the wheel.
-    $PIP_CMD install $PYTHON_WHEEL
+    $PIP_CMD install "$PYTHON_WHEEL"
 
     # Run a simple test script to make sure that the wheel works.
-    INSTALLED_RAY_DIRECTORY=$(dirname $($PYTHON_EXE -c "import ray; print(ray.__file__)"))
+    INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
     $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
   done
 else

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -64,7 +64,7 @@ if [[ "$platform" == "linux" ]]; then
   $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
   # Check that the other wheels are present.
-  NUMBER_OF_WHEELS=$(ls -1q "$ROOT_DIR/../../.whl/*.whl" | wc -l)
+  NUMBER_OF_WHEELS=$(ls -1q "$ROOT_DIR"/../../.whl/*.whl | wc -l)
   if [[ "$NUMBER_OF_WHEELS" != "4" ]]; then
     echo "Wrong number of wheels found."
     ls -l "$ROOT_DIR/../.whl/"

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -37,6 +37,7 @@ if [[ "$platform" == "linux" ]]; then
   PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '27')
 
   # Install the wheel.
+  $PIP_CMD install psutil setproctitle
   $PIP_CMD install "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
@@ -56,6 +57,7 @@ if [[ "$platform" == "linux" ]]; then
   PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '36')
 
   # Install the wheel.
+  $PIP_CMD install psutil setproctitle
   $PIP_CMD install "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
@@ -93,6 +95,7 @@ elif [[ "$platform" == "macosx" ]]; then
     PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
 
     # Install the wheel.
+    $PIP_CMD install psutil setproctitle
     $PIP_CMD install "$PYTHON_WHEEL"
 
     # Run a simple test script to make sure that the wheel works.

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -37,8 +37,7 @@ if [[ "$platform" == "linux" ]]; then
   PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '27')
 
   # Install the wheel.
-  $PIP_CMD install psutil setproctitle
-  $PIP_CMD install "$PYTHON_WHEEL"
+  $PIP_CMD install -q "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
   INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)")")
@@ -57,7 +56,7 @@ if [[ "$platform" == "linux" ]]; then
   PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 '36')
 
   # Install the wheel.
-  $PIP_CMD install "$PYTHON_WHEEL"
+  $PIP_CMD install -q "$PYTHON_WHEEL"
 
   # Run a simple test script to make sure that the wheel works.
   INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")
@@ -94,7 +93,7 @@ elif [[ "$platform" == "macosx" ]]; then
     PYTHON_WHEEL=$(find "$ROOT_DIR/../../.whl" -type f -maxdepth 1 -print | grep -m1 "$PY_WHEEL_VERSION")
 
     # Install the wheel.
-    $PIP_CMD install "$PYTHON_WHEEL"
+    $PIP_CMD install -q "$PYTHON_WHEEL"
 
     # Run a simple test script to make sure that the wheel works.
     INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -c "import ray; print(ray.__file__)" | tail -n1)")

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -79,3 +79,5 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     mv dist/*.whl ../.whl/
   popd
 done
+
+git clean -f -f -x -d -e .whl -e $DOWNLOAD_DIR

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -x
+
+# Cause the script to exit if a single command fails.
+set -e
+
 cat << EOF > "/usr/bin/nproc"
 #!/bin/bash
 echo 10
@@ -47,6 +52,8 @@ for ((i=0; i<${#PYTHONS[@]}; ++i)); do
     mv dist/*.whl ../.whl/
   popd
 done
+
+git clean -f -f -x -d -e .whl
 
 # Rename the wheels so that they can be uploaded to PyPI. TODO(rkn): This is a
 # hack, we should use auditwheel instead.


### PR DESCRIPTION
The test that tests the wheels built in CI currently doesn't actually run the test because it just calls `python test.py` instead of `python -m pytest test.py`. cc @mitchellstern 