### PR TITLE
[tune] Explicitly set scheduler in run()

### DIFF
--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -97,7 +97,13 @@ if __name__ == "__main__":
             "type": "range",
             "bounds": [0.0, 1.0],
         },
-        {
+        {run(easy_objective,
+
++        name="ax",
+
++        search_alg=algo,
+
++        scheduler=sche
             "name": "x6",
             "type": "range",
             "bounds": [0.0, 1.0],
@@ -113,4 +119,10 @@ if __name__ == "__main__":
     )
     algo = AxSearch(client, max_concurrent=4)
     scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="max")
-    run(easy_objective, name="ax", search_alg=algo, scheduler=scheduler, **config)
+    run(
+        easy_objective, 
+        name="ax", 
+        search_alg=algo, 
+        scheduler=scheduler, 
+        **config
+    )

--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -113,10 +113,8 @@ if __name__ == "__main__":
     )
     algo = AxSearch(client, max_concurrent=4)
     scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="max")
-    run(
-        easy_objective, 
-        name="ax", 
-        search_alg=algo, 
-        scheduler=scheduler, 
-        **config
-    )
+    run(easy_objective,
+        name="ax",
+        search_alg=algo,
+        scheduler=scheduler,
+        **config)

--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -97,13 +97,7 @@ if __name__ == "__main__":
             "type": "range",
             "bounds": [0.0, 1.0],
         },
-        {run(easy_objective,
-
-+        name="ax",
-
-+        search_alg=algo,
-
-+        scheduler=sche
+        {
             "name": "x6",
             "type": "range",
             "bounds": [0.0, 1.0],

--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -113,4 +113,4 @@ if __name__ == "__main__":
     )
     algo = AxSearch(client, max_concurrent=4)
     scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="max")
-    run(easy_objective, name="ax", search_alg=algo, **config)
+    run(easy_objective, name="ax", search_alg=algo, scheduler=scheduler, **config)


### PR DESCRIPTION
## Why are these changes needed?

The scheduler AsyncHyperBandScheduler was not explicitly called in tune.run(). Modified this.

Alternative to https://github.com/ray-project/ray/pull/5860
(where the custom scheduler definition is removed, using the default FIFO scheduler)

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
