### PR TITLE
Report census view data as part of raylet node stats

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -41,7 +41,11 @@ def test_worker_stats(ray_start_regular):
             continue
 
         # Check that the rest of the processes are workers, 1 for each CPU.
+        print(reply)
         assert len(reply.workers_stats) == num_cpus + 1
+        views = [view.view_name for view in reply.view_data]
+        assert "redis_latency" in views
+        assert "local_available_resource" in views
         # Check that all processes are Python.
         pids = [worker.pid for worker in reply.workers_stats]
         processes = [

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -25,8 +25,35 @@ message WorkerStats {
   bool is_driver = 2;
 }
 
+message ViewData {
+  message Measure {
+    // A short string that describes the tags for this mesaure.
+    string tags = 1;
+
+    // Int64 type value (if present).
+    int64 int_value = 2;
+
+    // Double type value (if present).
+    double double_value = 3;
+
+    // Distribution type value (if present).
+    double distribution_min = 4;
+    double distribution_mean = 5;
+    double distribution_max = 6;
+    double distribution_count = 7;
+    repeated double distribution_bucket_boundaries = 8;
+    repeated double distribution_bucket_counts = 9;
+  }
+
+  // The name of this Census view.
+  string view_name = 1;
+  // The list of measures recorded under this view.
+  repeated Measure measures = 2;
+}
+
 message NodeStatsReply {
   repeated WorkerStats workers_stats = 1;
+  repeated ViewData view_data = 2;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -27,15 +27,13 @@ message WorkerStats {
 
 message ViewData {
   message Measure {
-    // A short string that describes the tags for this mesaure.
+    // A short string that describes the tags for this mesaure, e.g.,
+    // "Tag1:Value1,Tag2:Value2,Tag3:Value3"
     string tags = 1;
-
     // Int64 type value (if present).
     int64 int_value = 2;
-
     // Double type value (if present).
     double double_value = 3;
-
     // Distribution type value (if present).
     double distribution_min = 4;
     double distribution_mean = 5;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2537,6 +2537,21 @@ std::string NodeManager::DebugString() const {
   return result.str();
 }
 
+// Summarizes a Census view and tag values into a compact string, e.g.,
+// "Tag1:Value1,Tag2:Value2,Tag3:Value3".
+std::string compact_tag_string(const opencensus::stats::ViewDescriptor &view,
+                               const std::vector<std::string> &values) {
+  std::stringstream result;
+  const auto &keys = view.columns();
+  for (size_t i = 0; i < values.size(); i++) {
+    result << keys[i].name() << ":" << values[i];
+    if (i < values.size() - 1) {
+      result << ",";
+    }
+  }
+  return result.str();
+}
+
 void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
                                          rpc::NodeStatsReply *reply,
                                          rpc::SendReplyCallback send_reply_callback) {
@@ -2550,10 +2565,49 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
     worker_stats->set_pid(driver->Pid());
     worker_stats->set_is_driver(true);
   }
+  // Ensure we never report an empty set of metrics.
+  if (!recorded_metrics_) {
+    RecordMetrics();
+    RAY_CHECK(recorded_metrics_);
+  }
+  for (const auto &view : opencensus::stats::StatsExporter::GetViewData()) {
+    auto view_data = reply->add_view_data();
+    view_data->set_view_name(view.first.name());
+    if (view.second.type() == opencensus::stats::ViewData::Type::kInt64) {
+      for (const auto &measure : view.second.int_data()) {
+        auto measure_data = view_data->add_measures();
+        measure_data->set_tags(compact_tag_string(view.first, measure.first));
+        measure_data->set_int_value(measure.second);
+      }
+    } else if (view.second.type() == opencensus::stats::ViewData::Type::kDouble) {
+      for (const auto &measure : view.second.double_data()) {
+        auto measure_data = view_data->add_measures();
+        measure_data->set_tags(compact_tag_string(view.first, measure.first));
+        measure_data->set_double_value(measure.second);
+      }
+    } else {
+      RAY_CHECK(view.second.type() == opencensus::stats::ViewData::Type::kDistribution);
+      for (const auto &measure : view.second.distribution_data()) {
+        auto measure_data = view_data->add_measures();
+        measure_data->set_tags(compact_tag_string(view.first, measure.first));
+        measure_data->set_distribution_min(measure.second.min());
+        measure_data->set_distribution_mean(measure.second.mean());
+        measure_data->set_distribution_max(measure.second.max());
+        measure_data->set_distribution_count(measure.second.count());
+        for (const auto &bound : measure.second.bucket_boundaries().lower_boundaries()) {
+          measure_data->add_distribution_bucket_boundaries(bound);
+        }
+        for (const auto &count : measure.second.bucket_counts()) {
+          measure_data->add_distribution_bucket_counts(count);
+        }
+      }
+    }
+  }
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-void NodeManager::RecordMetrics() const {
+void NodeManager::RecordMetrics() {
+  recorded_metrics_ = true;
   if (stats::StatsConfig::instance().IsStatsDisabled()) {
     return;
   }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -103,7 +103,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   std::string DebugString() const;
 
   /// Record metrics.
-  void RecordMetrics() const;
+  void RecordMetrics();
 
   /// Get the port of the node manager rpc server.
   int GetServerPort() const { return node_manager_server_.GetPort(); }
@@ -523,6 +523,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   bool fair_queueing_enabled_;
   /// Whether we have printed out a resource deadlock warning.
   bool resource_deadlock_warned_ = false;
+  /// Whether we have recorded any metrics yet.
+  bool recorded_metrics_ = false;
   /// The path to the ray temp dir.
   std::string temp_dir_;
   /// The timer used to get profiling information from the object manager and


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This adds the Census views data from the raylet to the stats message. We summarize the tag keys and values in a compact string for convenience.

Note that when no quantity is present for a particular set of tags, it means the quantity is zero (since that is the proto default).

```
$ pytest test_metrics.py -v -s
Test session starts (platform: linux, Python 3.6.8, pytest 5.1.3, pytest-sugar 0.9.2)
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/eric/Desktop/ray/python/ray/tests/.hypothesis/examples')
rootdir: /home/eric/Desktop/ray/python
plugins: flaky-3.6.1, hypothesis-4.28.0, sugar-0.9.2
collecting ... 2019-10-31 16:36:35,185	INFO resource_spec.py:216 -- Starting Ray with 6.1 GiB memory available for workers and up to 0.15 GiB for objects. You can adjust these settings with ray.init(memory=<bytes>, object_store_memory=<bytes>).
workers_stats {
  pid: 28939
}
workers_stats {
  pid: 28890
  is_driver: true
}
view_data {
  view_name: "actor_stats"
}
view_data {
  view_name: "task_dependency_manager_stats"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_task_dependencies"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_required_objects"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_required_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_pending_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_local_objects"
  }
}
view_data {
  view_name: "reconstruction_policy_stats"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_reconstructing_tasks"
  }
}
view_data {
  view_name: "scheduling_queue_stats"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_running_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_infeasible_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_placeable_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_swap_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_waiting_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_waiting for actor creation_tasks"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_ready_tasks"
  }
}
view_data {
  view_name: "lineage_cache_stats"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_children"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_lineages"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_subscribed_tasks"
  }
}
view_data {
  view_name: "redis_latency"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,CustomKey:"
    distribution_min: 84.0
    distribution_mean: 254.9090909090909
    distribution_max: 593.0
    distribution_count: 11.0
    distribution_bucket_boundaries: 100.0
    distribution_bucket_boundaries: 200.0
    distribution_bucket_boundaries: 300.0
    distribution_bucket_boundaries: 400.0
    distribution_bucket_boundaries: 500.0
    distribution_bucket_boundaries: 600.0
    distribution_bucket_boundaries: 700.0
    distribution_bucket_boundaries: 800.0
    distribution_bucket_boundaries: 900.0
    distribution_bucket_boundaries: 1000.0
    distribution_bucket_counts: 1.0
    distribution_bucket_counts: 7.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 3.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
    distribution_bucket_counts: 0.0
  }
}
view_data {
  view_name: "local_available_resource"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:object_store_memory"
    double_value: 2.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:CPU"
    double_value: 1.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:node:192.168.1.6"
    double_value: 1.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:memory"
    double_value: 125.0
  }
}
view_data {
  view_name: "local_total_resource"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:object_store_memory"
    double_value: 2.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:CPU"
    double_value: 1.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:node:192.168.1.6"
    double_value: 1.0
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ResourceName:memory"
    double_value: 125.0
  }
}
view_data {
  view_name: "current_worker"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,Language:PYTHON,WorkerPid:28939"
    double_value: 28939.0
  }
}
view_data {
  view_name: "object_manager_stats"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_local_objects"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_active_wait_requests"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_unfulfilled_push_requests"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_profile_events"
  }
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,ValueType:num_pull_requests"
  }
}
view_data {
  view_name: "current_driver"
  measures {
    tags: "JobName:raylet,Version:0.8.0.dev6,NodeAddress:192.168.1.6,Language:PYTHON,DriverPid:"
    double_value: 28890.0
  }
}
```