### PR TITLE
[autoscaler] Retry creating EC2 instances in new AZ

### DIFF
--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -147,6 +147,8 @@ REPORTER_UPDATE_INTERVAL_MS = env_integer("REPORTER_UPDATE_INTERVAL_MS", 500)
 
 # Max number of retries to AWS (default is 5, time increases exponentially)
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 12)
+# Max number of retries to create an EC2 node (retry different subnet)
+BOTO_CREATE_MAX_RETRIES = env_integer("BOTO_CREATE_MAX_RETRIES", 5)
 
 LOGGER_FORMAT = (
     "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR causes calls to create EC2 nodes to fail fast if they cannot be fulfilled, allowing Ray to intelligently retry the EC2 call in a different availability zone.

When requesting the creation of an EC2 node, AWS may be unable to satisfy the instance request due to limited capacity. This problem is particularly common with spot instance requests, but can rarely happen for on-demand instances. 

Ray already has logic to retry round-robin in different availability zones. However, Ray can only do this when the `boto` API call fails. `boto` will silently retry the API call up to `BOTO_MAX_RETRIES`. Currently, this is set to `12`, which given the exponential backoff causes node creation to block for `>30` minutes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

This is related to https://github.com/ray-project/ray/issues/2138 and https://github.com/ray-project/ray/issues/2177 which despite closed were only partially resolved.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
