### PR TITLE
[Java] Add the default redis password for Java

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/org/ray/runtime/gcs/GcsClient.java
@@ -48,7 +48,7 @@ public class GcsClient {
     List<byte[]> shardAddresses = primary.lrange("RedisShards".getBytes(), 0, -1);
     Preconditions.checkState(shardAddresses.size() == numShards);
     shards = shardAddresses.stream().map((byte[] address) -> {
-      return new RedisClient(new String(address));
+      return new RedisClient(new String(address), redisPassword);
     }).collect(Collectors.toList());
   }
 

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -60,9 +60,9 @@ ray {
     // If `redis.server` isn't provided, which port we should use to start redis server.
     head-port: 6379
     // The password used to start the redis server on the head node.
-    head-password: ""
+    head-password: "5241590000000000"
     // The password used to connect to the redis server.
-    password:""
+    password: "5241590000000000"
     // If `redis.server` isn't provided, how many Redis shards we should start in addition to the
     // primary Redis shard. The ports of these shards will be `head-port + 1`, `head-port + 2`, etc.
     shard-number: 1

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -59,6 +59,7 @@ ray {
     address: ""
     // If `redis.server` isn't provided, which port we should use to start redis server.
     head-port: 6379
+    // Below passwords should be consistent with the one defined in python/ray/ray_constants.py.
     // The password used to start the redis server on the head node.
     head-password: "5241590000000000"
     // The password used to connect to the redis server.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fix Java CI after https://github.com/ray-project/ray/pull/6481.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
