### PR TITLE
Make sure numpy >= 1.16.0 is installed for fast pickling support

### DIFF
--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -212,8 +212,8 @@ class RayParams(object):
                 "The redirect_output argument is deprecated.")
 
         if self.use_pickle:
-            assert (version.parse(np.__version__) >=
-                    version.parse("1.16.0")), (
-                "numpy >= 1.16.0 required for use_pickle=True support. "
-                "You can use ray.init(use_pickle=False) for older numpy "
-                "versions, but this may be removed in future versions.")
+            assert (version.parse(
+                np.__version__) >= version.parse("1.16.0")), (
+                    "numpy >= 1.16.0 required for use_pickle=True support. "
+                    "You can use ray.init(use_pickle=False) for older numpy "
+                    "versions, but this may be removed in future versions.")

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -4,6 +4,9 @@ from __future__ import print_function
 
 import logging
 
+import numpy as np
+from packaging import version
+
 import ray.ray_constants as ray_constants
 
 
@@ -207,3 +210,10 @@ class RayParams(object):
         if self.redirect_output is not None:
             raise DeprecationWarning(
                 "The redirect_output argument is deprecated.")
+
+        if self.use_pickle:
+            assert (version.parse(np.__version__) >=
+                    version.parse("1.16.0")), (
+                "numpy >= 1.16.0 required for use_pickle=True support. "
+                "You can use ray.init(use_pickle=False) for older numpy "
+                "versions, but this may be removed in future versions.")

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
 import hashlib
 import io
 import logging
 import time
+
+import numpy as np
 import pyarrow
 import pyarrow.plasma as plasma
+
 import ray.cloudpickle as pickle
 from ray import ray_constants, JobID
 import ray.utils
@@ -476,6 +480,9 @@ class SerializationContext(object):
             return RawSerializedObject(value)
 
         if self.worker.use_pickle:
+            assert hasattr(np.ndarray, "__reduce_ex__"), "Need "
+            "numpy >= 1.16.0 for use_pickle=True support. Use "
+            "ray.init(use_pickle=False) for older numpy versions."
             writer = Pickle5Writer()
             if ray.cloudpickle.FAST_CLOUDPICKLE_USED:
                 inband = pickle.dumps(

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -7,7 +7,6 @@ import io
 import logging
 import time
 
-import numpy as np
 import pyarrow
 import pyarrow.plasma as plasma
 
@@ -480,10 +479,6 @@ class SerializationContext(object):
             return RawSerializedObject(value)
 
         if self.worker.use_pickle:
-            assert not hasattr(np, "pkgload"), (
-                "numpy >= 1.16.0 required for use_pickle=True support. "
-                "You can use ray.init(use_pickle=False) for older numpy "
-                "versions, but this may be removed in future versions.")
             writer = Pickle5Writer()
             if ray.cloudpickle.FAST_CLOUDPICKLE_USED:
                 inband = pickle.dumps(

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -480,10 +480,11 @@ class SerializationContext(object):
             return RawSerializedObject(value)
 
         if self.worker.use_pickle:
-            assert not hasattr(np, "pkgload"), ("numpy "
-            ">= 1.16.0 required for use_pickle=True support. You can "
-            "use ray.init(use_pickle=False) for older numpy versions, "
-            "but this may be removed in future versions.")
+            assert not hasattr(np, "pkgload"), (
+                "numpy "
+                ">= 1.16.0 required for use_pickle=True support. You can "
+                "use ray.init(use_pickle=False) for older numpy versions, "
+                "but this may be removed in future versions.")
             writer = Pickle5Writer()
             if ray.cloudpickle.FAST_CLOUDPICKLE_USED:
                 inband = pickle.dumps(

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -481,10 +481,9 @@ class SerializationContext(object):
 
         if self.worker.use_pickle:
             assert not hasattr(np, "pkgload"), (
-                "numpy "
-                ">= 1.16.0 required for use_pickle=True support. You can "
-                "use ray.init(use_pickle=False) for older numpy versions, "
-                "but this may be removed in future versions.")
+                "numpy >= 1.16.0 required for use_pickle=True support. "
+                "You can use ray.init(use_pickle=False) for older numpy "
+                "versions, but this may be removed in future versions.")
             writer = Pickle5Writer()
             if ray.cloudpickle.FAST_CLOUDPICKLE_USED:
                 inband = pickle.dumps(

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -480,9 +480,10 @@ class SerializationContext(object):
             return RawSerializedObject(value)
 
         if self.worker.use_pickle:
-            assert hasattr(np.ndarray, "__reduce_ex__"), "Need "
-            "numpy >= 1.16.0 for use_pickle=True support. Use "
-            "ray.init(use_pickle=False) for older numpy versions."
+            assert not hasattr(np, "pkgload"), ("numpy "
+            ">= 1.16.0 required for use_pickle=True support. You can "
+            "use ray.init(use_pickle=False) for older numpy versions, "
+            "but this may be removed in future versions.")
             writer = Pickle5Writer()
             if ray.cloudpickle.FAST_CLOUDPICKLE_USED:
                 inband = pickle.dumps(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -20,6 +20,9 @@ import time
 import traceback
 import random
 
+import numpy as np
+import packaging
+
 # Ray modules
 import ray.cloudpickle as pickle
 import ray.gcs_utils
@@ -667,6 +670,13 @@ def init(address=None,
         driver_mode = LOCAL_MODE
     else:
         driver_mode = SCRIPT_MODE
+
+    if use_pickle:
+        assert (packaging.version.parse(np.__version__) >=
+                packaging.version.parse("1.16.0")), (
+            "numpy >= 1.16.0 required for use_pickle=True support. "
+            "You can use ray.init(use_pickle=False) for older numpy "
+            "versions, but this may be removed in future versions.")
 
     if setproctitle is None:
         logger.warning(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -20,9 +20,6 @@ import time
 import traceback
 import random
 
-import numpy as np
-import packaging
-
 # Ray modules
 import ray.cloudpickle as pickle
 import ray.gcs_utils
@@ -670,13 +667,6 @@ def init(address=None,
         driver_mode = LOCAL_MODE
     else:
         driver_mode = SCRIPT_MODE
-
-    if use_pickle:
-        assert (packaging.version.parse(np.__version__) >=
-                packaging.version.parse("1.16.0")), (
-            "numpy >= 1.16.0 required for use_pickle=True support. "
-            "You can use ray.init(use_pickle=False) for older numpy "
-            "versions, but this may be removed in future versions.")
 
     if setproctitle is None:
         logger.warning(

--- a/python/setup.py
+++ b/python/setup.py
@@ -163,7 +163,7 @@ def find_version(*filepath):
 
 
 requires = [
-    "numpy >= 1.14",
+    "numpy >= 1.16",
     "filelock",
     "jsonschema",
     "funcsigs",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fast pickling is only supported for numpy >= 1.16.0, so we make sure that is being used.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
