### PR TITLE
Perform LLVM install directly inside Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,30 @@ jobs:
       if: matrix.compiler == 'clang' || matrix.compiler == 'clang-cl'
       shell: bash
       run: |
+        set -euo pipefail
         if [ "${OSTYPE}" = "msys" ]; then
-          choco install --no-progress llvm
+          export MSYS2_ARG_CONV_EXCL="*"  # Don't let MSYS2 attempt to auto-translate arguments that look like paths
+          # Ideally we should be able to use the Chocolatey package manager:
+          #   choco install --no-progress llvm
+          # However, it frequently gives HTTP 503 errors, so we just download and install manually.
+          urldir="https://releases.llvm.org"
+          bits=64
+          if [ "${HOSTTYPE}" = "${HOSTTYPE%64}" ]; then bits=32; fi
+          curl -s --compressed -- "${urldir}/download.html" | sed -n "s/.*<a href=\"\([^\"]*\)\">Windows (${bits}-bit).*/\1/p" | {
+            href=""
+            while read -r href; do
+              if [ "${href}" = "${href#http://}" ] && [ "${href}" = "${href#https://}" ]; then
+                href="${urldir}/${href}"  # Relative URL, so make it absolute
+              fi
+              break  # Latest version is the first match
+            done
+            test -n "${href}"  # If this check fails, we couldn't find the download url
+            target="./LLVM.exe"
+            curl -s -L -R -o "${target}" "${href}"
+            chmod +x "${target}"
+            "${target}" /S
+            rm -f -- "${target}"
+          }
         elif 1>&- command -v pacman; then
           sudo pacman -S --needed --noconfirm --noprogressbar clang
         elif 1>&- command -v apt-get; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  LLVM_VERSION_WINDOWS: 9.0.0
+
 on: [push]
 
 jobs:
@@ -36,23 +39,13 @@ jobs:
           #   choco install --no-progress llvm
           # However, it frequently gives HTTP 503 errors, so we just download and install manually.
           urldir="https://releases.llvm.org"
-          bits=64
-          if [ "${HOSTTYPE}" = "${HOSTTYPE%64}" ]; then bits=32; fi
-          curl -s --compressed -- "${urldir}/download.html" | sed -n "s/.*<a href=\"\([^\"]*\)\">Windows (${bits}-bit).*/\1/p" | {
-            href=""
-            while read -r href; do
-              if [ "${href}" = "${href#http://}" ] && [ "${href}" = "${href#https://}" ]; then
-                href="${urldir}/${href}"  # Relative URL, so make it absolute
-              fi
-              break  # Latest version is the first match
-            done
-            test -n "${href}"  # If this check fails, we couldn't find the download url
-            target="./LLVM.exe"
-            curl -s -L -R -o "${target}" "${href}"
-            chmod +x "${target}"
-            "${target}" /S
-            rm -f -- "${target}"
-          }
+          arch=64
+          if [ "${HOSTTYPE}" = "${HOSTTYPE%64}" ]; then arch=32; fi
+          target="./LLVM-${LLVM_VERSION_WINDOWS}-win${arch}.exe"
+          curl -s -L -R -o "${target}" "http://releases.llvm.org/${LLVM_VERSION_WINDOWS}/${target##*/}"
+          chmod +x "${target}"
+          "${target}" /S
+          rm -f -- "${target}"
         elif 1>&- command -v pacman; then
           sudo pacman -S --needed --noconfirm --noprogressbar clang
         elif 1>&- command -v apt-get; then


### PR DESCRIPTION
## Why are these changes needed?

Clang/LLVM installations from Chocolatey are failing very frequently due to 503 server errors, so we just install the toolchains directly.

## Related issue number

#631, #6519

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
