### PR TITLE
Microbenchmark for inter-node object transfer

### DIFF
--- a/python/ray/ray_cluster_perf.py
+++ b/python/ray/ray_cluster_perf.py
@@ -9,7 +9,6 @@ import ray
 from ray.tests.cluster_utils import Cluster
 
 def main():
-    print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
     cluster = Cluster(initialize_head=True, connect=True, head_node_args={"object_store_memory":20*1024*1024*1024, "num_cpus":16})
     client_node = cluster.add_node(object_store_memory=20*1024*1024*1024, num_gpus=1, num_cpus=16)
 

--- a/python/ray/ray_cluster_perf.py
+++ b/python/ray/ray_cluster_perf.py
@@ -8,9 +8,6 @@ import ray
 
 from ray.tests.cluster_utils import Cluster
 
-# Only run tests matching this filter pattern.
-filter_pattern = os.environ.get("TESTS_TO_RUN", "")
-
 def main():
     print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
     cluster = Cluster(initialize_head=True, connect=True, head_node_args={"object_store_memory":20*1024*1024*1024, "num_cpus":16})
@@ -32,7 +29,6 @@ def main():
             time.sleep(1)
         return np.mean(diffs), np.std(diffs)
 
-    time.sleep(20)
     time_diff, time_diff_std = ray.get(f.remote(object_id_list))
 
     print ("latency to get an 1G object over network", round(time_diff, 2), "+-", round(time_diff_std, 2))

--- a/python/ray/ray_cluster_perf.py
+++ b/python/ray/ray_cluster_perf.py
@@ -1,0 +1,44 @@
+"""This is the script for `ray clusterbenchmark`."""
+
+import os
+import time
+import numpy as np
+import multiprocessing
+import ray
+
+from ray.tests.cluster_utils import Cluster
+
+# Only run tests matching this filter pattern.
+filter_pattern = os.environ.get("TESTS_TO_RUN", "")
+
+def main():
+    print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
+    cluster = Cluster(initialize_head=True, connect=True, head_node_args={"object_store_memory":20*1024*1024*1024, "num_cpus":16})
+    client_node = cluster.add_node(object_store_memory=20*1024*1024*1024, num_gpus=1, num_cpus=16)
+
+    object_id_list = []
+    for i in range(0,10):
+        object_id = ray.put(np.random.rand(1024*128, 1024))
+        object_id_list.append(object_id)
+
+    @ray.remote(num_gpus=1)
+    def f(object_id_list):
+        diffs = []
+        for object_id in object_id_list:
+            before = time.time()
+            x = ray.get(object_id)
+            after = time.time()
+            diffs.append(after - before)
+            time.sleep(1)
+        return np.mean(diffs), np.std(diffs)
+
+    time.sleep(20)
+    time_diff, time_diff_std = ray.get(f.remote(object_id_list))
+
+    print ("latency to get an 1G object over network", round(time_diff, 2), "+-", round(time_diff_std, 2))
+
+    ray.shutdown()
+    cluster.shutdown()
+
+if __name__ == "__main__":
+    main()

--- a/python/ray/ray_cluster_perf.py
+++ b/python/ray/ray_cluster_perf.py
@@ -1,20 +1,26 @@
 """This is the script for `ray clusterbenchmark`."""
 
-import os
 import time
 import numpy as np
-import multiprocessing
 import ray
 
 from ray.tests.cluster_utils import Cluster
 
+
 def main():
-    cluster = Cluster(initialize_head=True, connect=True, head_node_args={"object_store_memory":20*1024*1024*1024, "num_cpus":16})
-    client_node = cluster.add_node(object_store_memory=20*1024*1024*1024, num_gpus=1, num_cpus=16)
+    cluster = Cluster(
+        initialize_head=True,
+        connect=True,
+        head_node_args={
+            "object_store_memory": 20 * 1024 * 1024 * 1024,
+            "num_cpus": 16
+        })
+    cluster.add_node(
+        object_store_memory=20 * 1024 * 1024 * 1024, num_gpus=1, num_cpus=16)
 
     object_id_list = []
-    for i in range(0,10):
-        object_id = ray.put(np.random.rand(1024*128, 1024))
+    for i in range(0, 10):
+        object_id = ray.put(np.random.rand(1024 * 128, 1024))
         object_id_list.append(object_id)
 
     @ray.remote(num_gpus=1)
@@ -22,7 +28,7 @@ def main():
         diffs = []
         for object_id in object_id_list:
             before = time.time()
-            x = ray.get(object_id)
+            ray.get(object_id)
             after = time.time()
             diffs.append(after - before)
             time.sleep(1)
@@ -30,10 +36,12 @@ def main():
 
     time_diff, time_diff_std = ray.get(f.remote(object_id_list))
 
-    print ("latency to get an 1G object over network", round(time_diff, 2), "+-", round(time_diff_std, 2))
+    print("latency to get an 1G object over network", round(time_diff, 2),
+          "+-", round(time_diff_std, 2))
 
     ray.shutdown()
     cluster.shutdown()
+
 
 if __name__ == "__main__":
     main()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -787,10 +787,12 @@ def microbenchmark():
     from ray.ray_perf import main
     main()
 
+
 @cli.command()
 def clusterbenchmark():
     from ray.ray_cluster_perf import main
     main()
+
 
 @cli.command()
 @click.option(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -787,6 +787,10 @@ def microbenchmark():
     from ray.ray_perf import main
     main()
 
+@cli.command()
+def clusterbenchmark():
+    from ray.ray_cluster_perf import main
+    main()
 
 @cli.command()
 @click.option(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This pull request adds a microbenchmark to "ray microbenchmark" for object transfer on an emulated multi-node ray cluster.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
