### PR TITLE
Fix long running stress tests

### DIFF
--- a/ci/long_running_tests/workloads/actor_deaths.py
+++ b/ci/long_running_tests/workloads/actor_deaths.py
@@ -9,7 +9,7 @@ import sys
 import time
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 1
 redis_max_memory = 10**8

--- a/ci/long_running_tests/workloads/apex.py
+++ b/ci/long_running_tests/workloads/apex.py
@@ -5,7 +5,7 @@ from __future__ import division
 from __future__ import print_function
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 from ray.tune import run_experiments
 
 num_redis_shards = 5

--- a/ci/long_running_tests/workloads/impala.py
+++ b/ci/long_running_tests/workloads/impala.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import ray
 from ray.tune import run_experiments
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 5
 redis_max_memory = 10**8

--- a/ci/long_running_tests/workloads/many_actor_tasks.py
+++ b/ci/long_running_tests/workloads/many_actor_tasks.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 5
 redis_max_memory = 10**8

--- a/ci/long_running_tests/workloads/many_drivers.py
+++ b/ci/long_running_tests/workloads/many_drivers.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 from ray.test_utils import run_string_as_driver
 
 num_redis_shards = 5

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 5
 redis_max_memory = 10**8

--- a/ci/long_running_tests/workloads/node_failures.py
+++ b/ci/long_running_tests/workloads/node_failures.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import time
 
 import ray
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 5
 redis_max_memory = 10**8

--- a/ci/long_running_tests/workloads/pbt.py
+++ b/ci/long_running_tests/workloads/pbt.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import ray
 from ray.tune import run_experiments
 from ray.tune.schedulers import PopulationBasedTraining
-from ray.tests.cluster_utils import Cluster
+from ray.cluster_utils import Cluster
 
 num_redis_shards = 5
 redis_max_memory = 10**8


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The module `cluster_utils` moved into the `ray` namespace.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
