### PR TITLE
[Dashboard] Collecting worker stats in node manager and implement webui display in the backend

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -121,6 +121,7 @@ from ray.worker import (
     register_custom_serializer,
     remote,
     shutdown,
+    show_in_webui,
     wait,
 )  # noqa: E402
 import ray.internal  # noqa: E402
@@ -169,6 +170,7 @@ __all__ = [
     "register_custom_serializer",
     "remote",
     "shutdown",
+    "show_in_webui",
     "wait",
 ]
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -804,6 +804,9 @@ cdef class CoreWorker:
     def get_actor_id(self):
         return ActorID(self.core_worker.get().GetActorId().Binary())
 
+    def set_webui_display(self, message):
+        self.core_worker.get().SetWebuiDisplay(message)
+
     def get_objects(self, object_ids, TaskID current_task_id,
                     int64_t timeout_ms=-1):
         cdef:

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -388,7 +388,8 @@ class RayletStats(threading.Thread):
             for node in self.nodes:
                 node_id = node["NodeID"]
                 stub = self.stubs[node_id]
-                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=2)
+                reply = stub.GetNodeStats(
+                    node_manager_pb2.NodeStatsRequest(), timeout=2)
                 replies[node["NodeManagerAddress"]] = reply
             with self._raylet_stats_lock:
                 for address, reply in replies.items():

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -160,7 +160,7 @@ class Dashboard(object):
         async def raylet_info(req) -> aiohttp.web.Response:
             D = self.raylet_stats.get_raylet_stats()
             for address, data in D.items():
-                print(data.get("webuiDisplay", "KEY NOT EXISTS"))
+                # The webui string is in the worker stats
                 available_resources = data["availableResources"]
                 total_resources = data["totalResources"]
                 extra_info = ""

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -388,10 +388,7 @@ class RayletStats(threading.Thread):
             for node in self.nodes:
                 node_id = node["NodeID"]
                 stub = self.stubs[node_id]
-                print("requesting reply from {}".format(node_id))
-                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
-                # reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=2)
-                print("XXX reply: {}".format(reply))
+                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=2)
                 replies[node["NodeManagerAddress"]] = reply
             with self._raylet_stats_lock:
                 for address, reply in replies.items():

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -160,7 +160,6 @@ class Dashboard(object):
         async def raylet_info(req) -> aiohttp.web.Response:
             D = self.raylet_stats.get_raylet_stats()
             for address, data in D.items():
-                # The webui string is in the worker stats
                 available_resources = data["availableResources"]
                 total_resources = data["totalResources"]
                 extra_info = ""

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -160,6 +160,7 @@ class Dashboard(object):
         async def raylet_info(req) -> aiohttp.web.Response:
             D = self.raylet_stats.get_raylet_stats()
             for address, data in D.items():
+                print(data.get("webuiDisplay", "KEY NOT EXISTS"))
                 available_resources = data["availableResources"]
                 total_resources = data["totalResources"]
                 extra_info = ""
@@ -387,7 +388,10 @@ class RayletStats(threading.Thread):
             for node in self.nodes:
                 node_id = node["NodeID"]
                 stub = self.stubs[node_id]
+                print("requesting reply from {}".format(node_id))
                 reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
+                # reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=2)
+                print("XXX reply: {}".format(reply))
                 replies[node["NodeManagerAddress"]] = reply
             with self._raylet_stats_lock:
                 for address, reply in replies.items():

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -109,6 +109,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CJobID GetCurrentJobId()
         CTaskID GetCurrentTaskId()
         const CActorID &GetActorId()
+        void SetWebuiDisplay(const c_string &message)
         CTaskID GetCallerId()
         const ResourceMappingType &GetResourceIDs() const
         CActorID DeserializeAndRegisterActorHandle(const c_string &bytes)

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -56,23 +56,27 @@ def test_worker_stats(ray_start_regular):
     # Test show_in_webui for remote functions. 
     worker_pid = ray.get(f.remote())
     reply = try_get_node_stats()
+    target_worker_present = False
     for worker in reply.workers_stats:
         if worker.webui_display == "test":
-            print("{} shows test message".format(worker.pid))
+            target_worker_present = True
             assert worker.pid == worker_pid
         else:
             assert worker.webui_display == ""
+    assert target_worker_present
     
     # Test show_in_webui for remote actors. 
     a = Actor.remote()
     worker_pid = ray.get(a.f.remote())
     reply = try_get_node_stats()
+    target_worker_preset = False
     for worker in reply.workers_stats:
         if worker.webui_display == "test":
-            print("{} shows test message".format(worker.pid))
+            target_worker_present = True
             assert worker.pid == worker_pid
         else:
             assert worker.webui_display == ""
+    assert target_worker_present
     
     timeout_seconds = 20
     start_time = time.time()
@@ -84,7 +88,6 @@ def test_worker_stats(ray_start_regular):
         # Wait for the workers to start.
         if len(reply.workers_stats) < num_cpus + 1:
             time.sleep(1)
-            # reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
             reply = try_get_node_stats()
             continue
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -21,12 +21,59 @@ def test_worker_stats(ray_start_regular):
 
     channel = grpc.insecure_channel(raylet_address)
     stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
-    reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
+
+    def try_get_node_stats(num_retry=5, timeout=2):
+        reply = None
+        for _ in range(num_retry):
+            try:
+                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=timeout)
+                break
+            except:
+                continue
+        assert reply is not None
+        return reply
+    
+    reply = try_get_node_stats()
     # Check that there is one connected driver.
     drivers = [worker for worker in reply.workers_stats if worker.is_driver]
     assert len(drivers) == 1
     assert os.getpid() == drivers[0].pid
 
+    @ray.remote
+    def f():
+        ray.show_in_webui("test")
+        return os.getpid()
+
+    @ray.remote
+    class Actor(object):
+        def __init__(self):
+            pass
+        
+        def f(self):
+            ray.show_in_webui("test")
+            return os.getpid()
+
+    # Test show_in_webui for remote functions. 
+    worker_pid = ray.get(f.remote())
+    reply = try_get_node_stats()
+    for worker in reply.workers_stats:
+        if worker.webui_display == "test":
+            print("{} shows test message".format(worker.pid))
+            assert worker.pid == worker_pid
+        else:
+            assert worker.webui_display == ""
+    
+    # Test show_in_webui for remote actors. 
+    a = Actor.remote()
+    worker_pid = ray.get(a.f.remote())
+    reply = try_get_node_stats()
+    for worker in reply.workers_stats:
+        if worker.webui_display == "test":
+            print("{} shows test message".format(worker.pid))
+            assert worker.pid == worker_pid
+        else:
+            assert worker.webui_display == ""
+    
     timeout_seconds = 20
     start_time = time.time()
     while True:
@@ -37,7 +84,8 @@ def test_worker_stats(ray_start_regular):
         # Wait for the workers to start.
         if len(reply.workers_stats) < num_cpus + 1:
             time.sleep(1)
-            reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
+            # reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest())
+            reply = try_get_node_stats()
             continue
 
         # Check that the rest of the processes are workers, 1 for each CPU.

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -26,13 +26,14 @@ def test_worker_stats(ray_start_regular):
         reply = None
         for _ in range(num_retry):
             try:
-                reply = stub.GetNodeStats(node_manager_pb2.NodeStatsRequest(), timeout=timeout)
+                reply = stub.GetNodeStats(
+                    node_manager_pb2.NodeStatsRequest(), timeout=timeout)
                 break
-            except:
+            except grpc.RpcError:
                 continue
         assert reply is not None
         return reply
-    
+
     reply = try_get_node_stats()
     # Check that there is one connected driver.
     drivers = [worker for worker in reply.workers_stats if worker.is_driver]
@@ -48,12 +49,12 @@ def test_worker_stats(ray_start_regular):
     class Actor(object):
         def __init__(self):
             pass
-        
+
         def f(self):
             ray.show_in_webui("test")
             return os.getpid()
 
-    # Test show_in_webui for remote functions. 
+    # Test show_in_webui for remote functions.
     worker_pid = ray.get(f.remote())
     reply = try_get_node_stats()
     target_worker_present = False
@@ -64,12 +65,12 @@ def test_worker_stats(ray_start_regular):
         else:
             assert worker.webui_display == ""
     assert target_worker_present
-    
-    # Test show_in_webui for remote actors. 
+
+    # Test show_in_webui for remote actors.
     a = Actor.remote()
     worker_pid = ray.get(a.f.remote())
     reply = try_get_node_stats()
-    target_worker_preset = False
+    target_worker_present = False
     for worker in reply.workers_stats:
         if worker.webui_display == "test":
             target_worker_present = True
@@ -77,7 +78,7 @@ def test_worker_stats(ray_start_regular):
         else:
             assert worker.webui_display == ""
     assert target_worker_present
-    
+
     timeout_seconds = 20
     start_time = time.time()
     while True:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1413,6 +1413,10 @@ def register_custom_serializer(cls,
 def show_in_webui(message):
     """Display message in dashboard. 
 
+    Display message for the current task or actor in the dashboard. 
+    For example, this can be used to display the status of a long-running 
+    computation. 
+
     Args:
         message (str): Message to be displayed. 
     """

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1410,6 +1410,17 @@ def register_custom_serializer(cls,
         class_id=class_id)
 
 
+def show_in_webui(message):
+    """Display message in dashboard. 
+
+    Args:
+        message (str): Message to be displayed. 
+    """
+    worker = global_worker
+    worker.check_connected()
+    worker.core_worker.set_webui_display(message.encode())
+
+
 def get(object_ids, timeout=None):
     """Get a remote object or a list of remote objects from the object store.
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1413,14 +1413,14 @@ def register_custom_serializer(cls,
 
 
 def show_in_webui(message):
-    """Display message in dashboard. 
+    """Display message in dashboard.
 
-    Display message for the current task or actor in the dashboard. 
-    For example, this can be used to display the status of a long-running 
-    computation. 
+    Display message for the current task or actor in the dashboard.
+    For example, this can be used to display the status of a long-running
+    computation.
 
     Args:
-        message (str): Message to be displayed. 
+        message (str): Message to be displayed.
     """
     worker = global_worker
     worker.check_connected()

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1068,7 +1068,7 @@ void CoreWorker::HandleGetObjectStatus(const rpc::GetObjectStatusRequest &reques
 void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,
                                           rpc::GetCoreWorkerStatsReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
-  reply->set_webui_display("XXX webui string: " + actor_id_.Hex());
+  reply->set_webui_display(webui_display_);
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1065,6 +1065,13 @@ void CoreWorker::HandleGetObjectStatus(const rpc::GetObjectStatusRequest &reques
   }
 }
 
+void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,
+                                          rpc::GetCoreWorkerStatsReply *reply,
+                                          rpc::SendReplyCallback send_reply_callback) {
+  reply->set_webui_display("XXX webui string: " + actor_id_.Hex());
+  send_reply_callback(Status::OK(), nullptr, nullptr);
+}
+
 void CoreWorker::YieldCurrentFiber(FiberEvent &event) {
   RAY_CHECK(worker_context_.CurrentActorIsAsync());
   boost::this_fiber::yield();

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -102,6 +102,10 @@ class CoreWorker {
     actor_id_ = actor_id;
   }
 
+  void SetWebuiDisplay(const std::string &message) {
+    webui_display_ = message;
+  }
+
   /// Increase the reference count for this object ID.
   ///
   /// \param[in] object_id The object ID to increase the reference count for.
@@ -625,6 +629,9 @@ class CoreWorker {
 
   /// Our actor ID. If this is nil, then we execute only stateless tasks.
   ActorID actor_id_;
+
+  /// String to be displayed on Web UI. 
+  std::string webui_display_;
 
   /// Event loop where tasks are processed.
   boost::asio::io_service task_execution_service_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -102,9 +102,7 @@ class CoreWorker {
     actor_id_ = actor_id;
   }
 
-  void SetWebuiDisplay(const std::string &message) {
-    webui_display_ = message;
-  }
+  void SetWebuiDisplay(const std::string &message) { webui_display_ = message; }
 
   /// Increase the reference count for this object ID.
   /// Increase the local reference count for this object ID. Should be called
@@ -637,7 +635,7 @@ class CoreWorker {
   /// Our actor ID. If this is nil, then we execute only stateless tasks.
   ActorID actor_id_;
 
-  /// String to be displayed on Web UI. 
+  /// String to be displayed on Web UI.
   std::string webui_display_;
 
   /// Event loop where tasks are processed.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -32,7 +32,8 @@
   RAY_CORE_WORKER_RPC_HANDLER(AssignTask, 5)                       \
   RAY_CORE_WORKER_RPC_HANDLER(PushTask, 9999)                      \
   RAY_CORE_WORKER_RPC_HANDLER(DirectActorCallArgWaitComplete, 100) \
-  RAY_CORE_WORKER_RPC_HANDLER(GetObjectStatus, 9999)
+  RAY_CORE_WORKER_RPC_HANDLER(GetObjectStatus, 9999)               \
+  RAY_CORE_WORKER_RPC_HANDLER(GetCoreWorkerStats, 100)
 
 namespace ray {
 
@@ -393,6 +394,11 @@ class CoreWorker {
   void HandleGetObjectStatus(const rpc::GetObjectStatusRequest &request,
                              rpc::GetObjectStatusReply *reply,
                              rpc::SendReplyCallback send_reply_callback);
+
+  /// Get statistics from core worker.
+  void HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,
+                                rpc::GetCoreWorkerStatsReply *reply,
+                                rpc::SendReplyCallback send_reply_callback);
 
   ///
   /// Public methods related to async actor call. This should only be used when

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -115,6 +115,16 @@ message GetObjectStatusReply {
   ObjectStatus status = 1;
 }
 
+message GetCoreWorkerStatsRequest {
+  // The ID of the worker this message is intended for.
+  bytes intended_worker_id = 1;
+}
+
+message GetCoreWorkerStatsReply {
+  // String displayed on Web UI. 
+  string webui_display = 1;  
+}
+
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
   rpc AssignTask(AssignTaskRequest) returns (AssignTaskReply);
@@ -125,4 +135,6 @@ service CoreWorkerService {
       returns (DirectActorCallArgWaitCompleteReply);
   // Ask the object's owner about the object's current status.
   rpc GetObjectStatus(GetObjectStatusRequest) returns (GetObjectStatusReply);
+  // Get metrics from core workers. 
+  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -123,8 +123,8 @@ message GetCoreWorkerStatsRequest {
 }
 
 message GetCoreWorkerStatsReply {
-  // String displayed on Web UI. 
-  string webui_display = 1;  
+  // String displayed on Web UI.
+  string webui_display = 1;
 }
 
 service CoreWorkerService {
@@ -137,6 +137,6 @@ service CoreWorkerService {
       returns (DirectActorCallArgWaitCompleteReply);
   // Ask the object's owner about the object's current status.
   rpc GetObjectStatus(GetObjectStatusRequest) returns (GetObjectStatusReply);
-  // Get metrics from core workers. 
+  // Get metrics from core workers.
   rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
 }

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -53,7 +53,7 @@ message WorkerStats {
   uint32 pid = 1;
   // Whether this is a driver.
   bool is_driver = 2;
-  // String displayed on Web UI. 
+  // String displayed on Web UI.
   string webui_display = 3;
 }
 

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -86,7 +86,7 @@ message NodeStatsReply {
   repeated ViewData view_data = 2;
   map<string, double> available_resources = 3;
   map<string, double> total_resources = 4;
-  int32 num_workers = 5;
+  uint32 num_workers = 5;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -53,6 +53,8 @@ message WorkerStats {
   uint32 pid = 1;
   // Whether this is a driver.
   bool is_driver = 2;
+  // String displayed on Web UI. 
+  string webui_display = 3;
 }
 
 message ViewData {
@@ -84,6 +86,7 @@ message NodeStatsReply {
   repeated ViewData view_data = 2;
   map<string, double> available_resources = 3;
   map<string, double> total_resources = 4;
+  int32 num_workers = 5;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3034,25 +3034,27 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
       }
     }
   }
-  // As a result of the HandleNodeStatsRequest, we are collecting information from all workers
-  // on this node. This is done by calling GetCoreWorkerStats on each worker. In order to send 
-  // up-to-date information back, we wait until all workers have replied, and return the information
-  // from HandleNodesStatsRequest. 
-  // The caller of HandleNodeStatsRequest should set a timeout so that the rpc finishes even if
-  // not all workers have replied. 
+  // As a result of the HandleNodeStatsRequest, we are collecting information from all
+  // workers on this node. This is done by calling GetCoreWorkerStats on each worker. In
+  // order to send up-to-date information back, we wait until all workers have replied,
+  // and return the information from HandleNodesStatsRequest. The caller of
+  // HandleNodeStatsRequest should set a timeout so that the rpc finishes even if not all
+  // workers have replied.
   auto all_workers = worker_pool_.GetAllWorkers();
   for (const auto &worker : all_workers) {
-    rpc::GetCoreWorkerStatsRequest request; 
+    rpc::GetCoreWorkerStatsRequest request;
     request.set_intended_worker_id(worker->WorkerId().Binary());
     auto status = worker->rpc_client()->GetCoreWorkerStats(
-        request, [reply, worker, all_workers, send_reply_callback](const ray::Status &status, const rpc::GetCoreWorkerStatsReply &r) {
+        request, [reply, worker, all_workers, send_reply_callback](
+                     const ray::Status &status, const rpc::GetCoreWorkerStatsReply &r) {
           if (!status.ok()) {
-            RAY_LOG(WARNING) << "Failed to send get core worker stats request: " << status.ToString();
+            RAY_LOG(WARNING) << "Failed to send get core worker stats request: "
+                             << status.ToString();
           } else {
             auto worker_stats = reply->add_workers_stats();
             worker_stats->set_pid(worker->Pid());
             worker_stats->set_is_driver(false);
-            reply->set_num_workers(reply->num_workers()+1);
+            reply->set_num_workers(reply->num_workers() + 1);
             worker_stats->set_webui_display(r.webui_display());
             if (reply->num_workers() == all_workers.size()) {
               send_reply_callback(Status::OK(), nullptr, nullptr);
@@ -3060,7 +3062,8 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
           }
         });
     if (!status.ok()) {
-      RAY_LOG(WARNING) << "Failed to send get core worker stats request: " << status.ToString();
+      RAY_LOG(WARNING) << "Failed to send get core worker stats request: "
+                       << status.ToString();
     }
   }
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3036,19 +3036,18 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
   }
   auto all_workers = worker_pool_.GetAllWorkers();
   for (const auto &worker : all_workers) {
-    auto worker_stats = reply->add_workers_stats();
-    worker_stats->set_pid(worker->Pid());
-    worker_stats->set_is_driver(false);
     rpc::GetCoreWorkerStatsRequest request; 
     request.set_intended_worker_id(worker->WorkerId().Binary());
     auto status = worker->rpc_client()->GetCoreWorkerStats(
-        request, [worker_stats, reply, worker, all_workers, send_reply_callback](const ray::Status &status, const rpc::GetCoreWorkerStatsReply &) {
+        request, [reply, worker, all_workers, send_reply_callback](const ray::Status &status, const rpc::GetCoreWorkerStatsReply &r) {
           if (!status.ok()) {
             RAY_LOG(WARNING) << "Failed to send get core worker stats request: " << status.ToString();
           } else {
-            RAY_LOG(WARNING) << "Num Workers: " << std::to_string(reply->num_workers());
+            auto worker_stats = reply->add_workers_stats();
+            worker_stats->set_pid(worker->Pid());
+            worker_stats->set_is_driver(false);
             reply->set_num_workers(reply->num_workers()+1);
-            worker_stats->set_webui_display(std::to_string(worker->Pid()));
+            worker_stats->set_webui_display(r.webui_display());
             if (reply->num_workers() == all_workers.size()) {
               send_reply_callback(Status::OK(), nullptr, nullptr);
             }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3034,6 +3034,12 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
       }
     }
   }
+  // As a result of the HandleNodeStatsRequest, we are collecting information from all workers
+  // on this node. This is done by calling GetCoreWorkerStats on each worker. In order to send 
+  // up-to-date information back, we wait until all workers have replied, and return the information
+  // from HandleNodesStatsRequest. 
+  // The caller of HandleNodeStatsRequest should set a timeout so that the rpc finishes even if
+  // not all workers have replied. 
   auto all_workers = worker_pool_.GetAllWorkers();
   for (const auto &worker : all_workers) {
     rpc::GetCoreWorkerStatsRequest request; 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2974,11 +2974,6 @@ std::string compact_tag_string(const opencensus::stats::ViewDescriptor &view,
 void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
                                          rpc::NodeStatsReply *reply,
                                          rpc::SendReplyCallback send_reply_callback) {
-  for (const auto &worker : worker_pool_.GetAllWorkers()) {
-    auto worker_stats = reply->add_workers_stats();
-    worker_stats->set_pid(worker->Pid());
-    worker_stats->set_is_driver(false);
-  }
   for (const auto &driver : worker_pool_.GetAllDrivers()) {
     auto worker_stats = reply->add_workers_stats();
     worker_stats->set_pid(driver->Pid());
@@ -3039,7 +3034,30 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
       }
     }
   }
-  send_reply_callback(Status::OK(), nullptr, nullptr);
+  auto all_workers = worker_pool_.GetAllWorkers();
+  for (const auto &worker : all_workers) {
+    auto worker_stats = reply->add_workers_stats();
+    worker_stats->set_pid(worker->Pid());
+    worker_stats->set_is_driver(false);
+    rpc::GetCoreWorkerStatsRequest request; 
+    request.set_intended_worker_id(worker->WorkerId().Binary());
+    auto status = worker->rpc_client()->GetCoreWorkerStats(
+        request, [worker_stats, reply, worker, all_workers, send_reply_callback](const ray::Status &status, const rpc::GetCoreWorkerStatsReply &) {
+          if (!status.ok()) {
+            RAY_LOG(WARNING) << "Failed to send get core worker stats request: " << status.ToString();
+          } else {
+            RAY_LOG(WARNING) << "Num Workers: " << std::to_string(reply->num_workers());
+            reply->set_num_workers(reply->num_workers()+1);
+            worker_stats->set_webui_display(std::to_string(worker->Pid()));
+            if (reply->num_workers() == all_workers.size()) {
+              send_reply_callback(Status::OK(), nullptr, nullptr);
+            }
+          }
+        });
+    if (!status.ok()) {
+      RAY_LOG(WARNING) << "Failed to send get core worker stats request: " << status.ToString();
+    }
+  }
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -68,6 +68,10 @@ class Worker {
   void DirectActorCallArgWaitComplete(int64_t tag);
   void WorkerLeaseGranted(const std::string &address, int port);
 
+  rpc::CoreWorkerClient* rpc_client() {
+         return rpc_client_.get();
+  }
+
  private:
   /// The worker's ID.
   WorkerID worker_id_;

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -68,9 +68,7 @@ class Worker {
   void DirectActorCallArgWaitComplete(int64_t tag);
   void WorkerLeaseGranted(const std::string &address, int port);
 
-  rpc::CoreWorkerClient* rpc_client() {
-         return rpc_client_.get();
-  }
+  rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }
 
  private:
   /// The worker's ID.

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -122,7 +122,7 @@ class CoreWorkerClientInterface {
   }
 
   virtual ray::Status GetCoreWorkerStats(
-      const GetCoreWorkerStatsRequest &request, 
+      const GetCoreWorkerStatsRequest &request,
       const ClientCallback<GetCoreWorkerStatsReply> &callback) {
     return Status::NotImplemented("");
   }
@@ -204,12 +204,13 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   }
 
   virtual ray::Status GetCoreWorkerStats(
-      const GetCoreWorkerStatsRequest &request, 
+      const GetCoreWorkerStatsRequest &request,
       const ClientCallback<GetCoreWorkerStatsReply> &callback) override {
-    auto call = client_call_manager_.CreateCall<CoreWorkerService, 
-                                                GetCoreWorkerStatsRequest, 
-                                                GetCoreWorkerStatsReply>(
-        *stub_, &CoreWorkerService::Stub::PrepareAsyncGetCoreWorkerStats, request, callback);
+    auto call =
+        client_call_manager_.CreateCall<CoreWorkerService, GetCoreWorkerStatsRequest,
+                                        GetCoreWorkerStatsReply>(
+            *stub_, &CoreWorkerService::Stub::PrepareAsyncGetCoreWorkerStats, request,
+            callback);
     return call->GetStatus();
   }
 

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -121,6 +121,12 @@ class CoreWorkerClientInterface {
     return Status::NotImplemented("");
   }
 
+  virtual ray::Status GetCoreWorkerStats(
+      const GetCoreWorkerStatsRequest &request, 
+      const ClientCallback<GetCoreWorkerStatsReply> &callback) {
+    return Status::NotImplemented("");
+  }
+
   virtual ~CoreWorkerClientInterface(){};
 };
 
@@ -194,6 +200,16 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
     auto call = client_call_manager_.CreateCall<CoreWorkerService, GetObjectStatusRequest,
                                                 GetObjectStatusReply>(
         *stub_, &CoreWorkerService::Stub::PrepareAsyncGetObjectStatus, request, callback);
+    return call->GetStatus();
+  }
+
+  virtual ray::Status GetCoreWorkerStats(
+      const GetCoreWorkerStatsRequest &request, 
+      const ClientCallback<GetCoreWorkerStatsReply> &callback) override {
+    auto call = client_call_manager_.CreateCall<CoreWorkerService, 
+                                                GetCoreWorkerStatsRequest, 
+                                                GetCoreWorkerStatsReply>(
+        *stub_, &CoreWorkerService::Stub::PrepareAsyncGetCoreWorkerStats, request, callback);
     return call->GetStatus();
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Implement callbacks to collect worker stats in node manager. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
