### PR TITLE
[Projects] Fix overriding of params dictionary

### DIFF
--- a/python/ray/projects/projects.py
+++ b/python/ray/projects/projects.py
@@ -92,20 +92,22 @@ class ProjectDefinition:
         # with them, save it in the following dictionary.
         choices = {}
         for param in params:
-            name = param.pop("name")
+            # Construct arguments to pass into argparse's parser.add_argument.
+            argparse_kwargs = copy.deepcopy(param)
+            name = argparse_kwargs.pop("name")
             if wildcards and "choices" in param:
-                choices[name] = copy.deepcopy(param["choices"])
-                param["choices"] = param["choices"] + ["*"]
+                choices[name] = param["choices"]
+                argparse_kwargs["choices"] = param["choices"] + ["*"]
             if "type" in param:
                 types = {"int": int, "str": str, "float": float}
                 if param["type"] in types:
-                    param["type"] = types[param["type"]]
+                    argparse_kwargs["type"] = types[param["type"]]
                 else:
                     raise ValueError(
                         "Parameter {} has type {} which is not supported. "
                         "Type must be one of {}".format(
                             name, param["type"], list(types.keys())))
-            parser.add_argument("--" + name, dest=name, **param)
+            parser.add_argument("--" + name, dest=name, **argparse_kwargs)
 
         parsed_args = vars(parser.parse_args(list(args)))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR fixes a problem where the params section of the project config could be overridden by the `get_command_info` function. In particular, `param["type"] = "int"` could be overridden with `param["type"] = int` (the python `int` type instead of the string). This PR fixes that behavior by making sure the original project config is not modified when the argparse arguments are constructed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
