### PR TITLE
[autoscaler] uptime redirect fix

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -403,7 +403,7 @@ class NodeUpdater(object):
                     logger.debug(self.log_prefix +
                                  "Waiting for remote shell...")
 
-                    # Setting redirect=False allows the user to see errors like
+                    # Setting redirect=None allows the user to see errors like
                     # unix_listener: path "/tmp/rkn_ray_ssh_sockets/..." too
                     # long for Unix domain socket.
                     self.cmd_runner.run("uptime", timeout=5, redirect=None)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -406,8 +406,8 @@ class NodeUpdater(object):
                     # Setting redirect=False allows the user to see errors like
                     # unix_listener: path "/tmp/rkn_ray_ssh_sockets/..." too
                     # long for Unix domain socket.
-                    self.cmd_runner.run("uptime", timeout=5, redirect=False)
-
+                    self.cmd_runner.run("uptime", timeout=5, redirect=None)
+                    logger.debug("Uptime succeeded.")
                     return True
 
                 except Exception as e:
@@ -429,6 +429,7 @@ class NodeUpdater(object):
         self.wait_ready(deadline)
 
         node_tags = self.provider.node_tags(self.node_id)
+        logger.debug("Node tags: {}".format(str(node_tags)))
         if node_tags.get(TAG_RAY_RUNTIME_CONFIG) == self.runtime_hash:
             logger.info(self.log_prefix +
                         "{} already up-to-date, skip to ray start".format(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Uptime previously had `redirect=False`. For whatever reason, that not
only swallows the errors but also causes the autoscaler to hang.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.