### PR TITLE
[tune] Check node liveness before result fetch

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -302,8 +302,13 @@ class RayTrialExecutor(TrialExecutor):
         return {t.node_ip for t in self.get_running_trials()}
 
     def get_next_failed_trial(self):
+        """Gets the first trial found to be running on a node presumed dead.
+
+        Returns:
+            A Trial object that is ready for failure processing. None if
+            no failure detected.
+        """
         if ray.worker._mode() != ray.worker.LOCAL_MODE:
-            # Detect trials on failed nodes first.
             live_cluster_ips = self.get_alive_node_ips()
             if live_cluster_ips - self.get_current_trial_ips():
                 for trial in self.get_running_trials():

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -303,14 +303,11 @@ class RayTrialExecutor(TrialExecutor):
 
     def get_next_available_trial(self):
         if ray.worker._mode() != ray.worker.LOCAL_MODE:
+            # Detect trials on failed nodes first.
             live_cluster_ips = self.get_alive_node_ips()
             if live_cluster_ips - self.get_current_trial_ips():
                 for trial in self.get_running_trials():
                     if trial.node_ip and trial.node_ip not in live_cluster_ips:
-                        logger.warning(
-                            "{} (ip: {}) detected as stale. This is likely "
-                            "because the node was lost. Processing this "
-                            "trial first.".format(trial, trial.node_ip))
                         return trial
 
         shuffled_results = list(self._running.keys())

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -301,7 +301,7 @@ class RayTrialExecutor(TrialExecutor):
     def get_current_trial_ips(self):
         return {t.node_ip for t in self.get_running_trials()}
 
-    def get_next_available_trial(self):
+    def get_next_failed_trial(self):
         if ray.worker._mode() != ray.worker.LOCAL_MODE:
             # Detect trials on failed nodes first.
             live_cluster_ips = self.get_alive_node_ips()
@@ -309,7 +309,9 @@ class RayTrialExecutor(TrialExecutor):
                 for trial in self.get_running_trials():
                     if trial.node_ip and trial.node_ip not in live_cluster_ips:
                         return trial
+        return None
 
+    def get_next_available_trial(self):
         shuffled_results = list(self._running.keys())
         random.shuffle(shuffled_results)
         # Note: We shuffle the results because `ray.wait` by default returns

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -158,6 +158,15 @@ class TrialExecutor(object):
         """
         raise NotImplementedError
 
+    def get_next_failed_trial(self):
+        """Non-blocking call that detects and returns one failed trial.
+
+        Returns:
+            A Trial object that is ready for failure processing. None if
+            no failure detected.
+        """
+        raise NotImplementedError
+
     def fetch_result(self, trial):
         """Fetches one result for the trial.
 

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -497,13 +497,14 @@ class TrialRunner(object):
         return trial
 
     def _process_events(self):
-        trial = self.trial_executor.get_next_failed_trial()  # non-blocking
-        if trial:
-            with warn_if_slow("handle_failed_trial"):
+        failed_trial = self.trial_executor.get_next_failed_trial()
+        if failed_trial:
+            with warn_if_slow("process_failed_trial"):
                 self._process_trial_failure(
-                    trial,
+                    failed_trial,
                     error_msg="{} (ip: {}) detected as stale. This is likely"
-                    "because the node was lost".format(trial, trial.node_ip))
+                    "because the node was lost".format(failed_trial,
+                                                       failed_trial.node_ip))
         else:
             trial = self.trial_executor.get_next_available_trial()  # blocking
             with warn_if_slow("process_trial"):


### PR DESCRIPTION
## Why are these changes needed?

When we try to `ray.get` the result of a trial simultaneously with the trial's node failing, the fetch takes a while to error out (order of tens of seconds). This causes the entire event loop to stall while waiting for the `get` to return. 

We should check the liveness of the trial's node before trying to fetch the result. If it's dead try recovering the trial.

## Related issue number

Closes #5828 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.