### PR TITLE
[Java] Fix `instanceof RayPyActor`

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayJavaActor.java
+++ b/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayJavaActor.java
@@ -11,8 +11,7 @@ import org.ray.runtime.generated.Common.Language;
 public class NativeRayJavaActor extends NativeRayActor {
 
   NativeRayJavaActor(long nativeCoreWorkerPointer, byte[] actorId) {
-    super(nativeCoreWorkerPointer, actorId);
-    Preconditions.checkState(getLanguage() == Language.JAVA);
+    super(nativeCoreWorkerPointer, actorId, Language.JAVA);
   }
 
   /**

--- a/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayJavaActor.java
+++ b/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayJavaActor.java
@@ -1,0 +1,30 @@
+package org.ray.runtime.actor;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.io.ObjectInput;
+import org.ray.runtime.generated.Common.Language;
+
+/**
+ * RayActor Java implementation for cluster mode.
+ */
+public class NativeRayJavaActor extends NativeRayActor {
+
+  NativeRayJavaActor(long nativeCoreWorkerPointer, byte[] actorId) {
+    super(nativeCoreWorkerPointer, actorId);
+    Preconditions.checkState(getLanguage() == Language.JAVA);
+  }
+
+  /**
+   * Required by FST
+   */
+  public NativeRayJavaActor() {
+    super();
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    super.readExternal(in);
+    Preconditions.checkState(getLanguage() == Language.JAVA);
+  }
+}

--- a/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayPyActor.java
+++ b/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayPyActor.java
@@ -12,8 +12,7 @@ import org.ray.runtime.generated.Common.Language;
 public class NativeRayPyActor extends NativeRayActor implements RayPyActor {
 
   NativeRayPyActor(long nativeCoreWorkerPointer, byte[] actorId) {
-    super(nativeCoreWorkerPointer, actorId);
-    Preconditions.checkState(getLanguage() == Language.PYTHON);
+    super(nativeCoreWorkerPointer, actorId, Language.PYTHON);
   }
 
   /**

--- a/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayPyActor.java
+++ b/java/runtime/src/main/java/org/ray/runtime/actor/NativeRayPyActor.java
@@ -1,0 +1,41 @@
+package org.ray.runtime.actor;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.io.ObjectInput;
+import org.ray.api.RayPyActor;
+import org.ray.runtime.generated.Common.Language;
+
+/**
+ * RayActor Python implementation for cluster mode.
+ */
+public class NativeRayPyActor extends NativeRayActor implements RayPyActor {
+
+  NativeRayPyActor(long nativeCoreWorkerPointer, byte[] actorId) {
+    super(nativeCoreWorkerPointer, actorId);
+    Preconditions.checkState(getLanguage() == Language.PYTHON);
+  }
+
+  /**
+   * Required by FST
+   */
+  public NativeRayPyActor() {
+    super();
+  }
+
+  @Override
+  public String getModuleName() {
+    return nativeGetActorCreationTaskFunctionDescriptor(nativeCoreWorkerPointer, actorId).get(0);
+  }
+
+  @Override
+  public String getClassName() {
+    return nativeGetActorCreationTaskFunctionDescriptor(nativeCoreWorkerPointer, actorId).get(1);
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    super.readExternal(in);
+    Preconditions.checkState(getLanguage() == Language.PYTHON);
+  }
+}

--- a/java/runtime/src/main/java/org/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/org/ray/runtime/task/NativeTaskSubmitter.java
@@ -37,7 +37,7 @@ public class NativeTaskSubmitter implements TaskSubmitter {
       ActorCreationOptions options) {
     byte[] actorId = nativeCreateActor(nativeCoreWorkerPointer, functionDescriptor, args,
         options);
-    return new NativeRayActor(nativeCoreWorkerPointer, actorId);
+    return NativeRayActor.create(nativeCoreWorkerPointer, actorId);
   }
 
   @Override

--- a/java/runtime/src/main/java/org/ray/runtime/task/NativeTaskSubmitter.java
+++ b/java/runtime/src/main/java/org/ray/runtime/task/NativeTaskSubmitter.java
@@ -37,7 +37,7 @@ public class NativeTaskSubmitter implements TaskSubmitter {
       ActorCreationOptions options) {
     byte[] actorId = nativeCreateActor(nativeCoreWorkerPointer, functionDescriptor, args,
         options);
-    return NativeRayActor.create(nativeCoreWorkerPointer, actorId);
+    return NativeRayActor.create(nativeCoreWorkerPointer, actorId, functionDescriptor.getLanguage());
   }
 
   @Override

--- a/java/test/src/main/java/org/ray/api/test/ActorTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.ray.api.Ray;
 import org.ray.api.RayActor;
 import org.ray.api.RayObject;
+import org.ray.api.RayPyActor;
 import org.ray.api.TestUtils;
 import org.ray.api.TestUtils.LargeObject;
 import org.ray.api.annotation.RayRemote;
@@ -50,6 +51,8 @@ public class ActorTest extends BaseTest {
     // Test creating an actor from a constructor
     RayActor<Counter> actor = Ray.createActor(Counter::new, 1);
     Assert.assertNotEquals(actor.getId(), UniqueId.NIL);
+    // A java actor is not a python actor
+    Assert.assertFalse(actor instanceof RayPyActor);
     // Test calling an actor
     Assert.assertEquals(Integer.valueOf(1), Ray.call(Counter::getValue, actor).get());
     Ray.call(Counter::increase, actor, 1);

--- a/src/ray/core_worker/lib/java/org_ray_runtime_actor_NativeRayActor.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_actor_NativeRayActor.cc
@@ -13,16 +13,6 @@ inline ray::CoreWorker &GetCoreWorker(jlong nativeCoreWorkerPointer) {
 extern "C" {
 #endif
 
-JNIEXPORT jint JNICALL Java_org_ray_runtime_actor_NativeRayActor_nativeGetLanguage(
-    JNIEnv *env, jclass o, jlong nativeCoreWorkerPointer, jbyteArray actorId) {
-  auto actor_id = JavaByteArrayToId<ray::ActorID>(env, actorId);
-  ray::ActorHandle *native_actor_handle = nullptr;
-  auto status = GetCoreWorker(nativeCoreWorkerPointer)
-                    .GetActorHandle(actor_id, &native_actor_handle);
-  THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, (jint)0);
-  return (jint)native_actor_handle->ActorLanguage();
-}
-
 JNIEXPORT jboolean JNICALL
 Java_org_ray_runtime_actor_NativeRayActor_nativeIsDirectCallActor(
     JNIEnv *env, jclass o, jlong nativeCoreWorkerPointer, jbyteArray actorId) {

--- a/src/ray/core_worker/lib/java/org_ray_runtime_actor_NativeRayActor.h
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_actor_NativeRayActor.h
@@ -9,14 +9,6 @@ extern "C" {
 #endif
 /*
  * Class:     org_ray_runtime_actor_NativeRayActor
- * Method:    nativeGetLanguage
- * Signature: (J[B)I
- */
-JNIEXPORT jint JNICALL Java_org_ray_runtime_actor_NativeRayActor_nativeGetLanguage(
-    JNIEnv *, jclass, jlong, jbyteArray);
-
-/*
- * Class:     org_ray_runtime_actor_NativeRayActor
  * Method:    nativeIsDirectCallActor
  * Signature: (J[B)Z
  */


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For a Java actor, the `instanceof RayPyActor` should be `false`. This is a bug introduced in https://github.com/ray-project/ray/pull/5370.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
