### PR TITLE
[Java] disable actor checkpointing and reconstruction test in direct call mode

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
@@ -47,6 +47,9 @@ public class ActorReconstructionTest extends BaseTest {
 
   public void testActorReconstruction() throws InterruptedException, IOException {
     TestUtils.skipTestUnderSingleProcess();
+    // TODO (kfstorm): Actor reconstruction is currently not supporeted in direct actor call mode.
+    // Will re-enable the test once the issue got fixed.
+    TestUtils.skipTestIfDirectActorCallEnabled();
     ActorCreationOptions options =
         new ActorCreationOptions.Builder().setMaxReconstructions(1).createActorCreationOptions();
     RayActor<Counter> actor = Ray.createActor(Counter::new, options);
@@ -127,6 +130,10 @@ public class ActorReconstructionTest extends BaseTest {
 
   public void testActorCheckpointing() throws IOException, InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
+    // TODO (kfstorm): In direct actor call mode, the actor creation task is not pushed to raylet.
+    // But to save an actor checkpoint, raylet needs to know about this the actor. Will re-enable
+    // the test once the issue got fixed.
+    TestUtils.skipTestIfDirectActorCallEnabled();
     ActorCreationOptions options =
         new ActorCreationOptions.Builder().setMaxReconstructions(1).createActorCreationOptions();
     RayActor<CheckpointableCounter> actor = Ray.createActor(CheckpointableCounter::new, options);


### PR DESCRIPTION
## Why are these changes needed?

After https://github.com/ray-project/ray/pull/6375, two Java test cases are broken in direct actor call mode. Will re-enable it later.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
