### PR TITLE
Miscellaneous bug fixes to throw unreconstructable errors for direct calls

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -815,6 +815,8 @@ def test_direct_call_eviction(ray_start_cluster):
     def large_object():
         return np.zeros(10 * 1024 * 1024)
 
+    large_object = large_object.options(is_direct_call=True)
+
     obj = large_object.remote()
     assert (isinstance(ray.get(obj), np.ndarray))
     # Evict the object.
@@ -828,6 +830,8 @@ def test_direct_call_eviction(ray_start_cluster):
     @ray.remote
     def dependent_task(x):
         return
+
+    dependent_task = dependent_task.options(is_direct_call=True)
 
     # If the object is passed by reference, the task throws an
     # exception.
@@ -862,6 +866,9 @@ def test_direct_call_serialized_id_eviction(ray_start_cluster):
             ray.get(obj_id)
         print("get done", obj_ids)
 
+    large_object = large_object.options(is_direct_call=True)
+    get = get.options(is_direct_call=True)
+
     obj = large_object.remote()
     ray.get(get.remote([obj]))
 
@@ -890,6 +897,9 @@ def test_direct_call_serialized_id(ray_start_cluster):
         print("get", obj_ids)
         obj_id = obj_ids[0]
         assert ray.get(obj_id) == 1
+
+    small_object = small_object.options(is_direct_call=True)
+    get = get.options(is_direct_call=True)
 
     obj = small_object.remote()
     ray.get(get.remote([obj]))

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -15,7 +15,6 @@ import redis
 
 import ray
 import ray.ray_constants as ray_constants
-from ray.tests.conftest import generate_internal_config_map
 from ray.tests.cluster_utils import Cluster
 from ray.tests.utils import (
     relevant_errors,
@@ -804,108 +803,67 @@ def test_fill_object_store_exception(ray_start_cluster_head):
 
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
-        "object_store_memory": 150 * 1024 * 1024,
-        "num_nodes": 2,
-        "num_cpus": 5,
-        **generate_internal_config_map(
-            object_manager_repeated_push_delay_ms=1000,
-            initial_reconstruction_timeout_milliseconds=200,
-        )
-    }, {
-        "object_store_memory": 150 * 1024 * 1024,
         "num_nodes": 1,
-        "num_cpus": 10,
+        "num_cpus": 2,
+    }, {
+        "num_nodes": 2,
+        "num_cpus": 1,
     }],
     indirect=True)
 def test_direct_call_eviction(ray_start_cluster):
-    object_store_memory = 150 * 1024 * 1024
-    num_objects = 10
-
     @ray.remote
-    def create_object(size):
-        return np.random.rand(size)
+    def large_object():
+        return np.zeros(10 * 1024 * 1024)
 
-    # Submit enough tasks so that they exceed the size of the object store.
-    objects = []
-    for _ in range(num_objects):
-        obj = create_object.remote(object_store_memory // num_objects)
-        objects.append(obj)
-        # Get each object once to make sure each object gets created.
+    obj = large_object.remote()
+    assert (isinstance(ray.get(obj), np.ndarray))
+    # Evict the object.
+    ray.internal.free([obj])
+    while ray.worker.global_worker.core_worker.object_exists(obj):
+        time.sleep(1)
+    # ray.get throws an exception.
+    with pytest.raises(ray.exceptions.UnreconstructableError):
         ray.get(obj)
 
-    # Get each object again. At this point, the earlier objects should have
-    # been evicted.
-    num_evicted, num_success = 0, 0
-    for obj in objects:
-        try:
-            val = ray.get(obj)
-            assert isinstance(val, np.ndarray), val
-            num_success += 1
-        except ray.exceptions.UnreconstructableError:
-            num_evicted += 1
-    # Some objects should have been evicted, and some should still be in the
-    # object store.
-    assert num_evicted > 0
-    assert num_success > 0
+    @ray.remote
+    def dependent_task(x):
+        return
+
+    # If the object is passed by reference, the task throws an
+    # exception.
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.get(dependent_task.remote(obj))
 
 
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
-        "object_store_memory": 150 * 1024 * 1024,
-        "num_nodes": 2,
-        "num_cpus": 5,
-        **generate_internal_config_map(
-            object_manager_repeated_push_delay_ms=1000,
-            initial_reconstruction_timeout_milliseconds=200,
-        )
-    }, {
-        "object_store_memory": 150 * 1024 * 1024,
         "num_nodes": 1,
-        "num_cpus": 10,
+        "num_cpus": 2,
+    }, {
+        "num_nodes": 2,
+        "num_cpus": 1,
     }],
     indirect=True)
 def test_direct_call_serialized_id_eviction(ray_start_cluster):
-    object_store_memory = 150 * 1024 * 1024
-    num_objects = 10
-
     @ray.remote
-    def create_object(size):
-        print("create")
-        # Sleep a bit to allow getters to time out.
-        time.sleep(1)
-        print("create done")
-        return np.random.rand(size)
+    def large_object():
+        return np.zeros(10 * 1024 * 1024)
 
     @ray.remote
     def get(obj_ids):
         print("get", obj_ids)
         obj_id = obj_ids[0]
-        val = ray.get(obj_id)
+        assert (isinstance(ray.get(obj_id), np.ndarray))
+        # Evict the object.
+        ray.internal.free(obj_ids)
+        while ray.worker.global_worker.core_worker.object_exists(obj_id):
+            time.sleep(1)
+        with pytest.raises(ray.exceptions.UnreconstructableError):
+            ray.get(obj_id)
         print("get done", obj_ids)
-        assert isinstance(val, np.ndarray), val
 
-    # Submit enough tasks so that they exceed the size of the object store.
-    objects = []
-    for _ in range(num_objects):
-        obj = create_object.remote(object_store_memory // num_objects)
-        objects.append(obj)
-
-    tasks = [get.remote([obj]) for obj in objects]
-
-    # Get each object again. At this point, the earlier objects should have
-    # been evicted.
-    num_evicted, num_success = 0, 0
-    for task in tasks:
-        try:
-            val = ray.get(task)
-            assert val is None
-            num_success += 1
-        except ray.exceptions.UnreconstructableError:
-            num_evicted += 1
-        except ray.exceptions.RayTaskError:
-            num_evicted += 1
-    # Some objects should have been evicted.
-    assert num_evicted > 0
+    obj = large_object.remote()
+    ray.get(get.remote([obj]))
 
 
 @pytest.mark.skip(
@@ -921,52 +879,17 @@ def test_direct_call_serialized_id_eviction(ray_start_cluster):
     indirect=True)
 def test_direct_call_serialized_id(ray_start_cluster):
     @ray.remote
-    def create_object():
-        print("create")
-        # Sleep a bit to allow getters to time out.
+    def small_object():
+        # Sleep a bit before creating the object to force a timeout
+        # at the getter.
         time.sleep(1)
-        print("create done")
-        return np.random.rand(1)
+        return 1
 
     @ray.remote
     def get(obj_ids):
         print("get", obj_ids)
         obj_id = obj_ids[0]
-        val = ray.get(obj_id)
-        print("get done", obj_ids)
-        assert isinstance(val, np.ndarray), val
+        assert ray.get(obj_id) == 1
 
-    # Submit enough tasks so that they exceed the size of the object store.
-    objects = []
-    num_objects = 10
-    for _ in range(num_objects):
-        obj = create_object.remote()
-        objects.append(obj)
-
-    tasks = [get.remote([obj]) for obj in objects]
-    for obj in objects:
-        try:
-            ray.get(obj)
-        except ray.exceptions.UnreconstructableError:
-            pass
-        except ray.exceptions.RayTaskError:
-            pass
-
-    # Get each object again. At this point, the earlier objects should have
-    # been evicted.
-    num_evicted, num_success = 0, 0
-    for task in tasks:
-        try:
-            val = ray.get(task)
-            assert val is None
-            num_success += 1
-        except ray.exceptions.UnreconstructableError:
-            num_evicted += 1
-        except ray.exceptions.RayTaskError:
-            num_evicted += 1
-    # Some objects should have been evicted, and some should still be in the
-    # object store.
-    assert num_evicted == 0
-    # TODO(swang): Change this to > once eviction errors have been implemented
-    # for serialized IDs.
-    assert num_success > 0
+    obj = small_object.remote()
+    ray.get(get.remote([obj]))

--- a/src/ray/common/ray_object.cc
+++ b/src/ray/common/ray_object.cc
@@ -2,7 +2,7 @@
 
 namespace ray {
 
-bool RayObject::IsException() {
+bool RayObject::IsException() const {
   if (metadata_ == nullptr) {
     return false;
   }
@@ -19,7 +19,7 @@ bool RayObject::IsException() {
   return false;
 }
 
-bool RayObject::IsInPlasmaError() {
+bool RayObject::IsInPlasmaError() const {
   if (metadata_ == nullptr) {
     return false;
   }

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -62,11 +62,11 @@ class RayObject {
   bool HasMetadata() const { return metadata_ != nullptr; }
 
   /// Whether the object represents an exception.
-  bool IsException();
+  bool IsException() const;
 
   /// Whether the object has been promoted to plasma (i.e., since it was too
   /// large to return directly as part of a gRPC response).
-  bool IsInPlasmaError();
+  bool IsInPlasmaError() const;
 
  private:
   std::shared_ptr<Buffer> data_;

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -186,11 +186,13 @@ ObjectID TaskSpecification::ActorDummyObject() const {
   return ReturnId(NumReturns() - 1, TaskTransportType::RAYLET);
 }
 
-bool TaskSpecification::IsDirectCall() const {
+bool TaskSpecification::IsDirectCall() const { return message_->is_direct_call(); }
+
+bool TaskSpecification::IsDirectActorCreationCall() const {
   if (IsActorCreationTask()) {
     return message_->actor_creation_task_spec().is_direct_call();
   } else {
-    return message_->is_direct_call();
+    return false;
   }
 }
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -148,6 +148,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   bool IsDirectCall() const;
 
+  bool IsDirectActorCreationCall() const;
+
   int MaxActorConcurrency() const;
 
   bool IsAsyncioActor() const;

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -96,7 +96,7 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
     SetCurrentJobId(task_spec.JobId());
     RAY_CHECK(current_actor_id_.IsNil());
     current_actor_id_ = task_spec.ActorCreationId();
-    current_actor_is_direct_call_ = task_spec.IsDirectCall();
+    current_actor_is_direct_call_ = task_spec.IsDirectActorCreationCall();
     current_actor_max_concurrency_ = task_spec.MaxActorConcurrency();
     current_actor_is_asyncio_ = task_spec.IsAsyncioActor();
   } else if (task_spec.IsActorTask()) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -515,9 +515,9 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
   absl::flat_hash_set<ObjectID> memory_object_ids;
   GroupObjectIdsByStoreProvider(object_ids, &plasma_object_ids, &memory_object_ids);
 
+  memory_store_->Delete(memory_object_ids, &plasma_object_ids);
   RAY_RETURN_NOT_OK(plasma_store_provider_->Delete(plasma_object_ids, local_only,
                                                    delete_creating_tasks));
-  memory_store_->Delete(memory_object_ids);
 
   return Status::OK();
 }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -173,7 +173,11 @@ Status CoreWorkerMemoryStore::Put(const RayObject &object, const ObjectID &objec
     auto promoted_it = promoted_to_plasma_.find(object_id);
     if (promoted_it != promoted_to_plasma_.end()) {
       RAY_CHECK(store_in_plasma_ != nullptr);
-      store_in_plasma_(object, object_id.WithTransportType(TaskTransportType::RAYLET));
+      if (!object.IsInPlasmaError()) {
+        // Only need to promote to plasma if it wasn't already put into plasma
+        // by the task that created the object.
+        store_in_plasma_(object, object_id.WithTransportType(TaskTransportType::RAYLET));
+      }
       promoted_to_plasma_.erase(promoted_it);
     }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -82,10 +82,18 @@ class CoreWorkerMemoryStore {
   std::shared_ptr<RayObject> GetOrPromoteToPlasma(const ObjectID &object_id);
 
   /// Delete a list of objects from the object store.
+  /// NOTE(swang): Objects that contain IsInPlasmaError will not be
+  /// deleted from the in-memory store. Instead, any future Get
+  /// calls should check with plasma to see whether the object has
+  /// been deleted.
   ///
   /// \param[in] object_ids IDs of the objects to delete.
+  /// \param[out] plasma_ids_to_delete This will be extended to
+  /// include the IDs of the plasma objects to delete, based on the
+  /// in-memory objects that contained InPlasmaError.
   /// \return Void.
-  void Delete(const absl::flat_hash_set<ObjectID> &object_ids);
+  void Delete(const absl::flat_hash_set<ObjectID> &object_ids,
+              absl::flat_hash_set<ObjectID> *plasma_ids_to_delete);
 
   /// Delete a list of objects from the object store.
   ///

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -27,6 +27,7 @@ Status CoreWorkerPlasmaStoreProvider::SetClientOptions(std::string name,
 
 Status CoreWorkerPlasmaStoreProvider::Put(const RayObject &object,
                                           const ObjectID &object_id) {
+  RAY_CHECK(!object.IsInPlasmaError()) << object_id;
   std::shared_ptr<Buffer> data;
   RAY_RETURN_NOT_OK(Create(object.GetMetadata(),
                            object.HasData() ? object.GetData()->Size() : 0, object_id,

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -179,6 +179,9 @@ Status CoreWorkerPlasmaStoreProvider::Get(
     }
 
     size_t previous_size = remaining.size();
+    // TODO: For direct calls, use NotifyDirectCallTaskBlocked/Unblocked calls
+    // for missing objects instead of going through the normal fetch-and-get
+    // codepath.
     RAY_RETURN_NOT_OK(FetchAndGetFromPlasmaStore(remaining, batch_ids, batch_timeout,
                                                  /*fetch_only=*/false, task_id, results,
                                                  got_exception));

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -686,7 +686,9 @@ TEST_F(SingleNodeTest, TestMemoryStoreProvider) {
   // clear the reference held.
   results.clear();
 
-  provider.Delete(ids_set);
+  absl::flat_hash_set<ObjectID> plasma_object_ids;
+  provider.Delete(ids_set, &plasma_object_ids);
+  ASSERT_TRUE(plasma_object_ids.empty());
 
   usleep(200 * 1000);
   ASSERT_TRUE(provider.Get(ids_set, 0, ctx, &results, &got_exception).IsTimedOut());

--- a/src/ray/raylet/lineage_cache.cc
+++ b/src/ray/raylet/lineage_cache.cc
@@ -167,6 +167,9 @@ void LineageCache::AddUncommittedLineage(const TaskID &task_id,
   auto entry = uncommitted_lineage.GetEntry(task_id);
   if (!entry) {
     return;
+  } else if (entry->TaskData().GetTaskSpecification().IsDirectCall()) {
+    // Disable lineage logging for direct tasks.
+    return;
   }
   RAY_CHECK(entry->GetStatus() == GcsStatus::UNCOMMITTED);
 
@@ -184,6 +187,10 @@ void LineageCache::AddUncommittedLineage(const TaskID &task_id,
 }
 
 bool LineageCache::CommitTask(const Task &task) {
+  if (task.GetTaskSpecification().IsDirectCall()) {
+    // Disable lineage logging for direct tasks.
+    return true;
+  }
   const TaskID task_id = task.GetTaskSpecification().TaskId();
   RAY_LOG(DEBUG) << "Committing task " << task_id << " on " << client_id_;
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2418,6 +2418,11 @@ void NodeManager::ResubmitTask(const Task &task, const ObjectID &required_object
   RAY_LOG(DEBUG) << "Attempting to resubmit task "
                  << task.GetTaskSpecification().TaskId();
 
+  if (task.GetTaskSpecification().IsDirectCall()) {
+    TreatTaskAsFailed(task, ErrorType::OBJECT_UNRECONSTRUCTABLE);
+    return;
+  }
+
   // Actors should only be recreated if the first initialization failed or if
   // the most recent instance of the actor failed.
   if (task.GetTaskSpecification().IsActorCreationTask()) {
@@ -2582,6 +2587,7 @@ void NodeManager::ForwardTask(
                      << node_id;
     task.OnSpillback()(node_id, node_info.node_manager_address(),
                        node_info.node_manager_port());
+    task_dependency_manager_.TaskCanceled(task.GetTaskSpecification().TaskId());
     return;
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1918,11 +1918,7 @@ void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection>
     // blocked task matches the one assigned to the worker, then mark the
     // worker as blocked. This temporarily releases any resources that the
     // worker holds while it is blocked.
-    // TODO: For direct calls, the current task ID provided by the client may
-    // not match the assigned task ID. It's possible to get resource deadlock
-    // in this situation.
     if (!worker->IsBlocked() && current_task_id == worker->GetAssignedTaskId()) {
-      RAY_LOG(DEBUG) << "Releasing resources for task " << current_task_id;
       Task task;
       RAY_CHECK(local_queues_.RemoveTask(current_task_id, &task));
       local_queues_.QueueTasks({task}, TaskState::RUNNING);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1918,7 +1918,11 @@ void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection>
     // blocked task matches the one assigned to the worker, then mark the
     // worker as blocked. This temporarily releases any resources that the
     // worker holds while it is blocked.
+    // TODO: For direct calls, the current task ID provided by the client may
+    // not match the assigned task ID. It's possible to get resource deadlock
+    // in this situation.
     if (!worker->IsBlocked() && current_task_id == worker->GetAssignedTaskId()) {
+      RAY_LOG(DEBUG) << "Releasing resources for task " << current_task_id;
       Task task;
       RAY_CHECK(local_queues_.RemoveTask(current_task_id, &task));
       local_queues_.QueueTasks({task}, TaskState::RUNNING);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2587,7 +2587,6 @@ void NodeManager::ForwardTask(
                      << node_id;
     task.OnSpillback()(node_id, node_info.node_manager_address(),
                        node_info.node_manager_port());
-    task_dependency_manager_.TaskCanceled(task.GetTaskSpecification().TaskId());
     return;
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2181,7 +2181,7 @@ std::shared_ptr<ActorTableData> NodeManager::CreateActorTableDataFromCreationTas
     // This is the first time that the actor has been created, so the number
     // of remaining reconstructions is the max.
     actor_info_ptr->set_remaining_reconstructions(task_spec.MaxActorReconstructions());
-    actor_info_ptr->set_is_direct_call(task_spec.IsDirectCall());
+    actor_info_ptr->set_is_direct_call(task_spec.IsDirectActorCreationCall());
     actor_info_ptr->set_is_detached(task_spec.IsDetachedActor());
     actor_info_ptr->mutable_owner_address()->CopyFrom(
         task_spec.GetMessage().caller_address());

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -309,6 +309,11 @@ std::vector<TaskID> TaskDependencyManager::GetPendingTasks() const {
 }
 
 void TaskDependencyManager::TaskPending(const Task &task) {
+  // Direct tasks are not tracked by the raylet.
+  if (task.GetTaskSpecification().IsDirectCall()) {
+    return;
+  }
+
   TaskID task_id = task.GetTaskSpecification().TaskId();
   RAY_LOG(DEBUG) << "Task execution " << task_id << " pending";
 
@@ -330,9 +335,7 @@ void TaskDependencyManager::TaskPending(const Task &task) {
     }
 
     // Acquire the lease for the task's execution in the global lease table.
-    if (!task.IsDirectCall()) {
-      AcquireTaskLease(task_id);
-    }
+    AcquireTaskLease(task_id);
   }
 }
 

--- a/src/ray/raylet/task_dependency_manager.cc
+++ b/src/ray/raylet/task_dependency_manager.cc
@@ -330,7 +330,9 @@ void TaskDependencyManager::TaskPending(const Task &task) {
     }
 
     // Acquire the lease for the task's execution in the global lease table.
-    AcquireTaskLease(task_id);
+    if (!task.IsDirectCall()) {
+      AcquireTaskLease(task_id);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Some fixes to make sure that for object IDs that are serialized, tasks that later call `ray.get` on them should receive an `UnreconstructableError`. However, as of this PR, tasks can still receive spurious errors if they call `ray.get` on a deserialized ID.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
