### PR TITLE
Convert io_service_ from reference to smart pointer

### DIFF
--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -91,19 +91,19 @@ class RedisCallbackManager {
         : callback_(callback),
           is_subscription_(is_subscription),
           start_time_(start_time),
-          io_service_(io_service) {}
+          io_service_(&io_service) {}
 
     void Dispatch(std::shared_ptr<CallbackReply> &reply) {
       std::shared_ptr<CallbackItem> self = shared_from_this();
       if (callback_ != nullptr) {
-        io_service_.post([self, reply]() { self->callback_(std::move(reply)); });
+        io_service_->post([self, reply]() { self->callback_(std::move(reply)); });
       }
     }
 
     RedisCallback callback_;
     bool is_subscription_;
     int64_t start_time_;
-    boost::asio::io_service &io_service_;
+    boost::asio::io_service *io_service_;
   };
 
   int64_t add(const RedisCallback &function, bool is_subscription,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Storing a reference causes a compile warning that's turned into an error. Using smart pointers will make sure the lifetime is handled correctly and there should be no performance impact (since shared pointers are only constructed rarely).

## Related issue number

#631

#6231

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
