### PR TITLE
Remove unused function definition caching

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -315,39 +315,7 @@ class FunctionActorManager(object):
             job_id = ray.JobID.nil()
         return self._num_task_executions[job_id][function_id]
 
-    def export_cached(self):
-        """Export cached remote functions
-
-        Note: this should be called only once when worker is connected.
-        """
-        for remote_function in self._functions_to_export:
-            self._do_export(remote_function)
-        self._functions_to_export = None
-        for info in self._actors_to_export:
-            (key, actor_class_info) = info
-            self._publish_actor_class_to_key(key, actor_class_info)
-
-    def reset_cache(self):
-        self._functions_to_export = []
-        self._actors_to_export = []
-
     def export(self, remote_function):
-        """Export a remote function.
-
-        Args:
-            remote_function: the RemoteFunction object.
-        """
-        if self._worker.mode is None:
-            # If the worker isn't connected, cache the function
-            # and export it later.
-            self._functions_to_export.append(remote_function)
-            return
-        if self._worker.mode == ray.worker.LOCAL_MODE:
-            # Don't need to export if the worker is not a driver.
-            return
-        self._do_export(remote_function)
-
-    def _do_export(self, remote_function):
         """Pickle a remote function and export it to redis.
 
         Args:
@@ -355,6 +323,18 @@ class FunctionActorManager(object):
         """
         if self._worker.load_code_from_local:
             return
+
+        if self._worker.mode == ray.worker.LOCAL_MODE:
+            job_id = self._worker.current_job_id
+            function_id = remote_function._function_descriptor.function_id
+            self._function_execution_info[job_id][function_id] = (
+                FunctionExecutionInfo(
+                    function=remote_function._function,
+                    function_name=remote_function._function_name,
+                    max_calls=remote_function._max_calls))
+            self._num_task_executions[job_id][function_id] = 0
+            return
+
         function = remote_function._function
         pickled_function = pickle.dumps(function)
 
@@ -585,21 +565,10 @@ class FunctionActorManager(object):
                                actor_class_info["class_name"], "actor",
                                self._worker)
 
-        if self._worker.mode is None:
-            # This means that 'ray.init()' has not been called yet and so we
-            # must cache the actor class definition and export it when
-            # 'ray.init()' is called.
-            assert self._actors_to_export is not None
-            self._actors_to_export.append((key, actor_class_info))
-            # This caching code path is currently not used because we only
-            # export actor class definitions lazily when we instantiate the
-            # actor for the first time.
-            assert False, "This should be unreachable."
-        else:
-            self._publish_actor_class_to_key(key, actor_class_info)
-            # TODO(rkn): Currently we allow actor classes to be defined
-            # within tasks. I tried to disable this, but it may be necessary
-            # because of https://github.com/ray-project/ray/issues/1146.
+        self._publish_actor_class_to_key(key, actor_class_info)
+        # TODO(rkn): Currently we allow actor classes to be defined
+        # within tasks. I tried to disable this, but it may be necessary
+        # because of https://github.com/ray-project/ray/issues/1146.
 
     def load_actor_class(self, job_id, function_descriptor):
         """Load the actor class.

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -321,18 +321,9 @@ class FunctionActorManager(object):
         Args:
             remote_function: the RemoteFunction object.
         """
-        if self._worker.load_code_from_local:
-            return
-
         if self._worker.mode == ray.worker.LOCAL_MODE:
-            job_id = self._worker.current_job_id
-            function_id = remote_function._function_descriptor.function_id
-            self._function_execution_info[job_id][function_id] = (
-                FunctionExecutionInfo(
-                    function=remote_function._function,
-                    function_name=remote_function._function_name,
-                    max_calls=remote_function._max_calls))
-            self._num_task_executions[job_id][function_id] = 0
+            return
+        if self._worker.load_code_from_local:
             return
 
         function = remote_function._function

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1550,8 +1550,6 @@ def connect(node,
         # Export cached functions_to_run.
         for function in worker.cached_functions_to_run:
             worker.run_function_on_all_workers(function)
-        # Export cached remote functions and actors to the workers.
-        worker.function_actor_manager.export_cached()
     worker.cached_functions_to_run = None
 
 
@@ -1580,7 +1578,6 @@ def disconnect(exiting_interpreter=False):
 
     worker.node = None  # Disconnect the worker from the node.
     worker.cached_functions_to_run = []
-    worker.function_actor_manager.reset_cache()
     worker.serialization_context_map.clear()
 
     # We need to destruct the core worker here because after this function,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This code is unused because we export function and actor definitions when they're first invoked (for correctness).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
