### PR TITLE
Add draft of C-library interface to Ray

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -347,6 +347,7 @@ cc_library(
         "src/ray/core_worker/transport/*.h",
     ]),
     copts = COPTS,
+    visibility = ["//clib:__subpackages__"],
     deps = [
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/clib/BUILD.bazel
+++ b/clib/BUILD.bazel
@@ -1,0 +1,10 @@
+cc_library(
+    name = "ray",
+    srcs = ["lib.cpp"],
+    hdrs = glob([
+        "ray.h",
+    ]),
+    deps = [
+        "//:core_worker_lib",
+    ],
+)

--- a/clib/BUILD.bazel
+++ b/clib/BUILD.bazel
@@ -8,3 +8,11 @@ cc_library(
         "//:core_worker_lib",
     ],
 )
+
+cc_binary(
+    name = "test",
+    srcs = ["main.c"],
+    deps = [
+        ":ray",
+    ],
+)

--- a/clib/BUILD.bazel
+++ b/clib/BUILD.bazel
@@ -4,6 +4,7 @@ cc_library(
     hdrs = glob([
         "ray.h",
     ]),
+    copts = ["-g"],
     deps = [
         "//:core_worker_lib",
     ],
@@ -12,6 +13,7 @@ cc_library(
 cc_binary(
     name = "test",
     srcs = ["main.c"],
+    copts = ["-g"],
     deps = [
         ":ray",
     ],

--- a/clib/lib.cpp
+++ b/clib/lib.cpp
@@ -1,0 +1,314 @@
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+
+extern "C" {
+#include "ray.h"
+}
+
+#include "ray/common/id.h"
+#include "ray/core_worker/common.h"
+#include "ray/core_worker/core_worker.h"
+
+extern "C" {
+//
+// Worker methods
+//
+
+void become_ray_worker(int argc, char *argv[], TaskExecutionCallback callback) {
+  if (argc < 6) {
+    // TODO: error
+    return;
+  }
+
+  std::string store_socket = "";
+  std::string raylet_socket = "";
+  std::string node_ip_address = "";
+  int node_manager_port = 0;
+  std::string log_dir = "";
+  std::string gcs_redis_ip = "";
+  int gcs_redis_port = 0;
+  std::string gcs_redis_password = "";
+
+  // https://github.com/ray-project/ray/blob/33c768ebe414c2a2f93a8b8f8637e02b387bb7ea/python/ray/services.py#L1152
+  for (int i = 1; i < argc; i++) {
+    std::string arg(argv[i]);
+    if (arg.rfind("--node-ip-address=", 0) == 0) {
+      node_ip_address = arg.substr(arg.find("=") + 1);
+    } else if (arg.rfind("--node-manager-port=", 0) == 0) {
+      node_manager_port = stoi(arg.substr(arg.find("=") + 1));
+    } else if (arg.rfind("--object-store-name=", 0) == 0) {
+      store_socket = arg.substr(arg.find("=") + 1);
+    } else if (arg.rfind("--raylet-name=", 0) == 0) {
+      raylet_socket = arg.substr(arg.find("=") + 1);
+    } else if (arg.rfind("--redis-address=", 0) == 0) {
+      auto addr = arg.substr(arg.find("=") + 1);
+      gcs_redis_ip = addr.substr(0, addr.find(":"));
+      gcs_redis_port = stoi(addr.substr(addr.find(":") + 1));
+    } else if (arg == "--redis-password") {
+      gcs_redis_password = std::string(argv[i + 1]);
+      i += 1;
+    }
+  }
+
+  ray::gcs::GcsClientOptions gcs_opts(gcs_redis_ip, gcs_redis_port, gcs_redis_password);
+  ray::CoreWorker *w = nullptr;
+  w = new ray::CoreWorker(
+      ray::WorkerType::WORKER, ray::Language::NATIVE, store_socket, raylet_socket,
+      ray::JobID(), gcs_opts, log_dir, node_ip_address, node_manager_port,
+      [&w, callback](
+          TaskType task_type, const ray::RayFunction &ray_function,
+          const std::unordered_map<std::string, double> &required_resources,
+          const std::vector<std::shared_ptr<ray::RayObject>> &args,
+          const std::vector<ray::ObjectID> &arg_reference_ids,
+          const std::vector<ray::ObjectID> &return_ids,
+          std::vector<std::shared_ptr<ray::RayObject>> *results) -> ray::Status {
+        ray::Status *s =
+            (ray::Status *)(callback((Ray *)(w), (uint32_t)task_type,
+                                     ray_function.GetFunctionDescriptor()[0].c_str(),
+                                     (ResourceMap *)&required_resources, (Objects *)&args,
+                                     (ObjectIds *)&arg_reference_ids,
+                                     (ObjectIds *)&return_ids, (Objects *)results));
+
+        if (s == NULL) {
+          return ray::Status::OK();
+        }
+        return *s;
+      },
+      nullptr, NULL);
+
+  w->StartExecutingTasks();
+}
+
+Ray *ray_new(char *store_socket, char *raylet_socket, int job, struct GcsConnectArgs gcs,
+             char *node_ip_address, int node_manager_port) {
+  // TODO: avoid the copies here
+  const std::string &store_socket_s(store_socket);
+  const std::string &raylet_socket_s(raylet_socket);
+  const std::string &node_ip_address_s(node_ip_address);
+  const std::string &log_dir = "";
+  ray::JobID jid = ray::JobID::FromInt(job);
+  const ray::gcs::GcsClientOptions gcs_opts =
+      ray::gcs::GcsClientOptions(gcs.redis_ip, gcs.redis_port, gcs.redis_password);
+
+  ray::CoreWorker *w = new ray::CoreWorker(
+      ray::WorkerType::DRIVER, ray::Language::NATIVE, store_socket_s, raylet_socket_s,
+      jid, gcs_opts, log_dir, node_ip_address_s, node_manager_port, NULL, nullptr, NULL);
+  return (Ray *)w;
+}
+
+void ray_free(Ray *ray) { delete (ray::CoreWorker *)ray; }
+
+ExecutionResult *ray_allocate_returns(Ray *ray, const ObjectIds *ids,
+                                      const size_t sizes[], Objects *return_objects) {
+  auto ids_v = (std::vector<ray::ObjectID> *)(ids);
+  auto sizes_v = std::vector<size_t>(sizes, sizes + ids_v->size());
+  auto metadata_v = std::vector<std::shared_ptr<ray::Buffer>>(
+      ids_v->size(),
+      std::shared_ptr<ray::Buffer>(
+          std::make_shared<ray::LocalMemoryBuffer>((uint8_t *)"", 1, true)));
+
+  ray::Status s =
+      ((ray::CoreWorker *)(ray))
+          ->AllocateReturnObjects(
+              *ids_v, sizes_v, metadata_v,
+              (std::vector<std::shared_ptr<ray::RayObject>> *)(return_objects));
+  if (s.ok()) {
+    return NULL;
+  }
+  return (ExecutionResult *)(new ray::Status(s));
+}
+
+ExecutionResult *ray_put(Ray *ray, const char *bytes, size_t len, ObjectId *oid) {
+  // TODO: this is awkward -- how do we do zero-copy?
+  std::shared_ptr<ray::LocalMemoryBuffer> data =
+      std::make_shared<ray::LocalMemoryBuffer>((uint8_t *)bytes, len, true);
+
+  ray::ObjectID *object_id = (ray::ObjectID *)(oid);
+  ray::RayObject obj = ray::RayObject(
+      std::dynamic_pointer_cast<ray::Buffer, ray::LocalMemoryBuffer>(data), nullptr);
+
+  ray::Status s = ((ray::CoreWorker *)(ray))->Put(obj, object_id);
+  if (s.ok()) {
+    return NULL;
+  }
+  // XXX: do we need to also call Seal here?
+  return (ExecutionResult *)(new ray::Status(s));
+}
+
+ExecutionResult *ray_get(Ray *ray, const ObjectIds *ids, int64_t timeout_ms,
+                         Objects *results) {
+  ray::Status s = ((ray::CoreWorker *)(ray))
+                      ->Get(*(std::vector<ray::ObjectID> *)(ids), timeout_ms,
+                            (std::vector<std::shared_ptr<ray::RayObject>> *)(results));
+  if (s.ok()) {
+    return NULL;
+  }
+  return (ExecutionResult *)(new ray::Status(s));
+}
+
+ExecutionResult *ray_wait(Ray *ray, const ObjectIds *ids, size_t num_objects,
+                          int64_t timeout_ms, Ready *r) {
+  ray::Status s = ((ray::CoreWorker *)(ray))
+                      ->Wait(*(std::vector<ray::ObjectID> *)(ids), num_objects,
+                             timeout_ms, (std::vector<bool> *)(r));
+  if (s.ok()) {
+    return NULL;
+  }
+  return (ExecutionResult *)(new ray::Status(s));
+}
+
+ExecutionResult *ray_submit_task(Ray *ray, ActorId *actor, const char *function,
+                                 struct TaskOptions opts, Args *args,
+                                 ObjectIds *return_ids) {
+  auto resources = (std::unordered_map<std::string, double> *)(opts.resources);
+  ray::TaskOptions task_options(1, false, *resources);
+  const std::string func(function);
+  ray::Status s;
+  if (actor == NULL) {
+    s = ((ray::CoreWorker *)(ray))
+            ->SubmitTask(
+                ray::RayFunction(ray::Language::NATIVE, std::vector<std::string>({func})),
+                *(std::vector<ray::TaskArg> *)(args), task_options,
+                (std::vector<ray::ObjectID> *)(return_ids));
+  } else {
+    s = ((ray::CoreWorker *)(ray))
+            ->SubmitActorTask(
+                *(ray::ActorID *)(actor),
+                ray::RayFunction(ray::Language::NATIVE, std::vector<std::string>({func})),
+                *(std::vector<ray::TaskArg> *)(args), task_options,
+                (std::vector<ray::ObjectID> *)(return_ids));
+  }
+
+  if (s.ok()) {
+    return NULL;
+  }
+  return (ExecutionResult *)(new ray::Status(s));
+}
+
+//
+// Helper methods: ObjectIds
+// Equivalent to: std::vector<ray::ObjectID>
+//
+ObjectIds *object_ids_new() { return (ObjectIds *)(new std::vector<ray::ObjectID>()); }
+ObjectIds *object_ids_with_capacity(size_t cap) {
+  auto v = new std::vector<ray::ObjectID>();
+  v->reserve(cap);
+  return (ObjectIds *)(v);
+}
+ObjectId *object_ids_at(ObjectIds *oids, size_t index) {
+  return (ObjectId *)(&((std::vector<ray::ObjectID> *)(oids))->at(index));
+}
+size_t object_ids_len(ObjectIds *oids) {
+  return ((std::vector<ray::ObjectID> *)(oids))->size();
+}
+void object_ids_clear(ObjectIds *oids) {
+  ((std::vector<ray::ObjectID> *)(oids))->clear();
+}
+void object_ids_free(ObjectIds *oids) { delete ((std::vector<ray::ObjectID> *)(oids)); }
+
+//
+// Helper methods: Objects
+// Equivalent to: std::vector<std::shared_ptr<ray::RayObject>>
+//
+Objects *objects_new() {
+  return (Objects *)(new std::vector<std::shared_ptr<ray::RayObject>>());
+}
+Objects *objects_with_capacity(size_t cap) {
+  auto v = new std::vector<std::shared_ptr<ray::RayObject>>();
+  v->reserve(cap);
+  return (Objects *)(v);
+}
+Object *objects_at(Objects *os, size_t index) {
+  return (Object *)(&((std::vector<std::shared_ptr<ray::RayObject>> *)(os))->at(index));
+};
+size_t objects_len(Objects *os) {
+  return ((std::vector<std::shared_ptr<ray::RayObject>> *)(os))->size();
+}
+void objects_clear(Objects *os) {
+  ((std::vector<std::shared_ptr<ray::RayObject>> *)(os))->clear();
+}
+void objects_free(Objects *os) {
+  delete ((std::vector<std::shared_ptr<ray::RayObject>> *)(os));
+}
+
+//
+// Helper methods: Object
+// Equivalent to: std::shared_ptr<ray::RayObject>
+//
+char *object_buf(Object *o) {
+  return (char *)((*(std::shared_ptr<ray::RayObject> *)(o))->GetData()->Data());
+}
+size_t object_buf_size(Object *o) {
+  return ((std::shared_ptr<ray::RayObject> *)(o))->get()->GetData()->Size();
+}
+
+//
+// Helper methods: Ready
+// Equivalent to: std::vector<bool>
+//
+Ready *ready_new() { return (Ready *)(new std::vector<bool>()); }
+Ready *ready_with_capacity(size_t cap) {
+  auto v = new std::vector<bool>();
+  v->reserve(cap);
+  return (Ready *)(v);
+}
+bool ready_at(Ready *r, size_t index) { return ((std::vector<bool> *)(r))->at(index); }
+size_t ready_len(Ready *r) { return ((std::vector<bool> *)(r))->size(); }
+void ready_clear(Ready *r) { ((std::vector<bool> *)(r))->clear(); }
+void ready_free(Ready *r) { delete ((std::vector<bool> *)(r)); }
+
+//
+// Helper methods: Args
+// Equivalent to: std::vector<ray::TaskArg>
+//
+Args *args_new() { return (Args *)(new std::vector<ray::TaskArg>()); }
+Args *args_with_capacity(size_t cap) {
+  auto v = new std::vector<ray::TaskArg>();
+  v->reserve(cap);
+  return (Args *)(v);
+}
+Arg *args_at(Args *as, size_t index) {
+  return (Arg *)(&((std::vector<ray::TaskArg> *)(as))->at(index));
+};
+size_t args_len(Args *as) { return ((std::vector<ray::TaskArg> *)(as))->size(); }
+void args_clear(Args *as) { ((std::vector<ray::TaskArg> *)(as))->clear(); }
+void args_free(Args *as) { delete ((std::vector<ray::TaskArg> *)(as)); }
+
+//
+// Helper methods: ResourceMap
+// Equivalent to: std::unordered_map<std::string, double>
+//
+ResourceMap *resource_map_new() {
+  return (ResourceMap *)(new std::unordered_map<std::string, double>());
+}
+double resources_for(ResourceMap *rm, char *index) {
+  // TODO: avoid the copies here:
+  const std::string &idx(index);
+  return ((std::unordered_map<std::string, double> *)(rm))->at(idx);
+}
+void resource_map_free(ResourceMap *rm) {
+  delete ((std::unordered_map<std::string, double> *)(rm));
+}
+
+//
+// Helper methods: ExecutionResult
+// Equivalent to: Status
+//
+bool is_ok(ExecutionResult *e) { return (e == NULL || ((ray::Status *)(e))->ok()); }
+int err_code(ExecutionResult *e) {
+  ray::Status *s = (ray::Status *)(e);
+  if (s == NULL) {
+    return 0;
+  }
+  return (int)(s->code());
+}
+void result_free(ExecutionResult *e) {
+  if (e != NULL) {
+    delete ((ray::Status *)(e));
+  }
+}
+}
+
+// vim: expandtab:sw=2:ts=2:sts=2

--- a/clib/main.c
+++ b/clib/main.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ray.h"
+
+bool startsWith(const char *pre, const char *str);
+
+ExecutionResult *on_execute(Ray *ray, TaskType tt, const char *func,
+                            const ResourceMap *resources, const Objects *args,
+                            const ObjectIds *arg_reference_ids,
+                            const ObjectIds *return_ids, Objects *results) {
+  printf("==> Told to execute: %s\n", func);
+
+  printf("==> Allocating space for results\n");
+  size_t sizes[] = {sizeof(int)};
+  ExecutionResult *s = ray_allocate_returns(ray, return_ids, sizes, results);
+  if (!is_ok(s)) {
+    printf(" -> Allocation failed with error code: %d\n", err_code(s));
+    return s;
+  }
+
+  if (objects_len(results) != 1) {
+    printf(" -> Allocated space for %zu results, not 1\n", objects_len(results));
+  }
+
+  printf("==> Writing out result\n");
+  int rval = 42;
+  Object *ret = objects_at(results, 0);
+  printf(" -> Size of object buf: %zu\n", object_buf_size(ret));
+  memcpy(object_buf(ret), &rval, sizeof(int));
+  printf(" -> Results written\n");
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]) {
+  setbuf(stdout, NULL);
+
+  if (argc > 1 && startsWith("--node-ip-address=", argv[1])) {
+    // we're being run as a worker -- don't run the driver code
+    printf(":: Starting a native worker for test driver\n");
+    become_ray_worker(argc, argv, on_execute);
+    return 0;
+  }
+
+  if (argc < 3) {
+    printf("Usage: %s IP NODE_MANAGER_PORT REDIS_PORT\n", argv[0]);
+    return 1;
+  }
+
+  printf(":: Starting test driver\n");
+
+  char *ip = argv[1];
+  int node_manager_port = atoi(argv[2]);
+  int redis_port = atoi(argv[3]);
+
+  printf("==> Connecting to ray\n");
+
+  struct GcsConnectArgs gcs_args = {
+      .redis_ip = ip, .redis_port = redis_port, .redis_password = ""};
+  Ray *w = ray_new("/tmp/ray/session_latest/sockets/plasma_store",
+                   "/tmp/ray/session_latest/sockets/raylet", 123456, gcs_args, ip,
+                   node_manager_port);
+  ExecutionResult *s;
+
+  printf("==> Submitting task\n");
+
+  ResourceMap *rm = resource_map_new();
+  Args *args = args_new();
+  ObjectIds *rets = object_ids_new();
+  struct TaskOptions task = {
+      .resources = rm,
+  };
+  s = ray_submit_task(w, NULL, "hello world", task, args, rets);
+  if (!is_ok(s)) {
+    printf(" -> submit_taks failed with code: %d\n", err_code(s));
+    ray_free(w);
+    return 1;
+  }
+
+  if (object_ids_len(rets) != 1) {
+    printf(" -> Task has # return values != 1: %zu", object_ids_len(rets));
+  }
+
+  printf("==> Waiting for task\n");
+
+  Ready *ready = ready_with_capacity(object_ids_len(rets));
+  s = ray_wait(w, rets, object_ids_len(rets), -1, ready);
+  if (!is_ok(s)) {
+    printf(" -> ray_wait failed with code: %d\n", err_code(s));
+    ray_free(w);
+    return 1;
+  }
+
+  printf("==> Fetching task results\n");
+
+  Objects *results = objects_with_capacity(ready_len(ready));
+  s = ray_get(w, rets, -1, results);
+  if (!is_ok(s)) {
+    printf(" -> ray_get failed with code: %d\n", err_code(s));
+    ray_free(w);
+    return 1;
+  }
+
+  printf("==> Remote task finshed\n");
+
+  Object *ret = objects_at(results, 0);
+  int got = *(int *)(object_buf(ret));
+
+  printf(" -> It returned: %d\n", got);
+
+  ray_free(w);
+}
+
+bool startsWith(const char *pre, const char *str) {
+  size_t lenpre = strlen(pre), lenstr = strlen(str);
+  return lenstr < lenpre ? false : memcmp(pre, str, lenpre) == 0;
+}

--- a/clib/ray.h
+++ b/clib/ray.h
@@ -1,0 +1,159 @@
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+//
+// Opaque Ray types
+//
+
+// ray::CoreWorker
+struct Ray;
+typedef struct Ray Ray;
+
+// std::shared_ptr<ray::RayObject>
+struct Object;
+typedef struct Object Object;
+
+// std::vector<std::shared_ptr<ray::RayObject>>
+struct Objects;
+typedef struct Objects Objects;
+
+// ray::ObjectID
+struct ObjectId;
+typedef struct ObjectId ObjectId;
+
+// std::vector<ray::ObjectID>
+struct ObjectIds;
+typedef struct ObjectIds ObjectIds;
+
+// ray::ActorID
+struct ActorId;
+typedef struct ActorId ActorId;
+
+// ray::TaskArg
+struct Arg;
+typedef struct Arg Arg;
+
+// std::vector<ray::TaskArg>
+struct Args;
+typedef struct Args Args;
+
+// std::vector<bool>
+struct Ready;
+typedef struct Ready Ready;
+
+// std::unordered_map<std::string, double>
+struct ResourceMap;
+typedef struct ResourceMap ResourceMap;
+
+// ray::Status
+struct ExecutionResult;
+typedef struct ExecutionResult ExecutionResult;
+
+//
+// Public Ray types
+//
+
+struct GcsConnectArgs {
+  char *redis_ip;
+  int redis_port;
+  char *redis_password;
+};
+
+struct TaskOptions {
+  ResourceMap *resources;
+};
+
+typedef uint32_t TaskType;
+
+typedef ExecutionResult *(*TaskExecutionCallback)(Ray *, TaskType, const char *,
+                                                  const ResourceMap *, const Objects *,
+                                                  const ObjectIds *, const ObjectIds *,
+                                                  Objects *);
+
+//
+// Worker methods
+//
+
+void become_ray_worker(int argc, char *argv[], TaskExecutionCallback callback);
+
+ExecutionResult *ray_allocate_returns(Ray *ray, const ObjectIds *ids,
+                                      const size_t sizes[], Objects *return_objects);
+
+Ray *ray_new(char *store_socket, char *raylet_socket, int job, struct GcsConnectArgs gcs,
+             char *node_ip_address, int node_manager_port);
+
+ExecutionResult *ray_put(Ray *ray, const char *bytes, size_t len, ObjectId *oid);
+ExecutionResult *ray_get(Ray *ray, const ObjectIds *ids, int64_t timeout_ms,
+                         Objects *results);
+ExecutionResult *ray_wait(Ray *ray, const ObjectIds *ids, size_t num_objects,
+                          int64_t timeout_ms, Ready *r);
+ExecutionResult *ray_submit_task(Ray *ray, ActorId *actor, const char *function,
+                                 struct TaskOptions opts, Args *args,
+                                 ObjectIds *return_ids);
+
+void ray_free(Ray *ray);
+
+// create_actor
+
+//
+// Helper methods: ObjectIds
+//
+ObjectIds *object_ids_new();
+ObjectIds *object_ids_with_capacity(size_t cap);
+ObjectId *object_ids_at(ObjectIds *oids, size_t index);
+size_t object_ids_len(ObjectIds *oids);
+void object_ids_clear(ObjectIds *oids);
+void object_ids_free(ObjectIds *oids);
+
+//
+// Helper methods: Objects
+//
+Objects *objects_new();
+Objects *objects_with_capacity(size_t cap);
+Object *objects_at(Objects *os, size_t index);
+size_t objects_len(Objects *os);
+void objects_clear(Objects *os);
+void objects_free(Objects *os);
+
+//
+// Helper methods: Object
+//
+char *object_buf(Object *o);
+size_t object_buf_size(Object *o);
+
+//
+// Helper methods: Ready
+//
+Ready *ready_new();
+Ready *ready_with_capacity(size_t cap);
+bool ready_at(Ready *r, size_t index);
+size_t ready_len(Ready *r);
+void ready_clear(Ready *r);
+void ready_free(Ready *r);
+
+//
+// Helper methods: Args
+//
+Args *args_new();
+Args *args_with_capacity(size_t cap);
+Arg *args_at(Args *as, size_t index);
+size_t args_len(Args *as);
+void args_clear(Args *as);
+void args_free(Args *as);
+
+//
+// Helper methods: ResourceMap
+//
+ResourceMap *resource_map_new();
+double resources_for(ResourceMap *rm, char *index);
+void resource_map_free(ResourceMap *rm);
+
+//
+// Helper methods: ExecutionResult
+//
+bool is_ok(ExecutionResult *e);
+int err_code(ExecutionResult *e);
+void result_free(ExecutionResult *e);
+
+// vim: expandtab:sw=2:ts=2:sts=2

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -550,6 +550,7 @@ class Node(object):
             config=self._config,
             include_java=self._ray_params.include_java,
             java_worker_options=self._ray_params.java_worker_options,
+            native_worker_path=self._ray_params.native_worker_path,
             load_code_from_local=self._ray_params.load_code_from_local,
             use_pickle=self._ray_params.use_pickle)
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -53,6 +53,8 @@ class RayParams(object):
             be created.
         worker_path (str): The path of the source code that will be run by the
             worker.
+        native_worker_path (str): The path of the executable that will be run
+            by the worker when the NATIVE ray::Language is used.
         huge_pages: Boolean flag indicating whether to start the Object
             Store with hugetlbfs support. Requires plasma_directory.
         include_webui: Boolean flag indicating whether to start the web
@@ -118,6 +120,7 @@ class RayParams(object):
                  autoscaling_config=None,
                  include_java=False,
                  java_worker_options=None,
+                 native_worker_path=None,
                  load_code_from_local=False,
                  use_pickle=False,
                  _internal_config=None):
@@ -153,6 +156,7 @@ class RayParams(object):
         self.autoscaling_config = autoscaling_config
         self.include_java = include_java
         self.java_worker_options = java_worker_options
+        self.native_worker_path = native_worker_path
         self.load_code_from_local = load_code_from_local
         self.use_pickle = use_pickle
         self._internal_config = _internal_config

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -224,6 +224,12 @@ def cli(logging_level, logging_format):
     type=str,
     help="Overwrite the options to start Java workers.")
 @click.option(
+    "--native-worker-path",
+    required=False,
+    default=None,
+    type=str,
+    help="Set the path for the executable to use for native workers")
+@click.option(
     "--internal-config",
     default=None,
     type=str,
@@ -245,8 +251,8 @@ def start(node_ip_address, redis_address, address, redis_port,
           head, include_webui, webui_host, block, plasma_directory, huge_pages,
           autoscaling_config, no_redirect_worker_output, no_redirect_output,
           plasma_store_socket_name, raylet_socket_name, temp_dir, include_java,
-          java_worker_options, load_code_from_local, use_pickle,
-          internal_config):
+          java_worker_options, native_worker_path, load_code_from_local,
+          use_pickle, internal_config):
     # Convert hostnames to numerical IP address.
     if node_ip_address is not None:
         node_ip_address = services.address_to_ip(node_ip_address)
@@ -287,6 +293,7 @@ def start(node_ip_address, redis_address, address, redis_port,
         include_webui=include_webui,
         webui_host=webui_host,
         java_worker_options=java_worker_options,
+        native_worker_path=native_worker_path,
         load_code_from_local=load_code_from_local,
         use_pickle=use_pickle,
         _internal_config=internal_config)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -553,6 +553,7 @@ def init(address=None,
          plasma_store_socket_name=None,
          raylet_socket_name=None,
          temp_dir=None,
+         native_worker_path=None,
          load_code_from_local=False,
          use_pickle=ray.cloudpickle.FAST_CLOUDPICKLE_USED,
          _internal_config=None):
@@ -641,6 +642,8 @@ def init(address=None,
             used by the raylet process.
         temp_dir (str): If provided, it will specify the root temporary
             directory for the Ray process.
+        native_worker_path (str): If provided, the executable at this path will
+            be started to service native worker task.
         load_code_from_local: Whether code should be loaded from a local module
             or from the GCS.
         use_pickle: Whether data objects should be serialized with cloudpickle.
@@ -718,6 +721,7 @@ def init(address=None,
             plasma_store_socket_name=plasma_store_socket_name,
             raylet_socket_name=raylet_socket_name,
             temp_dir=temp_dir,
+            native_worker_path=native_worker_path,
             load_code_from_local=load_code_from_local,
             use_pickle=use_pickle,
             _internal_config=_internal_config,

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -9,6 +9,7 @@ enum Language {
   PYTHON = 0;
   JAVA = 1;
   CPP = 2;
+  NATIVE = 3;
 }
 
 // Type of a worker.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -22,6 +22,7 @@ DEFINE_string(static_resource_list, "", "The static resource list of this node."
 DEFINE_string(config_list, "", "The raylet config list of this node.");
 DEFINE_string(python_worker_command, "", "Python worker command.");
 DEFINE_string(java_worker_command, "", "Java worker command.");
+DEFINE_string(native_worker_command, "", "Native worker command.");
 DEFINE_string(redis_password, "", "The password of redis.");
 DEFINE_string(temp_dir, "", "Temporary directory.");
 DEFINE_string(session_dir, "", "The path of this ray session directory.");
@@ -54,6 +55,7 @@ int main(int argc, char *argv[]) {
   const std::string config_list = FLAGS_config_list;
   const std::string python_worker_command = FLAGS_python_worker_command;
   const std::string java_worker_command = FLAGS_java_worker_command;
+  const std::string native_worker_command = FLAGS_native_worker_command;
   const std::string redis_password = FLAGS_redis_password;
   const std::string temp_dir = FLAGS_temp_dir;
   const std::string session_dir = FLAGS_session_dir;
@@ -114,9 +116,13 @@ int main(int argc, char *argv[]) {
     node_manager_config.worker_commands.emplace(
         make_pair(ray::Language::JAVA, SplitStrByWhitespaces(java_worker_command)));
   }
-  if (python_worker_command.empty() && java_worker_command.empty()) {
-    RAY_CHECK(0)
-        << "Either Python worker command or Java worker command should be provided.";
+  if (!native_worker_command.empty()) {
+    node_manager_config.worker_commands.emplace(
+        make_pair(ray::Language::NATIVE, SplitStrByWhitespaces(native_worker_command)));
+  }
+  if (python_worker_command.empty() && java_worker_command.empty() &&
+      native_worker_command.empty()) {
+    RAY_CHECK(0) << "Python, Java, or native worker command should be provided.";
   }
 
   node_manager_config.heartbeat_period_ms =

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -62,6 +62,9 @@ WorkerPool::WorkerPool(int num_worker_processes, int maximum_startup_concurrency
       state.num_workers_per_process =
           RayConfig::instance().num_workers_per_process_java();
       break;
+    case Language::NATIVE:
+      state.num_workers_per_process = 1;
+      break;
     default:
       RAY_LOG(FATAL) << "The number of workers per process for "
                      << Language_Name(entry.first) << " worker is not set.";


### PR DESCRIPTION
This patch introduces a new directory, `clib`. `clib` includes a standalone C header (`clib/ray.h`) and builds an associated C-compatible `libray`. Compiled applications that wish to interact with Ray can use the C header and link against the generated `libray`. They do not need to be included in the Ray build pipeline. `libray` is generated using a thin C++ shim layer (`clib/lib.cpp`) which presents C function signatures and opaque types and internally makes the appropriate C++ calls to Ray.

The bindings are not complete, but cover the main basic building blocks needed to interact with Ray, including constructing a `CoreWorker`, and calling the main methods like `Wait`, `Get`, `Put`, and `SubmitTask`. The API is also overly simplified in places, such as object metadata always being empty, and various task options not being possible to specify. This should probably be fixed before an eventual release.

The patch also adds `clib/main.c`, a binary that uses only `ray.h` and `libray` to implement a proof-of-concept of a compiled Ray client.

See the commit messages on the individual commits for much more detail about the patches.