### PR TITLE
[direct task] For serialized object IDs, check with owner before declaring object unreconstructable

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1060,11 +1060,9 @@ cdef class CoreWorker:
             CAddress c_owner_address = CAddress()
         self.core_worker.get().PromoteToPlasmaAndGetOwnershipInfo(
                 c_object_id, &c_owner_id, &c_owner_address)
-        serialized_owner_address = (
-                c_owner_address.SerializeAsString())
         return (object_id,
                 TaskID(c_owner_id.Binary()),
-                serialized_owner_address)
+                c_owner_address.SerializeAsString())
 
     def deserialize_and_register_object_id(
             self, const c_string &object_id_binary, const c_string

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1064,7 +1064,7 @@ cdef class CoreWorker:
         if has_owner:
             serialized_owner_address = (
                     c_owner_address.SerializeAsString())
-        return (object_id.with_plasma_transport_type(),
+        return (object_id,
                 TaskID(c_owner_id.Binary()),
                 serialized_owner_address)
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1057,13 +1057,15 @@ cdef class CoreWorker:
         cdef:
             CObjectID c_object_id = object_id.native()
             CAddress owner_address = CAddress()
+            CTaskID c_owner_id
         has_owner = self.core_worker.get().SerializeObjectId(
-                c_object_id, &owner_address)
+                c_object_id, &c_owner_id, &owner_address)
         serialized_owner_address = ""
         if has_owner:
             serialized_owner_address = (
                     owner_address.SerializeAsString())
         return (object_id.with_plasma_transport_type(),
+                TaskID(c_owner_id.Binary()),
                 serialized_owner_address)
 
     # TODO: handle noreturn better

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -135,6 +135,7 @@ cdef extern from "ray/protobuf/common.pb.h" nogil:
     cdef cppclass CAddress "ray::rpc::Address":
         CAddress()
         const c_string &SerializeAsString()
+        void ParseFromString(const c_string &serialized)
 
 
 # This is a workaround for C++ enum class since Cython has no corresponding

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -132,6 +132,9 @@ cdef extern from "ray/protobuf/common.pb.h" nogil:
         pass
     cdef cppclass CTaskType "ray::TaskType":
         pass
+    cdef cppclass CAddress "ray::rpc::Address":
+        CAddress()
+        const c_string &SerializeAsString()
 
 
 # This is a workaround for C++ enum class since Cython has no corresponding

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -118,6 +118,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         void RemoveObjectIDReference(const CObjectID &object_id)
         void PromoteObjectToPlasma(const CObjectID &object_id)
         c_bool SerializeObjectId(const CObjectID &object_id,
+                                 CTaskID *owner_id,
                                  CAddress *owner_address)
 
         CRayStatus SetClientOptions(c_string client_name, int64_t limit)

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -17,6 +17,7 @@ from ray.includes.unique_ids cimport (
     CObjectID,
 )
 from ray.includes.common cimport (
+    CAddress,
     CActorCreationOptions,
     CBuffer,
     CRayFunction,
@@ -116,6 +117,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         void AddObjectIDReference(const CObjectID &object_id)
         void RemoveObjectIDReference(const CObjectID &object_id)
         void PromoteObjectToPlasma(const CObjectID &object_id)
+        c_bool SerializeObjectId(const CObjectID &object_id,
+                                 CAddress *owner_address)
 
         CRayStatus SetClientOptions(c_string client_name, int64_t limit)
         CRayStatus Put(const CRayObject &object, CObjectID *object_id)

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -120,6 +120,9 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         c_bool SerializeObjectId(const CObjectID &object_id,
                                  CTaskID *owner_id,
                                  CAddress *owner_address)
+        void DeserializeObjectId(const CObjectID &object_id,
+                                 const CTaskID &owner_id,
+                                 const CAddress &owner_address)
 
         CRayStatus SetClientOptions(c_string client_name, int64_t limit)
         CRayStatus Put(const CRayObject &object, CObjectID *object_id)

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -117,12 +117,12 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         void AddObjectIDReference(const CObjectID &object_id)
         void RemoveObjectIDReference(const CObjectID &object_id)
         void PromoteObjectToPlasma(const CObjectID &object_id)
-        c_bool SerializeObjectId(const CObjectID &object_id,
-                                 CTaskID *owner_id,
-                                 CAddress *owner_address)
-        void DeserializeObjectId(const CObjectID &object_id,
-                                 const CTaskID &owner_id,
-                                 const CAddress &owner_address)
+        void PromoteToPlasmaAndGetOwnershipInfo(const CObjectID &object_id,
+                                                CTaskID *owner_id,
+                                                CAddress *owner_address)
+        void RegisterOwnershipInfoAndResolveFuture(
+                const CObjectID &object_id, const CTaskID &owner_id, const
+                CAddress &owner_address)
 
         CRayStatus SetClientOptions(c_string client_name, int64_t limit)
         CRayStatus Put(const CRayObject &object, CObjectID *object_id)

--- a/python/ray/includes/task.pxd
+++ b/python/ray/includes/task.pxd
@@ -27,7 +27,6 @@ cdef extern from "ray/protobuf/common.pb.h" nogil:
     cdef cppclass RpcTask "ray::rpc::Task":
         RpcTaskSpec *mutable_task_spec()
 
-
 cdef extern from "ray/protobuf/gcs.pb.h" nogil:
     cdef cppclass TaskTableData "ray::rpc::TaskTableData":
         RpcTask *mutable_task()

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -157,8 +157,6 @@ class SerializationContext(object):
                 serialization_context)
 
             def id_serializer(obj):
-                if isinstance(obj, ray.ObjectID) and obj.is_direct_call_type():
-                    obj = self.worker.core_worker.serialize_object_id(obj)
                 return pickle.dumps(obj)
 
             def id_deserializer(serialized_obj):
@@ -171,7 +169,8 @@ class SerializationContext(object):
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
                     obj, owner_id, owner_address = (
-                        worker.core_worker.serialize_object_id(obj))
+                        worker.core_worker.serialize_and_promote_object_id(obj)
+                    )
                 obj = id_serializer(obj)
                 owner_id = id_serializer(owner_id) if owner_id else owner_id
                 return (obj, owner_id, owner_address)
@@ -184,7 +183,7 @@ class SerializationContext(object):
                 if owner_id:
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
-                    worker.core_worker.deserialize_object_id(
+                    worker.core_worker.deserialize_and_register_object_id(
                         *obj_id[1], *owner_id[1], owner_address)
                 obj_id = id_deserializer(obj_id)
                 return obj_id
@@ -232,7 +231,8 @@ class SerializationContext(object):
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
                     obj, owner_id, owner_address = (
-                        worker.core_worker.serialize_object_id(obj))
+                        worker.core_worker.serialize_and_promote_object_id(obj)
+                    )
                 obj = id_serializer(obj)
                 owner_id = id_serializer(owner_id) if owner_id else owner_id
                 return (obj, owner_id, owner_address)
@@ -245,7 +245,7 @@ class SerializationContext(object):
                 if owner_id:
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
-                    worker.core_worker.deserialize_object_id(
+                    worker.core_worker.deserialize_and_register_object_id(
                         *obj_id[1], *owner_id[1], owner_address)
                 obj_id = id_deserializer(obj_id)
                 return obj_id

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -183,6 +183,8 @@ class SerializationContext(object):
                 if owner_id:
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
+                    # UniqueIDs are serialized as
+                    # (class name, (unique bytes,)).
                     worker.core_worker.deserialize_and_register_object_id(
                         obj_id[1][0], owner_id[1][0], owner_address)
                 obj_id = obj_id[0](obj_id[1][0])
@@ -245,6 +247,8 @@ class SerializationContext(object):
                 if owner_id:
                     worker = ray.worker.get_global_worker()
                     worker.check_connected()
+                    # UniqueIDs are serialized as
+                    # (class name, (unique bytes,)).
                     worker.core_worker.deserialize_and_register_object_id(
                         obj_id[1][0], owner_id[1][0], owner_address)
                 obj_id = id_deserializer(obj_id)

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -167,12 +167,12 @@ class SerializationContext(object):
             def object_id_serializer(obj):
                 owner_address = ""
                 if obj.is_direct_call_type():
-                    obj, owner_address = (
+                    obj, owner_id, owner_address = (
                         self.worker.core_worker.serialize_object_id(obj))
-                return (id_serializer(obj), owner_address)
+                return (id_serializer(obj), owner_id, owner_address)
 
             def object_id_deserializer(serialized_obj):
-                obj_id, owner_address = serialized_obj
+                obj_id, owner_id, owner_address = serialized_obj
                 obj_id = id_deserializer(obj_id)
                 return obj_id
 
@@ -215,13 +215,15 @@ class SerializationContext(object):
             def object_id_serializer(obj):
                 owner_address = ""
                 if obj.is_direct_call_type():
-                    obj, owner_address = (
+                    obj, owner_id, owner_address = (
                         self.worker.core_worker.serialize_object_id(obj))
-                return (id_serializer(obj), owner_address)
+                return (id_serializer(obj), id_serializer(owner_id),
+                        owner_address)
 
             def object_id_deserializer(serialized_obj):
-                obj_id, owner_address = serialized_obj
+                obj_id, owner_id, owner_address = serialized_obj
                 obj_id = id_deserializer(obj_id)
+                owner_id = id_deserializer(owner_id)
                 return obj_id
 
             for id_type in ray._raylet._ID_TYPES:

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -876,10 +876,10 @@ def test_direct_call_serialized_id_eviction(ray_start_cluster):
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_nodes": 2,
-        "num_cpus": 10,
+        "num_cpus": 1,
     }, {
         "num_nodes": 1,
-        "num_cpus": 20,
+        "num_cpus": 2,
     }],
     indirect=True)
 def test_direct_call_serialized_id(ray_start_cluster):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -892,7 +892,7 @@ def test_direct_call_serialized_id(ray_start_cluster):
 
     @ray.remote
     def dependent_task(x):
-        return
+        return x
 
     @ray.remote
     def get(obj_ids, test_dependent_task):
@@ -904,6 +904,7 @@ def test_direct_call_serialized_id(ray_start_cluster):
             assert ray.get(obj_id) == 1
 
     small_object = small_object.options(is_direct_call=True)
+    dependent_task = dependent_task.options(is_direct_call=True)
     get = get.options(is_direct_call=True)
 
     obj = small_object.remote()

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -873,8 +873,6 @@ def test_direct_call_serialized_id_eviction(ray_start_cluster):
     ray.get(get.remote([obj]))
 
 
-@pytest.mark.skip(
-    "Uncomment once eviction errors for serialized IDs are implemented")
 @pytest.mark.parametrize(
     "ray_start_cluster", [{
         "num_nodes": 2,

--- a/src/ray/common/ray_object.cc
+++ b/src/ray/common/ray_object.cc
@@ -2,6 +2,17 @@
 
 namespace ray {
 
+std::shared_ptr<LocalMemoryBuffer> MakeErrorMetadataBuffer(rpc::ErrorType error_type) {
+  std::string meta = std::to_string(static_cast<int>(error_type));
+  auto metadata = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+  auto meta_buffer =
+      std::make_shared<LocalMemoryBuffer>(metadata, meta.size(), /*copy_data=*/true);
+  return meta_buffer;
+}
+
+RayObject::RayObject(rpc::ErrorType error_type)
+    : RayObject(nullptr, MakeErrorMetadataBuffer(error_type)) {}
+
 bool RayObject::IsException(rpc::ErrorType *error_type) const {
   if (metadata_ == nullptr) {
     return false;

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -42,6 +42,8 @@ class RayObject {
     RAY_CHECK(data_ || metadata_) << "Data and metadata cannot both be empty.";
   }
 
+  RayObject(rpc::ErrorType error_type);
+
   /// Return the data of the ray object.
   const std::shared_ptr<Buffer> &GetData() const { return data_; };
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -301,6 +301,11 @@ bool CoreWorker::SerializeObjectId(const ObjectID &object_id, TaskID *owner_id,
   return has_owner;
 }
 
+void CoreWorker::DeserializeObjectId(const ObjectID &object_id, const TaskID &owner_id,
+                                     const rpc::Address &owner_address) {
+  reference_counter_->AddBorrowedObject(object_id, owner_id, owner_address);
+}
+
 Status CoreWorker::SetClientOptions(std::string name, int64_t limit_bytes) {
   // Currently only the Plasma store supports client options.
   return plasma_store_provider_->SetClientOptions(name, limit_bytes);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -335,6 +335,8 @@ Status CoreWorker::Put(const RayObject &object, ObjectID *object_id) {
   *object_id = ObjectID::ForPut(worker_context_.GetCurrentTaskID(),
                                 worker_context_.GetNextPutIndex(),
                                 static_cast<uint8_t>(TaskTransportType::RAYLET));
+  reference_counter_->AddOwnedObject(*object_id, GetCallerId(), rpc_address_,
+                                     std::make_shared<std::vector<ObjectID>>());
   return Put(object, *object_id);
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -298,7 +298,7 @@ bool CoreWorker::SerializeObjectId(const ObjectID &object_id, TaskID *owner_id,
     // assertion.
     RAY_LOG(ERROR) << "Tried to serialize object ID " << object_id
                    << ", but we don't know its owner. Calling ray.get on this object may "
-                      "hang if the object is evicted.";
+                      "throw an error if the object takes too long to create.";
   }
   return has_owner;
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -557,7 +557,7 @@ void CoreWorker::PinObjectReferences(const TaskSpecification &task_spec,
 
   // Note that we call this even if task_deps.size() == 0, in order to pin the return id.
   for (size_t i = 0; i < num_returns; i++) {
-    reference_counter_->SetDependencies(task_spec.ReturnId(i, transport_type), task_deps);
+    reference_counter_->AddOwnedObject(task_spec.ReturnId(i, transport_type), task_deps);
   }
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -296,8 +296,9 @@ void CoreWorker::PromoteToPlasmaAndGetOwnershipInfo(const ObjectID &object_id,
   auto has_owner = reference_counter_->GetOwner(object_id, owner_id, owner_address);
   RAY_CHECK(has_owner)
       << "Object IDs generated randomly (ObjectID.from_random()) or out-of-band "
-         "(ObjectID.from_binary(...)) cannot be serialized because we do not know their "
-         "owner. If this was not how your object ID was generated, please file an issue "
+         "(ObjectID.from_binary(...)) cannot be serialized because Ray does not know "
+         "which task will create them. "
+         "If this was not how your object ID was generated, please file an issue "
          "at https://github.com/ray-project/ray/issues/";
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -118,14 +118,19 @@ class CoreWorker {
     }
   }
 
-  /// Promote an object to plasma. If it already exists locally, it will be
-  /// put into the plasma store. If it doesn't yet exist, it will be spilled to
-  /// plasma once available.
+  /// Serialize an ObjectID. This will promote the object to plasma. If it
+  /// already exists locally, it will be put into the plasma store. If it
+  /// doesn't yet exist, it will be spilled to plasma once available.
   ///
   /// Postcondition: Get(object_id.WithPlasmaTransportType()) is valid.
   ///
-  /// \param[in] object_id The object ID to promote to plasma.
-  void PromoteObjectToPlasma(const ObjectID &object_id);
+  /// \param[in] object_id The object ID to serialize.
+  /// \param[out] owner_address The address of the object's owner. This should
+  /// be appended to the serialized object ID.
+  /// \return Whether we had the object's owner or not. If we don't have the
+  /// object's owner, then calling ray.get on the deserialized object ID may
+  /// hang.
+  bool SerializeObjectId(const ObjectID &object_id, rpc::Address *owner_address);
 
   ///
   /// Public methods related to storing and retrieving objects.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -125,12 +125,15 @@ class CoreWorker {
   /// Postcondition: Get(object_id.WithPlasmaTransportType()) is valid.
   ///
   /// \param[in] object_id The object ID to serialize.
+  /// \param[out] owner_id The ID of the object's owner. This should be
+  /// appended to the serialized object ID.
   /// \param[out] owner_address The address of the object's owner. This should
   /// be appended to the serialized object ID.
   /// \return Whether we had the object's owner or not. If we don't have the
   /// object's owner, then calling ray.get on the deserialized object ID may
-  /// hang.
-  bool SerializeObjectId(const ObjectID &object_id, rpc::Address *owner_address);
+  /// hang if the object is evicted.
+  bool SerializeObjectId(const ObjectID &object_id, TaskID *owner_id,
+                         rpc::Address *owner_address);
 
   ///
   /// Public methods related to storing and retrieving objects.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -138,7 +138,6 @@ class CoreWorker {
   /// appended to the serialized object ID.
   /// \param[out] owner_address The address of the object's owner. This should
   /// be appended to the serialized object ID.
-  /// \return Void.
   void PromoteToPlasmaAndGetOwnershipInfo(const ObjectID &object_id, TaskID *owner_id,
                                           rpc::Address *owner_address);
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -135,6 +135,17 @@ class CoreWorker {
   bool SerializeObjectId(const ObjectID &object_id, TaskID *owner_id,
                          rpc::Address *owner_address);
 
+  /// Add a reference to an ObjectID that was deserialized by the language
+  /// frontend. When Get is called on such an object, the worker will
+  /// periodically contact the object's owner to determine whether the object
+  /// has been evicted.
+  ///
+  /// \param[in] object_id The object ID to deserialize.
+  /// \param[out] owner_id The ID of the object's owner.
+  /// \param[out] owner_address The address of the object's owner.
+  void DeserializeObjectId(const ObjectID &object_id, const TaskID &owner_id,
+                           const rpc::Address &owner_address);
+
   ///
   /// Public methods related to storing and retrieving objects.
   ///

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -104,7 +104,7 @@ class CoreWorker {
   ///
   /// \param[in] object_id The object ID to increase the reference count for.
   void AddObjectIDReference(const ObjectID &object_id) {
-    reference_counter_->AddReference(object_id);
+    reference_counter_->AddLocalReference(object_id);
   }
 
   /// Decrease the reference count for this object ID.
@@ -112,7 +112,7 @@ class CoreWorker {
   /// \param[in] object_id The object ID to decrease the reference count for.
   void RemoveObjectIDReference(const ObjectID &object_id) {
     std::vector<ObjectID> deleted;
-    reference_counter_->RemoveReference(object_id, &deleted);
+    reference_counter_->RemoveLocalReference(object_id, &deleted);
     if (ref_counting_enabled_) {
       memory_store_->Delete(deleted);
     }

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -4,6 +4,7 @@ namespace ray {
 
 void FutureResolver::ResolveFutureAsync(const ObjectID &object_id, const TaskID &owner_id,
                                         const rpc::Address &owner_address) {
+  RAY_CHECK(object_id.IsDirectCallType());
   absl::MutexLock lock(&mu_);
   auto it = owner_clients_.find(owner_id);
   if (it == owner_clients_.end()) {

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -1,0 +1,54 @@
+#include "ray/core_worker/future_resolver.h"
+
+namespace ray {
+
+void FutureResolver::ResolveFutureAsync(const ObjectID &object_id, const TaskID &owner_id,
+                                        const rpc::Address &owner_address) {
+  absl::MutexLock lock(&mu_);
+  auto it = owner_clients_.find(owner_id);
+  if (it == owner_clients_.end()) {
+    auto client = std::shared_ptr<rpc::CoreWorkerClientInterface>(
+        client_factory_({owner_address.ip_address(), owner_address.port()}));
+    owner_clients_.emplace(owner_id, std::move(client));
+  }
+
+  auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
+  AttemptFutureResolution(object_id, owner_id, std::move(timer));
+}
+
+void FutureResolver::AttemptFutureResolution(
+    const ObjectID &object_id, const TaskID &owner_id,
+    std::shared_ptr<boost::asio::deadline_timer> timer) {
+  auto &owner_client = owner_clients_[owner_id];
+  rpc::GetObjectStatusRequest request;
+  request.set_object_id(object_id.Binary());
+  request.set_owner_id(owner_id.Binary());
+  auto status = owner_client->GetObjectStatus(
+      request,
+      [this, object_id](const Status &status, const rpc::GetObjectStatusReply &reply) {
+        if (!status.ok() || reply.status() != rpc::GetObjectStatusReply::PENDING) {
+          // Either the owner is gone or the owner replied that the object has
+          // been created. In both cases, we can now try to fetch the object via
+          // plasma.
+          RAY_CHECK_OK(in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
+                                             object_id));
+        }
+      });
+  if (!status.ok()) {
+    RAY_CHECK_OK(
+        in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
+  } else {
+    timer->expires_from_now(
+        boost::posix_time::milliseconds(wait_object_eviction_milliseconds_));
+    timer->async_wait(
+        [this, object_id, owner_id, timer](const boost::system::error_code &error) {
+          if (error == boost::asio::error::operation_aborted) {
+            return;  // deadline adjusted
+          }
+          absl::MutexLock lock(&mu_);
+          AttemptFutureResolution(object_id, owner_id, std::move(timer));
+        });
+  }
+}
+
+}  // namespace ray

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -13,6 +13,7 @@ void FutureResolver::ResolveFutureAsync(const ObjectID &object_id, const TaskID 
     owner_clients_.emplace(owner_id, std::move(client));
   }
 
+  // This timer will get deallocated once the future has been resolved.
   auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
   AttemptFutureResolution(object_id, owner_id, std::move(timer));
 }
@@ -25,30 +26,28 @@ void FutureResolver::AttemptFutureResolution(
   request.set_object_id(object_id.Binary());
   request.set_owner_id(owner_id.Binary());
   auto status = owner_client->GetObjectStatus(
-      request,
-      [this, object_id](const Status &status, const rpc::GetObjectStatusReply &reply) {
+      request, [this, object_id, owner_id, timer](
+                   const Status &status, const rpc::GetObjectStatusReply &reply) {
         if (!status.ok() || reply.status() != rpc::GetObjectStatusReply::PENDING) {
           // Either the owner is gone or the owner replied that the object has
           // been created. In both cases, we can now try to fetch the object via
           // plasma.
           RAY_CHECK_OK(in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
                                              object_id));
+        } else {
+          // Try again later.
+          timer->expires_from_now(
+              boost::posix_time::milliseconds(wait_future_resolution_milliseconds_));
+          timer->async_wait(
+              [this, object_id, owner_id, timer](const boost::system::error_code &error) {
+                absl::MutexLock lock(&mu_);
+                AttemptFutureResolution(object_id, owner_id, std::move(timer));
+              });
         }
       });
   if (!status.ok()) {
     RAY_CHECK_OK(
         in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
-  } else {
-    timer->expires_from_now(
-        boost::posix_time::milliseconds(wait_object_eviction_milliseconds_));
-    timer->async_wait(
-        [this, object_id, owner_id, timer](const boost::system::error_code &error) {
-          if (error == boost::asio::error::operation_aborted) {
-            return;  // deadline adjusted
-          }
-          absl::MutexLock lock(&mu_);
-          AttemptFutureResolution(object_id, owner_id, std::move(timer));
-        });
   }
 }
 

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -18,13 +18,14 @@ const int kWaitObjectEvictionMilliseconds = 100;
 // was available. This class is thread-safe.
 class FutureResolver {
  public:
-  FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
-                 rpc::ClientFactoryFn client_factory, boost::asio::io_service &io_service,
-                 int wait_object_eviction_milliseconds = kWaitObjectEvictionMilliseconds)
+  FutureResolver(
+      std::shared_ptr<CoreWorkerMemoryStore> store, rpc::ClientFactoryFn client_factory,
+      boost::asio::io_service &io_service,
+      int wait_future_resolution_milliseconds = kWaitObjectEvictionMilliseconds)
       : in_memory_store_(store),
         client_factory_(client_factory),
         io_service_(io_service),
-        wait_object_eviction_milliseconds_(wait_object_eviction_milliseconds) {}
+        wait_future_resolution_milliseconds_(wait_future_resolution_milliseconds) {}
 
   /// Resolve the value for a future. This will periodically contact the given
   /// owner until the owner dies or the owner has finished creating the object.
@@ -53,7 +54,9 @@ class FutureResolver {
   /// Factory for producing new core worker clients.
   const rpc::ClientFactoryFn client_factory_;
 
-  const int wait_object_eviction_milliseconds_;
+  /// The amount of time to wait between requests to a future's owner to get
+  /// the object's current status.
+  const int wait_future_resolution_milliseconds_;
 
   /// Protects against concurrent access to internal state.
   absl::Mutex mu_;

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -26,10 +26,20 @@ class FutureResolver {
         io_service_(io_service),
         wait_object_eviction_milliseconds_(wait_object_eviction_milliseconds) {}
 
+  /// Resolve the value for a future. This will periodically contact the given
+  /// owner until the owner dies or the owner has finished creating the object.
+  /// In either case, this will put an OBJECT_IN_PLASMA error as the future's
+  /// value.
+  ///
+  /// \param[in] object_id The ID of the future to resolve.
+  /// \param[in] owner_id The ID of the task or actor that owns the future.
+  /// \param[in] owner_address The address of the task or actor that owns the
+  /// future.
   void ResolveFutureAsync(const ObjectID &object_id, const TaskID &owner_id,
                           const rpc::Address &owner_address);
 
  private:
+  // Attempt to contact the owner to ask about the future's current status.
   void AttemptFutureResolution(const ObjectID &object_id, const TaskID &owner_id,
                                std::shared_ptr<boost::asio::deadline_timer> timer)
       EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -10,8 +10,8 @@
 
 namespace ray {
 
-/// Max time between requests to the owner to check whether the object has been
-/// evicted.
+/// Max time between requests to the owner to check whether the object is still
+/// being computed.
 const int kWaitObjectEvictionMilliseconds = 100;
 
 // Resolve values for futures that were given to us before the value

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -1,0 +1,58 @@
+#ifndef RAY_CORE_WORKER_FUTURE_RESOLVER_H
+#define RAY_CORE_WORKER_FUTURE_RESOLVER_H
+
+#include <memory>
+
+#include "ray/common/id.h"
+#include "ray/core_worker/store_provider/memory_store/memory_store.h"
+#include "ray/protobuf/core_worker.pb.h"
+#include "ray/rpc/worker/core_worker_client.h"
+
+namespace ray {
+
+/// Max time between requests to the owner to check whether the object has been
+/// evicted.
+const int kWaitObjectEvictionMilliseconds = 100;
+
+// Resolve values for futures that were given to us before the value
+// was available. This class is thread-safe.
+class FutureResolver {
+ public:
+  FutureResolver(std::shared_ptr<CoreWorkerMemoryStore> store,
+                 rpc::ClientFactoryFn client_factory, boost::asio::io_service &io_service,
+                 int wait_object_eviction_milliseconds = kWaitObjectEvictionMilliseconds)
+      : in_memory_store_(store),
+        client_factory_(client_factory),
+        io_service_(io_service),
+        wait_object_eviction_milliseconds_(wait_object_eviction_milliseconds) {}
+
+  void ResolveFutureAsync(const ObjectID &object_id, const TaskID &owner_id,
+                          const rpc::Address &owner_address);
+
+ private:
+  void AttemptFutureResolution(const ObjectID &object_id, const TaskID &owner_id,
+                               std::shared_ptr<boost::asio::deadline_timer> timer)
+      EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Used to set timers.
+  boost::asio::io_service &io_service_;
+
+  /// Used to store values of resolved futures.
+  std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
+
+  /// Factory for producing new core worker clients.
+  const rpc::ClientFactoryFn client_factory_;
+
+  const int wait_object_eviction_milliseconds_;
+
+  /// Protects against concurrent access to internal state.
+  absl::Mutex mu_;
+
+  /// Cache of gRPC clients to the objects' owners.
+  absl::flat_hash_map<TaskID, std::shared_ptr<rpc::CoreWorkerClientInterface>>
+      owner_clients_ GUARDED_BY(mu_);
+};
+
+}  // namespace ray
+
+#endif  // RAY_CORE_WORKER_FUTURE_RESOLVER_H

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -2,42 +2,42 @@
 
 namespace ray {
 
-void ReferenceCounter::AddReference(const ObjectID &object_id) {
+void ReferenceCounter::AddBorrowedObject(const ObjectID &object_id,
+                                         const TaskID &owner_id,
+                                         const rpc::Address &owner_address) {
   absl::MutexLock lock(&mutex_);
-  AddReferenceInternal(object_id);
+  RAY_CHECK(
+      object_id_refs_.emplace(object_id, Reference(owner_id, owner_address)).second);
 }
 
-void ReferenceCounter::AddReferenceInternal(const ObjectID &object_id) {
-  auto entry = object_id_refs_.find(object_id);
-  if (entry == object_id_refs_.end()) {
-    object_id_refs_[object_id] = std::make_pair(1, nullptr);
-  } else {
-    entry->second.first++;
-  }
-}
-
-void ReferenceCounter::SetDependencies(
+void ReferenceCounter::AddOwnedObject(
     const ObjectID &object_id, std::shared_ptr<std::vector<ObjectID>> dependencies) {
   absl::MutexLock lock(&mutex_);
 
-  auto entry = object_id_refs_.find(object_id);
-  if (entry == object_id_refs_.end()) {
-    // If the entry doesn't exist, we initialize the direct reference count to zero
-    // because this corresponds to a submitted task whose return ObjectID will be created
-    // in the frontend language, incrementing the reference count.
-    object_id_refs_[object_id] = std::make_pair(0, dependencies);
-  } else {
-    RAY_CHECK(!entry->second.second);
-    entry->second.second = dependencies;
+  for (const ObjectID &dependency_id : *dependencies) {
+    AddLocalReferenceInternal(dependency_id);
   }
 
-  for (const ObjectID &dependency_id : *dependencies) {
-    AddReferenceInternal(dependency_id);
-  }
+  RAY_CHECK(object_id_refs_.count(object_id) == 0)
+      << "Cannot create an object that already exists. ObjectID: " << object_id;
+  // If the entry doesn't exist, we initialize the direct reference count to zero
+  // because this corresponds to a submitted task whose return ObjectID will be created
+  // in the frontend language, incrementing the reference count.
+  object_id_refs_.emplace(object_id, Reference(dependencies));
 }
 
-void ReferenceCounter::RemoveReference(const ObjectID &object_id,
-                                       std::vector<ObjectID> *deleted) {
+void ReferenceCounter::AddLocalReferenceInternal(const ObjectID &object_id) {
+  auto entry = object_id_refs_.find(object_id);
+  if (entry == object_id_refs_.end()) {
+    // TODO: Once ref counting is implemented, we should always know how the
+    // ObjectID was created, so there should always ben an entry.
+    entry = object_id_refs_.emplace(object_id, Reference()).first;
+  }
+  entry->second.local_ref_count++;
+}
+
+void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
+                                            std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
   RemoveReferenceRecursive(object_id, deleted);
 }
@@ -50,10 +50,10 @@ void ReferenceCounter::RemoveReferenceRecursive(const ObjectID &object_id,
                      << object_id;
     return;
   }
-  if (--entry->second.first == 0) {
+  if (--entry->second.local_ref_count == 0) {
     // If the reference count reached 0, decrease the reference count for each dependency.
-    if (entry->second.second) {
-      for (const ObjectID &pending_task_object_id : *entry->second.second) {
+    if (entry->second.dependencies) {
+      for (const ObjectID &pending_task_object_id : *entry->second.dependencies) {
         RemoveReferenceRecursive(pending_task_object_id, deleted);
       }
     }
@@ -93,12 +93,12 @@ void ReferenceCounter::LogDebugString() const {
 
   for (const auto &entry : object_id_refs_) {
     RAY_LOG(DEBUG) << "\t" << entry.first.Hex();
-    RAY_LOG(DEBUG) << "\t\treference count: " << entry.second.first;
+    RAY_LOG(DEBUG) << "\t\treference count: " << entry.second.local_ref_count;
     RAY_LOG(DEBUG) << "\t\tdependencies: ";
-    if (!entry.second.second) {
+    if (!entry.second.dependencies) {
       RAY_LOG(DEBUG) << "\t\t\tNULL";
     } else {
-      for (const ObjectID &pending_task_object_id : *entry.second.second) {
+      for (const ObjectID &pending_task_object_id : *entry.second.dependencies) {
         RAY_LOG(DEBUG) << "\t\t\t" << pending_task_object_id.Hex();
       }
     }

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -63,7 +63,7 @@ void ReferenceCounter::RemoveReferenceRecursive(const ObjectID &object_id,
         RemoveReferenceRecursive(pending_task_object_id, deleted);
       }
     }
-    object_id_refs_.erase(object_id);
+    object_id_refs_.erase(entry);
     deleted->push_back(object_id);
   }
 }

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -68,7 +68,7 @@ void ReferenceCounter::RemoveReferenceRecursive(const ObjectID &object_id,
   }
 }
 
-bool ReferenceCounter::GetOwner(const ObjectID &object_id,
+bool ReferenceCounter::GetOwner(const ObjectID &object_id, TaskID *owner_id,
                                 rpc::Address *owner_address) const {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
@@ -77,6 +77,7 @@ bool ReferenceCounter::GetOwner(const ObjectID &object_id,
   }
 
   if (it->second.owner.has_value()) {
+    *owner_id = it->second.owner.value().first;
     *owner_address = it->second.owner.value().second;
     return true;
   } else {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -93,7 +93,7 @@ class ReferenceCounter {
     Reference(const TaskID &owner_id, const rpc::Address &owner_address)
         : owned_by_us(false), owner({owner_id, owner_address}) {}
     /// The local ref count for the ObjectID in the language frontend.
-    size_t local_ref_count;
+    size_t local_ref_count = 0;
     /// The objects that this object depends on. Tracked only by the owner of
     /// the object. Dependencies are stored as shared_ptrs because the same set
     /// of dependencies can be shared among multiple entries. For example, when

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -63,8 +63,8 @@ class ReferenceCounter {
   void AddBorrowedObject(const ObjectID &object_id, const TaskID &owner_id,
                          const rpc::Address &owner_address) LOCKS_EXCLUDED(mutex_);
 
-  bool GetOwner(const ObjectID &object_id, rpc::Address *owner_address) const
-      LOCKS_EXCLUDED(mutex_);
+  bool GetOwner(const ObjectID &object_id, TaskID *owner_id,
+                rpc::Address *owner_address) const LOCKS_EXCLUDED(mutex_);
 
   /// Returns the total number of ObjectIDs currently in scope.
   size_t NumObjectIDsInScope() const LOCKS_EXCLUDED(mutex_);

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -48,7 +48,7 @@ class ReferenceCounter {
   /// \param[in] object_id The ID of the object that we own.
   /// \param[in] owner_id The ID of the object's owner.
   /// \param[in] owner_address The address of the object's owner.
-  /// \param[in] dependencies The obnects that the object depends on.
+  /// \param[in] dependencies The objects that the object depends on.
   void AddOwnedObject(const ObjectID &object_id, const TaskID &owner_id,
                       const rpc::Address &owner_address,
                       std::shared_ptr<std::vector<ObjectID>> dependencies)

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -25,12 +25,8 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
 
     if (return_object.in_plasma()) {
       // Mark it as in plasma with a dummy object.
-      std::string meta =
-          std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA));
-      auto metadata =
-          const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
-      auto meta_buffer = std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
-      RAY_CHECK_OK(in_memory_store_->Put(RayObject(nullptr, meta_buffer), object_id));
+      RAY_CHECK_OK(
+          in_memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
     } else {
       std::shared_ptr<LocalMemoryBuffer> data_buffer;
       if (return_object.data().size() > 0) {
@@ -70,10 +66,7 @@ void TaskManager::FailPendingTask(const TaskID &task_id, rpc::ErrorType error_ty
     const auto object_id = ObjectID::ForTaskReturn(
         task_id, /*index=*/i + 1,
         /*transport_type=*/static_cast<int>(TaskTransportType::DIRECT));
-    std::string meta = std::to_string(static_cast<int>(error_type));
-    auto metadata = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
-    auto meta_buffer = std::make_shared<LocalMemoryBuffer>(metadata, meta.size());
-    RAY_CHECK_OK(in_memory_store_->Put(RayObject(nullptr, meta_buffer), object_id));
+    RAY_CHECK_OK(in_memory_store_->Put(RayObject(error_type), object_id));
   }
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -110,6 +110,5 @@ service CoreWorkerService {
   rpc DirectActorCallArgWaitComplete(DirectActorCallArgWaitCompleteRequest)
       returns (DirectActorCallArgWaitCompleteReply);
   // Ask the object's owner about the object's current status.
-  rpc GetObjectStatus(GetObjectStatusRequest)
-      returns (GetObjectStatusReply);
+  rpc GetObjectStatus(GetObjectStatusRequest) returns (GetObjectStatusReply);
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -87,6 +87,20 @@ message DirectActorCallArgWaitCompleteRequest {
 message DirectActorCallArgWaitCompleteReply {
 }
 
+message GetObjectStatusRequest {
+  bytes owner_id = 1;
+  bytes object_id = 2;
+}
+
+message GetObjectStatusReply {
+  enum ObjectStatus {
+    PENDING = 0;
+    CREATED = 1;
+    WRONG_OWNER = 2;
+  }
+  ObjectStatus status = 1;
+}
+
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
   rpc AssignTask(AssignTaskRequest) returns (AssignTaskReply);
@@ -95,4 +109,7 @@ service CoreWorkerService {
   // Reply from raylet that wait for direct actor call args has completed.
   rpc DirectActorCallArgWaitComplete(DirectActorCallArgWaitCompleteRequest)
       returns (DirectActorCallArgWaitCompleteReply);
+  // Ask the object's owner about the object's current status.
+  rpc GetObjectStatus(GetObjectStatusRequest)
+      returns (GetObjectStatusReply);
 }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -81,6 +81,13 @@ class CoreWorkerClientInterface {
     return Status::NotImplemented("");
   }
 
+  /// Ask the owner of an object about the object's current status.
+  virtual ray::Status GetObjectStatus(
+      const GetObjectStatusRequest &request,
+      const ClientCallback<GetObjectStatusReply> &callback) {
+    return Status::NotImplemented("");
+  }
+
   virtual ~CoreWorkerClientInterface(){};
 };
 
@@ -148,6 +155,14 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
     return call->GetStatus();
   }
 
+  virtual ray::Status GetObjectStatus(
+      const GetObjectStatusRequest &request,
+      const ClientCallback<GetObjectStatusReply> &callback) {
+    auto call = client_call_manager_.CreateCall<CoreWorkerService, GetObjectStatusRequest,
+                                                GetObjectStatusReply>(
+        *stub_, &CoreWorkerService::Stub::PrepareAsyncGetObjectStatus, request, callback);
+    return call->GetStatus();
+  }
   /// Send as many pending tasks as possible. This method is thread-safe.
   ///
   /// The client will guarantee no more than kMaxBytesInFlight bytes of RPCs are being


### PR DESCRIPTION
## Why are these changes needed?

When object IDs are serialized and passed into a task, the submitter does not wait for them to become local before submitting the task. The task executor then tries to fetch the object via plasma. If the object does not appear in plasma before some timeout, the task executor will declare the object unreconstructable. This can cause spurious errors if the task that is supposed to create the object takes longer than the timeout.

This PR fixes this by serializing the object's owner with the object ID. The task that deserializes the object ID can then periodically contact the owner to discover the object's current status. If the object is still pending, then the task tries again later. If the object has been created, or if the owner is no longer reachable, then the task stores the IsInPlasmaError in its local memory store to signify that the object is now ready to fetch. Then, if the object is still not fetched within a timeout, it must have actually been evicted (or else, it is very slow to transfer).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
