### PR TITLE
Simplify patches and make them more robust

### DIFF
--- a/thirdparty/patches/arrow-headers-unused.patch
+++ b/thirdparty/patches/arrow-headers-unused.patch
@@ -1,26 +1,14 @@
 diff --git cpp/src/plasma/client.cc cpp/src/plasma/client.cc
 --- cpp/src/plasma/client.cc
 +++ cpp/src/plasma/client.cc
-@@ -19,10 +19,6 @@
- 
- #include "plasma/client.h"
- 
+@@ -22,4 +22,0 @@
 -#ifdef _WIN32
 -#include <Win32_Interop/win32_types.h>
 -#endif
 -
- #include <fcntl.h>
- #include <netinet/in.h>
- #include <stdio.h>
 diff --git cpp/src/plasma/plasma.h cpp/src/plasma/plasma.h
 --- cpp/src/plasma/plasma.h
 +++ cpp/src/plasma/plasma.h
-@@ -25,7 +25,6 @@
- #include <stdio.h>
- #include <stdlib.h>
- #include <string.h>
+@@ -28,1 +28,0 @@
 -#include <unistd.h>  // pid_t
- 
- #include <memory>
- #include <string>
 -- 

--- a/thirdparty/patches/arrow-headers-unused.patch
+++ b/thirdparty/patches/arrow-headers-unused.patch
@@ -1,5 +1,4 @@
 diff --git cpp/src/plasma/client.cc cpp/src/plasma/client.cc
-index 5142ee435..5266e3e66 100644
 --- cpp/src/plasma/client.cc
 +++ cpp/src/plasma/client.cc
 @@ -19,10 +19,6 @@
@@ -14,7 +13,6 @@ index 5142ee435..5266e3e66 100644
  #include <netinet/in.h>
  #include <stdio.h>
 diff --git cpp/src/plasma/plasma.h cpp/src/plasma/plasma.h
-index 79e33c2f0..c8241b2fe 100644
 --- cpp/src/plasma/plasma.h
 +++ cpp/src/plasma/plasma.h
 @@ -25,7 +25,6 @@

--- a/thirdparty/patches/arrow-windows-export.patch
+++ b/thirdparty/patches/arrow-windows-export.patch
@@ -1,5 +1,4 @@
 diff --git cpp/src/arrow/util/logging.cc cpp/src/arrow/util/logging.cc
-index e54a10e52..3dbfc7a12 100644
 --- cpp/src/arrow/util/logging.cc
 +++ cpp/src/arrow/util/logging.cc
 @@ -84,7 +84,9 @@ typedef google::LogMessage LoggingProvider;

--- a/thirdparty/patches/arrow-windows-export.patch
+++ b/thirdparty/patches/arrow-windows-export.patch
@@ -1,14 +1,8 @@
 diff --git cpp/src/arrow/util/logging.cc cpp/src/arrow/util/logging.cc
 --- cpp/src/arrow/util/logging.cc
 +++ cpp/src/arrow/util/logging.cc
-@@ -84,7 +84,9 @@ typedef google::LogMessage LoggingProvider;
- typedef CerrLog LoggingProvider;
- #endif
- 
+@@ -87,1 +87,3 @@
 +#if !defined(_WIN32) || defined(ARROW_STATIC) || defined(ARROW_EXPORTING) || !defined(ARROW_EXPORT)
  ArrowLogLevel ArrowLog::severity_threshold_ = ArrowLogLevel::ARROW_INFO;
 +#endif
- // Keep the log directory.
- static std::unique_ptr<std::string> log_dir_;
- 
 -- 

--- a/thirdparty/patches/arrow-windows-poll.patch
+++ b/thirdparty/patches/arrow-windows-poll.patch
@@ -1,5 +1,4 @@
 diff --git cpp/src/plasma/thirdparty/ae/ae.c cpp/src/plasma/thirdparty/ae/ae.c
-index dfb722444..96d9e537a 100644
 --- cpp/src/plasma/thirdparty/ae/ae.c
 +++ cpp/src/plasma/thirdparty/ae/ae.c
 @@ -428,19 +428,33 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)

--- a/thirdparty/patches/arrow-windows-sigpipe.patch
+++ b/thirdparty/patches/arrow-windows-sigpipe.patch
@@ -1,5 +1,4 @@
 diff --git cpp/src/plasma/store.cc cpp/src/plasma/store.cc
-index 01aabfc7c..876cb59a6 100644
 --- cpp/src/plasma/store.cc
 +++ cpp/src/plasma/store.cc
 @@ -1182,9 +1182,11 @@ void HandleSignal(int signal) {

--- a/thirdparty/patches/arrow-windows-sigpipe.patch
+++ b/thirdparty/patches/arrow-windows-sigpipe.patch
@@ -1,16 +1,10 @@
 diff --git cpp/src/plasma/store.cc cpp/src/plasma/store.cc
 --- cpp/src/plasma/store.cc
 +++ cpp/src/plasma/store.cc
-@@ -1182,9 +1182,11 @@ void HandleSignal(int signal) {
- 
- void StartServer(char* socket_name, std::string plasma_directory, bool hugepages_enabled,
-                  std::shared_ptr<ExternalStore> external_store) {
+@@ -1185,3 +1185,5 @@ void StartServer(char* socket_name, std::string plasma_directory, bool hugepages_enabled,
 +#ifndef _WIN32  // TODO(mehrdadn): Is there an equivalent of this we need for Windows?
    // Ignore SIGPIPE signals. If we don't do this, then when we attempt to write
    // to a client that has already died, the store could die.
    signal(SIGPIPE, SIG_IGN);
 +#endif
- 
-   g_runner.reset(new PlasmaStoreRunner());
-   signal(SIGTERM, HandleSignal);
 -- 

--- a/thirdparty/patches/arrow-windows-socket.patch
+++ b/thirdparty/patches/arrow-windows-socket.patch
@@ -1,5 +1,4 @@
 diff --git cpp/src/plasma/client.cc cpp/src/plasma/client.cc
-index 0cb1d81a2..5142ee435 100644
 --- cpp/src/plasma/client.cc
 +++ cpp/src/plasma/client.cc
 @@ -983,8 +983,13 @@ Status PlasmaClient::Impl::Subscribe(int* fd) {
@@ -17,7 +16,6 @@ index 0cb1d81a2..5142ee435 100644
    RETURN_NOT_OK(SendSubscribeRequest(store_conn_));
    // Send the file descriptor that the Plasma store should use to push
 diff --git cpp/src/plasma/fling.cc cpp/src/plasma/fling.cc
-index f0960aab6..2f3997534 100644
 --- cpp/src/plasma/fling.cc
 +++ cpp/src/plasma/fling.cc
 @@ -18,6 +18,10 @@

--- a/thirdparty/patches/arrow-windows-socket.patch
+++ b/thirdparty/patches/arrow-windows-socket.patch
@@ -1,9 +1,7 @@
 diff --git cpp/src/plasma/client.cc cpp/src/plasma/client.cc
 --- cpp/src/plasma/client.cc
 +++ cpp/src/plasma/client.cc
-@@ -983,8 +983,13 @@ Status PlasmaClient::Impl::Subscribe(int* fd) {
-   // notifications from the Plasma store to the client.
-   socketpair(AF_UNIX, SOCK_STREAM, 0, sock);
+@@ -985,3 +985,8 @@ Status PlasmaClient::Impl::Subscribe(int* fd) {
    // Make the socket non-blocking.
 +#ifdef _WINSOCKAPI_
 +  unsigned long value = 1;
@@ -12,9 +10,6 @@ diff --git cpp/src/plasma/client.cc cpp/src/plasma/client.cc
    int flags = fcntl(sock[1], F_GETFL, 0);
    ARROW_CHECK(fcntl(sock[1], F_SETFL, flags | O_NONBLOCK) == 0);
 +#endif
-   // Tell the Plasma store about the subscription.
-   RETURN_NOT_OK(SendSubscribeRequest(store_conn_));
-   // Send the file descriptor that the Plasma store should use to push
 diff --git cpp/src/plasma/fling.cc cpp/src/plasma/fling.cc
 --- cpp/src/plasma/fling.cc
 +++ cpp/src/plasma/fling.cc

--- a/thirdparty/patches/boost-exception-no_warn_typeid_evaluated.patch
+++ b/thirdparty/patches/boost-exception-no_warn_typeid_evaluated.patch
@@ -1,5 +1,4 @@
 diff --git boost/exception/info.hpp boost/exception/info.hpp
-index f7ac50e..9a18650 100644
 --- boost/exception/info.hpp
 +++ boost/exception/info.hpp
 @@ -84,3 +84,4 @@ boost

--- a/thirdparty/patches/boost-type_traits-trivial_move.patch
+++ b/thirdparty/patches/boost-type_traits-trivial_move.patch
@@ -13,10 +13,7 @@ diff --git boost/type_traits/has_trivial_move_assign.hpp boost/type_traits/has_t
 index 6d954ab..7b39269 100644
 --- boost/type_traits/has_trivial_move_assign.hpp
 +++ boost/type_traits/has_trivial_move_assign.hpp
-@@ -24,7 +24,7 @@
- #endif
- #endif
- 
+@@ -27,4 +27,4 @@
 -#if defined(__GNUC__) || defined(__clang)
 +#if defined(__GNUC__) || defined(__clang__)
  #include <boost/type_traits/is_assignable.hpp>
@@ -26,10 +23,7 @@ diff --git boost/type_traits/has_trivial_move_constructor.hpp boost/type_traits/
 index 5784f4b..2ecfc36 100644
 --- boost/type_traits/has_trivial_move_constructor.hpp
 +++ boost/type_traits/has_trivial_move_constructor.hpp
-@@ -22,7 +22,7 @@
- #include <boost/type_traits/is_volatile.hpp>
- #endif
- 
+@@ -25,4 +25,4 @@
 -#if defined(__GNUC__) || defined(__clang)
 +#if defined(__GNUC__) || defined(__clang__)
  #include <boost/type_traits/is_constructible.hpp>

--- a/thirdparty/patches/glog-stack-trace.patch
+++ b/thirdparty/patches/glog-stack-trace.patch
@@ -1,16 +1,11 @@
 diff --git bazel/glog.bzl bazel/glog.bzl
 --- bazel/glog.bzl
 +++ bazel/glog.bzl
-@@ -17,7 +17,6 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
-         "-DGLOG_BAZEL_BUILD",
-         "-DHAVE_STDINT_H",
+@@ -19,3 +19,2 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
          "-DHAVE_STRING_H",
 -        "-DHAVE_UNWIND_H",
      ] + (["-DHAVE_LIB_GFLAGS"] if with_gflags else [])
- 
-     linux_or_darwin_copts = [
-@@ -37,6 +36,8 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
-         "-DHAVE_SYS_TIME_H",
+@@ -38,5 +37,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
          # Enable dumping stacktrace upon sigaction.
          "-DHAVE_SIGACTION",
 +        "-DHAVE_EXECINFO_H",

--- a/thirdparty/patches/glog-stack-trace.patch
+++ b/thirdparty/patches/glog-stack-trace.patch
@@ -1,5 +1,4 @@
 diff --git bazel/glog.bzl bazel/glog.bzl
-index 4c11f12..2510ecc 100644
 --- bazel/glog.bzl
 +++ bazel/glog.bzl
 @@ -17,7 +17,6 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):

--- a/thirdparty/patches/grpc-command-quoting.patch
+++ b/thirdparty/patches/grpc-command-quoting.patch
@@ -1,13 +1,7 @@
 diff --git third_party/py/python_configure.bzl third_party/py/python_configure.bzl
 --- third_party/py/python_configure.bzl
 +++ third_party/py/python_configure.bzl
-@@ -190,7 +190,7 @@ def _get_python_lib(repository_ctx, python_bin, lib_path_key):
-         "for path in all_paths:\n" + "  if os.path.isdir(path):\n" +
-         "    paths.append(path)\n" + "if len(paths) >=1:\n" +
-         "  print(paths[0])\n" + "END")
+@@ -193,1 +193,1 @@ def _get_python_lib(repository_ctx, python_bin, lib_path_key):
 -    cmd = '%s - %s' % (python_bin, print_lib)
 +    cmd = '"%s" - %s' % (python_bin, print_lib)
-     result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
-     return result.stdout.strip('\n')
- 
 -- 

--- a/thirdparty/patches/grpc-command-quoting.patch
+++ b/thirdparty/patches/grpc-command-quoting.patch
@@ -1,5 +1,4 @@
 diff --git third_party/py/python_configure.bzl third_party/py/python_configure.bzl
-index 2cb84077e5..e733b9204e 100644
 --- third_party/py/python_configure.bzl
 +++ third_party/py/python_configure.bzl
 @@ -190,7 +190,7 @@ def _get_python_lib(repository_ctx, python_bin, lib_path_key):

--- a/thirdparty/patches/grpc-cython-copts.patch
+++ b/thirdparty/patches/grpc-cython-copts.patch
@@ -1,10 +1,7 @@
 diff --git bazel/cython_library.bzl bazel/cython_library.bzl
 --- bazel/cython_library.bzl
 +++ bazel/cython_library.bzl
-@@ -7,18 +7,20 @@
- # been written at cython/cython and tensorflow/tensorflow. We branch from
- # Tensorflow's version as it is more actively maintained and works for gRPC
- # Python's needs.
+@@ -10,14 +10,16 @@
 -def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
 +def pyx_library(name, deps=[], copts=[], cc_kwargs={}, py_deps=[], srcs=[], **kwargs):
      """Compiles a group of .pyx / .pxd / .py files.
@@ -26,9 +23,7 @@ diff --git bazel/cython_library.bzl bazel/cython_library.bzl
 +        cc_kwargs: cc_binary extra arguments such as linkstatic, linkopts, features
          py_deps: Pure Python dependencies of the final library.
          srcs: .py, .pyx, or .pxd files to either compile or pass through.
-         **kwargs: Extra keyword arguments passed to the py_library.
-@@ -57,9 +59,11 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
-         shared_object_name = stem + ".so"
+@@ -58,6 +60,8 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
          native.cc_binary(
              name=shared_object_name,
 -            srcs=[stem + ".cpp"],
@@ -38,11 +33,4 @@ diff --git bazel/cython_library.bzl bazel/cython_library.bzl
              linkshared=1,
 +            **cc_kwargs
          )
-         shared_objects.append(shared_object_name)
-
-@@ -72,3 +76,4 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
-         data=shared_objects,
-         **kwargs)
-
-+
 --

--- a/thirdparty/patches/grpc-cython-copts.patch
+++ b/thirdparty/patches/grpc-cython-copts.patch
@@ -1,5 +1,4 @@
 diff --git bazel/cython_library.bzl bazel/cython_library.bzl
-index 48b41d74e8..a9bc168e5d 100644
 --- bazel/cython_library.bzl
 +++ bazel/cython_library.bzl
 @@ -7,18 +7,20 @@

--- a/thirdparty/patches/hiredis-async-include-dict.patch
+++ b/thirdparty/patches/hiredis-async-include-dict.patch
@@ -1,9 +1,7 @@
 diff --git deps/hiredis/async.c deps/hiredis/async.c
 --- deps/hiredis/async.c
 +++ deps/hiredis/async.c
-@@ -40,3 +40,3 @@
- #include "net.h"
+@@ -41,1 +41,1 @@
 -#include "dict.c"
 +#include "hiredis/dict.c"
- #include "sds.h"
 -- 

--- a/thirdparty/patches/hiredis-async-include-dict.patch
+++ b/thirdparty/patches/hiredis-async-include-dict.patch
@@ -1,5 +1,4 @@
 diff --git deps/hiredis/async.c deps/hiredis/async.c
-index d955203f..026601de 100644
 --- deps/hiredis/async.c
 +++ deps/hiredis/async.c
 @@ -40,3 +40,3 @@

--- a/thirdparty/patches/prometheus-windows-pollfd.patch
+++ b/thirdparty/patches/prometheus-windows-pollfd.patch
@@ -10,7 +10,6 @@ Hence we block Windows from defining pollfd (which this project doesn't use).
  1 file changed, 1 insertion(+)
 
 diff --git bazel/civetweb.BUILD bazel/civetweb.BUILD
-index e8d6024..162f234 100644
 --- bazel/civetweb.BUILD
 +++ bazel/civetweb.BUILD
 @@ -34,6 +34,7 @@ cc_library(

--- a/thirdparty/patches/prometheus-windows-pollfd.patch
+++ b/thirdparty/patches/prometheus-windows-pollfd.patch
@@ -12,12 +12,11 @@ Hence we block Windows from defining pollfd (which this project doesn't use).
 diff --git bazel/civetweb.BUILD bazel/civetweb.BUILD
 --- bazel/civetweb.BUILD
 +++ bazel/civetweb.BUILD
-@@ -34,6 +34,7 @@ cc_library(
+@@ -34,5 +34,6 @@ cc_library(
          "-DNO_CACHING",
          "-DNO_SSL",
          "-DNO_FILES",
 +        "-D_WIN32_WINNT=0x0502",
          "-UDEBUG",
      ],
-     includes = [
 -- 

--- a/thirdparty/patches/prometheus-windows-zlib.patch
+++ b/thirdparty/patches/prometheus-windows-zlib.patch
@@ -7,39 +7,24 @@ diff --git README.md README.md
 index be8e683..1dbc917 100644
 --- README.md
 +++ README.md
-@@ -139,7 +139,7 @@ you introduce the following dependencies, if they do not exist yet, to your proj
- * `load_com_google_googletest()` to load `com_google_googletest` rules for Google gtest
- * `load_com_google_googlebenchmark()` to load `com_github_google_benchmark` rules for Googlebenchmark
- * `load_com_github_curl()` to load `com_github_curl` rules for curl
+@@ -142,1 +142,1 @@ you introduce the following dependencies, if they do not exist yet, to your proj
 -* `load_net_zlib_zlib()` to load `net_zlib_zlib` rules for zlib
 +* `load_com_github_madler_zlib()` to load `com_github_madler_zlib` rules for zlib
- 
- The list of dependencies is also available from file `repositories.bzl`.
- 
 diff --git pull/BUILD.bazel pull/BUILD.bazel
 index 6d90c23..d35f63e 100644
 --- pull/BUILD.bazel
 +++ pull/BUILD.bazel
-@@ -23,6 +23,6 @@ cc_library(
-     deps = [
-         "//core",
-         "@civetweb",
+@@ -26,1 +26,1 @@ cc_library(
 -        "@net_zlib_zlib//:z",
 +        "@com_github_madler_zlib//:z",
-     ],
- )
 diff --git bazel/repositories.bzl bazel/repositories.bzl
 index 258b73f..91398cf 100644
 --- bazel/repositories.bzl
 +++ bazel/repositories.bzl
-@@ -47,7 +47,8 @@ def prometheus_cpp_repositories():
- 
+@@ -48,3 +48,4 @@ def prometheus_cpp_repositories():
      maybe(
          http_archive,
 -        name = "net_zlib_zlib",
 +        # Named "com_github_madler_zlib" to match gRPC's import of zlib.
 +        name = "com_github_madler_zlib",
-         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-         strip_prefix = "zlib-1.2.11",
-         urls = [
 -- 

--- a/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
+++ b/thirdparty/patches/rules_boost-undefine-boost_fallthrough.patch
@@ -1,5 +1,4 @@
 diff --git BUILD.boost BUILD.boost
-index 104c726..108e778 100644
 --- BUILD.boost
 +++ BUILD.boost
 @@ -1356,3 +1356,2 @@ boost_library(


### PR DESCRIPTION
## Why are these changes needed?

Most of our patches have extraneous information and additional context that is unnecessary, confusing, or even outright wrong (such as file hashes that won't match, e.g. due to the order in which patches are applied).

Unnecessary context in particular can also result in extraneous conflicts when updating a library, and make it harder to understand what is going on.

Simplifying them to include only the relevant lines (instead of just the 3-line default) makes them easier to understand and maintain.

**Note: when reviewing:** I recommend **split view** when reviewing, rather than unified view, or the changes may be confusing. (You can switch by clicking the gear icon in the changes tab.)

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
