### PR TITLE
Fixed local mode actor id

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -589,7 +589,7 @@ class ActorHandle(object):
 
         if worker.mode == ray.LOCAL_MODE:
             # Increment task_index, otherwise done via the worker.submit_task
-            # call in non local mode.
+            # call in non-local mode.
             worker.task_context.task_index += 1
             function = getattr(worker.actors[self._ray_actor_id], method_name)
             object_ids = worker.local_mode_manager.execute(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -390,6 +390,9 @@ class ActorClass(object):
         # Instead, instantiate the actor locally and add it to the worker's
         # dictionary
         if worker.mode == ray.LOCAL_MODE:
+            # Increment task_index, otherwise done via the worker.submit_task
+            # call in non local mode.
+            worker.task_context.task_index += 1
             worker.actors[actor_id] = self._modified_class(
                 *copy.deepcopy(args), **copy.deepcopy(kwargs))
         else:
@@ -585,6 +588,9 @@ class ActorHandle(object):
             self._ray_module_name, method_name, self._ray_class_name)
 
         if worker.mode == ray.LOCAL_MODE:
+            # Increment task_index, otherwise done via the worker.submit_task
+            # call in non local mode.
+            worker.task_context.task_index += 1
             function = getattr(worker.actors[self._ray_actor_id], method_name)
             object_ids = worker.local_mode_manager.execute(
                 function, function_descriptor, args, num_return_vals)

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -391,7 +391,7 @@ class ActorClass(object):
         # dictionary
         if worker.mode == ray.LOCAL_MODE:
             # Increment task_index, otherwise done via the worker.submit_task
-            # call in non local mode.
+            # call in non-local mode.
             worker.task_context.task_index += 1
             worker.actors[actor_id] = self._modified_class(
                 *copy.deepcopy(args), **copy.deepcopy(kwargs))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1766,6 +1766,27 @@ def test_local_mode(shutdown_only):
     with pytest.raises(Exception, match=exception_str):
         ray.get(obj2)
 
+    # Check that Actors are not overwritten by remote calls from different
+    # classes.
+    @ray.remote
+    class RemoteWorker1(object):
+        def __init__(self):
+            pass
+
+        def function1(self):
+            return 0
+
+    @ray.remote
+    class RemoteWorker2(object):
+        def __init__(self):
+            pass
+
+        def function2(self):
+            return 1
+
+    worker1 = RemoteWorker1.remote()
+    worker2 = RemoteWorker2.remote()
+    assert ray.get(worker1.dummy1.remote()) == 0
 
 def test_resource_constraints(shutdown_only):
     num_workers = 20


### PR DESCRIPTION
Addressed issue #5715 

I incremented task index in local mode, which is usually handled through a separate method call in non local mode. Originally, the unchanging task index ended up generating duplicate actor id's, which would end up overriding older actors, hence the error.
