### PR TITLE
Return numpy arrays in long-running tests

### DIFF
--- a/ci/long_running_tests/workloads/many_actor_tasks.py
+++ b/ci/long_running_tests/workloads/many_actor_tasks.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 
 import time
 
+import numpy as np
+
 import ray
 from ray.cluster_utils import Cluster
 
@@ -43,6 +45,7 @@ class Actor(object):
 
     def method(self):
         self.value += 1
+        return np.zeros(1024, dtype=np.uint8)
 
 
 actors = [

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 
 import time
 
+import numpy as np
+
 import ray
 from ray.cluster_utils import Cluster
 
@@ -38,7 +40,7 @@ ray.init(address=cluster.address)
 
 @ray.remote
 def f(*xs):
-    return 1
+    return np.zeros(1024, dtype=np.uint8)
 
 
 iteration = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This was causing OOM failures because now that we use pickle5, small objects take less space in the plasma store. Therefore, we can fit more of them before eviction, increasing the memory usage for accounting in the raylet.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
