### PR TITLE
Restore support for Python 3.5

### DIFF
--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -41,7 +41,7 @@ def easy_objective(config, reporter):
     import time
     time.sleep(0.2)
     for i in range(config["iterations"]):
-        x = np.array([config.get("x{}".format(i+1)) for i in range(6)])
+        x = np.array([config.get("x{}".format(i + 1)) for i in range(6)])
         reporter(
             timesteps_total=i,
             hartmann6=hartmann6(x),

--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -41,7 +41,7 @@ def easy_objective(config, reporter):
     import time
     time.sleep(0.2)
     for i in range(config["iterations"]):
-        x = np.array([config.get(f"x{i+1}") for i in range(6)])
+        x = np.array([config.get("x{}".format(i+1)) for i in range(6)])
         reporter(
             timesteps_total=i,
             hartmann6=hartmann6(x),

--- a/python/setup.py
+++ b/python/setup.py
@@ -180,7 +180,7 @@ setup(
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     install_requires=requires,
     setup_requires=["cython >= 0.29"],
     extras_require=extras,

--- a/python/setup.py
+++ b/python/setup.py
@@ -180,6 +180,7 @@ setup(
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
+    python_requires=">=3.6",
     install_requires=requires,
     setup_requires=["cython >= 0.29"],
     extras_require=extras,

--- a/python/setup.py
+++ b/python/setup.py
@@ -180,7 +180,6 @@ setup(
     cmdclass={"build_ext": build_ext},
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
-    python_requires=">=3.5",
     install_requires=requires,
     setup_requires=["cython >= 0.29"],
     extras_require=extras,


### PR DESCRIPTION
ray/tune/examples/ax_example.py contains f-strings which limits support of this package to Python 3.6 and up.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
