### PR TITLE
Fix redis-server stoping in linux

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -443,7 +443,7 @@ def stop(force, verbose):
         ["plasma_store", True],
         ["raylet_monitor", True],
         ["monitor.py", False],
-        ["redis-server", True],
+        ["redis-server", False],
         ["default_worker.py", False],  # Python worker.
         ["ray::", True],  # Python worker.
         ["org.ray.runtime.runner.worker.DefaultWorker", False],  # Java worker.

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -162,6 +162,11 @@ def call_ray_start(request):
     # Kill the Ray cluster.
     subprocess.check_output(["ray", "stop"])
 
+@pytest.fixture
+def call_ray_stop_only():
+    yield
+    subprocess.check_output(["ray", "stop"])
+
 
 @pytest.fixture()
 def two_node_cluster():

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -321,7 +321,7 @@ print("success")
         process_handle.kill()
 
 
-def test_calling_start_ray_head():
+def test_calling_start_ray_head(call_ray_stop_only):
     # Test that we can call ray start with various command line
     # parameters. TODO(rkn): This test only tests the --head code path. We
     # should also test the non-head node code path.


### PR DESCRIPTION
`test_multi_node.py:test_calling_start_ray_head` doesn't have proper cleanup, if a ray start failed, the the ray cluster might not be stopped. 

