### PR TITLE
Fix Arrow and Windows linking issues in Bazel

### DIFF
--- a/bazel/BUILD.plasma
+++ b/bazel/BUILD.plasma
@@ -32,6 +32,7 @@ cc_library(
         "cpp/src/arrow/util/string.cc",
         "cpp/src/arrow/util/string_builder.cc",
         "cpp/src/arrow/util/thread_pool.cc",
+        "cpp/src/arrow/util/utf8.cc",
     ],
     hdrs = [
         "cpp/src/arrow/buffer.h",
@@ -64,6 +65,8 @@ cc_library(
         "cpp/src/arrow/util/visibility.h",
         "cpp/src/arrow/util/windows_compatibility.h",
         "cpp/src/arrow/vendored/string_view.hpp",
+        "cpp/src/arrow/vendored/utf8cpp/checked.h",
+        "cpp/src/arrow/vendored/utf8cpp/core.h",
         "cpp/src/arrow/vendored/variant.hpp",
         "cpp/src/arrow/vendored/xxhash.h",
         "cpp/src/arrow/vendored/xxhash/xxh3.h",

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -119,6 +119,8 @@ def ray_deps_setup():
         url = "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz",
         patches = [
             "//thirdparty/patches:boost-exception-no_warn_typeid_evaluated.patch",
+            # Prefer compiler intrinsics; they're faster & avoid linker issues
+            "//thirdparty/patches:boost-interlocked-prefer-intrinsics.patch",
             # Backport Clang-Cl patch on Boost 1.69 to Boost <= 1.68:
             #   https://lists.boost.org/Archives/boost/2018/09/243420.php
             "//thirdparty/patches:boost-type_traits-trivial_move.patch",
@@ -133,6 +135,7 @@ def ray_deps_setup():
         sha256 = "3775c5ab217e0c9cc380f56e243a4d75fe6fee8eaee1447899eaa04c5d582cf1",
         patches = [
             "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
+            "//thirdparty/patches:rules_boost-windows-linkopts.patch",
         ],
     )
 

--- a/thirdparty/patches/boost-interlocked-prefer-intrinsics.patch
+++ b/thirdparty/patches/boost-interlocked-prefer-intrinsics.patch
@@ -1,0 +1,10 @@
+diff --git boost/detail/interlocked.hpp boost/detail/interlocked.hpp
+--- boost/detail/interlocked.hpp
++++ boost/detail/interlocked.hpp
+@@ -21,1 +21,1 @@
+-#if defined( BOOST_USE_WINDOWS_H )
++#if 0
+@@ -33,1 +33,1 @@
+-#elif defined( BOOST_USE_INTRIN_H )
++#elif defined( BOOST_USE_INTRIN_H ) || defined(_WIN32)
+-- 

--- a/thirdparty/patches/rules_boost-windows-linkopts.patch
+++ b/thirdparty/patches/rules_boost-windows-linkopts.patch
@@ -1,0 +1,15 @@
+diff --git BUILD.boost BUILD.boost
+--- BUILD.boost
++++ BUILD.boost
+@@ -313,1 +313,9 @@ boost_library(name = "asio",
+-    linkopts = ["-lpthread"],
++    linkopts = select({
++        ":linux": [
++            "-lpthread",
++        ],
++        ":osx_x86_64": [
++            "-lpthread",
++        ],
++        "//conditions:default": [],
++    }),
+-- 


### PR DESCRIPTION
## Why are these changes needed?

- Some Arrow files (for `utf8cpp`) are missing declarations in the Bazel files
- Some obscure linking issues exist on Windows which can be avoided via compiler intrinsics

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
