### PR TITLE
[tune] demo exporting trained models in pbt examples

### DIFF
--- a/doc/source/tune-advanced-tutorial.rst
+++ b/doc/source/tune-advanced-tutorial.rst
@@ -214,7 +214,7 @@ We specify inception score as the metric and start the tuning:
    :start-after: __tune_begin__
    :end-before: __tune_end__
 
-The trained Generator models can be loaded from checkpoints, and generate images
+The trained Generator models can be loaded from log directory, and generate images
 from noise signals.
 
 .. image:: images/tune_advanced_dcgan_generated.gif

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -58,7 +58,7 @@ class PytorchTrainble(tune.Trainable):
             torch.save(self.model.state_dict(), path)
             return {export_formats[0]: path}
         else:
-            raise ValueError('unexpected formats: ' + str(export_formats))
+            raise ValueError("unexpected formats: " + str(export_formats))
 
     def reset_config(self, new_config):
         del self.optimizer

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -54,7 +54,7 @@ class PytorchTrainble(tune.Trainable):
 
     def _export_model(self, export_formats, export_dir):
         if export_formats == [ExportFormat.MODEL]:
-            path = export_dir + "/exported_convnet.pt"
+            path = os.path.join(export_dir, "exported_convnet.pt")
             torch.save(self.model.state_dict(), path)
             return {export_formats[0]: path}
         else:

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
             "netD_lr": lambda: np.random.uniform(1e-2, 1e-5),
         })
 
-    tune_iter = 5 if args.smoke_test else 30
+    tune_iter = 5 if args.smoke_test else 300
     analysis = tune.run(
         PytorchTrainable,
         name="pbt_dcgan_mnist",

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
@@ -298,7 +298,7 @@ class PytorchTrainable(tune.Trainable):
             }, path)
             return {ExportFormat.MODEL: path}
         else:
-            raise ValueError('unexpected formats: ' + str(export_formats))
+            raise ValueError("unexpected formats: " + str(export_formats))
 
 
 # __Trainable_end__

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import ray
 from ray import tune
 from ray.tune.schedulers import PopulationBasedTraining
+from ray.tune.trial import ExportFormat
 
 import argparse
 import os
@@ -288,6 +289,17 @@ class PytorchTrainable(tune.Trainable):
         self.config = new_config
         return True
 
+    def _export_model(self, export_formats, export_dir):
+        if export_formats == [ExportFormat.MODEL]:
+            path = os.path.join(export_dir, "exported_models")
+            torch.save({
+                "netDmodel": self.netD.state_dict(),
+                "netGmodel": self.netG.state_dict()
+            }, path)
+            return {ExportFormat.MODEL: path}
+        else:
+            raise ValueError('unexpected formats: ' + str(export_formats))
+
 
 # __Trainable_end__
 
@@ -334,7 +346,7 @@ if __name__ == "__main__":
             "netD_lr": lambda: np.random.uniform(1e-2, 1e-5),
         })
 
-    tune_iter = 5 if args.smoke_test else 300
+    tune_iter = 5 if args.smoke_test else 30
     analysis = tune.run(
         PytorchTrainable,
         name="pbt_dcgan_mnist",
@@ -346,6 +358,7 @@ if __name__ == "__main__":
             "training_iteration": tune_iter,
         },
         num_samples=8,
+        export_formats=[ExportFormat.MODEL],
         config={
             "netG_lr": tune.sample_from(
                 lambda spec: random.choice([0.0001, 0.0002, 0.0005])),
@@ -360,7 +373,7 @@ if __name__ == "__main__":
         img_list = []
         fixed_noise = torch.randn(64, nz, 1, 1)
         for d in logdirs:
-            netG_path = d + "/checkpoint_" + str(tune_iter) + "/checkpoint"
+            netG_path = os.path.join(d, "exported_models")
             loadedG = Generator()
             loadedG.load_state_dict(torch.load(netG_path)["netGmodel"])
             with torch.no_grad():


### PR DESCRIPTION
For pbt users, it's important to access the trained models after tuning.  Add the demo for exporting models in pbt examples since:
1. Loading from checkpoints in the current code is not robust.
2. Need some code example to demo the usage of exporting model API.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
