### PR TITLE
Make setup-dev.py more resilient

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -18,11 +18,8 @@ def do_link(package, force=False, local_path=""):
         os.path.join(ray.__file__, "../{}".format(package)))
     local_home = os.path.abspath(
         os.path.join(__file__, local_path + "../{}".format(package)))
-    for path in [package_home, local_home]:
-        if not os.path.exists(path):
-            print("{} does not exist. Skipping {}".format(path, package))
-            return
-    assert os.path.isdir(package_home), package_home
+    if not os.path.isdir(package_home):
+        print("{} does not exist. Continuing to link.".format(package_home))
     assert os.path.isdir(local_home), local_home
     if not force and not click.confirm(
             "This will replace:\n  {}\nwith a symlink to:\n  {}".format(

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -18,6 +18,10 @@ def do_link(package, force=False, local_path=""):
         os.path.join(ray.__file__, "../{}".format(package)))
     local_home = os.path.abspath(
         os.path.join(__file__, local_path + "../{}".format(package)))
+    for path in [package_home, local_home]:
+        if not os.path.exists(path):
+            print("{} does not exist. Skipping {}".format(path, package))
+            return
     assert os.path.isdir(package_home), package_home
     assert os.path.isdir(local_home), local_home
     if not force and not click.confirm(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`ray/tests` is not included in the wheel build. This breaks `Jenkins test tune`. This PR makes it so that `setup-dev.py` will continue running even if a ray module is missing.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.