### PR TITLE
[tune] Report failures in a separate table

### DIFF
--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -260,12 +260,11 @@ class Trial(object):
     def write_error_log(self, error_msg):
         if error_msg and self.logdir:
             self.num_failures += 1  # may be moved to outer scope?
-            error_file = os.path.join(self.logdir,
-                                      "error_{}.txt".format(date_str()))
-            with open(error_file, "a+") as f:
-                f.write("Failure # {}".format(self.num_failures) + "\n")
+            self.error_file = os.path.join(self.logdir, "error.txt")
+            with open(self.error_file, "a+") as f:
+                f.write("Failure # {} (occurred at {})\n".format(
+                    self.num_failures, date_str()))
                 f.write(error_msg + "\n")
-            self.error_file = error_file
             self.error_msg = error_msg
 
     def should_stop(self, result):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The error file is too many characters to display in a single row. Put it in a separate table so it doesn't distort the trial progress table during failures.

Also don't rely on `last_result` for trial loc since it's unreliable during failures.

- [x] test on ipython notebook
- [x] merge FT PR in and rebase

jupyter screenshot:

<img width="992" alt="Screen Shot 2019-11-19 at 5 19 35 PM" src="https://user-images.githubusercontent.com/8576139/69200770-0249ab80-0af1-11ea-8e0a-92d4054323ff.png">



## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
