### PR TITLE
Scheduling ids

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -218,8 +218,8 @@ cc_library(
         ":ray_util",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
-        "@plasma//:plasma_client",
         "@com_google_googletest//:gtest",
+        "@plasma//:plasma_client",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -425,6 +425,16 @@ cc_test(
 )
 
 cc_test(
+    name = "scheduling_test",
+    srcs = ["src/ray/common/scheduling/scheduling_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":ray_common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "lineage_cache_test",
     srcs = ["src/ray/raylet/lineage_cache_test.cc"],
     copts = COPTS,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -219,6 +219,7 @@ cc_library(
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
         "@plasma//:plasma_client",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -2,8 +2,12 @@
 using namespace std;
 
 int64_t StringIdMap::get(const string sid) {
-  if (string_to_int_.count(sid) == 0) return -1;
-  return string_to_int_[sid];
+  auto it = string_to_int_.find(sid);
+  if (it == string_to_int_.end()) {
+    return -1;
+  } else {
+    return it->second;
+  }
 };
 
 int64_t StringIdMap::insert(const string sid, bool test) {

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -1,14 +1,15 @@
 #include "scheduling_ids.h"
+using namespace std;
 
 int64_t ScheduleIds::getIdByInt(string sid) {
   if (string_to_int.count(sid) == 0) return 0;
   return string_to_int[sid];
 };
 
-int64_t ScheduleIds::insertIdByString(string sid) {
+int64_t ScheduleIds::insertIdByString(string sid, bool test) {
   auto sit = string_to_int.find(sid);
   if (sit == string_to_int.end()) {
-    int64_t id = hasher(sid);
+    int64_t id = test ? hasher(sid) % 5 : hasher(sid);
     for (int i = 0; true; i++) {
       auto it = int_to_string.find(id);
       if (it == int_to_string.end()) {
@@ -17,7 +18,7 @@ int64_t ScheduleIds::insertIdByString(string sid) {
         int_to_string.insert(make_pair(id, sid));
         break;
       }
-      id = hasher(sid + to_string(i));
+      id = test ? hasher(sid + to_string(i)) % 5 : hasher(sid + to_string(i));
     }
     return id;
   } else {

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -1,30 +1,31 @@
 #include "scheduling_ids.h"
 
-int64_t ScheduleIds::getIntId(string sid) {
+int64_t ScheduleIds::getIdByInt(string sid) {
   if (string_to_int.count(sid) == 0) return 0;
   return string_to_int[sid];
 };
 
-int64_t ScheduleIds::insertStringId(string sid) {
-  for (int i = 0; true; i++) {
-    uint64_t id;
-    if (i == 0) {
-      // There is a hash collision.
-      id = hasher(sid);
-    } else {
+int64_t ScheduleIds::insertIdByString(string sid) {
+  auto sit = string_to_int.find(sid);
+  if (sit == string_to_int.end()) {
+    int64_t id = hasher(sid);
+    for (int i = 0; true; i++) {
+      auto it = int_to_string.find(id);
+      if (it == int_to_string.end()) {
+        /// No hash collision, so associated sid with id.
+        string_to_int.insert(make_pair(sid, id));
+        int_to_string.insert(make_pair(id, sid));
+        break;
+      }
       id = hasher(sid + to_string(i));
     }
-    auto it = int_to_string.find(id);
-    if (it == int_to_string.end())  {
-      /// No hash collision, so associated sid with id.
-      string_to_int.insert(make_pair(sid, id));
-      int_to_string.insert(make_pair(id, sid));
-      return id;
-    }
+    return id;
+  } else {
+    return sit->second;
   }
 };
 
-void ScheduleIds::removeStringId(string sid) {
+void ScheduleIds::removeIdByString(string sid) {
   auto sit = string_to_int.find(sid);
   if (sit != string_to_int.end()) {
     uint64_t id = string_to_int[sid];
@@ -34,7 +35,7 @@ void ScheduleIds::removeStringId(string sid) {
   }
 };
 
-void ScheduleIds::removeIntId(int64_t id) {
+void ScheduleIds::removeIdByInt(int64_t id) {
   auto it = int_to_string.find(id);
   if (it != int_to_string.end()) {
     string sid = int_to_string[id];

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -1,24 +1,24 @@
 #include "scheduling_ids.h"
 using namespace std;
 
-int64_t ScheduleIds::getIdByInt(string sid) {
-  if (string_to_int.count(sid) == 0) return 0;
-  return string_to_int[sid];
+int64_t StringIdMap::get(const string sid) {
+  if (string_to_int_.count(sid) == 0) return -1;
+  return string_to_int_[sid];
 };
 
-int64_t ScheduleIds::insertIdByString(string sid, bool test) {
-  auto sit = string_to_int.find(sid);
-  if (sit == string_to_int.end()) {
-    int64_t id = test ? hasher(sid) % 5 : hasher(sid);
+int64_t StringIdMap::insert(const string sid, bool test) {
+  auto sit = string_to_int_.find(sid);
+  if (sit == string_to_int_.end()) {
+    int64_t id = test ? hasher_(sid) % 10 : hasher_(sid);
     for (int i = 0; true; i++) {
-      auto it = int_to_string.find(id);
-      if (it == int_to_string.end()) {
+      auto it = int_to_string_.find(id);
+      if (it == int_to_string_.end()) {
         /// No hash collision, so associated sid with id.
-        string_to_int.insert(make_pair(sid, id));
-        int_to_string.insert(make_pair(id, sid));
+        string_to_int_.insert(make_pair(sid, id));
+        int_to_string_.insert(make_pair(id, sid));
         break;
       }
-      id = test ? hasher(sid + to_string(i)) % 5 : hasher(sid + to_string(i));
+      id = test ? hasher_(sid + to_string(i)) % 10 : hasher_(sid + to_string(i));
     }
     return id;
   } else {
@@ -26,26 +26,26 @@ int64_t ScheduleIds::insertIdByString(string sid, bool test) {
   }
 };
 
-void ScheduleIds::removeIdByString(string sid) {
-  auto sit = string_to_int.find(sid);
-  if (sit != string_to_int.end()) {
-    uint64_t id = string_to_int[sid];
-    string_to_int.erase(sit);
-    auto it = int_to_string.find(id);
-    int_to_string.erase(it);
+void StringIdMap::remove(const string sid) {
+  auto sit = string_to_int_.find(sid);
+  if (sit != string_to_int_.end()) {
+    uint64_t id = string_to_int_[sid];
+    string_to_int_.erase(sit);
+    auto it = int_to_string_.find(id);
+    int_to_string_.erase(it);
   }
 };
 
-void ScheduleIds::removeIdByInt(int64_t id) {
-  auto it = int_to_string.find(id);
-  if (it != int_to_string.end()) {
-    string sid = int_to_string[id];
-    int_to_string.erase(it);
-    auto sit = string_to_int.find(sid);
-    string_to_int.erase(sit);
+void StringIdMap::remove(int64_t id) {
+  auto it = int_to_string_.find(id);
+  if (it != int_to_string_.end()) {
+    string sid = int_to_string_[id];
+    int_to_string_.erase(it);
+    auto sit = string_to_int_.find(sid);
+    string_to_int_.erase(sit);
   }
 };
 
-int64_t ScheduleIds::count() {
-  return string_to_int.size();
+int64_t StringIdMap::count() {
+  return string_to_int_.size();
 }

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -50,6 +50,4 @@ void StringIdMap::remove(int64_t id) {
   }
 };
 
-int64_t StringIdMap::count() {
-  return string_to_int_.size();
-}
+int64_t StringIdMap::count() { return string_to_int_.size(); }

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -1,0 +1,49 @@
+#include "scheduling_ids.h"
+
+int64_t ScheduleIds::getIntId(string sid) {
+  if (string_to_int.count(sid) == 0) return 0;
+  return string_to_int[sid];
+};
+
+int64_t ScheduleIds::insertStringId(string sid) {
+  for (int i = 0; true; i++) {
+    uint64_t id;
+    if (i == 0) {
+      // There is a hash collision.
+      id = hasher(sid);
+    } else {
+      id = hasher(sid + to_string(i));
+    }
+    auto it = int_to_string.find(id);
+    if (it == int_to_string.end())  {
+      /// No hash collision, so associated sid with id.
+      string_to_int.insert(make_pair(sid, id));
+      int_to_string.insert(make_pair(id, sid));
+      return id;
+    }
+  }
+};
+
+void ScheduleIds::removeStringId(string sid) {
+  auto sit = string_to_int.find(sid);
+  if (sit != string_to_int.end()) {
+    uint64_t id = string_to_int[sid];
+    string_to_int.erase(sit);
+    auto it = int_to_string.find(id);
+    int_to_string.erase(it);
+  }
+};
+
+void ScheduleIds::removeIntId(int64_t id) {
+  auto it = int_to_string.find(id);
+  if (it != int_to_string.end()) {
+    string sid = int_to_string[id];
+    int_to_string.erase(it);
+    auto sit = string_to_int.find(sid);
+    string_to_int.erase(sit);
+  }
+};
+
+int64_t ScheduleIds::count() {
+  return string_to_int.size();
+}

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -3,43 +3,43 @@
 
 #include <unordered_map>
 #include <string>
-#include <iterator>
-#include <stdlib.h>
 #include <gtest/gtest_prod.h>
 
 /// Class to map string IDs to unique integer IDs and back.
-class ScheduleIds {
-  std::unordered_map<string, int64_t> string_to_int;
-  std::unordered_map<int64_t, string> int_to_string;
-  std::hash<string> hasher;
+class StringIdMap {
+  std::unordered_map<std::string, int64_t> string_to_int_;
+  std::unordered_map<int64_t, std::string> int_to_string_;
+  std::hash<std::string> hasher_;
 
   FRIEND_TEST(SchedulingTest, SchedulingIdTest);
 
 public:
-  ScheduleIds() {};
-  ~ScheduleIds() {};
+  StringIdMap() {};
+  ~StringIdMap() {};
 
   /// Get integer ID associated with an existing string ID.
   ///
   /// \param String ID.
   /// \return The integer ID associated with the given string ID.
-  int64_t getIdByInt(string sid);
+  int64_t get(const std::string sid);
 
   /// Insert a string ID and get the associated integer ID.
   ///
   /// \param String ID to be inserted.
+  /// \param test: if "true" it specifies that the range of
+  ///        IDs is limited to 0..10 for testing purposes.
   /// \return The integer ID associated with string ID sid.
-  int64_t insertIdByString(string sid, bool test = false);
+  int64_t insert(const std::string sid, bool test = false);
 
   /// Delete an ID identified by its string format.
   ///
   /// \param ID to be deleted.
-  void removeIdByString(string sid);
+  void remove(const std::string sid);
 
   /// Delete an ID identified by its integer format.
   ///
   /// \param ID to be deleted.
-  void removeIdByInt(int64_t id);
+  void remove(int64_t id);
 
   /// Get number of identifiers.
   int64_t count();

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -1,0 +1,51 @@
+#ifndef RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
+#define RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
+
+#include <iostream>
+#include <map>
+#include <unordered_map>
+#include <string>
+#include <iterator>
+#include <stdlib.h>
+#include <chrono>
+#include <vector>
+using namespace std;
+
+/// Class to map string IDs to unique inntegre IDs and back.
+class ScheduleIds {
+  // use unordered_map
+  unordered_map<string, int64_t> string_to_int;
+  unordered_map<int64_t, string> int_to_string;
+  hash<string> hasher;
+
+public:
+  ScheduleIds() {};
+  ~ScheduleIds() {};
+
+  /// Get integer ID associated with an existing string ID.
+  ///
+  /// \param String ID.
+  /// \return The integer ID associated to the string ID.
+  int64_t getIntId(string sid);
+
+  /// Insert a string ID and get the associated integer ID.
+  ///
+  /// \param String ID to be inserted.
+  /// \return The integer ID associated with string ID sid.
+  int64_t insertStringId(string sid);
+
+  /// Delete an ID identified by its string format.
+  ///
+  /// \param ID to be deleted.
+  void removeStringId(string sid);
+
+  /// Delete an ID identified by its integer format.
+  ///
+  /// \param ID to be deleted.
+  void removeIntId(int64_t id);
+
+  /// Get number of identifiers.
+  int64_t count();
+};
+
+#endif // RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -3,15 +3,12 @@
 
 #include <unordered_map>
 #include <string>
-#include <gtest/gtest_prod.h>
 
 /// Class to map string IDs to unique integer IDs and back.
 class StringIdMap {
   std::unordered_map<std::string, int64_t> string_to_int_;
   std::unordered_map<int64_t, std::string> int_to_string_;
   std::hash<std::string> hasher_;
-
-  FRIEND_TEST(SchedulingTest, SchedulingIdTest);
 
 public:
   StringIdMap() {};

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -26,23 +26,23 @@ public:
   ///
   /// \param String ID.
   /// \return The integer ID associated to the string ID.
-  int64_t getIntId(string sid);
+  int64_t getIdByInt(string sid);
 
   /// Insert a string ID and get the associated integer ID.
   ///
   /// \param String ID to be inserted.
   /// \return The integer ID associated with string ID sid.
-  int64_t insertStringId(string sid);
+  int64_t insertIdByString(string sid);
 
   /// Delete an ID identified by its string format.
   ///
   /// \param ID to be deleted.
-  void removeStringId(string sid);
+  void removeIdByString(string sid);
 
   /// Delete an ID identified by its integer format.
   ///
   /// \param ID to be deleted.
-  void removeIntId(int64_t id);
+  void removeIdByInt(int64_t id);
 
   /// Get number of identifiers.
   int64_t count();

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -1,21 +1,19 @@
 #ifndef RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
 #define RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
 
-#include <iostream>
-#include <map>
 #include <unordered_map>
 #include <string>
 #include <iterator>
 #include <stdlib.h>
-#include <chrono>
-#include <vector>
-using namespace std;
+#include <gtest/gtest_prod.h>
 
 /// Class to map string IDs to unique integer IDs and back.
 class ScheduleIds {
-  unordered_map<string, int64_t> string_to_int;
-  unordered_map<int64_t, string> int_to_string;
-  hash<string> hasher;
+  std::unordered_map<string, int64_t> string_to_int;
+  std::unordered_map<int64_t, string> int_to_string;
+  std::hash<string> hasher;
+
+  FRIEND_TEST(SchedulingTest, SchedulingIdTest);
 
 public:
   ScheduleIds() {};
@@ -31,7 +29,7 @@ public:
   ///
   /// \param String ID to be inserted.
   /// \return The integer ID associated with string ID sid.
-  int64_t insertIdByString(string sid);
+  int64_t insertIdByString(string sid, bool test = false);
 
   /// Delete an ID identified by its string format.
   ///

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -11,9 +11,8 @@
 #include <vector>
 using namespace std;
 
-/// Class to map string IDs to unique inntegre IDs and back.
+/// Class to map string IDs to unique integer IDs and back.
 class ScheduleIds {
-  // use unordered_map
   unordered_map<string, int64_t> string_to_int;
   unordered_map<int64_t, string> int_to_string;
   hash<string> hasher;
@@ -25,7 +24,7 @@ public:
   /// Get integer ID associated with an existing string ID.
   ///
   /// \param String ID.
-  /// \return The integer ID associated to the string ID.
+  /// \return The integer ID associated with the given string ID.
   int64_t getIdByInt(string sid);
 
   /// Insert a string ID and get the associated integer ID.

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -42,4 +42,4 @@ class StringIdMap {
   int64_t count();
 };
 
-#endif // RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
+#endif  // RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -1,8 +1,8 @@
 #ifndef RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
 #define RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 /// Class to map string IDs to unique integer IDs and back.
 class StringIdMap {
@@ -10,9 +10,9 @@ class StringIdMap {
   std::unordered_map<int64_t, std::string> int_to_string_;
   std::hash<std::string> hasher_;
 
-public:
-  StringIdMap() {};
-  ~StringIdMap() {};
+ public:
+  StringIdMap(){};
+  ~StringIdMap(){};
 
   /// Get integer ID associated with an existing string ID.
   ///

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -1,8 +1,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <thread>
 #include <string>
+#include <thread>
 
 #include "ray/common/scheduling/scheduling_ids.h"
 using namespace std;

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -24,7 +24,7 @@ TEST_F(SchedulingTest, SchedulingIdTest) {
   ScheduleIds ids;
   hash<string> hasher;
   int num = 10;  // should be greater than 10.
-
+  
   for (int i = 0; i < num; i++) {
     ids.insertIdByString(to_string(i));
   }

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -1,0 +1,45 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <string>
+#include <stdlib.h>
+
+
+#include "ray/common/scheduling/scheduling_ids.h"
+
+namespace ray {
+
+class SchedulingTest : public ::testing::Test {
+ public:
+  void SetUp() {}
+
+  void Shutdown() {}
+};
+
+TEST_F(SchedulingTest, SchedulingIdTest) {
+  ScheduleIds ids;
+  hash<string> hasher;
+  int num = 10;  // should be greater than 10.
+
+  for (int i = 0; i < num; i++) {
+    ids.insertStringId(to_string(i));
+  }
+  ASSERT_EQ(ids.count(), num);
+
+  ids.removeStringId(to_string(1));
+  ASSERT_EQ(ids.count(), num - 1);
+
+  ids.removeIntId(hasher(to_string(2)));
+  ASSERT_EQ(ids.count(), num - 2);
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -26,14 +26,14 @@ TEST_F(SchedulingTest, SchedulingIdTest) {
   int num = 10;  // should be greater than 10.
 
   for (int i = 0; i < num; i++) {
-    ids.insertStringId(to_string(i));
+    ids.insertIdByString(to_string(i));
   }
   ASSERT_EQ(ids.count(), num);
 
-  ids.removeStringId(to_string(1));
+  ids.removeIdByString(to_string(1));
   ASSERT_EQ(ids.count(), num - 1);
 
-  ids.removeIntId(hasher(to_string(2)));
+  ids.removeIdByInt(hasher(to_string(2)));
   ASSERT_EQ(ids.count(), num - 2);
 }
 

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -1,15 +1,11 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <chrono>
-#include <iostream>
 #include <thread>
-#include <vector>
 #include <string>
-#include <stdlib.h>
-
 
 #include "ray/common/scheduling/scheduling_ids.h"
+using namespace std;
 
 namespace ray {
 
@@ -21,20 +17,33 @@ class SchedulingTest : public ::testing::Test {
 };
 
 TEST_F(SchedulingTest, SchedulingIdTest) {
-  ScheduleIds ids;
+  StringIdMap ids;
   hash<string> hasher;
   int num = 10;  // should be greater than 10.
-  
+
   for (int i = 0; i < num; i++) {
-    ids.insertIdByString(to_string(i));
+    ids.insert(to_string(i));
   }
   ASSERT_EQ(ids.count(), num);
 
-  ids.removeIdByString(to_string(1));
+  ids.remove(to_string(1));
   ASSERT_EQ(ids.count(), num - 1);
 
-  ids.removeIdByInt(hasher(to_string(2)));
+  ids.remove(hasher(to_string(2)));
   ASSERT_EQ(ids.count(), num - 2);
+
+  ASSERT_TRUE(ids.get(to_string(3)) == hasher(to_string(3)));
+
+  ASSERT_TRUE(ids.get(to_string(100)) == -1);
+
+  /// Test for handling collision.
+  StringIdMap short_ids;
+  for (int i = 0; i < 10; i++) {
+    /// "true" reduces the range of IDs to [0..9]
+    int64_t id = short_ids.insert(to_string(i), true);
+    ASSERT_TRUE(id < 10);
+  }
+  ASSERT_EQ(short_ids.count(), 10);
 }
 
 }  // namespace ray

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -32,7 +32,7 @@ TEST_F(SchedulingTest, SchedulingIdTest) {
   ids.remove(hasher(to_string(2)));
   ASSERT_EQ(ids.count(), num - 2);
 
-  ASSERT_TRUE(ids.get(to_string(3)) == hasher(to_string(3)));
+  ASSERT_TRUE(ids.get(to_string(3)) == static_cast<int64_t>(hasher(to_string(3))));
 
   ASSERT_TRUE(ids.get(to_string(100)) == -1);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

A simple utility to map string IDs to integer IDs. Examples of IDs are resource IDs and client IDs. This can considerably improve the performance when IDs are used as keys in map data structures.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
