### PR TITLE
Update Boost via our own rule instead of managing our own fork

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -104,9 +104,9 @@ def ray_deps_setup():
     github_repository(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-        commit = "e3b1c64a2d5d59dcf012d80e677f6e6df5b2802e",
+        commit = "df908358c605a7d5b8bbacde07afbaede5ac12cf",
         remote = "https://github.com/nelhage/rules_boost",
-        sha256 = "1065a0cea2f4898a36d0140e6ef1e49b293833fc89f47d7a7c7528e77211998f",
+        sha256 = "3775c5ab217e0c9cc380f56e243a4d75fe6fee8eaee1447899eaa04c5d582cf1",
     )
 
     github_repository(

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -99,6 +99,11 @@ def ray_deps_setup():
         sha256 = "da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf",
         strip_prefix = "boost_1_68_0",
         url = "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz",
+        patches = [
+            # Backport Clang-Cl patch on Boost 1.69 to Boost <= 1.68:
+            #   https://lists.boost.org/Archives/boost/2018/09/243420.php
+            "//thirdparty/patches:boost-type_traits-trivial_move.patch",
+        ],
     )
 
     github_repository(

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -85,24 +85,28 @@ def ray_deps_setup():
     )
 
     github_repository(
-        name = "bazel_skylib",
-        tag = "0.6.0",
-        remote = "https://github.com/bazelbuild/bazel-skylib",
-        sha256 = "54ee22e5b9f0dd2b42eb8a6c1878dee592cfe8eb33223a7dbbc583a383f6ee1a",
-    )
-
-    github_repository(
         name = "com_github_checkstyle_java",
         commit = "ef367030d1433877a3360bbfceca18a5d0791bdd",
         remote = "https://github.com/ray-project/checkstyle_java",
         sha256 = "2fc33ec804011a03106e76ae77d7f1b09091b0f830f8e2a0408f079a032ed716",
     )
 
+    http_archive(
+        # This rule is used by @com_github_nelhage_rules_boost and
+        # declaring it here allows us to avoid patching the latter.
+        name = "boost",
+        build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
+        sha256 = "da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf",
+        strip_prefix = "boost_1_68_0",
+        url = "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz",
+    )
+
     github_repository(
         name = "com_github_nelhage_rules_boost",
-        commit = "5171b9724fbb39c5fdad37b9ca9b544e8858d8ac",
-        remote = "https://github.com/ray-project/rules_boost",
-        sha256 = "14fa5cb327a3df811aa8713bbb7c5a63a89286868e7ec874c4a335829bf9c018",
+        # If you update the Boost version, remember to update the 'boost' rule.
+        commit = "e3b1c64a2d5d59dcf012d80e677f6e6df5b2802e",
+        remote = "https://github.com/nelhage/rules_boost",
+        sha256 = "1065a0cea2f4898a36d0140e6ef1e49b293833fc89f47d7a7c7528e77211998f",
     )
 
     github_repository(

--- a/thirdparty/patches/boost-type_traits-trivial_move.patch
+++ b/thirdparty/patches/boost-type_traits-trivial_move.patch
@@ -1,0 +1,38 @@
+From ad326841ecca3e1a31102d5ddaf4e82f55a13742 Mon Sep 17 00:00:00 2001
+From: jzmaddock <john@johnmaddock.co.uk>
+Date: Fri, 3 Aug 2018 18:31:46 +0100
+Subject: [PATCH] Correct spelling of "__clang__" so that the headers compile
+ on clang/windows.
+
+---
+ boost/type_traits/has_trivial_move_assign.hpp      | 2 +-
+ boost/type_traits/has_trivial_move_constructor.hpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git boost/type_traits/has_trivial_move_assign.hpp boost/type_traits/has_trivial_move_assign.hpp
+index 6d954ab..7b39269 100644
+--- boost/type_traits/has_trivial_move_assign.hpp
++++ boost/type_traits/has_trivial_move_assign.hpp
+@@ -24,7 +24,7 @@
+ #endif
+ #endif
+ 
+-#if defined(__GNUC__) || defined(__clang)
++#if defined(__GNUC__) || defined(__clang__)
+ #include <boost/type_traits/is_assignable.hpp>
+ #include <boost/type_traits/is_volatile.hpp>
+ #endif
+diff --git boost/type_traits/has_trivial_move_constructor.hpp boost/type_traits/has_trivial_move_constructor.hpp
+index 5784f4b..2ecfc36 100644
+--- boost/type_traits/has_trivial_move_constructor.hpp
++++ boost/type_traits/has_trivial_move_constructor.hpp
+@@ -22,7 +22,7 @@
+ #include <boost/type_traits/is_volatile.hpp>
+ #endif
+ 
+-#if defined(__GNUC__) || defined(__clang)
++#if defined(__GNUC__) || defined(__clang__)
+ #include <boost/type_traits/is_constructible.hpp>
+ #include <boost/type_traits/is_volatile.hpp>
+ #endif
+-- 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Updates Boost and rules_boost to resolve Windows compatibility issues.  
Also uses https://github.com/nelhage/rules_boost directly directly, removing the need maintaining our own fork.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
