### PR TITLE
[doc fix] fix a link in getting-involved.html

### DIFF
--- a/doc/source/getting-involved.rst
+++ b/doc/source/getting-involved.rst
@@ -31,7 +31,7 @@ There are a couple steps to merge a contribution.
      git fetch upstream
      git rebase upstream/master
 
-2. Make sure all existing tests `pass <contrib.html#testing>`__.
+2. Make sure all existing tests `pass <getting-involved.html#testing>`__.
 3. If introducing a new feature or patching a bug, be sure to add new test cases
    in the relevant file in `ray/python/ray/tests/`.
 4. Document the code. Public functions need to be documented, and remember to provide an usage


### PR DESCRIPTION
doc fix only. fix the link in getting-involved.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
