### PR TITLE
Add dependencies for dashboard to installation.rst

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -120,7 +120,19 @@ steps are included in the installation instructions above.
 
 .. _`Node.js`: https://nodejs.org/
 
-The dashboard requires Python 3, and can be enabled by setting
+The dashboard also requires:
+
+-  Python 3
+-  aiohttp
+-  psutil
+
+The latter two can be installed via pip:
+
+.. code-block:: bash
+
+  pip install aiohttp psutil
+ 
+The dashboard is enabled by setting
 ``include_webui=True`` during initialization, i.e.
 
 .. code-block:: python


### PR DESCRIPTION
## Why are these changes needed?

Updating the docs to include pip installing `aiohttp` and `psutil`, both of which the dashboard requires.  

Since the whole dashboard section is optional, I thought I'd just add it in the docs rather than make it an explicit requirement of the project.  Tell me if you'd prefer them as requirements in the `setup.py`, though.

## Related issue number

Closes #5938 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
