### PR TITLE
Fix running out of file descriptors in the WebUI

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -392,7 +392,8 @@ class RayletStats(threading.Thread):
                 if node_id not in self.stubs:
                     channel = grpc.insecure_channel("{}:{}".format(
                         node["NodeManagerAddress"], node["NodeManagerPort"]))
-                    stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
+                    stub = node_manager_pb2_grpc.NodeManagerServiceStub(
+                        channel)
                     self.stubs[node_id] = stub
 
     def get_raylet_stats(self) -> Dict:

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -383,7 +383,8 @@ class RayletStats(threading.Thread):
             # First remove node connections of disconnected nodes.
             for node_id in self.stubs.keys():
                 if node_id not in node_ids:
-                    self.stubs.pop(node_id)
+                    stub = self.stubs.pop(node_id)
+                    stub.close()
 
             # Now add node connections of new nodes.
             for node in self.nodes:
@@ -403,7 +404,9 @@ class RayletStats(threading.Thread):
         while True:
             time.sleep(1.0)
             with self._raylet_stats_lock:
-                for node, stub in zip(self.nodes, self.stubs.values()):
+                for node in self.nodes:
+                    node_id = node["NodeID"]
+                    stub = self.stubs[node_id]
                     reply = stub.GetNodeStats(
                         node_manager_pb2.NodeStatsRequest())
                     self._raylet_stats[node[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

GRPC's Python library doesn't seem to close existing connections if they go out of scope, so we try to reuse the stubs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
