### PR TITLE
Tentative workaround for some forks and signals on Windows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -643,6 +643,31 @@ cc_binary(
 )
 
 cc_library(
+    name = "platform_shims",
+    srcs = [] + select({
+        "@bazel_tools//src/conditions:windows": glob([
+            "src/shims/windows/**/*.c",
+            "src/shims/windows/**/*.cc",
+        ]),
+        "//conditions:default": [],
+    }),
+    hdrs = [] + select({
+        "@bazel_tools//src/conditions:windows": glob([
+            "src/shims/windows/**/*.h",
+        ]),
+        "//conditions:default": [],
+    }),
+    copts = COPTS,
+    includes = [] + select({
+        "@bazel_tools//src/conditions:windows": [
+            "src/shims/windows",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "ray_util",
     srcs = glob(
         [

--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -116,6 +116,7 @@ cc_library(
         ":common_fbs",
         ":plasma_fbs",
         "@com_github_google_glog//:glog",
+        "@com_github_ray_project_ray//:platform_shims",
     ],
 )
 
@@ -210,6 +211,7 @@ cc_library(
         ":ae",
         ":plasma_client",
         "@com_github_google_glog//:glog",
+        "@com_github_ray_project_ray//:platform_shims",
     ],
 )
 

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -28,5 +28,8 @@ cc_library(
     copts = COPTS,
     includes = ["deps"],
     strip_include_prefix = "deps",
+    deps = [
+        "@com_github_ray_project_ray//:platform_shims",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -245,12 +245,16 @@ void CoreWorker::Disconnect() {
 }
 
 void CoreWorker::RunIOService() {
+#ifdef _WIN32
+  // TODO(mehrdadn): Is there an equivalent for Windows we need here?
+#else
   // Block SIGINT and SIGTERM so they will be handled by the main thread.
   sigset_t mask;
   sigemptyset(&mask);
   sigaddset(&mask, SIGINT);
   sigaddset(&mask, SIGTERM);
   pthread_sigmask(SIG_BLOCK, &mask, NULL);
+#endif
 
   io_service_.run();
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -266,8 +266,10 @@ void NodeManager::KillWorker(std::shared_ptr<Worker> worker) {
   retry_timer->expires_from_now(retry_duration);
   retry_timer->async_wait([retry_timer, worker](const boost::system::error_code &error) {
     RAY_LOG(DEBUG) << "Send SIGKILL to worker, pid=" << worker->Pid();
-    // Force kill worker. TODO(rkn): Is there some small danger that the worker
-    // has already died and the PID has been reassigned to a different process?
+    // Force kill worker. TODO(mehrdadn, rkn): The worker may have already died
+    // and had its PID reassigned to a different process, at least on Windows.
+    // On Linux, this may or may not be the case, depending on e.g. whether
+    // the process has been already waited on. Regardless, this must be fixed.
     kill(worker->Pid(), SIGKILL);
   });
 }

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -261,7 +261,7 @@ pid_t WorkerPool::StartProcess(const std::vector<std::string> &worker_command_ar
   // Launch the process to create the worker.
   if (pid == -1) {
     // The worker failed to start. This is a fatal error.
-    RAY_LOG(FATAL) << "Failed to start worker with return value " << rv << ": "
+    RAY_LOG(FATAL) << "Failed to start worker with error " << errno << ": "
                    << strerror(errno);
   }
   return pid;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -257,10 +257,9 @@ pid_t WorkerPool::StartProcess(const std::vector<std::string> &worker_command_ar
     RAY_LOG(DEBUG) << stream.str();
   }
 
-  pid_t pid = spawnvp_wrapper(worker_command_args);
   // Launch the process to create the worker.
+  pid_t pid = spawnvp_wrapper(worker_command_args);
   if (pid == -1) {
-    // The worker failed to start. This is a fatal error.
     RAY_LOG(FATAL) << "Failed to start worker with error " << errno << ": "
                    << strerror(errno);
   }

--- a/src/ray/util/signal_test.cc
+++ b/src/ray/util/signal_test.cc
@@ -8,6 +8,7 @@
 
 // This test just print some call stack information.
 namespace ray {
+#ifndef _WIN32
 
 void Sleep() { usleep(100000); }
 
@@ -77,6 +78,7 @@ TEST(SignalTest, SIGILL_Test) {
   }
 }
 
+#endif  // !_WIN32
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/shims/windows/unistd.cc
+++ b/src/shims/windows/unistd.cc
@@ -1,0 +1,28 @@
+#include <unistd.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#include <Windows.h>
+
+int kill(pid_t pid, int sig) {
+  int result;
+  if (HANDLE process = OpenProcess(PROCESS_TERMINATE, FALSE, pid)) {
+    if (sig == SIGKILL) {
+      if (TerminateProcess(process, ERROR_PROCESS_ABORTED)) {
+        result = 0;
+      } else {
+        result = -1;
+        errno = EPERM;
+      }
+    } else {
+      result = -1;
+      errno = EINVAL;
+    }
+    CloseHandle(process);
+  } else {
+    result = -1;
+    errno = ESRCH;
+  }
+  return result;
+}

--- a/src/shims/windows/unistd.h
+++ b/src/shims/windows/unistd.h
@@ -1,0 +1,17 @@
+#ifndef UNISTD_H
+#define UNISTD_H
+
+typedef int pid_t /* technically unsigned on Windows, but no practical concern */;
+enum { SIGKILL = 9 };
+
+__declspec(
+    deprecated("Killing a process by ID has an inherent race condition on Windows"
+               " and is HIGHLY discouraged. "
+               "Furthermore, signals other than SIGKILL are NOT portable. "
+               "Please use a wrapper that keeps the process handle alive"
+               " and terminates it directly as needed. "
+               "For SIGNTERM or other signals, a different IPC mechanism may be"
+               " more appropriate (such as window messages on Windows)."
+               "")) int kill(pid_t pid, int sig);
+
+#endif /* UNISTD_H */

--- a/src/shims/windows/unistd.h
+++ b/src/shims/windows/unistd.h
@@ -10,7 +10,7 @@ __declspec(
                "Furthermore, signals other than SIGKILL are NOT portable. "
                "Please use a wrapper that keeps the process handle alive"
                " and terminates it directly as needed. "
-               "For SIGNTERM or other signals, a different IPC mechanism may be"
+               "For SIGTERM or other signals, a different IPC mechanism may be"
                " more appropriate (such as window messages on Windows)."
                "")) int kill(pid_t pid, int sig);
 


### PR DESCRIPTION
## Why are these changes needed?

Laying the groundwork for Windows compatibility for `fork` and `signal`.  
More work will be needed for a fully correct and robust solution (likely via `boost::process::child`).

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
