### PR TITLE
[tune] update params for optimizer in reset_config

### DIFF
--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -52,11 +52,11 @@ class PytorchTrainble(tune.Trainable):
         self.model.load_state_dict(torch.load(checkpoint_path))
 
     def reset_config(self, new_config):
-        del self.optimizer
-        self.optimizer = optim.SGD(
-            self.model.parameters(),
-            lr=new_config.get("lr", 0.01),
-            momentum=new_config.get("momentum", 0.9))
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = new_config.get("lr")
+            param_group["momentum"] = new_config.get("momentum")
+
+        self.config = new_config
         return True
 
 

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -53,8 +53,8 @@ class PytorchTrainble(tune.Trainable):
 
     def reset_config(self, new_config):
         for param_group in self.optimizer.param_groups:
-            param_group["lr"] = new_config.get("lr")
-            param_group["momentum"] = new_config.get("momentum")
+            param_group["lr"] = new_config.get("lr", 0.01)
+            param_group["momentum"] = new_config.get("momentum", 0.9)
 
         self.config = new_config
         return True

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -53,8 +53,10 @@ class PytorchTrainble(tune.Trainable):
 
     def reset_config(self, new_config):
         for param_group in self.optimizer.param_groups:
-            param_group["lr"] = new_config.get("lr", 0.01)
-            param_group["momentum"] = new_config.get("momentum", 0.9)
+            if "lr" in new_config:
+                param_group["lr"] = new_config["lr"]
+            if "momentum" in new_config:
+                param_group["momentum"] = new_config["momentum"]
 
         self.config = new_config
         return True

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
@@ -275,10 +275,12 @@ class PytorchTrainable(tune.Trainable):
         self.optimizerG.load_state_dict(checkpoint["optimG"])
 
     def reset_config(self, new_config):
-        for param_group in self.optimizerD.param_groups:
-            param_group["lr"] = new_config.get("netD_lr")
-        for param_group in self.optimizerG.param_groups:
-            param_group["lr"] = new_config.get("netG_lr")
+        if "netD_lr" in new_config:
+            for param_group in self.optimizerD.param_groups:
+                param_group["lr"] = new_config["netD_lr"]
+        if "netG_lr" in new_config:
+            for param_group in self.optimizerG.param_groups:
+                param_group["lr"] = new_config["netG_lr"]
 
         self.config = new_config
         return True

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
@@ -275,16 +275,11 @@ class PytorchTrainable(tune.Trainable):
         self.optimizerG.load_state_dict(checkpoint["optimG"])
 
     def reset_config(self, new_config):
-        del self.optimizerD
-        del self.optimizerG
-        self.optimizerD = optim.Adam(
-            self.netD.parameters(),
-            lr=new_config.get("netD_lr"),
-            betas=(beta1, 0.999))
-        self.optimizerG = optim.Adam(
-            self.netG.parameters(),
-            lr=new_config.get("netG_lr"),
-            betas=(beta1, 0.999))
+        for param_group in self.optimizerD.param_groups:
+            param_group["lr"] = new_config.get("netD_lr")
+        for param_group in self.optimizerG.param_groups:
+            param_group["lr"] = new_config.get("netG_lr")
+
         self.config = new_config
         return True
 


### PR DESCRIPTION
We should avoid replacing optimizer in `reset_config` since all the states info are discarded. 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
