### PR TITLE
Expanded with new pages for getting started, etc. Blog links unchanged.

### DIFF
--- a/doc/site/blog.html
+++ b/doc/site/blog.html
@@ -1,0 +1,88 @@
+---
+layout: default
+---
+
+<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+
+<embed>
+	<a href="https://github.com/ray-project/ray"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+</embed>
+
+<div class="home">
+
+<div>
+	| <a class href="index">Home</a> | Blog | <a href="get_ray">Get Ray!</a> |
+</div>
+
+<p>
+	<img src="https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png"/>
+</p>
+
+<h1>Ray Project Blog</h1>
+
+<ul class="posts">
+  {% for post in site.posts %}
+    <li>
+      <span>{{ post.date | date: "%b %-d, %Y" }}</span>
+      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+      {{ post.excerpt }}
+    </li>
+  {% endfor %}
+</ul>
+
+<p>Here are Ray-related posts on other sites. First, some posts that are good, first-time introductions to Ray:</p>
+
+<ul class="posts">
+  <li>
+    <span>February 11, 2019</span>
+    <a class="post-link" href="https://towardsdatascience.com/modern-parallel-and-distributed-python-a-quick-tutorial-on-ray-99f8d70369b8">Modern Parallel and Distributed Python: A Quick Tutorial on Ray</a>
+  </li>
+  <li>
+    <span>May 16, 2019</span>
+    <a class="post-link" href="https://towardsdatascience.com/10x-faster-parallel-python-without-python-multiprocessing-e5017c93cce1">10x Faster Parallel Python Without Python Multiprocessing</a>
+  </li>
+</ul>
+
+<p>Other useful posts on Ray:</p>
+
+<ul class="posts">
+  <li>
+    <span>November 28, 2019</span>
+    <a class="post-link" href="https://rise.cs.berkeley.edu/blog/using-ray-as-a-foundation-for-real-time-analytic-monitoring-framework/">Using Ray as a foundation for a real-time analytic monitoring framework - RISE Lab</a>
+  </li>
+  <li>
+    <span>November 25, 2019</span>
+    <a class="post-link" href="https://medium.com/@offercstephen/dkeras-make-keras-faster-with-a-few-lines-of-code-a1792b12dfa0">dKeras: Make Keras up to 30x faster with a few lines of code</a>
+  </li>
+  <li>
+    <span>September 17, 2019</span>
+    <a class="post-link" href="https://medium.com/riselab/functional-rl-with-keras-and-tensorflow-eager-7973f81d6345">Functional RL with Keras and Tensorflow Eager - riselab - Medium</a>
+  </li>
+  <li>
+    <span>August 19, 2019</span>
+    <a class="post-link" href="https://medium.com/riselab/cutting-edge-hyperparameter-tuning-with-ray-tune-be6c0447afdf">Cutting edge hyperparameter tuning with Ray Tune - riselab - Medium</a>
+  </li>
+  <li>
+    <span>July 1, 2019</span>
+    <a class="post-link" href="https://www.oreilly.com/radar/riselabs-autopandas-hints-at-automation-tech-that-will-change-the-nature-of-software-development/">RISELab’s AutoPandas hints at automation tech that will change the nature of software development – O’Reilly</a>
+  </li>
+  <li>
+    <span>February 20, 2019</span>
+    <a class="post-link" href="https://rise.cs.berkeley.edu/blog/ray-tips-for-first-time-users/">Programming in Ray - Tips for First-Time Users</a>
+  </li>
+  <li>
+    <span>August 15, 2018</span>
+    <a class="post-link" href="https://www.oreilly.com/ideas/notes-from-the-first-ray-meetup">Notes from the first Ray meetup - O’Reilly Media</a>
+  </li>
+  <li>
+    <span>February 21, 2019</span>
+    <a class="post-link" href="https://www.oreilly.com/radar/the-evolution-and-expanding-utility-of-ray/">The evolution and expanding utility of Ray – O’Reilly</a>
+  </li>
+  <li>
+    <span>January 19, 2018</span>
+    <a class="post-link" href="https://www.oreilly.com/ideas/introducing-rllib-a-composable-and-scalable-reinforcement-learning-library">Introducing RLlib: A composable and scalable reinforcement learning library - O’Reilly Media</a>
+  </li>
+</ul>
+
+
+</div>

--- a/doc/site/community.html
+++ b/doc/site/community.html
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+
+<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+
+<embed>
+	<a href="https://github.com/ray-project/ray"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+</embed>
+
+<div class="home">
+
+<div>
+	| <a class href="index">Home</a> | <a href="blog">Blog</a> | <a href="get_ray">Get Ray!</a> | Community |
+</div>
+
+<p>
+	<img src="https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png"/>
+</p>
+
+<h1>Ray Community</h1>
+
+<b>TIP:</b> Join our <a href="https://forms.gle/9TSdDYUgxYs8SA9e8">community slack</a> to discuss Ray!
+
+
+</div>

--- a/doc/site/get_ray.html
+++ b/doc/site/get_ray.html
@@ -11,28 +11,23 @@ layout: default
 <div class="home">
 
 <div>
-	| Home | <a class href="blog">Blog</a> | <a href="get_ray">Get Ray!</a> |
+	| <a href="index">Home</a> | <a class href="blog">Blog</a> | Get Ray! |
 </div>
 
 <p>
 	<img src="https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png"/>
 </p>
 
-<p>
-	<b>Ray is a fast and simple framework for building and running distributed applications.</b>
-</p>
+<h1>Getting Started with Ray</h1>
 
 <p>
-	Ray is packaged with the following libraries for accelerating machine learning workloads:
+	To get started with Ray:
 </p>
-
 <ul>
-	<li><em>Tune</em>: Scalable Hyperparameter Tuning</li>
-	<li><em>RLlib</em>: Scalable Reinforcement Learning</li>
-	<li><em>Distributed Training</em></li>
+	<li>Ray Project <a href="https://ray.io">web site</a></li>
+	<li><a href="https://ray.readthedocs.io/en/latest/">Documentation</a></li>
+	<li><a href="https://github.com/ray-project/">GitHub project</a></li>
+	<li><a href="https://github.com/ray-project/tutorial">Tutorials</a></li>
 </ul>
 
-<p>
-	To get started, visit the Ray Project <a href="https://ray.io">web site</a>, <a href="https://ray.readthedocs.io/en/latest/">documentation</a>, <a href="https://github.com/ray-project/">GitHub project</a>, or <a href="https://github.com/ray-project/tutorial">Tutorials</a>. 
-</p>
 </div>


### PR DESCRIPTION
## Why are these changes needed?

This PR makes the site a little more "full featured" and not just a place to park blog posts. It doesn't attempt to reproduce the details in `readthedocs`, and we can certainly expand the content later on.

## Related issue number

https://github.com/ray-project/ray/issues/6387

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
