### PR TITLE
For travis build, use `build --jobs=50`

### DIFF
--- a/ci/travis/install-ray.sh
+++ b/ci/travis/install-ray.sh
@@ -7,6 +7,15 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 echo "PYTHON is $PYTHON"
 
+# If we are in Travis, most of the compilation result will be cached.
+# This means we are I/O bounded. By default, Bazel set the number of concurrent
+# jobs to the the number cores on the machine, which are not efficient for 
+# network bounded cache downloading workload. Therefore we increase the number
+# of jobs to 50
+if [[ "$TRAVIS" == "true" ]]; then
+  echo "build --jobs=50" >> $HOME/.bazelrc
+fi
+
 if [[ "$PYTHON" == "2.7" ]]; then
 
   pushd "$ROOT_DIR/../../python"
@@ -32,8 +41,8 @@ elif [[ "$LINT" == "1" ]]; then
   pushd "$ROOT_DIR/../../python"
     python setup.py install --user
   popd
-
 else
   echo "Unrecognized Python version."
   exit 1
 fi
+


### PR DESCRIPTION
Result:
This makes each `install-ray.sh` wheel building 10-15min -> under 5 min.