### PR TITLE
[Java] fix ClassLoaderTest.java

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/ClassLoaderTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ClassLoaderTest.java
@@ -56,7 +56,7 @@ public class ClassLoaderTest extends BaseTest {
         + "import java.lang.management.ManagementFactory;\n"
         + "import java.lang.management.RuntimeMXBean;\n"
         + "\n"
-        + "class ClassLoaderTester {\n"
+        + "public class ClassLoaderTester {\n"
         + "\n"
         + "  static volatile int value;\n"
         + "\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The test case `testClassLoaderInMultiThreading` hangs because the worker can't find the `RayFunction` instance of `ClassLoadertester`'s default constructor from the `FunctionManager`, as the default constructor is not public, according to https://stackoverflow.com/questions/22007143/whats-the-access-modifier-of-the-default-constructor-in-java.

The bug was introduced by https://github.com/ray-project/ray/pull/6434.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
