### PR TITLE
[Dashboard] Move gRPC calls outside of Raylet stats lock

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -404,14 +404,15 @@ class RayletStats(threading.Thread):
         counter = 0
         while True:
             time.sleep(1.0)
+            replies = {}
+            for node in self.nodes:
+                node_id = node["NodeID"]
+                stub = self.stubs[node_id]
+                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
+                replies[node["NodeManagerAddress"]] = reply
             with self._raylet_stats_lock:
-                for node in self.nodes:
-                    node_id = node["NodeID"]
-                    stub = self.stubs[node_id]
-                    reply = stub.GetNodeStats(
-                        node_manager_pb2.NodeStatsRequest())
-                    self._raylet_stats[node[
-                        "NodeManagerAddress"]] = MessageToDict(reply)
+                for address, reply in replies.items():
+                    self._raylet_stats[address] = MessageToDict(reply)
             counter += 1
             # From time to time, check if new nodes have joined the cluster
             # and update self.nodes


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This drastically speeds up the call to the `/raylet_stats` endpoint (4000 ms --> 2 ms) by moving the gRPC calls for fetching the data outside of the Raylet stats lock. It is instead only necessary to lock the portion of the runner method where the stats are actually getting replaced.

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
