### PR TITLE
[rllib] Fix leak of TensorFlow assign operations in DQN/DDPG

### DIFF
--- a/rllib/utils/tf_ops.py
+++ b/rllib/utils/tf_ops.py
@@ -70,7 +70,7 @@ def make_tf_callable(session_or_none, dynamic_shape=False):
                     else:
                         args_flat.append(a)
                 args = args_flat
-                if not placeholders:
+                if symbolic_out[0] is None:
                     with session_or_none.graph.as_default():
                         for i, v in enumerate(args):
                             if dynamic_shape:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

It seems we were un-necessarily creating tf.assign() ops each time update_target() was called due to a slight bug in an if statement. The if statement was intended to create the graph operations just once, however if there were no arguments passed to this function, then the operations would be created each time.

I was able to reproduce the leak in #5977 by setting the target update interval and batch size to 1 for APEX, which causes TensorFlow to leak memory at a rate of ~10MB/s. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/5977

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
