### PR TITLE
Check that the core worker is connected before disconnecting clients

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -156,6 +156,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       WorkerID::FromBinary(worker_context_.GetWorkerID().Binary()),
       (worker_type_ == ray::WorkerType::WORKER), worker_context_.GetCurrentJobID(),
       language_, &local_raylet_id, core_worker_server_.GetPort()));
+  connected_ = true;
 
   // Set our own address.
   RAY_CHECK(!local_raylet_id.IsNil());
@@ -266,11 +267,14 @@ void CoreWorker::Shutdown() {
 
 void CoreWorker::Disconnect() {
   io_service_.stop();
-  if (gcs_client_) {
-    gcs_client_->Disconnect();
-  }
-  if (local_raylet_client_) {
-    RAY_IGNORE_EXPR(local_raylet_client_->Disconnect());
+  if (connected_) {
+    connected_ = false;
+    if (gcs_client_) {
+      gcs_client_->Disconnect();
+    }
+    if (local_raylet_client_) {
+      RAY_IGNORE_EXPR(local_raylet_client_->Disconnect());
+    }
   }
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -560,6 +560,9 @@ class CoreWorker {
   /// Address of our RPC server.
   rpc::Address rpc_address_;
 
+  /// Whether or not this worker is connected to the raylet and GCS.
+  bool connected_ = false;
+
   // Client to the GCS shared by core worker interfaces.
   std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Should fix recent error messages on Travis tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
