### PR TITLE
WIP [do not merge] Switch 'readthedocs' to the Alabaster theme

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -9,8 +9,17 @@ make html
 open _build/html/index.html
 ```
 
-To test if there are any build errors with the documentation, do the following.
+To test if there are any build errors with the documentation, do the following:
 
 ```
 sphinx-build -W -b html -d _build/doctrees source _build/html
 ```
+
+To find broken links, run either of the following commands (which aren't exactly identical!):
+
+```
+make linkcheck
+
+sphinx-build -b linkcheck -n -d _build/doctrees source _build/html -j auto
+```
+

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,3 +1,4 @@
+alabaster
 colorama
 click
 filelock
@@ -16,7 +17,6 @@ sphinx
 sphinx-click
 sphinx-gallery
 sphinx-jsonschema
-sphinx_rtd_theme
 tabulate
 pandas
 flask

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -180,14 +180,19 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-import sphinx_rtd_theme
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# NOTE: Roboto is the default font family for Alabaster
+html_theme_options = {
+    'font_family': 'Source Sans Pro, Roboto, Arial', 
+    'body_max_width': 'auto',
+    'page_width': '80%',
+    'code_font_size': '0.8em',
+    'fixed_sidebar': False,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -227,7 +232,16 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['index.html']}
+# Minimalist:
+# html_sidebars = {'**': ['index.html']}
+# Example from Alabaster documentatio:
+# html_sidebars = {'**': [
+#     'about.html',
+#     'index.html',
+#     'navigation.html',
+#     'relations.html',
+#     'searchbox.html',
+#     'donate.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -187,7 +187,7 @@ html_theme = 'alabaster'
 # documentation.
 # NOTE: Roboto is the default font family for Alabaster
 html_theme_options = {
-    'font_family': 'Source Sans Pro, Roboto, Arial', 
+    'font_family': 'Source Sans Pro, Roboto, Arial',
     'body_max_width': 'auto',
     'page_width': '80%',
     'code_font_size': '0.8em',

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -57,7 +57,7 @@ Dependencies
 To build Ray, first install the following dependencies. We recommend using
 `Anaconda`_.
 
-.. _`Anaconda`: https://www.continuum.io/downloads
+.. _`Anaconda`: https://www.anaconda.com/distribution/#download-section
 
 For Ubuntu, run the following commands:
 

--- a/doc/source/rllib-algorithms.rst
+++ b/doc/source/rllib-algorithms.rst
@@ -182,7 +182,7 @@ RLlib DQN is implemented using the SyncReplayOptimizer. The algorithm can be sca
 
     DQN architecture
 
-Tuned examples: `PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pong-dqn.yaml>`__, `Rainbow configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pong-rainbow.yaml>`__, `{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-basic-dqn.yaml>`__, `with Dueling and Double-Q <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-duel-ddqn.yaml>`__, `with Distributional DQN <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-dist-dqn.yaml>`__.
+Tuned examples: `PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pong-dqn.yaml>`__, `Rainbow configuration <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/pong-rainbow.yaml>`__, `{BeamRider,Breakout,Qbert,SpaceInvaders}NoFrameskip-v4 <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-dqn.yaml>`__, `with Dueling and Double-Q <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-duel-ddqn.yaml>`__, `with Distributional DQN <https://github.com/ray-project/ray/blob/master/rllib/tuned_examples/atari-dist-dqn.yaml>`__.
 
 .. tip::
     Consider using `Ape-X <#distributed-prioritized-experience-replay-ape-x>`__ for faster training with similar timestep efficiency.

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -57,7 +57,7 @@ class HyperBandScheduler(FIFOScheduler):
     Note that Tune's stopping criteria will be applied in conjunction with
     HyperBand's early stopping mechanisms.
 
-    See also: https://people.eecs.berkeley.edu/~kjamieson/hyperband.html
+    See also: https://homes.cs.washington.edu/~jamieson/hyperband.htmlhyperband.html
 
     Args:
         time_attr (str): The training result attr to use for comparing time.

--- a/python/ray/tune/schedulers/hyperband.py
+++ b/python/ray/tune/schedulers/hyperband.py
@@ -57,7 +57,7 @@ class HyperBandScheduler(FIFOScheduler):
     Note that Tune's stopping criteria will be applied in conjunction with
     HyperBand's early stopping mechanisms.
 
-    See also: https://homes.cs.washington.edu/~jamieson/hyperband.htmlhyperband.html
+    See also: https://homes.cs.washington.edu/~jamieson/hyperband.html
 
     Args:
         time_attr (str): The training result attr to use for comparing time.


### PR DESCRIPTION
## Why are these changes needed?

The intent is to provide a cleaner, more readable layout for the docs. This is the first change. A subsequent PR will reorganize the navigation links.

## Related issue number

First step for issue [6348](https://github.com/ray-project/ray/issues/6348).

**Note:** Don't merge yet, discussing with Richard, the left-hand ToC is not as readable with this theme change, compared to the current theme. Tweaking the CSS could fix this.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR. 
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.

[*] I ran into problems with the `flask8` script that I'm discussing with the core team. However, there are no Python changes in this PR, only doc changes.

Note: There are five warnings when building the docs:
```
.../ray-git/doc/source/sections/examples/auto_examples/plot_example-a3c.rst: WARNING: document isn't included in any toctree
.../ray-git/doc/source/sections/examples/auto_examples/plot_example-lm.rst: WARNING: document isn't included in any toctree
.../ray-git/doc/source/sections/examples/auto_examples/plot_lbfgs.rst: WARNING: document isn't included in any toctree
.../ray-git/doc/source/sections/examples/auto_examples/plot_newsreader.rst: WARNING: document isn't included in any toctree
.../ray-git/doc/source/sections/examples/auto_examples/plot_streaming.rst: WARNING: document isn't included in any toctree
```

In fact, these modules are referenced in `doc/examples/overview.rst`. A subsequent PR will also remove them completely.
