### PR TITLE
[tune] replace self.config to reflect the updated parameters in logs

### DIFF
--- a/python/ray/tune/examples/pbt_example.py
+++ b/python/ray/tune/examples/pbt_example.py
@@ -81,6 +81,7 @@ class PBTBenchmarkExample(Trainable):
 
     def reset_config(self, new_config):
         self.lr = new_config["lr"]
+        self.config = new_config
         return True
 
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -396,7 +396,8 @@ class Trainable(object):
 
         This method is optional, but can be implemented to speed up algorithms
         such as PBT, and to allow performance optimizations such as running
-        experiments with reuse_actors=True.
+        experiments with reuse_actors=True. Note that self.config need to
+        be updated to reflect the latest parameter information in Ray logs.
 
         Args:
             new_config (dir): Updated hyperparameter configuration


### PR DESCRIPTION

## Why are these changes needed?

Tuning logs (status info) use Trainablne.config to collect parameters and we need to update self.config in `reset_config` function.

## Related issue number
https://github.com/ray-project/ray/issues/6237

## Checks

- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [*] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [*] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
