### PR TITLE
Spawn processes in background sessions

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -442,7 +442,8 @@ def start_ray_process(command,
         env=modified_env,
         cwd=cwd,
         stdout=stdout_file,
-        stderr=stderr_file)
+        stderr=stderr_file,
+        preexec_fn=os.setsid)
 
     return ProcessInfo(
         process=process,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently `ray.init()` spawns child processes and leaves them in the foreground process session group, which means ctrl-c is propagated to them. This causes redis to crash, so we don't gracefully handle `KeyboardInterrupts` in interactive python shells.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
