### PR TITLE
fix gcs::RedisAsioClient non-thread safe

### DIFF
--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -68,6 +68,7 @@ void RedisAsioClient::handle_write(boost::system::error_code error_code) {
 }
 
 void RedisAsioClient::add_read() {
+  // Socket is non-thread safe, dispatch read to backend thread.
   io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_read, this));
 }
 
@@ -79,6 +80,7 @@ void RedisAsioClient::do_add_read() {
 void RedisAsioClient::del_read() { read_requested_ = false; }
 
 void RedisAsioClient::add_write() {
+  // Socket is non-thread safe, dispatch write to backend thread.
   io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_write, this));
 }
 

--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -5,6 +5,7 @@
 RedisAsioClient::RedisAsioClient(boost::asio::io_service &io_service,
                                  ray::gcs::RedisAsyncContext &redis_async_context)
     : redis_async_context_(redis_async_context),
+      io_service_(io_service),
       socket_(io_service),
       read_requested_(false),
       write_requested_(false),
@@ -67,6 +68,10 @@ void RedisAsioClient::handle_write(boost::system::error_code error_code) {
 }
 
 void RedisAsioClient::add_read() {
+  io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_read, this));
+}
+
+void RedisAsioClient::do_add_read() {
   read_requested_ = true;
   operate();
 }
@@ -74,6 +79,10 @@ void RedisAsioClient::add_read() {
 void RedisAsioClient::del_read() { read_requested_ = false; }
 
 void RedisAsioClient::add_write() {
+  io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_write, this));
+}
+
+void RedisAsioClient::do_add_write() {
   write_requested_ = true;
   operate();
 }

--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -68,25 +68,21 @@ void RedisAsioClient::handle_write(boost::system::error_code error_code) {
 }
 
 void RedisAsioClient::add_read() {
-  // Socket is non-thread safe, dispatch read to backend thread.
-  io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_read, this));
-}
-
-void RedisAsioClient::do_add_read() {
-  read_requested_ = true;
-  operate();
+  // Because redis commands are non-thread safe, dispatch the operation to backend thread.
+  io_service_.dispatch([this]() {
+    read_requested_ = true;
+    operate();
+  });
 }
 
 void RedisAsioClient::del_read() { read_requested_ = false; }
 
 void RedisAsioClient::add_write() {
-  // Socket is non-thread safe, dispatch write to backend thread.
-  io_service_.dispatch(boost::bind(&RedisAsioClient::do_add_write, this));
-}
-
-void RedisAsioClient::do_add_write() {
-  write_requested_ = true;
-  operate();
+  // Because redis commands are non-thread safe, dispatch the operation to backend thread.
+  io_service_.dispatch([this]() {
+    write_requested_ = true;
+    operate();
+  });
 }
 
 void RedisAsioClient::del_write() { write_requested_ = false; }

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -51,7 +51,7 @@ class RedisAsioClient {
  private:
   void do_add_read();
   void do_add_write();
-  
+
   ray::gcs::RedisAsyncContext &redis_async_context_;
 
   boost::asio::io_service &io_service_;

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -35,6 +35,13 @@
 
 class RedisAsioClient {
  public:
+  /// Constructor of RedisAsioClient.
+  /// Use single-threaded io_service as event loop (because the redis commands
+  /// that will run in the event loop are non-thread safe).
+  ///
+  /// \param io_service The single-threaded event loop for this client.
+  /// \param redis_async_context The redis async context used to execute redis commands
+  /// for this client.
   RedisAsioClient(boost::asio::io_service &io_service,
                   ray::gcs::RedisAsyncContext &redis_async_context);
 
@@ -49,9 +56,6 @@ class RedisAsioClient {
   void cleanup();
 
  private:
-  void do_add_read();
-  void do_add_write();
-
   ray::gcs::RedisAsyncContext &redis_async_context_;
 
   boost::asio::io_service &io_service_;

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -49,8 +49,12 @@ class RedisAsioClient {
   void cleanup();
 
  private:
+  void do_add_read();
+  void do_add_write();
+  
   ray::gcs::RedisAsyncContext &redis_async_context_;
 
+  boost::asio::io_service &io_service_;
   boost::asio::ip::tcp::socket socket_;
   // Hiredis wanted to add a read operation to the event loop
   // but the read might not have happened yet

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -33,6 +33,9 @@ class RAY_EXPORT RedisGcsClient : public GcsClientInterface {
   /// Connect to GCS Service. Non-thread safe.
   /// Call this function before calling other functions.
   ///
+  /// \param io_service The event loop for this client.
+  /// Must be single-threaded io_service (get more information from RedisAsioClient).
+  ///
   /// \return Status
   Status Connect(boost::asio::io_service &io_service);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
We might call gcs::RedisAsioClient in multi-threads(e.g. c++ core worker), but [boost socket is non-thread safe](https://www.boost.org/doc/libs/1_68_0/doc/html/boost_asio/reference/ip__tcp/socket.html), so we dispatch all socket operations to a single thread(backend thread), to make this client thread safe.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
