### PR TITLE
Turn on direct calls for test_failure.py

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -149,6 +149,15 @@ py_test(
 )
 
 py_test(
+    name = "test_failure_direct",
+    size = "medium",
+    srcs = ["test_failure_direct.py", "test_failure.py"],
+    tags = ["exclusive"],
+    deps = ["//:ray_lib"],
+    flaky = 1,
+)
+
+py_test(
     name = "test_garbage_collection",
     size = "medium",
     srcs = ["test_garbage_collection.py"],

--- a/python/ray/tests/test_failure_direct.py
+++ b/python/ray/tests/test_failure_direct.py
@@ -1,0 +1,16 @@
+"""Wrapper script that sets RAY_FORCE_DIRECT."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest
+import sys
+import os
+
+if __name__ == "__main__":
+    os.environ["RAY_FORCE_DIRECT"] = "1"
+    sys.exit(
+        pytest.main(
+            ["-v",
+             os.path.join(os.path.dirname(__file__), "test_failure.py")]))


### PR DESCRIPTION
## Why are these changes needed?

Turn on direct calls for test_failure.py

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
