### PR TITLE
[rpc] refactor GRPC client

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -389,7 +389,7 @@ class RayletStats(threading.Thread):
                 node_id = node["NodeID"]
                 stub = self.stubs[node_id]
                 reply = stub.GetNodeStats(
-                    node_manager_pb2.NodeStatsRequest(), timeout=2)
+                    node_manager_pb2.GetNodeStatsRequest(), timeout=2)
                 replies[node["NodeManagerAddress"]] = reply
             with self._raylet_stats_lock:
                 for address, reply in replies.items():

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -865,7 +865,7 @@ def stat(address):
         channel = grpc.insecure_channel(raylet_address)
         stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
         reply = stub.GetNodeStats(
-            node_manager_pb2.NodeStatsRequest(), timeout=2.0)
+            node_manager_pb2.GetNodeStatsRequest(), timeout=2.0)
         print(reply)
 
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -28,7 +28,7 @@ def test_worker_stats(shutdown_only):
         for _ in range(num_retry):
             try:
                 reply = stub.GetNodeStats(
-                    node_manager_pb2.NodeStatsRequest(), timeout=timeout)
+                    node_manager_pb2.GetNodeStatsRequest(), timeout=timeout)
                 break
             except grpc.RpcError:
                 continue

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -78,7 +78,7 @@ class MockRayletClient : public WorkerLeaseInterface {
 
   ray::Status RequestWorkerLease(
       const ray::TaskSpecification &resource_spec,
-      const rpc::ClientCallback<rpc::WorkerLeaseReply> &callback) override {
+      const rpc::ClientCallback<rpc::RequestWorkerLeaseReply> &callback) override {
     num_workers_requested += 1;
     callbacks.push_back(callback);
     return Status::OK();
@@ -87,7 +87,7 @@ class MockRayletClient : public WorkerLeaseInterface {
   // Trigger reply to RequestWorkerLease.
   bool GrantWorkerLease(const std::string &address, int port,
                         const ClientID &retry_at_raylet_id) {
-    rpc::WorkerLeaseReply reply;
+    rpc::RequestWorkerLeaseReply reply;
     if (!retry_at_raylet_id.IsNil()) {
       reply.mutable_retry_at_raylet_address()->set_ip_address(address);
       reply.mutable_retry_at_raylet_address()->set_port(port);
@@ -112,7 +112,7 @@ class MockRayletClient : public WorkerLeaseInterface {
   int num_workers_requested = 0;
   int num_workers_returned = 0;
   int num_workers_disconnected = 0;
-  std::list<rpc::ClientCallback<rpc::WorkerLeaseReply>> callbacks = {};
+  std::list<rpc::ClientCallback<rpc::RequestWorkerLeaseReply>> callbacks = {};
 };
 
 TEST(TestMemoryStore, TestPromoteToPlasma) {

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -108,7 +108,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
   auto status = lease_client->RequestWorkerLease(
       resource_spec,
       [this, lease_client, task_id, scheduling_key](
-          const Status &status, const rpc::WorkerLeaseReply &reply) mutable {
+          const Status &status, const rpc::RequestWorkerLeaseReply &reply) mutable {
         absl::MutexLock lock(&mu_);
         pending_lease_requests_.erase(scheduling_key);
         if (status.ok()) {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -5,12 +5,12 @@ package ray.rpc;
 import "src/ray/protobuf/common.proto";
 
 // Request a worker from the raylet with the specified resources.
-message WorkerLeaseRequest {
+message RequestWorkerLeaseRequest {
   // TaskSpec containing the requested resources.
   TaskSpec resource_spec = 1;
 }
 
-message WorkerLeaseReply {
+message RequestWorkerLeaseReply {
   // Address of the leased worker. If this is empty, then the request should be
   // retried at the provided raylet address.
   Address worker_address = 1;
@@ -45,7 +45,7 @@ message ForwardTaskRequest {
 message ForwardTaskReply {
 }
 
-message NodeStatsRequest {
+message GetNodeStatsRequest {
 }
 
 message WorkerStats {
@@ -83,7 +83,7 @@ message ViewData {
   repeated Measure measures = 2;
 }
 
-message NodeStatsReply {
+message GetNodeStatsReply {
   repeated WorkerStats workers_stats = 1;
   repeated ViewData view_data = 2;
   map<string, double> available_resources = 3;
@@ -94,11 +94,11 @@ message NodeStatsReply {
 // Service for inter-node-manager communication.
 service NodeManagerService {
   // Request a worker from the raylet.
-  rpc RequestWorkerLease(WorkerLeaseRequest) returns (WorkerLeaseReply);
+  rpc RequestWorkerLease(RequestWorkerLeaseRequest) returns (RequestWorkerLeaseReply);
   // Release a worker back to its raylet.
   rpc ReturnWorker(ReturnWorkerRequest) returns (ReturnWorkerReply);
   // Forward a task and its uncommitted lineage to the remote node manager.
   rpc ForwardTask(ForwardTaskRequest) returns (ForwardTaskReply);
   // Get the current node stats.
-  rpc GetNodeStats(NodeStatsRequest) returns (NodeStatsReply);
+  rpc GetNodeStats(GetNodeStatsRequest) returns (GetNodeStatsReply);
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1501,8 +1501,8 @@ void NodeManager::NewSchedulerSchedulePendingTasks() {
   DispatchScheduledTasksToWorkers();
 }
 
-void NodeManager::HandleWorkerLeaseRequest(const rpc::WorkerLeaseRequest &request,
-                                           rpc::WorkerLeaseReply *reply,
+void NodeManager::HandleWorkerLeaseRequest(const rpc::RequestWorkerLeaseRequest &request,
+                                           rpc::RequestWorkerLeaseReply *reply,
                                            rpc::SendReplyCallback send_reply_callback) {
   rpc::Task task_message;
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
@@ -2928,8 +2928,8 @@ std::string compact_tag_string(const opencensus::stats::ViewDescriptor &view,
   return result.str();
 }
 
-void NodeManager::HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
-                                         rpc::NodeStatsReply *reply,
+void NodeManager::HandleNodeStatsRequest(const rpc::GetNodeStatsRequest &request,
+                                         rpc::GetNodeStatsReply *reply,
                                          rpc::SendReplyCallback send_reply_callback) {
   for (const auto &driver : worker_pool_.GetAllDrivers()) {
     auto worker_stats = reply->add_workers_stats();

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -4,7 +4,7 @@
 #include <boost/asio/steady_timer.hpp>
 
 // clang-format off
-#include "ray/rpc/client_call.h"
+#include "ray/rpc/grpc_client.h"
 #include "ray/rpc/node_manager/node_manager_server.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
 #include "ray/common/task/task.h"
@@ -531,8 +531,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
                         bool success);
 
   /// Handle a `WorkerLease` request.
-  void HandleWorkerLeaseRequest(const rpc::WorkerLeaseRequest &request,
-                                rpc::WorkerLeaseReply *reply,
+  void HandleWorkerLeaseRequest(const rpc::RequestWorkerLeaseRequest &request,
+                                rpc::RequestWorkerLeaseReply *reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReturnWorker` request.
@@ -546,8 +546,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
                          rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `NodeStats` request.
-  void HandleNodeStatsRequest(const rpc::NodeStatsRequest &request,
-                              rpc::NodeStatsReply *reply,
+  void HandleNodeStatsRequest(const rpc::GetNodeStatsRequest &request,
+                              rpc::GetNodeStatsReply *reply,
                               rpc::SendReplyCallback send_reply_callback) override;
 
   /// Push an error to the driver if this node is full of actors and so we are

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -408,8 +408,8 @@ Status raylet::RayletClient::ReportActiveObjectIDs(
 
 Status raylet::RayletClient::RequestWorkerLease(
     const TaskSpecification &resource_spec,
-    const rpc::ClientCallback<rpc::WorkerLeaseReply> &callback) {
-  rpc::WorkerLeaseRequest request;
+    const rpc::ClientCallback<rpc::RequestWorkerLeaseReply> &callback) {
+  rpc::RequestWorkerLeaseRequest request;
   request.mutable_resource_spec()->CopyFrom(resource_spec.GetMessage());
   return grpc_client_->RequestWorkerLease(request, callback);
 }

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -40,7 +40,7 @@ class WorkerLeaseInterface {
   /// \return ray::Status
   virtual ray::Status RequestWorkerLease(
       const ray::TaskSpecification &resource_spec,
-      const ray::rpc::ClientCallback<ray::rpc::WorkerLeaseReply> &callback) = 0;
+      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback) = 0;
 
   /// Returns a worker to the raylet.
   /// \param worker_port The local port of the worker on the raylet node.
@@ -242,7 +242,7 @@ class RayletClient : public WorkerLeaseInterface {
   /// Implements WorkerLeaseInterface.
   ray::Status RequestWorkerLease(
       const ray::TaskSpecification &resource_spec,
-      const ray::rpc::ClientCallback<ray::rpc::WorkerLeaseReply> &callback) override;
+      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback) override;
 
   /// Implements WorkerLeaseInterface.
   ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -242,7 +242,8 @@ class RayletClient : public WorkerLeaseInterface {
   /// Implements WorkerLeaseInterface.
   ray::Status RequestWorkerLease(
       const ray::TaskSpecification &resource_spec,
-      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback) override;
+      const ray::rpc::ClientCallback<ray::rpc::RequestWorkerLeaseReply> &callback)
+      override;
 
   /// Implements WorkerLeaseInterface.
   ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -10,15 +10,6 @@
 namespace ray {
 namespace rpc {
 
-#define OLD_RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                       \
-  ({                                                                              \
-      auto call = client_call_manager_                                            \
-                      .CreateCall<SERVICE, METHOD##Request, METHOD##Reply>(       \
-                          *stub_, &SERVICE::Stub::PrepareAsync##METHOD,       \
-                          request, callback);                                     \
-      call->GetStatus();                                                             \                             
-  })                                                                              \               
-
 /// Represents an outgoing gRPC request.
 ///
 /// NOTE(hchen): Compared to `ClientCallImpl`, this abstract interface doesn't use

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -10,6 +10,15 @@
 namespace ray {
 namespace rpc {
 
+#define OLD_RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                       \
+  ({                                                                              \
+      auto call = client_call_manager_                                            \
+                      .CreateCall<SERVICE, METHOD##Request, METHOD##Reply>(       \
+                          *stub_, &SERVICE::Stub::PrepareAsync##METHOD,       \
+                          request, callback);                                     \
+      call->GetStatus();                                                             \                             
+  })                                                                              \               
+
 /// Represents an outgoing gRPC request.
 ///
 /// NOTE(hchen): Compared to `ClientCallImpl`, this abstract interface doesn't use

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -22,120 +22,67 @@ class GcsRpcClient {
   GcsRpcClient(const std::string &address, const int port,
                ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
-    job_info_rpc_client_ = std::unique_ptr<GrpcClient<JobInfoGcsService>>(
+    job_info_grpc_client_ = std::unique_ptr<GrpcClient<JobInfoGcsService>>(
         new GrpcClient<JobInfoGcsService>(address, port, client_call_manager));
-    actor_info_rpc_client_ = std::unique_ptr<GrpcClient<ActorInfoGcsService>>(
+    actor_info_grpc_client_ = std::unique_ptr<GrpcClient<ActorInfoGcsService>>(
         new GrpcClient<ActorInfoGcsService>(address, port, client_call_manager));
-    node_info_rpc_client_ = std::unique_ptr<GrpcClient<NodeInfoGcsService>>(
+    node_info_grpc_client_ = std::unique_ptr<GrpcClient<NodeInfoGcsService>>(
         new GrpcClient<NodeInfoGcsService>(address, port, client_call_manager));
-    object_info_rpc_client_ = std::unique_ptr<GrpcClient<ObjectInfoGcsService>>(
+    object_info_grpc_client_ = std::unique_ptr<GrpcClient<ObjectInfoGcsService>>(
         new GrpcClient<ObjectInfoGcsService>(address, port, client_call_manager));
   };
 
+  /// Note the following functions are defined using macros to simply code.
+  /// The semantics are these functions are like this:
+  ///
   /// Add job info to gcs server.
   ///
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server.
-  void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply> &callback) {
-    RPC_CALL_METHOD(JobInfoGcsService, AddJob, request, callback);
-  }
+  // 
+  // void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply> &callback) {
+  //   INVOKE_RPC_CALL(JobInfoGcsService, AddJob, request, callback, job_info_grpc_client_);
+  // }
+
+  /// Add job info to gcs server.
+  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, AddJob, request, callback, job_info_grpc_client_)
 
   /// Mark job as finished to gcs server.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void MarkJobFinished(const MarkJobFinishedRequest &request,
-                       const ClientCallback<MarkJobFinishedReply> &callback) {
-    RPC_CALL_METHOD(JobInfoGcsService, MarkJobFinished, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, MarkJobFinished, request, callback, job_info_grpc_client_)
 
   /// Get actor data from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void GetActorInfo(const GetActorInfoRequest &request,
-                    const ClientCallback<GetActorInfoReply> &callback) {
-    RPC_CALL_METHOD(ActorInfoGcsService, GetActorInfo, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, GetActorInfo, request, callback, actor_info_grpc_client_)
 
   /// Register an actor to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void RegisterActorInfo(const RegisterActorInfoRequest &request,
-                         const ClientCallback<RegisterActorInfoReply> &callback) {
-    RPC_CALL_METHOD(ActorInfoGcsService, RegisterActorInfo, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, RegisterActorInfo, request, callback, actor_info_grpc_client_)
 
   ///  Update actor info in GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void UpdateActorInfo(const UpdateActorInfoRequest &request,
-                       const ClientCallback<UpdateActorInfoReply> &callback) {
-    RPC_CALL_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback, actor_info_grpc_client_)
 
   /// Register a node to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void RegisterNode(const RegisterNodeRequest &request,
-                    const ClientCallback<RegisterNodeReply> &callback) {
-    RPC_CALL_METHOD(NodeInfoGcsService, RegisterNode, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, request, callback, node_info_grpc_client_)
 
   /// Unregister a node from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void UnregisterNode(const UnregisterNodeRequest &request,
-                      const ClientCallback<UnregisterNodeReply> &callback) {
-    RPC_CALL_METHOD(NodeInfoGcsService, UnregisterNode, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, UnregisterNode, request, callback, node_info_grpc_client_)
 
   /// Get information of all nodes from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void GetAllNodeInfo(const GetAllNodeInfoRequest &request,
-                      const ClientCallback<GetAllNodeInfoReply> &callback) {
-    RPC_CALL_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback, node_info_grpc_client_)
 
   /// Get object's locations from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void GetObjectLocations(const GetObjectLocationsRequest &request,
-                          const ClientCallback<GetObjectLocationsReply> &callback) {
-    RPC_CALL_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback, object_info_grpc_client_)
 
   /// Add location of object to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void AddObjectLocation(const AddObjectLocationRequest &request,
-                         const ClientCallback<AddObjectLocationReply> &callback) {
-    RPC_CALL_METHOD(ObjectInfoGcsService, AddObjectLocation, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, AddObjectLocation, request, callback, object_info_grpc_client_)
 
   /// Remove location of object to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void RemoveObjectLocation(const RemoveObjectLocationRequest &request,
-                            const ClientCallback<RemoveObjectLocationReply> &callback) {
-    RPC_CALL_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback, object_info_grpc_client_)
 
  private:
   /// The gRPC-generated stub.
-  std::unique_ptr<GrpcClient<JobInfoGcsService>> job_info_rpc_client_;
-  std::unique_ptr<GrpcClient<ActorInfoGcsService>> actor_info_rpc_client_;
-  std::unique_ptr<GrpcClient<NodeInfoGcsService>> node_info_rpc_client_;
-  std::unique_ptr<GrpcClient<ObjectInfoGcsService>> object_info_rpc_client_;
+  std::unique_ptr<GrpcClient<JobInfoGcsService>> job_info_grpc_client_;
+  std::unique_ptr<GrpcClient<ActorInfoGcsService>> actor_info_grpc_client_;
+  std::unique_ptr<GrpcClient<NodeInfoGcsService>> node_info_grpc_client_;
+  std::unique_ptr<GrpcClient<ObjectInfoGcsService>> object_info_grpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -6,7 +6,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include "src/ray/protobuf/gcs_service.pb.h"
-#include "src/ray/rpc/client_call.h"
+#include "src/ray/rpc/grpc_client.h"
 
 namespace ray {
 namespace rpc {
@@ -22,12 +22,14 @@ class GcsRpcClient {
   GcsRpcClient(const std::string &address, const int port,
                ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
-    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
-        address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
-    job_info_stub_ = JobInfoGcsService::NewStub(channel);
-    actor_info_stub_ = ActorInfoGcsService::NewStub(channel);
-    node_info_stub_ = NodeInfoGcsService::NewStub(channel);
-    object_info_stub_ = ObjectInfoGcsService::NewStub(channel);
+    job_info_rpc_client_ = std::unique_ptr<GrpcClient<JobInfoGcsService>>(
+      new GrpcClient<JobInfoGcsService>(address, port, client_call_manager));
+    actor_info_rpc_client_ = std::unique_ptr<GrpcClient<ActorInfoGcsService>>(
+      new GrpcClient<ActorInfoGcsService>(address, port, client_call_manager));
+    node_info_rpc_client_ = std::unique_ptr<GrpcClient<NodeInfoGcsService>>(
+      new GrpcClient<NodeInfoGcsService>(address, port, client_call_manager));
+    object_info_rpc_client_ = std::unique_ptr<GrpcClient<ObjectInfoGcsService>>(
+      new GrpcClient<ObjectInfoGcsService>(address, port, client_call_manager));    
   };
 
   /// Add job info to gcs server.
@@ -35,8 +37,7 @@ class GcsRpcClient {
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server.
   void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply> &callback) {
-    client_call_manager_.CreateCall<JobInfoGcsService, AddJobRequest, AddJobReply>(
-        *job_info_stub_, &JobInfoGcsService::Stub::PrepareAsyncAddJob, request, callback);
+    RPC_CALL_METHOD(JobInfoGcsService, AddJob, request, callback);        
   }
 
   /// Mark job as finished to gcs server.
@@ -45,10 +46,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void MarkJobFinished(const MarkJobFinishedRequest &request,
                        const ClientCallback<MarkJobFinishedReply> &callback) {
-    client_call_manager_
-        .CreateCall<JobInfoGcsService, MarkJobFinishedRequest, MarkJobFinishedReply>(
-            *job_info_stub_, &JobInfoGcsService::Stub::PrepareAsyncMarkJobFinished,
-            request, callback);
+    RPC_CALL_METHOD(JobInfoGcsService, MarkJobFinished, request, callback);
   }
 
   /// Get actor data from GCS Service.
@@ -57,10 +55,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void GetActorInfo(const GetActorInfoRequest &request,
                     const ClientCallback<GetActorInfoReply> &callback) {
-    client_call_manager_
-        .CreateCall<ActorInfoGcsService, GetActorInfoRequest, GetActorInfoReply>(
-            *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncGetActorInfo,
-            request, callback);
+    RPC_CALL_METHOD(ActorInfoGcsService, GetActorInfo, request, callback);
   }
 
   /// Register an actor to GCS Service.
@@ -69,10 +64,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void RegisterActorInfo(const RegisterActorInfoRequest &request,
                          const ClientCallback<RegisterActorInfoReply> &callback) {
-    client_call_manager_.CreateCall<ActorInfoGcsService, RegisterActorInfoRequest,
-                                    RegisterActorInfoReply>(
-        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncRegisterActorInfo,
-        request, callback);
+    RPC_CALL_METHOD(ActorInfoGcsService, RegisterActorInfo, request, callback);
   }
 
   ///  Update actor info in GCS Service.
@@ -81,10 +73,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void UpdateActorInfo(const UpdateActorInfoRequest &request,
                        const ClientCallback<UpdateActorInfoReply> &callback) {
-    client_call_manager_
-        .CreateCall<ActorInfoGcsService, UpdateActorInfoRequest, UpdateActorInfoReply>(
-            *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncUpdateActorInfo,
-            request, callback);
+    RPC_CALL_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback);
   }
 
   /// Register a node to GCS Service.
@@ -93,10 +82,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void RegisterNode(const RegisterNodeRequest &request,
                     const ClientCallback<RegisterNodeReply> &callback) {
-    client_call_manager_
-        .CreateCall<NodeInfoGcsService, RegisterNodeRequest, RegisterNodeReply>(
-            *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncRegisterNode,
-            request, callback);
+    RPC_CALL_METHOD(NodeInfoGcsService, RegisterNode, request, callback);
   }
 
   /// Unregister a node from GCS Service.
@@ -105,10 +91,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void UnregisterNode(const UnregisterNodeRequest &request,
                       const ClientCallback<UnregisterNodeReply> &callback) {
-    client_call_manager_
-        .CreateCall<NodeInfoGcsService, UnregisterNodeRequest, UnregisterNodeReply>(
-            *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncUnregisterNode,
-            request, callback);
+    RPC_CALL_METHOD(NodeInfoGcsService, UnregisterNode, request, callback);
   }
 
   /// Get information of all nodes from GCS Service.
@@ -117,10 +100,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void GetAllNodeInfo(const GetAllNodeInfoRequest &request,
                       const ClientCallback<GetAllNodeInfoReply> &callback) {
-    client_call_manager_
-        .CreateCall<NodeInfoGcsService, GetAllNodeInfoRequest, GetAllNodeInfoReply>(
-            *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncGetAllNodeInfo,
-            request, callback);
+    RPC_CALL_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback);
   }
 
   /// Get object's locations from GCS Service.
@@ -129,10 +109,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void GetObjectLocations(const GetObjectLocationsRequest &request,
                           const ClientCallback<GetObjectLocationsReply> &callback) {
-    client_call_manager_.CreateCall<ObjectInfoGcsService, GetObjectLocationsRequest,
-                                    GetObjectLocationsReply>(
-        *object_info_stub_, &ObjectInfoGcsService::Stub::PrepareAsyncGetObjectLocations,
-        request, callback);
+    RPC_CALL_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback);
   }
 
   /// Add location of object to GCS Service.
@@ -141,10 +118,7 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void AddObjectLocation(const AddObjectLocationRequest &request,
                          const ClientCallback<AddObjectLocationReply> &callback) {
-    client_call_manager_.CreateCall<ObjectInfoGcsService, AddObjectLocationRequest,
-                                    AddObjectLocationReply>(
-        *object_info_stub_, &ObjectInfoGcsService::Stub::PrepareAsyncAddObjectLocation,
-        request, callback);
+    RPC_CALL_METHOD(ObjectInfoGcsService, AddObjectLocation, request, callback);
   }
 
   /// Remove location of object to GCS Service.
@@ -153,18 +127,15 @@ class GcsRpcClient {
   /// \param callback The callback function that handles reply from server.
   void RemoveObjectLocation(const RemoveObjectLocationRequest &request,
                             const ClientCallback<RemoveObjectLocationReply> &callback) {
-    client_call_manager_.CreateCall<ObjectInfoGcsService, RemoveObjectLocationRequest,
-                                    RemoveObjectLocationReply>(
-        *object_info_stub_, &ObjectInfoGcsService::Stub::PrepareAsyncRemoveObjectLocation,
-        request, callback);
+    RPC_CALL_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback);
   }
 
  private:
   /// The gRPC-generated stub.
-  std::unique_ptr<JobInfoGcsService::Stub> job_info_stub_;
-  std::unique_ptr<ActorInfoGcsService::Stub> actor_info_stub_;
-  std::unique_ptr<NodeInfoGcsService::Stub> node_info_stub_;
-  std::unique_ptr<ObjectInfoGcsService::Stub> object_info_stub_;
+  std::unique_ptr<JobInfoGcsService::Stub> job_info_rpc_client_;
+  std::unique_ptr<ActorInfoGcsService::Stub> actor_info_rpc_client_;
+  std::unique_ptr<NodeInfoGcsService::Stub> node_info_rpc_client_;
+  std::unique_ptr<ObjectInfoGcsService::Stub> object_info_rpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -32,20 +32,6 @@ class GcsRpcClient {
         new GrpcClient<ObjectInfoGcsService>(address, port, client_call_manager));
   };
 
-  /// Note the following functions are defined using macros to simply code.
-  /// The semantics are these functions are like this:
-  ///
-  /// Add job info to gcs server.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  //
-  // void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply>
-  // &callback) {
-  //   INVOKE_RPC_CALL(JobInfoGcsService, AddJob, request, callback,
-  //   job_info_grpc_client_);
-  // }
-
   /// Add job info to gcs server.
   VOID_RPC_CLIENT_METHOD(JobInfoGcsService, AddJob, request, callback,
                          job_info_grpc_client_)

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -132,10 +132,10 @@ class GcsRpcClient {
 
  private:
   /// The gRPC-generated stub.
-  std::unique_ptr<JobInfoGcsService::Stub> job_info_rpc_client_;
-  std::unique_ptr<ActorInfoGcsService::Stub> actor_info_rpc_client_;
-  std::unique_ptr<NodeInfoGcsService::Stub> node_info_rpc_client_;
-  std::unique_ptr<ObjectInfoGcsService::Stub> object_info_rpc_client_;
+  std::unique_ptr<GrpcClient<JobInfoGcsService>> job_info_rpc_client_;
+  std::unique_ptr<GrpcClient<ActorInfoGcsService>> actor_info_rpc_client_;
+  std::unique_ptr<GrpcClient<NodeInfoGcsService>> node_info_rpc_client_;
+  std::unique_ptr<GrpcClient<ObjectInfoGcsService>> object_info_rpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -39,43 +39,56 @@ class GcsRpcClient {
   ///
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server.
-  // 
-  // void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply> &callback) {
-  //   INVOKE_RPC_CALL(JobInfoGcsService, AddJob, request, callback, job_info_grpc_client_);
+  //
+  // void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply>
+  // &callback) {
+  //   INVOKE_RPC_CALL(JobInfoGcsService, AddJob, request, callback,
+  //   job_info_grpc_client_);
   // }
 
   /// Add job info to gcs server.
-  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, AddJob, request, callback, job_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, AddJob, request, callback,
+                         job_info_grpc_client_)
 
   /// Mark job as finished to gcs server.
-  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, MarkJobFinished, request, callback, job_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(JobInfoGcsService, MarkJobFinished, request, callback,
+                         job_info_grpc_client_)
 
   /// Get actor data from GCS Service.
-  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, GetActorInfo, request, callback, actor_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, GetActorInfo, request, callback,
+                         actor_info_grpc_client_)
 
   /// Register an actor to GCS Service.
-  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, RegisterActorInfo, request, callback, actor_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, RegisterActorInfo, request, callback,
+                         actor_info_grpc_client_)
 
   ///  Update actor info in GCS Service.
-  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback, actor_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback,
+                         actor_info_grpc_client_)
 
   /// Register a node to GCS Service.
-  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, request, callback, node_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, request, callback,
+                         node_info_grpc_client_)
 
   /// Unregister a node from GCS Service.
-  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, UnregisterNode, request, callback, node_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, UnregisterNode, request, callback,
+                         node_info_grpc_client_)
 
   /// Get information of all nodes from GCS Service.
-  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback, node_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback,
+                         node_info_grpc_client_)
 
   /// Get object's locations from GCS Service.
-  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback, object_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback,
+                         object_info_grpc_client_)
 
   /// Add location of object to GCS Service.
-  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, AddObjectLocation, request, callback, object_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, AddObjectLocation, request, callback,
+                         object_info_grpc_client_)
 
   /// Remove location of object to GCS Service.
-  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback, object_info_grpc_client_)
+  VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback,
+                         object_info_grpc_client_)
 
  private:
   /// The gRPC-generated stub.

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -23,13 +23,13 @@ class GcsRpcClient {
                ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
     job_info_rpc_client_ = std::unique_ptr<GrpcClient<JobInfoGcsService>>(
-      new GrpcClient<JobInfoGcsService>(address, port, client_call_manager));
+        new GrpcClient<JobInfoGcsService>(address, port, client_call_manager));
     actor_info_rpc_client_ = std::unique_ptr<GrpcClient<ActorInfoGcsService>>(
-      new GrpcClient<ActorInfoGcsService>(address, port, client_call_manager));
+        new GrpcClient<ActorInfoGcsService>(address, port, client_call_manager));
     node_info_rpc_client_ = std::unique_ptr<GrpcClient<NodeInfoGcsService>>(
-      new GrpcClient<NodeInfoGcsService>(address, port, client_call_manager));
+        new GrpcClient<NodeInfoGcsService>(address, port, client_call_manager));
     object_info_rpc_client_ = std::unique_ptr<GrpcClient<ObjectInfoGcsService>>(
-      new GrpcClient<ObjectInfoGcsService>(address, port, client_call_manager));    
+        new GrpcClient<ObjectInfoGcsService>(address, port, client_call_manager));
   };
 
   /// Add job info to gcs server.
@@ -37,7 +37,7 @@ class GcsRpcClient {
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server.
   void AddJob(const AddJobRequest &request, const ClientCallback<AddJobReply> &callback) {
-    RPC_CALL_METHOD(JobInfoGcsService, AddJob, request, callback);        
+    RPC_CALL_METHOD(JobInfoGcsService, AddJob, request, callback);
   }
 
   /// Mark job as finished to gcs server.

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -11,15 +11,27 @@
 namespace ray {
 namespace rpc {
 
-// Call a specific rpc method.
-#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback) \
-  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)
+// This macro wraps the logic to call a specific RPC method of a service,
+// to make it easier to implement a new RPC client.
+#define INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client)    \
+  ({                                                                       \
+    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
+        &SERVICE::Stub::PrepareAsync##METHOD, request, callback);          \
+  })                                                                       \
 
-#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client) \
-  ({                                                                                \
-    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(                \
-        &SERVICE::Stub::PrepareAsync##METHOD, request, callback);                   \
-  })
+// Define a void RPC client method. 
+#define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)  \
+  void METHOD(const METHOD##Request &request,                                   \
+              const ClientCallback<METHOD##Reply> &callback) {                  \
+    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);     \
+  }                                                                             \
+
+// Define a RPC client method that returns ray::Status.
+#define RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)    \
+  ray::Status METHOD(const METHOD##Request &request,                         \
+              const ClientCallback<METHOD##Reply> &callback) {               \
+    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);  \
+  }                                                                          \
 
 template <class GrpcService>
 class GrpcClient {

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -12,21 +12,15 @@ namespace ray {
 namespace rpc {
 
 // Call a specific rpc method.
-#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                   \
-  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)            \
-/*  
-  ({                                                                          \
-      rpc_client_->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
-                        &SERVICE::Stub::PrepareAsync##METHOD,                 \
-                        request, callback);                                   \
-  })                                                                          \
-*/
-#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client)      \
-  ({                                                                         \
-      rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
-                        &SERVICE::Stub::PrepareAsync##METHOD,                \
-                        request, callback);                                  \
-  })                                                                         \
+#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                           \
+  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)        \
+
+#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client)   \
+  ({                                                                                  \
+      rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(                \
+                        &SERVICE::Stub::PrepareAsync##METHOD,                         \
+                        request, callback);                                           \
+  })                                                                                  \
 
 template <class GrpcService>
 class GrpcClient {

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -15,7 +15,7 @@ namespace rpc {
 // to make it easier to implement a new RPC client.
 #define INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client) \
   ({                                                                    \
-    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(    \
+    rpc_client->CallMethod<METHOD##Request, METHOD##Reply>(             \
         &SERVICE::Stub::PrepareAsync##METHOD, request, callback);       \
   })
 
@@ -58,18 +58,16 @@ class GrpcClient {
 
   /// Create a new `ClientCall` and send request.
   ///
-  /// \tparam GrpcService Type of the gRPC-generated service class.
   /// \tparam Request Type of the request message.
   /// \tparam Reply Type of the reply message.
   ///
-  /// \param[in] stub The gRPC-generated stub.
   /// \param[in] prepare_async_function Pointer to the gRPC-generated
   /// `FooService::Stub::PrepareAsyncBar` function.
   /// \param[in] request The request message.
   /// \param[in] callback The callback function that handles reply.
   ///
-  /// \return A `ClientCall` representing the request that was just sent.
-  template <class Method, class Request, class Reply>
+  /// \return Status.
+  template <class Request, class Reply>
   ray::Status CallMethod(
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
       const Request &request, const ClientCallback<Reply> &callback) {

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -20,10 +20,10 @@ namespace rpc {
   })
 
 // Define a void RPC client method.
-#define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client) \
-  void METHOD(const METHOD##Request &request,                                  \
-              const ClientCallback<METHOD##Reply> &callback) {                 \
-    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);    \
+#define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)   \
+  void METHOD(const METHOD##Request &request,                                    \
+              const ClientCallback<METHOD##Reply> &callback) {                   \
+    RAY_UNUSED(INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client)); \
   }
 
 // Define a RPC client method that returns ray::Status.

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -5,37 +5,35 @@
 #include <boost/asio.hpp>
 
 #include "ray/common/grpc_util.h"
-#include "ray/rpc/client_call.h"
 #include "ray/common/status.h"
+#include "ray/rpc/client_call.h"
 
 namespace ray {
 namespace rpc {
 
 // Call a specific rpc method.
-#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                           \
-  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)        \
+#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback) \
+  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)
 
-#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client)   \
-  ({                                                                                  \
-      rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(                \
-                        &SERVICE::Stub::PrepareAsync##METHOD,                         \
-                        request, callback);                                           \
-  })                                                                                  \
+#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client) \
+  ({                                                                                \
+    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(                \
+        &SERVICE::Stub::PrepareAsync##METHOD, request, callback);                   \
+  })
 
 template <class GrpcService>
 class GrpcClient {
  public:
   GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager)
-    : client_call_manager_(call_manager) {
+      : client_call_manager_(call_manager) {
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
         address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
     stub_ = GrpcService::NewStub(channel);
   }
 
   GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager,
-      int num_threads)
-    : client_call_manager_(call_manager) {
-
+             int num_threads)
+      : client_call_manager_(call_manager) {
     grpc::ResourceQuota quota;
     quota.SetMaxThreads(num_threads);
     grpc::ChannelArguments argument;
@@ -63,15 +61,12 @@ class GrpcClient {
   ray::Status CallMethod(
       const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
       const Request &request, const ClientCallback<Reply> &callback) {
-
-    auto call = client_call_manager_
-                    .CreateCall<GrpcService, Request, Reply>(
-                        *stub_, prepare_async_function, request,
-                        callback);
-    return call->GetStatus();    
+    auto call = client_call_manager_.CreateCall<GrpcService, Request, Reply>(
+        *stub_, prepare_async_function, request, callback);
+    return call->GetStatus();
   }
- private:
 
+ private:
   ClientCallManager &client_call_manager_;
   /// The gRPC-generated stub.
   std::unique_ptr<typename GrpcService::Stub> stub_;

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -13,25 +13,25 @@ namespace rpc {
 
 // This macro wraps the logic to call a specific RPC method of a service,
 // to make it easier to implement a new RPC client.
-#define INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client)    \
-  ({                                                                       \
-    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
-        &SERVICE::Stub::PrepareAsync##METHOD, request, callback);          \
-  })                                                                       \
+#define INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client) \
+  ({                                                                    \
+    rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(    \
+        &SERVICE::Stub::PrepareAsync##METHOD, request, callback);       \
+  })
 
-// Define a void RPC client method. 
-#define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)  \
-  void METHOD(const METHOD##Request &request,                                   \
-              const ClientCallback<METHOD##Reply> &callback) {                  \
-    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);     \
-  }                                                                             \
+// Define a void RPC client method.
+#define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client) \
+  void METHOD(const METHOD##Request &request,                                  \
+              const ClientCallback<METHOD##Reply> &callback) {                 \
+    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);    \
+  }
 
 // Define a RPC client method that returns ray::Status.
-#define RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)    \
-  ray::Status METHOD(const METHOD##Request &request,                         \
-              const ClientCallback<METHOD##Reply> &callback) {               \
-    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client);  \
-  }                                                                          \
+#define RPC_CLIENT_METHOD(SERVICE, METHOD, request, callback, rpc_client)   \
+  ray::Status METHOD(const METHOD##Request &request,                        \
+                     const ClientCallback<METHOD##Reply> &callback) {       \
+    return INVOKE_RPC_CALL(SERVICE, METHOD, request, callback, rpc_client); \
+  }
 
 template <class GrpcService>
 class GrpcClient {

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -1,0 +1,89 @@
+#ifndef RAY_RPC_GRPC_CLIENT_H
+#define RAY_RPC_GRPC_CLIENT_H
+
+#include <grpcpp/grpcpp.h>
+#include <boost/asio.hpp>
+
+#include "ray/common/grpc_util.h"
+#include "ray/rpc/client_call.h"
+#include "ray/common/status.h"
+
+namespace ray {
+namespace rpc {
+
+// Call a specific rpc method.
+#define RPC_CALL_METHOD(SERVICE, METHOD, request, callback)                   \
+  RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client_)            \
+/*  
+  ({                                                                          \
+      rpc_client_->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
+                        &SERVICE::Stub::PrepareAsync##METHOD,                 \
+                        request, callback);                                   \
+  })                                                                          \
+*/
+#define RPC_CALL_METHOD_WITH_CLIENT(SERVICE, METHOD, request, callback, rpc_client)      \
+  ({                                                                         \
+      rpc_client->CallMethod<SERVICE, METHOD##Request, METHOD##Reply>(       \
+                        &SERVICE::Stub::PrepareAsync##METHOD,                \
+                        request, callback);                                  \
+  })                                                                         \
+
+template <class GrpcService>
+class GrpcClient {
+ public:
+  GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager)
+    : client_call_manager_(call_manager) {
+    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
+        address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
+    stub_ = GrpcService::NewStub(channel);
+  }
+
+  GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager,
+      int num_threads)
+    : client_call_manager_(call_manager) {
+
+    grpc::ResourceQuota quota;
+    quota.SetMaxThreads(num_threads);
+    grpc::ChannelArguments argument;
+    argument.SetResourceQuota(quota);
+    std::shared_ptr<grpc::Channel> channel =
+        grpc::CreateCustomChannel(address + ":" + std::to_string(port),
+                                  grpc::InsecureChannelCredentials(), argument);
+    stub_ = GrpcService::NewStub(channel);
+  }
+
+  /// Create a new `ClientCall` and send request.
+  ///
+  /// \tparam GrpcService Type of the gRPC-generated service class.
+  /// \tparam Request Type of the request message.
+  /// \tparam Reply Type of the reply message.
+  ///
+  /// \param[in] stub The gRPC-generated stub.
+  /// \param[in] prepare_async_function Pointer to the gRPC-generated
+  /// `FooService::Stub::PrepareAsyncBar` function.
+  /// \param[in] request The request message.
+  /// \param[in] callback The callback function that handles reply.
+  ///
+  /// \return A `ClientCall` representing the request that was just sent.
+  template <class Method, class Request, class Reply>
+  ray::Status CallMethod(
+      const PrepareAsyncFunction<GrpcService, Request, Reply> prepare_async_function,
+      const Request &request, const ClientCallback<Reply> &callback) {
+
+    auto call = client_call_manager_
+                    .CreateCall<GrpcService, Request, Reply>(
+                        *stub_, prepare_async_function, request,
+                        callback);
+    return call->GetStatus();    
+  }
+ private:
+
+  ClientCallManager &client_call_manager_;
+  /// The gRPC-generated stub.
+  std::unique_ptr<typename GrpcService::Stub> stub_;
+};
+
+}  // namespace rpc
+}  // namespace ray
+
+#endif

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -25,7 +25,7 @@ class NodeManagerClient {
   NodeManagerClient(const std::string &address, const int port,
                     ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
-    rpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
+    grpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
         new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };
 
@@ -33,20 +33,19 @@ class NodeManagerClient {
   ///
   /// \param[in] request The request message.
   /// \param[in] callback The callback function that handles reply.
-  void ForwardTask(const ForwardTaskRequest &request,
-                   const ClientCallback<ForwardTaskReply> &callback) {
-    RPC_CALL_METHOD(NodeManagerService, ForwardTask, request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, ForwardTask, request, callback, grpc_client_)
 
   /// Get current node stats.
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, GetNodeStats, request, callback, grpc_client_)
+
   void GetNodeStats(const ClientCallback<GetNodeStatsReply> &callback) {
     GetNodeStatsRequest request;
-    RPC_CALL_METHOD(NodeManagerService, GetNodeStats, request, callback);
+    GetNodeStats(request, callback);
   }
 
  private:
   /// The RPC client.
-  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;
+  std::unique_ptr<GrpcClient<NodeManagerService>> grpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;
@@ -69,16 +68,10 @@ class NodeManagerWorkerClient
   }
 
   /// Request a worker lease.
-  ray::Status RequestWorkerLease(
-      const RequestWorkerLeaseRequest &request,
-      const ClientCallback<RequestWorkerLeaseReply> &callback) {
-    return RPC_CALL_METHOD(NodeManagerService, RequestWorkerLease, request, callback);
-  }
+  RPC_CLIENT_METHOD(NodeManagerService, RequestWorkerLease, request, callback, grpc_client_)
 
-  ray::Status ReturnWorker(const ReturnWorkerRequest &request,
-                           const ClientCallback<ReturnWorkerReply> &callback) {
-    return RPC_CALL_METHOD(NodeManagerService, ReturnWorker, request, callback);
-  }
+  /// Return a worker lease.
+  RPC_CLIENT_METHOD(NodeManagerService, ReturnWorker, request, callback, grpc_client_)
 
  private:
   /// Constructor.
@@ -89,12 +82,12 @@ class NodeManagerWorkerClient
   NodeManagerWorkerClient(const std::string &address, const int port,
                           ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
-    rpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
+    grpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
         new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };
 
   /// The RPC client.
-  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;
+  std::unique_ptr<GrpcClient<NodeManagerService>> grpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -26,7 +26,7 @@ class NodeManagerClient {
                     ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
     rpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
-      new GrpcClient<NodeManagerService>(address, port, client_call_manager));
+        new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };
 
   /// Forward a task and its uncommitted lineage.
@@ -46,7 +46,7 @@ class NodeManagerClient {
 
  private:
   /// The RPC client.
-  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;  
+  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;
@@ -69,8 +69,9 @@ class NodeManagerWorkerClient
   }
 
   /// Request a worker lease.
-  ray::Status RequestWorkerLease(const RequestWorkerLeaseRequest &request,
-                                 const ClientCallback<RequestWorkerLeaseReply> &callback) {
+  ray::Status RequestWorkerLease(
+      const RequestWorkerLeaseRequest &request,
+      const ClientCallback<RequestWorkerLeaseReply> &callback) {
     return RPC_CALL_METHOD(NodeManagerService, RequestWorkerLease, request, callback);
   }
 
@@ -89,11 +90,11 @@ class NodeManagerWorkerClient
                           ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
     rpc_client_ = std::unique_ptr<GrpcClient<NodeManagerService>>(
-      new GrpcClient<NodeManagerService>(address, port, client_call_manager));
+        new GrpcClient<NodeManagerService>(address, port, client_call_manager));
   };
 
   /// The RPC client.
-  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;  
+  std::unique_ptr<GrpcClient<NodeManagerService>> rpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -36,7 +36,8 @@ class NodeManagerClient {
   VOID_RPC_CLIENT_METHOD(NodeManagerService, ForwardTask, request, callback, grpc_client_)
 
   /// Get current node stats.
-  VOID_RPC_CLIENT_METHOD(NodeManagerService, GetNodeStats, request, callback, grpc_client_)
+  VOID_RPC_CLIENT_METHOD(NodeManagerService, GetNodeStats, request, callback,
+                         grpc_client_)
 
   void GetNodeStats(const ClientCallback<GetNodeStatsReply> &callback) {
     GetNodeStatsRequest request;
@@ -68,7 +69,8 @@ class NodeManagerWorkerClient
   }
 
   /// Request a worker lease.
-  RPC_CLIENT_METHOD(NodeManagerService, RequestWorkerLease, request, callback, grpc_client_)
+  RPC_CLIENT_METHOD(NodeManagerService, RequestWorkerLease, request, callback,
+                    grpc_client_)
 
   /// Return a worker lease.
   RPC_CLIENT_METHOD(NodeManagerService, ReturnWorker, request, callback, grpc_client_)

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -24,8 +24,8 @@ class NodeManagerServiceHandler {
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
 
-  virtual void HandleWorkerLeaseRequest(const WorkerLeaseRequest &request,
-                                        WorkerLeaseReply *reply,
+  virtual void HandleWorkerLeaseRequest(const RequestWorkerLeaseRequest &request,
+                                        RequestWorkerLeaseReply *reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleReturnWorker(const ReturnWorkerRequest &request,
@@ -36,8 +36,8 @@ class NodeManagerServiceHandler {
                                  ForwardTaskReply *reply,
                                  SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleNodeStatsRequest(const NodeStatsRequest &request,
-                                      NodeStatsReply *reply,
+  virtual void HandleNodeStatsRequest(const GetNodeStatsRequest &request,
+                                      GetNodeStatsReply *reply,
                                       SendReplyCallback send_reply_callback) = 0;
 };
 
@@ -62,7 +62,7 @@ class NodeManagerGrpcService : public GrpcService {
     // Initialize the factory for requests.
     std::unique_ptr<ServerCallFactory> request_worker_lease_call_factory(
         new ServerCallFactoryImpl<NodeManagerService, NodeManagerServiceHandler,
-                                  WorkerLeaseRequest, WorkerLeaseReply>(
+                                  RequestWorkerLeaseRequest, RequestWorkerLeaseReply>(
             service_, &NodeManagerService::AsyncService::RequestRequestWorkerLease,
             service_handler_, &NodeManagerServiceHandler::HandleWorkerLeaseRequest, cq,
             main_service_));
@@ -83,7 +83,7 @@ class NodeManagerGrpcService : public GrpcService {
 
     std::unique_ptr<ServerCallFactory> node_stats_call_factory(
         new ServerCallFactoryImpl<NodeManagerService, NodeManagerServiceHandler,
-                                  NodeStatsRequest, NodeStatsReply>(
+                                  GetNodeStatsRequest, GetNodeStatsReply>(
             service_, &NodeManagerService::AsyncService::RequestGetNodeStats,
             service_handler_, &NodeManagerServiceHandler::HandleNodeStatsRequest, cq,
             main_service_));

--- a/src/ray/rpc/object_manager/object_manager_client.h
+++ b/src/ray/rpc/object_manager/object_manager_client.h
@@ -32,7 +32,8 @@ class ObjectManagerClient {
     freeobjects_rr_index_ = rand() % num_connections_;
     rpc_clients_.reserve(num_connections_);
     for (int i = 0; i < num_connections_; i++) {
-      rpc_clients_.emplace_back(new GrpcClient<ObjectManagerService>(address, port, client_call_manager, num_connections_));
+      rpc_clients_.emplace_back(new GrpcClient<ObjectManagerService>(
+          address, port, client_call_manager, num_connections_));
     }
   };
 
@@ -42,7 +43,7 @@ class ObjectManagerClient {
   /// \param callback The callback function that handles reply from server
   void Push(const PushRequest &request, const ClientCallback<PushReply> &callback) {
     RPC_CALL_METHOD_WITH_CLIENT(ObjectManagerService, Push, request, callback,
-        rpc_clients_[push_rr_index_++ % num_connections_]);
+                                rpc_clients_[push_rr_index_++ % num_connections_]);
   }
 
   /// Pull object from remote object manager
@@ -51,7 +52,7 @@ class ObjectManagerClient {
   /// \param callback The callback function that handles reply from server
   void Pull(const PullRequest &request, const ClientCallback<PullReply> &callback) {
     RPC_CALL_METHOD_WITH_CLIENT(ObjectManagerService, Pull, request, callback,
-        rpc_clients_[push_rr_index_++ % num_connections_]);
+                                rpc_clients_[push_rr_index_++ % num_connections_]);
   }
 
   /// Tell remote object manager to free objects
@@ -61,7 +62,7 @@ class ObjectManagerClient {
   void FreeObjects(const FreeObjectsRequest &request,
                    const ClientCallback<FreeObjectsReply> &callback) {
     RPC_CALL_METHOD_WITH_CLIENT(ObjectManagerService, FreeObjects, request, callback,
-        rpc_clients_[push_rr_index_++ % num_connections_]);
+                                rpc_clients_[push_rr_index_++ % num_connections_]);
   }
 
  private:

--- a/src/ray/rpc/object_manager/object_manager_client.h
+++ b/src/ray/rpc/object_manager/object_manager_client.h
@@ -42,21 +42,21 @@ class ObjectManagerClient {
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server
   VOID_RPC_CLIENT_METHOD(ObjectManagerService, Push, request, callback,
-      grpc_clients_[push_rr_index_++ % num_connections_])
+                         grpc_clients_[push_rr_index_++ % num_connections_])
 
   /// Pull object from remote object manager
   ///
   /// \param request The request message
   /// \param callback The callback function that handles reply from server
   VOID_RPC_CLIENT_METHOD(ObjectManagerService, Pull, request, callback,
-      grpc_clients_[pull_rr_index_++ % num_connections_])  
+                         grpc_clients_[pull_rr_index_++ % num_connections_])
 
   /// Tell remote object manager to free objects
   ///
   /// \param request The request message
   /// \param callback  The callback function that handles reply
   VOID_RPC_CLIENT_METHOD(ObjectManagerService, FreeObjects, request, callback,
-      grpc_clients_[freeobjects_rr_index_++ % num_connections_])
+                         grpc_clients_[freeobjects_rr_index_++ % num_connections_])
 
  private:
   /// To optimize object manager performance we create multiple concurrent

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -225,7 +225,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       rpc_bytes_in_flight_ += task_size;
 
       auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](
-          Status status, const rpc::PushTaskReply &reply) {
+                              Status status, const rpc::PushTaskReply &reply) {
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (seq_no > max_finished_seq_no_) {

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -11,7 +11,7 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/hash/hash.h"
 #include "ray/common/status.h"
-#include "ray/rpc/client_call.h"
+#include "ray/rpc/grpc_client.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/core_worker.grpc.pb.h"
 #include "src/ray/protobuf/core_worker.pb.h"
@@ -148,18 +148,13 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   CoreWorkerClient(const std::string &address, const int port,
                    ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
-    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
-        address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
-    stub_ = CoreWorkerService::NewStub(channel);
+    rpc_client_ = std::unique_ptr<GrpcClient<CoreWorkerService>>(
+      new GrpcClient<CoreWorkerService>(address, port, client_call_manager));
   };
 
   ray::Status AssignTask(const AssignTaskRequest &request,
                          const ClientCallback<AssignTaskReply> &callback) override {
-    auto call = client_call_manager_
-                    .CreateCall<CoreWorkerService, AssignTaskRequest, AssignTaskReply>(
-                        *stub_, &CoreWorkerService::Stub::PrepareAsyncAssignTask, request,
-                        callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, AssignTask, request, callback);
   }
 
   ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request,
@@ -182,51 +177,30 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
                              const ClientCallback<PushTaskReply> &callback) override {
     request->set_sequence_number(-1);
     request->set_client_processed_up_to(-1);
-    auto call = client_call_manager_
-                    .CreateCall<CoreWorkerService, PushTaskRequest, PushTaskReply>(
-                        *stub_, &CoreWorkerService::Stub::PrepareAsyncPushTask, *request,
-                        callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, PushTask, *request, callback);
   }
 
   ray::Status DirectActorCallArgWaitComplete(
       const DirectActorCallArgWaitCompleteRequest &request,
       const ClientCallback<DirectActorCallArgWaitCompleteReply> &callback) override {
-    auto call = client_call_manager_.CreateCall<CoreWorkerService,
-                                                DirectActorCallArgWaitCompleteRequest,
-                                                DirectActorCallArgWaitCompleteReply>(
-        *stub_, &CoreWorkerService::Stub::PrepareAsyncDirectActorCallArgWaitComplete,
-        request, callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, DirectActorCallArgWaitComplete, request, callback);
   }
 
   virtual ray::Status GetObjectStatus(
       const GetObjectStatusRequest &request,
       const ClientCallback<GetObjectStatusReply> &callback) override {
-    auto call = client_call_manager_.CreateCall<CoreWorkerService, GetObjectStatusRequest,
-                                                GetObjectStatusReply>(
-        *stub_, &CoreWorkerService::Stub::PrepareAsyncGetObjectStatus, request, callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, GetObjectStatus, request, callback);
   }
 
   virtual ray::Status KillActor(const KillActorRequest &request,
                                 const ClientCallback<KillActorReply> &callback) override {
-    auto call = client_call_manager_
-                    .CreateCall<CoreWorkerService, KillActorRequest, KillActorReply>(
-                        *stub_, &CoreWorkerService::Stub::PrepareAsyncKillActor, request,
-                        callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, KillActor, request, callback);
   }
 
   virtual ray::Status GetCoreWorkerStats(
       const GetCoreWorkerStatsRequest &request,
       const ClientCallback<GetCoreWorkerStatsReply> &callback) override {
-    auto call =
-        client_call_manager_.CreateCall<CoreWorkerService, GetCoreWorkerStatsRequest,
-                                        GetCoreWorkerStatsReply>(
-            *stub_, &CoreWorkerService::Stub::PrepareAsyncGetCoreWorkerStats, request,
-            callback);
-    return call->GetStatus();
+    return RPC_CALL_METHOD(CoreWorkerService, GetCoreWorkerStats, request, callback);
   }
 
   /// Send as many pending tasks as possible. This method is thread-safe.
@@ -249,9 +223,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       request->set_client_processed_up_to(max_finished_seq_no_);
       rpc_bytes_in_flight_ += task_size;
 
-      client_call_manager_.CreateCall<CoreWorkerService, PushTaskRequest, PushTaskReply>(
-          *stub_, &CoreWorkerService::Stub::PrepareAsyncPushTask, *request,
-          [this, this_ptr, seq_no, task_size, callback](Status status,
+      auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](Status status,
                                                         const rpc::PushTaskReply &reply) {
             {
               std::lock_guard<std::mutex> lock(mutex_);
@@ -263,7 +235,9 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
             }
             SendRequests();
             callback(status, reply);
-          });
+          };
+
+      RPC_CALL_METHOD(CoreWorkerService, PushTask, *request, rpc_callback);
     }
 
     if (!send_queue_.empty()) {
@@ -275,8 +249,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   /// Protects against unsafe concurrent access from the callback thread.
   std::mutex mutex_;
 
-  /// The gRPC-generated stub.
-  std::unique_ptr<CoreWorkerService::Stub> stub_;
+  /// The RPC client.
+  std::unique_ptr<GrpcClient<CoreWorkerService>> rpc_client_;  
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -149,7 +149,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
                    ClientCallManager &client_call_manager)
       : client_call_manager_(client_call_manager) {
     rpc_client_ = std::unique_ptr<GrpcClient<CoreWorkerService>>(
-      new GrpcClient<CoreWorkerService>(address, port, client_call_manager));
+        new GrpcClient<CoreWorkerService>(address, port, client_call_manager));
   };
 
   ray::Status AssignTask(const AssignTaskRequest &request,
@@ -183,7 +183,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   ray::Status DirectActorCallArgWaitComplete(
       const DirectActorCallArgWaitCompleteRequest &request,
       const ClientCallback<DirectActorCallArgWaitCompleteReply> &callback) override {
-    return RPC_CALL_METHOD(CoreWorkerService, DirectActorCallArgWaitComplete, request, callback);
+    return RPC_CALL_METHOD(CoreWorkerService, DirectActorCallArgWaitComplete, request,
+                           callback);
   }
 
   virtual ray::Status GetObjectStatus(
@@ -223,19 +224,19 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       request->set_client_processed_up_to(max_finished_seq_no_);
       rpc_bytes_in_flight_ += task_size;
 
-      auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](Status status,
-                                                        const rpc::PushTaskReply &reply) {
-            {
-              std::lock_guard<std::mutex> lock(mutex_);
-              if (seq_no > max_finished_seq_no_) {
-                max_finished_seq_no_ = seq_no;
-              }
-              rpc_bytes_in_flight_ -= task_size;
-              RAY_CHECK(rpc_bytes_in_flight_ >= 0);
-            }
-            SendRequests();
-            callback(status, reply);
-          };
+      auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](
+          Status status, const rpc::PushTaskReply &reply) {
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          if (seq_no > max_finished_seq_no_) {
+            max_finished_seq_no_ = seq_no;
+          }
+          rpc_bytes_in_flight_ -= task_size;
+          RAY_CHECK(rpc_bytes_in_flight_ >= 0);
+        }
+        SendRequests();
+        callback(status, reply);
+      };
 
       RPC_CALL_METHOD(CoreWorkerService, PushTask, *request, rpc_callback);
     }
@@ -250,7 +251,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   std::mutex mutex_;
 
   /// The RPC client.
-  std::unique_ptr<GrpcClient<CoreWorkerService>> rpc_client_;  
+  std::unique_ptr<GrpcClient<CoreWorkerService>> rpc_client_;
 
   /// The `ClientCallManager` used for managing requests.
   ClientCallManager &client_call_manager_;

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -208,7 +208,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       rpc_bytes_in_flight_ += task_size;
 
       auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](
-          Status status, const rpc::PushTaskReply &reply) {
+                              Status status, const rpc::PushTaskReply &reply) {
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (seq_no > max_finished_seq_no_) {

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -154,13 +154,15 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   RPC_CLIENT_METHOD(CoreWorkerService, AssignTask, request, callback, grpc_client_)
 
-  RPC_CLIENT_METHOD(CoreWorkerService, DirectActorCallArgWaitComplete, request, callback, grpc_client_)
+  RPC_CLIENT_METHOD(CoreWorkerService, DirectActorCallArgWaitComplete, request, callback,
+                    grpc_client_)
 
   RPC_CLIENT_METHOD(CoreWorkerService, GetObjectStatus, request, callback, grpc_client_)
 
   RPC_CLIENT_METHOD(CoreWorkerService, KillActor, request, callback, grpc_client_)
 
-  RPC_CLIENT_METHOD(CoreWorkerService, GetCoreWorkerStats, request, callback, grpc_client_)
+  RPC_CLIENT_METHOD(CoreWorkerService, GetCoreWorkerStats, request, callback,
+                    grpc_client_)
 
   ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request,
                             const ClientCallback<PushTaskReply> &callback) override {
@@ -206,7 +208,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
       rpc_bytes_in_flight_ += task_size;
 
       auto rpc_callback = [this, this_ptr, seq_no, task_size, callback](
-                              Status status, const rpc::PushTaskReply &reply) {
+          Status status, const rpc::PushTaskReply &reply) {
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (seq_no > max_finished_seq_no_) {


### PR DESCRIPTION
## Why are these changes needed?

Currently application grpc clients still have some knowledge on GRPC unary implementations. These should be moved into GRPC client for better code abstraction. Also considering that we plan to add support for GRPC stream, which will have a different implementation from GRPC unary, this refactor would also make it easier to add stream support.

This PR also provides a macro to make it easier to add new grpc clients, which is similar to existing `RAY_CORE_WORKER_RPC_HANDLER` used in core worker.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
