### PR TITLE
[tune] Stopgap for ray.get with timeout

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -642,6 +642,7 @@ class RayTrialExecutor(TrialExecutor):
             logger.exception(
                 "Trial %s: runner task timed out; restoration failed.", trial)
             self.set_status(trial, Trial.ERROR)
+            return False
         except Exception:
             logger.exception("Trial %s: Error restoring runner", trial)
             self.set_status(trial, Trial.ERROR)


### PR DESCRIPTION
## Why are these changes needed?

Reduce probability of slow `ray.get` from occurring during worker failures by waiting with a timeout first. If a failure occurs during the wait that's okay because we timeout. Failures can still occur during `ray.get` but presumably less time is spent on that call so it will be less likely to happen.

This should be replaced by something like `ray.get(obj_id, timeout=timeout)`. 

Note: we don't replace the calls for checkpoint save/restore since those calls take unbounded time.

- [ ] Add test

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
