### PR TITLE
[Serve] Adding BackendConfig

### DIFF
--- a/python/ray/experimental/serve/__init__.py
+++ b/python/ray/experimental/serve/__init__.py
@@ -1,13 +1,14 @@
 import sys
+from ray.experimental.serve.backend_config import BackendConfig
 from ray.experimental.serve.policy import RoutePolicy
 if sys.version_info < (3, 0):
     raise ImportError("serve is Python 3 only.")
 
-from ray.experimental.serve.api import (init, create_backend, create_endpoint,
-                                        link, split, get_handle, stat,
-                                        scale)  # noqa: E402
-
+from ray.experimental.serve.api import (
+    init, create_backend, create_endpoint, link, split, get_handle, stat,
+    set_backend_config, get_backend_config)  # noqa: E402
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "get_handle",
-    "stat", "scale", "RoutePolicy"
+    "stat", "set_backend_config", "get_backend_config", "BackendConfig",
+    "RoutePolicy"
 ]

--- a/python/ray/experimental/serve/__init__.py
+++ b/python/ray/experimental/serve/__init__.py
@@ -6,9 +6,9 @@ if sys.version_info < (3, 0):
 
 from ray.experimental.serve.api import (
     init, create_backend, create_endpoint, link, split, get_handle, stat,
-    set_backend_config, get_backend_config)  # noqa: E402
+    set_backend_config, get_backend_config, accept_batch)  # noqa: E402
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "get_handle",
     "stat", "set_backend_config", "get_backend_config", "BackendConfig",
-    "RoutePolicy"
+    "RoutePolicy", "accept_batch"
 ]

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -204,8 +204,7 @@ def create_backend(func_or_class,
         # arg list for a fn is function itself
         arg_list = [func_or_class]
         # ignore lint on lambda expression
-        creator = lambda kwargs: ( 
-                            TaskRunnerActor._remote(**kwargs) ) # noqa: E731
+        creator = lambda kwrgs: TaskRunnerActor._remote(**kwrgs)  # noqa: E731
     elif inspect.isclass(func_or_class):
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -136,8 +136,9 @@ def set_backend_config(backend_tag, backend_config):
     """
     assert backend_tag in global_state.backend_table.list_backends(), (
         "Backend {} is not registered.".format(backend_tag))
-    assert isinstance(backend_config, BackendConfig), ("backend_config must be"
-                                                " of instance BackendConfig")
+    assert isinstance(backend_config,
+                      BackendConfig), ("backend_config must be"
+                                       " of instance BackendConfig")
     backend_config_d = backend_config._asdict()
 
     old_backend_config_d = global_state.backend_table.get_info(backend_tag)
@@ -153,8 +154,9 @@ def set_backend_config(backend_tag, backend_config):
     # related to restart_configs
     # TODO(alind) : have replica restarting policies selected by the user
 
-    need_to_restart_replicas = any(old_backend_config_d[k] !=
-        backend_config_d[k] for k in BackendConfig.restart_on_change_fields)
+    need_to_restart_replicas = any(
+        old_backend_config_d[k] != backend_config_d[k]
+        for k in BackendConfig.restart_on_change_fields)
     if need_to_restart_replicas:
         # kill all the replicas for restarting with new configurations
         scale(backend_tag, 0)
@@ -193,8 +195,9 @@ def create_backend(func_or_class,
         *actor_init_args (optional): the argument to pass to the class
             initialization method.
     """
-    assert isinstance(backend_config, BackendConfig), ("backend_config must be"
-                                                " of instance BackendConfig")
+    assert isinstance(backend_config,
+                      BackendConfig), ("backend_config must be"
+                                       " of instance BackendConfig")
     backend_config_d = backend_config._asdict()
     arg_list = []
     if inspect.isfunction(func_or_class):
@@ -253,8 +256,8 @@ def _start_replica(backend_tag):
 
     # Create the runner in the nursery
     [runner_handle] = ray.get(
-        global_state.actor_nursery_handle.start_actor_with_creator.
-        remote(creator, backend_config_d, replica_tag))
+        global_state.actor_nursery_handle.start_actor_with_creator.remote(
+            creator, backend_config_d, replica_tag))
 
     # Setup the worker
     ray.get(

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -204,7 +204,8 @@ def create_backend(func_or_class,
         # arg list for a fn is function itself
         arg_list = [func_or_class]
         # ignore lint on lambda expression
-        creator = lambda kwargs: TaskRunnerActor._remote(**kwargs)  # noqa: E731
+        creator = lambda kwargs: ( 
+                            TaskRunnerActor._remote(**kwargs) ) # noqa: E731
     elif inspect.isclass(func_or_class):
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -204,7 +204,7 @@ def create_backend(func_or_class,
         # arg list for a fn is function itself
         arg_list = [func_or_class]
         # ignore lint on lambda expression
-        creator = lambda kwargs: TaskRunnerActor._remote(**kwargs)# noqa: E731
+        creator = lambda kwargs: TaskRunnerActor._remote(**kwargs)  # noqa: E731
     elif inspect.isclass(func_or_class):
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -44,12 +44,13 @@ def accept_batch(f):
     to be passed into a list.
 
     Example:
-        @serve.accept_batch
+
+    >>> @serve.accept_batch
         def serving_func(flask_request):
             assert isinstance(flask_request, list)
             ...
 
-        class ServingActor:
+    >>> class ServingActor:
             @serve.accept_batch
             def __call__(self, *, python_arg=None):
                 assert isinstance(python_arg, list)

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -204,7 +204,7 @@ def create_backend(func_or_class,
         # arg list for a fn is function itself
         arg_list = [func_or_class]
         # ignore lint on lambda expression
-        creator = lambda kwargs: TaskRunnerActor._remote(**kwargs)  # noqa: E731
+        creator = lambda kwargs: TaskRunnerActor._remote(**kwargs)# noqa: E731
     elif inspect.isclass(func_or_class):
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -2,6 +2,7 @@ import pprint
 import json
 from copy import deepcopy
 
+
 class BackendConfig:
     # configs not needed for actor creation when
     # instantiating a replica
@@ -22,7 +23,6 @@ class BackendConfig:
         """
         Class for defining backend configuration.
         """
-        
 
         # serve configs
         self.num_replicas = num_replicas
@@ -54,9 +54,9 @@ class BackendConfig:
 
     def __str__(self):
         return json.dumps(self.__dict__)
-    
+
     def _asdict(self):
-        ret_d =  deepcopy(self.__dict__)
+        ret_d = deepcopy(self.__dict__)
         val = ret_d.pop('_num_replicas')
         ret_d['num_replicas'] = val
         return ret_d

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -50,9 +50,9 @@ class BackendConfig:
             key, val = k, self.__dict__[k]
             if key == '_num_replicas':
                 key = 'num_replicas'
-            yield key,val
+            yield key, val
 
-    def get_actor_creation_args(self,init_args):
+    def get_actor_creation_args(self, init_args):
         ret_d = deepcopy(self.__dict__)
         for k in self._serve_configs:
             ret_d.pop(k)

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -1,6 +1,6 @@
 import pprint
 import json
-
+from copy import deepcopy
 
 class BackendConfig:
     # configs not needed for actor creation when
@@ -56,7 +56,10 @@ class BackendConfig:
         return json.dumps(self.__dict__)
     
     def _asdict(self):
-        return self.__dict__
+        ret_d =  deepcopy(self.__dict__)
+        val = ret_d.pop('_num_replicas')
+        ret_d['num_replicas'] = val
+        return ret_d
 
     @classmethod
     def from_str(cls, json_string):

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -57,8 +57,8 @@ class BackendConfig:
 
     def _asdict(self):
         ret_d = deepcopy(self.__dict__)
-        val = ret_d.pop('_num_replicas')
-        ret_d['num_replicas'] = val
+        val = ret_d.pop("_num_replicas")
+        ret_d["num_replicas"] = val
         return ret_d
 
     @classmethod

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -1,0 +1,48 @@
+import pprint
+import json
+
+
+class BackendConfig:
+    # configs not needed for actor creation when
+    # instantiating a replica
+    serve_configs = ["num_replicas", "max_batch_size"]
+
+    # configs which when changed leads to restarting
+    # the existing replicas.
+    restart_configs = ["resources", "num_cpus", "num_gpus"]
+
+    def __init__(self,
+                 num_replicas=1,
+                 resources=None,
+                 max_batch_size=None,
+                 num_cpus=None,
+                 num_gpus=None,
+                 memory=None,
+                 object_store_memory=None):
+        """
+        Class for defining backend configuration.
+        """
+        # serve configs
+        self.num_replicas = num_replicas
+        self.max_batch_size = max_batch_size
+
+        # ray actor configs
+        self.resources = resources
+        self.num_cpus = num_cpus
+        self.num_gpus = num_gpus
+        self.memory = memory
+        self.object_store_memory = object_store_memory
+
+    def __repr__(self):
+        ret = "<{klass}({attrs})>".format(
+            klass=self.__class__.__name__,
+            attrs=", ".join(
+                "{}={!r}".format(k, v) for k, v in self.__dict__.items()))
+        return pprint.pformat(ret)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_str(cls, json_string):
+        return cls(**json.loads(json_string))

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -1,5 +1,3 @@
-import pprint
-import json
 from copy import deepcopy
 
 
@@ -48,13 +46,13 @@ class BackendConfig:
     def __iter__(self):
         for k in self.__dict__.keys():
             key, val = k, self.__dict__[k]
-            if key == '_num_replicas':
-                key = 'num_replicas'
+            if key == "_num_replicas":
+                key = "num_replicas"
             yield key, val
 
     def get_actor_creation_args(self, init_args):
         ret_d = deepcopy(self.__dict__)
         for k in self._serve_configs:
             ret_d.pop(k)
-        ret_d['args'] = init_args
+        ret_d["args"] = init_args
         return ret_d

--- a/python/ray/experimental/serve/backend_config.py
+++ b/python/ray/experimental/serve/backend_config.py
@@ -9,7 +9,7 @@ class BackendConfig:
 
     # configs which when changed leads to restarting
     # the existing replicas.
-    restart_configs = ["resources", "num_cpus", "num_gpus"]
+    restart_on_change_fields = ["resources", "num_cpus", "num_gpus"]
 
     def __init__(self,
                  num_replicas=1,
@@ -22,6 +22,8 @@ class BackendConfig:
         """
         Class for defining backend configuration.
         """
+        
+
         # serve configs
         self.num_replicas = num_replicas
         self.max_batch_size = max_batch_size
@@ -33,6 +35,16 @@ class BackendConfig:
         self.memory = memory
         self.object_store_memory = object_store_memory
 
+    @property
+    def num_replicas(self):
+        return self._num_replicas
+
+    @num_replicas.setter
+    def num_replicas(self, val):
+        if not (val > 0):
+            raise Exception("num_replicas must be greater than zero")
+        self._num_replicas = val
+
     def __repr__(self):
         ret = "<{klass}({attrs})>".format(
             klass=self.__class__.__name__,
@@ -42,6 +54,9 @@ class BackendConfig:
 
     def __str__(self):
         return json.dumps(self.__dict__)
+    
+    def _asdict(self):
+        return self.__dict__
 
     @classmethod
     def from_str(cls, json_string):

--- a/python/ray/experimental/serve/context.py
+++ b/python/ray/experimental/serve/context.py
@@ -16,7 +16,8 @@ web = False
 
 # batching information in serve context
 # batch_size == None : the backend doesn't support batching
-# batch_size == `intval`  : the batch size of input list is equal to `intval`
+# batch_size(int)    : the number of elements of input list
+
 batch_size = None
 _not_in_web_context_error = """
 Accessing the request object outside of the web context. Please use

--- a/python/ray/experimental/serve/context.py
+++ b/python/ray/experimental/serve/context.py
@@ -26,7 +26,7 @@ a web context.
 """
 
 
-class FakeFlaskQuest:
+class FakeFlaskRequest:
     def __getattribute__(self, name):
         raise RayServeException(_not_in_web_context_error)
 

--- a/python/ray/experimental/serve/context.py
+++ b/python/ray/experimental/serve/context.py
@@ -14,6 +14,10 @@ class TaskContext(IntEnum):
 # web == False: currently processing a request from python
 web = False
 
+# batching information in serve context
+# batch_size == None : the backend doesn't support batching
+# batch_size == `intval`  : the batch size of input list is equal to `intval`
+batch_size = None
 _not_in_web_context_error = """
 Accessing the request object outside of the web context. Please use
 "serve.context.web" to determine when the function is called within

--- a/python/ray/experimental/serve/context.py
+++ b/python/ray/experimental/serve/context.py
@@ -17,8 +17,8 @@ web = False
 # batching information in serve context
 # batch_size == None : the backend doesn't support batching
 # batch_size(int)    : the number of elements of input list
-
 batch_size = None
+
 _not_in_web_context_error = """
 Accessing the request object outside of the web context. Please use
 "serve.context.web" to determine when the function is called within

--- a/python/ray/experimental/serve/examples/echo_actor_batch.py
+++ b/python/ray/experimental/serve/examples/echo_actor_batch.py
@@ -1,7 +1,7 @@
 """
 Example actor that adds an increment to a number. This number can
 come from either web (parsing Flask request) or python call.
-
+The queries incoming to this actor are batched.
 This actor can be called from HTTP as well as from Python.
 """
 
@@ -12,21 +12,34 @@ import requests
 import ray
 from ray.experimental import serve
 from ray.experimental.serve.utils import pformat_color_json
+from ray.experimental.serve import BackendConfig
 
 
 class MagicCounter:
     def __init__(self, increment):
         self.increment = increment
 
-    def __call__(self, flask_request, base_number=None):
+    def __call__(self, flask_request_list, base_number=None):
+        batch_size = serve.context.batch_size
         if serve.context.web:
-            base_number = int(flask_request.args.get("base_number", "0"))
-        return base_number + self.increment
+            result = []
+            for flask_request in flask_request_list:
+                base_number = int(flask_request.args.get("base_number", "0"))
+                result.append(base_number)
+            return list(map(lambda x: x+self.increment, result))
+        else:
+            result = []
+            for b in base_number:
+                ans = b + self.increment
+                result.append(ans)
+            return result
 
 
 serve.init(blocking=True)
 serve.create_endpoint("magic_counter", "/counter", blocking=True)
-serve.create_backend(MagicCounter, "counter:v1", 42)  # increment=42
+b_config = BackendConfig(max_batch_size=5)
+serve.create_backend(MagicCounter, "counter:v1", 42,
+                     backend_config=b_config)  # increment=42
 serve.link("magic_counter", "counter:v1")
 
 print("Sending ten queries via HTTP")

--- a/python/ray/experimental/serve/examples/echo_actor_batch.py
+++ b/python/ray/experimental/serve/examples/echo_actor_batch.py
@@ -26,7 +26,7 @@ class MagicCounter:
             for flask_request in flask_request_list:
                 base_number = int(flask_request.args.get("base_number", "0"))
                 result.append(base_number)
-            return list(map(lambda x: x+self.increment, result))
+            return list(map(lambda x: x + self.increment, result))
         else:
             result = []
             for b in base_number:
@@ -38,8 +38,8 @@ class MagicCounter:
 serve.init(blocking=True)
 serve.create_endpoint("magic_counter", "/counter", blocking=True)
 b_config = BackendConfig(max_batch_size=5)
-serve.create_backend(MagicCounter, "counter:v1", 42,
-                     backend_config=b_config)  # increment=42
+serve.create_backend(
+    MagicCounter, "counter:v1", 42, backend_config=b_config)  # increment=42
 serve.link("magic_counter", "counter:v1")
 
 print("Sending ten queries via HTTP")

--- a/python/ray/experimental/serve/examples/echo_actor_batch.py
+++ b/python/ray/experimental/serve/examples/echo_actor_batch.py
@@ -19,6 +19,7 @@ class MagicCounter:
     def __init__(self, increment):
         self.increment = increment
 
+    @serve.accept_batch
     def __call__(self, flask_request_list, base_number=None):
         # batch_size = serve.context.batch_size
         if serve.context.web:

--- a/python/ray/experimental/serve/examples/echo_actor_batch.py
+++ b/python/ray/experimental/serve/examples/echo_actor_batch.py
@@ -20,7 +20,7 @@ class MagicCounter:
         self.increment = increment
 
     def __call__(self, flask_request_list, base_number=None):
-        batch_size = serve.context.batch_size
+        # batch_size = serve.context.batch_size
         if serve.context.web:
             result = []
             for flask_request in flask_request_list:

--- a/python/ray/experimental/serve/examples/echo_batching.py
+++ b/python/ray/experimental/serve/examples/echo_batching.py
@@ -11,6 +11,7 @@ class MagicCounter:
     def __init__(self, increment):
         self.increment = increment
 
+    @serve.accept_batch
     def __call__(self, flask_request, base_number=None):
         # __call__ fn should preserve the batch size
         # base_number is a python list

--- a/python/ray/experimental/serve/examples/echo_batching.py
+++ b/python/ray/experimental/serve/examples/echo_batching.py
@@ -1,0 +1,55 @@
+"""
+This example has backend which has batching functionality enabled.
+"""
+
+import ray
+from ray.experimental import serve
+from ray.experimental.serve import BackendConfig
+
+
+class MagicCounter:
+    def __init__(self, increment):
+        self.increment = increment
+
+    def __call__(self, flask_request, base_number=None):
+        # __call__ fn should preserve the batch size
+        # base_number is a python list
+
+        if serve.context.batch_size is not None:
+            batch_size = serve.context.batch_size
+            result = []
+            for base_num in base_number:
+                ret_str = "Number: {} Batch size: {}".format(
+                    base_num, batch_size)
+                result.append(ret_str)
+            return result
+        return ""
+
+
+serve.init(blocking=True)
+serve.create_endpoint("magic_counter", "/counter", blocking=True)
+# specify max_batch_size in BackendConfig
+b_config = BackendConfig(max_batch_size=5)
+serve.create_backend(
+    MagicCounter, "counter:v1", 42, backend_config=b_config)  # increment=42
+print("Backend Config for backend: 'counter:v1'")
+print(b_config)
+serve.link("magic_counter", "counter:v1")
+
+handle = serve.get_handle("magic_counter")
+future_list = []
+
+# fire 30 requests
+for r in range(30):
+    print("> [REMOTE] Pinging handle.remote(base_number={})".format(r))
+    f = handle.remote(base_number=r)
+    future_list.append(f)
+
+# get results of queries as they complete
+left_futures = future_list
+while left_futures:
+    completed_futures, remaining_futures = ray.wait(left_futures, timeout=0.05)
+    if len(completed_futures) > 0:
+        result = ray.get(completed_futures[0])
+        print("< " + result)
+    left_futures = remaining_futures

--- a/python/ray/experimental/serve/examples/echo_full.py
+++ b/python/ray/experimental/serve/examples/echo_full.py
@@ -27,7 +27,9 @@ def echo_v1(flask_request, response="hello from python!"):
 
 
 serve.create_backend(echo_v1, "echo:v1")
-
+b1_config = serve.get_backend_config("echo:v1")
+print("Config for Backend: 'echo:v1'")
+print(b1_config)
 # We can link an endpoint to a backend, the means all the traffic
 # goes to my_endpoint will now goes to echo:v1 backend.
 serve.link("my_endpoint", "echo:v1")
@@ -47,7 +49,9 @@ def echo_v2(flask_request):
 
 
 serve.create_backend(echo_v2, "echo:v2")
-
+b2_config = serve.get_backend_config("echo:v2")
+print("Config for Backend: 'echo:v2'")
+print(b2_config)
 # The two backend will now split the traffic 50%-50%.
 serve.split("my_endpoint", {"echo:v1": 0.5, "echo:v2": 0.5})
 
@@ -56,9 +60,12 @@ for _ in range(10):
     print(requests.get("http://127.0.0.1:8000/echo").json())
     time.sleep(0.5)
 
-# You can also scale each backend independently.
-serve.scale("echo:v1", 2)
-serve.scale("echo:v2", 2)
+# You can also change number of replicas
+# for each backend independently.
+b1_config.num_replicas = 2
+serve.set_backend_config("echo:v1", b1_config)
+b2_config.num_replicas = 2
+serve.set_backend_config("echo:v2", b2_config)
 
 # As well as retrieving relevant system metrics
 print(pformat_color_json(serve.stat()))

--- a/python/ray/experimental/serve/examples/echo_full.py
+++ b/python/ray/experimental/serve/examples/echo_full.py
@@ -27,9 +27,8 @@ def echo_v1(flask_request, response="hello from python!"):
 
 
 serve.create_backend(echo_v1, "echo:v1")
-b1_config = serve.get_backend_config("echo:v1")
-print("Config for Backend: 'echo:v1'")
-print(b1_config)
+backend_config_v1 = serve.get_backend_config("echo:v1")
+
 # We can link an endpoint to a backend, the means all the traffic
 # goes to my_endpoint will now goes to echo:v1 backend.
 serve.link("my_endpoint", "echo:v1")
@@ -49,9 +48,8 @@ def echo_v2(flask_request):
 
 
 serve.create_backend(echo_v2, "echo:v2")
-b2_config = serve.get_backend_config("echo:v2")
-print("Config for Backend: 'echo:v2'")
-print(b2_config)
+backend_config_v2 = serve.get_backend_config("echo:v2")
+
 # The two backend will now split the traffic 50%-50%.
 serve.split("my_endpoint", {"echo:v1": 0.5, "echo:v2": 0.5})
 
@@ -62,10 +60,10 @@ for _ in range(10):
 
 # You can also change number of replicas
 # for each backend independently.
-b1_config.num_replicas = 2
-serve.set_backend_config("echo:v1", b1_config)
-b2_config.num_replicas = 2
-serve.set_backend_config("echo:v2", b2_config)
+backend_config_v1.num_replicas = 2
+serve.set_backend_config("echo:v1", backend_config_v1)
+backend_config_v2.num_replicas = 2
+serve.set_backend_config("echo:v2", backend_config_v2)
 
 # As well as retrieving relevant system metrics
 print(pformat_color_json(serve.stat()))

--- a/python/ray/experimental/serve/global_state.py
+++ b/python/ray/experimental/serve/global_state.py
@@ -48,6 +48,11 @@ class ActorNursery:
         self.actor_handles[handle] = tag
         return [handle]
 
+    def start_actor_with_creator_kwargs(self, creator, kwargs, tag):
+        handle = creator(kwargs)
+        self.actor_handles[handle] = tag
+        return [handle]
+
     def get_all_handles(self):
         return {tag: handle for handle, tag in self.actor_handles.items()}
 

--- a/python/ray/experimental/serve/global_state.py
+++ b/python/ray/experimental/serve/global_state.py
@@ -43,12 +43,7 @@ class ActorNursery:
         self.actor_handles[handle] = tag
         return [handle]
 
-    def start_actor_with_creator(self, creator, tag):
-        handle = creator()
-        self.actor_handles[handle] = tag
-        return [handle]
-
-    def start_actor_with_creator_kwargs(self, creator, kwargs, tag):
+    def start_actor_with_creator(self, creator, kwargs, tag):
         handle = creator(kwargs)
         self.actor_handles[handle] = tag
         return [handle]

--- a/python/ray/experimental/serve/global_state.py
+++ b/python/ray/experimental/serve/global_state.py
@@ -44,6 +44,12 @@ class ActorNursery:
         return [handle]
 
     def start_actor_with_creator(self, creator, kwargs, tag):
+        """
+        Args:
+            creator (Callable[Dict]): a closure that should return
+                a newly created actor handle when called with kwargs.
+                The kwargs input is passed to `ActorCls_remote` method.
+        """
         handle = creator(kwargs)
         self.actor_handles[handle] = tag
         return [handle]

--- a/python/ray/experimental/serve/kv_store_service.py
+++ b/python/ray/experimental/serve/kv_store_service.py
@@ -212,10 +212,25 @@ class BackendTable:
     def __init__(self, kv_connector):
         self.backend_table = kv_connector("backend_creator")
         self.replica_table = kv_connector("replica_table")
+        self.backend_info = kv_connector("backend_info")
+        self.backend_init_args = kv_connector("backend_init_args")
 
     def register_backend(self, backend_tag: str, backend_creator):
         backend_creator_serialized = pickle.dumps(backend_creator)
         self.backend_table.put(backend_tag, backend_creator_serialized)
+
+    def save_init_args(self, backend_tag: str, arg_list):
+        serialized_arg_list = pickle.dumps(arg_list)
+        self.backend_init_args.put(backend_tag, serialized_arg_list)
+
+    def get_init_args(self, backend_tag):
+        return pickle.loads(self.backend_init_args.get(backend_tag))
+
+    def register_info(self, backend_tag: str, backend_info_d):
+        self.backend_info.put(backend_tag, json.dumps(backend_info_d))
+
+    def get_info(self, backend_tag):
+        return json.loads(self.backend_info.get(backend_tag, "{}"))
 
     def get_backend_creator(self, backend_tag):
         return pickle.loads(self.backend_table.get(backend_tag))

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -84,7 +84,7 @@ class CentralizedQueues:
         self.traffic = defaultdict(dict)
 
         # backend_name -> backend_config
-        self.backend_info = defaultdict()
+        self.backend_info = dict()
 
         # backend_name -> worker request queue
         self.workers = defaultdict(deque)

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -83,6 +83,9 @@ class CentralizedQueues:
         # service_name -> traffic_policy
         self.traffic = defaultdict(dict)
 
+        # backend_name -> backend_config
+        self.backend_info = defaultdict()
+
         # backend_name -> worker request queue
         self.workers = defaultdict(deque)
 
@@ -157,6 +160,11 @@ class CentralizedQueues:
         self.traffic[service] = traffic_dict
         self.flush()
 
+    def set_backend_config(self, backend, config_dict):
+        logger.debug("Setting backend config for backend %s to %s", backend,
+                     config_dict)
+        self.backend_info[backend] = config_dict
+
     def flush(self):
         """In the default case, flush calls ._flush.
 
@@ -184,11 +192,23 @@ class CentralizedQueues:
 
                 buffer_queue = self.buffer_queues[backend]
                 work_queue = self.workers[backend]
+                max_batch_size = None
+                if backend in self.backend_info:
+                    max_batch_size = self.backend_info[backend][
+                        "max_batch_size"]
+
                 while len(buffer_queue) and len(work_queue):
-                    request, work = (
-                        buffer_queue.pop(0),
-                        work_queue.popleft(),
-                    )
+                    # get the work from work intent queue
+                    work = work_queue.popleft()
+                    # see if backend accepts batched queries
+                    if max_batch_size is not None:
+                        pop_size = min(len(buffer_queue), max_batch_size)
+                        request = [
+                            buffer_queue.pop(0) for _ in range(pop_size)
+                        ]
+                    else:
+                        request = buffer_queue.pop(0)
+
                     work.replica_handle._ray_serve_call.remote(request)
 
     # selects the backend and puts the service queue query to the buffer

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -161,8 +161,8 @@ class CentralizedQueues:
         self.flush()
 
     def set_backend_config(self, backend, config_dict):
-        logger.debug("Setting backend config for backend %s to %s", backend,
-                     config_dict)
+        logger.debug("Setting backend config for "
+                     "backend {} to {}".format(backend,config_dict))
         self.backend_info[backend] = config_dict
 
     def flush(self):

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -162,7 +162,7 @@ class CentralizedQueues:
 
     def set_backend_config(self, backend, config_dict):
         logger.debug("Setting backend config for "
-                     "backend {} to {}".format(backend,config_dict))
+                     "backend {} to {}".format(backend, config_dict))
         self.backend_info[backend] = config_dict
 
     def flush(self):

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -126,10 +126,10 @@ class RayServeMixin:
 
         kwargs_list = defaultdict(list)
         result_object_ids, context_flag_list, arg_list = [], [], []
-        
+
         for item in request_item_list:
             args, kwargs, is_web_context, result_object_id = (
-                                                parse_request_item(item))
+                parse_request_item(item))
             context_flag_list.append(is_web_context)
 
             # Python context only have kwargs

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -3,7 +3,7 @@ import traceback
 
 import ray
 from ray.experimental.serve import context as serve_context
-from ray.experimental.serve.context import FakeFlaskQuest
+from ray.experimental.serve.context import FakeFlaskRequest
 from collections import defaultdict
 from ray.experimental.serve.utils import parse_request_item
 from ray.experimental.serve.exceptions import RayServeException
@@ -151,7 +151,7 @@ class RayServeMixin:
             if serve_context.web:
                 args = (arg_list, )
             else:
-                args = (FakeFlaskQuest(), )
+                args = (FakeFlaskRequest(), )
             # set the current batch size (n) for serve_context
             serve_context.batch_size = len(result_object_ids)
             start_timestamp = time.time()

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -1,4 +1,3 @@
-import io
 import time
 import traceback
 

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -103,7 +103,7 @@ class RayServeMixin:
                 serve_context.web = True
                 asgi_scope, body_bytes = work_item.request_args
                 flask_request = build_flask_request(asgi_scope,
-                                                  io.BytesIO(body_bytes))
+                                                    io.BytesIO(body_bytes))
                 args = (flask_request, )
                 kwargs = {}
             else:

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -130,8 +130,8 @@ class RayServeMixin:
         result_object_ids, context_flag_list, arg_list = [], [], []
         
         for item in request_item_list:
-            args, kwargs, is_web_context, result_object_id =
-                                                parse_request_item(item)
+            args, kwargs, is_web_context, result_object_id = (
+                                                parse_request_item(item))
             context_flag_list.append(is_web_context)
 
             # Python context only have kwargs

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -156,7 +156,8 @@ class RayServeMixin:
             serve_context.batch_size = len(result_object_ids)
             start_timestamp = time.time()
             result_list = self.__call__(*args, **kwargs_list)
-            if len(result_list) != len(result_object_ids):
+            if (not isinstance(result_list,list)) or (len(result_list) !=
+            len(result_object_ids)):
                 raise RayServeException("__call__ function "
                                         "doesn't preserve batch-size. "
                                         "Please return a list of result "

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -156,8 +156,8 @@ class RayServeMixin:
             serve_context.batch_size = len(result_object_ids)
             start_timestamp = time.time()
             result_list = self.__call__(*args, **kwargs_list)
-            if (not isinstance(result_list,list)) or (len(result_list) !=
-            len(result_object_ids)):
+            if (not isinstance(result_list, list)) or (len(result_list) !=
+                                                       len(result_object_ids)):
                 raise RayServeException("__call__ function "
                                         "doesn't preserve batch-size. "
                                         "Please return a list of result "

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -136,8 +136,8 @@ class RayServeMixin:
             # where n (current batch size) <= max_batch_size of a backend
             kwargs_list = defaultdict(list)
             result_object_ids = []
-            # flag for making sure request come from 
-            # Python context 
+            # flag for making sure request come from
+            # Python context
             flag = False
             try:
                 for item in work_item:
@@ -150,7 +150,7 @@ class RayServeMixin:
                     result_object_ids.append(item.result_object_id)
                 if flag:
                     raise Exception(
-                            "Batching not supported for HTTP Flask request")
+                        "Batching not supported for HTTP Flask request")
                 args = (FakeFlaskQuest(), )
                 # set the current batch size (n) for serve_context
                 serve_context.batch_size = len(result_object_ids)

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -128,24 +128,24 @@ class RayServeMixin:
             # TODO(alind) : create no-http services. The enqueues
             # from such services will always be TaskContext.Python.
 
-            # Assumption : all the requests in a bacth 
+            # Assumption : all the requests in a bacth
             # have same serve context.
 
             # For batching kwargs are modified as follows -
             # kwargs [Python Context] : key,val
             # kwargs_list             : key, [val1,val2, ... , valn]
-            # or 
+            # or
             # args[Web Context]       : val
-            # args_list               : [val1,val2, ...... , valn] 
+            # args_list               : [val1,val2, ...... , valn]
             # where n (current batch size) <= max_batch_size of a backend
             kwargs_list = defaultdict(list)
             result_object_ids, context_list, arg_list = [], [], []
-            
+
             for item in work_item:
                 if item.request_context == TaskContext.Web:
                     asgi_scope, body_bytes = item.request_args
-                    flask_request = build_flask_request(asgi_scope,
-                                                        io.BytesIO(body_bytes))
+                    flask_request = build_flask_request(
+                        asgi_scope, io.BytesIO(body_bytes))
                     arg_list.append(flask_request)
                     context_list.append(True)
                 else:
@@ -182,7 +182,6 @@ class RayServeMixin:
                 for result_object_id in result_object_ids:
                     ray.worker.global_worker.put_object(
                         wrapped_exception, result_object_id)
-
 
         serve_context.web = False
         serve_context.batch_size = None

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -5,7 +5,6 @@ import traceback
 import ray
 from ray.experimental.serve import context as serve_context
 from ray.experimental.serve.context import FakeFlaskQuest
-from ray.experimental.serve.http_util import build_flask_request
 from collections import defaultdict
 from ray.experimental.serve.utils import parse_request_item
 from ray.experimental.serve.exceptions import RayServeException

--- a/python/ray/experimental/serve/tests/conftest.py
+++ b/python/ray/experimental/serve/tests/conftest.py
@@ -10,7 +10,10 @@ from ray.experimental import serve
 @pytest.fixture(scope="session")
 def serve_instance():
     _, new_db_path = tempfile.mkstemp(suffix=".test.db")
-    serve.init(kv_store_path=new_db_path, blocking=True)
+    serve.init(
+        kv_store_path=new_db_path,
+        blocking=True,
+        ray_init_kwargs={"num_cpus": 36})
     yield
     os.remove(new_db_path)
 

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -127,7 +127,7 @@ def test_batching_exception(serve_instance):
     serve.link("exception-test", "exception:v1")
 
     handle = serve.get_handle("exception-test")
-    with pytest.raises(ray.exceptions.RayTaskError) as e:
+    with pytest.raises(ray.exceptions.RayTaskError):
         assert ray.get(handle.remote(temp=1))
 
 def test_killing_replicas(serve_instance):

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -82,6 +82,7 @@ def test_batching(serve_instance):
         def __init__(self):
             self.count = 0
 
+        @serve.accept_batch
         def __call__(self, flask_request, temp=None):
             self.count += 1
             batch_size = serve.context.batch_size
@@ -117,6 +118,7 @@ def test_batching_exception(serve_instance):
         def __init__(self):
             self.count = 0
 
+        @serve.accept_batch
         def __call__(self, flask_request, temp=None):
             batch_size = serve.context.batch_size
             return batch_size

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -5,8 +5,6 @@ import requests
 from ray.experimental import serve
 from ray.experimental.serve import BackendConfig
 import ray
-from ray.experimental.serve.exceptions import RayServeException
-
 
 def test_e2e(serve_instance):
     serve.init()  # so we have access to global state
@@ -129,7 +127,7 @@ def test_batching_exception(serve_instance):
     serve.link("exception-test", "exception:v1")
 
     handle = serve.get_handle("exception-test")
-    with pytest.raises(RayServeException) as e:
+    with pytest.raises(ray.exceptions.RayTaskError) as e:
         assert handle.remote(temp=1)
     assert str(e.value) == ("__call__ function "
                             "doesn't preserve batch-size. "

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -128,12 +128,7 @@ def test_batching_exception(serve_instance):
 
     handle = serve.get_handle("exception-test")
     with pytest.raises(ray.exceptions.RayTaskError) as e:
-        assert handle.remote(temp=1)
-    assert str(e.value) == ("__call__ function "
-                            "doesn't preserve batch-size. "
-                            "Please return a list of result "
-                            "with length equals to the batch "
-                            "size.")
+        assert ray.get(handle.remote(temp=1))
 
 def test_killing_replicas(serve_instance):
     class Simple:

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -106,6 +106,9 @@ def test_batching(serve_instance):
         future_list.append(f)
 
     counter_result = ray.get(future_list)
+    # since count is only updated per batch of queries
+    # If there atleast one __call__ fn call with batch size greater than 1
+    # counter result will always be less than 20
     assert max(counter_result) < 20
 
 
@@ -134,7 +137,10 @@ def test_killing_replicas(serve_instance):
     global_state.refresh_actor_handle_cache()
     new_all_tag_list = list(global_state.actor_handle_cache.keys())
 
+    # the new_replica_tag_list must be subset of all_tag_list
     assert set(new_replica_tag_list) <= set(new_all_tag_list)
+
+    # the old_replica_tag_list must not be subset of all_tag_list
     assert not set(old_replica_tag_list) <= set(new_all_tag_list)
 
 
@@ -164,5 +170,7 @@ def test_not_killing_replicas(serve_instance):
     global_state.refresh_actor_handle_cache()
     new_all_tag_list = list(global_state.actor_handle_cache.keys())
 
+    # the old and new replica tag list should be identical
+    # and should be subset of all_tag_list
     assert set(old_replica_tag_list) <= set(new_all_tag_list)
     assert set(old_replica_tag_list) == set(new_replica_tag_list)

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -172,6 +172,7 @@ def test_not_killing_replicas(serve_instance):
         def __init__(self):
             self.count = 0
 
+        @serve.accept_batch
         def __call__(self, flask_request, temp=None):
             batch_size = serve.context.batch_size
             return [1] * batch_size

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -5,6 +5,7 @@ import requests
 from ray.experimental import serve
 from ray.experimental.serve import BackendConfig
 import ray
+from ray.experimental.serve.exceptions import RayServeException
 
 
 def test_e2e(serve_instance):
@@ -128,7 +129,7 @@ def test_batching_exception(serve_instance):
     serve.link("exception-test", "exception:v1")
 
     handle = serve.get_handle("exception-test")
-    with pytest.raises(Exception) as e:
+    with pytest.raises(RayServeException) as e:
         assert handle.remote(temp=1)
     assert str(e.value) == ("__call__ function "
                             "doesn't preserve batch-size. "

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -6,6 +6,7 @@ from ray.experimental import serve
 from ray.experimental.serve import BackendConfig
 import ray
 
+
 def test_e2e(serve_instance):
     serve.init()  # so we have access to global state
     serve.create_endpoint("endpoint", "/api", blocking=True)
@@ -110,6 +111,7 @@ def test_batching(serve_instance):
     # counter result will always be less than 20
     assert max(counter_result) < 20
 
+
 def test_batching_exception(serve_instance):
     class NoListReturned:
         def __init__(self):
@@ -129,6 +131,7 @@ def test_batching_exception(serve_instance):
     handle = serve.get_handle("exception-test")
     with pytest.raises(ray.exceptions.RayTaskError):
         assert ray.get(handle.remote(temp=1))
+
 
 def test_killing_replicas(serve_instance):
     class Simple:

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -127,7 +127,7 @@ def test_batching_exception(serve_instance):
         NoListReturned, "exception:v1", backend_config=b_config)
     serve.link("exception-test", "exception:v1")
 
-    handle = serve.get_handle("exception-test"")
+    handle = serve.get_handle("exception-test")
     with pytest.raises(Exception) as e:
         assert handle.remote(temp=1)
     assert str(e.value) == ("__call__ function "

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -7,7 +7,7 @@ import io
 
 import requests
 from pygments import formatters, highlight, lexers
-from ray.experimental.serve.context import FakeFlaskQuest, TaskContext
+from ray.experimental.serve.context import FakeFlaskRequest, TaskContext
 from ray.experimental.serve.http_util import build_flask_request
 
 
@@ -20,7 +20,7 @@ def parse_request_item(request_item):
         kwargs = {}
     else:
         is_web_context = False
-        args = (FakeFlaskQuest(), )
+        args = (FakeFlaskRequest(), )
         kwargs = request_item.request_kwargs
 
     result_object_id = request_item.result_object_id

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -10,12 +10,12 @@ from pygments import formatters, highlight, lexers
 from ray.experimental.serve.context import FakeFlaskQuest, TaskContext
 from ray.experimental.serve.http_util import build_flask_request
 
+
 def parse_request_item(request_item):
     if request_item.request_context == TaskContext.Web:
         is_web_context = True
         asgi_scope, body_bytes = request_item.request_args
-        flask_request = build_flask_request(asgi_scope,
-                                            io.BytesIO(body_bytes))
+        flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes))
         args = (flask_request, )
         kwargs = {}
     else:
@@ -25,6 +25,7 @@ def parse_request_item(request_item):
 
     result_object_id = request_item.result_object_id
     return args, kwargs, is_web_context, result_object_id
+
 
 def _get_logger():
     logger = logging.getLogger("ray.serve")

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -3,6 +3,7 @@ import logging
 import random
 import string
 import time
+import io
 
 import requests
 from pygments import formatters, highlight, lexers

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -6,7 +6,23 @@ import time
 
 import requests
 from pygments import formatters, highlight, lexers
+from ray.experimental.serve.context import FakeFlaskQuest, TaskContext
 
+def parse_request_item(request_item):
+    if request_item.request_context == TaskContext.Web:
+        is_web_context = True
+        asgi_scope, body_bytes = request_item.request_args
+        flask_request = build_flask_request(asgi_scope,
+                                            io.BytesIO(body_bytes))
+        args = (flask_request, )
+        kwargs = {}
+    else:
+        is_web_context = False
+        args = (FakeFlaskQuest(), )
+        kwargs = request_item.request_kwargs
+
+    result_object_id = request_item.result_object_id
+    return args, kwargs, is_web_context, result_object_id
 
 def _get_logger():
     logger = logging.getLogger("ray.serve")

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -7,6 +7,7 @@ import time
 import requests
 from pygments import formatters, highlight, lexers
 from ray.experimental.serve.context import FakeFlaskQuest, TaskContext
+from ray.experimental.serve.http_util import build_flask_request
 
 def parse_request_item(request_item):
     if request_item.request_context == TaskContext.Web:


### PR DESCRIPTION
1. Added BackendConfig
2. Added set_backend_config, get_backend_config
3. BackendConfig is saved in the persistent.
4. Router also has BackendConfig info
5. Added pytest and examples
6. Added batching support in ray serve

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
