### PR TITLE
Fix `session attach` command

### DIFF
--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -308,12 +308,15 @@ def get_session_runs(name, command, parsed_args):
 
 
 @session_cli.command(help="Attach to an existing cluster")
+@click.option(
+    "--screen", is_flag=True, default=False, help="Run the command in screen.")
 @click.option("--tmux", help="Attach to tmux session", is_flag=True)
-def attach(tmux):
+def attach(screen, tmux):
     project_definition = load_project_or_throw()
     attach_cluster(
         project_definition.cluster_yaml(),
         start=False,
+        use_screen=screen,
         use_tmux=tmux,
         override_cluster_name=None,
         new=False,


### PR DESCRIPTION
## Why are these changes needed?

`session attach` requires an argument for whether to use screen.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
