### PR TITLE
[Serve] Added features for arbitrary (DAG) pipelines

### DIFF
--- a/doc/source/serve.rst
+++ b/doc/source/serve.rst
@@ -18,3 +18,20 @@ API
 ---
 .. automodule:: ray.experimental.serve
     :members:
+
+Policies For Backend Selection
+------------------------------
+.. autoclass:: ray.experimental.serve.queues.RandomPolicyQueue
+.. autoclass:: ray.experimental.serve.queues.RoundRobinPolicyQueue
+.. autoclass:: ray.experimental.serve.queues.PowerOfTwoPolicyQueue
+.. autoclass:: ray.experimental.serve.queues.FixedPackingPolicyQueue
+
+Serve Request Classes
+---------------------
+.. autoclass:: ray.experimental.serve.request_params.RequestParams
+.. autoclass:: ray.experimental.serve.request_params.RequestInfo
+
+Serve Router
+------------
+.. autoclass:: ray.experimental.serve.queues.CentralizedQueues
+    :members:

--- a/python/ray/experimental/serve/examples/echo_pipeline.py
+++ b/python/ray/experimental/serve/examples/echo_pipeline.py
@@ -1,0 +1,104 @@
+"""
+Ray serve pipeline example
+"""
+import ray
+import ray.experimental.serve as serve
+
+# initialize ray serve system.
+# blocking=True will wait for HTTP server to be ready to serve request.
+serve.init(blocking=True)
+
+
+# a backend can be a function or class.
+# it can be made to be invoked from web as well as python.
+def echo_v1(_, response="hello from python!"):
+    return f"echo_v1({response})"
+
+
+def echo_v2(_, relay=""):
+    return f"echo_v2({relay})"
+
+
+def echo_v3(_, relay=""):
+    return f"echo_v3({relay})"
+
+
+def echo_v4(_, relay1="", relay2=""):
+    return f"echo_v4({relay1} , {relay2})"
+
+
+# an endpoint is associated with an http URL.
+serve.create_endpoint("my_endpoint1", "/echo1")
+serve.create_endpoint("my_endpoint2", "/echo2")
+serve.create_endpoint("my_endpoint3", "/echo3")
+serve.create_endpoint("my_endpoint4", "/echo4")
+
+# create backends
+serve.create_backend(echo_v1, "echo:v1")
+serve.create_backend(echo_v2, "echo:v2")
+serve.create_backend(echo_v3, "echo:v3")
+serve.create_backend(echo_v4, "echo:v4")
+
+# link service to backends
+serve.link("my_endpoint1", "echo:v1")
+serve.link("my_endpoint2", "echo:v2")
+serve.link("my_endpoint3", "echo:v3")
+serve.link("my_endpoint4", "echo:v4")
+
+# get the handle of the endpoints
+handle1 = serve.get_handle("my_endpoint1")
+handle2 = serve.get_handle("my_endpoint2")
+handle3 = serve.get_handle("my_endpoint3")
+handle4 = serve.get_handle("my_endpoint4")
+"""
+The pipeline created is as follows -
+            "my_endpoint1"
+                  /\
+                 /  \
+                /    \
+               /      \
+              /        \
+             /          \
+  "my_endpoint2"     "my_endpoint3"
+            \            /
+             \          /
+              \        /
+               \      /
+                \    /
+                 \  /
+                  \/
+            "my_endpoint4"
+"""
+# get ObjectID and wall clock time
+# this wall clock time will be passed to further remote calls
+first_object_id, wall_clock_slo = handle1.remote(
+    response="hello", return_wall_clock_time=True)
+
+# create ObjectIDs for getting the result
+second_object_id = ray.ObjectID.from_random()
+third_object_id = ray.ObjectID.from_random()
+
+# pass the wall clock time and ObjectIDS. This remote will be completely
+# asynchronous! All the remote calls below are completely asynchronous
+temp1 = handle2.remote(
+    relay=first_object_id,
+    return_object_ids=[second_object_id],
+    slo_ms=wall_clock_slo,
+    is_wall_clock_time=True)
+
+# check for this call to be asynchronous
+assert temp1 is None
+handle3.remote(
+    relay=first_object_id,
+    return_object_ids=[third_object_id],
+    slo_ms=wall_clock_slo,
+    is_wall_clock_time=True)
+fourth_object_id = ray.ObjectID.from_random()
+temp2 = handle4.remote(
+    relay1=second_object_id,
+    relay2=third_object_id,
+    return_object_ids=[fourth_object_id],
+    slo_ms=wall_clock_slo,
+    is_wall_clock_time=True)
+assert temp2 is None
+print(ray.get(fourth_object_id))

--- a/python/ray/experimental/serve/policy.py
+++ b/python/ray/experimental/serve/policy.py
@@ -10,6 +10,15 @@ class RoutePolicy(Enum):
     Add a name and the corresponding class.
     Serve will support the added policy and policy can be accessed
     in `serve.init` method through name provided here.
+
+    Args:
+        Random(RandomPolicyQueue): Random policy for backend selection
+        RoundRobin(RoundRobinPolicyQueue): Round Robin policy for
+            backend selection
+        PowerOfTwo(PowerOfTwoPolicyQueue): Power of two policy for
+            backend selection
+        FixedPacking(FixedPackingPolicyQueue): Fixed packing policy for
+            backend selection
     """
     Random = RandomPolicyQueueActor
     RoundRobin = RoundRobinPolicyQueueActor

--- a/python/ray/experimental/serve/request_params.py
+++ b/python/ray/experimental/serve/request_params.py
@@ -1,0 +1,86 @@
+import inspect
+
+
+class RequestParams:
+    """
+    Request Arguments required for enqueuing a request to the service
+    queue.
+
+    Args:
+        service(str): A registered service endpoint.
+        request_context(TaskContext): Context of a request.
+        request_slo_ms(float): Expected time for the query to get
+            completed.
+        return_object_ids(list[ray.ObjectID]): List of ObjectIds where
+            result of the request will be put.
+        is_wall_clock_time(bool): if True, router won't add wall clock
+            time to `request_slo_ms`.
+        return_wall_clock_time(bool): if True, wall clock time for query
+            completion will be returned when query is enqueued.
+
+    """
+
+    def __init__(self,
+                 service,
+                 request_context,
+                 request_slo_ms=None,
+                 return_object_ids=None,
+                 is_wall_clock_time=False,
+                 return_wall_clock_time=False):
+
+        self.service = service
+        self.request_context = request_context
+        self.request_slo_ms = request_slo_ms
+        self.return_object_ids = return_object_ids
+        self.is_wall_clock_time = is_wall_clock_time
+        self.return_wall_clock_time = return_wall_clock_time
+        if request_slo_ms is None:
+            self.is_wall_clock_time = False
+
+    @classmethod
+    def get_default_kwargs(cls):
+        signature = inspect.signature(cls)
+        return_dict = {
+            k: v.default
+            for k, v in signature.parameters.items()
+            if v.default is not inspect.Parameter.empty
+        }
+        val = return_dict.pop("request_slo_ms")
+        return_dict["slo_ms"] = val
+        return return_dict
+
+
+class RequestInfo:
+    """
+    Request Information that will be returned when the request gets enqueued.
+
+    Args:
+        result_object_id(list[ray.ObjectID]): Ray ObjectIDs got
+            from `RequestParams`.
+        return_object_id(bool): If True, `RayServeHandle` remote call
+            returns ObjectIDs.
+        request_slo_ms(float): The wall clock deadline time of the query.
+        return_wall_clock_time(bool): If True, `RayServeHandle` remote call
+            returns wall clock deadline time.
+    """
+
+    def __init__(self, result_object_id, return_object_id, request_slo_ms,
+                 return_wall_clock_time):
+        self.result_object_id = result_object_id
+        self.return_object_id = return_object_id
+        self.request_slo_ms = request_slo_ms
+        self.return_wall_clock_time = return_wall_clock_time
+
+    def __iter__(self):
+        if self.return_object_id:
+            for object_id in self.result_object_id:
+                yield object_id
+        if self.return_wall_clock_time:
+            yield self.request_slo_ms
+
+    @staticmethod
+    def wait_for_requestInfo(request_params):
+        if (request_params.return_object_ids is None
+                or request_params.return_wall_clock_time):
+            return True
+        return False

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -176,8 +176,7 @@ class RayServeMixin:
             for result, result_object_id in zip(result_list,
                                                 result_object_ids):
                 for return_id in result_object_id:
-                    ray.worker.global_worker.put_object(result,
-                                                        return_id)
+                    ray.worker.global_worker.put_object(result, return_id)
 
             self._serve_metric_latency_list.append(time.time() -
                                                    start_timestamp)
@@ -186,8 +185,8 @@ class RayServeMixin:
             self._serve_metric_error_counter += len(result_object_ids)
             for result_object_id in result_object_ids:
                 for return_id in result_object_id:
-                    ray.worker.global_worker.put_object(wrapped_exception,
-                                                        return_id)
+                    ray.worker.global_worker.put_object(
+                        wrapped_exception, return_id)
 
     def _ray_serve_call(self, request):
         work_item = request

--- a/python/ray/experimental/serve/task_runner.py
+++ b/python/ray/experimental/serve/task_runner.py
@@ -101,12 +101,13 @@ class RayServeMixin:
         start_timestamp = time.time()
         try:
             result = self.__call__(*args, **kwargs)
-            ray.worker.global_worker.put_object(result, result_object_id)
+            for rid in result_object_id:
+                ray.worker.global_worker.put_object(result, rid)
         except Exception as e:
             wrapped_exception = wrap_to_ray_error(e)
             self._serve_metric_error_counter += 1
-            ray.worker.global_worker.put_object(wrapped_exception,
-                                                result_object_id)
+            for rid in result_object_id:
+                ray.worker.global_worker.put_object(wrapped_exception, rid)
         self._serve_metric_latency_list.append(time.time() - start_timestamp)
 
     def invoke_batch(self, request_item_list):

--- a/python/ray/experimental/serve/tests/conftest.py
+++ b/python/ray/experimental/serve/tests/conftest.py
@@ -9,6 +9,7 @@ from ray.experimental import serve
 
 @pytest.fixture(scope="session")
 def serve_instance():
+    ray_already_initialized = ray.is_initialized()
     _, new_db_path = tempfile.mkstemp(suffix=".test.db")
     serve.init(
         kv_store_path=new_db_path,
@@ -16,6 +17,8 @@ def serve_instance():
         ray_init_kwargs={"num_cpus": 36})
     yield
     os.remove(new_db_path)
+    if not ray_already_initialized:
+        ray.shutdown()
 
 
 @pytest.fixture(scope="session")

--- a/python/ray/experimental/serve/tests/test_queue.py
+++ b/python/ray/experimental/serve/tests/test_queue.py
@@ -3,10 +3,11 @@ import ray
 from ray.experimental.serve.queues import RandomPolicyQueue
 from ray.experimental.serve.queues import (RoundRobinPolicyQueue,
                                            FixedPackingPolicyQueue)
+from ray.experimental.serve.request_params import RequestParams
 
 
 @pytest.fixture(scope="session")
-def task_runner_mock_actor():
+def task_runner_mock_actor(serve_instance):
     @ray.remote
     class TaskRunnerMock:
         def __init__(self):
@@ -26,14 +27,15 @@ def test_single_prod_cons_queue(serve_instance, task_runner_mock_actor):
     q = RandomPolicyQueue()
     q.link("svc", "backend")
 
-    result_object_id = q.enqueue_request("svc", 1, "kwargs", None)
+    result_object_id = next(
+        iter(q.enqueue_request(RequestParams("svc", None), 1)))
     q.dequeue_request("backend", task_runner_mock_actor)
     got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
-    assert got_work.request_args == 1
-    assert got_work.request_kwargs == "kwargs"
+    assert got_work.request_args[0] == 1
+    assert got_work.request_kwargs == {}
 
-    ray.worker.global_worker.put_object(2, got_work.result_object_id)
-    assert ray.get(ray.ObjectID(result_object_id)) == 2
+    ray.worker.global_worker.put_object(2, got_work.result_object_id[0])
+    assert ray.get(result_object_id) == 2
 
 
 def test_slo(serve_instance, task_runner_mock_actor):
@@ -42,31 +44,33 @@ def test_slo(serve_instance, task_runner_mock_actor):
 
     for i in range(10):
         slo_ms = 1000 - 100 * i
-        q.enqueue_request("svc", i, "kwargs", None, request_slo_ms=slo_ms)
+        q.enqueue_request(RequestParams("svc", None, request_slo_ms=slo_ms), i)
     for i in range(10):
         q.dequeue_request("backend", task_runner_mock_actor)
         got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
-        assert got_work.request_args == (9 - i)
+        assert got_work.request_args[0] == (9 - i)
 
 
 def test_alter_backend(serve_instance, task_runner_mock_actor):
     q = RandomPolicyQueue()
 
     q.set_traffic("svc", {"backend-1": 1})
-    result_object_id = q.enqueue_request("svc", 1, "kwargs", None)
+    result_object_id = next(
+        iter(q.enqueue_request(RequestParams("svc", None), 1)))
     q.dequeue_request("backend-1", task_runner_mock_actor)
     got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
-    assert got_work.request_args == 1
-    ray.worker.global_worker.put_object(2, got_work.result_object_id)
-    assert ray.get(ray.ObjectID(result_object_id)) == 2
+    assert got_work.request_args[0] == 1
+    ray.worker.global_worker.put_object(2, got_work.result_object_id[0])
+    assert ray.get(result_object_id) == 2
 
     q.set_traffic("svc", {"backend-2": 1})
-    result_object_id = q.enqueue_request("svc", 1, "kwargs", None)
+    result_object_id = next(
+        iter(q.enqueue_request(RequestParams("svc", None), 1)))
     q.dequeue_request("backend-2", task_runner_mock_actor)
     got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
-    assert got_work.request_args == 1
-    ray.worker.global_worker.put_object(2, got_work.result_object_id)
-    assert ray.get(ray.ObjectID(result_object_id)) == 2
+    assert got_work.request_args[0] == 1
+    ray.worker.global_worker.put_object(2, got_work.result_object_id[0])
+    assert ray.get(result_object_id) == 2
 
 
 def test_split_traffic(serve_instance, task_runner_mock_actor):
@@ -76,14 +80,14 @@ def test_split_traffic(serve_instance, task_runner_mock_actor):
     # assume 50% split, the probability of all 20 requests goes to a
     # single queue is 0.5^20 ~ 1-6
     for _ in range(20):
-        q.enqueue_request("svc", 1, "kwargs", None)
+        q.enqueue_request(RequestParams("svc", None), 1)
     q.dequeue_request("backend-1", task_runner_mock_actor)
     result_one = ray.get(task_runner_mock_actor.get_recent_call.remote())
     q.dequeue_request("backend-2", task_runner_mock_actor)
     result_two = ray.get(task_runner_mock_actor.get_recent_call.remote())
 
     got_work = [result_one, result_two]
-    assert [g.request_args for g in got_work] == [1, 1]
+    assert [g.request_args[0] for g in got_work] == [1, 1]
 
 
 def test_split_traffic_round_robin(serve_instance, task_runner_mock_actor):
@@ -92,14 +96,14 @@ def test_split_traffic_round_robin(serve_instance, task_runner_mock_actor):
     # since round robin policy is stateful firing two queries consecutively
     # would transfer the queries to two different backends
     for _ in range(2):
-        q.enqueue_request("svc", 1, "kwargs", None)
+        q.enqueue_request(RequestParams("svc", None), 1)
     q.dequeue_request("backend-1", task_runner_mock_actor)
     result_one = ray.get(task_runner_mock_actor.get_recent_call.remote())
     q.dequeue_request("backend-2", task_runner_mock_actor)
     result_two = ray.get(task_runner_mock_actor.get_recent_call.remote())
 
     got_work = [result_one, result_two]
-    assert [g.request_args for g in got_work] == [1, 1]
+    assert [g.request_args[0] for g in got_work] == [1, 1]
 
 
 def test_split_traffic_fixed_packing(serve_instance, task_runner_mock_actor):
@@ -109,7 +113,7 @@ def test_split_traffic_fixed_packing(serve_instance, task_runner_mock_actor):
 
     # fire twice the number of queries as the packing number
     for i in range(2 * packing_num):
-        q.enqueue_request("svc", i, "kwargs", None)
+        q.enqueue_request(RequestParams("svc", None), i)
 
     # both the backends will get equal number of queries
     # as it is packed round robin
@@ -124,7 +128,7 @@ def test_split_traffic_fixed_packing(serve_instance, task_runner_mock_actor):
     result_two = ray.get(task_runner_mock_actor.get_recent_call.remote())
 
     got_work = [result_one, result_two]
-    assert [g.request_args
+    assert [g.request_args[0]
             for g in got_work] == [packing_num - 1, 2 * packing_num - 1]
 
 

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -15,7 +15,8 @@ def parse_request_item(request_item):
     if request_item.request_context == TaskContext.Web:
         is_web_context = True
         asgi_scope, body_bytes = request_item.request_args
-        flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes[0]))
+        flask_request = build_flask_request(asgi_scope,
+                                            io.BytesIO(body_bytes[0]))
         args = (flask_request, )
         kwargs = {}
     else:

--- a/python/ray/experimental/serve/utils.py
+++ b/python/ray/experimental/serve/utils.py
@@ -15,7 +15,7 @@ def parse_request_item(request_item):
     if request_item.request_context == TaskContext.Web:
         is_web_context = True
         asgi_scope, body_bytes = request_item.request_args
-        flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes))
+        flask_request = build_flask_request(asgi_scope, io.BytesIO(body_bytes[0]))
         args = (flask_request, )
         kwargs = {}
     else:


### PR DESCRIPTION
1. Added support for return_object_ids
2. RayServeHandle remote calls can be completely asynchronous
3. Added support for specifying wall clock time while enqueuing the request
4. Updated documentation. 
5. Modified pytest accordingly 
6. Implemented a pipeline example

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
