### PR TITLE
Fix wait for Trainable to finish its stop call

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -94,7 +94,7 @@ class RayTrialExecutor(TrialExecutor):
         if self._cached_actor:
             logger.debug("Cannot reuse cached runner {} for new trial".format(
                 self._cached_actor))
-            self._cached_actor.stop.remote()
+            ray.get(self._cached_actor.stop.remote())
             self._cached_actor.__ray_terminate__.remote()
             self._cached_actor = None
 
@@ -187,7 +187,7 @@ class RayTrialExecutor(TrialExecutor):
                     self._cached_actor = trial.runner
                 else:
                     logger.debug("Trial %s: Destroying actor.", trial)
-                    trial.runner.stop.remote()
+                    ray.get(trial.runner.stop.remote())
                     trial.runner.__ray_terminate__.remote()
         except Exception:
             logger.exception("Trial %s: Error stopping runner.", trial)

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -94,7 +94,7 @@ class RayTrialExecutor(TrialExecutor):
         if self._cached_actor:
             logger.debug("Cannot reuse cached runner {} for new trial".format(
                 self._cached_actor))
-            ray.get(self._cached_actor.stop.remote())
+            ray.get(self._cached_actor.stop.remote(), DEFAULT_GET_TIMEOUT)
             self._cached_actor.__ray_terminate__.remote()
             self._cached_actor = None
 
@@ -187,7 +187,7 @@ class RayTrialExecutor(TrialExecutor):
                     self._cached_actor = trial.runner
                 else:
                     logger.debug("Trial %s: Destroying actor.", trial)
-                    ray.get(trial.runner.stop.remote())
+                    ray.get(trial.runner.stop.remote(), DEFAULT_GET_TIMEOUT)
                     trial.runner.__ray_terminate__.remote()
         except Exception:
             logger.exception("Trial %s: Error stopping runner.", trial)


### PR DESCRIPTION

## Why are these changes needed?

Otherwise, the ray actor can be terminated in the middle of `Trainable.stop()`

## Related issue number

None

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.

A simple fix. I have done none of the above.