### PR TITLE
[WIP] Build ray 3.8 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
 
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:3.8 /ray/python/build-wheel-manylinux1.sh
 
         # Ignore any error for successful wheel uploads
         - $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
 
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:3.8 /ray/python/build-wheel-manylinux1.sh
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:python-3.8 /ray/python/build-wheel-manylinux1.sh
 
         # Ignore any error for successful wheel uploads
         - $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
         # This command should be kept in sync with ray/python/README-building-wheels.md,
         # except the `$MOUNT_BAZEL_CACHE` part.
 
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:python-3.8 /ray/python/build-wheel-manylinux1.sh
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:python-3.8.0 /ray/python/build-wheel-manylinux1.sh
 
         # Ignore any error for successful wheel uploads
         - $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -829,7 +829,7 @@ pyx_library(
             ],
         }),
     },
-    copts = COPTS + if_linux_x86_64(["-fno-gnu-unique"]),
+    copts = COPTS + ["-Wno-deprecated-declarations"] + if_linux_x86_64(["-fno-gnu-unique"]),
     deps = [
         "//:core_worker_lib",
         "//:raylet_lib",
@@ -851,6 +851,7 @@ pyx_library(
         "python/ray/streaming/includes/*.pxd",
         "python/ray/streaming/includes/*.pxi",
     ]),
+    copts = COPTS + ["-Wno-deprecated-declarations"],
     deps = [
         "//streaming:streaming_lib",
     ],

--- a/build.sh
+++ b/build.sh
@@ -93,15 +93,6 @@ fi
 
 pushd "$BUILD_DIR"
 
-# The following line installs pyarrow from S3, these wheels have been
-# generated from https://github.com/ray-project/arrow-build from
-# the commit listed in the command.
-if [ -z "$SKIP_PYARROW_INSTALL" ]; then
-    "$PYTHON_EXECUTABLE" -m pip install -q \
-        --target="$ROOT_DIR/python/ray/pyarrow_files" pyarrow==0.14.0.RAY \
-        --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/3a11193d9530fe8ec7fdb98057f853b708f6f6ae/index.html
-fi
-
 PYTHON_VERSION=`"$PYTHON_EXECUTABLE" -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'`
 if [[ "$PYTHON_VERSION" == "3.6" || "$PYTHON_VERSION" == "3.7" ]]; then
   WORK_DIR=`mktemp -d`
@@ -113,6 +104,15 @@ if [[ "$PYTHON_VERSION" == "3.6" || "$PYTHON_VERSION" == "3.7" ]]; then
       unzip -o dist/*.whl -d "$ROOT_DIR/python/ray/pickle5_files"
     popd
   popd
+else
+  # The following line installs pyarrow from S3, these wheels have been
+  # generated from https://github.com/ray-project/arrow-build from
+  # the commit listed in the command.
+  if [ -z "$SKIP_PYARROW_INSTALL" ]; then
+    "$PYTHON_EXECUTABLE" -m pip install -q \
+        --target="$ROOT_DIR/python/ray/pyarrow_files" pyarrow==0.14.0.RAY \
+        --find-links https://s3-us-west-2.amazonaws.com/arrow-wheels/3a11193d9530fe8ec7fdb98057f853b708f6f6ae/index.html
+  fi
 fi
 
 export PYTHON3_BIN_PATH="$PYTHON_EXECUTABLE"

--- a/build.sh
+++ b/build.sh
@@ -104,6 +104,8 @@ if [[ "$PYTHON_VERSION" == "3.6" || "$PYTHON_VERSION" == "3.7" ]]; then
       unzip -o dist/*.whl -d "$ROOT_DIR/python/ray/pickle5_files"
     popd
   popd
+elif [[ "$PYTHON_VERSION" == "3.8" ]]; then
+  echo "For python 3.8 we can use the built in pickle5"
 else
   # The following line installs pyarrow from S3, these wheels have been
   # generated from https://github.com/ray-project/arrow-build from

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -16,19 +16,23 @@ DOWNLOAD_DIR=python_downloads
 PY_VERSIONS=("2.7.13"
              "3.5.3"
              "3.6.1"
-             "3.7.0")
+             "3.7.0"
+             "3.8.0")
 PY_INSTS=("python-2.7.13-macosx10.6.pkg"
           "python-3.5.3-macosx10.6.pkg"
           "python-3.6.1-macosx10.6.pkg"
-          "python-3.7.0-macosx10.6.pkg")
+          "python-3.7.0-macosx10.6.pkg"
+          "python-3.8.0-macosx10.6.pkg")
 PY_MMS=("2.7"
         "3.5"
         "3.6"
-        "3.7")
+        "3.7"
+        "3.8")
 
 # The minimum supported numpy version is 1.14, see
 # https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
+                "1.14.5"
                 "1.14.5"
                 "1.14.5"
                 "1.14.5")

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -22,7 +22,7 @@ PY_INSTS=("python-2.7.13-macosx10.6.pkg"
           "python-3.5.3-macosx10.6.pkg"
           "python-3.6.1-macosx10.6.pkg"
           "python-3.7.0-macosx10.6.pkg"
-          "python-3.8.0-macosx10.6.pkg")
+          "python-3.8.0-macosx10.9.pkg")
 PY_MMS=("2.7"
         "3.5"
         "3.6"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -84,7 +84,7 @@ for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
     $PIP_CMD install -q setuptools_scm==3.1.0
     # Fix the numpy version because this will be the oldest numpy version we can
     # support.
-    $PIP_CMD install -q numpy==$NUMPY_VERSION cython==0.29.0
+    $PIP_CMD install -q numpy==$NUMPY_VERSION cython==0.29.14
     # Install wheel to avoid the error "invalid command 'bdist_wheel'".
     $PIP_CMD install -q wheel
     # Add the correct Python to the path and build the wheel. This is only

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -14,11 +14,13 @@ chmod +x /usr/bin/nproc
 PYTHONS=("cp27-cp27mu"
          "cp35-cp35m"
          "cp36-cp36m"
-         "cp37-cp37m")
+         "cp37-cp37m"
+         "cp38-cp38m")
 
 # The minimum supported numpy version is 1.14, see
 # https://issues.apache.org/jira/browse/ARROW-3141
 NUMPY_VERSIONS=("1.14.5"
+                "1.14.5"
                 "1.14.5"
                 "1.14.5"
                 "1.14.5")

--- a/python/build-wheel-manylinux1.sh
+++ b/python/build-wheel-manylinux1.sh
@@ -15,7 +15,7 @@ PYTHONS=("cp27-cp27mu"
          "cp35-cp35m"
          "cp36-cp36m"
          "cp37-cp37m"
-         "cp38-cp38m")
+         "cp38-cp38")
 
 # The minimum supported numpy version is 1.14, see
 # https://issues.apache.org/jira/browse/ARROW-3141

--- a/python/setup.py
+++ b/python/setup.py
@@ -196,7 +196,7 @@ setup(
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
     install_requires=requires,
-    setup_requires=["cython >= 0.29"],
+    setup_requires=["cython >= 0.29.14"],
     extras_require=extras,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Building wheels for Python 3.8.

The linux base image needed to be rebuilt using
```
docker build -t arrow_linux_x86_64_base -f Dockerfile-x86_64_ubuntu .
docker tag d7ee05ce021e rayproject/arrow_linux_x86_64_base:python-3.8.0
```
inside of https://github.com/apache/arrow/tree/master/python/manylinux1.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
