### PR TITLE
Deactivate bazel caching for linux wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,16 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
-        # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+        # Mount bazel cache dir to the docker container.
+        # For the linux wheel build, we use a shared cache between all
+        # wheels, but not between different travis runs, because that
+        # caused timeouts in the past. See the "cache: false" line below.
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
+
+        # This command should be kept in sync with ray/python/README-building-wheels.md,
+        # except the `$MOUNT_BAZEL_CACHE` part.
+
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
       script:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
         # Mount bazel cache dir to the docker container.
-        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
+        # - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
         - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,15 +112,13 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
 
-        # Mount bazel cache dir to the docker container.
-        # - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true"
-        # This command should be kept in sync with ray/python/README-building-wheels.md,
-        # except the `$MOUNT_BAZEL_CACHE` part.
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
       script:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
 
         - ./ci/travis/test-wheels.sh
+      cache: false
 
     # Build MacOS wheels.
     - os: osx


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Linux wheels are failing to build a lot, some of it due to the Bazel caching timing out. This is trying to fix that issue by deactivating the cache.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
