### PR TITLE
fix deprecated warning in rllib

### DIFF
--- a/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
+++ b/python/ray/experimental/sgd/pytorch/pytorch_trainer.py
@@ -113,7 +113,7 @@ class PyTorchTrainer(object):
             batch_size_per_replica = batch_size // num_replicas
             if batch_size % num_replicas > 0:
                 new_batch_size = batch_size_per_replica * num_replicas
-                logger.warn(
+                logger.warning(
                     ("Changing batch size from {old_batch_size} to "
                      "{new_batch_size} to evenly distribute batches across "
                      "{num_replicas} replicas.").format(

--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -32,7 +32,7 @@ def _setup_logger():
     logger.propagate = False
 
     if sys.version_info[0] < 3:
-        logger.warn(
+        logger.warning(
             "RLlib Python 2 support is deprecated, and will be removed "
             "in a future release.")
 

--- a/rllib/optimizers/multi_gpu_impl.py
+++ b/rllib/optimizers/multi_gpu_impl.py
@@ -170,7 +170,7 @@ class LocalSyncParallelOptimizer(object):
             self.max_per_device_batch_size // self._loaded_max_seq_len * len(
                 self.devices))
         if sequences_per_minibatch < 1:
-            logger.warn(
+            logger.warning(
                 ("Target minibatch size is {}, however the rollout sequence "
                  "length is {}, hence the minibatch size will be raised to "
                  "{}.").format(self.max_per_device_batch_size,

--- a/rllib/optimizers/sync_samples_optimizer.py
+++ b/rllib/optimizers/sync_samples_optimizer.py
@@ -139,7 +139,7 @@ class SyncSamplesOptimizer(PolicyOptimizer):
                 "Minibatching not implemented for multi-agent in simple mode")
 
         if "state_in_0" in samples.data:
-            logger.warn("Not shuffling RNN data for SGD in simple mode")
+            logger.warning("Not shuffling RNN data for SGD in simple mode")
         else:
             samples.shuffle()
 

--- a/rllib/utils/__init__.py
+++ b/rllib/utils/__init__.py
@@ -17,9 +17,9 @@ def renamed_class(cls, old_name):
         # note: **kw not supported for ray.remote classes
         def __init__(self, *args, **kw):
             new_name = cls.__module__ + "." + cls.__name__
-            logger.warn("DeprecationWarning: {} has been renamed to {}. ".
-                        format(old_name, new_name) +
-                        "This will raise an error in the future.")
+            logger.warning("DeprecationWarning: {} has been renamed to {}. ".
+                           format(old_name, new_name) +
+                           "This will raise an error in the future.")
             cls.__init__(self, *args, **kw)
 
     DeprecationWrapper.__name__ = cls.__name__
@@ -49,9 +49,9 @@ def renamed_agent(cls):
         def __init__(self, config=None, env=None, logger_creator=None):
             old_name = cls.__name__.replace("Trainer", "Agent")
             new_name = cls.__module__ + "." + cls.__name__
-            logger.warn("DeprecationWarning: {} has been renamed to {}. ".
-                        format(old_name, new_name) +
-                        "This will raise an error in the future.")
+            logger.warning("DeprecationWarning: {} has been renamed to {}. ".
+                           format(old_name, new_name) +
+                           "This will raise an error in the future.")
             cls.__init__(self, config, env, logger_creator)
 
     DeprecationWrapper.__name__ = cls.__name__


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fix deprecated warning in rllib

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
