### PR TITLE
[Serve] No http-service and Serve Profiling Feature

### DIFF
--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -443,11 +443,7 @@ def get_handle(endpoint_name):
     # Delay import due to it's dependency on global_state
     from ray.experimental.serve.handle import RayServeHandle
 
-    http_enabled = (
-        endpoint_name in global_state.route_table.list_service().values())
-    return RayServeHandle(global_state.init_or_get_router(),
-                          global_state.policy_table, endpoint_name,
-                          http_enabled)
+    return RayServeHandle(global_state.init_or_get_router(), endpoint_name)
 
 
 @_ensure_connected

--- a/python/ray/experimental/serve/constants.py
+++ b/python/ray/experimental/serve/constants.py
@@ -15,3 +15,6 @@ DEFAULT_HTTP_HOST = "0.0.0.0"
 
 #: HTTP Port
 DEFAULT_HTTP_PORT = 8000
+
+#: Default path for profiling services
+SERVE_PROFILE_PATH = "/RayServeProfile"

--- a/python/ray/experimental/serve/handle.py
+++ b/python/ray/experimental/serve/handle.py
@@ -26,15 +26,9 @@ class RayServeHandle:
        # raises RayTaskError Exception
     """
 
-    def __init__(self, router_handle, policy_table, endpoint_name,
-                 http_enabled):
+    def __init__(self, router_handle, endpoint_name):
         self.router_handle = router_handle
-
-        # TODO(alind): Need to find a better way for passing policy
-        # information. Right now handle has access to all the policies.
-        self.policy_table = policy_table
         self.endpoint_name = endpoint_name
-        self.http_enabled = http_enabled
 
     def remote(self, *args, **kwargs):
         if len(args) != 0:
@@ -67,33 +61,8 @@ class RayServeHandle:
         # because we are sure handle and global_state are in the same process.
         # However, once global_state is deprecated, this method need to be
         # updated accordingly.
-        traffic_d = self.policy_table.list_traffic_policy()
-        return traffic_d[self.endpoint_name]
-
-    def get_http_endpoint(self):
-        return DEFAULT_HTTP_ADDRESS
-
-    def __repr__(self):
-        if self.http_enabled:
-            return """
-                    RayServeHandle(
-                        Endpoint="{endpoint_name}",
-                        URL="{http_endpoint}/{endpoint_name}",
-                        Traffic={traffic_policy}
-                    )
-                    """.format(
-                endpoint_name=self.endpoint_name,
-                http_endpoint=self.get_http_endpoint(),
-                traffic_policy=self.get_traffic_policy())
-
-        return """
-                RayServeHandle(
-                    Endpoint="{endpoint_name}",
-                    Traffic={traffic_policy}
-                )
-                """.format(
-            endpoint_name=self.endpoint_name,
-            traffic_policy=self.get_traffic_policy())
+        return ray.get(self.router_handle.get_traffic.remote
+                       (self.endpoint_name))
 
     # TODO(simon): a convenience function that dumps equivalent requests
     # code for a given call.

--- a/python/ray/experimental/serve/handle.py
+++ b/python/ray/experimental/serve/handle.py
@@ -1,7 +1,6 @@
 import ray
 from ray.experimental.serve.context import TaskContext
 from ray.experimental.serve.exceptions import RayServeException
-from ray.experimental.serve.constants import DEFAULT_HTTP_ADDRESS
 
 
 class RayServeHandle:

--- a/python/ray/experimental/serve/handle.py
+++ b/python/ray/experimental/serve/handle.py
@@ -61,8 +61,8 @@ class RayServeHandle:
         # because we are sure handle and global_state are in the same process.
         # However, once global_state is deprecated, this method need to be
         # updated accordingly.
-        return ray.get(self.router_handle.get_traffic.remote
-                       (self.endpoint_name))
+        return ray.get(
+            self.router_handle.get_traffic.remote(self.endpoint_name))
 
     # TODO(simon): a convenience function that dumps equivalent requests
     # code for a given call.

--- a/python/ray/experimental/serve/kv_store_service.py
+++ b/python/ray/experimental/serve/kv_store_service.py
@@ -172,6 +172,8 @@ class SQLiteKVStore(NamespacedKVStore):
 class RoutingTable:
     def __init__(self, kv_connector):
         self.routing_table = kv_connector("routing_table")
+        self.no_route_service_table = kv_connector("no_route")
+        self.profile_info = kv_connector("profile_info")
         self.request_count = 0
 
     def register_service(self, route: str, service: str):
@@ -185,6 +187,38 @@ class RoutingTable:
         logger.debug("[KV] Registering route {} to service {}.".format(
             route, service))
         self.routing_table.put(route, service)
+
+    def register_no_route_service(self, service: str):
+        """Create an entry in no route service table
+
+        Args:
+            service: service name. This service can only be accessed via
+                remote calls.
+        """
+        logger.debug("[KV] Registering no route service: {}".format(service))
+        self.no_route_service_table.put(service, "")
+
+    def get_no_route_services(self):
+        return list(self.no_route_service_table.as_dict().keys())
+
+    def register_kwargs_creator(self, service: str, kwargs_creator):
+        """Create an entry in profile info table for profiling this service.
+
+        Args:
+            service: service name. This is the name http actor will push
+                the request to.
+            kwargs_creator: a lambda function which creates kwargs for
+                profiling information.
+
+        """
+        logger.debug("[KV] Registering lambda function for "
+                     "profiling service {}".format(service))
+        self.profile_info.put(service, pickle.dumps(kwargs_creator))
+
+    def get_profile_info(self):
+        """Returns the profile info."""
+        table = self.profile_info.as_dict()
+        return table
 
     def list_service(self):
         """Returns the routing table."""
@@ -263,5 +297,5 @@ class TrafficPolicyTable:
     def list_traffic_policy(self):
         return {
             service: json.loads(policy)
-            for service, policy in self.traffic_policy_table.as_dict()
+            for service, policy in self.traffic_policy_table.as_dict().items()
         }

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -159,11 +159,11 @@ class CentralizedQueues:
                      traffic_dict)
         self.traffic[service] = traffic_dict
         self.flush()
-    
+
     def get_traffic(self, service):
         if service in self.traffic:
             return self.traffic[service]
-            
+
     def set_backend_config(self, backend, config_dict):
         logger.debug("Setting backend config for "
                      "backend {} to {}".format(backend, config_dict))

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -159,7 +159,11 @@ class CentralizedQueues:
                      traffic_dict)
         self.traffic[service] = traffic_dict
         self.flush()
-
+    
+    def get_traffic(self, service):
+        if service in self.traffic:
+            return self.traffic[service]
+            
     def set_backend_config(self, backend, config_dict):
         logger.debug("Setting backend config for "
                      "backend {} to {}".format(backend, config_dict))


### PR DESCRIPTION
1. Added support for no http route service
2. Added support for profiling a service with any pythonic input. 
3. Added code for profiling latency of incoming requests for a service registered with profiling option.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
