### PR TITLE
Fix random numbers on linux wheel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,9 @@ matrix:
       install:
         - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
 
+        # The following line makes the absl random number generation library
+        # compile on gcc 4.8, see also https://github.com/ray-project/ray/pull/5975.
+        - export CC_OPT_FLAGS="-maes"
         - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,6 @@ matrix:
       install:
         - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
 
-        # The following line makes the absl random number generation library
-        # compile on gcc 4.8, see also https://github.com/ray-project/ray/pull/5975.
-        - export CC_OPT_FLAGS="-maes"
         - ./ci/suppress_output ./ci/travis/install-bazel.sh
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -595,6 +595,7 @@ cc_library(
     deps = [
         ":sha256",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/time",
         "@plasma//:plasma_client",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -595,7 +595,6 @@ cc_library(
     deps = [
         ":sha256",
         "@com_github_google_glog//:glog",
-        "@com_google_absl//absl/random",
         "@plasma//:plasma_client",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("@//bazel:ray.bzl", "flatbuffer_py_library")
 load("@//bazel:cython_library.bzl", "pyx_library")
 
-COPTS = ["-DRAY_USE_GLOG"]
+COPTS = ["-DRAY_USE_GLOG", "-maes"]
 
 # === Begin of protobuf definitions ===
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("@//bazel:ray.bzl", "flatbuffer_py_library")
 load("@//bazel:cython_library.bzl", "pyx_library")
 
-COPTS = ["-DRAY_USE_GLOG", "-maes"]
+COPTS = ["-DRAY_USE_GLOG"]
 
 # === Begin of protobuf definitions ===
 

--- a/src/ray/util/sample.h
+++ b/src/ray/util/sample.h
@@ -1,8 +1,9 @@
 #ifndef RAY_UTIL_SAMPLE_H
 #define RAY_UTIL_SAMPLE_H
 
-#include "absl/random/random.h"
-#include "absl/random/uniform_int_distribution.h"
+#include <random>
+
+#include "absl/time/clock.h"
 
 // Randomly samples num_elements from the elements between first and last using reservoir
 // sampling.
@@ -10,17 +11,17 @@ template <class Iterator, class T = typename std::iterator_traits<Iterator>::val
 void random_sample(Iterator begin, Iterator end, size_t num_elements,
                    std::vector<T> *out) {
   out->resize(0);
-  absl::BitGen gen;
   if (num_elements == 0) {
     return;
   }
 
+  std::default_random_engine gen(absl::GetCurrentTimeNanos());
   size_t current_index = 0;
   for (auto it = begin; it != end; it++) {
     if (current_index < num_elements) {
       out->push_back(*it);
     } else {
-      size_t random_index = absl::uniform_int_distribution<size_t>(0, current_index)(gen);
+      size_t random_index = std::uniform_int_distribution<size_t>(0, current_index)(gen);
       if (random_index < num_elements) {
         out->at(random_index) = *it;
       }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is an old gcc bug, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56298 that absl exposes. It seems to be fixed since then, but right now we are stuck on the old gcc version that comes with the manylinux1 toolchain. We just replace the absl random number generators with ones from the c++ standard library.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
