### PR TITLE
Serialize StringIO with pickle

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import collections
 from concurrent.futures import ThreadPoolExecutor
 import glob
+import io
 import json
 import logging
 from multiprocessing import Process
@@ -303,6 +304,13 @@ def test_complex_serialization(ray_start_regular):
     for obj in RAY_TEST_OBJECTS:
         assert_equal(obj, ray.get(f.remote(obj)))
         assert_equal(obj, ray.get(ray.put(obj)))
+
+    # Test StringIO serialization
+    s = io.StringIO("Hello, world!\n")
+    s.seek(0)
+    line = s.readline()
+    s.seek(0)
+    assert ray.get(ray.put(s)).readline() == line
 
 
 def test_nested_functions(ray_start_regular):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -306,7 +306,7 @@ def test_complex_serialization(ray_start_regular):
         assert_equal(obj, ray.get(ray.put(obj)))
 
     # Test StringIO serialization
-    s = io.StringIO("Hello, world!\n")
+    s = io.StringIO(u"Hello, world!\n")
     s.seek(0)
     line = s.readline()
     s.seek(0)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1279,7 +1279,10 @@ def _initialize_serialization(job_id, worker=global_worker):
             local=True,
             job_id=job_id,
             class_id="ray.signature.FunctionSignature")
-        # Tell Ray to serialize StringIO with pickle.
+        # Tell Ray to serialize StringIO with pickle. We do this because
+        # Ray's default __dict__ serialization is incorrect for this type
+        # (the object's __dict__ is empty and therefore doesn't
+        # contain the full state of the object).
         register_custom_serializer(
             io.StringIO,
             use_pickle=True,

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -8,6 +8,7 @@ import atexit
 import faulthandler
 import hashlib
 import inspect
+import io
 import json
 import logging
 import numpy as np
@@ -1278,6 +1279,13 @@ def _initialize_serialization(job_id, worker=global_worker):
             local=True,
             job_id=job_id,
             class_id="ray.signature.FunctionSignature")
+        # Tell Ray to serialize StringIO with pickle.
+        register_custom_serializer(
+            io.StringIO,
+            use_pickle=True,
+            local=True,
+            job_id=job_id,
+            class_id="io.StringIO")
 
 
 def init(address=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

StringIO was previously serialized incorrectly, as it has an empty ``__dict__``, so Ray attempts to serialize it with the`` __dict__`` serializer, but then when the object is restored, it doesn't have information about the state of the serialized StringIO object any more.

## Related issue number

Closes https://github.com/ray-project/ray/issues/5769

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
