### PR TITLE
Patch Cython in grpc to use COPTS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -775,6 +775,7 @@ pyx_library(
         "python/ray/includes/*.pxd",
         "python/ray/includes/*.pxi",
     ]),
+    copts = COPTS,
     deps = [
         "//:core_worker_lib",
         "//:raylet_lib",

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -118,6 +118,9 @@ def ray_deps_setup():
         commit = "93e8830070e9afcbaa992c75817009ee3f4b63a0",
         remote = "https://github.com/grpc/grpc.git",
         shallow_since = "1571118670 -0700",
+        patches = [
+            "//thirdparty/patches:grpc-cython-copts.patch",
+        ],
     )
 
     git_repository(

--- a/thirdparty/patches/grpc-cython-copts.patch
+++ b/thirdparty/patches/grpc-cython-copts.patch
@@ -1,0 +1,30 @@
+diff --git bazel/cython_library.bzl bazel/cython_library.bzl
+index 48b41d74e8..6084734f59 100644
+--- bazel/cython_library.bzl
++++ bazel/cython_library.bzl
+@@ -7,7 +7,7 @@
+ # been written at cython/cython and tensorflow/tensorflow. We branch from
+ # Tensorflow's version as it is more actively maintained and works for gRPC
+ # Python's needs.
+-def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
++def pyx_library(name, deps=[], copts=[], py_deps=[], srcs=[], **kwargs):
+     """Compiles a group of .pyx / .pxd / .py files.
+ 
+     First runs Cython to create .cpp files for each input .pyx or .py + .pxd
+@@ -19,6 +19,7 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
+     Args:
+         name: Name for the rule.
+         deps: C/C++ dependencies of the Cython (e.g. Numpy headers).
++        copts: C/C++ compiler options for Cython
+         py_deps: Pure Python dependencies of the final library.
+         srcs: .py, .pyx, or .pxd files to either compile or pass through.
+         **kwargs: Extra keyword arguments passed to the py_library.
+@@ -58,6 +59,7 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
+         native.cc_binary(
+             name=shared_object_name,
+             srcs=[stem + ".cpp"],
++            copts=copts,
+             deps=deps + ["@local_config_python//:python_headers"],
+             linkshared=1,
+         )
+-- 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`pyx_library` needs a mechanism to pass `copts`.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
