### PR TITLE
Exit on SIGINT and SIGTERM in core worker

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -28,20 +28,11 @@ CoreWorker::CoreWorker(
     RayLog::InstallFailureSignalHandler();
   }
 
-  boost::asio::signal_set sigint(io_service_, SIGINT);
-  sigint.async_wait(
+  boost::asio::signal_set signals(io_service_, SIGINT, SIGTERM);
+  signals.async_wait(
       [](const boost::system::error_code &error, int signal_number) -> void {
         if (!error) {
-          RAY_LOG(WARNING) << "Got SIGINT " << signal_number << ", ignoring it.";
-        }
-      });
-
-  boost::asio::signal_set sigterm(io_service_, SIGTERM);
-  sigterm.async_wait(
-      [this](const boost::system::error_code &error, int signal_number) -> void {
-        if (!error) {
-          RAY_LOG(WARNING) << "Got SIGTERM " << signal_number << ", shutting down.";
-          io_service_.stop();
+          exit(signal_number);
         }
       });
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Previously we were stopping the Io service in the signal handler for SIGTERM, but causes issues in some cases because it's also called in the destructor. For now, we should just simply exit when we get SIGINT or SIGTERM.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
