### PR TITLE
Fix prometheus-cpp failure

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -105,7 +105,7 @@ def ray_deps_setup():
     # OpenCensus depends on jupp0r/prometheus-cpp
     git_repository(
         name = "com_github_jupp0r_prometheus_cpp",
-        commit = "78ac107937ee3b94f0b011f9ef0c12b912a222e7",
+        commit = "5c45ba7ddc0585d765a43d136764dd2a542bd495",
         # TODO(qwang): We should use the repository of `jupp0r` here when this PR
         # `https://github.com/jupp0r/prometheus-cpp/pull/225` getting merged.
         remote = "https://github.com/ray-project/prometheus-cpp.git",

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -103,14 +103,12 @@ def ray_deps_setup():
     )
 
     # OpenCensus depends on jupp0r/prometheus-cpp
-    http_archive(
+    git_repository(
         name = "com_github_jupp0r_prometheus_cpp",
-        strip_prefix = "prometheus-cpp-master",
-
+        commit = "78ac107937ee3b94f0b011f9ef0c12b912a222e7",
         # TODO(qwang): We should use the repository of `jupp0r` here when this PR
         # `https://github.com/jupp0r/prometheus-cpp/pull/225` getting merged.
-        urls = ["https://github.com/jovany-wang/prometheus-cpp/archive/master.zip"],
-	sha256 = "d0c773da8af3db99c543dd0413f4427d835170eddfd517bfeba104236a8d2c07",
+        remote = "https://github.com/ray-project/prometheus-cpp.git",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This fixes the following build failure on the latest master:
```
ERROR: An error occurred during the fetch of repository 'com_github_jupp0r_prometheus_cpp':
   java.io.IOException: Error downloading [https://github.com/jovany-wang/prometheus-cpp/archive/master.zip] to /home/travis/.cache/bazel/_bazel_travis/b88c129a127452fc94033a29d9f90e20/external/com_github_jupp0r_prometheus_cpp/master.zip: GET returned 404 Not Found
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
