### PR TITLE
Fix error message when failing to start UI if grpcio not installed.

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1070,7 +1070,7 @@ def start_dashboard(host,
         import aiohttp  # noqa: F401
         import psutil  # noqa: F401
         import setproctitle  # noqa: F401
-        import grpc
+        import grpc  # noqa: F401
     except ImportError:
         raise ImportError(
             "Failed to start the dashboard. The dashboard requires Python 3 "

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1070,10 +1070,11 @@ def start_dashboard(host,
         import aiohttp  # noqa: F401
         import psutil  # noqa: F401
         import setproctitle  # noqa: F401
+        import grpc
     except ImportError:
         raise ImportError(
             "Failed to start the dashboard. The dashboard requires Python 3 "
-            "as well as 'pip install aiohttp psutil setproctitle'.")
+            "as well as 'pip install aiohttp psutil setproctitle grpcio'.")
 
     process_info = start_ray_process(
         command,


### PR DESCRIPTION
## Related issue number

This fixes https://github.com/ray-project/ray/issues/6123 and https://github.com/ray-project/ray/issues/6430.