### PR TITLE
Seed RND using multiple time samples

### DIFF
--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -8,6 +8,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <unordered_map>
 
 #include "ray/common/status.h"
@@ -95,6 +96,13 @@ void FillRandom(T *data) {
   RAY_CHECK(data != nullptr);
   auto randomly_seeded_mersenne_twister = []() {
     auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    // To increase the entropy, mix in a number of time samples instead of a single one.
+    // This avoids the possibility of duplicate seeds for many workers that start in
+    // close succession.
+    for (int i = 0; i < 128; i++) {
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+      seed += std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    }
     std::mt19937 seeded_engine(seed);
     return seeded_engine;
   };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Seed the random ID generator with multiple time samples instead of one. We use the entropy introduced by sleep() calls to avoid seed collisions.

Without this change, you will see a worker ID collision every few thousand actors launched. This is not surprising, since it only takes ~100k samples within a population of 1e9 (i.e., 1 second at nanosecond resolution) to guarantee a collision.

This can be tested by running on a large machine:

```while rllib train -f ppo.yaml; do sleep 1; done```

```
atari-ppo:
    env: BreakoutNoFrameskip-v4
    run: PPO
    num_samples: 20
    stop:
        time_total_s: 3
    config:
        lambda: 0.95
        kl_coeff: 0.5
        clip_rewards: True
        clip_param: 0.1
        vf_clip_param: 10.0
        entropy_coeff: 0.01
        train_batch_size: 50
        sample_batch_size: 10
        sgd_minibatch_size: 5
        num_sgd_iter: 10
        num_workers: 0
        num_envs_per_worker: 1
        batch_mode: truncate_episodes
        observation_filter: NoFilter
        vf_share_layers: true
```