### PR TITLE
Fix plasma_store_server path

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -168,6 +168,19 @@ filegroup(
     ],
 )
 
+# plasma_store_server binary should be located in jar root path
+# and keep in sync with mvn resource
+genrule(
+    name = "cp_plasma_store_server",
+    srcs = [
+        "@plasma//:plasma_store_server",
+    ],
+    outs = ["plasma_store_server"],
+    cmd = """
+        cp -f $(location @plasma//:plasma_store_server) $@
+    """
+)
+
 filegroup(
     name = "java_native_deps",
     srcs = [
@@ -175,7 +188,7 @@ filegroup(
         "//:libray_redis_module.so",
         "//:raylet",
         "//:core_worker_library_java",
-        "@plasma//:plasma_store_server",
+        ":cp_plasma_store_server",
     ],
 )
 

--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -353,7 +353,7 @@ public class RunManager {
 
   private void startObjectStore() {
     try (FileUtil.TempFile plasmaStoreFile = FileUtil
-        .getTempFileFromResource("external/plasma/plasma_store_server")) {
+        .getTempFileFromResource("plasma_store_server")) {
       plasmaStoreFile.getFile().setExecutable(true);
       List<String> command = ImmutableList.of(
           // The plasma store executable file.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Bazel package `plasma_store_server` as a java resource should be consisitent with maven.
Currently, bazel package `plasma_store_server ` to `external/plasma/plasma_store_server` path, while maven package it to `plasma_store_server` path. So `RunManager#startObjectStore` will fail when running with java. This PR fix it by packaging `plasma_store_server` to `plasma_store_server` path of jar for both bazel and maven.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
