### PR TITLE
Fix pending task dependency garbage collection test

### DIFF
--- a/python/ray/tests/test_garbage_collection.py
+++ b/python/ray/tests/test_garbage_collection.py
@@ -68,7 +68,7 @@ def test_pending_task_dependency(shutdown_only):
     for _ in range(2):
         # Need to sleep here because the active object ID set is only broadcast
         # every 500ms by default.
-        time.sleep(1)
+        time.sleep(2)
         ray.put(np_array, weakref=True)
 
     ray.get(oid)

--- a/python/ray/tests/test_garbage_collection.py
+++ b/python/ray/tests/test_garbage_collection.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import json
 import numpy as np
 import time
 import logging
@@ -49,9 +48,7 @@ def test_basic_gc(shutdown_only):
 
 
 def test_pending_task_dependency(shutdown_only):
-    ray.init(
-        object_store_memory=100 * 1024 * 1024,
-        use_pickle=True)
+    ray.init(object_store_memory=100 * 1024 * 1024, use_pickle=True)
 
     @ray.remote
     def pending(input1, input2):
@@ -70,7 +67,7 @@ def test_pending_task_dependency(shutdown_only):
     oid = pending.remote(np_array, dependency.remote(dep_id))
 
     for _ in range(2):
-        time.sleep(2)
+        time.sleep(5)
         ray.put(np_array, weakref=True)
 
     ray.worker.global_worker.put_object(None, object_id=dep_id)

--- a/python/ray/tests/test_garbage_collection.py
+++ b/python/ray/tests/test_garbage_collection.py
@@ -51,10 +51,7 @@ def test_basic_gc(shutdown_only):
 def test_pending_task_dependency(shutdown_only):
     ray.init(
         object_store_memory=100 * 1024 * 1024,
-        use_pickle=True,
-        _internal_config=json.dumps({
-            "worker_heartbeat_timeout_milliseconds": 50
-        }))
+        use_pickle=True)
 
     @ray.remote
     def pending(input1, input2):

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -29,7 +29,12 @@ def ray_start_sharded(request):
         object_store_memory=int(0.5 * 10**9),
         num_cpus=10,
         num_redis_shards=num_redis_shards,
-        redis_max_memory=10**7)
+        redis_max_memory=10**7,
+        # TODO(edoakes): the stopgap GC measure breaks
+        # test_submitting_many_tasks, so we need to disable it here.
+        _internal_config=json.dumps({
+            "raylet_max_active_object_ids": 0
+        }))
 
     yield None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Test has been failing due to the loop running too quickly so object IDs don't have the chance to be broadcast.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
