### PR TITLE
Use Boost's socket_holder instead of manually managing the socket

### DIFF
--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -7,6 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <boost/asio/detail/socket_holder.hpp>
+
 #include "ray/common/status.h"
 #include "ray/common/task/task_spec.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
@@ -25,6 +27,7 @@ using ray::rpc::ProfileTableData;
 using MessageType = ray::protocol::MessageType;
 using ResourceMappingType =
     std::unordered_map<std::string, std::vector<std::pair<int64_t, double>>>;
+using Socket = boost::asio::detail::socket_holder;
 using WaitResultPair = std::pair<std::vector<ObjectID>, std::vector<ObjectID>>;
 
 class RayletConnection {
@@ -40,7 +43,6 @@ class RayletConnection {
   /// \return The connection information.
   RayletConnection(const std::string &raylet_socket, int num_retries, int64_t timeout);
 
-  ~RayletConnection() { close(conn_); }
   /// Notify the raylet that this client is disconnecting gracefully. This
   /// is used by actors to exit gracefully so that the raylet doesn't
   /// propagate an error message to the driver.
@@ -55,8 +57,8 @@ class RayletConnection {
                                  flatbuffers::FlatBufferBuilder *fbb = nullptr);
 
  private:
-  /// File descriptor of the Unix domain socket that connects to raylet.
-  int conn_;
+  /// The Unix domain socket that connects to raylet.
+  Socket conn_;
   /// A mutex to protect stateful operations of the raylet client.
   std::mutex mutex_;
   /// A mutex to protect write operations of the raylet client.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -1,21 +1,18 @@
-
 #include "src/ray/rpc/grpc_server.h"
+
+#include <boost/asio/detail/socket_holder.hpp>
 #include <grpcpp/impl/service_type.h>
 
 namespace {
 
 bool PortNotInUse(int port) {
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
-  if (fd == -1) {
-    return false;
-  }
+  boost::asio::detail::socket_holder fd(socket(AF_INET, SOCK_STREAM, 0));
   struct sockaddr_in server_addr = {0};
   server_addr.sin_family = AF_INET;
   server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
   server_addr.sin_port = htons(port);
-  int err = bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-  close(fd);
-  return err == 0;
+  return fd.get() >= 0 &&
+    bind(fd.get(), (struct sockaddr *)&server_addr, sizeof(server_addr)) == 0;
 }
 
 }  // namespace

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -1,7 +1,7 @@
 #include "src/ray/rpc/grpc_server.h"
 
-#include <boost/asio/detail/socket_holder.hpp>
 #include <grpcpp/impl/service_type.h>
+#include <boost/asio/detail/socket_holder.hpp>
 
 namespace {
 
@@ -12,7 +12,7 @@ bool PortNotInUse(int port) {
   server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
   server_addr.sin_port = htons(port);
   return fd.get() >= 0 &&
-    bind(fd.get(), (struct sockaddr *)&server_addr, sizeof(server_addr)) == 0;
+         bind(fd.get(), (struct sockaddr *)&server_addr, sizeof(server_addr)) == 0;
 }
 
 }  // namespace


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Socket types are not `int`s on Windows, and we should be using a wrapper type for proper lifetime management anyway.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.