### PR TITLE
[direct task] Fix bug that starts duplicate connections from the worker to the local raylet

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -207,7 +207,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
             return std::shared_ptr<RayletClient>(
                 new RayletClient(std::move(grpc_client)));
           },
-          memory_store_, task_manager_,
+          memory_store_, task_manager_, raylet_id,
           RayConfig::instance().worker_lease_timeout_milliseconds()));
   future_resolver_.reset(new FutureResolver(memory_store_, client_factory, io_service_));
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -106,8 +106,9 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
     RAY_CHECK(task_execution_callback_ != nullptr);
     auto execute_task = std::bind(&CoreWorker::ExecuteTask, this, std::placeholders::_1,
                                   std::placeholders::_2, std::placeholders::_3);
-    raylet_task_receiver_ = std::unique_ptr<CoreWorkerRayletTaskReceiver>(
-        new CoreWorkerRayletTaskReceiver(raylet_client_, execute_task, exit_handler));
+    raylet_task_receiver_ =
+        std::unique_ptr<CoreWorkerRayletTaskReceiver>(new CoreWorkerRayletTaskReceiver(
+            local_raylet_client_, execute_task, exit_handler));
     direct_task_receiver_ =
         std::unique_ptr<CoreWorkerDirectTaskReceiver>(new CoreWorkerDirectTaskReceiver(
             worker_context_, task_execution_service_, execute_task, exit_handler));
@@ -124,22 +125,22 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
   // instead of crashing.
   auto grpc_client = rpc::NodeManagerWorkerClient::make(
       node_ip_address, node_manager_port, *client_call_manager_);
-  ClientID raylet_id;
-  raylet_client_ = std::shared_ptr<RayletClient>(new RayletClient(
+  ClientID local_raylet_id;
+  local_raylet_client_ = std::shared_ptr<RayletClient>(new RayletClient(
       std::move(grpc_client), raylet_socket,
       WorkerID::FromBinary(worker_context_.GetWorkerID().Binary()),
       (worker_type_ == ray::WorkerType::WORKER), worker_context_.GetCurrentJobID(),
-      language_, &raylet_id, core_worker_server_.GetPort()));
+      language_, &local_raylet_id, core_worker_server_.GetPort()));
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (direct_task_receiver_ != nullptr) {
-    direct_task_receiver_->Init(*raylet_client_);
+    direct_task_receiver_->Init(*local_raylet_client_);
   }
 
   // Set our own address.
-  RAY_CHECK(!raylet_id.IsNil());
+  RAY_CHECK(!local_raylet_id.IsNil());
   rpc_address_.set_ip_address(node_ip_address);
   rpc_address_.set_port(core_worker_server_.GetPort());
-  rpc_address_.set_raylet_id(raylet_id.Binary());
+  rpc_address_.set_raylet_id(local_raylet_id.Binary());
 
   // Set timer to periodically send heartbeats containing active object IDs to the raylet.
   // If the heartbeat timeout is < 0, the heartbeats are disabled.
@@ -157,13 +158,13 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
 
   io_thread_ = std::thread(&CoreWorker::RunIOService, this);
 
-  plasma_store_provider_.reset(
-      new CoreWorkerPlasmaStoreProvider(store_socket, raylet_client_, check_signals_));
+  plasma_store_provider_.reset(new CoreWorkerPlasmaStoreProvider(
+      store_socket, local_raylet_client_, check_signals_));
   memory_store_.reset(new CoreWorkerMemoryStore(
       [this](const RayObject &obj, const ObjectID &obj_id) {
         RAY_CHECK_OK(plasma_store_provider_->Put(obj, obj_id));
       },
-      ref_counting_enabled ? reference_counter_ : nullptr, raylet_client_));
+      ref_counting_enabled ? reference_counter_ : nullptr, local_raylet_client_));
 
   task_manager_.reset(new TaskManager(memory_store_));
   resolver_.reset(new LocalDependencyResolver(memory_store_));
@@ -200,14 +201,14 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
 
   direct_task_submitter_ =
       std::unique_ptr<CoreWorkerDirectTaskSubmitter>(new CoreWorkerDirectTaskSubmitter(
-          raylet_client_, client_factory,
+          local_raylet_client_, client_factory,
           [this](const rpc::Address &address) {
             auto grpc_client = rpc::NodeManagerWorkerClient::make(
                 address.ip_address(), address.port(), *client_call_manager_);
             return std::shared_ptr<RayletClient>(
                 new RayletClient(std::move(grpc_client)));
           },
-          memory_store_, task_manager_, raylet_id,
+          memory_store_, task_manager_, local_raylet_id,
           RayConfig::instance().worker_lease_timeout_milliseconds()));
   future_resolver_.reset(new FutureResolver(memory_store_, client_factory, io_service_));
 }
@@ -233,8 +234,8 @@ void CoreWorker::Shutdown() {
 void CoreWorker::Disconnect() {
   io_service_.stop();
   gcs_client_->Disconnect();
-  if (raylet_client_) {
-    RAY_IGNORE_EXPR(raylet_client_->Disconnect());
+  if (local_raylet_client_) {
+    RAY_IGNORE_EXPR(local_raylet_client_->Disconnect());
   }
 }
 
@@ -270,7 +271,7 @@ void CoreWorker::ReportActiveObjectIDs() {
     RAY_LOG(INFO) << active_object_ids.size() << " object IDs are currently in scope.";
   }
 
-  if (!raylet_client_->ReportActiveObjectIDs(active_object_ids).ok()) {
+  if (!local_raylet_client_->ReportActiveObjectIDs(active_object_ids).ok()) {
     RAY_LOG(ERROR) << "Raylet connection failed. Shutting down.";
     Shutdown();
   }
@@ -613,7 +614,7 @@ Status CoreWorker::SubmitTask(const RayFunction &function,
     return direct_task_submitter_->SubmitTask(task_spec);
   } else {
     PinObjectReferences(task_spec, TaskTransportType::RAYLET);
-    return raylet_client_->SubmitTask(task_spec);
+    return local_raylet_client_->SubmitTask(task_spec);
   }
 }
 
@@ -652,7 +653,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   // TODO(ekl) if we moved actor creation to use direct call tasks, then we won't
   // need to manually resolve direct call args here.
   resolver_->ResolveDependencies(task_spec, [this, task_spec]() {
-    RAY_CHECK_OK(raylet_client_->SubmitTask(task_spec));
+    RAY_CHECK_OK(local_raylet_client_->SubmitTask(task_spec));
   });
   return Status::OK();
 }
@@ -696,7 +697,7 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
     status = direct_actor_submitter_->SubmitTask(task_spec);
   } else {
     PinObjectReferences(task_spec, TaskTransportType::RAYLET);
-    RAY_CHECK_OK(raylet_client_->SubmitTask(task_spec));
+    RAY_CHECK_OK(local_raylet_client_->SubmitTask(task_spec));
   }
   return status;
 }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -89,7 +89,7 @@ class CoreWorker {
 
   WorkerContext &GetWorkerContext() { return worker_context_; }
 
-  RayletClient &GetRayletClient() { return *raylet_client_; }
+  RayletClient &GetRayletClient() { return *local_raylet_client_; }
 
   const TaskID &GetCurrentTaskId() const { return worker_context_.GetCurrentTaskID(); }
 
@@ -524,7 +524,7 @@ class CoreWorker {
   // shared_ptr for direct calls because we can lease multiple workers through
   // one client, and we need to keep the connection alive until we return all
   // of the workers.
-  std::shared_ptr<RayletClient> raylet_client_;
+  std::shared_ptr<RayletClient> local_raylet_client_;
 
   // Thread that runs a boost::asio service to process IO events.
   std::thread io_thread_;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -62,8 +62,9 @@ std::shared_ptr<WorkerLeaseInterface>
 CoreWorkerDirectTaskSubmitter::GetOrConnectLeaseClient(
     const rpc::Address *raylet_address) {
   std::shared_ptr<WorkerLeaseInterface> lease_client;
-  if (raylet_address) {
-    // Connect to raylet.
+  if (raylet_address &&
+      ClientID::FromBinary(raylet_address->raylet_id()) != local_raylet_id_) {
+    // A remote raylet was specified. Connect to the raylet if needed.
     ClientID raylet_id = ClientID::FromBinary(raylet_address->raylet_id());
     auto it = remote_lease_clients_.find(raylet_id);
     if (it == remote_lease_clients_.end()) {

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -34,12 +34,13 @@ class CoreWorkerDirectTaskSubmitter {
                                 LeaseClientFactoryFn lease_client_factory,
                                 std::shared_ptr<CoreWorkerMemoryStore> store,
                                 std::shared_ptr<TaskFinisherInterface> task_finisher,
-                                int64_t lease_timeout_ms)
+                                ClientID local_raylet_id, int64_t lease_timeout_ms)
       : local_lease_client_(lease_client),
         client_factory_(client_factory),
         lease_client_factory_(lease_client_factory),
         resolver_(store),
         task_finisher_(task_finisher),
+        local_raylet_id_(local_raylet_id),
         lease_timeout_ms_(lease_timeout_ms) {}
 
   /// Schedule a task for direct submission to a worker.
@@ -100,6 +101,10 @@ class CoreWorkerDirectTaskSubmitter {
   /// The timeout for worker leases; after this duration, workers will be returned
   /// to the raylet.
   int64_t lease_timeout_ms_;
+
+  /// The local raylet ID. Used to make sure that we use the local lease client
+  /// if a remote raylet tells us to spill the task back to the local raylet.
+  const ClientID local_raylet_id_;
 
   // Protects task submission state below.
   absl::Mutex mu_;


### PR DESCRIPTION
## Why are these changes needed?

If a task is spilled back to a remote node, then spilled back again to the local node, then the worker will mistakenly create a second grpc client to the local node. This should be okay in most cases but could cause problems if the local raylet fails, since the worker will not fate-share with the local raylet.

This fixes the bug by checking the retry_at_raylet_id in the spillback message against the local raylet ID.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
