### PR TITLE
[autoscaler] Worker-Head termination + Better Scale-up message

### DIFF
--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -331,17 +331,17 @@ class AWSNodeProvider(NodeProvider):
                 else:
                     on_demand_ids += [node_id]
 
-            if spot_ids:
-                logger.info(
-                    "AWSNodeProvider: terminating nodes {} (spot nodes cannot "
-                    "be stopped, only terminated)".format(spot_ids))
-                self.ec2.meta.client.terminate_instances(InstanceIds=spot_ids)
             if on_demand_ids:
                 logger.info(
                     "AWSNodeProvider: stopping nodes {}. To terminate nodes "
                     "on stop, set 'cache_stopped_nodes: False' in the "
                     "provider config.".format(on_demand_ids))
                 self.ec2.meta.client.stop_instances(InstanceIds=on_demand_ids)
+            if spot_ids:
+                logger.info(
+                    "AWSNodeProvider: terminating nodes {} (spot nodes cannot "
+                    "be stopped, only terminated)".format(spot_ids))
+                self.ec2.meta.client.terminate_instances(InstanceIds=spot_ids)
         else:
             self.ec2.meta.client.terminate_instances(InstanceIds=node_ids)
 

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -321,20 +321,27 @@ class AWSNodeProvider(NodeProvider):
     def terminate_nodes(self, node_ids):
         if not node_ids:
             return
-
-        node0 = self._get_cached_node(node_ids[0])
         if self.cache_stopped_nodes:
-            if node0.spot_instance_request_id:
+            spot_ids = []
+            on_demand_ids = []
+
+            for node_id in node_ids:
+                if self._get_cached_node(node_id).spot_instance_request_id:
+                    spot_ids += [node_id]
+                else:
+                    on_demand_ids += [node_id]
+
+            if spot_ids:
                 logger.info(
                     "AWSNodeProvider: terminating nodes {} (spot nodes cannot "
-                    "be stopped, only terminated)".format(node_ids))
-                self.ec2.meta.client.terminate_instances(InstanceIds=node_ids)
+                    "be stopped, only terminated)".format(spot_ids))
+                self.ec2.meta.client.terminate_instances(InstanceIds=spot_ids)
             else:
                 logger.info(
                     "AWSNodeProvider: stopping nodes {}. To terminate nodes "
                     "on stop, set 'cache_stopped_nodes: False' in the "
-                    "provider config.".format(node_ids))
-                self.ec2.meta.client.stop_instances(InstanceIds=node_ids)
+                    "provider config.".format(on_demand_ids))
+                self.ec2.meta.client.stop_instances(InstanceIds=on_demand_ids)
         else:
             self.ec2.meta.client.terminate_instances(InstanceIds=node_ids)
 

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -336,7 +336,7 @@ class AWSNodeProvider(NodeProvider):
                     "AWSNodeProvider: terminating nodes {} (spot nodes cannot "
                     "be stopped, only terminated)".format(spot_ids))
                 self.ec2.meta.client.terminate_instances(InstanceIds=spot_ids)
-            else:
+            if on_demand_ids:
                 logger.info(
                     "AWSNodeProvider: stopping nodes {}. To terminate nodes "
                     "on stop, set 'cache_stopped_nodes: False' in the "

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -112,7 +112,7 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name):
                 head = remaining_heads()
             while A:
                 logger.info("teardown_cluster: "
-                            "Shutting down {} nodes...".format(len(A)))
+                            "Shutting down {} worker nodes...".format(len(A)))
                 provider.terminate_nodes(A)
                 time.sleep(1)
                 A = remaining_workers()

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -84,38 +84,33 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name):
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:
 
-        def remaining_heads():
-            return [
-                node_id for node_id in provider.non_terminated_nodes({
-                    TAG_RAY_NODE_TYPE: NODE_TYPE_HEAD
-                })
-            ]
+        def remaining_nodes():
+            if workers_only:
+                A = []
+            else:
+                A = [
+                    node_id for node_id in provider.non_terminated_nodes({
+                        TAG_RAY_NODE_TYPE: NODE_TYPE_HEAD
+                    })
+                ]
 
-        def remaining_workers():
-            return [
+            A += [
                 node_id for node_id in provider.non_terminated_nodes({
                     TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER
                 })
             ]
+            return A
 
         # Loop here to check that both the head and worker nodes are actually
         #   really gone
-        head = remaining_heads()
-        A = remaining_workers()
+        A = remaining_nodes()
         with LogTimer("teardown_cluster: done."):
-            while head and not workers_only:
-                logger.info("teardown_cluster: "
-                            "Shutting down {} head node(s)...".format(
-                                len(head)))
-                provider.terminate_nodes(head)
-                time.sleep(1)
-                head = remaining_heads()
             while A:
                 logger.info("teardown_cluster: "
-                            "Shutting down {} worker nodes...".format(len(A)))
+                            "Shutting down {} nodes...".format(len(A)))
                 provider.terminate_nodes(A)
                 time.sleep(1)
-                A = remaining_workers()
+                A = remaining_nodes()
     finally:
         provider.cleanup()
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -410,7 +410,8 @@ void NodeManager::WarnResourceDeadlock() {
         << " pending actors on this node. "
         << "This is likely due to all cluster resources being claimed by actors. "
         << "To resolve the issue, consider creating fewer actors or increase the "
-        << "resources available to this Ray cluster.";
+        << "resources available to this Ray cluster. You can ignore this message "
+        << "if this Ray cluster is expected to auto-scale.";
     RAY_CHECK_OK(gcs_client_->error_table().PushErrorToDriver(
         exemplar.GetTaskSpecification().JobId(), "resource_deadlock", error_message.str(),
         current_time_ms()));


### PR DESCRIPTION
This PR addresses two small autoscaler changes. 

One is that `ray down` occasionally fails with spot instances and `cache_stopped_nodes=True`. This is because the first node of `remaining_nodes` in `teardown_cluster` is likely an on-demand instance, causing:

```
╭─ ~/Research/ec2/clustercfgs 
╰─ ray down tune_ft_cluster.yaml -y
2019-10-13 14:25:36,497	INFO commands.py:110 -- teardown_cluster: Shutting down 4 nodes...
2019-10-13 14:25:36,638	INFO node_provider.py:336 -- AWSNodeProvider: stopping nodes ['i-011dd955fa0d87ec5', 'i-02cfa22b696c983fe', 'i-0dfaadb95ea05a4b9', 'i-056251fa79b12458a']. To terminate nodes on stop, set 'cache_stopped_nodes: False' in the provider config.
2019-10-13 14:25:36,825	INFO log_timer.py:21 -- teardown_cluster: done. [LogTimer=328ms]
...
  File "/Users/rliaw/miniconda3/lib/python3.7/site-packages/ray/scripts/scripts.py", line 510, in teardown
    teardown_cluster(cluster_config_file, yes, workers_only, cluster_name)
  File "/Users/rliaw/miniconda3/lib/python3.7/site-packages/ray/autoscaler/commands.py", line 111, in teardown_cluster
    provider.terminate_nodes(A)
  File "/Users/rliaw/miniconda3/lib/python3.7/site-packages/ray/autoscaler/aws/node_provider.py", line 337, in terminate_nodes
    self.ec2.meta.client.stop_instances(InstanceIds=node_ids)
  File "/Users/rliaw/miniconda3/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/rliaw/miniconda3/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (UnsupportedOperation) when calling the StopInstances operation: The instance 'i-0dfaadb95ea05a4b9' is a spot instance and may not be stopped.
```

The other is that the current error message for infeasibility does not provide any indication that the autoscaler may be in action. This can be confusing to users.