### PR TITLE
Reduce RLlib log verbosity

### DIFF
--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -575,7 +575,7 @@ You can control the trainer log level via the ``"log_level"`` flag. Valid values
         --run=A2C --config '{"num_workers": 2, "log_level": "DEBUG"}'
 
     rllib train --env=PongDeterministic-v4 \
-        --run=A2C --config '{"num_workers": 2}' --debug
+        --run=A2C --config '{"num_workers": 2}' -vv
 
 The default log level is ``WARN``. We strongly recommend using at least ``INFO`` level logging for development.
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -567,12 +567,17 @@ You can use the `data output API <rllib-offline.html>`__ to save episode traces 
 Log Verbosity
 ~~~~~~~~~~~~~
 
-You can control the trainer log level via the ``"log_level"`` flag. Valid values are "INFO" (default), "DEBUG", "WARN", and "ERROR". This can be used to increase or decrease the verbosity of internal logging. For example:
+You can control the trainer log level via the ``"log_level"`` flag. Valid values are "INFO" (default), "DEBUG", "WARN", and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are equivalent:
 
 .. code-block:: bash
 
     rllib train --env=PongDeterministic-v4 \
         --run=A2C --config '{"num_workers": 2, "log_level": "DEBUG"}'
+
+    rllib train --env=PongDeterministic-v4 \
+        --run=A2C --config '{"num_workers": 2}' --debug
+
+The default log level is ``WARN``. We strongly recommend using at least ``INFO`` level logging for development.
 
 Stack Traces
 ~~~~~~~~~~~~

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -567,7 +567,7 @@ You can use the `data output API <rllib-offline.html>`__ to save episode traces 
 Log Verbosity
 ~~~~~~~~~~~~~
 
-You can control the trainer log level via the ``"log_level"`` flag. Valid values are "DEBUG", "INFO", "WARN" (default), and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are about equivalent:
+You can control the trainer log level via the ``"log_level"`` flag. Valid values are "DEBUG", "INFO", "WARN" (default), and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``-v`` and ``-vv`` flags. For example, the following two commands are about equivalent:
 
 .. code-block:: bash
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -567,7 +567,7 @@ You can use the `data output API <rllib-offline.html>`__ to save episode traces 
 Log Verbosity
 ~~~~~~~~~~~~~
 
-You can control the trainer log level via the ``"log_level"`` flag. Valid values are "INFO" (default), "DEBUG", "WARN", and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are equivalent:
+You can control the trainer log level via the ``"log_level"`` flag. Valid values are "DEBUG", "INFO", "WARN" (default), and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are equivalent:
 
 .. code-block:: bash
 

--- a/doc/source/rllib-training.rst
+++ b/doc/source/rllib-training.rst
@@ -567,7 +567,7 @@ You can use the `data output API <rllib-offline.html>`__ to save episode traces 
 Log Verbosity
 ~~~~~~~~~~~~~
 
-You can control the trainer log level via the ``"log_level"`` flag. Valid values are "DEBUG", "INFO", "WARN" (default), and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are equivalent:
+You can control the trainer log level via the ``"log_level"`` flag. Valid values are "DEBUG", "INFO", "WARN" (default), and "ERROR". This can be used to increase or decrease the verbosity of internal logging. You can also use the ``--info`` and ``--debug`` flags. For example, the following two commands are about equivalent:
 
 .. code-block:: bash
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -483,8 +483,8 @@ class Trainer(Trainable):
         if log_level in ["WARN", "ERROR"]:
             logger.info(
                 "Current log_level is {}. For more information, "
-                "set 'log_level': 'INFO' / 'DEBUG' or use the --info and "
-                "--debug flags.".format(log_level))
+                "set 'log_level': 'INFO' / 'DEBUG' or use the -v and "
+                "-vv flags.".format(log_level))
         if self.config.get("log_level"):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -47,7 +47,7 @@ COMMON_CONFIG = {
     # Should be one of DEBUG, INFO, WARN, or ERROR. The DEBUG level will also
     # periodically print out summaries of relevant internal dataflow (this is
     # also printed out once at startup at the INFO level).
-    "log_level": "INFO",
+    "log_level": "WARN",
     # Callbacks that will be run during various phases of training. These all
     # take a single "info" dict as an argument. For episode callbacks, custom
     # metrics can be attached to the episode by updating the episode object's
@@ -479,6 +479,12 @@ class Trainer(Trainable):
         self.raw_user_config = config
         self.config = merged_config
         Trainer._validate_config(self.config)
+        log_level = self.config.get("log_level")
+        if log_level in ["WARN", "ERROR"]:
+            logger.info(
+                "Current log_level is {}. For more information, "
+                "set 'log_level': 'INFO' / 'DEBUG' or use the --info and "
+                "--debug flags.".format(log_level))
         if self.config.get("log_level"):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -481,10 +481,9 @@ class Trainer(Trainable):
         Trainer._validate_config(self.config)
         log_level = self.config.get("log_level")
         if log_level in ["WARN", "ERROR"]:
-            logger.info(
-                "Current log_level is {}. For more information, "
-                "set 'log_level': 'INFO' / 'DEBUG' or use the -v and "
-                "-vv flags.".format(log_level))
+            logger.info("Current log_level is {}. For more information, "
+                        "set 'log_level': 'INFO' / 'DEBUG' or use the -v and "
+                        "-vv flags.".format(log_level))
         if self.config.get("log_level"):
             logging.getLogger("ray.rllib").setLevel(self.config["log_level"])
 

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -89,11 +89,11 @@ def create_parser(parser_creator=None):
         type=str,
         help="Optional URI to sync training results to (e.g. s3://bucket).")
     parser.add_argument(
-        "--info",
+        "-v",
         action="store_true",
         help="Whether to use INFO level logging.")
     parser.add_argument(
-        "--debug",
+        "-vv",
         action="store_true",
         help="Whether to use DEBUG level logging.")
     parser.add_argument(

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -89,6 +89,14 @@ def create_parser(parser_creator=None):
         type=str,
         help="Optional URI to sync training results to (e.g. s3://bucket).")
     parser.add_argument(
+        "--info",
+        action="store_true",
+        help="Whether to use INFO level logging.")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Whether to use DEBUG level logging.")
+    parser.add_argument(
         "--resume",
         action="store_true",
         help="Whether to attempt to resume previous Tune experiments.")
@@ -143,6 +151,7 @@ def run(args, parser):
             }
         }
 
+    verbose = 1
     for exp in experiments.values():
         if not exp.get("run"):
             parser.error("the following arguments are required: --run")
@@ -150,6 +159,12 @@ def run(args, parser):
             parser.error("the following arguments are required: --env")
         if args.eager:
             exp["config"]["eager"] = True
+        if args.info:
+            exp["config"]["log_level"] = "INFO"
+            verbose = 2
+        if args.debug:
+            exp["config"]["log_level"] = "DEBUG"
+            verbose = 3
         if args.trace:
             if not exp["config"].get("eager"):
                 raise ValueError("Must enable --eager to enable tracing.")
@@ -177,7 +192,8 @@ def run(args, parser):
         experiments,
         scheduler=_make_scheduler(args),
         queue_trials=args.queue_trials,
-        resume=args.resume)
+        resume=args.resume,
+        verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -89,13 +89,9 @@ def create_parser(parser_creator=None):
         type=str,
         help="Optional URI to sync training results to (e.g. s3://bucket).")
     parser.add_argument(
-        "-v",
-        action="store_true",
-        help="Whether to use INFO level logging.")
+        "-v", action="store_true", help="Whether to use INFO level logging.")
     parser.add_argument(
-        "-vv",
-        action="store_true",
-        help="Whether to use DEBUG level logging.")
+        "-vv", action="store_true", help="Whether to use DEBUG level logging.")
     parser.add_argument(
         "--resume",
         action="store_true",

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -155,10 +155,10 @@ def run(args, parser):
             parser.error("the following arguments are required: --env")
         if args.eager:
             exp["config"]["eager"] = True
-        if args.info:
+        if args.v:
             exp["config"]["log_level"] = "INFO"
             verbose = 2
-        if args.debug:
+        if args.vv:
             exp["config"]["log_level"] = "DEBUG"
             verbose = 3
         if args.trace:


### PR DESCRIPTION
This is what it looks like by default now:

```
2019-11-12 21:57:27,037	INFO resource_spec.py:216 -- Starting Ray with 5.18 GiB memory available for workers and up to 2.61 GiB for objects. You can adjust these settings with ray.init(memory=<bytes>, object_store_memory=<bytes>).
2019-11-12 21:57:27,300	INFO services.py:1043 -- View the Ray dashboard at localhost:8081.
== Status ==
Memory usage on this node: 5.0/15.4 GiB
Using FIFO scheduling algorithm.
Resources requested: 3/8 CPUs, 0/0 GPUs, 0.0/5.18 GiB heap, 0.0/1.76 GiB objects
Number of trials: 1 ({'RUNNING': 1})
Result logdir: /home/eric/ray_results/default
+--------------------------+----------+-------+
| Trial name               | status   | loc   |
|--------------------------+----------+-------|
| PPO_CartPole-v0_7a764efe | RUNNING  |       |
+--------------------------+----------+-------+

(pid=32541) 2019-11-12 21:57:32,540	INFO trainer.py:345 -- Tip: set 'eager': true or the --eager flag to enable TensorFlow eager execution
(pid=32541) 2019-11-12 21:57:32,541	INFO trainer.py:487 -- Current log_level is WARN. For more information, set 'log_level': 'INFO' / 'DEBUG' or use the --info and --debug flags.
== Status ==
Memory usage on this node: 5.7/15.4 GiB
Using FIFO scheduling algorithm.
Resources requested: 3/8 CPUs, 0/0 GPUs, 0.0/5.18 GiB heap, 0.0/1.76 GiB objects
Number of trials: 1 ({'RUNNING': 1})
Result logdir: /home/eric/ray_results/default
+--------------------------+----------+-----------+--------+------------------+-------------+----------+
| Trial name               | status   | loc       |   iter |   total time (s) |   timesteps |   reward |
|--------------------------+----------+-----------+--------+------------------+-------------+----------|
| PPO_CartPole-v0_7a764efe | RUNNING  | pid=32541 |      1 |          6.60818 |        4000 |  22.5028 |
+--------------------------+----------+-----------+--------+------------------+-------------+----------+

== Status ==
Memory usage on this node: 5.7/15.4 GiB
Using FIFO scheduling algorithm.
Resources requested: 3/8 CPUs, 0/0 GPUs, 0.0/5.18 GiB heap, 0.0/1.76 GiB objects
Number of trials: 1 ({'RUNNING': 1})
Result logdir: /home/eric/ray_results/default
+--------------------------+----------+-----------+--------+------------------+-------------+----------+
| Trial name               | status   | loc       |   iter |   total time (s) |   timesteps |   reward |
|--------------------------+----------+-----------+--------+------------------+-------------+----------|
| PPO_CartPole-v0_7a764efe | RUNNING  | pid=32541 |      3 |          16.5555 |       12000 |    67.16 |
+--------------------------+----------+-----------+--------+------------------+-------------+----------+
```