### PR TITLE
Direct Bazel install and remote cache for Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -19,12 +19,16 @@ jobs:
             os: windows-latest
             compiler: clang-cl
     steps:
-    - name: Install Bazel
+    - name: Checkout repository
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Setup Bazel
       shell: bash
-      run: |
-        if [ "${OSTYPE}" = "msys" ]; then
-          choco install --no-progress bazel
-        fi
+      env:
+        BAZEL_CACHE_CREDENTIAL_B64: ${{ secrets.BAZEL_CACHE_CREDENTIAL_B64 }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./ci/travis/install-bazel.sh
     - name: Install C/C++ toolchains
       if: matrix.compiler == 'clang' || matrix.compiler == 'clang-cl'
       shell: bash
@@ -41,10 +45,6 @@ jobs:
       uses: numworks/setup-msys2@v1
       with:
         update: false
-    - name: Checkout repository
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
     - name: Perform build
       shell: bash
       run: |

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -1,44 +1,79 @@
 #!/usr/bin/env bash
 
-# Cause the script to exit if a single command fails
-set -e
+set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
+version="1.1.0"
+achitecture="${HOSTTYPE}"
 platform="unknown"
-unamestr="$(uname)"
-if [[ "$unamestr" == "Linux" ]]; then
-  echo "Platform is linux."
-  platform="linux"
-elif [[ "$unamestr" == "Darwin" ]]; then
-  echo "Platform is macosx."
-  platform="darwin"
+case "${OSTYPE}" in
+  msys)
+    echo "Platform is Windows."
+    platform="windows"
+    # No installer for Windows
+    ;;
+  darwin*)
+    echo "Platform is Mac OS X."
+    platform="darwin"
+    ;;
+  linux*)
+    echo "Platform is Linux (or WSL)."
+    platform="linux"
+    ;;
+  *)
+    echo "Unrecognized platform."
+    exit 1
+esac
+
+if [ "${OSTYPE}" = "msys" ]; then
+  target="${MINGW_DIR-/usr}/bin/bazel.exe"
+  mkdir -p "${target%/*}"
+  curl -s -L -R -o "${target}" "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-${platform}-${achitecture}.exe"
 else
-  echo "Unrecognized platform."
-  exit 1
+  target="./install.sh"
+  curl -s -L -R -o "${target}" "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-installer-${platform}-${achitecture}.sh"
+  chmod +x "${target}"
+  "${target}" --user
+  rm -f "${target}"
 fi
 
-URL="https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-installer-${platform}-x86_64.sh"
-wget -O install.sh $URL
-chmod +x install.sh
-./install.sh --user
-rm -f install.sh
-
-if [[ "$TRAVIS" == "true"  ]]; then
+if [ "${TRAVIS-}" = true ]; then
   # Use bazel disk cache if this script is running in Travis.
-  mkdir -p $HOME/ray-bazel-cache
-  echo "build --disk_cache=$HOME/ray-bazel-cache" >> $HOME/.bazelrc
-
+  mkdir -p "${HOME}/ray-bazel-cache"
+  echo "build --disk_cache=${HOME}/ray-bazel-cache" >> "${HOME}/.bazelrc"
+fi
+if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_TOKEN-}" ]; then
   # Use ray google cloud cache
-  echo "build --remote_cache=https://storage.googleapis.com/ray-bazel-cache" >> $HOME/.bazelrc
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    # If we are in master build, we can write to the cache as well.
-    openssl aes-256-cbc -K $encrypted_1c30b31fe1ee_key \
-      -iv $encrypted_1c30b31fe1ee_iv \
-      -in $ROOT_DIR/bazel_cache_credential.json.enc \
-      -out $HOME/bazel_cache_credential.json -d
-    echo "build --google_credentials=$HOME/bazel_cache_credential.json" >> $HOME/.bazelrc
+  echo "build --remote_cache=https://storage.googleapis.com/ray-bazel-cache" >> "${HOME}/.bazelrc"
+  # If we are in master build, we can write to the cache as well.
+  upload=0
+  if [ "${TRAVIS_PULL_REQUEST-false}" = false ]; then
+    if [ -n "${BAZEL_CACHE_CREDENTIAL_B64:+x}" ]; then
+      {
+        printf "%s" "${BAZEL_CACHE_CREDENTIAL_B64}" | base64 -d - >> "${HOME}/bazel_cache_credential.json"
+      } 2>&-  # avoid printing secrets
+      upload=1
+    elif [ -n "${encrypted_1c30b31fe1ee_key:+x}" ]; then
+      {
+        openssl aes-256-cbc -K "${encrypted_1c30b31fe1ee_key}"
+            -iv "${encrypted_1c30b31fe1ee_iv}" \
+            -in "${ROOT_DIR}/bazel_cache_credential.json.enc" \
+            -out "${HOME}/bazel_cache_credential.json" -d
+      } 2>&-  # avoid printing secrets
+      if [ 0 -eq $? ]; then
+        upload=1
+      fi
+    fi
+  fi
+  if [ 0 -ne "${upload}" ]; then
+    translated_path="${HOME}/bazel_cache_credential.json"
+    if [ "${OSTYPE}" = msys ]; then  # On Windows, we need path translation
+      translated_path="$(cygpath -m -- "${translated_path}")"
+    fi
+    echo "build --google_credentials=\"${translated_path}\"" >> "${HOME}/.bazelrc"
   else
-    echo "build --remote_upload_local_results=false" >> $HOME/.bazelrc
+    echo "Using remote build cache in read-only mode." 1>&2
+    echo "build --remote_upload_local_results=false" >> "${HOME}/.bazelrc"
   fi
 fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

- Bazel installs via Chocolatey have been failing a lot due to server errors
- We want to set up remote caching for Windows CI

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
