### PR TITLE
[Serve] First iteration of replica scaling + metric API

### DIFF
--- a/python/ray/experimental/serve/__init__.py
+++ b/python/ray/experimental/serve/__init__.py
@@ -2,11 +2,11 @@ import sys
 if sys.version_info < (3, 0):
     raise ImportError("serve is Python 3 only.")
 
-from ray.experimental.serve.api import (init, create_backend, create_endpoint,
-                                        link, split, rollback, get_handle,
-                                        global_state)  # noqa: E402
+from ray.experimental.serve.api import (
+    init, create_backend, create_endpoint, link, split, rollback, get_handle,
+    global_state, set_replica, blacklist, stat)  # noqa: E402
 
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "rollback",
-    "get_handle", "global_state"
+    "get_handle", "global_state", "set_replica", "blacklist", "stat"
 ]

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -33,8 +33,20 @@ def init(blocking=False, object_store_memory=int(1e8)):
     global_state.init_router()
     global_state.init_http_server()
 
+    # Monitor depends on the router to be initialized properly.
+    global_state.init_monitor()
+    global_state.monitor_handle.add_target.remote(
+        global_state.router_actor_handle)
+
     if blocking:
         global_state.wait_until_http_ready()
+
+
+def stat():
+    """Retrieve metric statistics from all components"""
+    # TODO(simon): this function should accept parameters including
+    # endpoint_name, backend_name, compoenent_name ("router")
+    return ray.get(global_state.monitor_handle.get_stats.remote())
 
 
 def create_endpoint(endpoint_name, route_expression, blocking=True):
@@ -67,27 +79,69 @@ def create_backend(func_or_class, backend_tag, *actor_init_args):
             initialization method.
     """
     if inspect.isfunction(func_or_class):
-        runner = TaskRunnerActor.remote(func_or_class)
+        runner_factory = lambda: TaskRunnerActor.remote(func_or_class)  # noqa: E501 E731
+        # For linter trailing comment above: we ignored warning about
+        # inline-lambda and line-to-long
     elif inspect.isclass(func_or_class):
+        assert hasattr(func_or_class,
+                       "__call__"), "Backend class must implement __call__"
+
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.
         @ray.remote
         class CustomActor(RayServeMixin, func_or_class):
             pass
 
-        runner = CustomActor.remote(*actor_init_args)
+        runner_factory = lambda: CustomActor.remote(*actor_init_args)  # noqa: E501 E731
     else:
         raise TypeError(
             "Backend must be a function or class, it is {}.".format(
                 type(func_or_class)))
 
-    global_state.backend_actor_handles.append(runner)
-
-    runner._ray_serve_setup.remote(backend_tag,
-                                   global_state.router_actor_handle)
-    runner._ray_serve_main_loop.remote(runner)
-
+    global_state.backend_actor_facotry[backend_tag] = runner_factory
     global_state.registered_backends.add(backend_tag)
+    set_replica(backend_tag, 1)
+
+
+def set_replica(backend_tag, new_replica):
+    old_replica = global_state.num_replicas[backend_tag]
+    if new_replica > old_replica:
+        for _ in range(new_replica - old_replica):
+            replica_id = global_state.replica_id_counter[backend_tag]
+            _add_replica(backend_tag, replica_id)
+            global_state.active_replicas[backend_tag].add(replica_id)
+            global_state.replica_id_counter[backend_tag] += 1
+    elif new_replica < old_replica:
+        for _ in range(old_replica - new_replica):
+            replica_to_be_removed = global_state.active_replicas[
+                backend_tag].pop()
+            blacklist(backend_tag, replica_to_be_removed)
+            _remove_replica(backend_tag, replica_to_be_removed)
+
+    global_state.num_replicas[backend_tag] = new_replica
+    global_state.router_actor_handle.flush.remote()
+
+
+def blacklist(backend_tag, replica_id):
+    global_state.router_actor_handle.black_list.remote(backend_tag, replica_id)
+
+
+def _add_replica(backend_tag, replica_id):
+    assert backend_tag in global_state.registered_backends
+    runner_actor_handle = global_state.backend_actor_facotry[backend_tag]()
+    runner_actor_handle._ray_serve_setup.remote(
+        backend_tag, global_state.router_actor_handle, replica_id)
+    runner_actor_handle._ray_serve_main_loop.remote(runner_actor_handle)
+    global_state.backend_actor_handles[(backend_tag,
+                                        replica_id)] = runner_actor_handle
+    global_state.monitor_handle.add_target.remote(runner_actor_handle)
+
+
+def _remove_replica(backend_tag, replica_id):
+    runner_actor_handle = global_state.backend_actor_handles.pop((backend_tag,
+                                                                  replica_id))
+    global_state.monitor_handle.remove_target.remote(runner_actor_handle)
+    del runner_actor_handle
 
 
 def link(endpoint_name, backend_tag):
@@ -135,9 +189,7 @@ def split(endpoint_name, traffic_policy_dictionary):
         assert (backend in global_state.registered_backends
                 ), "backend {} is not registered".format(backend)
     assert np.isclose(
-        prob, 1,
-        atol=0.02), "weights must sum to 1, currently it sums to {}".format(
-            prob)
+        prob, 1), "weights must sum to 1, currently it sums to {}".format(prob)
 
     global_state.router_actor_handle.set_traffic.remote(
         endpoint_name, traffic_policy_dictionary)

--- a/python/ray/experimental/serve/examples/echo_monitor.py
+++ b/python/ray/experimental/serve/examples/echo_monitor.py
@@ -1,0 +1,38 @@
+"""
+Example service that prints out metric information
+"""
+
+import time
+
+import requests
+
+from ray.experimental import serve
+from ray.experimental.serve.utils import pformat_color_json
+
+
+def echo(context):
+    time.sleep(0.2)
+    return context
+
+def throw(_):
+    raise Exception("oh no")
+
+
+serve.init(blocking=True)
+
+serve.create_endpoint("echo", "/echo", blocking=True)
+serve.create_backend(echo, "echo:v1")
+serve.create_backend(throw, "echo:v2")
+serve.split("echo", {"echo:v1": 0.5, "echo:v2": 0.5})
+serve.set_replica("echo:v1", 2)
+
+
+handle = serve.get_handle("echo")
+for _ in range(20):
+    handle.remote("")
+
+for _ in range(5):
+    print("Getting stats")
+    print(pformat_color_json(serve.stat()))
+    time.sleep(2)
+

--- a/python/ray/experimental/serve/examples/echo_replicas.py
+++ b/python/ray/experimental/serve/examples/echo_replicas.py
@@ -1,0 +1,84 @@
+"""
+This example demostrates replica scaling ability. It implements a service
+that returns its own replica ids. The example will show case the following
+states:
+1. Just one replica
+2. Scale 1->2
+3. Blacklist the first replica. You should see only the second replica is
+   serving the query
+4. Scale 2->8. More replicas joined.
+5. 8->0. You should see the final request will be blocking.
+"""
+
+import time
+
+import requests
+from werkzeug import urls
+
+from ray.experimental import serve
+from ray.experimental.serve.utils import pformat_color_json
+
+
+class EchoActor:
+    def __init__(self, message):
+        self.message = message
+
+    def __call__(self, context):
+        query_string_dict = urls.url_decode(context["query_string"])
+        message = ""
+        message += query_string_dict.get("message", "")
+        message += " "
+        message += self.message
+        message += " my id: {}".format(getattr(self, "_ray_serve_replica_id", "unknown"))
+        return message
+
+
+serve.init(blocking=True)
+
+serve.create_endpoint("my_endpoint", "/echo", blocking=True)
+serve.create_backend(EchoActor, "echo:v1", "world")
+serve.link("my_endpoint", "echo:v1")
+serve.set_replica("echo:v1", 2)
+
+for _ in range(10):
+    resp = requests.get("http://127.0.0.1:8000/echo?message=hello").json()
+    print(pformat_color_json(resp))
+
+    print("...Sleeping for 1 seconds...")
+    time.sleep(1)
+
+print('-'*40)
+print("Blacklisting replica 0")
+serve.blacklist("echo:v1", 0)
+print('-'*40)
+
+for _ in range(10):
+    resp = requests.get("http://127.0.0.1:8000/echo?message=hello").json()
+    print(pformat_color_json(resp))
+
+    print("...Sleeping for 1 seconds...")
+    time.sleep(1)
+
+print('-'*40)
+print("Starting 6 more replicas")
+serve.set_replica("echo:v1", 8)
+print('-'*40)
+
+for _ in range(20):
+    resp = requests.get("http://127.0.0.1:8000/echo?message=hello").json()
+    print(pformat_color_json(resp))
+
+    print("...Sleeping for 1 seconds...")
+    time.sleep(1)
+
+print('-'*40)
+print("Scaling down to 0")
+serve.set_replica("echo:v1", 0)
+print('-'*40)
+
+while True:
+    resp = requests.get("http://127.0.0.1:8000/echo?message=hello").json()
+    print(pformat_color_json(resp))
+
+    print("...Sleeping for 2 seconds...")
+    time.sleep(2)

--- a/python/ray/experimental/serve/monitor.py
+++ b/python/ray/experimental/serve/monitor.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+import time
+
+import ray
+from ray.experimental.serve.utils import logger
+
+@ray.remote
+class MetricMonitor:
+    """A simple metric aggregator that pulls metrics from registered actors.
+
+    Example:
+    >>> monitor = MetricMonitor.remote()
+    >>> start_monitor_loop.remote(monitor)
+    >>> monitor.add_target.remote(some_other_actor)
+    >>> ray.get(monitor.get_stats.remote())
+    {"some_other_actor.metric_name": [1.1, 1.0, 0.9, ...]}
+
+    Note:
+        The monitored actor is expected to implement the following interface:
+        ```
+        def health_check(self):
+            return {
+                "metric_name": metric_value_list,
+                "metric_name": metric_value_list
+            }
+        ```
+    """
+    def __init__(self):
+        self.backends_to_watch = dict()
+        self.stats = defaultdict(list)
+    
+    def scrape(self):
+        if not len(self.backends_to_watch):
+            return
+
+        aggregated_result = ray.get([handle.health_check.remote() for handle in self.backends_to_watch.values()])
+        for actor_result in aggregated_result:
+            for metric_name, metric_values in actor_result.items():
+                if isinstance(metric_values, list):
+                    self.stats[metric_name].extend(metric_values)
+                else:
+                    self.stats[metric_name].append(metric_values)
+        
+    def add_target(self, handle):
+        # HACK: we use _actor_id because two actor handles pointing 
+        # to the same actor are not equal in python.
+        self.backends_to_watch[handle._actor_id] = handle
+
+    def remove_target(self, handle):
+        self.backends_to_watch.pop(handle._actor_id)
+
+    def get_stats(self):
+        return self.stats
+
+@ray.remote(num_cpus=0)
+def start_monitor_loop(monitor_actor_handle, interval_s=2):
+    while True:
+        ray.get(monitor_actor_handle.scrape.remote())
+        time.sleep(interval_s)
+        

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -1,6 +1,7 @@
 import traceback
 
 import ray
+import time
 
 
 class TaskRunner:
@@ -18,12 +19,20 @@ class TaskRunner:
 
 
 def wrap_to_ray_error(callable_obj, *args):
-    """Utility method that catch and seal exceptions in execution"""
+    """Utility method that catch and seal exceptions in execution
+
+    Returns:
+        (object, bool): A tuple (call_result, has_errored). If the
+            call errored, the object will be wrapped into RayTaskError. The
+            second item of the tuple is True if the call didn't erorr, else
+            if the call errored.
+    """
     try:
-        return callable_obj(*args)
+        return callable_obj(*args), False
     except Exception:
         traceback_str = ray.utils.format_error_message(traceback.format_exc())
-        return ray.exceptions.RayTaskError(str(callable_obj), traceback_str)
+        return ray.exceptions.RayTaskError(str(callable_obj),
+                                           traceback_str), True
 
 
 class RayServeMixin:
@@ -46,30 +55,81 @@ class RayServeMixin:
     _ray_serve_router_handle = None
     _ray_serve_setup_completed = False
     _ray_serve_dequeue_requestr_name = None
+    _ray_serve_replica_id = None
 
-    def _ray_serve_setup(self, my_name, _ray_serve_router_handle):
+    #: If true, this work token will be used to instead of fetching new one
+    #  from the router.
+    _ray_serve_work_token_cache = None
+
+    # Buffer for internal metric aggregation.
+    _ray_serve_latency_buffer = []
+    _ray_serve_error_counter = 0
+
+    def health_check(self):
+        metric_prefix = "replica.{}.{}.".format(
+            self._ray_serve_dequeue_requestr_name, self._ray_serve_replica_id)
+        metric = {
+            metric_prefix + "healthy_timestamp_s": time.time(),
+            metric_prefix + "latency_s": list(self._ray_serve_latency_buffer),
+            metric_prefix + "error_counter": int(self._ray_serve_error_counter)
+        }
+
+        # reset internal buffer
+        self._ray_serve_latency_buffer = []
+
+        return metric
+
+    def _ray_serve_setup(self, my_name, router_handle, replica_id):
         self._ray_serve_dequeue_requestr_name = my_name
-        self._ray_serve_router_handle = _ray_serve_router_handle
+        self._ray_serve_router_handle = router_handle
+        self._ray_serve_replica_id = replica_id
         self._ray_serve_setup_completed = True
 
     def _ray_serve_main_loop(self, my_handle):
         assert self._ray_serve_setup_completed
         self._ray_serve_self_handle = my_handle
 
-        work_token = ray.get(
-            self._ray_serve_router_handle.dequeue_request.remote(
-                self._ray_serve_dequeue_requestr_name))
-        work_item = ray.get(ray.ObjectID(work_token))
+        # If true, this means we still need to work on last work_token
+        # because it was un-fullfiled after 1s timeout.
+        if self._ray_serve_work_token_cache:
+            work_token = self._ray_serve_work_token_cache
+        else:
+            work_token = ray.get(
+                self._ray_serve_router_handle.dequeue_request.remote(
+                    self._ray_serve_dequeue_requestr_name,
+                    self._ray_serve_replica_id))
+
+        # Try to fetch the unit of work with 1s timeout.
+        ready, not_ready = ray.wait([ray.ObjectID(work_token)], timeout=1.0)
+
+        # There isn't a unit of work for us. Cache the token and re-schedule
+        # the main_loop
+        if len(not_ready) == 1:
+            self._ray_serve_self_handle._ray_serve_main_loop.remote(my_handle)
+            self._ray_serve_work_token_cache = work_token
+            return
+
+        # We found work to do.
+        work_item = ray.get(ready[0])
+        self._ray_serve_work_token_cache = None
 
         # TODO(simon):
         # __call__ should be able to take multiple *args and **kwargs.
-        result = wrap_to_ray_error(self.__call__, work_item.request_body)
+        start = time.time()
+        result, failed = wrap_to_ray_error(self.__call__,
+                                           work_item.request_body)
+
+        # insert values into metric buffer
+        self._ray_serve_latency_buffer.append(time.time() - start)
+        if failed:
+            self._ray_serve_error_counter += 1
+
+        # put the result into result_object_id
         result_object_id = work_item.result_object_id
         ray.worker.global_worker.put_object(result_object_id, result)
 
         # The worker finished one unit of work.
         # It will now tail recursively schedule the main_loop again.
-
         # TODO(simon): remove tail recursion, ask router to callback instead
         self._ray_serve_self_handle._ray_serve_main_loop.remote(my_handle)
 

--- a/python/ray/experimental/serve/tests/test_queue.py
+++ b/python/ray/experimental/serve/tests/test_queue.py
@@ -19,36 +19,20 @@ def test_alter_backend(serve_instance):
     q = CentralizedQueues()
 
     result_object_id = q.enqueue_request("svc", 1)
-    work_object_id = q.dequeue_request("backend-1")
     q.set_traffic("svc", {"backend-1": 1})
+    work_object_id = q.dequeue_request("backend-1")
     got_work = ray.get(ray.ObjectID(work_object_id))
     assert got_work.request_body == 1
     ray.worker.global_worker.put_object(got_work.result_object_id, 2)
     assert ray.get(ray.ObjectID(result_object_id)) == 2
 
+    q.set_traffic("svc", {"backend-2": 1})
     result_object_id = q.enqueue_request("svc", 1)
     work_object_id = q.dequeue_request("backend-2")
-    q.set_traffic("svc", {"backend-2": 1})
     got_work = ray.get(ray.ObjectID(work_object_id))
     assert got_work.request_body == 1
     ray.worker.global_worker.put_object(got_work.result_object_id, 2)
     assert ray.get(ray.ObjectID(result_object_id)) == 2
-
-
-def test_split_traffic(serve_instance):
-    q = CentralizedQueues()
-
-    q.enqueue_request("svc", 1)
-    q.enqueue_request("svc", 1)
-    q.set_traffic("svc", {})
-    work_object_id_1 = q.dequeue_request("backend-1")
-    work_object_id_2 = q.dequeue_request("backend-2")
-    q.set_traffic("svc", {"backend-1": 0.5, "backend-2": 0.5})
-
-    got_work = ray.get(
-        [ray.ObjectID(work_object_id_1),
-         ray.ObjectID(work_object_id_2)])
-    assert [g.request_body for g in got_work] == [1, 1]
 
 
 def test_probabilities(serve_instance):

--- a/python/ray/experimental/serve/tests/test_replicas.py
+++ b/python/ray/experimental/serve/tests/test_replicas.py
@@ -1,0 +1,32 @@
+import time
+
+import ray
+from ray.experimental import serve
+
+def test_scaling(serve_instance):
+    class WhoAmI:
+        def __call__(self,_):
+            return getattr(self, "_ray_serve_replica_id", "unknown")
+    
+    # Setup
+    serve.create_endpoint("scaling", "/scaling")
+    serve.create_backend(WhoAmI, "scaling-backend:v1")
+    serve.link("scaling", "scaling-backend:v1")
+
+    # Test basic function
+    handle = serve.get_handle("scaling")
+    replica_id = ray.get(handle.remote())
+    assert replica_id == 0
+
+    # Test scaling up
+    serve.set_replica("scaling-backend:v1", 2)
+    time.sleep(0.5) # wait for the second replica to come up
+    replica_ids = ray.get([handle.remote() for _ in range(10)])
+    assert set(replica_ids) == {0, 1}
+
+    # Test scaling down to 0
+    serve.set_replica("scaling-backend:v1", 0)
+    time.sleep(0.5) # wait for the two replicas to be removed
+    blocked_return = handle.remote()
+    ready, not_ready = ray.wait([blocked_return], 1, timeout=0.1)
+    assert len(not_ready) == 1, print(ray.get(ready))


### PR DESCRIPTION
This PR adds a first iteration of the following features:
- Add and remove replicas for backends
- Add built-in metric system
- Add `serve.blacklist` as top level API to stop sending traffic to one replica. 

However this PR does not do:
```diff
- proper queue draining when replicas are removed
- export prometheus metrics
- export aggregated metrics over time (e.g. mean latency over 1s,5s,10s,...)
- properly define blacklist semantics
```