### PR TITLE
[WIP] add prioritised io_context

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -597,6 +597,16 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "prioritised_io_context_test",
+    srcs = ["src/ray/util/prioritised_io_context_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":ray_util",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "object_manager",
     srcs = glob([
@@ -664,6 +674,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/time",
         "@plasma//:plasma_client",
+        "@boost//:asio",
     ],
 )
 

--- a/src/ray/util/prioritised_io_context.h
+++ b/src/ray/util/prioritised_io_context.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <boost/function.hpp>
+#include <queue>
+#include "logging.h"
+
+namespace ray {
+enum Priority { HIGH, LOW, COUNT };
+
+class HandlerPriorityQueue : public boost::asio::execution_context {
+ public:
+  void add(Priority priority, boost::function<void()> function) {
+    handlers_[priority].push(QueuedHandler(priority, std::move(function)));
+  }
+
+  void execute_all() {
+    for (int i = 0; i < Priority::COUNT; ++i) {
+      while (!handlers_[i].empty()) {
+        QueuedHandler handler = handlers_[i].front();
+        handler.execute();
+        handlers_[i].pop();
+      }
+    }
+  }
+
+  class Executor {
+   public:
+    Executor(HandlerPriorityQueue &q, Priority p) : context_(q), priority_(p) {}
+
+    HandlerPriorityQueue &context() const { return context_; }
+
+    template <typename Function, typename Allocator>
+    void dispatch(const Function &f, const Allocator &) const {
+      context_.add(priority_, f);
+    }
+
+    template <typename Function, typename Allocator>
+    void post(const Function &f, const Allocator &) const {
+      context_.add(priority_, f);
+    }
+
+    template <typename Function, typename Allocator>
+    void defer(const Function &f, const Allocator &) const {
+      context_.add(priority_, f);
+    }
+
+    void on_work_started() const {}
+    void on_work_finished() const {}
+
+    bool operator==(const Executor &other) const {
+      return &context_ == &other.context_ && priority_ == other.priority_;
+    }
+
+    bool operator!=(const Executor &other) const { return !operator==(other); }
+
+   private:
+    HandlerPriorityQueue &context_;
+    Priority priority_;
+  };
+
+  template <typename Handler>
+  boost::asio::executor_binder<Handler, Executor> wrap(Priority priority,
+                                                       Handler handler) {
+    return boost::asio::bind_executor(Executor(*this, priority), handler);
+  }
+
+ private:
+  class QueuedHandler {
+   public:
+    QueuedHandler(Priority p, boost::function<void()> &&f)
+        : priority_(p), function_(std::move(f)) {}
+
+    void execute() { function_(); }
+
+    Priority priority() const { return priority_; }
+
+   private:
+    Priority priority_;
+    boost::function<void()> function_;
+  };
+
+  std::array<std::queue<QueuedHandler>, Priority::COUNT> handlers_;
+};
+
+class IOContext {
+ public:
+  ~IOContext() {
+    stop();
+    std::lock_guard<std::mutex> lock(mutex_);
+  }
+
+  template <typename Handler>
+  bool post(Handler handler, Priority priority = Priority::LOW) {
+    RAY_CHECK(priority >= Priority::HIGH && priority <= Priority::LOW)
+        << "Invalid priority " << priority;
+    boost::asio::post(io_context_, pri_queue_.wrap(priority, handler));
+  }
+
+  void run() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    boost::asio::io_context::work worker(io_context_);
+    while (io_context_.run_one()) {
+      // The custom invocation hook adds the handlers to the priority queue
+      // rather than executing them from within the poll_one() call.
+      while (io_context_.poll_one())
+        ;
+      pri_queue_.execute_all();
+    }
+  }
+
+  void stop() { io_context_.stop(); }
+
+  template <typename Handler>
+  void async_wait_timer(boost::asio::deadline_timer &timer, Handler handler,
+                        Priority priority = Priority::LOW) {
+    RAY_CHECK(priority >= Priority::HIGH && priority <= Priority::LOW)
+        << "Invalid priority " << priority;
+    timer.async_wait(pri_queue_.wrap(priority, handler));
+  }
+
+  boost::asio::io_context &io_context() { return io_context_; }
+
+ private:
+  boost::asio::io_context io_context_;
+  HandlerPriorityQueue pri_queue_;
+  std::mutex mutex_;
+};
+
+}  // namespace ray

--- a/src/ray/util/prioritised_io_context_test.cc
+++ b/src/ray/util/prioritised_io_context_test.cc
@@ -1,0 +1,91 @@
+#include "ray/util/prioritised_io_context.h"
+#include "gtest/gtest.h"
+
+namespace ray {
+
+class PrioritisedIoContextTest : public ::testing::Test {
+ protected:
+  bool IsOrdered(const std::vector<int> &queue) const {
+    int current = -1;
+    int next = -1;
+    for (auto value : queue) {
+      current = next;
+      next = value;
+      if (next <= current) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+TEST_F(PrioritisedIoContextTest, TestFIFO) {
+  ray::IOContext io_context;
+  std::thread([&] { io_context.run(); }).detach();
+
+  int count = 1000;
+  std::vector<int> queue;
+  for (int i = 0; i < count; ++i) {
+    io_context.post([&queue, i] { queue.emplace_back(i); });
+  }
+
+  while (queue.size() != count) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  ASSERT_TRUE(IsOrdered(queue));
+
+  io_context.stop();
+}
+
+TEST_F(PrioritisedIoContextTest, TestPriority) {
+  ray::IOContext io_context;
+  std::thread([&] { io_context.run(); }).detach();
+
+  int count = 1000;
+  std::vector<int> queue;
+  for (int i = 0; i < count; ++i) {
+    io_context.post([&queue, i] { queue.emplace_back(i); }, Priority(i % 2));
+  }
+
+  while (queue.size() != count) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  ASSERT_FALSE(IsOrdered(queue));
+
+  io_context.stop();
+}
+
+TEST_F(PrioritisedIoContextTest, TestTimerFIFO) {
+  ray::IOContext io_context;
+  std::thread([&] { io_context.run(); }).detach();
+
+  int count = 100;
+  std::vector<int> queue;
+  for (int i = 0; i < count; ++i) {
+    auto timer = std::make_shared<boost::asio::deadline_timer>(io_context.io_context());
+    auto interval = boost::posix_time::milliseconds(100);
+    timer->expires_from_now(interval);
+    io_context.async_wait_timer(
+        *timer, [timer, &queue, i](const boost::system::error_code & /*ec*/) {
+          queue.emplace_back(i);
+        });
+    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+  }
+
+  while (queue.size() != count) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  ASSERT_TRUE(IsOrdered(queue));
+
+  io_context.stop();
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
There is no difference in the priority of events inner boost::asio::io_context, but sometimes we expect some events(e.g. timer event of heatbeat) could be executed with high priority. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
