### PR TITLE
Revert "Use plasma with batched CreateAndSeal implemented"

### DIFF
--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -9,23 +9,19 @@ cc_library(
         "cpp/src/arrow/io/interfaces.cc",
         "cpp/src/arrow/memory_pool.cc",
         "cpp/src/arrow/status.cc",
-        "cpp/src/arrow/util/io_util.cc",
+        "cpp/src/arrow/util/io-util.cc",
         "cpp/src/arrow/util/logging.cc",
         "cpp/src/arrow/util/memory.cc",
-        "cpp/src/arrow/util/string.cc",
         "cpp/src/arrow/util/string_builder.cc",
-        "cpp/src/arrow/util/thread_pool.cc",
+        "cpp/src/arrow/util/thread-pool.cc",
     ],
     hdrs = [
         "cpp/src/arrow/buffer.h",
-        "cpp/src/arrow/io/concurrency.h",
         "cpp/src/arrow/io/interfaces.h",
-        "cpp/src/arrow/io/util_internal.h",
         "cpp/src/arrow/memory_pool.h",
         "cpp/src/arrow/status.h",
-        "cpp/src/arrow/util/bit_util.h",
-        "cpp/src/arrow/util/checked_cast.h",
-        "cpp/src/arrow/util/io_util.h",
+        "cpp/src/arrow/util/bit-util.h",
+        "cpp/src/arrow/util/io-util.h",
         "cpp/src/arrow/util/logging.h",
         "cpp/src/arrow/util/macros.h",
         "cpp/src/arrow/util/memory.h",
@@ -33,14 +29,12 @@ cc_library(
         "cpp/src/arrow/util/string.h",
         "cpp/src/arrow/util/string_builder.h",
         "cpp/src/arrow/util/string_view.h",
-        "cpp/src/arrow/util/thread_pool.h",
+        "cpp/src/arrow/util/thread-pool.h",
         "cpp/src/arrow/util/type_traits.h",
         "cpp/src/arrow/util/ubsan.h",
         "cpp/src/arrow/util/visibility.h",
         "cpp/src/arrow/util/windows_compatibility.h",
         "cpp/src/arrow/vendored/string_view.hpp",
-        "cpp/src/arrow/vendored/xxhash.h",
-        "cpp/src/arrow/vendored/xxhash/xxh3.h",
         "cpp/src/arrow/vendored/xxhash/xxhash.c",
         "cpp/src/arrow/vendored/xxhash/xxhash.h",
     ],
@@ -182,17 +176,17 @@ FLATC_ARGS = [
 
 flatbuffer_cc_library(
     name = "common_fbs",
-    srcs = ["cpp/src/plasma/common.fbs"],
+    srcs = ["cpp/src/plasma/format/common.fbs"],
     flatc_args = FLATC_ARGS,
     out_prefix = "cpp/src/plasma/",
 )
 
 flatbuffer_cc_library(
     name = "plasma_fbs",
-    srcs = ["cpp/src/plasma/plasma.fbs"],
+    srcs = ["cpp/src/plasma/format/plasma.fbs"],
     flatc_args = FLATC_ARGS,
-    includes = ["cpp/src/plasma/common.fbs"],
+    includes = ["cpp/src/plasma/format/common.fbs"],
     out_prefix = "cpp/src/plasma/",
 )
 
-exports_files(["cpp/src/plasma/common.fbs"])
+exports_files(["cpp/src/plasma/format/common.fbs"])

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -74,7 +74,7 @@ def ray_deps_setup():
     new_git_repository(
         name = "plasma",
         build_file = "@//bazel:BUILD.plasma",
-        commit = "0aad5a08e539a7b7f4abd4ee57e08fe78957d412",
+        commit = "141a213a54f4979ab0b94b94928739359a2ee9ad",
         remote = "https://github.com/apache/arrow",
     )
 


### PR DESCRIPTION
Reverts ray-project/ray#5864

It introduced https://github.com/ray-project/ray/issues/6016. The reason is that the C++ plasma server went out of sync with the python client, because the PR changes the MessageType in https://github.com/apache/arrow/pull/5596. It can be fixed by either appending the messages to the end, or updating the the Python client.