### PR TITLE
[tune] Hooks in trial runner for save+restore

### DIFF
--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -208,7 +208,8 @@ class HyperOptSearch(SuggestionAlgorithm):
         return len(self._live_trial_mapping)
 
     def save(self, checkpoint_dir):
-        trials_object = (self._hpopt_trials, self._points_to_evaluate, self.rstate.get_state())
+        trials_object = (self._hpopt_trials, self._points_to_evaluate,
+                         self.rstate.get_state())
         with open(checkpoint_dir, "wb") as outputFile:
             pickle.dump(trials_object, outputFile)
 

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -208,7 +208,7 @@ class HyperOptSearch(SuggestionAlgorithm):
         return len(self._live_trial_mapping)
 
     def save(self, checkpoint_dir):
-        trials_object = (self._hpopt_trials, self.rstate.get_state())
+        trials_object = (self._hpopt_trials, self._points_to_evaluate, self.rstate.get_state())
         with open(checkpoint_dir, "wb") as outputFile:
             pickle.dump(trials_object, outputFile)
 
@@ -216,4 +216,6 @@ class HyperOptSearch(SuggestionAlgorithm):
         with open(checkpoint_dir, "rb") as inputFile:
             trials_object = pickle.load(inputFile)
         self._hpopt_trials = trials_object[0]
-        self.rstate.set_state(trials_object[1])
+        self._hpopt_trials.refresh()
+        self._points_to_evaluate = trials_object[1]
+        self.rstate.set_state(trials_object[2])

--- a/python/ray/tune/suggest/search.py
+++ b/python/ray/tune/suggest/search.py
@@ -70,7 +70,11 @@ class SearchAlgorithm(object):
         raise NotImplementedError
 
     def save(self, checkpoint_dir):
+        """Save search alg state to checkpoint_dir
+        """
         raise NotImplementedError
 
     def restore(self, checkpoint_dir):
+        """Restore search alg state from checkpoint_dir
+        """
         raise NotImplementedError

--- a/python/ray/tune/suggest/search.py
+++ b/python/ray/tune/suggest/search.py
@@ -68,3 +68,9 @@ class SearchAlgorithm(object):
         Can return True before all trials have finished executing.
         """
         raise NotImplementedError
+
+    def save(self, checkpoint_dir):
+        raise NotImplementedError
+
+    def restore(self, checkpoint_dir):
+        raise NotImplementedError

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -129,12 +129,6 @@ class SuggestionAlgorithm(SearchAlgorithm):
         """
         raise NotImplementedError
 
-    def save(self, checkpoint_dir):
-        raise NotImplementedError
-
-    def restore(self, checkpoint_dir):
-        raise NotImplementedError
-
 
 class _MockSuggestionAlgorithm(SuggestionAlgorithm):
     def __init__(self, max_concurrent=2, **kwargs):

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import itertools
 import copy
+import logging
 
 from ray.tune.error import TuneError
 from ray.tune.trial import Trial
@@ -12,6 +13,8 @@ from ray.tune.experiment import convert_to_experiment_list
 from ray.tune.config_parser import make_parser, create_trial_from_spec
 from ray.tune.suggest.search import SearchAlgorithm
 from ray.tune.suggest.variant_generator import format_vars, resolve_nested_dict
+
+logger = logging.getLogger(__name__)
 
 
 class SuggestionAlgorithm(SearchAlgorithm):
@@ -127,6 +130,22 @@ class SuggestionAlgorithm(SearchAlgorithm):
             >>> parameters_2 = suggester._suggest()
             >>> parameters_2 is not None
         """
+        raise NotImplementedError
+
+    def save(self, checkpoint_dir):
+        """Save search alg state to checkpoint_dir
+        """
+        logger.info(
+            "Unable to save search alg {}: not implemented.".format(
+                self.__class__.__name__))
+        raise NotImplementedError
+
+    def restore(self, checkpoint_dir):
+        """Restore search alg state from checkpoint_dir
+        """
+        logger.info(
+            "Unable to restore search alg {}: not implemented.".format(
+                self.__class__.__name__))
         raise NotImplementedError
 
 

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -135,17 +135,15 @@ class SuggestionAlgorithm(SearchAlgorithm):
     def save(self, checkpoint_dir):
         """Save search alg state to checkpoint_dir
         """
-        logger.info(
-            "Unable to save search alg {}: not implemented.".format(
-                self.__class__.__name__))
+        logger.info("Unable to save search alg {}: not implemented.".format(
+            self.__class__.__name__))
         raise NotImplementedError
 
     def restore(self, checkpoint_dir):
         """Restore search alg state from checkpoint_dir
         """
-        logger.info(
-            "Unable to restore search alg {}: not implemented.".format(
-                self.__class__.__name__))
+        logger.info("Unable to restore search alg {}: not implemented.".format(
+            self.__class__.__name__))
         raise NotImplementedError
 
 

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -701,7 +701,9 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
     cluster = _start_new_cluster()
 
     script_after_shutdown = script.format(
-        address=cluster.address, checkpoint_dir=dirpath, resume_bool="\"LOCAL\"")
+        address=cluster.address,
+        checkpoint_dir=dirpath,
+        resume_bool="\"LOCAL\"")
     run_string_as_driver_nonblocking(script_after_shutdown)
 
     time.sleep(2)
@@ -710,11 +712,11 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
     for i in range(50):
         if TrialRunner.checkpoint_exists(local_checkpoint_dir):
             # Inspect the internal trialrunner
-            runner = TrialRunner( # if _resumed is false + len(trials) == 0: continue
+            runner = TrialRunner(
                 resume="LOCAL", local_checkpoint_dir=local_checkpoint_dir)
             trials = runner.get_trials()
             if (not runner._resumed) and (len(trials) == 0):
-                continue # nonblocking script hasn't resumed yet, wait
+                continue  # nonblocking script hasn't resumed yet, wait
             reached = True
             assert len(trials) >= 10
             assert len(trials) <= 20

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -624,7 +624,6 @@ class MyTrainableClass(Trainable):
         self.timestep += 1
         v = np.tanh(float(self.timestep) / self.config.get("width", 1))
         v *= self.config.get("height", 1)
-        time.sleep(2)
         return {{"mean_loss": v}}
     def _save(self, checkpoint_dir):
         path = os.path.join(checkpoint_dir, "checkpoint")
@@ -653,9 +652,6 @@ current_best_params = [
 ]
 config = {{
     "num_samples": 20,
-    "config": {{
-        "iterations": 100,
-    }},
     "stop": {{
         "training_iteration": 2
     }},
@@ -688,7 +684,7 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
             trials = runner.get_trials()
             if trials and len(trials) >= 10:
                 break
-        time.sleep(2)
+        time.sleep(.5)
 
     if not TrialRunner.checkpoint_exists(local_checkpoint_dir):
         raise RuntimeError("Checkpoint file didn't appear.")
@@ -715,14 +711,14 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
             runner = TrialRunner(
                 resume="LOCAL", local_checkpoint_dir=local_checkpoint_dir)
             trials = runner.get_trials()
-            if (not runner._resumed) and (len(trials) == 0):
+            if len(trials) == 0:
                 continue  # nonblocking script hasn't resumed yet, wait
             reached = True
             assert len(trials) >= 10
             assert len(trials) <= 20
             if len(trials) == 20:
                 break
-        time.sleep(2)
+        time.sleep(.5)
     assert reached is True
 
     ray.shutdown()

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -698,7 +698,7 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
     cluster = _start_new_cluster()
 
     script_after_shutdown = script.format(
-        address=cluster.address, checkpoint_dir=dirpath, resume_bool=True)
+        address=cluster.address, checkpoint_dir=dirpath, resume_bool="LOCAL")
     run_string_as_driver_nonblocking(script_after_shutdown)
 
     for i in range(50):
@@ -710,8 +710,6 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
             assert (len(trials) >= 10)
             assert (len(trials <= 20))
         time.sleep(0.2)
-
-    # TODO(hershg) : make sure script completes?
 
     ray.shutdown()
     cluster.shutdown()

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -666,12 +666,11 @@ algo = HyperOptSearch(
         mode="min",
         random_state_seed=5,
         points_to_evaluate=current_best_params)
-run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0, resume={resume_bool}, **config)
+run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
+    resume={resume_bool}, **config)
 """
     script_before_shutdown = script.format(
-        address=cluster.address,
-        checkpoint_dir=dirpath,
-        resume_bool=False)
+        address=cluster.address, checkpoint_dir=dirpath, resume_bool=False)
     run_string_as_driver_nonblocking(script_before_shutdown)
 
     # Wait until the right checkpoint is saved.
@@ -698,9 +697,7 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0, resume={resum
     cluster.shutdown()
 
     script_after_shutdown = script.format(
-        address=cluster.address,
-        checkpoint_dir=dirpath,
-        resume_bool=True)
+        address=cluster.address, checkpoint_dir=dirpath, resume_bool=True)
     run_string_as_driver_nonblocking(script_after_shutdown)
 
     for i in range(50):
@@ -709,8 +706,8 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0, resume={resum
             runner = TrialRunner(
                 resume="LOCAL", local_checkpoint_dir=local_checkpoint_dir)
             trials = runner.get_trials()
-            assert(len(trials) >= 10)
-            assert(len(trials <= 20))
+            assert (len(trials) >= 10)
+            assert (len(trials <= 20))
         time.sleep(0.2)
 
     # TODO(hershg) : make sure script completes?

--- a/python/ray/tune/tests/test_cluster.py
+++ b/python/ray/tune/tests/test_cluster.py
@@ -695,6 +695,7 @@ run(MyTrainableClass, search_alg=algo, global_checkpoint_period=0,
 
     ray.shutdown()
     cluster.shutdown()
+    cluster = _start_new_cluster()
 
     script_after_shutdown = script.format(
         address=cluster.address, checkpoint_dir=dirpath, resume_bool=True)

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -242,9 +242,11 @@ class TrialRunner(object):
         if not self._resumed:
             self._search_alg.add_configurations([experiment])
         else:
-            experiment.spec["num_samples"] = max(0, experiment.spec["num_samples"] - len(self._trials))
+            experiment.spec["num_samples"] = max(
+                0, experiment.spec["num_samples"] - len(self._trials))
             self._search_alg.add_configurations([experiment])
-            # logger.info("TrialRunner resumed, ignoring new add_experiment.") TODO(hershg)
+            # logger.info("TrialRunner resumed, ignoring new add_experiment.")
+            # TODO(hershg)
 
     def checkpoint(self, force=False):
         """Saves execution state to `self._local_checkpoint_dir`.

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -45,6 +45,16 @@ def _find_newest_ckpt(ckpt_dir):
     return max(full_paths)
 
 
+def _find_newest_searcher_ckpt(ckpt_dir):
+    """Returns path to most recently modified checkpoint."""
+    full_paths = [
+        os.path.join(ckpt_dir, fname) for fname in os.listdir(ckpt_dir)
+        if fname.startswith("experiment_state_searcher_ckpt")
+        and fname.endswith(".pkl")
+    ]
+    return max(full_paths)
+
+
 class _TuneFunctionEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, types.FunctionType):
@@ -99,6 +109,7 @@ class TrialRunner(object):
     """
 
     CKPT_FILE_TMPL = "experiment_state-{}.json"
+    SEARCHER_CKPT_FILE_TMPL = "experiment_state_searcher_ckpt-{}.pkl"
     VALID_RESUME_TYPES = [True, "LOCAL", "REMOTE", "PROMPT"]
 
     def __init__(self,
@@ -180,10 +191,14 @@ class TrialRunner(object):
         self._session_str = datetime.fromtimestamp(
             self._start_time).strftime("%Y-%m-%d_%H-%M-%S")
         self.checkpoint_file = None
+        self.searcher_checkpoint_file = None
         if self._local_checkpoint_dir:
             self.checkpoint_file = os.path.join(
                 self._local_checkpoint_dir,
                 TrialRunner.CKPT_FILE_TMPL.format(self._session_str))
+            self.searcher_checkpoint_file = os.path.join(
+                self._local_checkpoint_dir,
+                TrialRunner.SEARCHER_CKPT_FILE_TMPL.format(self._session_str))
 
     def _validate_resume(self, resume_type):
         """Checks whether to resume experiment.
@@ -233,6 +248,14 @@ class TrialRunner(object):
             (fname.startswith("experiment_state") and fname.endswith(".json"))
             for fname in os.listdir(directory))
 
+    @classmethod
+    def searcher_checkpoint_exists(cls, directory):
+        if not os.path.exists(directory):
+            return False
+        return any((fname.startswith("experiment_state_searcher_ckpt")
+                    and fname.endswith(".pkl"))
+                   for fname in os.listdir(directory))
+
     def add_experiment(self, experiment):
         if not self._resumed:
             self._search_alg.add_configurations([experiment])
@@ -270,6 +293,17 @@ class TrialRunner(object):
             json.dump(runner_state, f, indent=2, cls=_TuneFunctionEncoder)
 
         os.rename(tmp_file_name, self.checkpoint_file)
+
+        try:
+            ckpt_tmp_file_name = os.path.join(self._local_checkpoint_dir,
+                                              ".tmp_searcher_ckpt")
+            self._search_alg.save(ckpt_tmp_file_name)
+            os.rename(ckpt_tmp_file_name, self.searcher_checkpoint_file)
+        except NotImplementedError:
+            logger.warning(
+                "Unable to save search alg {}: not implemented.".format(
+                    self._search_alg.__class__.__name__))
+
         if force:
             self._syncer.sync_up()
         else:
@@ -305,6 +339,15 @@ class TrialRunner(object):
         for trial in sorted(
                 trials, key=lambda t: t.last_update_time, reverse=True):
             self.add_trial(trial)
+
+        try:
+            newest_searcher_ckpt_path = _find_newest_searcher_ckpt(
+                self._local_checkpoint_dir)
+            self._search_alg.restore(newest_searcher_ckpt_path)
+        except NotImplementedError:
+            logger.warning(
+                "Unable to restore search alg {}: not implemented.".format(
+                    self._search_alg.__class__.__name__))
 
     def is_finished(self):
         """Returns whether all trials have finished running."""

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -282,9 +282,7 @@ class TrialRunner(object):
             self._search_alg.save(ckpt_tmp_file_name)
             os.rename(ckpt_tmp_file_name, self.searcher_checkpoint_file)
         except NotImplementedError:
-            logger.warning(
-                "Unable to save search alg {}: not implemented.".format(
-                    self._search_alg.__class__.__name__))
+            pass
 
         if force:
             self._syncer.sync_up()
@@ -327,9 +325,7 @@ class TrialRunner(object):
                 self._local_checkpoint_dir)
             self._search_alg.restore(newest_searcher_ckpt_path)
         except NotImplementedError:
-            logger.warning(
-                "Unable to restore search alg {}: not implemented.".format(
-                    self._search_alg.__class__.__name__))
+            pass
 
     def is_finished(self):
         """Returns whether all trials have finished running."""

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -242,7 +242,9 @@ class TrialRunner(object):
         if not self._resumed:
             self._search_alg.add_configurations([experiment])
         else:
-            logger.info("TrialRunner resumed, ignoring new add_experiment.")
+            experiment.spec["num_samples"] = max(0, experiment.spec["num_samples"] - len(self._trials))
+            self._search_alg.add_configurations([experiment])
+            # logger.info("TrialRunner resumed, ignoring new add_experiment.") TODO(hershg)
 
     def checkpoint(self, force=False):
         """Saves execution state to `self._local_checkpoint_dir`.

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -239,14 +239,10 @@ class TrialRunner(object):
         return find_newest_dated_path(directory, cls.SEARCHER_CKPT_FILE_REGEX)
 
     def add_experiment(self, experiment):
-        if not self._resumed:
-            self._search_alg.add_configurations([experiment])
-        else:
+        if self._resumed:
             experiment.spec["num_samples"] = max(
                 0, experiment.spec["num_samples"] - len(self._trials))
-            self._search_alg.add_configurations([experiment])
-            # logger.info("TrialRunner resumed, ignoring new add_experiment.")
-            # TODO(hershg)
+        self._search_alg.add_configurations([experiment])
 
     def checkpoint(self, force=False):
         """Saves execution state to `self._local_checkpoint_dir`.
@@ -327,7 +323,8 @@ class TrialRunner(object):
         try:
             newest_searcher_ckpt_path = self._find_newest_searcher_ckpt(
                 self._local_checkpoint_dir)
-            self._search_alg.restore(newest_searcher_ckpt_path)
+            if newest_searcher_ckpt_path is not None:
+                self._search_alg.restore(newest_searcher_ckpt_path)
         except NotImplementedError:
             pass
 

--- a/python/ray/tune/util.py
+++ b/python/ray/tune/util.py
@@ -11,6 +11,8 @@ from threading import Thread
 
 import numpy as np
 import ray
+import glob
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +244,17 @@ def validate_save_restore(trainable_cls,
     res = ray.get(trainable_2.train.remote())
     assert res[TRAINING_ITERATION] == 5
     return True
+
+
+def file_exists(directory, file_pattern):
+    path_pattern = glob.glob(os.path.join(directory, file_pattern))
+    return len(glob.glob(path_pattern)) > 0
+
+
+def find_newest_dated_path(directory, file_pattern):
+    """Assumes files have timestamp in file name, returns newest file."""
+    path_pattern = glob.glob(os.path.join(directory, file_pattern))
+    return max(glob.glob(path_pattern))
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/util.py
+++ b/python/ray/tune/util.py
@@ -248,14 +248,13 @@ def validate_save_restore(trainable_cls,
 
 def file_exists(directory, file_pattern):
     found_paths = glob.glob(os.path.join(directory, file_pattern))
-    print("PATH PATTERN: " + str(found_paths))
     return len(found_paths) > 0
 
 
 def find_newest_dated_path(directory, file_pattern):
     """Assumes files have timestamp in file name, returns newest file."""
     found_paths = glob.glob(os.path.join(directory, file_pattern))
-    return max(found_paths)
+    return max(found_paths) if len(found_paths) else None
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/util.py
+++ b/python/ray/tune/util.py
@@ -247,14 +247,15 @@ def validate_save_restore(trainable_cls,
 
 
 def file_exists(directory, file_pattern):
-    path_pattern = glob.glob(os.path.join(directory, file_pattern))
-    return len(glob.glob(path_pattern)) > 0
+    found_paths = glob.glob(os.path.join(directory, file_pattern))
+    print("PATH PATTERN: " + str(found_paths))
+    return len(found_paths) > 0
 
 
 def find_newest_dated_path(directory, file_pattern):
     """Assumes files have timestamp in file name, returns newest file."""
-    path_pattern = glob.glob(os.path.join(directory, file_pattern))
-    return max(glob.glob(path_pattern))
+    found_paths = glob.glob(os.path.join(directory, file_pattern))
+    return max(found_paths)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Recently added save/restore methods to searcher algs of Tune; this commit hooks these into `trial_runner.py` checkpoint and resume methods.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
