### PR TITLE
[docs] fix code block display

### DIFF
--- a/doc/examples/plot_example-lm.rst
+++ b/doc/examples/plot_example-lm.rst
@@ -42,7 +42,7 @@ Run the following command on your local machine to start the Ray cluster:
 You can move these files manually, or use the following command to upload
 files from a local path:
 
-.. code-block::
+.. code-block:: bash
 
   ray rsync-up lm-cluster.yaml PATH/TO/LM '~/efs/lm'
 

--- a/doc/source/using-ray-with-tensorflow.rst
+++ b/doc/source/using-ray-with-tensorflow.rst
@@ -15,7 +15,7 @@ Common Issues: Pickling
 
 One common issue with TensorFlow2.0 is a pickling error like the following:
 
-.. code-block::
+.. code-block:: none
 
     File "/home/***/venv/lib/python3.6/site-packages/ray/actor.py", line 322, in remote
       return self._remote(args=args, kwargs=kwargs)
@@ -41,7 +41,7 @@ One common issue with TensorFlow2.0 is a pickling error like the following:
 
 To resolve this, you should move all instances of ``import tensorflow`` into the Ray actor or function, as follows:
 
-.. code-block::
+.. code-block:: python
 
     def create_model():
         import tensorflow as tf


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

there were two code blocks which do not state which highlighting language to use. This breaks the display on readthedocs (the code block does not appear), even though it looks fine on the github preview

## Related issue number

Closes #5966
