### PR TITLE
Update max resource label and give better error message

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -54,7 +54,7 @@ PICKLE_OBJECT_WARNING_SIZE = 10**7
 # The maximum resource quantity that is allowed. TODO(rkn): This could be
 # relaxed, but the current implementation of the node manager will be slower
 # for large resource quantities due to bookkeeping of specific resource IDs.
-MAX_RESOURCE_QUANTITY = 20000
+MAX_RESOURCE_QUANTITY = 40000
 
 # Each memory "resource" counts as this many bytes of memory.
 MEMORY_RESOURCE_UNIT_BYTES = 50 * 1024 * 1024

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -113,8 +113,10 @@ class ResourceSpec(
                                  "Received {}.".format(resources))
             if resource_quantity > ray_constants.MAX_RESOURCE_QUANTITY:
                 raise ValueError(
-                    "Resource quantities must be at most {}.".format(
-                        ray_constants.MAX_RESOURCE_QUANTITY))
+                    "Resource quantities must be at most {}. "
+                    "Received {}.".format(
+                        ray_constants.MAX_RESOURCE_QUANTITY,
+                        resources))
 
         return resources
 

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -107,20 +107,17 @@ class ResourceSpec(
                     and not resource_quantity.is_integer()):
                 raise ValueError(
                     "Resource quantities must all be whole numbers. "
-                    "Violated by resource '{}' in {}."
-                    .format(resource_label, resources))
-            if resource_quantity < 0:
-                raise ValueError(
-                    "Resource quantities must be nonnegative. "
-                    "Violated by resource '{}' in {}."
-                    .format(resource_label, resources))
-            if resource_quantity > ray_constants.MAX_RESOURCE_QUANTITY:
-                raise ValueError(
-                    "Resource quantities must be at most {}. "
                     "Violated by resource '{}' in {}.".format(
-                        ray_constants.MAX_RESOURCE_QUANTITY,
-                        resource_label,
-                        resources))
+                        resource_label, resources))
+            if resource_quantity < 0:
+                raise ValueError("Resource quantities must be nonnegative. "
+                                 "Violated by resource '{}' in {}.".format(
+                                     resource_label, resources))
+            if resource_quantity > ray_constants.MAX_RESOURCE_QUANTITY:
+                raise ValueError("Resource quantities must be at most {}. "
+                                 "Violated by resource '{}' in {}.".format(
+                                     ray_constants.MAX_RESOURCE_QUANTITY,
+                                     resource_label, resources))
 
         return resources
 

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -100,22 +100,26 @@ class ResourceSpec(
         }
 
         # Check types.
-        for _, resource_quantity in resources.items():
+        for resource_label, resource_quantity in resources.items():
             assert (isinstance(resource_quantity, int)
                     or isinstance(resource_quantity, float))
             if (isinstance(resource_quantity, float)
                     and not resource_quantity.is_integer()):
                 raise ValueError(
                     "Resource quantities must all be whole numbers. "
-                    "Received {}.".format(resources))
+                    "Violated by resource '{}' in {}."
+                    .format(resource_label, resources))
             if resource_quantity < 0:
-                raise ValueError("Resource quantities must be nonnegative. "
-                                 "Received {}.".format(resources))
+                raise ValueError(
+                    "Resource quantities must be nonnegative. "
+                    "Violated by resource '{}' in {}."
+                    .format(resource_label, resources))
             if resource_quantity > ray_constants.MAX_RESOURCE_QUANTITY:
                 raise ValueError(
                     "Resource quantities must be at most {}. "
-                    "Received {}.".format(
+                    "Violated by resource '{}' in {}.".format(
                         ray_constants.MAX_RESOURCE_QUANTITY,
+                        resource_label,
                         resources))
 
         return resources


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is to support the `memory` resource label on machines with main memory >= 2TB. Also fix the error message.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
