### PR TITLE
Serve small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,8 +145,8 @@ script:
   - ./ci/suppress_output bazel test --build_tests_only --show_progress_rate_limit=100 --test_output=errors //:all
 
   # ray serve tests
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || RAY_FORCE_DIRECT=0 python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || RAY_FORCE_DIRECT=0 ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -c 'import sys;exit(sys.version_info>=(3,5))' || ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
 
   # ray tests
   # Python3.5+ only. Otherwise we will get `SyntaxError` regardless of how we set the tester.

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -1,5 +1,6 @@
 import inspect
 from functools import wraps
+from tempfile import mkstemp
 
 import numpy as np
 
@@ -35,7 +36,7 @@ def _ensure_connected(f):
 
 
 def init(kv_store_connector=None,
-         kv_store_path="/tmp/ray_serve.db",
+         kv_store_path=None,
          blocking=False,
          http_host=DEFAULT_HTTP_HOST,
          http_port=DEFAULT_HTTP_PORT,
@@ -81,6 +82,9 @@ def init(kv_store_connector=None,
         return
     except ValueError:
         pass
+
+    if kv_store_path is None:
+        _, kv_store_path = mkstemp()
 
     # Serve has not been initialized, perform init sequence
     # Todo, move the db to session_dir

--- a/python/ray/experimental/serve/server.py
+++ b/python/ray/experimental/serve/server.py
@@ -148,7 +148,8 @@ class HTTPProxy:
                 await JSONResponse({"error": str(e)})(scope, receive, send)
                 return
 
-        result_object_id_bytes = await (self.serve_global_state.init_or_get_router()
+        result_object_id_bytes = await (
+            self.serve_global_state.init_or_get_router()
             .enqueue_request.remote(
                 service=endpoint_name,
                 request_args=(scope, http_body_bytes),

--- a/python/ray/experimental/serve/server.py
+++ b/python/ray/experimental/serve/server.py
@@ -4,7 +4,7 @@ import json
 import uvicorn
 
 import ray
-from ray.experimental.async_api import _async_init, as_future
+from ray.experimental.async_api import _async_init
 from ray.experimental.serve.constants import HTTP_ROUTER_CHECKER_INTERVAL_S
 from ray.experimental.serve.context import TaskContext
 from ray.experimental.serve.utils import BytesEncoder
@@ -148,8 +148,7 @@ class HTTPProxy:
                 await JSONResponse({"error": str(e)})(scope, receive, send)
                 return
 
-        result_object_id_bytes = await as_future(
-            self.serve_global_state.init_or_get_router()
+        result_object_id_bytes = await (self.serve_global_state.init_or_get_router()
             .enqueue_request.remote(
                 service=endpoint_name,
                 request_args=(scope, http_body_bytes),
@@ -157,7 +156,7 @@ class HTTPProxy:
                 request_context=TaskContext.Web,
                 request_slo_ms=request_slo_ms))
 
-        result = await as_future(ray.ObjectID(result_object_id_bytes))
+        result = await ray.ObjectID(result_object_id_bytes)
 
         if isinstance(result, ray.exceptions.RayTaskError):
             await JSONResponse({

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -99,7 +99,8 @@ class RayServeMixin:
         if work_item.request_context == TaskContext.Web:
             serve_context.web = True
             asgi_scope, body_bytes = work_item.request_args
-            flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes))
+            flask_request = build_flask_request(asgi_scope,
+                                                io.BytesIO(body_bytes))
             args = (flask_request, )
             kwargs = {}
         else:

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -1,3 +1,4 @@
+import io
 import time
 import traceback
 
@@ -98,7 +99,7 @@ class RayServeMixin:
         if work_item.request_context == TaskContext.Web:
             serve_context.web = True
             asgi_scope, body_bytes = work_item.request_args
-            flask_request = build_flask_request(asgi_scope, body_bytes)
+            flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes))
             args = (flask_request, )
             kwargs = {}
         else:


### PR DESCRIPTION
- fix flask request. it takes BytesIO not bytes
- use tmp for kv_store for now. this pave ways for a more robust persistence and fault tolerance design.
- enable async object id for web server. this is the first PR enabling async mode for serve. This enable serve to work with direct call