### PR TITLE
[Java] explicit delete local reference in `task_execution_callback` for GC

### DIFF
--- a/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
@@ -64,6 +64,10 @@ JNIEXPORT jlong JNICALL Java_org_ray_runtime_RayNativeRuntime_nativeInitCoreWork
         for (auto &obj : return_objects) {
           results->push_back(obj);
         }
+
+        env->DeleteLocalRef(java_return_objects);
+        env->DeleteLocalRef(args_array_list);
+        env->DeleteLocalRef(ray_function_array_list);
         return ray::Status::OK();
       };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`task_execution_callback` is called within C++ domain by `io_service`, which causes that the local references created in it cannot be deleted automatically. This leads to OOM because these local references cannot be garbage collected.

Solution: delete local references manually in `task_execution_callback` and related helper functions.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
