### PR TITLE
[tune] Really disable retries by default

### DIFF
--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -76,7 +76,7 @@ class Experiment(object):
                  keep_checkpoints_num=None,
                  checkpoint_score_attr=None,
                  export_formats=None,
-                 max_failures=3,
+                 max_failures=0,
                  restore=None,
                  repeat=None,
                  trial_resources=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

RLlib hits a different code path, so a previous PR to set default num failures to zero did not work.
