### PR TITLE
Fix sigterm_handler

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -192,10 +192,10 @@ class Node(object):
 
         atexit.register(atexit_handler)
 
-        # Register the a handler to be called if we get a SIGTERM.
+        # Register the handler to be called if we get a SIGTERM.
         # In this case, we want to exit with an error code (1) after
         # cleaning up child processes.
-        def sigterm_handler():
+        def sigterm_handler(signum, frame):
             return clean_up_children(lambda *args, **kwargs: sys.exit(1))
 
         signal.signal(signal.SIGTERM, sigterm_handler)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Handler in `node.py` didn't accept the correct arguments so it would throw an error on `SIGTERM`.

## Related issue number

Closes #2615.
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
