### PR TITLE
[WIP] Soft placement resources

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -615,9 +615,11 @@ cdef class CoreWorker:
                     function_descriptor,
                     args,
                     int num_return_vals,
-                    resources):
+                    resources,
+                    soft_resources):
         cdef:
             unordered_map[c_string, double] c_resources
+            unordered_map[c_string, double] c_soft_resources
             CTaskOptions task_options
             CRayFunction ray_function
             c_vector[CTaskArg] args_vector
@@ -625,7 +627,9 @@ cdef class CoreWorker:
 
         with profiling.profile("submit_task"):
             prepare_resources(resources, &c_resources)
-            task_options = CTaskOptions(num_return_vals, c_resources)
+            prepare_resources(soft_resources, &c_soft_resources)
+            task_options = CTaskOptions(
+                num_return_vals, c_resources, c_soft_resources)
             ray_function = CRayFunction(
                 LANGUAGE_PYTHON, string_vector_from_list(function_descriptor))
             prepare_args(args, &args_vector)

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -189,6 +189,9 @@ cdef extern from "ray/core_worker/task_interface.h" nogil:
         CTaskOptions()
         CTaskOptions(int num_returns,
                      unordered_map[c_string, double] &resources)
+        CTaskOptions(int num_returns,
+                     unordered_map[c_string, double] &resources,
+                     unordered_map[c_string, double] &soft_resources)
 
     cdef cppclass CActorCreationOptions "ray::ActorCreationOptions":
         CActorCreationOptions()

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -274,9 +274,10 @@ def set_cuda_visible_devices(gpu_ids):
 
 def resources_from_resource_arguments(
         default_num_cpus, default_num_gpus, default_memory,
-        default_object_store_memory, default_resources, runtime_num_cpus,
-        runtime_num_gpus, runtime_memory, runtime_object_store_memory,
-        runtime_resources):
+        default_object_store_memory, default_resources, default_soft_resources,
+        runtime_num_cpus, runtime_num_gpus, runtime_memory,
+        runtime_object_store_memory, runtime_resources,
+        runtime_soft_resources):
     """Determine a task's resource requirements.
 
     Args:
@@ -290,6 +291,8 @@ def resources_from_resource_arguments(
             by this function or actor method.
         default_resources: The default custom resources required by this
             function or actor method.
+        default_soft_resources: The default soft resources for this function or
+            actor method.
         runtime_num_cpus: The number of CPUs requested when the task was
             invoked.
         runtime_num_gpus: The number of GPUs requested when the task was
@@ -299,6 +302,8 @@ def resources_from_resource_arguments(
             the task was invoked.
         runtime_resources: The custom resources requested when the task was
             invoked.
+        runtime_soft_resources: The custom soft resources requested when the
+            task was invoked.
 
     Returns:
         A dictionary of the resource requirements for the task.
@@ -309,6 +314,12 @@ def resources_from_resource_arguments(
         resources = default_resources.copy()
     else:
         resources = {}
+    if runtime_soft_resources is not None:
+        soft_resources = runtime_soft_resources.copy()
+    elif default_soft_resources is not None:
+        soft_resources = default_soft_resources.copy()
+    else:
+        soft_resources = {}
 
     if "CPU" in resources or "GPU" in resources:
         raise ValueError("The resources dictionary must not "
@@ -336,7 +347,7 @@ def resources_from_resource_arguments(
         resources["object_store_memory"] = ray_constants.to_memory_units(
             object_store_memory, round_up=True)
 
-    return resources
+    return resources, {"soft:" + k: v for k, v in soft_resources.items()}
 
 
 _default_handler = None

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -173,6 +173,16 @@ class ResourceSet {
   /// \return True if the resource capacity is zero. False otherwise.
   bool IsEmpty() const;
 
+  /// Return true if the resource set has any soft constraints.
+  ///
+  /// \return True if the resource set has any soft constraints.
+  bool HasSoftResources() const;
+
+  /// Return the resource set without any soft constraints.
+  ///
+  /// \return The resource set without any soft constraints.
+  ResourceSet WithoutSoftResources() const;
+
   // TODO(atumanov): implement const_iterator class for the ResourceSet container.
   // TODO(williamma12): Make sure that everywhere we use doubles we don't
   // convert it back to FractionalResourceQuantity.
@@ -194,6 +204,8 @@ class ResourceSet {
  private:
   /// Resource capacity map.
   std::unordered_map<std::string, FractionalResourceQuantity> resource_capacity_;
+  /// The set of the keys that are soft constraints only.
+  std::unordered_set<std::string> soft_resource_keys_;
 };
 
 /// \class ResourceIds

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -27,6 +27,8 @@ void TaskSpecification::ComputeResources() {
   }
   required_resources_.reset(new ResourceSet(required_resources));
   required_placement_resources_.reset(new ResourceSet(required_placement_resources));
+  RAY_CHECK(!required_resources_->HasSoftResources())
+      << "Soft resource constraints are only allowed for placement, not execution.";
 
   // Map the scheduling class descriptor to an integer for performance.
   auto sched_cls = std::make_pair(GetRequiredResources(), FunctionDescriptor());

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -63,7 +63,8 @@ Status CoreWorkerTaskInterface::SubmitTask(const RayFunction &function,
                             worker_context_.GetCurrentTaskID(), next_task_index);
   BuildCommonTaskSpec(builder, worker_context_.GetCurrentJobID(), task_id,
                       next_task_index, function, args, task_options.num_returns,
-                      task_options.resources, {}, TaskTransportType::RAYLET, return_ids);
+                      task_options.resources, task_options.soft_resources,
+                      TaskTransportType::RAYLET, return_ids);
   return task_submitters_[TaskTransportType::RAYLET]->SubmitTask(builder.Build());
 }
 

--- a/src/ray/core_worker/task_interface.h
+++ b/src/ray/core_worker/task_interface.h
@@ -23,11 +23,16 @@ struct TaskOptions {
   TaskOptions() {}
   TaskOptions(int num_returns, std::unordered_map<std::string, double> &resources)
       : num_returns(num_returns), resources(resources) {}
+  TaskOptions(int num_returns, std::unordered_map<std::string, double> &resources,
+              std::unordered_map<std::string, double> &soft_resources)
+      : num_returns(num_returns), resources(resources), soft_resources(soft_resources) {}
 
   /// Number of returns of this task.
   int num_returns = 1;
   /// Resources required by this task.
   std::unordered_map<std::string, double> resources;
+  /// Soft resources of this task.
+  std::unordered_map<std::string, double> soft_resources;
 };
 
 /// Options of an actor creation task.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -813,18 +813,15 @@ void NodeManager::DispatchTasks(
       }
     }
   }
-  // Requeue any tasks without soft resources, and retry dispatch.
+  // See if we can dispatch any tasks ignoring their soft placement resources.
   if (should_retry_without_soft_resources) {
     for (const auto &it : fair_order) {
-      // Without soft resources
       const auto &hard_resources =
           TaskSpecification::GetSchedulingClassDescriptor(it->first)
               .first.WithoutSoftResources();
       for (const auto &task_id : it->second) {
         const auto &task = local_queues_.GetTaskOfState(task_id, TaskState::READY);
         if (!local_available_resources_.Contains(hard_resources)) {
-          // All the tasks in it.second have the same resource shape, so
-          // once the first task is not feasible, we can break out of this loop
           break;
         }
         RAY_LOG(INFO) << "Dispatching task " << task_id

--- a/src/ray/raylet/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling_policy.cc
@@ -147,7 +147,8 @@ std::vector<TaskID> SchedulingPolicy::SpillOver(
   // Check if we can accommodate infeasible tasks.
   for (const auto &task : scheduling_queue_.GetTasks(TaskState::INFEASIBLE)) {
     const auto &spec = task.GetTaskSpecification();
-    const auto &placement_resources = spec.GetRequiredPlacementResources();
+    const auto &placement_resources =
+        spec.GetRequiredPlacementResources().WithoutSoftResources();
     if (placement_resources.IsSubset(remote_scheduling_resources.GetTotalResources())) {
       decision.push_back(spec.TaskId());
       new_load.AddResources(spec.GetRequiredResources());
@@ -159,7 +160,7 @@ std::vector<TaskID> SchedulingPolicy::SpillOver(
     const auto &spec = task.GetTaskSpecification();
     if (!spec.IsActorTask()) {
       // Make sure the node has enough available resources to prevent forwarding cycles.
-      if (spec.GetRequiredPlacementResources().IsSubset(
+      if (spec.GetRequiredPlacementResources().WithoutSoftResources().IsSubset(
               remote_scheduling_resources.GetAvailableResources())) {
         decision.push_back(spec.TaskId());
         new_load.AddResources(spec.GetRequiredResources());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is a potential way to implement "preferred for placement" resources. For example, it can be used to place tasks on a particular node, but falling back to the default placement should the node be busy or otherwise not available.

This is done by introducing the idea of a "soft" placement resource, which can be specified via `ray.remote(preferred_placement_resources={<label>: <value}, ...})` These resources are only considered for placing the task or actor. They are totally ignored for the purposes of execution, which means they don't count towards the "in use" resources on the node once the task or actor starts to run.

Unlike the current placement resources which are required, these are optional. We implement this optionality by dropping the soft resources during scheduling if the task turns out to be not runnable due to resource constraints.

These soft resources are indicated by adding a "soft:" prefix to the resource name. The raylet will strip the "soft:" prefix internally and note it is a soft dependency (note: this is a bit hacky, but avoids a huge refactoring to add a new resource type). This means that "soft:GPU" and "GPU" name the same resources, but the raylet will treat the former as optional for placement. Soft resources are disallowed for execution.