### PR TITLE
[Core] Fix estimate_available_memory() in utils.py

### DIFF
--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -451,8 +451,13 @@ def estimate_available_memory():
         The total amount of available memory in bytes. It may be an
         overestimate if psutil is not installed.
     """
+    # Handle Linux.
+    if sys.platform == "linux" or sys.platform == "linux2":
+        bytes_in_kilobyte = 1024
+        return (
+            vmstat("total memory") - vmstat("used memory")) * bytes_in_kilobyte
 
-    # check cgroup memory first
+    # check cgroup memory
     try:
         with open("/sys/fs/cgroup/memory/memory.usage_in_bytes", "rb") as f:
             cgroup_memory_usage = int(f.read())
@@ -468,12 +473,6 @@ def estimate_available_memory():
         return psutil.virtual_memory().available
     except ImportError:
         pass
-
-    # Handle Linux.
-    if sys.platform == "linux" or sys.platform == "linux2":
-        bytes_in_kilobyte = 1024
-        return (
-            vmstat("total memory") - vmstat("used memory")) * bytes_in_kilobyte
 
     # Give up
     return get_system_memory()

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -451,21 +451,6 @@ def estimate_available_memory():
         The total amount of available memory in bytes. It may be an
         overestimate if psutil is not installed.
     """
-    # Handle Linux.
-    if sys.platform == "linux" or sys.platform == "linux2":
-        bytes_in_kilobyte = 1024
-        return (
-            vmstat("total memory") - vmstat("used memory")) * bytes_in_kilobyte
-
-    # check cgroup memory
-    try:
-        with open("/sys/fs/cgroup/memory/memory.usage_in_bytes", "rb") as f:
-            cgroup_memory_usage = int(f.read())
-    except IOError:
-        cgroup_memory_usage = None
-
-    if cgroup_memory_usage is not None:
-        return get_system_memory() - cgroup_memory_usage
 
     # Use psutil if it is available.
     try:
@@ -473,6 +458,12 @@ def estimate_available_memory():
         return psutil.virtual_memory().available
     except ImportError:
         pass
+
+    # Handle Linux.
+    if sys.platform == "linux" or sys.platform == "linux2":
+        bytes_in_kilobyte = 1024
+        return (
+            vmstat("total memory") - vmstat("used memory")) * bytes_in_kilobyte
 
     # Give up
     return get_system_memory()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Here I met an exception when starting ray cluster:

```
  File "/home/admin/X_PACK/run/venv/lib/python3.6/site-packages/ray/node.py", line 598, in start_plasma_store
    external_store_endpoint=self._ray_params.external_store_endpoint)
  File "/home/admin/X_PACK/run/venv/lib/python3.6/site-packages/ray/services.py", line 1499, in start_plasma_store
    ray_constants.OBJECT_STORE_MINIMUM_MEMORY_BYTES))
ValueError: Attempting to cap object store memory usage at 15460761 bytes, but the minimum allowed is 78643200 bytes.
```
Then I looked into `resource_spec.py`

```
avail_memory = ray.utils.estimate_available_memory()
        object_store_memory = self.object_store_memory
        if object_store_memory is None:
            object_store_memory = int(avail_memory * 0.3)
```
It seems that ray use my available memory to calculate the store size. But my free memory is larger than 30GB, how could ` int(avail_memory * 0.3)` be 15460761 bytes(14MB)?
![image](https://user-images.githubusercontent.com/19600697/69697432-671e8a80-111d-11ea-891b-571b4d289870.png)

Then I looked into`utils.py`, `estimate_available_memory()`, and finally found the problem:
```
def estimate_available_memory():
    """Return the currently available amount of system memory in bytes.

    Returns:
        The total amount of available memory in bytes. It may be an
        overestimate if psutil is not installed.
    """
    # -------------THIS IS  NOT CORRECT---------------
    # check cgroup memory first
    try:
        with open("/sys/fs/cgroup/memory/memory.usage_in_bytes", "rb") as f:
            cgroup_memory_usage = int(f.read())
    except IOError:
        cgroup_memory_usage = None

    if cgroup_memory_usage is not None:
        return get_system_memory() - cgroup_memory_usage

    # Use psutil if it is available.
    try:
        import psutil
        return psutil.virtual_memory().available
    except ImportError:
        pass

    # -------------THIS IS CORRECT---------------
    # Handle Linux.
    if sys.platform == "linux" or sys.platform == "linux2":
        bytes_in_kilobyte = 1024
        return (
            vmstat("total memory") - vmstat("used memory")) * bytes_in_kilobyte

    # Give up
    return get_system_memory()

```
Ray use cgroup_memory_usage as used memory, but it contains the cached memory, which should be seemed as available memory. But the `Handle Linux` part in the end of the function is correct.

So I moved the `Handle Linux` part up to the top of this function, and no exception any more.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
