### PR TITLE
Add heartbeat methods to gcs server node info handler

### DIFF
--- a/src/ray/gcs/gcs_server/node_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/node_info_handler_impl.cc
@@ -66,15 +66,47 @@ void DefaultNodeInfoHandler::HandleReportHeartbeat(
     SendReplyCallback send_reply_callback) {
   ClientID node_id = ClientID::FromBinary(request.heartbeat().client_id());
   RAY_LOG(DEBUG) << "Reporting heartbeat, node id = " << node_id;
+
+  auto on_done = [node_id, send_reply_callback](Status status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to report heartbeat: " << status.ToString()
+                     << ", node id = " << node_id;
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  auto heartbeat_data = std::make_shared<rpc::HeartbeatTableData>();
+  heartbeat_data->CopyFrom(request.heartbeat());
+  Status status = gcs_client_.Nodes().AsyncReportHeartbeat(heartbeat_data, on_done);
+  if (!status.ok()) {
+    on_done(status);
+  }
   RAY_LOG(DEBUG) << "Finished reporting heartbeat, node id = " << node_id;
 }
 
 void DefaultNodeInfoHandler::HandleReportBatchHeartbeat(
     const ReportBatchHeartbeatRequest &request, ReportBatchHeartbeatReply *reply,
     SendReplyCallback send_reply_callback) {
-  RAY_LOG(DEBUG) << "Reporting batch heartbeat, batch size is: "
+  RAY_LOG(DEBUG) << "Reporting batch heartbeat, batch size = "
                  << request.heartbeat_batch().batch_size();
-  RAY_LOG(DEBUG) << "Finished reporting batch heartbeat, batch size is: "
+
+  auto on_done = [&request, send_reply_callback](Status status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to report batch heartbeat: " << status.ToString()
+                     << ", batch size = " << request.heartbeat_batch().batch_size();
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  auto heartbeat_batch_data = std::make_shared<rpc::HeartbeatBatchTableData>();
+  heartbeat_batch_data->CopyFrom(request.heartbeat_batch());
+  Status status =
+      gcs_client_.Nodes().AsyncReportBatchHeartbeat(heartbeat_batch_data, on_done);
+  if (!status.ok()) {
+    on_done(status);
+  }
+
+  RAY_LOG(DEBUG) << "Finished reporting batch heartbeat, batch size = "
                  << request.heartbeat_batch().batch_size();
 }
 

--- a/src/ray/gcs/gcs_server/node_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/node_info_handler_impl.cc
@@ -61,5 +61,22 @@ void DefaultNodeInfoHandler::HandleGetAllNodeInfo(
   RAY_LOG(DEBUG) << "Finished getting all node info.";
 }
 
+void DefaultNodeInfoHandler::HandleReportHeartbeat(
+    const ReportHeartbeatRequest &request, ReportHeartbeatReply *reply,
+    SendReplyCallback send_reply_callback) {
+  ClientID node_id = ClientID::FromBinary(request.heartbeat().client_id());
+  RAY_LOG(DEBUG) << "Reporting heartbeat, node id = " << node_id;
+  RAY_LOG(DEBUG) << "Finished reporting heartbeat, node id = " << node_id;
+}
+
+void DefaultNodeInfoHandler::HandleReportBatchHeartbeat(
+    const ReportBatchHeartbeatRequest &request, ReportBatchHeartbeatReply *reply,
+    SendReplyCallback send_reply_callback) {
+  RAY_LOG(DEBUG) << "Reporting batch heartbeat, batch size is: "
+                 << request.heartbeat_batch().batch_size();
+  RAY_LOG(DEBUG) << "Finished reporting batch heartbeat, batch size is: "
+                 << request.heartbeat_batch().batch_size();
+}
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/node_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/node_info_handler_impl.h
@@ -24,6 +24,14 @@ class DefaultNodeInfoHandler : public rpc::NodeInfoHandler {
                             GetAllNodeInfoReply *reply,
                             SendReplyCallback send_reply_callback) override;
 
+  void HandleReportHeartbeat(const ReportHeartbeatRequest &request,
+                             ReportHeartbeatReply *reply,
+                             SendReplyCallback send_reply_callback) override;
+
+  void HandleReportBatchHeartbeat(const ReportBatchHeartbeatRequest &request,
+                                  ReportBatchHeartbeatReply *reply,
+                                  SendReplyCallback send_reply_callback) override;
+
  private:
   gcs::RedisGcsClient &gcs_client_;
 };

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -89,6 +89,20 @@ message GetAllNodeInfoReply {
   repeated GcsNodeInfo node_info_list = 1;
 }
 
+message ReportHeartbeatRequest {
+  HeartbeatTableData heartbeat = 1;
+}
+
+message ReportHeartbeatReply {
+}
+
+message ReportBatchHeartbeatRequest {
+  HeartbeatBatchTableData heartbeat_batch = 1;
+}
+
+message ReportBatchHeartbeatReply {
+}
+
 // Service for node info access.
 service NodeInfoGcsService {
   // Register a node to GCS Service.
@@ -97,6 +111,11 @@ service NodeInfoGcsService {
   rpc UnregisterNode(UnregisterNodeRequest) returns (UnregisterNodeReply);
   // Get information of all nodes from GCS Service.
   rpc GetAllNodeInfo(GetAllNodeInfoRequest) returns (GetAllNodeInfoReply);
+  // Report heartbeat of a node to GCS Service.
+  rpc ReportHeartbeat(ReportHeartbeatRequest) returns (ReportHeartbeatReply);
+  // Report state of all nodes to GCS Service.
+  rpc ReportBatchHeartbeat(ReportBatchHeartbeatRequest)
+      returns (ReportBatchHeartbeatReply);
 }
 
 message GetObjectLocationsRequest {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -113,7 +113,7 @@ service NodeInfoGcsService {
   rpc GetAllNodeInfo(GetAllNodeInfoRequest) returns (GetAllNodeInfoReply);
   // Report heartbeat of a node to GCS Service.
   rpc ReportHeartbeat(ReportHeartbeatRequest) returns (ReportHeartbeatReply);
-  // Report state of all nodes to GCS Service.
+  // Report batch heartbeat to GCS Service.
   rpc ReportBatchHeartbeat(ReportBatchHeartbeatRequest)
       returns (ReportBatchHeartbeatReply);
 }

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -171,7 +171,7 @@ class GcsRpcClient {
             request, callback);
   }
 
-  /// Report state of all nodes to GCS Service.
+  /// Report batch heartbeat to GCS Service.
   ///
   /// \param request The request message.
   /// \param callback The callback function that handles reply from server.

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -156,6 +156,28 @@ class GcsRpcClient {
     client_call_manager_.CreateCall<ObjectInfoGcsService, RemoveObjectLocationRequest,
                                     RemoveObjectLocationReply>(
         *object_info_stub_, &ObjectInfoGcsService::Stub::PrepareAsyncRemoveObjectLocation,
+
+  /// Report heartbeat of a node to GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void ReportHeartbeat(const ReportHeartbeatRequest &request,
+                       const ClientCallback<ReportHeartbeatReply> &callback) {
+    client_call_manager_
+        .CreateCall<NodeInfoGcsService, ReportHeartbeatRequest, ReportHeartbeatReply>(
+            *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncReportHeartbeat,
+            request, callback);
+  }
+
+  /// Report state of all nodes to GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void ReportBatchHeartbeat(const ReportBatchHeartbeatRequest &request,
+                            const ClientCallback<ReportBatchHeartbeatReply> &callback) {
+    client_call_manager_.CreateCall<NodeInfoGcsService, ReportBatchHeartbeatRequest,
+                                    ReportBatchHeartbeatReply>(
+        *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncReportBatchHeartbeat,
         request, callback);
   }
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -156,6 +156,8 @@ class GcsRpcClient {
     client_call_manager_.CreateCall<ObjectInfoGcsService, RemoveObjectLocationRequest,
                                     RemoveObjectLocationReply>(
         *object_info_stub_, &ObjectInfoGcsService::Stub::PrepareAsyncRemoveObjectLocation,
+        request, callback);
+  }
 
   /// Report heartbeat of a node to GCS Service.
   ///

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -146,6 +146,14 @@ class NodeInfoHandler {
   virtual void HandleGetAllNodeInfo(const GetAllNodeInfoRequest &request,
                                     GetAllNodeInfoReply *reply,
                                     SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleReportHeartbeat(const ReportHeartbeatRequest &request,
+                                     ReportHeartbeatReply *reply,
+                                     SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleReportBatchHeartbeat(const ReportBatchHeartbeatRequest &request,
+                                          ReportBatchHeartbeatReply *reply,
+                                          SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `NodeInfoGcsService`.
@@ -168,6 +176,8 @@ class NodeInfoGrpcService : public GrpcService {
     NODE_INFO_SERVICE_RPC_HANDLER(RegisterNode, 1);
     NODE_INFO_SERVICE_RPC_HANDLER(UnregisterNode, 1);
     NODE_INFO_SERVICE_RPC_HANDLER(GetAllNodeInfo, 1);
+    NODE_INFO_SERVICE_RPC_HANDLER(ReportHeartbeat, 1);
+    NODE_INFO_SERVICE_RPC_HANDLER(ReportBatchHeartbeat, 1);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This is the fifth pr of gcs server which add heartbeat methods to gcs server node info handler.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/6401

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
