### PR TITLE
Modify RayLogLevel to avoid conflicts with DEBUG macro and ERROR macros that are defined externally

### DIFF
--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -6,13 +6,16 @@
 
 #if defined(_WIN32)
 #ifndef _WINDOWS_
-#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related headers you need manually. (https://stackoverflow.com/a/8294669)
+#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related
+                             // headers you need manually.
+                             // (https://stackoverflow.com/a/8294669)
 #define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
 #endif
 #include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
 #endif
 #ifdef ERROR  // Should be true unless someone else undef'd it already
-#undef ERROR  // Windows GDI defines this macro; make it a global enum so it doesn't conflict with our code
+#undef ERROR  // Windows GDI defines this macro; make it a global enum so it doesn't
+              // conflict with our code
 enum { ERROR = 0 };
 #endif
 #endif

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -4,6 +4,18 @@
 #include <iostream>
 #include <string>
 
+#if defined(_WIN32)
+#ifndef _WINDOWS_
+#ifndef WIN32_LEAN_AND_MEAN  // Sorry for the inconvenience. Please include any related headers you need manually. (https://stackoverflow.com/a/8294669)
+#define WIN32_LEAN_AND_MEAN  // Prevent inclusion of WinSock2.h
+#endif
+#include <Windows.h>  // Force inclusion of WinGDI here to resolve name conflict
+#endif
+#ifdef ERROR  // Should be true unless someone else undef'd it already
+#undef ERROR  // Windows GDI defines this macro; make it a global enum so it doesn't conflict with our code
+enum { ERROR = 0 };
+#endif
+#endif
 namespace ray {
 
 enum class RayLogLevel { DEBUG = -1, INFO = 0, WARNING = 1, ERROR = 2, FATAL = 3 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The log severity macros are far too generic and easily conflict with those defined externally. For example:

- `DEBUG` is defined in debug builds
- `ERROR` is defined by Windows

## Related issue number

`glog` handles this a bit differently:

https://github.com/google/glog/commit/6febec361e73860cc77d9cb0c6c14013c0e36ef0#diff-6cf325139803cd98ccab9ff58ebaa0b3

But their solution is still problematic since there's still no way to refer to the `DEBUG` and `ERROR` variables once the macros are defined.

Also, it seems to me their solution increases their own logging code's verbosity in return for making it more terse for users who don't include such macros. In our case, it's the opposite: we want to minimize our own code's verbosity. The shortest way I could think of was making `RAY_LOG_ERROR()` a macro and also a regular `enum` value.

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
