### PR TITLE
Use shared_ptr for profilier

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -51,8 +51,8 @@ CoreWorker::CoreWorker(
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
 
   // Initialize profiler.
-  profiler_ = std::unique_ptr<worker::Profiler>(
-      new worker::Profiler(worker_context_, node_ip_address, io_service_, gcs_client_));
+  profiler_ = std::make_shared<worker::Profiler>(worker_context_, node_ip_address,
+                                                 io_service_, gcs_client_);
 
   object_interface_ =
       std::unique_ptr<CoreWorkerObjectInterface>(new CoreWorkerObjectInterface(

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -101,7 +101,7 @@ class CoreWorker {
   boost::asio::io_service::work io_work_;
 
   std::thread io_thread_;
-  std::unique_ptr<worker::Profiler> profiler_;
+  std::shared_ptr<worker::Profiler> profiler_;
   std::unique_ptr<RayletClient> raylet_client_;
   std::unique_ptr<gcs::RedisGcsClient> gcs_client_;
   std::unique_ptr<CoreWorkerTaskInterface> task_interface_;

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -6,7 +6,7 @@ namespace ray {
 
 namespace worker {
 
-ProfileEvent::ProfileEvent(const std::unique_ptr<Profiler> &profiler,
+ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> profiler,
                            const std::string &event_type)
     : profiler_(profiler) {
   rpc_event_.set_event_type(event_type);

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -37,7 +37,7 @@ class Profiler {
 
 class ProfileEvent {
  public:
-  ProfileEvent(const std::unique_ptr<Profiler> &profiler, const std::string &event_type);
+  ProfileEvent(const std::shared_ptr<Profiler> profiler, const std::string &event_type);
 
   ~ProfileEvent() {
     rpc_event_.set_end_time(current_sys_time_seconds());
@@ -49,7 +49,7 @@ class ProfileEvent {
   }
 
  private:
-  const std::unique_ptr<Profiler> &profiler_;
+  const std::shared_ptr<Profiler> profiler_;
   rpc::ProfileTableData::ProfileEvent rpc_event_;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Wasn't passing stress tests, now it is.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
