### PR TITLE
Fix hang on actor creation task failure

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1450,7 +1450,7 @@ def test_kill(ray_start_regular):
 # This test verifies actor creation task failure will not
 # hang the caller.
 def test_actor_creation_task_crash(ray_start_regular):
-     # Test actor death in constructor.
+    # Test actor death in constructor.
     @ray.remote(max_reconstructions=0)
     class Actor(object):
         def __init__(self):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -19,7 +19,6 @@ import ray.cluster_utils
 from ray import ray_constants
 from ray.test_utils import run_string_as_driver
 from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
-import pickle
 
 RAY_FORCE_DIRECT = ray_constants.direct_call_enabled()
 

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -5,17 +5,22 @@ namespace ray {
 
 void ActorManager::PublishCreatedActor(const TaskSpecification &actor_creation_task,
                                        const rpc::Address &address) {
-  auto actor_id = actor_creation_task.ActorCreationId();
-  auto data = gcs::CreateActorTableData(actor_creation_task, address,
-                                        gcs::ActorTableData::ALIVE, 0);
-  RAY_CHECK_OK(global_actor_table_.Append(JobID::Nil(), actor_id, data, nullptr));
+  // Actor creation is currently published by raylet when a new actor is created.
+  // So this function is a no-op.
 }
 
 void ActorManager::PublishTerminatedActor(const TaskSpecification &actor_creation_task) {
   auto actor_id = actor_creation_task.ActorCreationId();
   auto data = gcs::CreateActorTableData(actor_creation_task, rpc::Address(),
                                         gcs::ActorTableData::DEAD, 0);
-  RAY_CHECK_OK(global_actor_table_.Append(JobID::Nil(), actor_id, data, nullptr));
+
+  auto update_callback = [actor_id](Status status) {
+    if (!status.ok()) {
+      // Only one node at a time should succeed at creating or updating the actor.
+      RAY_LOG(FATAL) << "Failed to update state to DEAD for actor " << actor_id;
+    }
+  };
+  RAY_CHECK_OK(actor_accessor_.AsyncRegister(data, update_callback));
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -3,12 +3,6 @@
 
 namespace ray {
 
-void ActorManager::PublishCreatedActor(const TaskSpecification &actor_creation_task,
-                                       const rpc::Address &address) {
-  // Actor creation is currently published by raylet when a new actor is created.
-  // So this function is a no-op.
-}
-
 void ActorManager::PublishTerminatedActor(const TaskSpecification &actor_creation_task) {
   auto actor_id = actor_creation_task.ActorCreationId();
   auto data = gcs::CreateActorTableData(actor_creation_task, rpc::Address(),

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -11,7 +11,8 @@ void ActorManager::PublishTerminatedActor(const TaskSpecification &actor_creatio
   auto update_callback = [actor_id](Status status) {
     if (!status.ok()) {
       // Only one node at a time should succeed at creating or updating the actor.
-      RAY_LOG(FATAL) << "Failed to update state to DEAD for actor " << actor_id;
+      RAY_LOG(ERROR) << "Failed to update state to DEAD for actor " << actor_id
+                     << ", error: " << status.ToString();
     }
   };
   RAY_CHECK_OK(actor_accessor_.AsyncRegister(data, update_callback));

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -9,23 +9,19 @@ namespace ray {
 // Interface for testing.
 class ActorManagerInterface {
  public:
-  virtual void PublishCreatedActor(const TaskSpecification &actor_creation_task,
-                                   const rpc::Address &address) = 0;
-
   virtual void PublishTerminatedActor(const TaskSpecification &actor_creation_task) = 0;
 
   virtual ~ActorManagerInterface() {}
 };
 
 /// Class to manage lifetimes of actors that we create (actor children).
+/// Currently this class is only used to publish actor DEAD event
+/// for actor creation task failures. All other cases are managed
+/// by raylet.
 class ActorManager : public ActorManagerInterface {
  public:
   ActorManager(gcs::ActorInfoAccessor &actor_accessor)
       : actor_accessor_(actor_accessor) {}
-
-  /// Called when an actor creation task that we submitted finishes.
-  void PublishCreatedActor(const TaskSpecification &actor_creation_task,
-                           const rpc::Address &address) override;
 
   /// Called when an actor that we own can no longer be restarted.
   void PublishTerminatedActor(const TaskSpecification &actor_creation_task) override;

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -20,8 +20,8 @@ class ActorManagerInterface {
 /// Class to manage lifetimes of actors that we create (actor children).
 class ActorManager : public ActorManagerInterface {
  public:
-  ActorManager(gcs::DirectActorTable &global_actor_table)
-      : global_actor_table_(global_actor_table) {}
+  ActorManager(gcs::ActorInfoAccessor &actor_accessor)
+      : actor_accessor_(actor_accessor) {}
 
   /// Called when an actor creation task that we submitted finishes.
   void PublishCreatedActor(const TaskSpecification &actor_creation_task,
@@ -32,7 +32,7 @@ class ActorManager : public ActorManagerInterface {
 
  private:
   /// Global database of actors.
-  gcs::DirectActorTable &global_actor_table_;
+  gcs::ActorInfoAccessor &actor_accessor_;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -102,6 +102,9 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
   gcs_client_ = std::make_shared<gcs::RedisGcsClient>(gcs_options);
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
 
+  actor_manager_ =	
+      std::unique_ptr<ActorManager>(new ActorManager(gcs_client_->Actors()));
+
   // Initialize profiler.
   profiler_ = std::make_shared<worker::Profiler>(worker_context_, node_ip_address,
                                                  io_service_, gcs_client_);
@@ -187,7 +190,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       ref_counting_enabled ? reference_counter_ : nullptr, local_raylet_client_));
 
   task_manager_.reset(new TaskManager(
-      memory_store_, reference_counter_, nullptr, [this](const TaskSpecification &spec) {
+      memory_store_, reference_counter_, actor_manager_, [this](const TaskSpecification &spec) {
         // Retry after a delay to emulate the existing Raylet reconstruction
         // behaviour. TODO(ekl) backoff exponentially.
         RAY_LOG(ERROR) << "Will resubmit task after a 5 second delay: "

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -102,8 +102,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
   gcs_client_ = std::make_shared<gcs::RedisGcsClient>(gcs_options);
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
 
-  actor_manager_ =	
-      std::unique_ptr<ActorManager>(new ActorManager(gcs_client_->Actors()));
+  actor_manager_ = std::unique_ptr<ActorManager>(new ActorManager(gcs_client_->Actors()));
 
   // Initialize profiler.
   profiler_ = std::make_shared<worker::Profiler>(worker_context_, node_ip_address,
@@ -190,7 +189,8 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       ref_counting_enabled ? reference_counter_ : nullptr, local_raylet_client_));
 
   task_manager_.reset(new TaskManager(
-      memory_store_, reference_counter_, actor_manager_, [this](const TaskSpecification &spec) {
+      memory_store_, reference_counter_, actor_manager_,
+      [this](const TaskSpecification &spec) {
         // Retry after a delay to emulate the existing Raylet reconstruction
         // behaviour. TODO(ekl) backoff exponentially.
         RAY_LOG(ERROR) << "Will resubmit task after a 5 second delay: "

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -617,7 +617,7 @@ class CoreWorker {
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;
 
-  // Interface for publishing actor creation.
+  // Interface for publishing actor death event for actor creation failure.
   std::shared_ptr<ActorManager> actor_manager_;
 
   // Interface to submit tasks directly to other actors.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -617,7 +617,7 @@ class CoreWorker {
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;
 
-  // Interface for publishing actor creation.	
+  // Interface for publishing actor creation.
   std::shared_ptr<ActorManager> actor_manager_;
 
   // Interface to submit tasks directly to other actors.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -617,6 +617,9 @@ class CoreWorker {
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;
 
+  // Interface for publishing actor creation.	
+  std::shared_ptr<ActorManager> actor_manager_;
+
   // Interface to submit tasks directly to other actors.
   std::unique_ptr<CoreWorkerDirectActorTaskSubmitter> direct_actor_submitter_;
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -207,7 +207,7 @@ void TaskManager::MarkPendingTaskFailed(const TaskID &task_id,
   if (spec.IsActorCreationTask()) {
     // Publish actor death if actor creation task failed after
     // a number of retries.
-    actor_manager_->PublishTerminatedActor(spec);	
+    actor_manager_->PublishTerminatedActor(spec);
   }
 }
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -203,6 +203,12 @@ void TaskManager::MarkPendingTaskFailed(const TaskID &task_id,
         /*transport_type=*/static_cast<int>(TaskTransportType::DIRECT));
     RAY_CHECK_OK(in_memory_store_->Put(RayObject(error_type), object_id));
   }
+
+  if (spec.IsActorCreationTask()) {
+    // Publish actor death if actor creation task failed after
+    // a number of retries.
+    actor_manager_->PublishTerminatedActor(spec);	
+  }
 }
 
 TaskSpecification TaskManager::GetTaskSpec(const TaskID &task_id) const {

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -21,7 +21,6 @@ TaskSpecification CreateTaskHelper(uint64_t num_returns,
 }
 
 class MockActorManager : public ActorManagerInterface {
-
   void PublishTerminatedActor(const TaskSpecification &actor_creation_task) override {
     num_terminations += 1;
   }

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -21,10 +21,6 @@ TaskSpecification CreateTaskHelper(uint64_t num_returns,
 }
 
 class MockActorManager : public ActorManagerInterface {
-  void PublishCreatedActor(const TaskSpecification &actor_creation_task,
-                           const rpc::Address &address) override {
-    num_publishes += 1;
-  }
 
   void PublishTerminatedActor(const TaskSpecification &actor_creation_task) override {
     num_terminations += 1;


### PR DESCRIPTION
## Why are these changes needed?

Currently if actor creation task fails, raylet will not publish DEAD status, and other callers of the actor can block forever. This PR leverages actor owner to do the publishing after it detects actor is dead after a number of retries. 

## Related issue number

#6612 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
