### PR TITLE
[direct call] Fix max_calls interaction with background tasks.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -688,8 +688,6 @@ cdef execute_task(
         # If we've reached the max number of executions for this worker, exit.
         task_counter = manager.get_task_counter(job_id, function_descriptor)
         if task_counter == execution_info.max_calls:
-            # TODO(ekl) how do we suppress the worker died error without
-            # destroying the core worker also?
             exit = SystemExit(0)
             exit.is_ray_terminate = True
             raise exit

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -688,10 +688,11 @@ cdef execute_task(
         # If we've reached the max number of executions for this worker, exit.
         task_counter = manager.get_task_counter(job_id, function_descriptor)
         if task_counter == execution_info.max_calls:
-            # Intentionally disconnect so the raylet doesn't print an error.
-            # TODO(edoakes): we should handle max_calls in the core worker.
-            worker.core_worker.disconnect()
-            sys.exit(0)
+            # TODO(ekl) how do we suppress the worker died error without
+            # destroying the core worker also?
+            exit = SystemExit(0)
+            exit.is_ray_terminate = True
+            raise exit
 
 
 cdef CRayStatus task_execution_handler(

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -720,11 +720,13 @@ cdef CRayStatus task_execution_handler(
                     job_id=None)
                 sys.exit(1)
         except SystemExit as e:
-            if not hasattr(e, "is_ray_terminate"):
-                logger.exception("SystemExit was raised from the worker")
             # Tell the core worker to exit as soon as the result objects
             # are processed.
-            return CRayStatus.SystemExit()
+            if hasattr(e, "is_ray_terminate"):
+                return CRayStatus.IntentionalSystemExit()
+            else:
+                logger.exception("SystemExit was raised from the worker")
+                return CRayStatus.UnintentionalSystemExit()
 
     return CRayStatus.OK()
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -726,7 +726,7 @@ cdef CRayStatus task_execution_handler(
                 return CRayStatus.IntentionalSystemExit()
             else:
                 logger.exception("SystemExit was raised from the worker")
-                return CRayStatus.UnintentionalSystemExit()
+                return CRayStatus.UnexpectedSystemExit()
 
     return CRayStatus.OK()
 

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -83,7 +83,7 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         CRayStatus IntentionalSystemExit()
 
         @staticmethod
-        CRayStatus UnintentionalSystemExit()
+        CRayStatus UnexpectedSystemExit()
 
         c_bool ok()
         c_bool IsOutOfMemory()

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -80,7 +80,10 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         CRayStatus Interrupted(const c_string &msg)
 
         @staticmethod
-        CRayStatus SystemExit()
+        CRayStatus IntentionalSystemExit()
+
+        @staticmethod
+        CRayStatus UnintentionalSystemExit()
 
         c_bool ok()
         c_bool IsOutOfMemory()

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -82,7 +82,7 @@ enum class StatusCode : char {
   TimedOut = 12,
   Interrupted = 13,
   IntentionalSystemExit = 14,
-  UnintentionalSystemExit = 15,
+  UnexpectedSystemExit = 15,
 };
 
 #if defined(__clang__)
@@ -158,8 +158,8 @@ class RAY_EXPORT Status {
     return Status(StatusCode::IntentionalSystemExit, "intentional system exit");
   }
 
-  static Status UnintentionalSystemExit() {
-    return Status(StatusCode::UnintentionalSystemExit, "user code caused exit");
+  static Status UnexpectedSystemExit() {
+    return Status(StatusCode::UnexpectedSystemExit, "user code caused exit");
   }
 
   // Returns true iff the status indicates success.
@@ -179,7 +179,7 @@ class RAY_EXPORT Status {
   bool IsInterrupted() const { return code() == StatusCode::Interrupted; }
   bool IsSystemExit() const {
     return code() == StatusCode::IntentionalSystemExit ||
-           code() == StatusCode::UnintentionalSystemExit;
+           code() == StatusCode::UnexpectedSystemExit;
   }
   bool IsIntentionalSystemExit() const {
     return code() == StatusCode::IntentionalSystemExit;

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -81,7 +81,8 @@ enum class StatusCode : char {
   RedisError = 11,
   TimedOut = 12,
   Interrupted = 13,
-  SystemExit = 14,
+  IntentionalSystemExit = 14,
+  UnintentionalSystemExit = 15,
 };
 
 #if defined(__clang__)
@@ -153,8 +154,12 @@ class RAY_EXPORT Status {
     return Status(StatusCode::Interrupted, msg);
   }
 
-  static Status SystemExit() {
-    return Status(StatusCode::SystemExit, "process requested exit");
+  static Status IntentionalSystemExit() {
+    return Status(StatusCode::IntentionalSystemExit, "intentional system exit");
+  }
+
+  static Status UnintentionalSystemExit() {
+    return Status(StatusCode::UnintentionalSystemExit, "user code caused exit");
   }
 
   // Returns true iff the status indicates success.
@@ -172,7 +177,13 @@ class RAY_EXPORT Status {
   bool IsRedisError() const { return code() == StatusCode::RedisError; }
   bool IsTimedOut() const { return code() == StatusCode::TimedOut; }
   bool IsInterrupted() const { return code() == StatusCode::Interrupted; }
-  bool IsSystemExit() const { return code() == StatusCode::SystemExit; }
+  bool IsSystemExit() const {
+    return code() == StatusCode::IntentionalSystemExit ||
+           code() == StatusCode::UnintentionalSystemExit;
+  }
+  bool IsIntentionalSystemExit() const {
+    return code() == StatusCode::IntentionalSystemExit;
+  }
 
   // Return a string representation of this status suitable for printing.
   // Returns the string "OK" for success.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -117,14 +117,16 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
     RAY_CHECK(task_execution_callback_ != nullptr);
     auto execute_task = std::bind(&CoreWorker::ExecuteTask, this, std::placeholders::_1,
                                   std::placeholders::_2, std::placeholders::_3);
-    auto exit = [this]() {
+    auto exit = [this](bool intentional) {
       // Release the resources early in case draining takes a long time.
       RAY_CHECK_OK(local_raylet_client_->NotifyDirectCallTaskBlocked());
-      task_manager_->DrainAndShutdown([this]() {
+      task_manager_->DrainAndShutdown([this, intentional]() {
         // To avoid problems, make sure shutdown is always called from the same
         // event loop each time.
-        task_execution_service_.post([this]() {
-          Disconnect();  // Notify the raylet this is an intentional exit.
+        task_execution_service_.post([this, intentional]() {
+          if (intentional) {
+            Disconnect();  // Notify the raylet this is an intentional exit.
+          }
           Shutdown();
         });
       });

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1040,7 +1040,6 @@ void CoreWorker::HandleDirectActorCallArgWaitComplete(
 void CoreWorker::HandleGetObjectStatus(const rpc::GetObjectStatusRequest &request,
                                        rpc::GetObjectStatusReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(ERROR) << "handle object status";
   ObjectID object_id = ObjectID::FromBinary(request.object_id());
   TaskID owner_id = TaskID::FromBinary(request.owner_id());
   if (owner_id != GetCallerId()) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -124,8 +124,8 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
         // To avoid problems, make sure shutdown is always called from the same
         // event loop each time.
         task_execution_service_.post([this]() {
-            Disconnect();  // Notify the raylet this is an intentional exit.
-            Shutdown();
+          Disconnect();  // Notify the raylet this is an intentional exit.
+          Shutdown();
         });
       });
     };

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -123,7 +123,10 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       task_manager_->DrainAndShutdown([this]() {
         // To avoid problems, make sure shutdown is always called from the same
         // event loop each time.
-        task_execution_service_.post([this]() { Shutdown(); });
+        task_execution_service_.post([this]() {
+            Disconnect();  // Notify the raylet this is an intentional exit.
+            Shutdown();
+        });
       });
     };
     raylet_task_receiver_ =

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -20,8 +20,8 @@ void FutureResolver::ResolveFutureAsync(const ObjectID &object_id, const TaskID 
       request,
       [this, object_id](const Status &status, const rpc::GetObjectStatusReply &reply) {
         if (!status.ok()) {
-          RAY_LOG(ERROR) << "Error retrieving the value of object ID " << object_id
-                         << " that was deserialized: " << status.ToString();
+          RAY_LOG(WARNING) << "Error retrieving the value of object ID " << object_id
+                           << " that was deserialized: " << status.ToString();
         }
         // Either the owner is gone or the owner replied that the object has
         // been created. In both cases, we can now try to fetch the object via

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -23,7 +23,7 @@ void TaskManager::DrainAndShutdown(std::function<void()> shutdown) {
   } else {
     RAY_LOG(ERROR)
         << "This worker is still managing " << pending_tasks_.size()
-        << " background tasks, waiting for them to finish before shutting down.";
+        << " in flight tasks, waiting for them to finish before shutting down.";
   }
   shutdown_hook_ = shutdown;
 }
@@ -142,7 +142,7 @@ void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_
 void TaskManager::ShutdownIfNeeded() {
   absl::MutexLock lock(&mu_);
   if (shutdown_hook_ && pending_tasks_.empty()) {
-    RAY_LOG(ERROR) << "All background tasks finished, shutting down worker.";
+    RAY_LOG(ERROR) << "All in flight tasks finished, shutting down worker.";
     shutdown_hook_();
   }
 }

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -11,7 +11,6 @@ const int64_t kTaskFailureLoggingFrequencyMillis = 5000;
 
 void TaskManager::AddPendingTask(const TaskSpecification &spec, int max_retries) {
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId();
-  RAY_CHECK(shutdown_hook_ == nullptr);
   absl::MutexLock lock(&mu_);
   std::pair<TaskSpecification, int> entry = {spec, max_retries};
   RAY_CHECK(pending_tasks_.emplace(spec.TaskId(), std::move(entry)).second);

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -21,7 +21,7 @@ void TaskManager::DrainAndShutdown(std::function<void()> shutdown) {
   if (pending_tasks_.empty()) {
     shutdown();
   } else {
-    RAY_LOG(ERROR)
+    RAY_LOG(WARNING)
         << "This worker is still managing " << pending_tasks_.size()
         << " in flight tasks, waiting for them to finish before shutting down.";
   }
@@ -142,7 +142,7 @@ void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_
 void TaskManager::ShutdownIfNeeded() {
   absl::MutexLock lock(&mu_);
   if (shutdown_hook_ && pending_tasks_.empty()) {
-    RAY_LOG(ERROR) << "All in flight tasks finished, shutting down worker.";
+    RAY_LOG(WARNING) << "All in flight tasks finished, shutting down worker.";
     shutdown_hook_();
   }
 }

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -22,7 +22,7 @@ void TaskManager::DrainAndShutdown(std::function<void()> shutdown) {
     shutdown();
   } else {
     RAY_LOG(ERROR)
-        << "This worker is still waiting for " << pending_tasks_.size()
+        << "This worker is still managing " << pending_tasks_.size()
         << " background tasks, waiting for them to finish before shutting down.";
   }
   shutdown_hook_ = shutdown;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -44,6 +44,11 @@ class TaskManager : public TaskFinisherInterface {
   /// \return Void.
   void AddPendingTask(const TaskSpecification &spec, int max_retries = 0);
 
+  /// Wait for all pending tasks to finish, and then shutdown.
+  ///
+  /// \param shutdown The shutdown callback to call.
+  void DrainAndShutdown(std::function<void()> shutdown);
+
   /// Return whether the task is pending.
   ///
   /// \param[in] task_id ID of the task to query.
@@ -77,6 +82,9 @@ class TaskManager : public TaskFinisherInterface {
   void MarkPendingTaskFailed(const TaskID &task_id, const TaskSpecification &spec,
                              rpc::ErrorType error_type) LOCKS_EXCLUDED(mu_);
 
+  /// Shutdown if all tasks are finished and shutdown is scheduled.
+  void ShutdownIfNeeded() LOCKS_EXCLUDED(mu_);
+
   /// Used to store task results.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
 
@@ -105,6 +113,9 @@ class TaskManager : public TaskFinisherInterface {
   /// storing a shared_ptr to a PushTaskRequest protobuf for all tasks.
   absl::flat_hash_map<TaskID, std::pair<TaskSpecification, int>> pending_tasks_
       GUARDED_BY(mu_);
+
+  /// Optional shutdown hook to call when pending tasks all finish.
+  std::function<void()> shutdown_hook_ GUARDED_BY(mu_) = nullptr;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -268,9 +268,10 @@ void CoreWorkerDirectTaskReceiver::HandlePushTask(
         // This happens when max_calls is hit. We still need to return the objects.
         send_reply_callback(Status::OK(), nullptr, nullptr);
       } else {
-        send_reply_callback(Status::SystemExit(), nullptr, nullptr);
+        send_reply_callback(status, nullptr, nullptr);
       }
-      task_main_io_service_.post([this]() { exit_handler_(); });
+      task_main_io_service_.post(
+          [this, status]() { exit_handler_(status.IsIntentionalSystemExit()); });
     } else {
       RAY_CHECK(objects_valid) << return_objects.size() << "  " << num_returns;
       send_reply_callback(status, nullptr, nullptr);

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -257,11 +257,15 @@ void CoreWorkerDirectTaskReceiver::HandlePushTask(
       }
     }
     if (status.IsSystemExit()) {
+      // Don't allow the worker to be reused, even though the reply status is OK.
+      // The worker will be shutting down shortly.
+      reply->set_worker_exiting(true);
       // In Python, SystemExit can only be raised on the main thread. To
       // work around this when we are executing tasks on worker threads,
       // we re-post the exit event explicitly on the main thread.
       exiting_ = true;
       if (objects_valid) {
+        // This happens when max_calls is hit. We still need to return the objects.
         send_reply_callback(Status::OK(), nullptr, nullptr);
       } else {
         send_reply_callback(Status::SystemExit(), nullptr, nullptr);

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -423,7 +423,7 @@ class CoreWorkerDirectTaskReceiver {
   CoreWorkerDirectTaskReceiver(WorkerContext &worker_context,
                                boost::asio::io_service &main_io_service,
                                const TaskHandler &task_handler,
-                               const std::function<void()> &exit_handler)
+                               const std::function<void(bool)> &exit_handler)
       : worker_context_(worker_context),
         task_handler_(task_handler),
         exit_handler_(exit_handler),
@@ -470,7 +470,7 @@ class CoreWorkerDirectTaskReceiver {
   /// The callback function to process a task.
   TaskHandler task_handler_;
   /// The callback function to exit the worker.
-  std::function<void()> exit_handler_;
+  std::function<void(bool)> exit_handler_;
   /// The IO event loop for running tasks on.
   boost::asio::io_service &task_main_io_service_;
   /// Factory for producing new core worker clients.

--- a/src/ray/core_worker/transport/raylet_transport.cc
+++ b/src/ray/core_worker/transport/raylet_transport.cc
@@ -7,7 +7,7 @@ namespace ray {
 
 CoreWorkerRayletTaskReceiver::CoreWorkerRayletTaskReceiver(
     const WorkerID &worker_id, std::shared_ptr<raylet::RayletClient> &raylet_client,
-    const TaskHandler &task_handler, const std::function<void()> &exit_handler)
+    const TaskHandler &task_handler, const std::function<void(bool)> &exit_handler)
     : worker_id_(worker_id),
       raylet_client_(raylet_client),
       task_handler_(task_handler),
@@ -50,7 +50,7 @@ void CoreWorkerRayletTaskReceiver::HandleAssignTask(
   std::vector<std::shared_ptr<RayObject>> results;
   auto status = task_handler_(task_spec, resource_ids, &results);
   if (status.IsSystemExit()) {
-    exit_handler_();
+    exit_handler_(status.IsIntentionalSystemExit());
     return;
   }
 

--- a/src/ray/core_worker/transport/raylet_transport.h
+++ b/src/ray/core_worker/transport/raylet_transport.h
@@ -19,7 +19,7 @@ class CoreWorkerRayletTaskReceiver {
   CoreWorkerRayletTaskReceiver(const WorkerID &worker_id,
                                std::shared_ptr<raylet::RayletClient> &raylet_client,
                                const TaskHandler &task_handler,
-                               const std::function<void()> &exit_handler);
+                               const std::function<void(bool)> &exit_handler);
 
   /// Handle a `AssignTask` request.
   /// The implementation can handle this request asynchronously. When handling is done,
@@ -41,7 +41,7 @@ class CoreWorkerRayletTaskReceiver {
   /// The callback function to process a task.
   TaskHandler task_handler_;
   /// The callback function to exit the worker.
-  std::function<void()> exit_handler_;
+  std::function<void(bool)> exit_handler_;
   /// The callback to process arg wait complete.
   std::function<void(int64_t)> on_wait_complete_;
 };

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -86,6 +86,8 @@ message PushTaskRequest {
 message PushTaskReply {
   // The returned objects.
   repeated ReturnObject return_objects = 1;
+  // Set to true if the worker will be exiting.
+  bool worker_exiting = 2;
 }
 
 message DirectActorCallArgWaitCompleteRequest {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

With direct calls, workers may be handling RPC replies in the background even after a task finishes. This poses a problem if a task has max_calls set, which will kill the worker immediately after the task is done.

To workaround this, when exiting a max_calls task, instead of killing the worker we only release resources and wait for background processing to finish before really exiting.

A more robust long term solution may be to run these types of tasks in dedicated workers instead of randomly pulling from the shared worker pool.