### PR TITLE
Rename UpdateResource due to conflict with Windows

### DIFF
--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -762,8 +762,8 @@ void SchedulingResources::Acquire(const ResourceSet &resources) {
   resources_available_.SubtractResourcesStrict(resources);
 }
 
-void SchedulingResources::UpdateResource_(const std::string &resource_name,
-                                          int64_t capacity) {
+void SchedulingResources::UpdateResourceCapacity(const std::string &resource_name,
+                                                 int64_t capacity) {
   const FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
   const FractionalResourceQuantity &current_capacity =
       resources_total_.GetResource(resource_name);

--- a/src/ray/common/task/scheduling_resources.cc
+++ b/src/ray/common/task/scheduling_resources.cc
@@ -762,8 +762,8 @@ void SchedulingResources::Acquire(const ResourceSet &resources) {
   resources_available_.SubtractResourcesStrict(resources);
 }
 
-void SchedulingResources::UpdateResource(const std::string &resource_name,
-                                         int64_t capacity) {
+void SchedulingResources::UpdateResource_(const std::string &resource_name,
+                                          int64_t capacity) {
   const FractionalResourceQuantity new_capacity = FractionalResourceQuantity(capacity);
   const FractionalResourceQuantity &current_capacity =
       resources_total_.GetResource(resource_name);

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -506,7 +506,7 @@ class SchedulingResources {
   /// \param resource_name: Name of the resource to be modified
   /// \param capacity: New capacity of the resource.
   /// \return Void.
-  void UpdateResource(const std::string &resource_name, int64_t capacity);
+  void UpdateResource_(const std::string &resource_name, int64_t capacity);
 
   /// \brief Delete resource from total, available and load resources.
   ///

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -506,7 +506,7 @@ class SchedulingResources {
   /// \param resource_name: Name of the resource to be modified
   /// \param capacity: New capacity of the resource.
   /// \return Void.
-  void UpdateResource_(const std::string &resource_name, int64_t capacity);
+  void UpdateResourceCapacity(const std::string &resource_name, int64_t capacity);
 
   /// \brief Delete resource from total, available and load resources.
   ///

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -568,7 +568,7 @@ void NodeManager::ResourceCreateUpdated(const ClientID &client_id,
     const std::string &resource_label = resource_pair.first;
     const double &new_resource_capacity = resource_pair.second;
 
-    cluster_schedres.UpdateResource(resource_label, new_resource_capacity);
+    cluster_schedres.UpdateResource_(resource_label, new_resource_capacity);
     if (client_id == local_client_id) {
       local_available_resources_.AddOrUpdateResource(resource_label,
                                                      new_resource_capacity);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -568,7 +568,7 @@ void NodeManager::ResourceCreateUpdated(const ClientID &client_id,
     const std::string &resource_label = resource_pair.first;
     const double &new_resource_capacity = resource_pair.second;
 
-    cluster_schedres.UpdateResource_(resource_label, new_resource_capacity);
+    cluster_schedres.UpdateResourceCapacity(resource_label, new_resource_capacity);
     if (client_id == local_client_id) {
       local_available_resources_.AddOrUpdateResource(resource_label,
                                                      new_resource_capacity);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`UpdateResource` is a predefined macro in Windows, so I renamed it to avoid the conflict.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
