### PR TITLE
Resolve dependencies locally before submitting direct actor tasks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -406,6 +406,16 @@ cc_binary(
 )
 
 cc_test(
+    name = "direct_actor_transport_test",
+    srcs = ["src/ray/core_worker/test/direct_actor_transport_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":core_worker_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "direct_task_transport_test",
     srcs = ["src/ray/core_worker/test/direct_task_transport_test.cc"],
     copts = COPTS,

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -10,6 +10,7 @@
 #include "ray/util/util.h"
 
 namespace ray {
+
 using WorkerType = rpc::WorkerType;
 
 // Return a string representation of the worker type.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -62,37 +62,6 @@ void GroupObjectIdsByStoreProvider(const std::vector<ObjectID> &object_ids,
 
 namespace ray {
 
-// Prepare direct call args for sending to a direct call *actor*. Direct call actors
-// always resolve their dependencies remotely, so we need some client-side preprocessing
-// to ensure they don't try to resolve a direct call object ID remotely (which is
-// impossible).
-//  - Direct call args that are local and small will be inlined.
-//  - Direct call args that are non-local or large will be promoted to plasma.
-// Note that args for direct call *tasks* are handled by LocalDependencyResolver.
-std::vector<TaskArg> PrepareDirectActorCallArgs(
-    const std::vector<TaskArg> &args,
-    std::shared_ptr<CoreWorkerMemoryStore> memory_store) {
-  std::vector<TaskArg> out;
-  for (const auto &arg : args) {
-    if (arg.IsPassedByReference() && arg.GetReference().IsDirectCallType()) {
-      const ObjectID &obj_id = arg.GetReference();
-      // TODO(ekl) we should consider resolving these dependencies on the client side
-      // for actor calls. It is a little tricky since we have to also preserve the
-      // task ordering so we can't simply use LocalDependencyResolver.
-      std::shared_ptr<RayObject> obj = memory_store->GetOrPromoteToPlasma(obj_id);
-      if (obj != nullptr) {
-        out.push_back(TaskArg::PassByValue(obj));
-      } else {
-        out.push_back(TaskArg::PassByReference(
-            obj_id.WithTransportType(TaskTransportType::RAYLET)));
-      }
-    } else {
-      out.push_back(arg);
-    }
-  }
-  return out;
-}
-
 CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
                        const std::string &store_socket, const std::string &raylet_socket,
                        const JobID &job_id, const gcs::GcsClientOptions &gcs_options,
@@ -657,11 +626,10 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
   const TaskID actor_task_id = TaskID::ForActorTask(
       worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
       next_task_index, actor_handle->GetActorID());
-  BuildCommonTaskSpec(
-      builder, actor_handle->CreationJobID(), actor_task_id,
-      worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(), rpc_address_,
-      function, is_direct_call ? PrepareDirectActorCallArgs(args, memory_store_) : args,
-      num_returns, task_options.resources, {}, transport_type, return_ids);
+  BuildCommonTaskSpec(builder, actor_handle->CreationJobID(), actor_task_id,
+                      worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
+                      rpc_address_, function, args, num_returns, task_options.resources,
+                      {}, transport_type, return_ids);
 
   const ObjectID new_cursor = return_ids->back();
   actor_handle->SetActorTaskSpec(builder, transport_type, new_cursor);

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -22,7 +22,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
   }
 
   std::vector<rpc::ClientCallback<rpc::PushTaskReply>> callbacks;
-  int64_t counter = 0;
+  uint64_t counter = 0;
 };
 
 TaskSpecification CreateActorTaskHelper(ActorID actor_id, int64_t counter) {

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -1,0 +1,130 @@
+#include "gtest/gtest.h"
+
+#include "ray/common/task/task_spec.h"
+#include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/core_worker/store_provider/memory_store_provider.h"
+#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/raylet/raylet_client.h"
+#include "ray/rpc/worker/core_worker_client.h"
+#include "src/ray/util/test_util.h"
+
+namespace ray {
+
+class MockWorkerClient : public rpc::CoreWorkerClientInterface {
+ public:
+  ray::Status PushActorTask(
+      std::unique_ptr<rpc::PushTaskRequest> request,
+      const rpc::ClientCallback<rpc::PushTaskReply> &callback) override {
+    RAY_CHECK(counter == request->task_spec().actor_task_spec().actor_counter());
+    counter++;
+    callbacks.push_back(callback);
+    return Status::OK();
+  }
+
+  std::vector<rpc::ClientCallback<rpc::PushTaskReply>> callbacks;
+  int64_t counter = 0;
+};
+
+TaskSpecification CreateActorTaskHelper(ActorID actor_id, int64_t counter) {
+  TaskSpecification task;
+  task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
+  task.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_id(actor_id.Binary());
+  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_counter(counter);
+  return task;
+}
+
+class DirectActorTransportTest : public ::testing::Test {
+ public:
+  DirectActorTransportTest()
+      : worker_client_(std::shared_ptr<MockWorkerClient>(new MockWorkerClient())),
+        ptr_(std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore())),
+        store_(std::make_shared<CoreWorkerMemoryStoreProvider>(ptr_)),
+        submitter_([&](const rpc::WorkerAddress &addr) { return worker_client_; },
+                   store_) {}
+
+  std::shared_ptr<MockWorkerClient> worker_client_;
+  std::shared_ptr<CoreWorkerMemoryStore> ptr_;
+  std::shared_ptr<CoreWorkerMemoryStoreProvider> store_;
+  CoreWorkerDirectActorTaskSubmitter submitter_;
+};
+
+TEST_F(DirectActorTransportTest, TestSubmitTask) {
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+
+  auto task = CreateActorTaskHelper(actor_id, 0);
+  ASSERT_TRUE(submitter_.SubmitTask(task).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  gcs::ActorTableData actor_data;
+  submitter_.HandleActorUpdate(actor_id, actor_data);
+  ASSERT_EQ(worker_client_->callbacks.size(), 1);
+
+  task = CreateActorTaskHelper(actor_id, 1);
+  ASSERT_TRUE(submitter_.SubmitTask(task).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 2);
+}
+
+TEST_F(DirectActorTransportTest, TestDependencies) {
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  gcs::ActorTableData actor_data;
+  submitter_.HandleActorUpdate(actor_id, actor_data);
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Create two tasks for the actor with different arguments.
+  ObjectID obj1 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
+  ObjectID obj2 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
+  auto task1 = CreateActorTaskHelper(actor_id, 0);
+  task1.GetMutableMessage().add_args()->add_object_ids(obj1.Binary());
+  auto task2 = CreateActorTaskHelper(actor_id, 1);
+  task2.GetMutableMessage().add_args()->add_object_ids(obj2.Binary());
+
+  // Neither task can be submitted yet because they are still waiting on
+  // dependencies.
+  ASSERT_TRUE(submitter_.SubmitTask(task1).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Put the dependencies in the store in the same order as task submission.
+  auto data = GenerateRandomObject();
+  ASSERT_TRUE(store_->Put(*data, obj1).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 1);
+  ASSERT_TRUE(store_->Put(*data, obj2).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 2);
+}
+
+TEST_F(DirectActorTransportTest, TestOutOfOrderDependencies) {
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  gcs::ActorTableData actor_data;
+  submitter_.HandleActorUpdate(actor_id, actor_data);
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Create two tasks for the actor with different arguments.
+  ObjectID obj1 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
+  ObjectID obj2 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
+  auto task1 = CreateActorTaskHelper(actor_id, 0);
+  task1.GetMutableMessage().add_args()->add_object_ids(obj1.Binary());
+  auto task2 = CreateActorTaskHelper(actor_id, 1);
+  task2.GetMutableMessage().add_args()->add_object_ids(obj2.Binary());
+
+  // Neither task can be submitted yet because they are still waiting on
+  // dependencies.
+  ASSERT_TRUE(submitter_.SubmitTask(task1).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Put the dependencies in the store in the opposite order of task
+  // submission.
+  auto data = GenerateRandomObject();
+  ASSERT_TRUE(store_->Put(*data, obj2).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+  ASSERT_TRUE(store_->Put(*data, obj1).ok());
+  ASSERT_EQ(worker_client_->callbacks.size(), 2);
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -192,7 +192,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
   CoreWorkerDirectTaskSubmitter submitter(raylet_client, factory, nullptr, store);
   TaskSpecification task;
   task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
@@ -214,7 +214,7 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
   CoreWorkerDirectTaskSubmitter submitter(raylet_client, factory, nullptr, store);
   TaskSpecification task;
   task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
@@ -232,7 +232,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
   CoreWorkerDirectTaskSubmitter submitter(raylet_client, factory, nullptr, store);
   TaskSpecification task1;
   TaskSpecification task2;
@@ -273,7 +273,7 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
   CoreWorkerDirectTaskSubmitter submitter(raylet_client, factory, nullptr, store);
   TaskSpecification task1;
   TaskSpecification task2;
@@ -316,7 +316,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
   CoreWorkerDirectTaskSubmitter submitter(raylet_client, factory, nullptr, store);
   TaskSpecification task1;
   TaskSpecification task2;
@@ -349,7 +349,7 @@ TEST(DirectTaskTransportTest, TestSpillback) {
   auto worker_client = std::shared_ptr<MockWorkerClient>(new MockWorkerClient());
   auto ptr = std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore());
   auto store = std::make_shared<CoreWorkerMemoryStoreProvider>(ptr);
-  auto factory = [&](WorkerAddress addr) { return worker_client; };
+  auto factory = [&](const rpc::WorkerAddress &addr) { return worker_client; };
 
   std::unordered_map<ClientID, std::shared_ptr<MockRayletClient>> remote_lease_clients;
   auto lease_client_factory = [&](const rpc::Address &addr) {

--- a/src/ray/core_worker/transport/dependency_resolver.cc
+++ b/src/ray/core_worker/transport/dependency_resolver.cc
@@ -1,0 +1,89 @@
+#include "ray/core_worker/transport/dependency_resolver.h"
+
+namespace ray {
+
+struct TaskState {
+  /// The task to be run.
+  TaskSpecification task;
+  /// The remaining dependencies to resolve for this task.
+  absl::flat_hash_set<ObjectID> local_dependencies;
+};
+
+void DoInlineObjectValue(const ObjectID &obj_id, std::shared_ptr<RayObject> value,
+                         TaskSpecification &task) {
+  auto &msg = task.GetMutableMessage();
+  bool found = false;
+  for (size_t i = 0; i < task.NumArgs(); i++) {
+    auto count = task.ArgIdCount(i);
+    if (count > 0) {
+      const auto &id = task.ArgId(i, 0);
+      if (id == obj_id) {
+        auto *mutable_arg = msg.mutable_args(i);
+        mutable_arg->clear_object_ids();
+        if (value->IsInPlasmaError()) {
+          // Promote the object id to plasma.
+          mutable_arg->add_object_ids(
+              obj_id.WithTransportType(TaskTransportType::RAYLET).Binary());
+        } else {
+          // Inline the object value.
+          if (value->HasData()) {
+            const auto &data = value->GetData();
+            mutable_arg->set_data(data->Data(), data->Size());
+          }
+          if (value->HasMetadata()) {
+            const auto &metadata = value->GetMetadata();
+            mutable_arg->set_metadata(metadata->Data(), metadata->Size());
+          }
+        }
+        found = true;
+      }
+    }
+  }
+  RAY_CHECK(found) << "obj id " << obj_id << " not found";
+}
+
+void LocalDependencyResolver::ResolveDependencies(const TaskSpecification &task,
+                                                  std::function<void()> on_complete) {
+  absl::flat_hash_set<ObjectID> local_dependencies;
+  for (size_t i = 0; i < task.NumArgs(); i++) {
+    auto count = task.ArgIdCount(i);
+    if (count > 0) {
+      RAY_CHECK(count <= 1) << "multi args not implemented";
+      const auto &id = task.ArgId(i, 0);
+      if (id.IsDirectCallType()) {
+        local_dependencies.insert(id);
+      }
+    }
+  }
+  if (local_dependencies.empty()) {
+    on_complete();
+    return;
+  }
+
+  // This is deleted when the last dependency fetch callback finishes.
+  std::shared_ptr<TaskState> state =
+      std::shared_ptr<TaskState>(new TaskState{task, std::move(local_dependencies)});
+  num_pending_ += 1;
+
+  for (const auto &obj_id : state->local_dependencies) {
+    in_memory_store_->GetAsync(
+        obj_id, [this, state, obj_id, on_complete](std::shared_ptr<RayObject> obj) {
+          RAY_CHECK(obj != nullptr);
+          bool complete = false;
+          {
+            absl::MutexLock lock(&mu_);
+            state->local_dependencies.erase(obj_id);
+            DoInlineObjectValue(obj_id, obj, state->task);
+            if (state->local_dependencies.empty()) {
+              complete = true;
+              num_pending_ -= 1;
+            }
+          }
+          if (complete) {
+            on_complete();
+          }
+        });
+  }
+}
+
+}  // namespace ray

--- a/src/ray/core_worker/transport/dependency_resolver.h
+++ b/src/ray/core_worker/transport/dependency_resolver.h
@@ -1,0 +1,45 @@
+#ifndef RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H
+#define RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H
+
+#include <memory>
+
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/core_worker/store_provider/memory_store_provider.h"
+
+namespace ray {
+
+// This class is thread-safe.
+class LocalDependencyResolver {
+ public:
+  LocalDependencyResolver(std::shared_ptr<CoreWorkerMemoryStoreProvider> store_provider)
+      : in_memory_store_(store_provider), num_pending_(0) {}
+
+  /// Resolve all local and remote dependencies for the task, calling the specified
+  /// callback when done. Direct call ids in the task specification will be resolved
+  /// to concrete values and inlined.
+  //
+  /// Note: This method **will mutate** the given TaskSpecification.
+  ///
+  /// Postcondition: all direct call ids in arguments are converted to values.
+  void ResolveDependencies(const TaskSpecification &task,
+                           std::function<void()> on_complete);
+
+  /// Return the number of tasks pending dependency resolution.
+  /// TODO(ekl) this should be exposed in worker stats.
+  int NumPendingTasks() const { return num_pending_; }
+
+ private:
+  /// The store provider.
+  std::shared_ptr<CoreWorkerMemoryStoreProvider> in_memory_store_;
+
+  /// Number of tasks pending dependency resolution.
+  std::atomic<int> num_pending_;
+
+  /// Protects against concurrent access to internal state.
+  absl::Mutex mu_;
+};
+
+}  // namespace ray
+
+#endif  // RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -60,7 +60,9 @@ void WriteObjectsToMemoryStore(
 CoreWorkerDirectActorTaskSubmitter::CoreWorkerDirectActorTaskSubmitter(
     rpc::ClientCallManager &client_call_manager,
     std::shared_ptr<CoreWorkerMemoryStoreProvider> store_provider)
-    : client_call_manager_(client_call_manager), in_memory_store_(store_provider) {}
+    : client_call_manager_(client_call_manager),
+      in_memory_store_(store_provider),
+      resolver_(in_memory_store_) {}
 
 Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
   RAY_LOG(DEBUG) << "Submitting task " << task_spec.TaskId();

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -42,13 +42,12 @@ class extended_priority_queue : public std::priority_queue<T, Container, Compare
 
 namespace ray {
 
+/// PushTaskRequest comparator to order requests for the same actor by the
+/// order of submission.
 class ComparePushTaskRequest {
  public:
   bool operator()(const std::unique_ptr<rpc::PushTaskRequest> &a,
-                  const std::unique_ptr<rpc::PushTaskRequest> &b) const {
-    return b->task_spec().actor_task_spec().actor_counter() <
-           a->task_spec().actor_task_spec().actor_counter();
-  }
+                  const std::unique_ptr<rpc::PushTaskRequest> &b) const;
 };
 
 /// The max time to wait for out-of-order tasks.
@@ -123,16 +122,13 @@ class CoreWorkerDirectActorTaskSubmitter {
                      std::unique_ptr<rpc::PushTaskRequest> request,
                      const ActorID &actor_id, const TaskID &task_id, int num_returns);
 
-  /// Create connection to actor and send all pending tasks.
+  /// Send all pending tasks for an actor.
   /// Note that this function doesn't take lock, the caller is expected to hold
   /// `mutex_` before calling this function.
   ///
   /// \param[in] actor_id Actor ID.
-  /// \param[in] ip_address The ip address of the node that the actor is running on.
-  /// \param[in] port The port that the actor is listening on.
   /// \return Void.
-  void ConnectAndSendPendingTasks(const ActorID &actor_id, std::string ip_address,
-                                  int port);
+  void SendPendingTasks(const ActorID &actor_id);
 
   /// Whether the specified actor is alive.
   ///

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -141,7 +141,7 @@ class CoreWorkerDirectActorTaskSubmitter {
   /// The store provider.
   std::shared_ptr<CoreWorkerMemoryStoreProvider> in_memory_store_;
 
-  /// Resolve local and remote dependencies;
+  /// Resolve direct call object dependencies;
   LocalDependencyResolver resolver_;
 
   friend class CoreWorkerTest;

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -14,6 +14,7 @@
 #include "ray/common/ray_object.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/store_provider/memory_store_provider.h"
+#include "ray/core_worker/transport/dependency_resolver.h"
 #include "ray/gcs/redis_gcs_client.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/worker/core_worker_client.h"
@@ -172,6 +173,9 @@ class CoreWorkerDirectActorTaskSubmitter {
 
   /// The store provider.
   std::shared_ptr<CoreWorkerMemoryStoreProvider> in_memory_store_;
+
+  /// Resolve local and remote dependencies;
+  LocalDependencyResolver resolver_;
 
   friend class CoreWorkerTest;
 };

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -15,7 +15,7 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
 }
 
 void CoreWorkerDirectTaskSubmitter::HandleWorkerLeaseGranted(
-    const WorkerAddress &addr, std::shared_ptr<WorkerLeaseInterface> lease_client) {
+    const rpc::WorkerAddress &addr, std::shared_ptr<WorkerLeaseInterface> lease_client) {
   // Setup client state for this worker.
   {
     absl::MutexLock lock(&mu_);
@@ -34,7 +34,7 @@ void CoreWorkerDirectTaskSubmitter::HandleWorkerLeaseGranted(
   OnWorkerIdle(addr, /*error=*/false);
 }
 
-void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(const WorkerAddress &addr,
+void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(const rpc::WorkerAddress &addr,
                                                  bool was_error) {
   absl::MutexLock lock(&mu_);
   if (queued_tasks_.empty() || was_error) {
@@ -123,7 +123,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
   worker_request_pending_ = true;
 }
 
-void CoreWorkerDirectTaskSubmitter::PushNormalTask(const WorkerAddress &addr,
+void CoreWorkerDirectTaskSubmitter::PushNormalTask(const rpc::WorkerAddress &addr,
                                                    rpc::CoreWorkerClientInterface &client,
                                                    TaskSpecification &task_spec) {
   auto task_id = task_spec.TaskId();

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -1,84 +1,8 @@
 #include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/dependency_resolver.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
 
 namespace ray {
-
-void DoInlineObjectValue(const ObjectID &obj_id, std::shared_ptr<RayObject> value,
-                         TaskSpecification &task) {
-  auto &msg = task.GetMutableMessage();
-  bool found = false;
-  for (size_t i = 0; i < task.NumArgs(); i++) {
-    auto count = task.ArgIdCount(i);
-    if (count > 0) {
-      const auto &id = task.ArgId(i, 0);
-      if (id == obj_id) {
-        auto *mutable_arg = msg.mutable_args(i);
-        mutable_arg->clear_object_ids();
-        if (value->IsInPlasmaError()) {
-          // Promote the object id to plasma.
-          mutable_arg->add_object_ids(
-              obj_id.WithTransportType(TaskTransportType::RAYLET).Binary());
-        } else {
-          // Inline the object value.
-          if (value->HasData()) {
-            const auto &data = value->GetData();
-            mutable_arg->set_data(data->Data(), data->Size());
-          }
-          if (value->HasMetadata()) {
-            const auto &metadata = value->GetMetadata();
-            mutable_arg->set_metadata(metadata->Data(), metadata->Size());
-          }
-        }
-        found = true;
-      }
-    }
-  }
-  RAY_CHECK(found) << "obj id " << obj_id << " not found";
-}
-
-void LocalDependencyResolver::ResolveDependencies(const TaskSpecification &task,
-                                                  std::function<void()> on_complete) {
-  absl::flat_hash_set<ObjectID> local_dependencies;
-  for (size_t i = 0; i < task.NumArgs(); i++) {
-    auto count = task.ArgIdCount(i);
-    if (count > 0) {
-      RAY_CHECK(count <= 1) << "multi args not implemented";
-      const auto &id = task.ArgId(i, 0);
-      if (id.IsDirectCallType()) {
-        local_dependencies.insert(id);
-      }
-    }
-  }
-  if (local_dependencies.empty()) {
-    on_complete();
-    return;
-  }
-
-  // This is deleted when the last dependency fetch callback finishes.
-  std::shared_ptr<TaskState> state =
-      std::shared_ptr<TaskState>(new TaskState{task, std::move(local_dependencies)});
-  num_pending_ += 1;
-
-  for (const auto &obj_id : state->local_dependencies) {
-    in_memory_store_->GetAsync(
-        obj_id, [this, state, obj_id, on_complete](std::shared_ptr<RayObject> obj) {
-          RAY_CHECK(obj != nullptr);
-          bool complete = false;
-          {
-            absl::MutexLock lock(&mu_);
-            state->local_dependencies.erase(obj_id);
-            DoInlineObjectValue(obj_id, obj, state->task);
-            if (state->local_dependencies.empty()) {
-              complete = true;
-              num_pending_ -= 1;
-            }
-          }
-          if (complete) {
-            on_complete();
-          }
-        });
-  }
-}
 
 Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
   resolver_.ResolveDependencies(task_spec, [this, task_spec]() {

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -33,6 +33,13 @@ const static int64_t RequestSizeInBytes(const PushTaskRequest &request) {
   return size;
 }
 
+// Shared between direct actor and task submitters.
+// TODO(swang): Remove and replace with rpc::Address.
+class CoreWorkerClientInterface;
+typedef std::pair<std::string, int> WorkerAddress;
+typedef std::function<std::shared_ptr<CoreWorkerClientInterface>(const WorkerAddress &)>
+    ClientFactoryFn;
+
 /// Abstract client interface for testing.
 class CoreWorkerClientInterface {
  public:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Uses the local dependency resolver used by direct task calls to resolve arguments for direct actors. The sender queues actor tasks with dependencies until the dependent tasks have finished before submitting the task to the executing actor.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
