### PR TITLE
Add 'ray stat' command for debugging

### DIFF
--- a/doc/source/package-ref.rst
+++ b/doc/source/package-ref.rst
@@ -91,6 +91,10 @@ The Ray Command Line API
    :prog: ray stack
    :show-nested:
 
+.. click:: ray.scripts.scripts:stat
+   :prog: ray stat
+   :show-nested:
+
 .. click:: ray.scripts.scripts:timeline
    :prog: ray timeline
    :show-nested:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -853,7 +853,6 @@ def stat(address):
     logger.info("Connecting to Ray instance at {}.".format(address))
     ray.init(address=address)
     raylet = ray.nodes()[0]
-    num_cpus = raylet["Resources"]["CPU"]
     raylet_address = "{}:{}".format(raylet["NodeManagerAddress"],
                                     ray.nodes()[0]["NodeManagerPort"])
 

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -60,9 +60,9 @@ WorkerContext::WorkerContext(WorkerType worker_type, const JobID &job_id)
   // For worker main thread which initializes the WorkerContext,
   // set task_id according to whether current worker is a driver.
   // (For other threads it's set to random ID via GetThreadContext).
-  GetThreadContext(true).SetCurrentTaskId((worker_type_ == WorkerType::DRIVER)
-                                              ? TaskID::ForDriverTask(job_id)
-                                              : TaskID::Nil());
+  GetThreadContext().SetCurrentTaskId((worker_type_ == WorkerType::DRIVER)
+                                          ? TaskID::ForDriverTask(job_id)
+                                          : TaskID::Nil());
 }
 
 const WorkerType WorkerContext::GetWorkerType() const { return worker_type_; }
@@ -148,7 +148,7 @@ int WorkerContext::CurrentActorMaxConcurrency() const {
 
 bool WorkerContext::CurrentActorIsAsync() const { return current_actor_is_asyncio_; }
 
-WorkerThreadContext &WorkerContext::GetThreadContext(bool for_main_thread) {
+WorkerThreadContext &WorkerContext::GetThreadContext() {
   if (thread_context_ == nullptr) {
     thread_context_ = std::unique_ptr<WorkerThreadContext>(new WorkerThreadContext());
   }

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -72,7 +72,7 @@ class WorkerContext {
   boost::thread::id main_thread_id_;
 
  private:
-  static WorkerThreadContext &GetThreadContext(bool for_main_thread = false);
+  static WorkerThreadContext &GetThreadContext();
 
   /// Per-thread worker context.
   static thread_local std::unique_ptr<WorkerThreadContext> thread_context_;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1075,7 +1075,7 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
   stats->set_actor_id(worker_context_.GetCurrentActorID().Hex());
   stats->set_num_pending_tasks(task_manager_->NumPendingTasks());
   stats->set_num_object_ids_in_scope(reference_counter_->NumObjectIDsInScope());
-  auto current_task = worker_Context_.GetCurrentTask();
+  auto current_task = worker_context_.GetCurrentTask();
   if (current_task) {
     stats->set_current_task_desc(current_task->DebugString());
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1110,4 +1110,15 @@ void CoreWorker::GetAsync(const ObjectID &object_id, SetResultCallback success_c
   });
 }
 
+void CoreWorker::SetActorId(const ActorID &actor_id) {
+  RAY_CHECK(actor_id_.IsNil());
+  absl::MutexLock lock(&mutex_);
+  actor_id_ = actor_id;
+}
+
+void CoreWorker::SetWebuiDisplay(const std::string &message) {
+  absl::MutexLock lock(&mutex_);
+  webui_display_ = message;
+}
+
 }  // namespace ray

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1070,6 +1070,15 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
                                           rpc::GetCoreWorkerStatsReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   reply->set_webui_display(webui_display_);
+  auto stats = reply->mutable_core_worker_stats();
+  stats->set_job_id(worker_context_.GetCurrentJobID().Hex());
+  stats->set_actor_id(worker_context_.GetCurrentActorID().Hex());
+  stats->set_num_pending_tasks(task_manager_->NumPendingTasks());
+  stats->set_num_object_ids_in_scope(reference_counter_->NumObjectIDsInScope());
+  auto current_task = worker_Context_.GetCurrentTask();
+  if (current_task) {
+    stats->set_current_task_desc(current_task->DebugString());
+  }
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -100,10 +100,14 @@ class CoreWorker {
 
   void SetActorId(const ActorID &actor_id) {
     RAY_CHECK(actor_id_.IsNil());
+    absl::MutexLock lock(&mutex_);
     actor_id_ = actor_id;
   }
 
-  void SetWebuiDisplay(const std::string &message) { webui_display_ = message; }
+  void SetWebuiDisplay(const std::string &message) {
+    absl::MutexLock lock(&mutex_);
+    webui_display_ = message;
+  }
 
   /// Increase the reference count for this object ID.
   /// Increase the local reference count for this object ID. Should be called
@@ -638,11 +642,19 @@ class CoreWorker {
   /// Fields related to task execution.
   ///
 
+  /// Protects around accesses to fields below. This should only ever be held
+  /// for short-running periods of time.
+  mutable absl::Mutex mutex_;
+
   /// Our actor ID. If this is nil, then we execute only stateless tasks.
-  ActorID actor_id_;
+  ActorID actor_id_ GUARDED_BY(mutex_);
+
+  /// The currently executing task spec. We have to track this separately since
+  /// we cannot access the thread-local worker contexts from GetCoreWorkerStats()
+  TaskSpecification current_task_ GUARDED_BY(mutex_);
 
   /// String to be displayed on Web UI.
-  std::string webui_display_;
+  std::string webui_display_ GUARDED_BY(mutex_);
 
   /// Event loop where tasks are processed.
   boost::asio::io_service task_execution_service_;
@@ -671,7 +683,7 @@ class CoreWorker {
   std::unique_ptr<CoreWorkerDirectTaskReceiver> direct_task_receiver_;
 
   // Queue of tasks to resubmit when the specified time passes.
-  std::deque<std::pair<int64_t, TaskSpecification>> to_resubmit_;
+  std::deque<std::pair<int64_t, TaskSpecification>> to_resubmit_ GUARDED_BY(mutex_);
 
   friend class CoreWorkerTest;
 };

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -98,16 +98,9 @@ class CoreWorker {
 
   const JobID &GetCurrentJobId() const { return worker_context_.GetCurrentJobID(); }
 
-  void SetActorId(const ActorID &actor_id) {
-    RAY_CHECK(actor_id_.IsNil());
-    absl::MutexLock lock(&mutex_);
-    actor_id_ = actor_id;
-  }
+  void SetActorId(const ActorID &actor_id);
 
-  void SetWebuiDisplay(const std::string &message) {
-    absl::MutexLock lock(&mutex_);
-    webui_display_ = message;
-  }
+  void SetWebuiDisplay(const std::string &message);
 
   /// Increase the reference count for this object ID.
   /// Increase the local reference count for this object ID. Should be called

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -85,9 +85,7 @@ class TaskManager : public TaskFinisherInterface {
   TaskSpecification GetTaskSpec(const TaskID &task_id) const;
 
   /// Return the number of pending tasks.
-  int NumPendingTasks() const {
-    return pending_tasks_.size();
-  }
+  int NumPendingTasks() const { return pending_tasks_.size(); }
 
  private:
   /// Treat a pending task as failed. The lock should not be held when calling

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -84,6 +84,11 @@ class TaskManager : public TaskFinisherInterface {
   /// Return the spec for a pending task.
   TaskSpecification GetTaskSpec(const TaskID &task_id) const;
 
+  /// Return the number of pending tasks.
+  int NumPendingTasks() const {
+    return pending_tasks_.size();
+  }
+
  private:
   /// Treat a pending task as failed. The lock should not be held when calling
   /// this method because it may trigger callbacks in this or other classes.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -161,3 +161,17 @@ message ResourceMapEntry {
   // The set of resource ids assigned.
   repeated ResourceId resource_ids = 2;
 }
+
+// Debug info returned from the core worker.
+message CoreWorkerStats {
+  // Currently assigned job id.
+  string job_id = 1;
+  // Currently assigned actor id.
+  string actor_id = 2;
+  // Number of pending normal and actor tasks.
+  int32 num_pending_tasks = 3;
+  // Number of object ids in local scope.
+  int32 num_object_ids_in_scope = 4;
+  // Debug string of the currently executing task.
+  string current_task_desc = 5;
+}

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -164,14 +164,10 @@ message ResourceMapEntry {
 
 // Debug info returned from the core worker.
 message CoreWorkerStats {
-  // Currently assigned job id.
-  string job_id = 1;
-  // Currently assigned actor id.
-  string actor_id = 2;
-  // Number of pending normal and actor tasks.
-  int32 num_pending_tasks = 3;
-  // Number of object ids in local scope.
-  int32 num_object_ids_in_scope = 4;
   // Debug string of the currently executing task.
-  string current_task_desc = 5;
+  string current_task_desc = 1;
+  // Number of pending normal and actor tasks.
+  int32 num_pending_tasks = 2;
+  // Number of object ids in local scope.
+  int32 num_object_ids_in_scope = 3;
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -133,6 +133,8 @@ message GetCoreWorkerStatsRequest {
 message GetCoreWorkerStatsReply {
   // String displayed on Web UI.
   string webui_display = 1;
+  // Debug information returned from the core worker.
+  CoreWorkerStats core_worker_stats = 2;
 }
 
 service CoreWorkerService {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -55,6 +55,8 @@ message WorkerStats {
   bool is_driver = 2;
   // String displayed on Web UI.
   string webui_display = 3;
+  // Debug information returned from the core worker.
+  CoreWorkerStats core_worker_stats = 4;
 }
 
 message ViewData {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -89,6 +89,7 @@ message NodeStatsReply {
   map<string, double> available_resources = 3;
   map<string, double> total_resources = 4;
   uint32 num_workers = 5;
+  string debug_string = 6;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -89,7 +89,6 @@ message NodeStatsReply {
   map<string, double> available_resources = 3;
   map<string, double> total_resources = 4;
   uint32 num_workers = 5;
-  string debug_string = 6;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3013,6 +3013,7 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
             worker_stats->set_is_driver(false);
             reply->set_num_workers(reply->num_workers() + 1);
             worker_stats->set_webui_display(r.webui_display());
+            worker_stats->mutable_core_worker_stats()->MergeFrom(r.core_worker_stats());
             if (reply->num_workers() == all_workers.size()) {
               send_reply_callback(Status::OK(), nullptr, nullptr);
             }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3024,6 +3024,7 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
                        << status.ToString();
     }
   }
+  reply->set_debug_string(DebugString());
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3024,7 +3024,6 @@ void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
                        << status.ToString();
     }
   }
-  reply->set_debug_string(DebugString());
 }
 
 void NodeManager::RecordMetrics() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This adds a `ray stat` command, which prints out the proto response of the `GetNodeStats` RPC against a cluster.

```
workers_stats {
  pid: 22035
  core_worker_stats {
    current_task_desc: "Type=ACTOR_TASK, Language=PYTHON, 
function_descriptor=ray.rllib.evaluation.rollout_worker,RolloutWorker,sample,
 task_id=bb9e8ca32831dbbb2512146c0100, job_id=0100, num_args=0, num_returns=2,
 actor_task_spec={actor_id=2512146c0100, actor_caller_id=ffffffffffffffff45b95b1c0100, 
actor_counter=49}"
  }
}
workers_stats {
  pid: 22034
  core_worker_stats {
    current_task_desc: "Type=ACTOR_TASK, Language=PYTHON, 
function_descriptor=ray.rllib.evaluation.rollout_worker,RolloutWorker,sample, 
task_id=89a8f327090333064d81fd5d0100, job_id=0100, num_args=0, num_returns=2, 
actor_task_spec={actor_id=4d81fd5d0100, actor_caller_id=ffffffffffffffff45b95b1c0100, 
actor_counter=49}"
  }
}
workers_stats {
  pid: 22038
  core_worker_stats {
    current_task_desc: "Type=ACTOR_TASK, Language=PYTHON, 
function_descriptor=ray.rllib.agents.trainer_template,PPO,train, 
task_id=7e0a4dfc4c87306f45b95b1c0100, job_id=0100, num_args=0, num_returns=2, 
actor_task_spec={actor_id=45b95b1c0100, actor_caller_id=ffffffffffffffffffffffff0100,
actor_counter=3}"
    num_pending_tasks: 2
    num_object_ids_in_scope: 34
  }
}
```