### PR TITLE
Revert stray change in NotifyBlocked

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1949,14 +1949,12 @@ void NodeManager::HandleTaskBlocked(const std::shared_ptr<LocalClientConnection>
   // Subscribe to the objects required by the task. These objects will be
   // fetched and/or reconstructed as necessary, until the objects become local
   // or are unsubscribed.
-  if (!required_object_ids.empty()) {
-    if (ray_get) {
-      task_dependency_manager_.SubscribeGetDependencies(current_task_id,
-                                                        required_object_ids);
-    } else {
-      task_dependency_manager_.SubscribeWaitDependencies(worker->WorkerId(),
-                                                         required_object_ids);
-    }
+  if (ray_get) {
+    task_dependency_manager_.SubscribeGetDependencies(current_task_id,
+                                                      required_object_ids);
+  } else {
+    task_dependency_manager_.SubscribeWaitDependencies(worker->WorkerId(),
+                                                       required_object_ids);
   }
 }
 


### PR DESCRIPTION
This reverts a stray line change from https://github.com/ray-project/ray/pull/6177/files#diff-50e88810cd198c83bbce3317b1bc9924R1948, which may be causing test instability. It was not needed for that PR.