### PR TITLE
Add timeout param to ray.get

### DIFF
--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -40,7 +40,7 @@ Ray enables arbitrary Python functions to be executed asynchronously. These asyn
     def remote_function():
         return 1
 
-This causes a few things changes in behavior:
+This causes a few changes in behavior:
 
     1. **Invocation:** The regular version is called with ``regular_function()``, whereas the remote version is called with ``remote_function.remote()``.
     2. **Return values:** ``regular_function`` immediately executes and returns ``1``, whereas ``remote_function`` immediately returns an object ID (a future) and then creates a task that will be executed on a worker process. The result can be retrieved with ``ray.get``.
@@ -145,7 +145,7 @@ Below are more examples of resource specifications:
   def f():
       return 1
 
-Further, remote function can return multiple object IDs.
+Further, remote functions can return multiple object IDs.
 
 .. code-block:: python
 
@@ -188,7 +188,7 @@ Object IDs can be created in multiple ways.
 Fetching Results
 ----------------
 
-The command ``ray.get(x_id)`` takes an object ID and creates a Python object
+The command ``ray.get(x_id, timeout=None)`` takes an object ID and creates a Python object
 from the corresponding remote object. First, if the current node's object store
 does not contain the object, the object is downloaded. Then, if the object is a `numpy array <https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html>`__
 or a collection of numpy arrays, the ``get`` call is zero-copy and returns arrays backed by shared object store memory.
@@ -199,6 +199,22 @@ Otherwise, we deserialize the object data into a Python object.
     y = 1
     obj_id = ray.put(y)
     assert ray.get(obj_id) == 1
+
+You can also set a timeout to return early from a ``get`` that's blocking for too long.
+
+.. code-block:: python
+
+    from ray.exceptions import RayTimeoutException
+
+    @ray.remote
+    def long_running_function()
+        time.sleep(8)
+
+    obj_id = long_running_function.remote()
+    try:
+        ray.get(obj_id, timeout=4)
+    except RayTimeoutError:
+        print("`get` timed out.")
 
 .. autofunction:: ray.get
     :noindex:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -84,7 +84,8 @@ from ray.exceptions import (
     RayError,
     RayletError,
     RayTaskError,
-    ObjectStoreFullError
+    ObjectStoreFullError,
+    RayTimeoutError,
 )
 from ray.experimental.no_return import NoReturn
 from ray.function_manager import FunctionDescriptor
@@ -138,6 +139,8 @@ cdef int check_status(const CRayStatus& status) nogil except -1:
         raise ObjectStoreFullError(message)
     elif status.IsInterrupted():
         raise KeyboardInterrupt()
+    elif status.IsTimedOut():
+        raise RayTimeoutError(message)
     else:
         raise RayletError(message)
 

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -161,6 +161,11 @@ class UnreconstructableError(RayError):
                 "https://ray.readthedocs.io/en/latest/memory-management.html"))
 
 
+class RayTimeoutError(RayError):
+    """Indicates that a call to the worker timed out."""
+    pass
+
+
 RAY_EXCEPTION_TYPES = [
     RayError,
     RayTaskError,
@@ -168,4 +173,5 @@ RAY_EXCEPTION_TYPES = [
     RayActorError,
     ObjectStoreFullError,
     UnreconstructableError,
+    RayTimeoutError,
 ]

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -74,6 +74,9 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         CRayStatus RedisError(const c_string &msg)
 
         @staticmethod
+        CRayStatus TimedOut(const c_string &msg)
+
+        @staticmethod
         CRayStatus Interrupted(const c_string &msg)
 
         @staticmethod
@@ -89,7 +92,9 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         c_bool IsNotImplemented()
         c_bool IsObjectStoreFull()
         c_bool IsRedisError()
+        c_bool IsTimedOut()
         c_bool IsInterrupted()
+        c_bool IsSystemExit()
 
         c_string ToString()
         c_string CodeAsString()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -291,7 +291,7 @@ class Worker(object):
         return context.deserialize_objects(data_metadata_pairs, object_ids,
                                            error_timeout)
 
-    def get_objects(self, object_ids):
+    def get_objects(self, object_ids, timeout=None):
         """Get the values in the object store associated with the IDs.
 
         Return the values from the local object store for object_ids. This will
@@ -301,6 +301,8 @@ class Worker(object):
         Args:
             object_ids (List[object_id.ObjectID]): A list of the object IDs
                 whose values should be retrieved.
+            timeout (float): timeout (float): The maximum amount of time in
+                seconds to wait before returning.
 
         Raises:
             Exception if running in LOCAL_MODE and any of the object IDs do not
@@ -314,10 +316,14 @@ class Worker(object):
                     "which is not an ray.ObjectID.".format(object_id))
 
         if self.mode == LOCAL_MODE:
+            if timeout is not None:
+                raise ValueError(
+                    "`get` must be called with timeout=None in local mode.")
             return self.local_mode_manager.get_objects(object_ids)
 
+        timeout_ms = int(timeout * 1000) if timeout else -1
         data_metadata_pairs = self.core_worker.get_objects(
-            object_ids, self.current_task_id)
+            object_ids, self.current_task_id, timeout_ms)
         return self.deserialize_objects(data_metadata_pairs, object_ids)
 
     def run_function_on_all_workers(self, function,
@@ -1393,7 +1399,7 @@ def register_custom_serializer(cls,
         class_id=class_id)
 
 
-def get(object_ids):
+def get(object_ids, timeout=None):
     """Get a remote object or a list of remote objects from the object store.
 
     This method blocks until the object corresponding to the object ID is
@@ -1405,11 +1411,15 @@ def get(object_ids):
     Args:
         object_ids: Object ID of the object to get or a list of object IDs to
             get.
+        timeout (float): The maximum amount of time in seconds to wait before
+            returning.
 
     Returns:
         A Python object or a list of Python objects.
 
     Raises:
+        RayTimeoutError: A RayTimeoutError is raised if a timeout is set and
+            the get takes longer than timeout to return.
         Exception: An exception is raised if the task that created the object
             or that created one of the objects raised an exception.
     """
@@ -1425,7 +1435,7 @@ def get(object_ids):
                              "or a list of object IDs.")
 
         global last_task_error_raise_time
-        values = worker.get_objects(object_ids)
+        values = worker.get_objects(object_ids, timeout=timeout)
         for i, value in enumerate(values):
             if isinstance(value, RayError):
                 last_task_error_raise_time = time.time()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -316,6 +316,7 @@ class Worker(object):
                     "which is not an ray.ObjectID.".format(object_id))
 
         if self.mode == LOCAL_MODE:
+            # TODO(ujvl): Remove check when local mode moved to core worker.
             if timeout is not None:
                 raise ValueError(
                     "`get` must be called with timeout=None in local mode.")
@@ -1435,6 +1436,7 @@ def get(object_ids, timeout=None):
                              "or a list of object IDs.")
 
         global last_task_error_raise_time
+        # TODO(ujvl): Consider how to allow user to retrieve the ready objects.
         values = worker.get_objects(object_ids, timeout=timeout)
         for i, value in enumerate(values):
             if isinstance(value, RayError):

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -74,6 +74,9 @@ std::string Status::CodeAsString() const {
   case StatusCode::RedisError:
     type = "RedisError";
     break;
+  case StatusCode::TimedOut:
+    type = "TimedOut";
+    break;
   case StatusCode::Interrupted:
     type = "Interrupted";
     break;

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -79,8 +79,9 @@ enum class StatusCode : char {
   UnknownError = 9,
   NotImplemented = 10,
   RedisError = 11,
-  Interrupted = 12,
-  SystemExit = 13,
+  TimedOut = 12,
+  Interrupted = 13,
+  SystemExit = 14,
 };
 
 #if defined(__clang__)
@@ -144,6 +145,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::RedisError, msg);
   }
 
+  static Status TimedOut(const std::string &msg) {
+    return Status(StatusCode::TimedOut, msg);
+  }
+
   static Status Interrupted(const std::string &msg) {
     return Status(StatusCode::Interrupted, msg);
   }
@@ -165,6 +170,7 @@ class RAY_EXPORT Status {
   bool IsUnknownError() const { return code() == StatusCode::UnknownError; }
   bool IsNotImplemented() const { return code() == StatusCode::NotImplemented; }
   bool IsRedisError() const { return code() == StatusCode::RedisError; }
+  bool IsTimedOut() const { return code() == StatusCode::TimedOut; }
   bool IsInterrupted() const { return code() == StatusCode::Interrupted; }
   bool IsSystemExit() const { return code() == StatusCode::SystemExit; }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -223,7 +223,9 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
   }
 
   // Wait for remaining objects (or timeout).
-  get_request->Wait(timeout_ms);
+  if (!get_request->Wait(timeout_ms)) {
+    return Status::TimedOut("Get timed out: object(s) not ready.");
+  }
 
   {
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -223,9 +223,7 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
   }
 
   // Wait for remaining objects (or timeout).
-  if (!get_request->Wait(timeout_ms)) {
-    return Status::TimedOut("Get timed out: object(s) not ready.");
-  }
+  bool done = get_request->Wait(timeout_ms);
 
   {
     absl::MutexLock lock(&mu_);
@@ -255,7 +253,11 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
     }
   }
 
-  return Status::OK();
+  if (done) {
+    return Status::OK();
+  } else {
+    return Status::TimedOut("Get timed out: some object(s) not ready.");
+  }
 }
 
 void CoreWorkerMemoryStore::Delete(const std::vector<ObjectID> &object_ids) {

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -56,7 +56,7 @@ Status CoreWorkerMemoryStoreProvider::Wait(
   std::vector<std::shared_ptr<RayObject>> result_objects;
   RAY_CHECK(object_ids.size() == id_vector.size());
   auto status = store_->Get(id_vector, num_objects, timeout_ms, false, &result_objects);
-  // Absorb TimedOut statuses.
+  // Ignore TimedOut statuses since we return ready objects explicitly.
   if (!status.IsTimedOut()) {
     RAY_RETURN_NOT_OK(status);
   }

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -55,8 +55,11 @@ Status CoreWorkerMemoryStoreProvider::Wait(
   std::vector<ObjectID> id_vector(object_ids.begin(), object_ids.end());
   std::vector<std::shared_ptr<RayObject>> result_objects;
   RAY_CHECK(object_ids.size() == id_vector.size());
-  RAY_RETURN_NOT_OK(
-      store_->Get(id_vector, num_objects, timeout_ms, false, &result_objects));
+  auto status = store_->Get(id_vector, num_objects, timeout_ms, false, &result_objects);
+  // Absorb TimedOut statuses.
+  if (!status.IsTimedOut()) {
+    RAY_RETURN_NOT_OK(status);
+  }
 
   for (size_t i = 0; i < id_vector.size(); i++) {
     if (result_objects[i] != nullptr) {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -197,7 +197,7 @@ Status CoreWorkerPlasmaStoreProvider::Get(
 
   if (!remaining.empty() && timed_out) {
     RAY_RETURN_NOT_OK(raylet_client_->NotifyUnblocked(task_id));
-    return Status::TimedOut("Get timed out: object(s) not ready.");
+    return Status::TimedOut("Get timed out: some object(s) not ready.");
   }
 
   // Notify unblocked because we blocked when calling FetchOrReconstruct with

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -33,6 +33,7 @@ Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
                            &data));
   // data could be a nullptr if the ObjectID already existed, but this does
   // not throw an error.
+
   if (data != nullptr) {
     if (object.HasData()) {
       memcpy(data->Data(), object.GetData()->Data(), object.GetData()->Size());
@@ -172,6 +173,9 @@ Status CoreWorkerPlasmaStoreProvider::Get(
       batch_timeout = std::min(remaining_timeout, batch_timeout);
       remaining_timeout -= batch_timeout;
       should_break = remaining_timeout <= 0;
+    } else if (timeout_ms > 0) {
+      RAY_RETURN_NOT_OK(raylet_client_->NotifyUnblocked(task_id));
+      return Status::TimedOut("Get timed out: object(s) not ready.");
     }
 
     size_t previous_size = remaining.size();

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -33,7 +33,6 @@ Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
                            &data));
   // data could be a nullptr if the ObjectID already existed, but this does
   // not throw an error.
-
   if (data != nullptr) {
     if (object.HasData()) {
       memcpy(data->Data(), object.GetData()->Data(), object.GetData()->Size());
@@ -157,6 +156,7 @@ Status CoreWorkerPlasmaStoreProvider::Get(
   // objects are all fetched if timeout is -1.
   int unsuccessful_attempts = 0;
   bool should_break = false;
+  bool timed_out = false;
   int64_t remaining_timeout = timeout_ms;
   while (!remaining.empty() && !should_break) {
     batch_ids.clear();
@@ -172,17 +172,14 @@ Status CoreWorkerPlasmaStoreProvider::Get(
     if (remaining_timeout >= 0) {
       batch_timeout = std::min(remaining_timeout, batch_timeout);
       remaining_timeout -= batch_timeout;
-      should_break = remaining_timeout <= 0;
-    } else if (timeout_ms > 0) {
-      RAY_RETURN_NOT_OK(raylet_client_->NotifyUnblocked(task_id));
-      return Status::TimedOut("Get timed out: object(s) not ready.");
+      timed_out = remaining_timeout <= 0;
     }
 
     size_t previous_size = remaining.size();
     RAY_RETURN_NOT_OK(FetchAndGetFromPlasmaStore(remaining, batch_ids, batch_timeout,
                                                  /*fetch_only=*/false, task_id, results,
                                                  got_exception));
-    should_break = should_break || *got_exception;
+    should_break = timed_out || *got_exception;
 
     if ((previous_size - remaining.size()) < batch_ids.size()) {
       unsuccessful_attempts++;
@@ -196,6 +193,11 @@ Status CoreWorkerPlasmaStoreProvider::Get(
         return status;
       }
     }
+  }
+
+  if (!remaining.empty() && timed_out) {
+    RAY_RETURN_NOT_OK(raylet_client_->NotifyUnblocked(task_id));
+    return Status::TimedOut("Get timed out: object(s) not ready.");
   }
 
   // Notify unblocked because we blocked when calling FetchOrReconstruct with

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -683,7 +683,8 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   RAY_CHECK_OK(provider.Delete(ids_set));
 
   usleep(200 * 1000);
-  ASSERT_TRUE(provider.Get(ids_set, 0, RandomTaskId(), &results, &got_exception).IsTimedOut());
+  ASSERT_TRUE(
+      provider.Get(ids_set, 0, RandomTaskId(), &results, &got_exception).IsTimedOut());
   ASSERT_TRUE(!got_exception);
   ASSERT_EQ(results.size(), 0);
 

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -683,7 +683,7 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   RAY_CHECK_OK(provider.Delete(ids_set));
 
   usleep(200 * 1000);
-  RAY_CHECK_OK(provider.Get(ids_set, 0, RandomTaskId(), &results, &got_exception));
+  ASSERT_TRUE(provider.Get(ids_set, 0, RandomTaskId(), &results, &got_exception).IsTimedOut());
   ASSERT_TRUE(!got_exception);
   ASSERT_EQ(results.size(), 0);
 
@@ -811,7 +811,7 @@ TEST_F(SingleNodeTest, TestObjectInterface) {
   // wait for objects being deleted, so wait a while for plasma store
   // to process the command.
   usleep(200 * 1000);
-  RAY_CHECK_OK(core_worker.Get(ids, 0, &results));
+  ASSERT_TRUE(core_worker.Get(ids, 0, &results).IsTimedOut());
   ASSERT_EQ(results.size(), 2);
   ASSERT_TRUE(!results[0]);
   ASSERT_TRUE(!results[1]);
@@ -872,12 +872,12 @@ TEST_F(TwoNodeTest, TestObjectInterfaceCrossNodes) {
   // to process the command.
   usleep(1000 * 1000);
   // Verify objects are deleted from both machines.
-  RAY_CHECK_OK(worker2.Get(ids, 0, &results));
+  ASSERT_TRUE(worker2.Get(ids, 0, &results).IsTimedOut());
   ASSERT_EQ(results.size(), 2);
   ASSERT_TRUE(!results[0]);
   ASSERT_TRUE(!results[1]);
 
-  RAY_CHECK_OK(worker1.Get(ids, 0, &results));
+  ASSERT_TRUE(worker1.Get(ids, 0, &results).IsTimedOut());
   ASSERT_EQ(results.size(), 2);
   ASSERT_TRUE(!results[0]);
   ASSERT_TRUE(!results[1]);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Exposes `timeout` in `ray.get`, which is already a parameter in `CoreWorker::get_objects`. Changes the behavior so that we raise an exception if the get times out.

Motivation: bounding recovery time in Tune in the case of a failure occurring during a `ray.get`, without depending on the internal task lease expiry time. See #6097 

- [x] add tests 

Example:
```
import ray, time
from ray.exceptions import RayTimeoutError

ray.init()

@ray.remote
def f(a):
    time.sleep(a)
    return a

try:
    obj_id = f.remote(3)
    print(ray.get(obj_id, timeout=2))
except RayTimeoutError:
    print(ray.get(obj_id, timeout=2))
```

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
