### PR TITLE
Fix duplicated logging if log dir is not set

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -140,11 +140,8 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
   google::InitGoogleLogging(app_name_.c_str());
   if (log_dir_.empty()) {
     google::SetStderrLogging(GetMappedSeverity(RayLogLevel::ERROR));
-    for (int i = static_cast<int>(severity_threshold_);
-         i <= static_cast<int>(RayLogLevel::FATAL); ++i) {
-      int level = GetMappedSeverity(static_cast<RayLogLevel>(i));
-      google::base::SetLogger(level, &stdout_logger_singleton);
-    }
+    int level = GetMappedSeverity(severity_threshold_);
+    google::base::SetLogger(level, &stdout_logger_singleton);
   } else {
     // Enable log file if log_dir_ is not empty.
     auto dir_ends_with_slash = log_dir_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If we pass an empty string as the `log_dir` parameter when invoking `RayLog::StartRayLog`, we may see duplicated log messages. To be precise, 2 duplicated logs for a `WARNING` log, 3 for an `ERROR` log, and 4 for a `FATAL` log.

A glog logger is associated with a log level to write all logs **equal to or more severe than** the associated level. So if call `google::base::SetLogger` multiple times with different levels and the same destination, we actually created multiple loggers with overlaps on log levels. So we will see duplicates. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
