### PR TITLE
Fix worker signal.SIGTERM handler being installed from outside the main thread

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -849,8 +849,11 @@ atexit.register(shutdown, True)
 def sigterm_handler(signum, frame):
     sys.exit(signal.SIGTERM)
 
-
-signal.signal(signal.SIGTERM, sigterm_handler)
+try:
+    signal.signal(signal.SIGTERM, sigterm_handler)
+except ValueError:
+    logger.warning("Processes might not be terminated properly if SIGTERM is sent"
+                   "(tried to set signal from outside the main thread).")
 
 # Define a custom excepthook so that if the driver exits with an exception, we
 # can push that exception to Redis.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -852,8 +852,8 @@ def sigterm_handler(signum, frame):
 try:
     signal.signal(signal.SIGTERM, sigterm_handler)
 except ValueError:
-    logger.warning("Processes might not be terminated properly if SIGTERM is sent"
-                   "(tried to set signal from outside the main thread).")
+    logger.warning("Failed to set SIGTERM handler, processes might"
+                   "not be cleaned up properly on exit.")
 
 # Define a custom excepthook so that if the driver exits with an exception, we
 # can push that exception to Redis.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -849,6 +849,7 @@ atexit.register(shutdown, True)
 def sigterm_handler(signum, frame):
     sys.exit(signal.SIGTERM)
 
+
 try:
     signal.signal(signal.SIGTERM, sigterm_handler)
 except ValueError:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This error happens for me if I initialize Ray inside of a flask server:
```
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/ubuntu/cli/backend/server/app.py", line 10, in <module>
    import ray
  File "/home/ubuntu/ray/python/ray/__init__.py", line 99, in <module>
    from ray.worker import (
  File "/home/ubuntu/ray/python/ray/worker.py", line 853, in <module>
    signal.signal(signal.SIGTERM, sigterm_handler)
  File "/home/ubuntu/anaconda3/lib/python3.7/signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
ValueError: signal only works in main thread
```

This PR fixes that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
