### PR TITLE
Fix flaky checkpoint tests

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -25,6 +25,7 @@ from ray.tests.utils import (
     relevant_errors,
     wait_for_condition,
     wait_for_errors,
+    wait_for_pid_to_exit,
 )
 
 
@@ -2387,7 +2388,7 @@ def kill_actor(actor):
     """A helper function that kills an actor process."""
     pid = ray.get(actor.get_pid.remote())
     os.kill(pid, signal.SIGKILL)
-    time.sleep(1)
+    wait_for_pid_to_exit(pid)
 
 
 def test_checkpointing(ray_start_regular, ray_checkpointable_actor_cls):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Looks like these are caused by a race condition between SIGKILLing the actor in the tests and checks that assume it's dead. Instead of sleeping, we now wait for the pid to exit.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
