### PR TITLE
properly handle a forwarded task that gets forwarded back

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2806,6 +2806,12 @@ void NodeManager::ForwardTask(
 
   client->ForwardTask(request, [this, on_error, task, task_id, node_id](
                                    Status status, const rpc::ForwardTaskReply &reply) {
+    if (local_queues_.HasTask(task)) {
+      // It must have been forwarded back to us if it's in the queue again
+      // so just return here.
+      return;
+    }
+
     if (status.ok()) {
       const auto &spec = task.GetTaskSpecification();
       // Mark as forwarded so that the task and its lineage are not

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2806,7 +2806,7 @@ void NodeManager::ForwardTask(
 
   client->ForwardTask(request, [this, on_error, task, task_id, node_id](
                                    Status status, const rpc::ForwardTaskReply &reply) {
-    if (local_queues_.HasTask(task)) {
+    if (local_queues_.HasTask(task_id)) {
       // It must have been forwarded back to us if it's in the queue again
       // so just return here.
       return;


### PR DESCRIPTION
## Why are these changes needed?

It's possible that a task forwarded by a raylet gets forwarded back to itself, and in that case it's also possible that the reply for the original forward request arrives later than the forwarded back task, in that case when the original reply arrives, the task may already start execution, so we need to check for it and should not cancel the task in this case. 

This problem happened with our production workload, have verified this fixes the issue.

## Related issue number

## Checks

- [Y] I've run `scripts/format.sh` to lint the changes in this PR.
- [Y] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
