### PR TITLE
[tune] Fix duplicate progress output

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -52,7 +52,8 @@ class JupyterNotebookReporter(ProgressReporter):
         messages = [
             "== Status ==",
             memory_debug_str(),
-            trial_runner.debug_string(delim=delim),
+            trial_runner.scheduler_alg.debug_string(),
+            trial_runner.trial_executor.debug_string(),
             trial_progress_str(trial_runner.get_trials(), fmt="html"),
             trial_errors_str(trial_runner.get_trials(), fmt="html"),
         ]
@@ -68,7 +69,8 @@ class CLIReporter(ProgressReporter):
         messages = [
             "== Status ==",
             memory_debug_str(),
-            trial_runner.debug_string(),
+            trial_runner.scheduler_alg.debug_string(),
+            trial_runner.trial_executor.debug_string(),
             trial_progress_str(trial_runner.get_trials()),
             trial_errors_str(trial_runner.get_trials()),
         ]

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -186,6 +186,10 @@ class TrialRunner(object):
                 self._local_checkpoint_dir,
                 TrialRunner.CKPT_FILE_TMPL.format(self._session_str))
 
+    @property
+    def scheduler_alg(self):
+        return self._scheduler_alg
+
     def _validate_resume(self, resume_type):
         """Checks whether to resume experiment.
 


### PR DESCRIPTION
Fixes minor regression introduced in #6367 where `trail_runner.debug_string()` now contains duplicate information so it shouldn't be called directly.