### PR TITLE
[Serve] Implement metric interface

### DIFF
--- a/python/ray/experimental/serve/__init__.py
+++ b/python/ray/experimental/serve/__init__.py
@@ -2,9 +2,9 @@ import sys
 if sys.version_info < (3, 0):
     raise ImportError("serve is Python 3 only.")
 
-from ray.experimental.serve.api import (init, create_backend, create_endpoint,
-                                        link, split, rollback, get_handle,
-                                        global_state, stat, scale)  # noqa: E402
+from ray.experimental.serve.api import (
+    init, create_backend, create_endpoint, link, split, rollback, get_handle,
+    global_state, stat, scale)  # noqa: E402
 
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "rollback",

--- a/python/ray/experimental/serve/__init__.py
+++ b/python/ray/experimental/serve/__init__.py
@@ -4,9 +4,9 @@ if sys.version_info < (3, 0):
 
 from ray.experimental.serve.api import (init, create_backend, create_endpoint,
                                         link, split, rollback, get_handle,
-                                        global_state, scale)  # noqa: E402
+                                        global_state, stat, scale)  # noqa: E402
 
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "rollback",
-    "get_handle", "global_state", "scale"
+    "get_handle", "global_state", "stat", "scale"
 ]

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -19,7 +19,7 @@ def init(blocking=False, object_store_memory=int(1e8), gc_window_seconds=3600):
 
     Args:
         blocking (bool): If true, the function will wait for the HTTP server to
-            be healthy before returns.
+            be healthy, and other components to be ready before returns.
         object_store_memory (int): Allocated shared memory size in bytes. The
             default is 100MiB. The default is kept low for latency stability
             reason.
@@ -40,6 +40,9 @@ def init(blocking=False, object_store_memory=int(1e8), gc_window_seconds=3600):
 
     if blocking:
         global_state.wait_until_http_ready()
+        ray.get(global_state.router_actor_handle.is_ready.remote())
+        ray.get(global_state.kv_store_actor_handle.is_ready.remote())
+        ray.get(global_state.metric_monitor_handle.is_ready.remote())
 
 
 def create_endpoint(endpoint_name, route_expression, blocking=True):

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -10,7 +10,7 @@ from ray.experimental.serve.global_state import GlobalState
 global_state = GlobalState()
 
 
-def init(blocking=False, object_store_memory=int(1e8)):
+def init(blocking=False, object_store_memory=int(1e8), gc_window_seconds=3600):
     """Initialize a serve cluster.
 
     Calling `ray.init` before `serve.init` is optional. When there is not a ray
@@ -23,15 +23,20 @@ def init(blocking=False, object_store_memory=int(1e8)):
         object_store_memory (int): Allocated shared memory size in bytes. The
             default is 100MiB. The default is kept low for latency stability
             reason.
+        gc_window_seconds(int): How long will we keep the metric data in
+            memory. Data older than the gc_window will be deleted. The default
+            is 3600 seconds, which is 1 hour.
     """
     if not ray.is_initialized():
         ray.init(object_store_memory=object_store_memory)
 
     # NOTE(simon): Currently the initialization order is fixed.
     # HTTP server depends on the API server.
+    # Metric monitor depends on the router.
     global_state.init_api_server()
     global_state.init_router()
     global_state.init_http_server()
+    global_state.init_metric_monitor()
 
     if blocking:
         global_state.wait_until_http_ready()
@@ -103,7 +108,7 @@ def _start_replica(backend_tag):
     runner._ray_serve_main_loop.remote(runner)
 
     global_state.backend_replicas[backend_tag].append(runner)
-
+    global_state.metric_monitor_handle.add_target.remote(runner)
 
 def _remove_replica(backend_tag):
     assert backend_tag in global_state.registered_backends, (
@@ -114,6 +119,8 @@ def _remove_replica(backend_tag):
 
     replicas = global_state.backend_replicas[backend_tag]
     oldest_replica_handle = replicas.popleft()
+    
+    global_state.metric_monitor_handle.remove_target.remote(oldest_replica_handle)
     # explicitly terminate that actor
     del oldest_replica_handle
 
@@ -139,6 +146,7 @@ def scale(backend_tag, num_replicas):
     elif delta_num_replicas < 0:
         for _ in range(-delta_num_replicas):
             _remove_replica(backend_tag)
+
 
 
 def link(endpoint_name, backend_tag):
@@ -236,3 +244,19 @@ def get_handle(endpoint_name):
     from ray.experimental.serve.handle import RayServeHandle
 
     return RayServeHandle(global_state.router_actor_handle, endpoint_name)
+
+
+def stat(percentiles=[50, 90, 95],
+         agg_windows_seconds=[10, 60, 300, 600, 3600]):
+    """Retrieve metric statistics about ray serve system.
+
+    Args:
+        percentiles(List[int]): The percentiles for aggregation operations.
+            Default is 50th, 90th, 95th percentile.
+        agg_windows_seconds(List[int]): The aggregation windows in seconds.
+            The longest aggregation window must be shorter or equal to the
+            gc_window_seconds.
+    """
+    return ray.get(
+        global_state.metric_monitor_handle.collect.remote(
+            percentiles, agg_windows_seconds))

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -113,6 +113,7 @@ def _start_replica(backend_tag):
     global_state.backend_replicas[backend_tag].append(runner)
     global_state.metric_monitor_handle.add_target.remote(runner)
 
+
 def _remove_replica(backend_tag):
     assert backend_tag in global_state.registered_backends, (
         "Backend {} is not registered.".format(backend_tag))
@@ -122,8 +123,9 @@ def _remove_replica(backend_tag):
 
     replicas = global_state.backend_replicas[backend_tag]
     oldest_replica_handle = replicas.popleft()
-    
-    global_state.metric_monitor_handle.remove_target.remote(oldest_replica_handle)
+
+    global_state.metric_monitor_handle.remove_target.remote(
+        oldest_replica_handle)
     # explicitly terminate that actor
     del oldest_replica_handle
 
@@ -149,7 +151,6 @@ def scale(backend_tag, num_replicas):
     elif delta_num_replicas < 0:
         for _ in range(-delta_num_replicas):
             _remove_replica(backend_tag)
-
 
 
 def link(endpoint_name, backend_tag):

--- a/python/ray/experimental/serve/examples/echo_full.py
+++ b/python/ray/experimental/serve/examples/echo_full.py
@@ -4,6 +4,7 @@ Full example of ray.serve module
 
 import ray
 import ray.experimental.serve as serve
+from ray.experimental.serve.utils import pformat_color_json
 import requests
 import time
 
@@ -56,3 +57,6 @@ for _ in range(10):
 # You can also scale each backend independently.
 serve.scale("echo:v1", 2)
 serve.scale("echo:v2", 2)
+
+# As well as retrieving relevant system metrics
+print(pformat_color_json(serve.stat()))

--- a/python/ray/experimental/serve/kv_store_service.py
+++ b/python/ray/experimental/serve/kv_store_service.py
@@ -171,3 +171,6 @@ class KVStoreProxy:
 class KVStoreProxyActor(KVStoreProxy):
     def __init__(self, kv_class=RayInternalKVStore):
         super().__init__(kv_class=kv_class)
+
+    def is_ready(self):
+        return True

--- a/python/ray/experimental/serve/kv_store_service.py
+++ b/python/ray/experimental/serve/kv_store_service.py
@@ -167,7 +167,7 @@ class KVStoreProxy:
         return self.request_count
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 class KVStoreProxyActor(KVStoreProxy):
     def __init__(self, kv_class=RayInternalKVStore):
         super().__init__(kv_class=kv_class)

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -15,7 +15,8 @@ class MetricMonitor:
             gc_window_seconds(int): How long will we keep the metric data in
                 memory. Data older than the gc_window will be deleted.
         """
-        self.actor_handles = []
+        #: Mapping actor ID (hex) -> actor handle
+        self.actor_handles = dict()
 
         self.data_entries = []
 
@@ -23,16 +24,12 @@ class MetricMonitor:
         self.latest_gc_time = time.time()
 
     def add_target(self, target_handle):
-        self.actor_handles.append(target_handle)
+        hex_id = target_handle._ray_actor_id.hex()
+        self.actor_handles[hex_id] = target_handle
 
     def remove_target(self, target_handle):
-        found_idx = None
-        for i, handle in enumerate(self.actor_handles):
-            if handle._ray_actor_id.hex() == target_handle._ray_actor_id.hex():
-                found_idx = i
-
-        if found_idx is not None:
-            self.actor_handles.pop(found_idx)
+        hex_id = target_handle._ray_actor_id.hex()
+        self.actor_handles.pop(hex_id)
 
     def scrape(self):
         # If expected gc time has passed, we will perform metric value GC.

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -40,7 +40,7 @@ class MetricMonitor:
 
         curr_time = time.time()
         result = [
-            handle._serve_metric.remote() for handle in self.actor_handles
+            handle._serve_metric.remote() for handle in self.actor_handles.values()
         ]
         for handle_result in ray.get(result):
             for metric_name, metric_info in handle_result.items():

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -40,7 +40,8 @@ class MetricMonitor:
 
         curr_time = time.time()
         result = [
-            handle._serve_metric.remote() for handle in self.actor_handles.values()
+            handle._serve_metric.remote()
+            for handle in self.actor_handles.values()
         ]
         for handle_result in ray.get(result):
             for metric_name, metric_info in handle_result.items():

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 class MetricMonitor:
     def __init__(self, gc_window_seconds=3600):
         """Metric monitor scrapes metrics from ray serve actors

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -23,6 +23,9 @@ class MetricMonitor:
         self.gc_window_seconds = gc_window_seconds
         self.latest_gc_time = time.time()
 
+    def is_ready(self):
+        return True
+
     def add_target(self, target_handle):
         hex_id = target_handle._ray_actor_id.hex()
         self.actor_handles[hex_id] = target_handle
@@ -148,5 +151,5 @@ class MetricMonitor:
 @ray.remote(num_cpus=0)
 def start_metric_monitor_loop(monitor_handle, duration_s=5):
     while True:
-        monitor_handle.scrape.remote()
+        ray.get(monitor_handle.scrape.remote())
         time.sleep(duration_s)

--- a/python/ray/experimental/serve/metric.py
+++ b/python/ray/experimental/serve/metric.py
@@ -1,0 +1,154 @@
+import time
+
+import ray
+import numpy as np
+import pandas as pd
+
+
+@ray.remote
+class MetricMonitor:
+    def __init__(self, gc_window_seconds=3600):
+        """Metric monitor scrapes metrics from ray serve actors
+        and allow windowed query operations.
+
+        Args:
+            gc_window_seconds(int): How long will we keep the metric data in
+                memory. Data older than the gc_window will be deleted.
+        """
+        self.actor_handles = []
+
+        self.data_entries = []
+
+        self.gc_window_seconds = gc_window_seconds
+        self.latest_gc_time = time.time()
+
+    def add_target(self, target_handle):
+        self.actor_handles.append(target_handle)
+
+    def remove_target(self, target_handle):
+        found_idx = None
+        for i, handle in enumerate(self.actor_handles):
+            if handle._ray_actor_id.hex() == target_handle._ray_actor_id.hex():
+                found_idx = i
+
+        if found_idx is not None:
+            self.actor_handles.pop(found_idx)
+
+    def scrape(self):
+        # If expected gc time has passed, we will perform metric value GC.
+        expected_gc_time = self.latest_gc_time + self.gc_window_seconds
+        if expected_gc_time < time.time():
+            self._perform_gc()
+            self.latest_gc_time = time.time()
+
+        curr_time = time.time()
+        result = [
+            handle._serve_metric.remote() for handle in self.actor_handles
+        ]
+        for handle_result in ray.get(result):
+            for metric_name, metric_info in handle_result.items():
+                data_entry = {
+                    "retrieved_at": curr_time,
+                    "name": metric_name,
+                    "type": metric_info["type"],
+                }
+
+                if metric_info["type"] == "counter":
+                    data_entry["value"] = metric_info["value"]
+                    self.data_entries.append(data_entry)
+
+                elif metric_info["type"] == "list":
+                    for metric_value in metric_info["value"]:
+                        new_entry = data_entry.copy()
+                        new_entry["value"] = metric_value
+                        self.data_entries.append(new_entry)
+
+    def _perform_gc(self):
+        curr_time = time.time()
+        earliest_time_allowed = curr_time - self.gc_window_seconds
+
+        # If we don"t have any data at hand, no need to gc.
+        if len(self.data_entries) == 0:
+            return
+
+        df = pd.DataFrame(self.data_entries)
+        df = df[df["retrieved_at"] >= earliest_time_allowed]
+        self.data_entries = df.to_dict(orient="record")
+
+    def _get_dataframe(self):
+        return pd.DataFrame(self.data_entries)
+
+    def collect(self,
+                percentiles=[50, 90, 95],
+                agg_windows_seconds=[10, 60, 300, 600, 3600]):
+        """Collect and perform aggregation on all metrics.
+
+        Args:
+            percentiles(List[int]): The percentiles for aggregation operations.
+                Default is 50th, 90th, 95th percentile.
+            agg_windows_seconds(List[int]): The aggregation windows in seconds.
+                The longest aggregation window must be shorter or equal to the
+                gc_window_seconds.
+        """
+        result = {}
+        df = pd.DataFrame(self.data_entries)
+
+        if len(df) == 0:  # no metric to report
+            return {}
+
+        # Retrieve the {metric_name -> metric_type} mapping
+        metric_types = df[["name",
+                           "type"]].set_index("name").squeeze().to_dict()
+
+        for metric_name, metric_type in metric_types.items():
+            if metric_type == "counter":
+                result[metric_name] = df.loc[df["name"] == metric_name,
+                                             "value"].tolist()[-1]
+            if metric_type == "list":
+                result.update(
+                    self._aggregate(metric_name, percentiles,
+                                    agg_windows_seconds))
+        return result
+
+    def _aggregate(self, metric_name, percentiles, agg_windows_seconds):
+        """Perform aggregation over a metric.
+
+        Note:
+            This metric must have type `list`.
+        """
+        assert max(agg_windows_seconds) <= self.gc_window_seconds, (
+            "Aggregation window exceeds gc window. You should set a longer gc "
+            "window or shorter aggregation window.")
+
+        curr_time = time.time()
+        df = pd.DataFrame(self.data_entries)
+        filtered_df = df[df["name"] == metric_name]
+        if len(filtered_df) == 0:
+            return dict()
+
+        data_types = filtered_df["type"].unique().tolist()
+        assert data_types == [
+            "list"
+        ], ("Can't aggreagte over non-list type. {} has type {}".format(
+            metric_name, data_types))
+
+        aggregated_metric = {}
+        for window in agg_windows_seconds:
+            earliest_time = curr_time - window
+            windowed_df = filtered_df[
+                filtered_df["retrieved_at"] > earliest_time]
+            percentile_values = np.percentile(windowed_df["value"],
+                                              percentiles)
+            for percentile, value in zip(percentiles, percentile_values):
+                result_key = "{name}_{perc}th_perc_{window}_window".format(
+                    name=metric_name, perc=percentile, window=window)
+                aggregated_metric[result_key] = value
+
+        return aggregated_metric
+
+
+@ray.remote(num_cpus=0)
+def start_metric_monitor_loop(monitor_handle, duration_s=5):
+    while True:
+        monitor_handle.scrape.remote()
+        time.sleep(duration_s)

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -76,6 +76,15 @@ class CentralizedQueues:
         # backend_name -> worker queue
         self.workers = defaultdict(deque)
 
+    def _serve_metric(self):
+        return {
+            "service_{}_queue_size".format(service_name): {
+                "value": len(queue),
+                "type": "counter",
+            }
+            for service_name, queue in self.queues.items()
+        }
+
     def enqueue_request(self, service, request_args, request_kwargs,
                         request_context):
         query = Query(request_args, request_kwargs, request_context)

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -76,6 +76,9 @@ class CentralizedQueues:
         # backend_name -> worker queue
         self.workers = defaultdict(deque)
 
+    def is_ready(self):
+        return True
+
     def _serve_metric(self):
         return {
             "service_{}_queue_size".format(service_name): {

--- a/python/ray/experimental/serve/tests/test_metric.py
+++ b/python/ray/experimental/serve/tests/test_metric.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pytest
+
+import ray
+
+from ray.experimental.serve.metric import MetricMonitor
+
+
+@pytest.fixture(scope="session")
+def start_target_actor(ray_instance):
+    @ray.remote
+    class Target():
+        def __init__(self):
+            self.counter_value = 0
+
+        def _serve_metric(self):
+            self.counter_value += 1
+            return {
+                "latency_list": {
+                    "type": "list",
+                    # Generate 0 to 100 inclusive.
+                    # This means total of 101 items.
+                    "value": np.arange(101).tolist()
+                },
+                "counter": {
+                    "type": "counter",
+                    "value": self.counter_value
+                }
+            }
+
+        def get_counter_value(self):
+            return self.counter_value
+
+    yield Target.remote()
+
+
+def test_metric_gc(ray_instance, start_target_actor):
+    target_actor = start_target_actor
+    # this means when new scrapes are invoked, the
+    metric_monitor = MetricMonitor.remote(gc_window_seconds=0)
+    metric_monitor.add_target.remote(target_actor)
+
+    ray.get(metric_monitor.scrape.remote())
+    df = ray.get(metric_monitor._get_dataframe.remote())
+    print(df)
+    assert len(df) == 102
+
+    # Old metric sould be cleared. So only 1 counter + 101 list values left.
+    ray.get(metric_monitor.scrape.remote())
+    df = ray.get(metric_monitor._get_dataframe.remote())
+    assert len(df) == 102
+
+
+def test_metric_system(ray_instance, start_target_actor):
+    target_actor = start_target_actor
+
+    metric_monitor = MetricMonitor.remote()
+
+    metric_monitor.add_target.remote(target_actor)
+
+    # Scrape once
+    metric_monitor.scrape.remote()
+
+    percentiles = [50, 90, 95]
+    agg_windows_seconds = [60]
+    result = ray.get(
+        metric_monitor.collect.remote(percentiles, agg_windows_seconds))
+    real_counter_value = ray.get(target_actor.get_counter_value.remote())
+
+    expected_result = {
+        "counter": real_counter_value,
+        "latency_list_50th_perc_60_window": 50.0,
+        "latency_list_90th_perc_60_window": 90.0,
+        "latency_list_95th_perc_60_window": 95.0,
+    }
+    assert result == expected_result

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,7 +77,7 @@ extras = {
     ],
     "debug": ["psutil", "setproctitle", "py-spy >= 0.2.0"],
     "dashboard": ["aiohttp", "psutil", "setproctitle"],
-    "serve": ["uvicorn", "pygments", "werkzeug", "flask"],
+    "serve": ["uvicorn", "pygments", "werkzeug", "flask", "pandas"],
 }
 
 


### PR DESCRIPTION
Implement a metric interface that aggregate metrics from router and worker. 

```python
>>> serve.stat()
{
    "echo:v1_error_counter": 0.0,
    "echo:v1_latency_s_50th_perc_10_window": 0.0006570816040039062,
    "echo:v1_latency_s_50th_perc_300_window": 0.0006570816040039062,
    "echo:v1_latency_s_50th_perc_3600_window": 0.0006570816040039062,
   ...
}
```