### PR TITLE
Fix bug in which remote function redefinition doesn't happen.

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -125,9 +125,7 @@ class FunctionDescriptor(object):
         function_name = function.__name__
         class_name = ""
 
-        hasher = hashlib.sha1()
-        hasher.update(pickled_function)
-        pickled_function_hash = hasher.digest()
+        pickled_function_hash = hashlib.sha1(pickled_function).digest()
 
         return cls(module_name, function_name, class_name,
                    pickled_function_hash)
@@ -313,7 +311,7 @@ class FunctionActorManager(object):
         """The identifier is used to detect excessive duplicate exports.
 
         The identifier is used to determine when the same function or class is
-        exported many times. This can yielf false positives.
+        exported many times. This can yield false positives.
 
         Args:
             function_or_class: The function or class to compute an identifier
@@ -341,9 +339,7 @@ class FunctionActorManager(object):
             collision_identifier = function_or_class.__name__
 
         # Return a hash of the identifier in case it is too large.
-        hasher = hashlib.sha1()
-        hasher.update(collision_identifier.encode("ascii"))
-        return hasher.digest()
+        return hashlib.sha1(collision_identifier.encode("ascii")).digest()
 
     def export(self, remote_function):
         """Pickle a remote function and export it to redis.
@@ -369,7 +365,7 @@ class FunctionActorManager(object):
                 "job_id": self._worker.current_job_id.binary(),
                 "function_id": remote_function._function_descriptor.
                 function_id.binary(),
-                "name": remote_function._function_name,
+                "function_name": remote_function._function_name,
                 "module": function.__module__,
                 "function": pickled_function,
                 "collision_identifier": self.compute_collision_identifier(
@@ -383,8 +379,8 @@ class FunctionActorManager(object):
         (job_id_str, function_id_str, function_name, serialized_function,
          num_return_vals, module, resources,
          max_calls) = self._worker.redis_client.hmget(key, [
-             "job_id", "function_id", "name", "function", "num_return_vals",
-             "module", "resources", "max_calls"
+             "job_id", "function_id", "function_name", "function",
+             "num_return_vals", "module", "resources", "max_calls"
          ])
         function_id = ray.FunctionID(function_id_str)
         job_id = ray.JobID(job_id_str)

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -120,17 +120,9 @@ class FunctionDescriptor(object):
         function_name = function.__name__
         class_name = ""
 
-        pickled_function_hasher = hashlib.sha1()
-        try:
-            # If we are running a script or are in IPython, include the source
-            # code in the hash.
-            pickled_function = pickle.dumps(function)
-            pickled_function_hasher.update(pickled_function)
-            pickled_function_hash = pickled_function_hasher.digest()
-        except (IOError, OSError, TypeError):
-            # Source code may not be available:
-            # e.g. Cython or Python interpreter.
-            pickled_function_hash = b""
+        hasher = hashlib.sha1()
+        hasher.update(pickle.dumps(function))
+        pickled_function_hash = hasher.digest()
 
         return cls(module_name, function_name, class_name,
                    pickled_function_hash)

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -101,7 +101,7 @@ class FunctionDescriptor(object):
                 "Invalid input for FunctionDescriptor.from_bytes_list")
 
     @classmethod
-    def from_function(cls, function):
+    def from_function(cls, function, pickled_function):
         """Create a FunctionDescriptor from a function instance.
 
         This function is used to create the function descriptor from
@@ -112,6 +112,9 @@ class FunctionDescriptor(object):
             cls: Current class which is required argument for classmethod.
             function: the python function used to create the function
                 descriptor.
+            pickled_function: This is factored in to ensure that any
+                modifications to the function result in a different function
+                descriptor.
 
         Returns:
             The FunctionDescriptor instance created according to the function.
@@ -121,7 +124,7 @@ class FunctionDescriptor(object):
         class_name = ""
 
         hasher = hashlib.sha1()
-        hasher.update(pickle.dumps(function))
+        hasher.update(pickled_function)
         pickled_function_hash = hasher.digest()
 
         return cls(module_name, function_name, class_name,

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -7,7 +7,6 @@ import importlib
 import inspect
 import json
 import logging
-import sys
 import time
 import threading
 import traceback
@@ -121,22 +120,20 @@ class FunctionDescriptor(object):
         function_name = function.__name__
         class_name = ""
 
-        function_source_hasher = hashlib.sha1()
+        pickled_function_hasher = hashlib.sha1()
         try:
             # If we are running a script or are in IPython, include the source
             # code in the hash.
-            source = inspect.getsource(function)
-            if sys.version_info[0] >= 3:
-                source = source.encode()
-            function_source_hasher.update(source)
-            function_source_hash = function_source_hasher.digest()
+            pickled_function = pickle.dumps(function)
+            pickled_function_hasher.update(pickled_function)
+            pickled_function_hash = pickled_function_hasher.digest()
         except (IOError, OSError, TypeError):
             # Source code may not be available:
             # e.g. Cython or Python interpreter.
-            function_source_hash = b""
+            pickled_function_hash = b""
 
         return cls(module_name, function_name, class_name,
-                   function_source_hash)
+                   pickled_function_hash)
 
     @classmethod
     def from_class(cls, target_class):

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -32,11 +32,11 @@ class ImportThread(object):
         redis_client: the redis client used to query exports.
         threads_stopped (threading.Event): A threading event used to signal to
             the thread that it should exit.
-        imported_collision_identifiers: This is a dicitonary mapping strings
-            containing the collision identifier of the remote functions that
-            have been exported to the number of times each remote function has
-            been imported. this is used to provide good error messages when the
-            same function is exported many many times.
+        imported_collision_identifiers: This is a dictionary mapping collision
+            identifiers for the exported remote functions and actor classes to
+            the number of times that collision identifier has appeared. This is
+            used to provide good error messages when the same function or class
+            is exported many times.
     """
 
     def __init__(self, worker, mode, threads_stopped):
@@ -128,7 +128,7 @@ class ImportThread(object):
                 if key.startswith(b"RemoteFunction"):
                     collision_identifier, function_name = (
                         self.redis_client.hmget(
-                            key, ["collision_identifier", "name"]))
+                            key, ["collision_identifier", "function_name"]))
                     self.imported_collision_identifiers[
                         collision_identifier] += 1
                     if (self.imported_collision_identifiers[

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -51,6 +51,10 @@ DEFAULT_ACTOR_METHOD_NUM_RETURN_VALS = 1
 # greater than this quantity, print an warning.
 PICKLE_OBJECT_WARNING_SIZE = 10**7
 
+# If remote functions with the same source are imported this many times, then
+# print a warning.
+DUPLICATE_REMOTE_FUNCTION_THRESHOLD = 100
+
 # The maximum resource quantity that is allowed. TODO(rkn): This could be
 # relaxed, but the current implementation of the node manager will be slower
 # for large resource quantities due to bookkeeping of specific resource IDs.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -964,26 +964,6 @@ def test_variable_number_of_args(shutdown_only):
 def test_defining_remote_functions(shutdown_only):
     ray.init(num_cpus=3)
 
-    # Test that we can define a remote function in the shell.
-    @ray.remote
-    def f(x):
-        return x + 1
-
-    assert ray.get(f.remote(0)) == 1
-
-    # Test that we can redefine the remote function.
-    @ray.remote
-    def f(x):
-        return x + 10
-
-    while True:
-        val = ray.get(f.remote(0))
-        assert val in [1, 10]
-        if val == 10:
-            break
-        else:
-            logger.info("Still using old definition of f, trying again.")
-
     # Test that we can close over plain old data.
     data = [
         np.zeros([3, 5]), (1, 2, "a"), [0.0, 1.0, 1 << 62], 1 << 60, {
@@ -1028,8 +1008,29 @@ def test_defining_remote_functions(shutdown_only):
     assert ray.get(k2.remote(1)) == 2
     assert ray.get(m.remote(1)) == 2
 
+
 def test_redefining_remote_functions(shutdown_only):
     ray.init(num_cpus=1)
+
+    # Test that we can define a remote function in the shell.
+    @ray.remote
+    def f(x):
+        return x + 1
+
+    assert ray.get(f.remote(0)) == 1
+
+    # Test that we can redefine the remote function.
+    @ray.remote
+    def f(x):
+        return x + 10
+
+    while True:
+        val = ray.get(f.remote(0))
+        assert val in [1, 10]
+        if val == 10:
+            break
+        else:
+            logger.info("Still using old definition of f, trying again.")
 
     # Check that we can redefine functions even when the remote function source
     # doesn't change (see https://github.com/ray-project/ray/issues/6130).
@@ -1057,6 +1058,7 @@ def test_redefining_remote_functions(shutdown_only):
         @ray.remote
         def h():
             return i
+
         return h.remote()
 
     for i in range(20):

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1035,34 +1035,34 @@ def test_redefining_remote_functions(shutdown_only):
     # Check that we can redefine functions even when the remote function source
     # doesn't change (see https://github.com/ray-project/ray/issues/6130).
     @ray.remote
-    def f():
+    def g():
         return nonexistent()
 
     with pytest.raises(ray.exceptions.RayTaskError, match="nonexistent"):
-        ray.get(f.remote())
+        ray.get(g.remote())
 
     def nonexistent():
         return 1
 
     # Redefine the function and make sure it succeeds.
     @ray.remote
-    def f():
+    def g():
         return nonexistent()
 
-    assert ray.get(f.remote()) == 1
+    assert ray.get(g.remote()) == 1
 
     # Check the same thing but when the redefined function is inside of another
     # task.
     @ray.remote
-    def g(i):
+    def h(i):
         @ray.remote
-        def h():
+        def j():
             return i
 
-        return h.remote()
+        return j.remote()
 
     for i in range(20):
-        assert ray.get(ray.get(g.remote(i))) == i
+        assert ray.get(ray.get(h.remote(i))) == i
 
 
 @pytest.mark.skipif(RAY_FORCE_DIRECT, reason="reconstruction not implemented")

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1028,24 +1028,39 @@ def test_defining_remote_functions(shutdown_only):
     assert ray.get(k2.remote(1)) == 2
     assert ray.get(m.remote(1)) == 2
 
+def test_redefining_remote_functions(shutdown_only):
+    ray.init(num_cpus=1)
+
     # Check that we can redefine functions even when the remote function source
     # doesn't change (see https://github.com/ray-project/ray/issues/6130).
     @ray.remote
-    def n():
+    def f():
         return nonexistent()
 
     with pytest.raises(ray.exceptions.RayTaskError, match="nonexistent"):
-        ray.get(n.remote())
+        ray.get(f.remote())
 
     def nonexistent():
         return 1
 
     # Redefine the function and make sure it succeeds.
     @ray.remote
-    def n():
+    def f():
         return nonexistent()
 
-    assert ray.get(n.remote()) == 1
+    assert ray.get(f.remote()) == 1
+
+    # Check the same thing but when the redefined function is inside of another
+    # task.
+    @ray.remote
+    def g(i):
+        @ray.remote
+        def h():
+            return i
+        return h.remote()
+
+    for i in range(20):
+        assert ray.get(ray.get(g.remote(i))) == i
 
 
 @pytest.mark.skipif(RAY_FORCE_DIRECT, reason="reconstruction not implemented")

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -3,14 +3,15 @@ from __future__ import division
 from __future__ import print_function
 
 import json
+import logging
 import os
-import pytest
 import sys
 import tempfile
 import threading
 import time
 
 import numpy as np
+import pytest
 import redis
 
 import ray
@@ -638,6 +639,41 @@ def test_warning_for_too_many_nested_tasks(shutdown_only):
 
     [g.remote() for _ in range(num_cpus * 4)]
     wait_for_errors(ray_constants.WORKER_POOL_LARGE_ERROR, 1)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 0), reason="This test requires Python 3.")
+def test_warning_for_too_many_duplicate_remote_functions(shutdown_only):
+    ray.init(num_cpus=1)
+
+    @ray.remote
+    def f():
+        @ray.remote
+        def g():
+            return 1
+
+        return ray.get(g.remote())
+
+    for _ in range(ray_constants.DUPLICATE_REMOTE_FUNCTION_THRESHOLD - 1):
+        ray.get(f.remote())
+
+    import io
+    log_capture_string = io.StringIO()
+    ch = logging.StreamHandler(log_capture_string)
+    ch.setLevel(logging.DEBUG)
+
+    ray.import_thread.logger.addHandler(ch)
+
+    ray.get(f.remote())
+
+    start_time = time.time()
+    while time.time() < start_time + 10:
+        log_contents = log_capture_string.getvalue()
+        if len(log_contents) > 0:
+            break
+
+    assert "has been exported {} times.".format(
+        ray_constants.DUPLICATE_REMOTE_FUNCTION_THRESHOLD) in log_contents
 
 
 def test_redis_module_failure(ray_start_regular):


### PR DESCRIPTION
- This should fix https://github.com/ray-project/ray/issues/6130.
- If a user defines the same remote function many (100) times (e.g., from within 100 separate tasks), then a warning will be printed.
- We also warn for actors.
- Spurious warnings are possible (e.g., if the something in the remote functions closure changes so the remote function is not actually the same).
- This only works for Python 3 because it uses the `dis` module.
- The behavior is slightly different for Python 3.7+ (hopefully better), but I didn't actually try it out yet.
- It's possible that `dis.dis` is sufficiently nondeterministic that we don't always get the warning when we should. However, I haven't noticed this happening.