### PR TITLE
[autoscaler] Revert to double-spawning updater threads

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -553,7 +553,10 @@ class StandardAutoscaler(object):
             nodes = self.workers()
             self.log_info_string(nodes, target_workers)
 
-        # Update nodes with out-of-date files
+        # Update nodes with out-of-date files.
+        # TODO(edoakes): Spawning these threads directly seems to cause
+        # problems. They should at a minimum be spawned as daemon threads.
+        # See https://github.com/ray-project/ray/pull/5903 for more info.
         T = []
         for node_id, commands, ray_start in (self.should_update(node_id)
                                              for node_id in nodes):

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -430,9 +430,9 @@ class NodeUpdater(object):
 
         node_tags = self.provider.node_tags(self.node_id)
         if node_tags.get(TAG_RAY_RUNTIME_CONFIG) == self.runtime_hash:
-            logger.info(
-                "NodeUpdater: {} already up-to-date, skip to ray start".format(
-                    self.node_id))
+            logger.info(self.log_prefix +
+                        "{} already up-to-date, skip to ray start".format(
+                            self.node_id))
         else:
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_SYNCING_FILES})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

493364d3bd3b11dd953001c4efde338513da99a7 seems to have caused some problems with the autoscaler. Observed when running the `test_many_tasks` stress test for releasing, the worker nodes consistently failed to update and the relevant output is not contained in the logs. Also noticed that the updater process hangs forever if you try to kill it (which seems to be because the spawned threads are no longer daemon threads so the main thread can't exit without joining them).

`test_many_tasks` is working when this change is included, so we should merge this, cherry-pick it onto the release, and then diagnose further in master.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
