### PR TITLE
Consistent Name for Process Title

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -536,14 +536,14 @@ cdef execute_task(
                   b' "task_id": ' + task_id.Hex() + b'}')
 
     if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
-        title = "ray_worker:{}()".format(function_name)
-        next_title = "ray_worker"
+        title = "ray_worker::{}()".format(function_name)
+        next_title = "ray_worker::IDLE"
         function_executor = execution_info.function
     else:
         actor = worker.actors[core_worker.get_actor_id()]
         class_name = actor.__class__.__name__
-        title = "ray_{}:{}()".format(class_name, function_name)
-        next_title = "ray_{}".format(class_name)
+        title = "ray_actor::{}.{}()".format(class_name, function_name)
+        next_title = "ray_actor::{}".format(class_name)
         worker_name = "ray_{}_{}".format(class_name, os.getpid())
         if c_resources.find(b"memory") != c_resources.end():
             worker.memory_monitor.set_heap_limit(

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -536,14 +536,14 @@ cdef execute_task(
                   b' "task_id": ' + task_id.Hex() + b'}')
 
     if <int>task_type == <int>TASK_TYPE_NORMAL_TASK:
-        title = "ray_worker::{}()".format(function_name)
-        next_title = "ray_worker::IDLE"
+        title = "ray::{}()".format(function_name)
+        next_title = "ray::IDLE"
         function_executor = execution_info.function
     else:
         actor = worker.actors[core_worker.get_actor_id()]
         class_name = actor.__class__.__name__
-        title = "ray_actor::{}.{}()".format(class_name, function_name)
-        next_title = "ray_actor::{}".format(class_name)
+        title = "ray::{}.{}()".format(class_name, function_name)
+        next_title = "ray::{}".format(class_name)
         worker_name = "ray_{}_{}".format(class_name, os.getpid())
         if c_resources.find(b"memory") != c_resources.end():
             worker.memory_monitor.set_heap_limit(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -440,8 +440,7 @@ def stop(force):
         ["monitor.py", False],
         ["redis-server", True],
         ["default_worker.py", False],  # Python worker.
-        ["ray_worker::", True],  # Python worker.
-        ["ray_actor::", True],  # Python worker.
+        ["ray::", True],  # Python worker.
         ["org.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
         ["log_monitor.py", False],
         ["reporter.py", False],

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -440,7 +440,8 @@ def stop(force):
         ["monitor.py", False],
         ["redis-server", True],
         ["default_worker.py", False],  # Python worker.
-        ["ray_", True],  # Python worker.
+        ["ray_worker::", True],  # Python worker.
+        ["ray_actor::", True],  # Python worker.
         ["org.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.
         ["log_monitor.py", False],
         ["reporter.py", False],

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -420,7 +420,12 @@ def start(node_ip_address, redis_address, address, redis_port,
     "--force",
     is_flag=True,
     help="If set, ray will send SIGKILL instead of SIGTERM.")
-def stop(force):
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="If set, ray prints out more information about processes to kill.")
+def stop(force, verbose):
     # Note that raylet needs to exit before object store, otherwise
     # it cannot exit gracefully.
     processes_to_kill = [
@@ -463,13 +468,19 @@ def stop(force):
                                  str(len(keyword)) + ". Filter: " + keyword)
         else:
             ps_format = "pid,args"
+
+        debug_operator = "| tee /dev/stderr" if verbose else ""
+
         command = (
-            "kill -s {} $(ps ax -o {} | grep {} | grep -v grep | grep ray | "
+            "kill -s {} $(ps ax -o {} | grep {} | grep -v grep {} | grep ray |"
             "awk '{{ print $1 }}') 2> /dev/null".format(
                 # ^^ This is how you escape braces in python format string.
                 signal_name,
                 ps_format,
-                keyword))
+                keyword,
+                debug_operator))
+        if verbose:
+            logger.info("Calling '{}'".format(command))
         subprocess.call([command], shell=True)
 
 

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -1843,10 +1843,10 @@ def test_ray_setproctitle(ray_start_2_cpus):
     @ray.remote
     class UniqueName(object):
         def __init__(self):
-            assert setproctitle.getproctitle() == "ray_UniqueName:__init__()"
+            assert setproctitle.getproctitle() == "ray::UniqueName.__init__()"
 
         def f(self):
-            assert setproctitle.getproctitle() == "ray_UniqueName:f()"
+            assert setproctitle.getproctitle() == "ray::UniqueName.f()"
 
     @ray.remote
     def unique_1():

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1094,7 +1094,7 @@ def connect(node,
         # TODO(qwang): Rename this to `worker_id_str` or type to `WorkerID`
         worker.worker_id = _random_string()
         if setproctitle:
-            setproctitle.setproctitle("ray_worker::IDLE")
+            setproctitle.setproctitle("ray::IDLE")
     elif mode is LOCAL_MODE:
         # Code path of local mode
         if job_id is None:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1094,7 +1094,7 @@ def connect(node,
         # TODO(qwang): Rename this to `worker_id_str` or type to `WorkerID`
         worker.worker_id = _random_string()
         if setproctitle:
-            setproctitle.setproctitle("ray_worker")
+            setproctitle.setproctitle("ray_worker::IDLE")
     elif mode is LOCAL_MODE:
         # Code path of local mode
         if job_id is None:


### PR DESCRIPTION
Unify naming for process title to:
- `ray_worker::IDLE`
- `ray_worker::task_name()`
- `ray_actor::actor_name`
- `ray_actor::actor_name.method_name()`

This fix `ray stop` killing bazel processes because bazel test contains `ray_` in command line string. 