### PR TITLE
[tune] get checkpoints paths for a trial after tuning

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -126,7 +126,7 @@ class Analysis:
         Arguments:
             trial(Trial): The log directory of a trial, or a trial instance.
             metric (str): key for trial info to return, e.g. "mean_accuracy".
-            "training_iteration" is used by default.
+                "training_iteration" is used by default.
         """
 
         if isinstance(trial, str):

--- a/python/ray/tune/examples/pbt_convnet_example.py
+++ b/python/ray/tune/examples/pbt_convnet_example.py
@@ -118,9 +118,23 @@ if __name__ == "__main__":
         verbose=1,
         stop=stopper.stop,
         export_formats=[ExportFormat.MODEL],
+        checkpoint_score_attr="mean_accuracy",
+        checkpoint_freq=5,
+        keep_checkpoints_num=4,
         num_samples=4,
         config={
             "lr": tune.uniform(0.001, 1),
             "momentum": tune.uniform(0.001, 1),
         })
     # __tune_end__
+
+    best_trial = analysis.get_best_trial("mean_accuracy")
+    best_checkpoint = max(
+        analysis.get_trial_checkpoints_paths(best_trial, "mean_accuracy"))
+    restored_trainable = PytorchTrainble()
+    restored_trainable.restore(best_checkpoint[0])
+    best_model = restored_trainable.model
+    # Note that test only runs on a small random set of the test data, thus the
+    # accuracy may be different from metrics shown in tuning process.
+    test_acc = test(best_model, get_data_loaders()[1])
+    print("best model accuracy: ", test_acc)

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -30,6 +30,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
             name=self.test_name,
             local_dir=self.test_dir,
             stop={"training_iteration": 1},
+            checkpoint_freq=1,
             num_samples=self.num_samples,
             config={
                 "width": sample_from(
@@ -68,6 +69,22 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         logdir2 = self.ea.get_best_logdir(self.metric, mode="min")
         self.assertTrue(logdir2.startswith(self.test_path))
         self.assertNotEquals(logdir, logdir2)
+
+    def testGetTrialCheckpointsPaths(self):
+        best_trial = self.ea.get_best_trial(self.metric)
+        checkpoints_metrics = self.ea.get_trial_checkpoints_paths(best_trial)
+        logdir = self.ea.get_best_logdir(self.metric)
+        expected_path = os.path.join(logdir, "checkpoint_1", "checkpoint")
+        assert checkpoints_metrics[0][0] == expected_path
+        assert checkpoints_metrics[0][1] == 1
+
+    def testGetTrialCheckpointsPathsWithMetric(self):
+        best_trial = self.ea.get_best_trial(self.metric)
+        paths = self.ea.get_trial_checkpoints_paths(best_trial, self.metric)
+        logdir = self.ea.get_best_logdir(self.metric)
+        expected_path = os.path.join(logdir, "checkpoint_1", "checkpoint")
+        assert paths[0][0] == expected_path
+        assert paths[0][1] == best_trial.metric_analysis[self.metric]["last"]
 
     def testAllDataframes(self):
         dataframes = self.ea.trial_dataframes

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -70,7 +70,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         self.assertTrue(logdir2.startswith(self.test_path))
         self.assertNotEquals(logdir, logdir2)
 
-    def testGetTrialCheckpointsPathsWithTrial(self):
+    def testGetTrialCheckpointsPathsByTrial(self):
         best_trial = self.ea.get_best_trial(self.metric)
         checkpoints_metrics = self.ea.get_trial_checkpoints_paths(best_trial)
         logdir = self.ea.get_best_logdir(self.metric)
@@ -78,14 +78,14 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         assert checkpoints_metrics[0][0] == expected_path
         assert checkpoints_metrics[0][1] == 1
 
-    def testGetTrialCheckpointsPathsWithPath(self):
+    def testGetTrialCheckpointsPathsByPath(self):
         logdir = self.ea.get_best_logdir(self.metric)
         checkpoints_metrics = self.ea.get_trial_checkpoints_paths(logdir)
         expected_path = os.path.join(logdir, "checkpoint_1/", "checkpoint")
         assert checkpoints_metrics[0][0] == expected_path
         assert checkpoints_metrics[0][1] == 1
 
-    def testGetTrialCheckpointsPathsWithMetric(self):
+    def testGetTrialCheckpointsPathsWithMetricByTrial(self):
         best_trial = self.ea.get_best_trial(self.metric)
         paths = self.ea.get_trial_checkpoints_paths(best_trial, self.metric)
         logdir = self.ea.get_best_logdir(self.metric)
@@ -93,7 +93,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         assert paths[0][0] == expected_path
         assert paths[0][1] == best_trial.metric_analysis[self.metric]["last"]
 
-    def testGetTrialCheckpointsPathsWithMetricWithPath(self):
+    def testGetTrialCheckpointsPathsWithMetricByPath(self):
         best_trial = self.ea.get_best_trial(self.metric)
         logdir = self.ea.get_best_logdir(self.metric)
         paths = self.ea.get_trial_checkpoints_paths(best_trial, self.metric)

--- a/python/ray/tune/tests/test_experiment_analysis.py
+++ b/python/ray/tune/tests/test_experiment_analysis.py
@@ -70,7 +70,7 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         self.assertTrue(logdir2.startswith(self.test_path))
         self.assertNotEquals(logdir, logdir2)
 
-    def testGetTrialCheckpointsPaths(self):
+    def testGetTrialCheckpointsPathsWithTrial(self):
         best_trial = self.ea.get_best_trial(self.metric)
         checkpoints_metrics = self.ea.get_trial_checkpoints_paths(best_trial)
         logdir = self.ea.get_best_logdir(self.metric)
@@ -78,10 +78,25 @@ class ExperimentAnalysisSuite(unittest.TestCase):
         assert checkpoints_metrics[0][0] == expected_path
         assert checkpoints_metrics[0][1] == 1
 
+    def testGetTrialCheckpointsPathsWithPath(self):
+        logdir = self.ea.get_best_logdir(self.metric)
+        checkpoints_metrics = self.ea.get_trial_checkpoints_paths(logdir)
+        expected_path = os.path.join(logdir, "checkpoint_1/", "checkpoint")
+        assert checkpoints_metrics[0][0] == expected_path
+        assert checkpoints_metrics[0][1] == 1
+
     def testGetTrialCheckpointsPathsWithMetric(self):
         best_trial = self.ea.get_best_trial(self.metric)
         paths = self.ea.get_trial_checkpoints_paths(best_trial, self.metric)
         logdir = self.ea.get_best_logdir(self.metric)
+        expected_path = os.path.join(logdir, "checkpoint_1", "checkpoint")
+        assert paths[0][0] == expected_path
+        assert paths[0][1] == best_trial.metric_analysis[self.metric]["last"]
+
+    def testGetTrialCheckpointsPathsWithMetricWithPath(self):
+        best_trial = self.ea.get_best_trial(self.metric)
+        logdir = self.ea.get_best_logdir(self.metric)
+        paths = self.ea.get_trial_checkpoints_paths(best_trial, self.metric)
         expected_path = os.path.join(logdir, "checkpoint_1", "checkpoint")
         assert paths[0][0] == expected_path
         assert paths[0][1] == best_trial.metric_analysis[self.metric]["last"]


### PR DESCRIPTION
Add a new API in Analysis to fetch the checkpoint paths for a trial.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
