### PR TITLE
[Projects] Return parameters for a command

### DIFF
--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -270,10 +270,11 @@ def get_session_runs(name, command, parsed_args):
         List of sessions to start, which are dictionaries with keys:
             "name": Name of the session to start,
             "command": Command to run after starting the session,
+            "params": Parameters for this run,
             "num_steps": 4 if a command should be run, 3 if not.
     """
     if not command:
-        return [{"name": name, "command": None, "num_steps": 3}]
+        return [{"name": name, "command": None, "params": {}, "num_steps": 3}]
 
     # Try to find a wildcard argument (i.e. one that has a list of values)
     # and give an error if there is more than one (currently unsupported).
@@ -290,6 +291,7 @@ def get_session_runs(name, command, parsed_args):
         session_run = {
             "name": name,
             "command": format_command(command, parsed_args),
+            "params": parsed_args,
             "num_steps": 4
         }
         return [session_run]
@@ -301,6 +303,7 @@ def get_session_runs(name, command, parsed_args):
             session_run = {
                 "name": "{}-{}-{}".format(name, wildcard_arg, val),
                 "command": format_command(command, parsed_args),
+                "params": parsed_args,
                 "num_steps": 4
             }
             session_runs.append(session_run)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This makes it possible to detect the parameters that were used for a particular session start command.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
