### PR TITLE
Fix FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated

### DIFF
--- a/python/ray/experimental/array/distributed/core.py
+++ b/python/ray/experimental/array/distributed/core.py
@@ -63,8 +63,8 @@ class DistArray(object):
         for index in np.ndindex(*self.num_blocks):
             lower = DistArray.compute_block_lower(index, self.shape)
             upper = DistArray.compute_block_upper(index, self.shape)
-            result[[slice(l, u) for (l, u) in zip(lower, upper)]] = ray.get(
-                self.objectids[index])
+            value = ray.get(self.objectids[index])
+            result[tuple(slice(l, u) for (l, u) in zip(lower, upper))] = value
         return result
 
     def __getitem__(self, sliced):
@@ -86,8 +86,8 @@ def numpy_to_dist(a):
     for index in np.ndindex(*result.num_blocks):
         lower = DistArray.compute_block_lower(index, a.shape)
         upper = DistArray.compute_block_upper(index, a.shape)
-        result.objectids[index] = ray.put(
-            a[[slice(l, u) for (l, u) in zip(lower, upper)]])
+        idx = tuple(slice(l, u) for (l, u) in zip(lower, upper))
+        result.objectids[index] = ray.put(a[idx])
     return result
 
 

--- a/python/ray/experimental/array/remote/core.py
+++ b/python/ray/experimental/array/remote/core.py
@@ -47,7 +47,8 @@ def hstack(*xs):
 # TODO(rkn): Be consistent about using "index" versus "indices".
 @ray.remote
 def subarray(a, lower_indices, upper_indices):
-    return a[[slice(l, u) for (l, u) in zip(lower_indices, upper_indices)]]
+    idx = tuple(slice(l, u) for (l, u) in zip(lower_indices, upper_indices))
+    return a[idx]
 
 
 @ray.remote


### PR DESCRIPTION
## Why are these changes needed?

Code will break, and also warnings are very noisy.


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
