### PR TITLE
Improve flaky test_warning_monitor_died

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -491,11 +491,11 @@ def test_version_mismatch(shutdown_only):
 
 
 def test_warning_monitor_died(ray_start_2_cpus):
-    # Wait for the monitor process to start.
     @ray.remote
     def f():
         pass
 
+    # Wait for the monitor process to start.
     ray.get(f.remote())
     time.sleep(1)
 

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -490,13 +490,17 @@ def test_version_mismatch(shutdown_only):
     ray.__version__ = ray_version
 
 
-def test_warning_monitor_died(shutdown_only):
-    ray.init(num_cpus=0)
+def test_warning_monitor_died(ray_start_2_cpus):
+    # Wait for the monitor process to start.
+    @ray.remote
+    def f():
+        pass
 
-    time.sleep(1)  # Make sure the monitor has started.
+    ray.get(f.remote())
+    time.sleep(1)
 
     # Cause the monitor to raise an exception by pushing a malformed message to
-    # Redis. This will probably kill the raylets and the raylet_monitor in
+    # Redis. This will probably kill the raylet and the raylet_monitor in
     # addition to the monitor.
     fake_id = 20 * b"\x00"
     malformed_message = "asdf"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
