### PR TITLE
[tune] Add error case for member functions passed as stopping criteria

### DIFF
--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import os
 import six
+import types
 
 from ray.tune.error import TuneError
 from ray.tune.registry import register_trainable
@@ -92,9 +93,13 @@ class Experiment(object):
         if not isinstance(stop, dict) and not callable(stop):
             raise ValueError("Invalid stop criteria: {}. Must be a callable "
                              "or dict".format(stop))
-        if callable(stop) and len(inspect.getargspec(stop).args) != 2:
-            raise ValueError("Invalid stop criteria: {}. Callable criteria "
-                             "must take exactly 2 parameters.".format(stop))
+        if callable(stop):
+            nargs = len(inspect.getargspec(stop).args)
+            is_method = isinstance(stop, types.MethodType)
+            if (is_method and nargs != 3) or (not is_method and nargs != 2):
+                raise ValueError(
+                    "Invalid stop criteria: {}. Callable "
+                    "criteria must take exactly 2 parameters.".format(stop))
 
         config = config or {}
         run_identifier = Experiment._register_if_needed(run)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Address exception case missed in #5754: class member functions should actually have 3 parameters, not 2 (including "self").

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
