### PR TITLE
Work around some compile errors for boost::asio::generic::stream_protocol

### DIFF
--- a/src/ray/object_manager/object_store_notification_manager.cc
+++ b/src/ray/object_manager/object_store_notification_manager.cc
@@ -24,7 +24,12 @@ ObjectStoreNotificationManager::ObjectStoreNotificationManager(
 
   RAY_ARROW_CHECK_OK(store_client_.Subscribe(&c_socket_));
   boost::system::error_code ec;
-  socket_.assign(local_stream_protocol(), c_socket_, ec);
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+  local_stream_protocol sp;
+#else  // TODO(mehrdadn): HACK: FIXME: This is just to get things compiling!
+  local_stream_protocol sp(AF_UNIX, 0);
+#endif
+  socket_.assign(sp, c_socket_, ec);
   assert(!ec.value());
   NotificationWait();
 }

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -51,7 +51,13 @@ Raylet::Raylet(boost::asio::io_service &main_service, const std::string &socket_
       node_manager_(main_service, node_manager_config, object_manager_, gcs_client_,
                     object_directory_),
       socket_name_(socket_name),
-      acceptor_(main_service, local_stream_protocol::endpoint(socket_name)),
+      acceptor_(main_service, local_stream_protocol::endpoint(
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+                                  socket_name
+#else  // TODO(mehrdadn): HACK: FIXME: This is just to get things compiling!
+                                  socket_name.data(), socket_name.size()
+#endif
+                                  )),
       socket_(main_service) {
   // Start listening for clients.
   DoAccept();

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -76,7 +76,7 @@ class Raylet {
   std::string socket_name_;
 
   /// An acceptor for new clients.
-  local_stream_protocol::acceptor acceptor_;
+  boost::asio::basic_socket_acceptor<local_stream_protocol> acceptor_;
   /// The socket to listen on for new clients.
   local_stream_protocol::socket socket_;
 };


### PR DESCRIPTION
## Why are these changes needed?

Works around some UNIX socket incompatibilities on Windows to allow the code to at least compile.  
Working implementations will be provided in a later PR.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
