### PR TITLE
Fix use of select() instead of poll()

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -78,6 +78,7 @@ def ray_deps_setup():
         sha256 = "8e5997b447b1afdd1efd33731968484d2fe71c271fa7f1cd6b2476367e964e0e",
         patches = [
             "//thirdparty/patches:hiredis-async-include-dict.patch",
+            "//thirdparty/patches:redis-windows-poll.patch",
         ],
     )
 

--- a/thirdparty/patches/arrow-windows-poll.patch
+++ b/thirdparty/patches/arrow-windows-poll.patch
@@ -1,20 +1,13 @@
 diff --git cpp/src/plasma/thirdparty/ae/ae.c cpp/src/plasma/thirdparty/ae/ae.c
-index dfb722444..96d9e537a 100644
 --- cpp/src/plasma/thirdparty/ae/ae.c
 +++ cpp/src/plasma/thirdparty/ae/ae.c
-@@ -428,19 +428,33 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
+@@ -428,20 +428,43 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
  /* Wait for milliseconds until the given file descriptor becomes
   * writable/readable/exception */
  int aeWait(int fd, int mask, long long milliseconds) {
--    struct pollfd pfd;
++    int retmask = 0, retval;
 +    short revents = 0;
-+    struct timeval tv = { milliseconds / 1000, (milliseconds % 1000) * 1000 };
-     int retmask = 0, retval;
- 
--    memset(&pfd, 0, sizeof(pfd));
--    pfd.fd = fd;
--    if (mask & AE_READABLE) pfd.events |= POLLIN;
--    if (mask & AE_WRITABLE) pfd.events |= POLLOUT;
++#ifdef _WINSOCKAPI_
 +    fd_set rset, wset;
 +    FD_ZERO(&rset);
 +    FD_ZERO(&wset);
@@ -23,8 +16,8 @@ index dfb722444..96d9e537a 100644
 +    } else if (mask & AE_WRITABLE) {
 +        FD_SET(fd, &wset);
 +    }
-+
-+    if ((retval = select(fd + 1, &rset, &wset, NULL, &tv)) > 0) {
++    struct timeval tv = { milliseconds / 1000, (milliseconds % 1000) * 1000 };
++    if ((retval = select(fd + 1, &rset, &wset, NULL, milliseconds >= 0 ? &tv : NULL)) > 0) {
 +        if (FD_ISSET(fd, &rset)) {
 +            revents |= POLLIN;
 +        }
@@ -32,12 +25,23 @@ index dfb722444..96d9e537a 100644
 +            revents |= POLLOUT;
 +        }
 +    }
++#else
+     struct pollfd pfd;
+-    int retmask = 0, retval;
  
+     memset(&pfd, 0, sizeof(pfd));
+     pfd.fd = fd;
+     if (mask & AE_READABLE) pfd.events |= POLLIN;
+     if (mask & AE_WRITABLE) pfd.events |= POLLOUT;
+ 
++    retval = poll(&pfd, 1, milliseconds);
++    revents = pfd.revents;
 -    if ((retval = poll(&pfd, 1, milliseconds))== 1) {
 -        if (pfd.revents & POLLIN) retmask |= AE_READABLE;
 -        if (pfd.revents & POLLOUT) retmask |= AE_WRITABLE;
 -	if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
 -        if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE;
++#endif
 +    if (retval== 1) {
 +        if (revents & POLLIN) retmask |= AE_READABLE;
 +        if (revents & POLLOUT) retmask |= AE_WRITABLE;
@@ -46,4 +50,6 @@ index dfb722444..96d9e537a 100644
          return retmask;
      } else {
          return retval;
+     }
+ }
 -- 

--- a/thirdparty/patches/redis-windows-poll.patch
+++ b/thirdparty/patches/redis-windows-poll.patch
@@ -1,0 +1,55 @@
+diff --git src/ae.c src/ae.c
+--- src/ae.c
++++ src/ae.c
+@@ -474,21 +474,44 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
+ /* Wait for milliseconds until the given file descriptor becomes
+  * writable/readable/exception */
+ int aeWait(int fd, int mask, long long milliseconds) {
++    int retmask = 0, retval;
++    short revents = 0;
++#ifdef _WINSOCKAPI_
++    fd_set rset, wset;
++    FD_ZERO(&rset);
++    FD_ZERO(&wset);
++    if (mask & AE_READABLE) {
++        FD_SET(fd, &rset);
++    } else if (mask & AE_WRITABLE) {
++        FD_SET(fd, &wset);
++    }
++    struct timeval tv = { milliseconds / 1000, (milliseconds % 1000) * 1000 };
++    if ((retval = select(fd + 1, &rset, &wset, NULL, milliseconds >= 0 ? &tv : NULL)) > 0) {
++        if (FD_ISSET(fd, &rset)) {
++            revents |= POLLIN;
++        }
++        if (FD_ISSET(fd, &wset)) {
++            revents |= POLLOUT;
++        }
++    }
++#else
+     struct pollfd pfd;
+-    int retmask = 0, retval;
+ 
+     memset(&pfd, 0, sizeof(pfd));
+     pfd.fd = fd;
+     if (mask & AE_READABLE) pfd.events |= POLLIN;
+     if (mask & AE_WRITABLE) pfd.events |= POLLOUT;
+ 
++    retval = poll(&pfd, 1, milliseconds);
++    revents = pfd.revents;
+-    if ((retval = poll(&pfd, 1, milliseconds))== 1) {
+-        if (pfd.revents & POLLIN) retmask |= AE_READABLE;
+-        if (pfd.revents & POLLOUT) retmask |= AE_WRITABLE;
+-        if (pfd.revents & POLLERR) retmask |= AE_WRITABLE;
+-        if (pfd.revents & POLLHUP) retmask |= AE_WRITABLE;
++#endif
++    if (retval== 1) {
++        if (revents & POLLIN) retmask |= AE_READABLE;
++        if (revents & POLLOUT) retmask |= AE_WRITABLE;
++        if (revents & POLLERR) retmask |= AE_WRITABLE;
++        if (revents & POLLHUP) retmask |= AE_WRITABLE;
+         return retmask;
+     } else {
+         return retval;
+     }
+ }
+-- 


### PR DESCRIPTION
## Why are these changes needed?

Negative timeout for `poll()` was not translated to infinite timeout for `select()`.

## Related issue number

#631

#6363 ([line](https://github.com/ray-project/ray/pull/6363/files#diff-16f6e97789727ba446b03ce217273e35R27))

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
