### PR TITLE
rllib: use pytorch's fn to see if gpu is available

### DIFF
--- a/rllib/agents/qmix/qmix_policy.py
+++ b/rllib/agents/qmix/qmix_policy.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 from gym.spaces import Tuple, Discrete, Dict
-import os
 import logging
 import numpy as np
 import torch as th
@@ -172,8 +171,7 @@ class QMixTorchPolicy(Policy):
         self.has_env_global_state = False
         self.has_action_mask = False
         self.device = (th.device("cuda")
-                       if bool(os.environ.get("CUDA_VISIBLE_DEVICES", None))
-                       else th.device("cpu"))
+                       if th.cuda.is_available() else th.device("cpu"))
 
         agent_obs_space = obs_space.original_space.spaces[0]
         if isinstance(agent_obs_space, Dict):

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import os
 
 try:
     import torch
@@ -49,8 +48,7 @@ class TorchPolicy(Policy):
         self.observation_space = observation_space
         self.action_space = action_space
         self.device = (torch.device("cuda")
-                       if bool(os.environ.get("CUDA_VISIBLE_DEVICES", None))
-                       else torch.device("cpu"))
+                       if torch.cuda.is_available() else torch.device("cpu"))
         self.model = model.to(self.device)
         self._loss = loss
         self._optimizer = self.optimizer()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This replaces a check of the CUDA_AVAILABLE_DEVICES env var with a call to the Pytorch function `torch.cuda.is_available()` to see if a gpu is available in rllib's Pytorch graphs.

This function `torch.cuda.is_available()` is already used in other parts of ray.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/. 
- [ The examples in rllib's examples dir that use pytorch seem to still work] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
