### PR TITLE
Fix multiple drivers for named actors

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -130,6 +130,7 @@ CoreWorker::CoreWorker(
     data->mutable_task()->mutable_task_spec()->CopyFrom(builder.Build().GetMessage());
     RAY_CHECK_OK(gcs_client_->raylet_task_table().Add(job_id, task_id, data, nullptr));
     worker_context_.SetCurrentTaskId(task_id);
+    SetCurrentTaskId(task_id);
   }
 
   direct_actor_submitter_ = std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(


### PR DESCRIPTION
## Why are these changes needed?

Fixes a bug introduced by #5889 that broke multiple drivers accessing the same named actor. The bug was that the "current task ID" was not set properly for drivers.

## Related issue number

Closes #5954.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
