### PR TITLE
Initializing default saver inside rollout function

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -297,10 +297,13 @@ def rollout(agent,
             env_name,
             num_steps,
             num_episodes=0,
-            saver=RolloutSaver(),
+            saver=None,
             no_render=True,
             monitor=False):
     policy_agent_mapping = default_policy_agent_mapping
+
+    if saver is None:
+        saver = RolloutSaver()
 
     if hasattr(agent, "workers"):
         env = agent.workers.local_worker().env


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When an object is initialized as a default argument it belongs to the environment where the function is defined. For example:

```
In [1]: def f(x=[1]):
   ...:     x.append(2)
   ...:     print(x)
   ...:

In [2]: f()
[1, 2]

In [3]: f()
[1, 2, 2]

In [4]: f()
[1, 2, 2, 2]
```

This change initializes the default `saver` variable inside of the `rollout` function, matching the intended effect of one saver per `rollout` call.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
