### PR TITLE
Fix worker exit cleanup

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -690,7 +690,7 @@ cdef execute_task(
         if task_counter == execution_info.max_calls:
             # Intentionally disconnect so the raylet doesn't print an error.
             # TODO(edoakes): we should handle max_calls in the core worker.
-            worker.core_worker.disconnect(True)
+            worker.core_worker.disconnect()
             sys.exit(0)
 
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -689,8 +689,7 @@ cdef execute_task(
         task_counter = manager.get_task_counter(job_id, function_descriptor)
         if task_counter == execution_info.max_calls:
             # Intentionally disconnect so the raylet doesn't print an error.
-            # TODO(edoakes): we should just return a special status for this
-            # and handle it in the core worker.
+            # TODO(edoakes): we should handle max_calls in the core worker.
             worker.core_worker.disconnect(True)
             sys.exit(0)
 
@@ -740,6 +739,9 @@ cdef CRayStatus check_signals() nogil:
 
 cdef void exit_handler() nogil:
     with gil:
+        # Delete the core worker. Its destructor will stop the event loop
+        # and deleting it here prevents python from running the destructor
+        # again during normal cleanup.
         del ray.worker.global_worker.core_worker
 
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -807,7 +807,7 @@ def exit_actor():
     if worker.mode == ray.WORKER_MODE and not worker.actor_id.is_nil():
         # Intentionally disconnect the core worker from the raylet so the
         # raylet won't push an error message to the driver.
-        worker.core_worker.disconnect()
+        worker.core_worker.disconnect(True)
         ray.disconnect()
         # Disconnect global state from GCS.
         ray.state.state.disconnect()

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -807,7 +807,7 @@ def exit_actor():
     if worker.mode == ray.WORKER_MODE and not worker.actor_id.is_nil():
         # Intentionally disconnect the core worker from the raylet so the
         # raylet won't push an error message to the driver.
-        worker.core_worker.disconnect(True)
+        worker.core_worker.disconnect()
         ray.disconnect()
         # Disconnect global state from GCS.
         ray.state.state.disconnect()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -76,9 +76,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                         const c_vector[CObjectID] &return_ids,
                         c_vector[shared_ptr[CRayObject]] *returns) nogil,
                     CRayStatus() nogil,
-                    void () nogil,
                     c_bool ref_counting_enabled)
-        void Disconnect(c_bool intentional)
+        void Disconnect()
         CWorkerType &GetWorkerType()
         CLanguage &GetLanguage()
 

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -78,7 +78,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                     CRayStatus() nogil,
                     void () nogil,
                     c_bool ref_counting_enabled)
-        void Disconnect()
+        void Disconnect(c_bool intentional)
         CWorkerType &GetWorkerType()
         CLanguage &GetLanguage()
 

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -37,13 +37,12 @@ def test_conn_cluster():
         "temp_dir must not be provided.")
 
 
-def test_tempdir():
+def test_tempdir(shutdown_only):
     shutil.rmtree("/tmp/ray", ignore_errors=True)
     ray.init(temp_dir="/tmp/i_am_a_temp_dir")
     assert os.path.exists(
         "/tmp/i_am_a_temp_dir"), "Specified temp dir not found."
     assert not os.path.exists("/tmp/ray"), "Default temp dir should not exist."
-    ray.shutdown()
     shutil.rmtree("/tmp/i_am_a_temp_dir", ignore_errors=True)
 
 
@@ -57,7 +56,7 @@ def test_tempdir_commandline():
     shutil.rmtree("/tmp/i_am_a_temp_dir2", ignore_errors=True)
 
 
-def test_raylet_socket_name():
+def test_raylet_socket_name(shutdown_only):
     ray.init(raylet_socket_name="/tmp/i_am_a_temp_socket")
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket"), "Specified socket path not found."
@@ -77,7 +76,7 @@ def test_raylet_socket_name():
         pass  # It could have been removed by Ray.
 
 
-def test_temp_plasma_store_socket():
+def test_temp_plasma_store_socket(shutdown_only):
     ray.init(plasma_store_socket_name="/tmp/i_am_a_temp_socket")
     assert os.path.exists(
         "/tmp/i_am_a_temp_socket"), "Specified socket path not found."
@@ -97,7 +96,7 @@ def test_temp_plasma_store_socket():
         pass  # It could have been removed by Ray.
 
 
-def test_raylet_tempfiles():
+def test_raylet_tempfiles(shutdown_only):
     ray.init(num_cpus=0)
     node = ray.worker._global_node
     top_levels = set(os.listdir(node.get_session_dir_path()))
@@ -132,15 +131,13 @@ def test_raylet_tempfiles():
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
     assert socket_files == {"plasma_store", "raylet"}
-    ray.shutdown()
 
 
-def test_tempdir_privilege():
+def test_tempdir_privilege(shutdown_only):
     os.chmod("/tmp/ray", 0o000)
     ray.init(num_cpus=1)
     session_dir = ray.worker._global_node.get_session_dir_path()
     assert os.path.exists(session_dir), "Specified socket path not found."
-    ray.shutdown()
 
 
 def test_session_dir_uniqueness():

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1336,7 +1336,7 @@ def disconnect(exiting_interpreter=False):
     # we will tear down any processes spawned by ray.init() and the background
     # threads in the core worker don't currently handle that gracefully.
     if hasattr(worker, "core_worker"):
-        del worker.core_worker
+        worker.core_worker.disconnect(False)
 
 
 @contextmanager

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -426,6 +426,7 @@ class Worker(object):
         """The main loop a worker runs to receive and execute tasks."""
 
         def sigterm_handler(signum, frame):
+            shutdown(True)
             sys.exit(1)
 
         signal.signal(signal.SIGTERM, sigterm_handler)
@@ -849,7 +850,7 @@ def shutdown(exiting_interpreter=False):
         _global_node.kill_all_processes(check_alive=False, allow_graceful=True)
         _global_node = None
 
-    # TODO(rkn): Instead of manually reseting some of the worker fields, we
+    # TODO(rkn): Instead of manually resetting some of the worker fields, we
     # should simply set "global_worker" to equal "None" or something like that.
     global_worker.set_mode(None)
     global_worker._post_get_hooks = []

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -227,20 +227,24 @@ void CoreWorker::Shutdown() {
   if (!shutdown_) {
     shutdown_ = true;
     io_service_.stop();
-    if (worker_type_ == WorkerType::WORKER) {
-      task_execution_service_.stop();
-    }
     if (log_dir_ != "") {
       RayLog::ShutDownRayLog();
+    }
+    if (worker_type_ == WorkerType::WORKER) {
+      task_execution_service_.stop();
     }
   }
 }
 
-void CoreWorker::Disconnect() {
+void CoreWorker::Disconnect(bool intentional) {
   io_service_.stop();
-  gcs_client_->Disconnect();
-  if (local_raylet_client_) {
-    RAY_IGNORE_EXPR(local_raylet_client_->Disconnect());
+  if (intentional) {
+    if (gcs_client_) {
+      gcs_client_->Disconnect();
+    }
+    if (local_raylet_client_) {
+      RAY_IGNORE_EXPR(local_raylet_client_->Disconnect());
+    }
   }
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -80,7 +80,7 @@ class CoreWorker {
 
   ~CoreWorker();
 
-  void Disconnect();
+  void Disconnect(bool intentional);
 
   WorkerType GetWorkerType() const { return worker_type_; }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -64,8 +64,6 @@ class CoreWorker {
   /// \param[in] check_signals Language worker function to check for signals and handle
   ///            them. If the function returns anything but StatusOK, any long-running
   ///            operations in the core worker will short circuit and return that status.
-  /// \param[in] exit_handler Language worker function to orderly shutdown the worker.
-  ///            We guarantee this will be run on the main thread of the worker.
   /// \param[in] ref_counting_enabled Whether to enable object ref counting.
   ///
   /// NOTE(zhijunfu): the constructor would throw if a failure happens.
@@ -75,12 +73,11 @@ class CoreWorker {
              const std::string &log_dir, const std::string &node_ip_address,
              int node_manager_port, const TaskExecutionCallback &task_execution_callback,
              std::function<Status()> check_signals = nullptr,
-             std::function<void()> exit_handler = nullptr,
              bool ref_counting_enabled = false);
 
   ~CoreWorker();
 
-  void Disconnect(bool intentional);
+  void Disconnect();
 
   WorkerType GetWorkerType() const { return worker_type_; }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -8,9 +8,9 @@
 #include <queue>
 #include <set>
 #include <utility>
-#include "absl/container/flat_hash_map.h"
 
 #include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/id.h"
 #include "ray/common/ray_object.h"
@@ -353,8 +353,7 @@ class SchedulingQueue {
           fiber_rate_limiter_->Acquire();
           request.Accept();
           fiber_rate_limiter_->Release();
-        })
-            .detach();
+        }).detach();
       } else if (pool_ != nullptr) {
         pool_->PostBlocking([request]() mutable { request.Accept(); });
       } else {
@@ -433,7 +432,10 @@ class CoreWorkerDirectTaskReceiver {
 
   ~CoreWorkerDirectTaskReceiver() {
     fiber_shutdown_event_.Notify();
-    fiber_runner_thread_.join();
+    // Only join the fiber thread if it was spawned in the first place.
+    if (fiber_runner_thread_.joinable()) {
+      fiber_runner_thread_.join();
+    }
   }
 
   /// Initialize this receiver. This must be called prior to use.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -8,9 +8,9 @@
 #include <queue>
 #include <set>
 #include <utility>
+#include "absl/container/flat_hash_map.h"
 
 #include "absl/base/thread_annotations.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/id.h"
 #include "ray/common/ray_object.h"
@@ -353,7 +353,8 @@ class SchedulingQueue {
           fiber_rate_limiter_->Acquire();
           request.Accept();
           fiber_rate_limiter_->Release();
-        }).detach();
+        })
+            .detach();
       } else if (pool_ != nullptr) {
         pool_->PostBlocking([request]() mutable { request.Accept(); });
       } else {

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -1,11 +1,11 @@
 #ifndef RAY_RPC_GRPC_SERVER_H
 #define RAY_RPC_GRPC_SERVER_H
 
+#include <grpcpp/grpcpp.h>
+
+#include <boost/asio.hpp>
 #include <thread>
 #include <utility>
-
-#include <grpcpp/grpcpp.h>
-#include <boost/asio.hpp>
 
 #include "ray/common/status.h"
 #include "ray/rpc/server_call.h"
@@ -42,7 +42,9 @@ class GrpcServer {
   // Shutdown this server
   void Shutdown() {
     if (!is_closed_) {
-      server_->Shutdown();
+      // Shutdown the server with an immediate deadline.
+      // TODO(edoakes): do we want to do this in all cases?
+      server_->Shutdown(gpr_now(GPR_CLOCK_REALTIME));
       for (const auto &cq : cqs_) {
         cq->Shutdown();
       }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We were seeing strange issues during worker shutdown due to the core worker destructor stopping the asio event loop. This PR changes it to stop the event loop and exit normally on `SystemExit` and not stop the event loop in the destructor.

## Related issue number

Closes #6431

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
