### PR TITLE
Fix missing double quotes for spaces in paths

### DIFF
--- a/bazel/python_configure.bzl
+++ b/bazel/python_configure.bzl
@@ -184,7 +184,7 @@ def _get_python_lib(repository_ctx, python_bin):
         "for path in all_paths:\n" + "  if os.path.isdir(path):\n" +
         "    paths.append(path)\n" + "if len(paths) >=1:\n" +
         "  print(paths[0])\n" + "END")
-    cmd = '%s - %s' % (python_bin, print_lib)
+    cmd = '"%s" - %s' % (python_bin, print_lib)
     result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
     return result.stdout.strip('\n')
 

--- a/build.sh
+++ b/build.sh
@@ -101,18 +101,18 @@ pushd "$BUILD_DIR"
 # generated from https://github.com/ray-project/arrow-build from
 # the commit listed in the command.
 if [ -z "$SKIP_PYARROW_INSTALL" ]; then
-    $PYTHON_EXECUTABLE -m pip install -q \
+    "$PYTHON_EXECUTABLE" -m pip install -q \
         --target="$ROOT_DIR/python/ray/pyarrow_files" pyarrow==0.14.0.RAY \
         --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/516e15028091b5e287200b5df77d77f72d9a6c9a/index.html
 fi
 export PYTHON_BIN_PATH="$PYTHON_EXECUTABLE"
 
 if [ "$RAY_BUILD_JAVA" == "YES" ]; then
-  $BAZEL_EXECUTABLE build //java:all --verbose_failures
+  "$BAZEL_EXECUTABLE" build //java:all --verbose_failures
 fi
 
 if [ "$RAY_BUILD_PYTHON" == "YES" ]; then
-  $BAZEL_EXECUTABLE build //:ray_pkg --verbose_failures
+  "$BAZEL_EXECUTABLE" build //:ray_pkg --verbose_failures
 fi
 
 popd


### PR DESCRIPTION
## Why are these changes needed?

Paths on Windows contain spaces.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
