### PR TITLE
Fix flaky test_actors_and_tasks_with_gpus_version_two test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,6 @@ matrix:
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
 
     - os: linux
-      env:
-        - JDK='Oracle JDK 8'
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
-        - RAY_INSTALL_JAVA=1
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./ci/suppress_output ./ci/travis/install-bazel.sh
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
-      script:
-        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./java/test.sh
-
-    - os: linux
       env: LINT=1 PYTHONWARNINGS=ignore
       before_install:
         - sudo apt-get update -qq
@@ -67,76 +51,6 @@ matrix:
         - go get github.com/bazelbuild/buildtools/buildifier
         - ./ci/travis/bazel-format.sh
 
-    - os: linux
-      env: VALGRIND=1 PYTHON=2.7 PYTHONWARNINGS=ignore
-      before_install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
-
-        # Install a newer version of valgrind, the one that comes with
-        # Ubuntu 16.04 is broken (Illegal instruction)
-        - sudo add-apt-repository -y ppa:msulikowski/valgrind
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq valgrind
-
-      install:
-        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/suppress_output ./ci/travis/install-bazel.sh
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
-
-      script:
-        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
-
-        - bash src/ray/test/run_object_manager_valgrind.sh
-
-        - export RAY_PLASMA_STORE_VALGRIND=1
-        # - export RAY_RAYLET_VALGRIND=1
-        # - export RAY_RAYLET_MONITOR_VALGRIND=1
-        # - export RAY_REDIS_SERVER_VALGRIND=1
-
-        # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
-        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_mini.py
-        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_array.py
-        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_multi_node_2.py
-        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_node_manager.py
-
-    # Build Linux wheels.
-    - os: linux
-      env: LINUX_WHEELS=1 PYTHONWARNINGS=ignore
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-
-        # Mount bazel cache dir to the docker container.
-        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
-        # This command should be kept in sync with ray/python/README-building-wheels.md,
-        # except the `$MOUNT_BAZEL_CACHE` part.
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
-      script:
-        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/travis/test-wheels.sh
-
-    # Build MacOS wheels.
-    - os: osx
-      osx_image: xcode7
-      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./ci/suppress_output ./python/build-wheel-macos.sh
-      script:
-        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/travis/test-wheels.sh
 
 install:
   - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -148,14 +62,6 @@ install:
   - ./ci/suppress_output ./ci/travis/install-ray.sh
   - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
 
-  - ./ci/suppress_output bash src/ray/test/run_gcs_tests.sh
-
-  # core worker test.
-  - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-
-  # Raylet tests.
-  - ./ci/suppress_output bash src/ray/test/run_object_manager_tests.sh
-  - ./ci/suppress_output bazel test --build_tests_only --test_lang_filters=cc //:all
   # Shutdown bazel to release the memory held by bazel.
   - bazel shutdown
 
@@ -167,16 +73,8 @@ script:
   # module is only found if the test directory is in the PYTHONPATH.
   # - export PYTHONPATH="$PYTHONPATH:./ci/"
 
-  # ray tune tests
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
-  # `cluster_tests.py` runs on Jenkins, not Travis.
-  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest --durations=10 --timeout=300 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_tune_restore.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
-
-  # ray tests
-  # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --timeout=300 python/ray/tests --ignore=python/ray/tests/perf_integration_tests; fi
+  - for i in {1..20}; do python -m pytest -v -s python/ray/tests/test_actor.py::test_actors_and_tasks_with_gpus_version_two; done
+  - for i in {1..20}; do python -m pytest -v -s python/ray/tests/test_actor.py::test_actors_and_tasks_with_gpus; done
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,22 @@ matrix:
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
 
     - os: linux
+      env:
+        - JDK='Oracle JDK 8'
+        - PYTHON=3.5 PYTHONWARNINGS=ignore
+        - RAY_INSTALL_JAVA=1
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
+        - ./ci/suppress_output ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+      script:
+        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
+        - ./java/test.sh
+
+    - os: linux
       env: LINT=1 PYTHONWARNINGS=ignore
       before_install:
         - sudo apt-get update -qq
@@ -51,6 +67,76 @@ matrix:
         - go get github.com/bazelbuild/buildtools/buildifier
         - ./ci/travis/bazel-format.sh
 
+    - os: linux
+      env: VALGRIND=1 PYTHON=2.7 PYTHONWARNINGS=ignore
+      before_install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
+
+        # Install a newer version of valgrind, the one that comes with
+        # Ubuntu 16.04 is broken (Illegal instruction)
+        - sudo add-apt-repository -y ppa:msulikowski/valgrind
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq valgrind
+
+      install:
+        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/suppress_output ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+
+      script:
+        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
+
+        - bash src/ray/test/run_object_manager_valgrind.sh
+
+        - export RAY_PLASMA_STORE_VALGRIND=1
+        # - export RAY_RAYLET_VALGRIND=1
+        # - export RAY_RAYLET_MONITOR_VALGRIND=1
+        # - export RAY_REDIS_SERVER_VALGRIND=1
+
+        # # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
+        - python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 python/ray/experimental/test/async_test.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_mini.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_array.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_multi_node_2.py
+        - python -m pytest -v --durations=5 --timeout=300 python/ray/tests/test_node_manager.py
+
+    # Build Linux wheels.
+    - os: linux
+      env: LINUX_WHEELS=1 PYTHONWARNINGS=ignore
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+
+        # Mount bazel cache dir to the docker container.
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
+        # This command should be kept in sync with ray/python/README-building-wheels.md,
+        # except the `$MOUNT_BAZEL_CACHE` part.
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+      script:
+        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/travis/test-wheels.sh
+
+    # Build MacOS wheels.
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./ci/suppress_output ./python/build-wheel-macos.sh
+      script:
+        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/travis/test-wheels.sh
 
 install:
   - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -62,6 +148,14 @@ install:
   - ./ci/suppress_output ./ci/travis/install-ray.sh
   - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
 
+  - ./ci/suppress_output bash src/ray/test/run_gcs_tests.sh
+
+  # core worker test.
+  - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+
+  # Raylet tests.
+  - ./ci/suppress_output bash src/ray/test/run_object_manager_tests.sh
+  - ./ci/suppress_output bazel test --build_tests_only --test_lang_filters=cc //:all
   # Shutdown bazel to release the memory held by bazel.
   - bazel shutdown
 
@@ -73,8 +167,16 @@ script:
   # module is only found if the test directory is in the PYTHONPATH.
   # - export PYTHONPATH="$PYTHONPATH:./ci/"
 
-  - for i in {1..20}; do python -m pytest -v -s python/ray/tests/test_actor.py::test_actors_and_tasks_with_gpus_version_two; done
-  - for i in {1..20}; do python -m pytest -v -s python/ray/tests/test_actor.py::test_actors_and_tasks_with_gpus; done
+  # ray tune tests
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/tune/tests/test_dependency.py; fi
+  # `cluster_tests.py` runs on Jenkins, not Travis.
+  - if [ $RAY_CI_TUNE_AFFECTED == "1" ]; then python -m pytest --durations=10 --timeout=300 --ignore=python/ray/tune/tests/test_cluster.py --ignore=python/ray/tune/tests/test_tune_restore.py --ignore=python/ray/tune/tests/test_actor_reuse.py python/ray/tune/tests; fi
+
+  # ray tests
+  # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=10 --timeout=300 python/ray/tests --ignore=python/ray/tests/perf_integration_tests; fi
 
 deploy:
   - provider: s3

--- a/python/ray/tests/utils.py
+++ b/python/ray/tests/utils.py
@@ -4,11 +4,12 @@ from __future__ import print_function
 
 import fnmatch
 import os
-import psutil
 import subprocess
 import sys
 import tempfile
 import time
+
+import psutil
 
 import ray
 


### PR DESCRIPTION
The issue with the test is that if things are really slow (e.g,. the worker processes take a long time to start), then a GPU ID can be reused, causing the test to fail. This PR fixes that.