### PR TITLE
[Dashboard] Improve handling of logs and errors in dashboard backend

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -1,7 +1,9 @@
 import CssBaseline from "@material-ui/core/CssBaseline";
 import React from "react";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Route } from "react-router-dom";
 import Dashboard from "./Dashboard";
+import Errors from "./Errors";
+import Logs from "./Logs";
 
 class App extends React.Component {
   render() {
@@ -9,6 +11,8 @@ class App extends React.Component {
       <BrowserRouter>
         <CssBaseline />
         <Dashboard />
+        <Route component={Logs} path="/logs/:hostname/:pid?" />
+        <Route component={Errors} path="/errors/:hostname/:pid?" />
       </BrowserRouter>
     );
   }

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -272,6 +272,24 @@ class NodeStats(threading.Thread):
              for y in (v["workers"] for v in self._node_stats.values())
              for x in y))
 
+    def calculate_log_counts(self):
+        return {
+            ip: {
+                pid: len(logs_for_pid)
+                for pid, logs_for_pid in logs_for_ip.items()
+            }
+            for ip, logs_for_ip in self._logs.items()
+        }
+
+    def calculate_error_counts(self):
+        return {
+            ip: {
+                pid: len(errors_for_pid)
+                for pid, errors_for_pid in errors_for_ip.items()
+            }
+            for ip, errors_for_ip in self._errors.items()
+        }
+
     def purge_outdated_stats(self):
         def current(then, now):
             if (now - then) > 5:
@@ -283,20 +301,6 @@ class NodeStats(threading.Thread):
         self._node_stats = {
             k: v
             for k, v in self._node_stats.items() if current(v["now"], now)
-        }
-
-    def calculate_log_counts(self):
-        return {
-            ip: {pid: len(logs[pid])
-                 for pid in logs}
-            for ip, logs in self._logs.items()
-        }
-
-    def calculate_error_counts(self):
-        return {
-            ip: {pid: len(errors[pid])
-                 for pid in errors}
-            for ip, errors in self._errors.items()
         }
 
     def get_node_stats(self) -> Dict:

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import logging
 import os
+import re
 import threading
 import traceback
 import yaml
@@ -165,6 +166,18 @@ class Dashboard(object):
             D = self.node_stats.get_node_stats()
             return await json_response(result=D, ts=now)
 
+        async def logs(req) -> aiohttp.web.Response:
+            hostname = req.query.get("hostname")
+            pid = req.query.get("pid")
+            result = self.node_stats.get_logs(hostname, pid)
+            return await json_response(result=result)
+
+        async def errors(req) -> aiohttp.web.Response:
+            hostname = req.query.get("hostname")
+            pid = req.query.get("pid")
+            result = self.node_stats.get_errors(hostname, pid)
+            return await json_response(result=result)
+
         self.app.router.add_get("/", get_index)
 
         static_dir = os.path.join(
@@ -176,8 +189,10 @@ class Dashboard(object):
                 "required to build the dashboard.".format(static_dir))
         self.app.router.add_static("/static", static_dir)
 
-        self.app.router.add_get("/api/node_info", node_info)
         self.app.router.add_get("/api/ray_config", ray_config)
+        self.app.router.add_get("/api/node_info", node_info)
+        self.app.router.add_get("/api/logs", logs)
+        self.app.router.add_get("/api/errors", errors)
 
         self.app.router.add_get("/{_}", get_forbidden)
 
@@ -204,6 +219,9 @@ class NodeStats(threading.Thread):
 
         # Mapping from IP address to PID to list of log lines
         self._logs = defaultdict(lambda: defaultdict(list))
+
+        # Mapping from IP address to PID to list of error messages
+        self._errors = defaultdict(lambda: defaultdict(list))
 
         ray.init(redis_address=redis_address, redis_password=redis_password)
 
@@ -267,6 +285,20 @@ class NodeStats(threading.Thread):
             for k, v in self._node_stats.items() if current(v["now"], now)
         }
 
+    def calculate_log_counts(self):
+        return {
+            ip: {pid: len(logs[pid])
+                 for pid in logs}
+            for ip, logs in self._logs.items()
+        }
+
+    def calculate_error_counts(self):
+        return {
+            ip: {pid: len(errors[pid])
+                 for pid in errors}
+            for ip, errors in self._errors.items()
+        }
+
     def get_node_stats(self) -> Dict:
         with self._node_stats_lock:
             self.purge_outdated_stats()
@@ -277,9 +309,23 @@ class NodeStats(threading.Thread):
                 "totals": self.calculate_totals(),
                 "tasks": self.calculate_tasks(),
                 "clients": node_stats,
-                "logs": self._logs,
-                "errors": ray.errors(all_jobs=True),
+                "log_counts": self.calculate_log_counts(),
+                "error_counts": self.calculate_error_counts(),
             }
+
+    def get_logs(self, hostname, pid):
+        ip = self._node_stats.get(hostname, {"ip": None})["ip"]
+        logs = self._logs.get(ip, {})
+        if pid:
+            logs = {pid: logs.get(pid, [])}
+        return logs
+
+    def get_errors(self, hostname, pid):
+        ip = self._node_stats.get(hostname, {"ip": None})["ip"]
+        errors = self._errors.get(ip, {})
+        if pid:
+            errors = {pid: errors.get(pid, [])}
+        return errors
 
     def run(self):
         p = self.redis_client.pubsub(ignore_subscribe_messages=True)
@@ -291,16 +337,38 @@ class NodeStats(threading.Thread):
         p.subscribe(log_channel)
         logger.info("NodeStats: subscribed to {}".format(log_channel))
 
+        error_channel = ray.gcs_utils.TablePubsub.Value("ERROR_INFO_PUBSUB")
+        p.subscribe(error_channel)
+        logger.info("NodeStats: subscribed to {}".format(error_channel))
+
         for x in p.listen():
             try:
                 with self._node_stats_lock:
                     channel = ray.utils.decode(x["channel"])
+                    data = x["data"]
                     if channel == log_channel:
-                        D = json.loads(ray.utils.decode(x["data"]))
-                        self._logs[D["ip"]][D["pid"]].extend(D["lines"])
+                        data = json.loads(ray.utils.decode(data))
+                        ip = data["ip"]
+                        pid = str(data["pid"])
+                        self._logs[ip][pid].extend(data["lines"])
+                    elif channel == str(error_channel):
+                        gcs_entry = ray.gcs_utils.GcsEntry.FromString(data)
+                        error_data = ray.gcs_utils.ErrorTableData.FromString(
+                            gcs_entry.entries[0])
+                        message = error_data.error_message
+                        message = re.sub(r"\x1b\[\d+m", "", message)
+                        match = re.search(r"\(pid=(\d+), ip=(.*?)\)", message)
+                        if match:
+                            pid = match.group(1)
+                            ip = match.group(2)
+                            self._errors[ip][pid].append({
+                                "message": message,
+                                "timestamp": error_data.timestamp,
+                                "type": error_data.type
+                            })
                     else:
-                        D = json.loads(ray.utils.decode(x["data"]))
-                        self._node_stats[D["hostname"]] = D
+                        data = json.loads(ray.utils.decode(data))
+                        self._node_stats[data["hostname"]] = data
             except Exception:
                 logger.exception(traceback.format_exc())
                 continue


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This addresses an efficiency issue in the initial version of the dashboard backend wherein the full set of logs and errors were being sent on every update. This PR introduces a better solution where only the log and error counts are sent by default, with two new API routes for retrieving logs and errors themselves (either for a specific (IP address, PID) pair or everything for a single IP address).

This PR moreover unifies the backend handling of logs and errors through the consistent use of IP addresses as identifiers, instead of using IP addresses for logs and hostnames for errors.

In addition, a minor discrepancy on some systems in the reporter is fixed by replacing a the custom `determine_ip_address()` function with a call to `ray.services.get_node_ip_address()`.

CC @simon-mo @robertnishihara 

## Related issue number

N/A

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
