### PR TITLE
Remove UsePush logic from raylet

### DIFF
--- a/python/ray/includes/libraylet.pxd
+++ b/python/ray/includes/libraylet.pxd
@@ -48,8 +48,6 @@ cdef extern from "ray/raylet/raylet_client.h" nogil:
                       const CLanguage &language)
         CRayStatus Disconnect()
         CRayStatus SubmitTask(const CTaskSpec &task_spec)
-        CRayStatus GetTask(unique_ptr[CTaskSpec] *task_spec)
-        CRayStatus TaskDone()
         CRayStatus FetchOrReconstruct(c_vector[CObjectID] &object_ids,
                                       c_bool fetch_only,
                                       const CTaskID &current_task_id)

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -25,9 +25,6 @@ enum MessageType:int {
   // Notify the raylet that this client is disconnecting gracefully.
   // This is sent from a worker to a raylet.
   IntentionalDisconnectClient,
-  // Get a new task from the raylet. This is sent from a worker to a
-  // raylet.
-  GetTask,
   // Tell a worker to execute a task. This is sent from a raylet to a
   // worker.
   ExecuteTask,
@@ -119,14 +116,6 @@ table ResourceIdSetInfos {
   resource_infos: [ResourceIdSetInfo];
 }
 
-// This message is sent from the raylet to a worker.
-table GetTaskReply {
-  // A string of bytes representing the task specification.
-  task_spec: string;
-  // A list of the resources reserved for this worker.
-  fractional_resource_ids: ResourceIdSetInfos;
-}
-
 // This struct is used to register a new worker with the raylet.
 // It is shipped as part of raylet_connect.
 table RegisterClientRequest {
@@ -142,8 +131,6 @@ table RegisterClientRequest {
   // TODO(hchen): Use `Language` in `common.proto`.
   language: int;
   // Port that this worker is listening on.
-  // If port > 0, then worker will listen to this port and wait for
-  // raylet to push tasks, instead of invoking GetTask().
   port: int;
 }
 

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -84,14 +84,6 @@ class RayletClient {
   /// \return ray::Status.
   ray::Status SubmitTask(const ray::TaskSpecification &task_spec);
 
-  /// Get next task for this client. This will block until the scheduler assigns
-  /// a task to this worker. The caller takes ownership of the returned task
-  /// specification and must free it.
-  ///
-  /// \param task_spec The assigned task.
-  /// \return ray::Status.
-  ray::Status GetTask(std::unique_ptr<ray::TaskSpecification> *task_spec);
-
   /// Tell the raylet that the client has finished executing a task.
   ///
   /// \return ray::Status.

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -121,52 +121,33 @@ void Worker::SetActiveObjectIds(const std::unordered_set<ObjectID> &&object_ids)
   active_object_ids_ = object_ids;
 }
 
-bool Worker::UsePush() const { return rpc_client_ != nullptr; }
-
 void Worker::AssignTask(const Task &task, const ResourceIdSet &resource_id_set,
                         const std::function<void(Status)> finish_assign_callback) {
-  const TaskSpecification &spec = task.GetTaskSpecification();
-  if (rpc_client_ != nullptr) {
-    // Use push mode.
-    RAY_CHECK(port_ > 0);
-    rpc::AssignTaskRequest request;
-    request.mutable_task()->mutable_task_spec()->CopyFrom(
-        task.GetTaskSpecification().GetMessage());
-    request.mutable_task()->mutable_task_execution_spec()->CopyFrom(
-        task.GetTaskExecutionSpec().GetMessage());
-    request.set_resource_ids(resource_id_set.Serialize());
+  // Use push mode.
+  RAY_CHECK(port_ > 0);
+  rpc::AssignTaskRequest request;
+  request.mutable_task()->mutable_task_spec()->CopyFrom(
+      task.GetTaskSpecification().GetMessage());
+  request.mutable_task()->mutable_task_execution_spec()->CopyFrom(
+      task.GetTaskExecutionSpec().GetMessage());
+  request.set_resource_ids(resource_id_set.Serialize());
 
-    auto status = rpc_client_->AssignTask(request, [](Status status,
-                                                      const rpc::AssignTaskReply &reply) {
-      if (!status.ok()) {
-        RAY_LOG(DEBUG) << "Worker failed to finish executing task: " << status.ToString();
-      }
-      // Worker has finished this task. There's nothing to do here
-      // and assigning new task will be done when raylet receives
-      // `TaskDone` message.
-    });
-    finish_assign_callback(status);
+  auto status = rpc_client_->AssignTask(request, [](Status status,
+                                                    const rpc::AssignTaskReply &reply) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to assign task " << task.GetTaskSpecification().TaskId()
-                     << " to worker " << worker_id_;
-    } else {
-      RAY_LOG(DEBUG) << "Assigned task " << task.GetTaskSpecification().TaskId()
-                     << " to worker " << worker_id_;
+      RAY_LOG(DEBUG) << "Worker failed to finish executing task: " << status.ToString();
     }
+    // Worker has finished this task. There's nothing to do here
+    // and assigning new task will be done when raylet receives
+    // `TaskDone` message.
+  });
+  finish_assign_callback(status);
+  if (!status.ok()) {
+    RAY_LOG(ERROR) << "Failed to assign task " << task.GetTaskSpecification().TaskId()
+                   << " to worker " << worker_id_;
   } else {
-    // Use pull mode. This corresponds to existing python/java workers that haven't been
-    // migrated to core worker architecture.
-    flatbuffers::FlatBufferBuilder fbb;
-    auto resource_id_set_flatbuf = resource_id_set.ToFlatbuf(fbb);
-
-    auto message =
-        protocol::CreateGetTaskReply(fbb, fbb.CreateString(spec.Serialize()),
-                                     protocol::CreateResourceIdSetInfos(
-                                         fbb, fbb.CreateVector(resource_id_set_flatbuf)));
-    fbb.Finish(message);
-    Connection()->WriteMessageAsync(
-        static_cast<int64_t>(protocol::MessageType::ExecuteTask), fbb.GetSize(),
-        fbb.GetBufferPointer(), finish_assign_callback);
+    RAY_LOG(DEBUG) << "Assigned task " << task.GetTaskSpecification().TaskId()
+                   << " to worker " << worker_id_;
   }
 }
 

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -123,7 +123,6 @@ void Worker::SetActiveObjectIds(const std::unordered_set<ObjectID> &&object_ids)
 
 void Worker::AssignTask(const Task &task, const ResourceIdSet &resource_id_set,
                         const std::function<void(Status)> finish_assign_callback) {
-  // Use push mode.
   RAY_CHECK(port_ > 0);
   rpc::AssignTaskRequest request;
   request.mutable_task()->mutable_task_spec()->CopyFrom(

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -60,7 +60,6 @@ class Worker {
   const std::unordered_set<ObjectID> &GetActiveObjectIds() const;
   void SetActiveObjectIds(const std::unordered_set<ObjectID> &&object_ids);
 
-  bool UsePush() const;
   void AssignTask(const Task &task, const ResourceIdSet &resource_id_set,
                   const std::function<void(Status)> finish_assign_callback);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We were temporarily supporting both "push" and "pull" mode for task assignments, but now that the python worker is migrated to use the core worker, we can remove this logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
