### PR TITLE
[Tune] call show_in_webui in trainable

### DIFF
--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -550,6 +550,7 @@ class Trainable(object):
         Args:
             result (dict): Training result returned by _train().
         """
+        ray.show_in_webui("mean accuracy: {}".format(result["mean_accuracy"]))
         self._result_logger.on_result(result)
 
     def _stop(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Call show_in_webui in trainable to display mean accuracy in dashboard. Should be merged after #6574 is merged. 

cc @richardliaw 
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
