### PR TITLE
Fix bash syntax error in test-wheels.sh

### DIFF
--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -104,11 +104,11 @@ elif [[ "$platform" == "macosx" ]]; then
     INSTALLED_RAY_DIRECTORY=$(dirname "$($PYTHON_EXE -u -c "import ray; print(ray.__file__)" | tail -n1)")
     # $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$TEST_SCRIPT"
 
-    if (( $(echo "$PY_MM >= 3.0" | bc) )); then
+    # if (( $(echo "$PY_MM >= 3.0" | bc) )); then
       # Run the UI test to make sure that the packaged UI works.
       # $PIP_CMD install -q aiohttp google grpcio psutil requests setproctitle
       # $PYTHON_EXE -m pytest -v "$INSTALLED_RAY_DIRECTORY/$UI_TEST_SCRIPT"
-    fi
+    # fi
   done
 else
   echo "Unrecognized environment."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Hotfix to fix bazel builds caused wheel building to break because the full body of an if statement was commented out.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
