### PR TITLE
[minor] Reduce perf overhead of object ref tracking

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -337,6 +337,7 @@ cc_library(
         "@boost//:asio",
         "@com_github_jupp0r_prometheus_cpp//pull",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
@@ -369,6 +370,7 @@ cc_library(
     ]),
     copts = COPTS,
     deps = [
+        "@com_google_absl//absl/container:flat_hash_set",
         ":core_worker_cc_proto",
         ":ray_common",
         ":ray_util",

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1054,5 +1054,5 @@ cdef class CoreWorker:
     def remove_active_object_id(self, ObjectID object_id):
         cdef:
             CObjectID c_object_id = object_id.native()
-        # note: faster to not release GIL for short-running op
+        # Note: faster to not release GIL for short-running op.
         self.core_worker.get().RemoveActiveObjectID(c_object_id)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1048,7 +1048,7 @@ cdef class CoreWorker:
     def add_active_object_id(self, ObjectID object_id):
         cdef:
             CObjectID c_object_id = object_id.native()
-        # note: faster to not release GIL for short-running op
+        # Note: faster to not release GIL for short-running op.
         self.core_worker.get().AddActiveObjectID(c_object_id)
 
     def remove_active_object_id(self, ObjectID object_id):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1048,11 +1048,11 @@ cdef class CoreWorker:
     def add_active_object_id(self, ObjectID object_id):
         cdef:
             CObjectID c_object_id = object_id.native()
-        with nogil:
-            self.core_worker.get().AddActiveObjectID(c_object_id)
+        # note: faster to not release GIL for short-running op
+        self.core_worker.get().AddActiveObjectID(c_object_id)
 
     def remove_active_object_id(self, ObjectID object_id):
         cdef:
             CObjectID c_object_id = object_id.native()
-        with nogil:
-            self.core_worker.get().RemoveActiveObjectID(c_object_id)
+        # note: faster to not release GIL for short-running op
+        self.core_worker.get().RemoveActiveObjectID(c_object_id)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -244,7 +244,9 @@ void CoreWorker::ReportActiveObjectIDs() {
                        << "object IDs are currently in scope. "
                        << "This may lead to required objects being garbage collected.";
     }
-    RAY_CHECK_OK(raylet_client_->ReportActiveObjectIDs(active_object_ids_));
+    std::unordered_set<ObjectID> copy;
+    copy.insert(active_object_ids_.begin(), active_object_ids_.end());
+    RAY_CHECK_OK(raylet_client_->ReportActiveObjectIDs(copy));
   }
 
   // Reset the timer from the previous expiration time to avoid drift.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1,6 +1,9 @@
 #ifndef RAY_CORE_WORKER_CORE_WORKER_H
 #define RAY_CORE_WORKER_CORE_WORKER_H
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+
 #include "ray/common/buffer.h"
 #include "ray/core_worker/actor_handle.h"
 #include "ray/core_worker/common.h"
@@ -81,11 +84,11 @@ class CoreWorker {
 
   // Add this object ID to the set of active object IDs that is sent to the raylet
   // in the heartbeat messsage.
-  void AddActiveObjectID(const ObjectID &object_id);
+  void AddActiveObjectID(const ObjectID &object_id) LOCKS_EXCLUDED(object_ref_mu_);
 
   // Remove this object ID from the set of active object IDs that is sent to the raylet
   // in the heartbeat messsage.
-  void RemoveActiveObjectID(const ObjectID &object_id);
+  void RemoveActiveObjectID(const ObjectID &object_id) LOCKS_EXCLUDED(object_ref_mu_);
 
   /* Public methods related to storing and retrieving objects. */
 
@@ -279,7 +282,7 @@ class CoreWorker {
   void RunIOService();
 
   /// Send the list of active object IDs to the raylet.
-  void ReportActiveObjectIDs();
+  void ReportActiveObjectIDs() LOCKS_EXCLUDED(object_ref_mu_);
 
   /* Private methods related to task submission. */
 
@@ -379,12 +382,19 @@ class CoreWorker {
   // Thread that runs a boost::asio service to process IO events.
   std::thread io_thread_;
 
+  /* Fields related to ref counting objects. */
+
+  /// Protects access to the set of active object ids. Since this set is updated
+  /// very frequently, it is faster to lock around accesses rather than serialize
+  /// accesses via the event loop.
+  absl::Mutex object_ref_mu_;
+
   /// Set of object IDs that are in scope in the language worker.
-  std::unordered_set<ObjectID> active_object_ids_;
+  std::unordered_set<ObjectID> active_object_ids_ GUARDED_BY(object_ref_mu_);
 
   /// Indicates whether or not the active_object_ids map has changed since the
   /// last time it was sent to the raylet.
-  bool active_object_ids_updated_ = false;
+  bool active_object_ids_updated_ GUARDED_BY(object_ref_mu_) = false;
 
   /* Fields related to storing and retrieving objects. */
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -2,6 +2,7 @@
 #define RAY_CORE_WORKER_CORE_WORKER_H
 
 #include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 
 #include "ray/common/buffer.h"
@@ -390,7 +391,7 @@ class CoreWorker {
   absl::Mutex object_ref_mu_;
 
   /// Set of object IDs that are in scope in the language worker.
-  std::unordered_set<ObjectID> active_object_ids_ GUARDED_BY(object_ref_mu_);
+  absl::flat_hash_set<ObjectID> active_object_ids_ GUARDED_BY(object_ref_mu_);
 
   /// Indicates whether or not the active_object_ids map has changed since the
   /// last time it was sent to the raylet.


### PR DESCRIPTION
- Posting to asio is fairly expensive, so use a mutex instead.
- Releasing the GIL also has some overheads.

After this change AddActiveObjectID no longer appears in profiles, e.g.:

`sudo py-spy record --duration 10 --native --output out.svg --format flamegraph --threads -F --pid <pid>`