### PR TITLE
Disable port sharing in grpc server

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -3,19 +3,7 @@
 #include <grpcpp/impl/service_type.h>
 #include <boost/asio/detail/socket_holder.hpp>
 
-namespace {
-
-bool PortNotInUse(int port) {
-  boost::asio::detail::socket_holder fd(socket(AF_INET, SOCK_STREAM, 0));
-  struct sockaddr_in server_addr = {0};
-  server_addr.sin_family = AF_INET;
-  server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  server_addr.sin_port = htons(port);
-  return fd.get() >= 0 &&
-         bind(fd.get(), (struct sockaddr *)&server_addr, sizeof(server_addr)) == 0;
-}
-
-}  // namespace
+namespace {}  // namespace
 
 namespace ray {
 namespace rpc {
@@ -26,18 +14,14 @@ GrpcServer::GrpcServer(std::string name, const uint32_t port, int num_threads)
 }
 
 void GrpcServer::Run() {
+  uint32_t specified_port = port_;
   std::string server_address("0.0.0.0:" + std::to_string(port_));
-  // Unfortunately, grpc will not return an error if the specified port is in
-  // use. There is a race condition here where two servers could check the same
-  // port, but only one would succeed in binding.
-  if (port_ > 0) {
-    RAY_CHECK(PortNotInUse(port_))
-        << "Port " << port_
-        << " specified by caller already in use. Try passing node_manager_port=... into "
-           "ray.init() to pick a specific port";
-  }
 
   grpc::ServerBuilder builder;
+  // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
+  // (default behavior in grpc), we may see multiple workers listen on the same port and
+  // the requests sent to this port may be handled by any of the workers.
+  builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
   // TODO(hchen): Add options for authentication.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &port_);
   // Register all the services to this server.
@@ -54,6 +38,11 @@ void GrpcServer::Run() {
   }
   // Build and start server.
   server_ = builder.BuildAndStart();
+  // If the grpc server failed to bind the port, the `port_` will be set to 0.
+  RAY_CHECK(port_ > 0)
+      << "Port " << specified_port
+      << " specified by caller already in use. Try passing node_manager_port=... into "
+         "ray.init() to pick a specific port";
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 
   // Create calls for all the server call factories.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -3,8 +3,6 @@
 #include <grpcpp/impl/service_type.h>
 #include <boost/asio/detail/socket_holder.hpp>
 
-namespace {}  // namespace
-
 namespace ray {
 namespace rpc {
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

GRPC enables the `SO_REUSEPORT` option by default. See https://lwn.net/Articles/542629/ for details about this option.

However, ray doesn't need this option because we have no need to load balancing requests between different grpc servers. Actually, if this option is enabled, we may see multiple workers listen on the same port and the requests sent to this port may be handled by any of the workers.

## Related issue number

Closes https://github.com/ray-project/ray/issues/6460

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
