### PR TITLE
Use shared_ptr for gcs client in profiler

### DIFF
--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -462,7 +462,7 @@ class CoreWorker {
   rpc::GrpcServer core_worker_server_;
 
   // Client to the GCS shared by core worker interfaces.
-  gcs::RedisGcsClient gcs_client_;
+  std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
 
   // Client to the raylet shared by core worker interfaces.
   std::unique_ptr<RayletClient> raylet_client_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1,9 +1,7 @@
 #ifndef RAY_CORE_WORKER_CORE_WORKER_H
 #define RAY_CORE_WORKER_CORE_WORKER_H
 
-#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
-#include "absl/synchronization/mutex.h"
 
 #include "ray/common/buffer.h"
 #include "ray/core_worker/actor_handle.h"
@@ -321,11 +319,11 @@ class CoreWorker {
                                const std::vector<std::shared_ptr<Buffer>> &metadatas,
                                std::vector<std::shared_ptr<RayObject>> *return_objects);
 
-  /**
-   * The following methods are handlers for the core worker's gRPC server, which follow
-   * a macro-generated call convention. These are executed on the io_service_ and
-   * post work to the appropriate event loop.
-   */
+  ///
+  /// The following methods are handlers for the core worker's gRPC server, which follow
+  /// a macro-generated call convention. These are executed on the io_service_ and
+  /// post work to the appropriate event loop.
+  ///
 
   /// Implements gRPC server handler.
   void HandleAssignTask(const rpc::AssignTaskRequest &request,

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -15,7 +15,7 @@ ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> &profiler,
 
 Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
                    boost::asio::io_service &io_service,
-                   std::shared_ptr<gcs::RedisGcsClient> &gcs_client)
+                   const std::shared_ptr<gcs::RedisGcsClient> &gcs_client)
     : io_service_(io_service),
       timer_(io_service_, boost::asio::chrono::seconds(1)),
       gcs_client_(gcs_client) {

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -6,7 +6,7 @@ namespace ray {
 
 namespace worker {
 
-ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> profiler,
+ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> &profiler,
                            const std::string &event_type)
     : profiler_(profiler) {
   rpc_event_.set_event_type(event_type);
@@ -14,7 +14,8 @@ ProfileEvent::ProfileEvent(const std::shared_ptr<Profiler> profiler,
 }
 
 Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
-                   boost::asio::io_service &io_service, gcs::RedisGcsClient &gcs_client)
+                   boost::asio::io_service &io_service,
+                   std::shared_ptr<gcs::RedisGcsClient> &gcs_client)
     : io_service_(io_service),
       timer_(io_service_, boost::asio::chrono::seconds(1)),
       gcs_client_(gcs_client) {
@@ -35,7 +36,7 @@ void Profiler::FlushEvents() {
   if (rpc_profile_data_.profile_events_size() != 0) {
     // TODO(edoakes): this should be migrated to use the new GCS client interface
     // instead of the raw table interface once it's ready.
-    if (!gcs_client_.profile_table().AddProfileEventBatch(rpc_profile_data_).ok()) {
+    if (!gcs_client_->profile_table().AddProfileEventBatch(rpc_profile_data_).ok()) {
       RAY_LOG(WARNING) << "Failed to push profile events to GCS.";
     } else {
       RAY_LOG(DEBUG) << "Pushed " << rpc_profile_data_.profile_events_size()

--- a/src/ray/core_worker/profiling.cc
+++ b/src/ray/core_worker/profiling.cc
@@ -19,7 +19,6 @@ Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_add
     : io_service_(io_service),
       timer_(io_service_, boost::asio::chrono::seconds(1)),
       gcs_client_(gcs_client) {
-  absl::MutexLock l(&mu_);
   rpc_profile_data_.set_component_type(WorkerTypeString(worker_context.GetWorkerType()));
   rpc_profile_data_.set_component_id(worker_context.GetWorkerID().Binary());
   rpc_profile_data_.set_node_ip_address(node_ip_address);
@@ -27,12 +26,12 @@ Profiler::Profiler(WorkerContext &worker_context, const std::string &node_ip_add
 }
 
 void Profiler::AddEvent(const rpc::ProfileTableData::ProfileEvent &event) {
-  absl::MutexLock l(&mu_);
+  absl::MutexLock lock(&mutex_);
   rpc_profile_data_.add_profile_events()->CopyFrom(event);
 }
 
 void Profiler::FlushEvents() {
-  absl::MutexLock l(&mu_);
+  absl::MutexLock lock(&mutex_);
   if (rpc_profile_data_.profile_events_size() != 0) {
     // TODO(edoakes): this should be migrated to use the new GCS client interface
     // instead of the raw table interface once it's ready.

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -14,7 +14,8 @@ namespace worker {
 class Profiler {
  public:
   Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
-           boost::asio::io_service &io_service, gcs::RedisGcsClient &gcs_client);
+           boost::asio::io_service &io_service,
+           std::shared_ptr<gcs::RedisGcsClient> &gcs_client);
 
   // Add an event to the queue to be flushed periodically.
   void AddEvent(const rpc::ProfileTableData::ProfileEvent &event);
@@ -33,7 +34,7 @@ class Profiler {
   // until they are flushed.
   rpc::ProfileTableData rpc_profile_data_ GUARDED_BY(mu_);
 
-  gcs::RedisGcsClient &gcs_client_;
+  const std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
 
   absl::Mutex mu_;
 };

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -41,7 +41,7 @@ class Profiler {
 
 class ProfileEvent {
  public:
-  ProfileEvent(const std::shared_ptr<Profiler> profiler, const std::string &event_type);
+  ProfileEvent(const std::shared_ptr<Profiler> &profiler, const std::string &event_type);
 
   ~ProfileEvent() {
     rpc_event_.set_end_time(absl::GetCurrentTimeNanos() / 1e9);

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -15,7 +15,7 @@ class Profiler {
  public:
   Profiler(WorkerContext &worker_context, const std::string &node_ip_address,
            boost::asio::io_service &io_service,
-           std::shared_ptr<gcs::RedisGcsClient> &gcs_client);
+           const std::shared_ptr<gcs::RedisGcsClient> &gcs_client);
 
   // Add an event to the queue to be flushed periodically.
   void AddEvent(const rpc::ProfileTableData::ProfileEvent &event);

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -1,6 +1,7 @@
 #ifndef RAY_CORE_WORKER_PROFILING_H
 #define RAY_CORE_WORKER_PROFILING_H
 
+#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 
@@ -18,11 +19,14 @@ class Profiler {
            const std::shared_ptr<gcs::RedisGcsClient> &gcs_client);
 
   // Add an event to the queue to be flushed periodically.
-  void AddEvent(const rpc::ProfileTableData::ProfileEvent &event);
+  void AddEvent(const rpc::ProfileTableData::ProfileEvent &event) LOCKS_EXCLUDED(mutex_);
 
  private:
   // Flush all of the events that have been added since last flush to the GCS.
-  void FlushEvents();
+  void FlushEvents() LOCKS_EXCLUDED(mutex_);
+
+  // Mutex guarding rpc_profile_data_.
+  absl::Mutex mutex_;
 
   // ASIO IO service event loop. Must be started by the caller.
   boost::asio::io_service &io_service_;
@@ -32,28 +36,32 @@ class Profiler {
 
   // RPC message containing profiling data. Holds the queue of profile events
   // until they are flushed.
-  rpc::ProfileTableData rpc_profile_data_ GUARDED_BY(mu_);
+  rpc::ProfileTableData rpc_profile_data_ GUARDED_BY(mutex_);
 
-  const std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
-
-  absl::Mutex mu_;
+  // Client to the GCS used to push profile events to it.
+  std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
 };
 
 class ProfileEvent {
  public:
   ProfileEvent(const std::shared_ptr<Profiler> &profiler, const std::string &event_type);
 
+  // Set the end time for the event and add it to the profiler.
   ~ProfileEvent() {
     rpc_event_.set_end_time(absl::GetCurrentTimeNanos() / 1e9);
     profiler_->AddEvent(rpc_event_);
   }
 
+  // Set extra metadata for the event, which could change during the event.
   void SetExtraData(const std::string &extra_data) {
     rpc_event_.set_extra_data(extra_data);
   }
 
  private:
-  const std::shared_ptr<Profiler> profiler_;
+  // shared_ptr to the profiler that this event will be added to when it is destructed.
+  std::shared_ptr<Profiler> profiler_;
+
+  // Underlying proto data structure that holds the event data.
   rpc::ProfileTableData::ProfileEvent rpc_event_;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

A `shared_ptr` to the profiler is given out to profiling events created using the core worker. This means that the profiler can still exist after the core worker is destructed, so we need to make sure the gcs client isn't destructed until the profiler is too.

## Related issue number

#6103

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
