### PR TITLE
Clean up dead leased workers for direct calls

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1169,6 +1169,10 @@ void NodeManager::ProcessDisconnectClientMessage(
 
     // Since some resources may have been released, we can try to dispatch more tasks.
     DispatchTasks(local_queues_.GetReadyTasksByClass());
+
+    // Remove the worker's lease. If the lessee tries to return it, it will get
+    // an error status.
+    leased_workers_.erase(worker->Port());
   } else if (is_driver) {
     // The client is a driver.
     const auto job_id = worker->GetAssignedJobId();

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -392,6 +392,10 @@ ray::Status RayletClient::ReturnWorker(int worker_port) {
   request.set_worker_port(worker_port);
   return grpc_client_->ReturnWorker(
       request, [](const ray::Status &status, const ray::rpc::ReturnWorkerReply &reply) {
-        RAY_CHECK_OK(status);
+        if (status.IsInvalid()) {
+          RAY_LOG(ERROR) << "A worker died before we could return it to the scheduler";
+        } else {
+          RAY_CHECK_OK(status);
+        }
       });
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Remove leases for workers that die.

Now, `﻿RAY_FORCE_DIRECT=1 pytest -sv python/ray/tests/test_failure.py::test_worker_raising_exception` should pass.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
