### PR TITLE
Add WorkerID check to AssignTask

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -108,7 +108,8 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
                                   std::placeholders::_2, std::placeholders::_3);
     raylet_task_receiver_ =
         std::unique_ptr<CoreWorkerRayletTaskReceiver>(new CoreWorkerRayletTaskReceiver(
-            local_raylet_client_, execute_task, exit_handler));
+            worker_context_.GetWorkerID(), local_raylet_client_, execute_task,
+            exit_handler));
     direct_task_receiver_ =
         std::unique_ptr<CoreWorkerDirectTaskReceiver>(new CoreWorkerDirectTaskReceiver(
             worker_context_, task_execution_service_, execute_task, exit_handler));

--- a/src/ray/core_worker/transport/raylet_transport.cc
+++ b/src/ray/core_worker/transport/raylet_transport.cc
@@ -6,15 +6,23 @@
 namespace ray {
 
 CoreWorkerRayletTaskReceiver::CoreWorkerRayletTaskReceiver(
-    std::shared_ptr<RayletClient> &raylet_client, const TaskHandler &task_handler,
-    const std::function<void()> &exit_handler)
-    : raylet_client_(raylet_client),
+    const WorkerID &worker_id, std::shared_ptr<RayletClient> &raylet_client,
+    const TaskHandler &task_handler, const std::function<void()> &exit_handler)
+    : worker_id_(worker_id),
+      raylet_client_(raylet_client),
       task_handler_(task_handler),
       exit_handler_(exit_handler) {}
 
 void CoreWorkerRayletTaskReceiver::HandleAssignTask(
     const rpc::AssignTaskRequest &request, rpc::AssignTaskReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
+  WorkerID intended_worker_id = WorkerID::FromBinary(request.worker_id());
+  if (intended_worker_id != worker_id_) {
+    RAY_LOG(WARNING) << "Received task for mismatched WorkerID " << intended_worker_id;
+    send_reply_callback(Status::Invalid("Mismatched WorkerID"), nullptr, nullptr);
+    return;
+  }
+
   const Task task(request.task());
   const auto &task_spec = task.GetTaskSpecification();
   RAY_LOG(DEBUG) << "Received task " << task_spec.TaskId() << " is create "

--- a/src/ray/core_worker/transport/raylet_transport.h
+++ b/src/ray/core_worker/transport/raylet_transport.h
@@ -15,7 +15,8 @@ class CoreWorkerRayletTaskReceiver {
       const TaskSpecification &task_spec, const ResourceMappingType &resource_ids,
       std::vector<std::shared_ptr<RayObject>> *return_objects)>;
 
-  CoreWorkerRayletTaskReceiver(std::shared_ptr<RayletClient> &raylet_client,
+  CoreWorkerRayletTaskReceiver(const WorkerID &worker_id,
+                               std::shared_ptr<RayletClient> &raylet_client,
                                const TaskHandler &task_handler,
                                const std::function<void()> &exit_handler);
 
@@ -31,6 +32,8 @@ class CoreWorkerRayletTaskReceiver {
                         rpc::SendReplyCallback send_reply_callback);
 
  private:
+  // WorkerID of this worker.
+  WorkerID worker_id_;
   /// Reference to the core worker's raylet client. This is a pointer ref so that it
   /// can be initialized by core worker after this class is constructed.
   std::shared_ptr<RayletClient> &raylet_client_;

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -33,12 +33,16 @@ message ActorHandle {
 }
 
 message AssignTaskRequest {
+   // The ID of the worker this message is intended for. This is used to
+   // ensure that workers don't try to execute tasks assigned to workers
+   // that used to be bound to the same port.
+   bytes worker_id = 1;
   // The task to be pushed.
-  Task task = 1;
+  Task task = 2;
   // A list of the resources reserved for this worker.
   // TODO(zhijunfu): `resource_ids` is represented as
   // flatbutters-serialized bytes, will be moved to protobuf later.
-  bytes resource_ids = 2;
+  bytes resource_ids = 3;
 }
 
 message AssignTaskReply {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -33,12 +33,14 @@ message ActorHandle {
 }
 
 message AssignTaskRequest {
-   // The ID of the worker this message is intended for. This is used to
-   // ensure that workers don't try to execute tasks assigned to workers
-   // that used to be bound to the same port.
-   bytes worker_id = 1;
+  // The ID of the worker this message is intended for. This is used to
+  // ensure that workers don't try to execute tasks assigned to workers
+  // that used to be bound to the same port.
+  bytes worker_id = 1;
+
   // The task to be pushed.
   Task task = 2;
+
   // A list of the resources reserved for this worker.
   // TODO(zhijunfu): `resource_ids` is represented as
   // flatbutters-serialized bytes, will be moved to protobuf later.

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -131,6 +131,7 @@ void Worker::SetActiveObjectIds(const std::unordered_set<ObjectID> &&object_ids)
 Status Worker::AssignTask(const Task &task, const ResourceIdSet &resource_id_set) {
   RAY_CHECK(port_ > 0);
   rpc::AssignTaskRequest request;
+  request.set_worker_id(worker_id_.Binary());
   request.mutable_task()->mutable_task_spec()->CopyFrom(
       task.GetTaskSpecification().GetMessage());
   request.mutable_task()->mutable_task_execution_spec()->CopyFrom(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

It's possible for workers to reuse ports for their gRPC servers (e.g., if there is a lot of churn in workers/actors). When this happens, in-flight messages bound for the old worker might be delivered to the new one. This change causes those messages to be dropped, which is equivalent to them not being delivered in the case that the previous server remained down. Verified to fix the issue in release tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
