### PR TITLE
[rllib] Fix preprocessor observation space to not have float.max/min as lo/hi bounds

### DIFF
--- a/rllib/models/preprocessors.py
+++ b/rllib/models/preprocessors.py
@@ -77,11 +77,7 @@ class Preprocessor(object):
     @property
     @PublicAPI
     def observation_space(self):
-        obs_space = gym.spaces.Box(
-            np.finfo(np.float32).min,
-            np.finfo(np.float32).max,
-            self.shape,
-            dtype=np.float32)
+        obs_space = gym.spaces.Box(-1., 1., self.shape, dtype=np.float32)
         # Stash the unwrapped space so that we can unwrap dict and tuple spaces
         # automatically in model.py
         if (isinstance(self, TupleFlatteningPreprocessor)
@@ -174,6 +170,11 @@ class NoPreprocessor(Preprocessor):
     def write(self, observation, array, offset):
         array[offset:offset + self._size] = np.array(
             observation, copy=False).ravel()
+
+    @property
+    @override(Preprocessor)
+    def observation_space(self):
+        return self._obs_space
 
 
 class TupleFlatteningPreprocessor(Preprocessor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The lo/high bounds for the observation were not defined for the preprocessor observation space. This causes observations sampled from these spaces to have very high values, potentially causing policies to emit nan values.

## Related issue number

https://github.com/ray-project/ray/issues/5568

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
