### PR TITLE
(Bug Fix): Remove the extra 0.5 in the Diagonal Gaussian entropy

### DIFF
--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -166,7 +166,7 @@ class DiagGaussian(TFActionDistribution):
     @override(ActionDistribution)
     def entropy(self):
         return tf.reduce_sum(
-            .5 * self.log_std + .5 * np.log(2.0 * np.pi * np.e),
+            self.log_std + .5 * np.log(2.0 * np.pi * np.e),
             reduction_indices=[1])
 
     @override(TFActionDistribution)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The Diagonal Gaussian policy has an extra 0.5 in front of the entropy computation due to the use of the log stds instead of the log variance.

## Related issue number

Closes #6393 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
