### PR TITLE
[tune] minor doc fix for tune.run schdulers

### DIFF
--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -166,7 +166,8 @@ def run(run_or_experiment,
             BasicVariantGenerator.
         scheduler (TrialScheduler): Scheduler for executing
             the experiment. Choose among FIFO (default), MedianStopping,
-            AsyncHyperBand, and HyperBand.
+            AsyncHyperBand, HyperBand and PopulationBasedTraining. Refer to
+            ray.tune.schedulers for more options.
         with_server (bool): Starts a background Tune server. Needed for
             using the Client API.
         server_port (int): Port number for launching TuneServer.


### PR DESCRIPTION
It's minor but still an important parameter for the public API.
## Checks

- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [*] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [*] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
