### PR TITLE
Allow compiling with debug symbols by setting RAY_DEBUG=1

### DIFF
--- a/src/ray/test/run_core_worker_tests.sh
+++ b/src/ray/test/run_core_worker_tests.sh
@@ -22,7 +22,7 @@ fi
 set -e
 set -x
 
-bazel build "//:core_worker_test" "//:mock_worker"  "//:raylet" "//:libray_redis_module.so" "@plasma//:plasma_store_server"
+bazel build --copt -g "//:core_worker_test" "//:mock_worker"  "//:raylet" "//:libray_redis_module.so" "@plasma//:plasma_store_server"
 
 # Get the directory in which this script is executing.
 SCRIPT_DIR="`dirname \"$0\"`"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This enables line numbers to be reported in stack traces for the Ray binaries. Settings this flag increases the size of the Ray binaries to ~130MB, which is probably too big to ship on by default.

Longer term, it would be nice to enable -g by default for all builds except production wheels, but this PR will do for now.
