### PR TITLE
Improved Pickle5 pickling

### DIFF
--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -12,7 +12,7 @@ DEF kMemcopyDefaultThreshold = 1024 * 1024
 
 cdef extern from "arrow/util/memory.h" namespace "arrow::internal" nogil:
     void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
-                          uintptr_t block_size, int num_threads);
+                          uintptr_t block_size, int num_threads)
 
 cdef extern from "google/protobuf/repeated_field.h" nogil:
     cdef cppclass RepeatedField[Element]:

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -1,6 +1,5 @@
 from libc.string cimport memcpy
 from libc.stdint cimport uintptr_t, uint64_t, INT32_MAX
-from cython.parallel cimport prange
 
 # This is the default alignment value for len(buffer) < 2048.
 DEF kMinorBufferAlign = 8

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -25,7 +25,6 @@ import random
 # Ray modules
 import pyarrow
 import pyarrow.plasma as plasma
-import pickle as native_pickle
 import ray.cloudpickle as pickle
 from ray.cloudpickle import USE_NEW_SERIALIZER
 import ray.experimental.signal as ray_signal
@@ -435,14 +434,9 @@ class Worker(object):
                     value, object_id, memcopy_threads=self.memcopy_threads)
             else:
                 writer = Pickle5Writer()
-                try:
-                    inband = native_pickle.dumps(
-                        value, protocol=5,
-                        buffer_callback=writer.buffer_callback)
-                except native_pickle.PicklingError:
-                    inband = pickle.dumps(
-                        value, protocol=5,
-                        buffer_callback=writer.buffer_callback)
+                inband = pickle.dumps(
+                    value, protocol=5,
+                    buffer_callback=writer.buffer_callback)
                 self.core_worker.put_pickle5_buffers(object_id, inband, writer,
                                                      self.memcopy_threads)
         except pyarrow.plasma.PlasmaObjectExists:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -435,8 +435,7 @@ class Worker(object):
             else:
                 writer = Pickle5Writer()
                 inband = pickle.dumps(
-                    value, protocol=5,
-                    buffer_callback=writer.buffer_callback)
+                    value, protocol=5, buffer_callback=writer.buffer_callback)
                 self.core_worker.put_pickle5_buffers(object_id, inband, writer,
                                                      self.memcopy_threads)
         except pyarrow.plasma.PlasmaObjectExists:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This fixes the performance issue in https://github.com/ray-project/ray/pull/5725
I just find out that we can make use of the pyarrow parallel copy utils. Also with
other optimizations to decrease overhead.

```
New:

single core get calls per second 30435.44 +- 719.15
single core put calls per second 7124.12 +- 34.82
single core put gigabytes per second 7.15 +- 0.84
multi core put calls per second 10485.25 +- 66.36
multi core put gigabytes per second 3.77 +- 0.4
single core tasks sync per second 1907.34 +- 15.23
single core tasks async per second 3901.02 +- 39.17
multi core tasks async per second 3444.92 +- 27.59
single core actor calls sync per second 1651.49 +- 5.11
single core actor calls async per second 2313.01 +- 25.78
multi core actor calls async per second 2655.78 +- 30.72

Old:

single core get calls per second 19254.83 +- 125.76
single core put calls per second 4833.33 +- 48.43
single core put gigabytes per second 7.47 +- 0.32
multi core put calls per second 7584.14 +- 23.62
multi core put gigabytes per second 3.95 +- 0.45
single core tasks sync per second 1588.93 +- 27.0
single core tasks async per second 3378.86 +- 20.79
multi core tasks async per second 3085.38 +- 34.96
single core actor calls sync per second 1404.19 +- 17.0
single core actor calls async per second 1957.33 +- 9.04
multi core actor calls async per second 2360.81 +- 21.27
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
