### PR TITLE
[Java] Add java exception check in JNI

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/util/JniExceptionUtil.java
+++ b/java/runtime/src/main/java/org/ray/runtime/util/JniExceptionUtil.java
@@ -1,0 +1,19 @@
+package org.ray.runtime.util;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Required by JNI macro RAY_CHECK_JAVA_EXCEPTION
+public final class JniExceptionUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JniExceptionUtil.class);
+
+  public static String getStackTrace(String fileName, int lineNumber, String function,
+      Throwable throwable) {
+    LOGGER.error("An unexpected exception occurred while executing Java code from JNI ({}:{} {}).",
+        fileName, lineNumber, function, throwable);
+    // Return the exception in string form to JNI.
+    return ExceptionUtils.getStackTrace(throwable);
+  }
+}

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -16,11 +16,7 @@ jmethodID java_array_list_init;
 jmethodID java_array_list_init_with_capacity;
 
 jclass java_map_class;
-jmethodID java_map_put;
 jmethodID java_map_entry_set;
-
-jclass java_hash_map_class;
-jmethodID java_hash_map_init;
 
 jclass java_set_class;
 jmethodID java_set_iterator;
@@ -110,12 +106,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
       env->GetMethodID(java_array_list_class, "<init>", "(I)V");
 
   java_map_class = LoadClass(env, "java/util/Map");
-  java_map_put = env->GetMethodID(
-      java_map_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
   java_map_entry_set = env->GetMethodID(java_map_class, "entrySet", "()Ljava/util/Set;");
-
-  java_hash_map_class = LoadClass(env, "java/util/HashMap");
-  java_hash_map_init = env->GetMethodID(java_hash_map_class, "<init>", "()V");
 
   java_set_class = LoadClass(env, "java/util/Set");
   java_set_iterator =
@@ -208,7 +199,6 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
   env->DeleteGlobalRef(java_list_class);
   env->DeleteGlobalRef(java_array_list_class);
   env->DeleteGlobalRef(java_map_class);
-  env->DeleteGlobalRef(java_hash_map_class);
   env->DeleteGlobalRef(java_set_class);
   env->DeleteGlobalRef(java_iterator_class);
   env->DeleteGlobalRef(java_map_entry_class);

--- a/src/ray/core_worker/lib/java/jni_init.cc
+++ b/src/ray/core_worker/lib/java/jni_init.cc
@@ -16,7 +16,11 @@ jmethodID java_array_list_init;
 jmethodID java_array_list_init_with_capacity;
 
 jclass java_map_class;
+jmethodID java_map_put;
 jmethodID java_map_entry_set;
+
+jclass java_hash_map_class;
+jmethodID java_hash_map_init;
 
 jclass java_set_class;
 jmethodID java_set_iterator;
@@ -30,6 +34,9 @@ jmethodID java_map_entry_get_key;
 jmethodID java_map_entry_get_value;
 
 jclass java_ray_exception_class;
+
+jclass java_jni_exception_util_class;
+jmethodID java_jni_exception_util_get_stack_trace;
 
 jclass java_base_id_class;
 jmethodID java_base_id_get_bytes;
@@ -103,7 +110,12 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
       env->GetMethodID(java_array_list_class, "<init>", "(I)V");
 
   java_map_class = LoadClass(env, "java/util/Map");
+  java_map_put = env->GetMethodID(
+      java_map_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
   java_map_entry_set = env->GetMethodID(java_map_class, "entrySet", "()Ljava/util/Set;");
+
+  java_hash_map_class = LoadClass(env, "java/util/HashMap");
+  java_hash_map_init = env->GetMethodID(java_hash_map_class, "<init>", "()V");
 
   java_set_class = LoadClass(env, "java/util/Set");
   java_set_iterator =
@@ -121,6 +133,11 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
       env->GetMethodID(java_map_entry_class, "getValue", "()Ljava/lang/Object;");
 
   java_ray_exception_class = LoadClass(env, "org/ray/api/exception/RayException");
+
+  java_jni_exception_util_class = LoadClass(env, "org/ray/runtime/util/JniExceptionUtil");
+  java_jni_exception_util_get_stack_trace = env->GetStaticMethodID(
+      java_jni_exception_util_class, "getStackTrace",
+      "(Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)Ljava/lang/String;");
 
   java_base_id_class = LoadClass(env, "org/ray/api/id/BaseId");
   java_base_id_get_bytes = env->GetMethodID(java_base_id_class, "getBytes", "()[B");
@@ -191,10 +208,12 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
   env->DeleteGlobalRef(java_list_class);
   env->DeleteGlobalRef(java_array_list_class);
   env->DeleteGlobalRef(java_map_class);
+  env->DeleteGlobalRef(java_hash_map_class);
   env->DeleteGlobalRef(java_set_class);
   env->DeleteGlobalRef(java_iterator_class);
   env->DeleteGlobalRef(java_map_entry_class);
   env->DeleteGlobalRef(java_ray_exception_class);
+  env->DeleteGlobalRef(java_jni_exception_util_class);
   env->DeleteGlobalRef(java_base_id_class);
   env->DeleteGlobalRef(java_function_descriptor_class);
   env->DeleteGlobalRef(java_language_class);

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -35,15 +35,8 @@ extern jmethodID java_array_list_init_with_capacity;
 
 /// Map interface
 extern jclass java_map_class;
-/// put method of Map interface
-extern jmethodID java_map_put;
 /// entrySet method of Map interface
 extern jmethodID java_map_entry_set;
-
-/// HashMap class
-extern jclass java_hash_map_class;
-/// Constructor of HashMap class
-extern jmethodID java_hash_map_init;
 
 /// Set interface
 extern jclass java_set_class;

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -35,8 +35,15 @@ extern jmethodID java_array_list_init_with_capacity;
 
 /// Map interface
 extern jclass java_map_class;
+/// put method of Map interface
+extern jmethodID java_map_put;
 /// entrySet method of Map interface
 extern jmethodID java_map_entry_set;
+
+/// HashMap class
+extern jclass java_hash_map_class;
+/// Constructor of HashMap class
+extern jmethodID java_hash_map_init;
 
 /// Set interface
 extern jclass java_set_class;
@@ -59,6 +66,11 @@ extern jmethodID java_map_entry_get_value;
 
 /// RayException class
 extern jclass java_ray_exception_class;
+
+/// JniExceptionUtil class
+extern jclass java_jni_exception_util_class;
+/// getStackTrace method of JniExceptionUtil class
+extern jmethodID java_jni_exception_util_get_stack_trace;
 
 /// BaseId class
 extern jclass java_base_id_class;
@@ -136,6 +148,29 @@ extern JavaVM *jvm;
     }                                                                        \
   }
 
+#define RAY_CHECK_JAVA_EXCEPTION(env)                                                 \
+  {                                                                                   \
+    jthrowable throwable = env->ExceptionOccurred();                                  \
+    if (throwable) {                                                                  \
+      jstring java_file_name = env->NewStringUTF(__FILE__);                           \
+      jstring java_function = env->NewStringUTF(__func__);                            \
+      jobject java_error_message = env->CallStaticObjectMethod(                       \
+          java_jni_exception_util_class, java_jni_exception_util_get_stack_trace,     \
+          java_file_name, __LINE__, java_function, throwable);                        \
+      std::string error_message =                                                     \
+          JavaStringToNativeString(env, static_cast<jstring>(java_error_message));    \
+      env->DeleteLocalRef(throwable);                                                 \
+      env->DeleteLocalRef(java_file_name);                                            \
+      env->DeleteLocalRef(java_function);                                             \
+      env->DeleteLocalRef(java_error_message);                                        \
+      RAY_LOG(FATAL) << "An unexpected exception occurred while executing Java code " \
+                        "from JNI ("                                                  \
+                     << __FILE__ << ":" << __LINE__ << " " << __func__ << ")."        \
+                     << "\n"                                                          \
+                     << error_message;                                                \
+    }                                                                                 \
+  }
+
 /// Represents a byte buffer of Java byte array.
 /// The destructor will automatically call ReleaseByteArrayElements.
 /// NOTE: Instances of this class cannot be used across threads.
@@ -203,10 +238,12 @@ inline void JavaListToNativeVector(
     JNIEnv *env, jobject java_list, std::vector<NativeT> *native_vector,
     std::function<NativeT(JNIEnv *, jobject)> element_converter) {
   int size = env->CallIntMethod(java_list, java_list_size);
+  RAY_CHECK_JAVA_EXCEPTION(env);
   native_vector->clear();
   for (int i = 0; i < size; i++) {
-    native_vector->emplace_back(
-        element_converter(env, env->CallObjectMethod(java_list, java_list_get, (jint)i)));
+    auto element = env->CallObjectMethod(java_list, java_list_get, (jint)i);
+    RAY_CHECK_JAVA_EXCEPTION(env);
+    native_vector->emplace_back(element_converter(env, element));
   }
 }
 
@@ -229,6 +266,7 @@ inline jobject NativeVectorToJavaList(
                      (jint)native_vector.size());
   for (const auto &item : native_vector) {
     env->CallVoidMethod(java_list, java_list_add, element_converter(env, item));
+    RAY_CHECK_JAVA_EXCEPTION(env);
   }
   return java_list;
 }

--- a/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
@@ -55,6 +55,7 @@ JNIEXPORT jlong JNICALL Java_org_ray_runtime_RayNativeRuntime_nativeInitCoreWork
         jobject java_return_objects =
             env->CallObjectMethod(local_java_task_executor, java_task_executor_execute,
                                   ray_function_array_list, args_array_list);
+        RAY_CHECK_JAVA_EXCEPTION(env);
         std::vector<std::shared_ptr<ray::RayObject>> return_objects;
         JavaListToNativeVector<std::shared_ptr<ray::RayObject>>(
             env, java_return_objects, &return_objects,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If `env->Call***Method(...)` throws any Java exception, we need to manually process it in JNI code. So we let it crash.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
