### PR TITLE
Fix flaky test_component_failures.py::test_dying_worker_get

### DIFF
--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -26,6 +26,7 @@ from ray.tests.utils import (run_string_as_driver_nonblocking,
 def test_dying_worker_get(ray_start_2_cpus):
     @ray.remote
     def sleep_forever():
+        ray.experimental.signal.send("ready")
         time.sleep(10**6)
 
     @ray.remote
@@ -33,7 +34,7 @@ def test_dying_worker_get(ray_start_2_cpus):
         return os.getpid()
 
     x_id = sleep_forever.remote()
-    time.sleep(0.01)  # Try to wait for the sleep task to get scheduled.
+    ray.experimental.signal.receive([x_id])  # Block until it is scheduled.
     # Get the PID of the other worker.
     worker_pid = ray.get(get_worker_pid.remote())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This test was failing since it relied on FIFO queueing order to succeed. With fair queueing this order was no longer guaranteed. The fix is to block explicitly until the first task is scheduled.

## Related issue number
Closes https://github.com/ray-project/ray/issues/5899