### PR TITLE
Fix bazel build caching issue, apply shallow-since and sha256

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -17,6 +17,7 @@ def ray_deps_setup():
         name = "bazel_common",
         strip_prefix = "bazel-common-f1115e0f777f08c3cdb115526c4e663005bec69b",
         url = "https://github.com/google/bazel-common/archive/f1115e0f777f08c3cdb115526c4e663005bec69b.zip",
+	sha256 = "1e05a4791cc3470d3ecf7edb556f796b1d340359f1c4d293f175d4d0946cf84c",
     )
 
     BAZEL_SKYLIB_TAG = "0.6.0"
@@ -25,36 +26,42 @@ def ray_deps_setup():
         name = "bazel_skylib",
         strip_prefix = "bazel-skylib-%s" % BAZEL_SKYLIB_TAG,
         url = "https://github.com/bazelbuild/bazel-skylib/archive/%s.tar.gz" % BAZEL_SKYLIB_TAG,
+	sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
     )
 
     git_repository(
         name = "com_github_checkstyle_java",
         commit = "85f37871ca03b9d3fee63c69c8107f167e24e77b",
         remote = "https://github.com/ruifangChen/checkstyle_java",
+	shallow_since = "1552542575 +0800",
     )
 
     git_repository(
         name = "com_github_nelhage_rules_boost",
         commit = "5171b9724fbb39c5fdad37b9ca9b544e8858d8ac",
         remote = "https://github.com/ray-project/rules_boost",
+	shallow_since = "1556014830 +0800",
     )
 
     git_repository(
         name = "com_github_google_flatbuffers",
         commit = "63d51afd1196336a7d1f56a988091ef05deb1c62",
         remote = "https://github.com/google/flatbuffers.git",
+	shallow_since = "1547755012 -0800",
     )
 
     git_repository(
         name = "com_google_googletest",
         commit = "3306848f697568aacf4bcca330f6bdd5ce671899",
         remote = "https://github.com/google/googletest",
+	shallow_since = "1534270723 -0700",
     )
 
     git_repository(
         name = "com_github_gflags_gflags",
         remote = "https://github.com/gflags/gflags.git",
-        tag = "v2.2.2",
+	commit = "e171aa2d15ed9eb17054558e0b3a6a413bb01067",
+	shallow_since = "1541971260 +0000",
     )
 
     new_git_repository(
@@ -76,12 +83,14 @@ def ray_deps_setup():
         build_file = "@//bazel:BUILD.cython",
         commit = "49414dbc7ddc2ca2979d6dbe1e44714b10d72e7e",
         remote = "https://github.com/cython/cython",
+	shallow_since = "1547888711 +0100",
     )
 
     http_archive(
         name = "io_opencensus_cpp",
         strip_prefix = "opencensus-cpp-3aa11f20dd610cb8d2f7c62e58d1e69196aadf11",
         urls = ["https://github.com/census-instrumentation/opencensus-cpp/archive/3aa11f20dd610cb8d2f7c62e58d1e69196aadf11.zip"],
+	sha256 = "92eef77c44d01e8472f68a2f1329919a1bb59317a4bb1e4d76081ab5c13a56d6",
     )
 
     # OpenCensus depends on Abseil so we have to explicitly pull it in.
@@ -90,6 +99,7 @@ def ray_deps_setup():
         name = "com_google_absl",
         commit = "aa844899c937bde5d2b24f276b59997e5b668bde",
         remote = "https://github.com/abseil/abseil-cpp.git",
+	shallow_since = "1565288385 -0400",
     )
 
     # OpenCensus depends on jupp0r/prometheus-cpp
@@ -100,6 +110,7 @@ def ray_deps_setup():
         # TODO(qwang): We should use the repository of `jupp0r` here when this PR
         # `https://github.com/jupp0r/prometheus-cpp/pull/225` getting merged.
         urls = ["https://github.com/jovany-wang/prometheus-cpp/archive/master.zip"],
+	sha256 = "d0c773da8af3db99c543dd0413f4427d835170eddfd517bfeba104236a8d2c07",
     )
 
     http_archive(
@@ -108,6 +119,7 @@ def ray_deps_setup():
             "https://github.com/grpc/grpc/archive/76a381869413834692b8ed305fbe923c0f9c4472.tar.gz",
         ],
         strip_prefix = "grpc-76a381869413834692b8ed305fbe923c0f9c4472",
+	sha256 = "b5efbe086b9a00826a3f830094312e6d1647157b5a5e7954a8ac4179bce3de8b",
     )
 
     http_archive(


### PR DESCRIPTION
Hopefully this will resolved the build issue that grpc and other libraries are not cached properly and rebuilt a lot of time. 

I applied all the warning messages that bazel print out on a fresh installation (minus glog and plasma):
```
DEBUG: Rule 'com_github_checkstyle_java' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1552542575 +0800"
DEBUG: Rule 'com_github_nelhage_rules_boost' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1556014830 +0800"
DEBUG: Rule 'com_github_jupp0r_prometheus_cpp' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "d0c773da8af3db99c543dd0413f4427d835170eddfd517bfeba104236a8d2c07"
DEBUG: Rule 'com_github_grpc_grpc' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "b5efbe086b9a00826a3f830094312e6d1647157b5a5e7954a8ac4179bce3de8b"
DEBUG: Rule 'bazel_common' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "1e05a4791cc3470d3ecf7edb556f796b1d340359f1c4d293f175d4d0946cf84c"
DEBUG: Rule 'bazel_skylib' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867"
DEBUG: Rule 'com_github_google_flatbuffers' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1547755012 -0800"
DEBUG: Rule 'plasma' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1570611764 -0700"
DEBUG: Rule 'com_github_google_glog' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1550458164 +0900"
DEBUG: Rule 'io_opencensus_cpp' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "92eef77c44d01e8472f68a2f1329919a1bb59317a4bb1e4d76081ab5c13a56d6"
DEBUG: Rule 'com_github_gflags_gflags' indicated that a canonical reproducible form can be obtained by modifying arguments commit = "e171aa2d15ed9eb17054558e0b3a6a413bb01067", shallow_since = "1541971260 +0000" and dropping ["tag"]
DEBUG: Rule 'com_google_absl' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1565288385 -0400"
DEBUG: Rule 'com_google_googletest' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1534270723 -0700"
DEBUG: Rule 'cython' indicated that a canonical reproducible form can be obtained by modifying arguments shallow_since = "1547888711 +0100"
DEBUG: Rule 'boringssl' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "e0cbd6a2e7bfbbf306936828da5340a96ba2db18c501400932c1f38ee527375c"
```
