### PR TITLE
Make JSON schema for projects more explicit

### DIFF
--- a/python/ray/projects/schema.json
+++ b/python/ray/projects/schema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "name": {
@@ -13,16 +14,16 @@
       "description": "The URL of the repo this project is part of",
       "type": "string"
     },
+    "documentation": {
+      "description": "Link to the documentation of this project",
+      "type": "string"
+    },
     "tags": {
       "description": "Relevant tags for this project",
       "type": "array",
       "items": {
         "type": "string"
       }
-    },
-    "documentation": {
-      "description": "Link to the documentation of this project",
-      "type": "string"
     },
     "cluster": {
       "type": "object",
@@ -91,7 +92,8 @@
             "type": "string"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "commands": {
       "type": "array",
@@ -103,11 +105,15 @@
             "description": "Name of the command",
             "type": "string"
           },
+          "help": {
+            "description": "Help string for the command",
+            "type": "string"
+          },
           "command": {
             "description": "Shell command to run on the cluster",
             "type": "string"
           },
-          "params" : {
+          "params": {
             "type": "array",
             "items": {
               "description": "Possible parameters in the command",
@@ -124,8 +130,23 @@
                 "choices": {
                   "description": "Possible values the parameter can take",
                   "type": "array"
+                },
+                "default": {
+                },
+                "type": {
+                  "description": "Required type for the parameter",
+                  "type": "string",
+                  "enum": [
+                    "int",
+                    "float",
+                    "str"
+                  ]
                 }
-              }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false
             }
           },
           "config": {
@@ -142,12 +163,18 @@
               "additionalProperties": false
             }
           }
-        }
+        },
+        "required": [
+          "name",
+          "command"
+        ],
+        "additionalProperties": false
       }
     }
   },
   "required": [
     "name",
     "cluster"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/python/ray/projects/schema.json
+++ b/python/ray/projects/schema.json
@@ -170,7 +170,8 @@
         ],
         "additionalProperties": false
       }
-    }
+    },
+    "output_files": {}
   },
   "required": [
     "name",

--- a/python/ray/tests/project_files/docker_project/ray-project/project.yaml
+++ b/python/ray/tests/project_files/docker_project/ray-project/project.yaml
@@ -2,7 +2,7 @@ name: testproject1
 description: "Test project for docker environment"
 
 environment:
-  docker: "Dockerfile"
+  dockerfile: "Dockerfile"
 
 cluster:
   config: cluster.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR updates the JSON schema file for projects by making it more explicit and conservative about the files it's willing to accept.

@pcmoritz Can you confirm that all the existing project files still validate against this schema?

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
