### PR TITLE
Update pong-apex tuned example

### DIFF
--- a/rllib/tuned_examples/pong-apex.yaml
+++ b/rllib/tuned_examples/pong-apex.yaml
@@ -1,13 +1,14 @@
-# This can be expected to reach 20.8 reward within an hour when using a V100 GPU
-# (e.g. p3.2xl instance on AWS, and m4.4xl workers). It also can reach ~21 reward
-# within an hour with fewer workers (e.g. 4-8) but less reliably.
+# This reaches ~20 reward in 50 minutes (6M train steps, 2M env steps) on a
+# p3.2xlarge AWS instance.
+# See https://app.wandb.ai/zplizzi/test/runs/ayuuhixr?workspace=user-zplizzi
+# for training curves.
 pong-apex:
     env: PongNoFrameskip-v4
     run: APEX
     config:
-        target_network_update_freq: 50000
-        num_workers: 32
-        ## can also enable vectorization within processes
-        # num_envs_per_worker: 4
-        lr: .0001
+        target_network_update_freq: 20000
+        num_workers: 4
+        num_envs_per_worker: 8
+        lr: .00005
+        train_batch_size: 64
         gamma: 0.99


### PR DESCRIPTION
## Why are these changes needed?

As discussed in #6452, I found a set of hyperparameters for this env/algo combo that converges more quickly and efficiently using less CPU workers.

Before:
10M train/env steps, 4.5 hours
https://app.wandb.ai/zplizzi/test/runs/2dthszrq?workspace=user-zplizzi

After:
6M train/ 1.5M env steps, 1 hour
https://app.wandb.ai/zplizzi/test/runs/ayuuhixr?workspace=user-zplizzi

This does somewhat diminish the value of this example as a demonstration of the sheer throughput  that Ray can achieve using Apex, as it changes the default # of workers to be lower and decreases training throughput by using a smaller batch size. But given that convergence is similar/maybe faster than before while using 1/8 the CPUs, it seems worth it to me.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
