### PR TITLE
Add actor checkpoint methods to gcs server actor info handler

### DIFF
--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
@@ -74,5 +74,109 @@ void DefaultActorInfoHandler::HandleUpdateActorInfo(
   RAY_LOG(DEBUG) << "Finished updating actor info, actor id = " << actor_id;
 }
 
+void DefaultActorInfoHandler::HandleAddActorCheckpoint(
+    const AddActorCheckpointRequest &request, AddActorCheckpointReply *reply,
+    SendReplyCallback send_reply_callback) {
+  ActorID actor_id = ActorID::FromBinary(request.checkpoint_data().actor_id());
+  RAY_LOG(DEBUG) << "Adding actor checkpoint, actor id = " << actor_id;
+  auto actor_checkpoint_data = std::make_shared<ActorCheckpointData>();
+  actor_checkpoint_data->CopyFrom(request.checkpoint_data());
+  auto on_done = [actor_id, send_reply_callback](Status status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to add actor checkpoint: " << status.ToString()
+                     << ", actor id = " << actor_id;
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  //  Status status = gcs_client_.Actors().AsyncAddCheckpoint(actor_checkpoint_data,
+  //  on_done);
+  Status status;
+  if (!status.ok()) {
+    on_done(status);
+  }
+  RAY_LOG(DEBUG) << "Finished adding actor checkpoint, actor id = " << actor_id;
+}
+
+void DefaultActorInfoHandler::HandleGetActorCheckpoint(
+    const GetActorCheckpointRequest &request, GetActorCheckpointReply *reply,
+    SendReplyCallback send_reply_callback) {
+  ActorCheckpointID checkpoint_id =
+      ActorCheckpointID::FromBinary(request.checkpoint_id());
+  RAY_LOG(DEBUG) << "Getting actor checkpoint, checkpoint id = " << checkpoint_id;
+  auto on_done = [checkpoint_id, reply, send_reply_callback](
+                     Status status, const boost::optional<ActorCheckpointData> &result) {
+    if (status.ok()) {
+      assert(result);
+      reply->mutable_checkpoint_data()->CopyFrom(*result);
+    } else {
+      RAY_LOG(ERROR) << "Failed to get actor checkpoint: " << status.ToString()
+                     << ", checkpoint id = " << checkpoint_id;
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  //  Status status = gcs_client_.Actors().AsyncGetCheckpoint(checkpoint_id, on_done);
+  Status status;
+  if (!status.ok()) {
+    on_done(status, boost::none);
+  }
+  RAY_LOG(DEBUG) << "Finished getting actor checkpoint, checkpoint id = "
+                 << checkpoint_id;
+}
+
+void DefaultActorInfoHandler::HandleAddActorCheckpointID(
+    const AddActorCheckpointIDRequest &request, AddActorCheckpointIDReply *reply,
+    SendReplyCallback send_reply_callback) {
+  ActorID actor_id = ActorID::FromBinary(request.actor_id());
+  ActorCheckpointID checkpoint_id =
+      ActorCheckpointID::FromBinary(request.checkpoint_id());
+  RAY_LOG(DEBUG) << "Adding actor checkpoint id, actor id = " << actor_id
+                 << ", checkpoint id = " << checkpoint_id;
+  auto on_done = [actor_id, checkpoint_id, send_reply_callback](Status status) {
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to add actor checkpoint id: " << status.ToString()
+                     << ", actor id = " << actor_id
+                     << ", checkpoint id = " << checkpoint_id;
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  //  Status status = gcs_client_.Actors().AsyncAddCheckpointID(actor_id, checkpoint_id,
+  //  on_done);
+  Status status;
+  if (!status.ok()) {
+    on_done(status);
+  }
+  RAY_LOG(DEBUG) << "Finished adding actor checkpoint id, actor id = " << actor_id
+                 << ", checkpoint id = " << checkpoint_id;
+}
+
+void DefaultActorInfoHandler::HandleGetActorCheckpointID(
+    const GetActorCheckpointIDRequest &request, GetActorCheckpointIDReply *reply,
+    SendReplyCallback send_reply_callback) {
+  ActorID actor_id = ActorID::FromBinary(request.actor_id());
+  RAY_LOG(DEBUG) << "Getting actor checkpoint id, actor id = " << actor_id;
+  auto on_done = [actor_id, reply, send_reply_callback](
+                     Status status,
+                     const boost::optional<ActorCheckpointIdData> &result) {
+    if (status.ok()) {
+      assert(result);
+      reply->mutable_checkpoint_id_data()->CopyFrom(*result);
+    } else {
+      RAY_LOG(ERROR) << "Failed to get actor checkpoint id: " << status.ToString()
+                     << ", actor id = " << actor_id;
+    }
+    send_reply_callback(status, nullptr, nullptr);
+  };
+
+  //  Status status = gcs_client_.Actors().AsyncGetCheckpointID(actor_id, on_done);
+  Status status;
+  if (!status.ok()) {
+    on_done(status, boost::none);
+  }
+  RAY_LOG(DEBUG) << "Finished getting actor checkpoint id, actor id = " << actor_id;
+}
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
@@ -89,9 +89,7 @@ void DefaultActorInfoHandler::HandleAddActorCheckpoint(
     send_reply_callback(status, nullptr, nullptr);
   };
 
-  //  Status status = gcs_client_.Actors().AsyncAddCheckpoint(actor_checkpoint_data,
-  //  on_done);
-  Status status;
+  Status status = gcs_client_.Actors().AsyncAddCheckpoint(actor_checkpoint_data, on_done);
   if (!status.ok()) {
     on_done(status);
   }
@@ -116,40 +114,12 @@ void DefaultActorInfoHandler::HandleGetActorCheckpoint(
     send_reply_callback(status, nullptr, nullptr);
   };
 
-  //  Status status = gcs_client_.Actors().AsyncGetCheckpoint(checkpoint_id, on_done);
-  Status status;
+  Status status = gcs_client_.Actors().AsyncGetCheckpoint(checkpoint_id, on_done);
   if (!status.ok()) {
     on_done(status, boost::none);
   }
   RAY_LOG(DEBUG) << "Finished getting actor checkpoint, checkpoint id = "
                  << checkpoint_id;
-}
-
-void DefaultActorInfoHandler::HandleAddActorCheckpointID(
-    const AddActorCheckpointIDRequest &request, AddActorCheckpointIDReply *reply,
-    SendReplyCallback send_reply_callback) {
-  ActorID actor_id = ActorID::FromBinary(request.actor_id());
-  ActorCheckpointID checkpoint_id =
-      ActorCheckpointID::FromBinary(request.checkpoint_id());
-  RAY_LOG(DEBUG) << "Adding actor checkpoint id, actor id = " << actor_id
-                 << ", checkpoint id = " << checkpoint_id;
-  auto on_done = [actor_id, checkpoint_id, send_reply_callback](Status status) {
-    if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to add actor checkpoint id: " << status.ToString()
-                     << ", actor id = " << actor_id
-                     << ", checkpoint id = " << checkpoint_id;
-    }
-    send_reply_callback(status, nullptr, nullptr);
-  };
-
-  //  Status status = gcs_client_.Actors().AsyncAddCheckpointID(actor_id, checkpoint_id,
-  //  on_done);
-  Status status;
-  if (!status.ok()) {
-    on_done(status);
-  }
-  RAY_LOG(DEBUG) << "Finished adding actor checkpoint id, actor id = " << actor_id
-                 << ", checkpoint id = " << checkpoint_id;
 }
 
 void DefaultActorInfoHandler::HandleGetActorCheckpointID(
@@ -170,8 +140,7 @@ void DefaultActorInfoHandler::HandleGetActorCheckpointID(
     send_reply_callback(status, nullptr, nullptr);
   };
 
-  //  Status status = gcs_client_.Actors().AsyncGetCheckpointID(actor_id, on_done);
-  Status status;
+  Status status = gcs_client_.Actors().AsyncGetCheckpointID(actor_id, on_done);
   if (!status.ok()) {
     on_done(status, boost::none);
   }

--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.h
@@ -32,10 +32,6 @@ class DefaultActorInfoHandler : public rpc::ActorInfoHandler {
                                 GetActorCheckpointReply *reply,
                                 SendReplyCallback send_reply_callback) override;
 
-  void HandleAddActorCheckpointID(const AddActorCheckpointIDRequest &request,
-                                  AddActorCheckpointIDReply *reply,
-                                  SendReplyCallback send_reply_callback) override;
-
   void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest &request,
                                   GetActorCheckpointIDReply *reply,
                                   SendReplyCallback send_reply_callback) override;

--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.h
@@ -24,6 +24,22 @@ class DefaultActorInfoHandler : public rpc::ActorInfoHandler {
                              UpdateActorInfoReply *reply,
                              SendReplyCallback send_reply_callback) override;
 
+  void HandleAddActorCheckpoint(const AddActorCheckpointRequest &request,
+                                AddActorCheckpointReply *reply,
+                                SendReplyCallback send_reply_callback) override;
+
+  void HandleGetActorCheckpoint(const GetActorCheckpointRequest &request,
+                                GetActorCheckpointReply *reply,
+                                SendReplyCallback send_reply_callback) override;
+
+  void HandleAddActorCheckpointID(const AddActorCheckpointIDRequest &request,
+                                  AddActorCheckpointIDReply *reply,
+                                  SendReplyCallback send_reply_callback) override;
+
+  void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest &request,
+                                  GetActorCheckpointIDReply *reply,
+                                  SendReplyCallback send_reply_callback) override;
+
  private:
   gcs::RedisGcsClient &gcs_client_;
 };

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -133,17 +133,6 @@ class GcsServerTest : public RedisServiceManagerForTest {
     return checkpoint_data;
   }
 
-  bool AddActorCheckpointID(const rpc::AddActorCheckpointIDRequest &request) {
-    std::promise<bool> promise;
-    client_->AddActorCheckpointID(
-        request,
-        [&promise](const Status &status, const rpc::AddActorCheckpointIDReply &reply) {
-          RAY_CHECK_OK(status);
-          promise.set_value(true);
-        });
-    return WaitReady(promise.get_future(), timeout_ms_);
-  }
-
   rpc::ActorCheckpointIdData GetActorCheckpointID(const std::string &actor_id) {
     rpc::GetActorCheckpointIDRequest request;
     request.set_actor_id(actor_id);
@@ -289,18 +278,6 @@ class GcsServerTest : public RedisServiceManagerForTest {
     return actor_table_data;
   }
 
-  rpc::ActorCheckpointData GenActorCheckpointData(const std::string &actor_id) {
-    rpc::ActorCheckpointData actor_checkpoint_data;
-    actor_checkpoint_data.set_actor_id(actor_id);
-    return actor_checkpoint_data;
-  }
-
-  rpc::ActorCheckpointIdData GenActorCheckpointIdData(const std::string &actor_id) {
-    rpc::ActorCheckpointIdData actor_checkpoint_id_data;
-    actor_checkpoint_id_data.set_actor_id(actor_id);
-    return actor_checkpoint_id_data;
-  }
-
   rpc::GcsNodeInfo GenGcsNodeInfo(const std::string &node_id) {
     rpc::GcsNodeInfo gcs_node_info;
     gcs_node_info.set_node_id(node_id);
@@ -348,24 +325,22 @@ TEST_F(GcsServerTest, TestActorInfo) {
               rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
 
   // Add actor checkpoint
-  rpc::ActorCheckpointData actor_checkpoint_data =
-      GenActorCheckpointData(actor_table_data.actor_id());
-  rpc::AddActorCheckpointRequest add_actor_checkpoint_request;
-  add_actor_checkpoint_request.mutable_checkpoint_data()->CopyFrom(actor_checkpoint_data);
-  ASSERT_TRUE(AddActorCheckpoint(add_actor_checkpoint_request));
-  rpc::ActorCheckpointData checkpoint = GetActorCheckpoint("");
-  ASSERT_TRUE(checkpoint.actor_id() == actor_table_data.actor_id());
+  ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
+  rpc::ActorCheckpointData checkpoint;
+  checkpoint.set_actor_id(actor_table_data.actor_id());
+  checkpoint.set_checkpoint_id(checkpoint_id.Binary());
+  checkpoint.set_execution_dependency(checkpoint_id.Binary());
 
-  // Add actor checkpoint id
-  rpc::ActorCheckpointIdData actor_checkpoint_id_data =
-      GenActorCheckpointIdData(actor_table_data.actor_id());
-  rpc::AddActorCheckpointIDRequest add_actor_checkpoint_id_request;
-  add_actor_checkpoint_id_request.set_actor_id(actor_table_data.actor_id());
-  add_actor_checkpoint_id_request.set_checkpoint_id("");
-  ASSERT_TRUE(AddActorCheckpointID(add_actor_checkpoint_id_request));
-  rpc::ActorCheckpointIdData checkpoint_id =
+  rpc::AddActorCheckpointRequest add_actor_checkpoint_request;
+  add_actor_checkpoint_request.mutable_checkpoint_data()->CopyFrom(checkpoint);
+  ASSERT_TRUE(AddActorCheckpoint(add_actor_checkpoint_request));
+  rpc::ActorCheckpointData checkpoint_result = GetActorCheckpoint(checkpoint_id.Binary());
+  ASSERT_TRUE(checkpoint_result.actor_id() == actor_table_data.actor_id());
+  ASSERT_TRUE(checkpoint_result.checkpoint_id() == checkpoint_id.Binary());
+  rpc::ActorCheckpointIdData checkpoint_id_result =
       GetActorCheckpointID(actor_table_data.actor_id());
-  ASSERT_TRUE(checkpoint_id.actor_id() == actor_table_data.actor_id());
+  ASSERT_TRUE(checkpoint_id_result.actor_id() == actor_table_data.actor_id());
+  ASSERT_TRUE(checkpoint_id_result.checkpoint_ids_size() == 1);
 }
 
 TEST_F(GcsServerTest, TestJobInfo) {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -71,6 +71,14 @@ message GetActorCheckpointReply {
   ActorCheckpointData checkpoint_data = 1;
 }
 
+message AddActorCheckpointIDRequest {
+  bytes actor_id = 1;
+  bytes checkpoint_id = 2;
+}
+
+message AddActorCheckpointIDReply {
+}
+
 message GetActorCheckpointIDRequest {
   bytes actor_id = 1;
 }
@@ -91,8 +99,12 @@ service ActorInfoGcsService {
   rpc AddActorCheckpoint(AddActorCheckpointRequest) returns (AddActorCheckpointReply);
   // Get actor checkpoint data from GCS Service.
   rpc GetActorCheckpoint(GetActorCheckpointRequest) returns (GetActorCheckpointReply);
+  // Add actor checkpoint id data to GCS Service.
+  rpc AddActorCheckpointID(AddActorCheckpointIDRequest)
+      returns (AddActorCheckpointIDReply);
   // Get actor checkpoint id data from GCS Service.
-  rpc GetActorCheckpointID(GetActorCheckpointIDRequest) returns (GetActorCheckpointIDReply);
+  rpc GetActorCheckpointID(GetActorCheckpointIDRequest)
+      returns (GetActorCheckpointIDReply);
 }
 
 message RegisterNodeRequest {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -71,14 +71,6 @@ message GetActorCheckpointReply {
   ActorCheckpointData checkpoint_data = 1;
 }
 
-message AddActorCheckpointIDRequest {
-  bytes actor_id = 1;
-  bytes checkpoint_id = 2;
-}
-
-message AddActorCheckpointIDReply {
-}
-
 message GetActorCheckpointIDRequest {
   bytes actor_id = 1;
 }
@@ -99,9 +91,6 @@ service ActorInfoGcsService {
   rpc AddActorCheckpoint(AddActorCheckpointRequest) returns (AddActorCheckpointReply);
   // Get actor checkpoint data from GCS Service.
   rpc GetActorCheckpoint(GetActorCheckpointRequest) returns (GetActorCheckpointReply);
-  // Add actor checkpoint id data to GCS Service.
-  rpc AddActorCheckpointID(AddActorCheckpointIDRequest)
-      returns (AddActorCheckpointIDReply);
   // Get actor checkpoint id data from GCS Service.
   rpc GetActorCheckpointID(GetActorCheckpointIDRequest)
       returns (GetActorCheckpointIDReply);

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -56,6 +56,29 @@ message UpdateActorInfoRequest {
 message UpdateActorInfoReply {
 }
 
+message AddActorCheckpointRequest {
+  ActorCheckpointData checkpoint_data = 1;
+}
+
+message AddActorCheckpointReply {
+}
+
+message GetActorCheckpointRequest {
+  bytes checkpoint_id = 1;
+}
+
+message GetActorCheckpointReply {
+  ActorCheckpointData checkpoint_data = 1;
+}
+
+message GetActorCheckpointIDRequest {
+  bytes actor_id = 1;
+}
+
+message GetActorCheckpointIDReply {
+  ActorCheckpointIdData checkpoint_id_data = 1;
+}
+
 // Service for actor info access.
 service ActorInfoGcsService {
   // Get actor data from GCS Service.
@@ -64,6 +87,12 @@ service ActorInfoGcsService {
   rpc RegisterActorInfo(RegisterActorInfoRequest) returns (RegisterActorInfoReply);
   // Update actor info in GCS Service.
   rpc UpdateActorInfo(UpdateActorInfoRequest) returns (UpdateActorInfoReply);
+  // Add actor checkpoint data to GCS Service.
+  rpc AddActorCheckpoint(AddActorCheckpointRequest) returns (AddActorCheckpointReply);
+  // Get actor checkpoint data from GCS Service.
+  rpc GetActorCheckpoint(GetActorCheckpointRequest) returns (GetActorCheckpointReply);
+  // Get actor checkpoint id data from GCS Service.
+  rpc GetActorCheckpointID(GetActorCheckpointIDRequest) returns (GetActorCheckpointIDReply);
 }
 
 message RegisterNodeRequest {

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -53,52 +53,16 @@ class GcsRpcClient {
                          actor_info_grpc_client_)
 
   ///  Add actor checkpoint data to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void AddActorCheckpoint(const AddActorCheckpointRequest &request,
-                          const ClientCallback<AddActorCheckpointReply> &callback) {
-    client_call_manager_.CreateCall<ActorInfoGcsService, AddActorCheckpointRequest,
-                                    AddActorCheckpointReply>(
-        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncAddActorCheckpoint,
-        request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, AddActorCheckpoint, request, callback,
+                         actor_info_grpc_client_)
 
   ///  Get actor checkpoint data from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void GetActorCheckpoint(const GetActorCheckpointRequest &request,
-                          const ClientCallback<GetActorCheckpointReply> &callback) {
-    client_call_manager_.CreateCall<ActorInfoGcsService, GetActorCheckpointRequest,
-                                    GetActorCheckpointReply>(
-        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncGetActorCheckpoint,
-        request, callback);
-  }
-
-  ///  Add actor checkpoint id data to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void AddActorCheckpointID(const AddActorCheckpointIDRequest &request,
-                            const ClientCallback<AddActorCheckpointIDReply> &callback) {
-    client_call_manager_.CreateCall<ActorInfoGcsService, AddActorCheckpointIDRequest,
-                                    AddActorCheckpointIDReply>(
-        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncAddActorCheckpointID,
-        request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, GetActorCheckpoint, request, callback,
+                         actor_info_grpc_client_)
 
   ///  Get actor checkpoint id data from GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void GetActorCheckpointID(const GetActorCheckpointIDRequest &request,
-                            const ClientCallback<GetActorCheckpointIDReply> &callback) {
-    client_call_manager_.CreateCall<ActorInfoGcsService, GetActorCheckpointIDRequest,
-                                    GetActorCheckpointIDReply>(
-        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncGetActorCheckpointID,
-        request, callback);
-  }
+  VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, GetActorCheckpointID, request, callback,
+                         actor_info_grpc_client_)
 
   /// Register a node to GCS Service.
   VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, request, callback,
@@ -112,6 +76,14 @@ class GcsRpcClient {
   VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, GetAllNodeInfo, request, callback,
                          node_info_grpc_client_)
 
+  /// Report heartbeat of a node to GCS Service.
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, ReportHeartbeat, request, callback,
+                         node_info_grpc_client_)
+
+  /// Report batch heartbeat to GCS Service.
+  VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, ReportBatchHeartbeat, request, callback,
+                         node_info_grpc_client_)
+
   /// Get object's locations from GCS Service.
   VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, GetObjectLocations, request, callback,
                          object_info_grpc_client_)
@@ -123,30 +95,6 @@ class GcsRpcClient {
   /// Remove location of object to GCS Service.
   VOID_RPC_CLIENT_METHOD(ObjectInfoGcsService, RemoveObjectLocation, request, callback,
                          object_info_grpc_client_)
-
-  /// Report heartbeat of a node to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void ReportHeartbeat(const ReportHeartbeatRequest &request,
-                       const ClientCallback<ReportHeartbeatReply> &callback) {
-    client_call_manager_
-        .CreateCall<NodeInfoGcsService, ReportHeartbeatRequest, ReportHeartbeatReply>(
-            *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncReportHeartbeat,
-            request, callback);
-  }
-
-  /// Report batch heartbeat to GCS Service.
-  ///
-  /// \param request The request message.
-  /// \param callback The callback function that handles reply from server.
-  void ReportBatchHeartbeat(const ReportBatchHeartbeatRequest &request,
-                            const ClientCallback<ReportBatchHeartbeatReply> &callback) {
-    client_call_manager_.CreateCall<NodeInfoGcsService, ReportBatchHeartbeatRequest,
-                                    ReportBatchHeartbeatReply>(
-        *node_info_stub_, &NodeInfoGcsService::Stub::PrepareAsyncReportBatchHeartbeat,
-        request, callback);
-  }
 
  private:
   /// The gRPC-generated stub.

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -52,6 +52,54 @@ class GcsRpcClient {
   VOID_RPC_CLIENT_METHOD(ActorInfoGcsService, UpdateActorInfo, request, callback,
                          actor_info_grpc_client_)
 
+  ///  Add actor checkpoint data to GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void AddActorCheckpoint(const AddActorCheckpointRequest &request,
+                          const ClientCallback<AddActorCheckpointReply> &callback) {
+    client_call_manager_.CreateCall<ActorInfoGcsService, AddActorCheckpointRequest,
+                                    AddActorCheckpointReply>(
+        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncAddActorCheckpoint,
+        request, callback);
+  }
+
+  ///  Get actor checkpoint data from GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void GetActorCheckpoint(const GetActorCheckpointRequest &request,
+                          const ClientCallback<GetActorCheckpointReply> &callback) {
+    client_call_manager_.CreateCall<ActorInfoGcsService, GetActorCheckpointRequest,
+                                    GetActorCheckpointReply>(
+        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncGetActorCheckpoint,
+        request, callback);
+  }
+
+  ///  Add actor checkpoint id data to GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void AddActorCheckpointID(const AddActorCheckpointIDRequest &request,
+                            const ClientCallback<AddActorCheckpointIDReply> &callback) {
+    client_call_manager_.CreateCall<ActorInfoGcsService, AddActorCheckpointIDRequest,
+                                    AddActorCheckpointIDReply>(
+        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncAddActorCheckpointID,
+        request, callback);
+  }
+
+  ///  Get actor checkpoint id data from GCS Service.
+  ///
+  /// \param request The request message.
+  /// \param callback The callback function that handles reply from server.
+  void GetActorCheckpointID(const GetActorCheckpointIDRequest &request,
+                            const ClientCallback<GetActorCheckpointIDReply> &callback) {
+    client_call_manager_.CreateCall<ActorInfoGcsService, GetActorCheckpointIDRequest,
+                                    GetActorCheckpointIDReply>(
+        *actor_info_stub_, &ActorInfoGcsService::Stub::PrepareAsyncGetActorCheckpointID,
+        request, callback);
+  }
+
   /// Register a node to GCS Service.
   VOID_RPC_CLIENT_METHOD(NodeInfoGcsService, RegisterNode, request, callback,
                          node_info_grpc_client_)

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -109,10 +109,6 @@ class ActorInfoHandler {
                                         GetActorCheckpointReply *reply,
                                         SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleAddActorCheckpointID(const AddActorCheckpointIDRequest &request,
-                                          AddActorCheckpointIDReply *reply,
-                                          SendReplyCallback send_reply_callback) = 0;
-
   virtual void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest &request,
                                           GetActorCheckpointIDReply *reply,
                                           SendReplyCallback send_reply_callback) = 0;
@@ -140,7 +136,6 @@ class ActorInfoGrpcService : public GrpcService {
     ACTOR_INFO_SERVICE_RPC_HANDLER(UpdateActorInfo, 1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(AddActorCheckpoint, 1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorCheckpoint, 1);
-    ACTOR_INFO_SERVICE_RPC_HANDLER(AddActorCheckpointID, 1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorCheckpointID, 1);
   }
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -100,6 +100,22 @@ class ActorInfoHandler {
   virtual void HandleUpdateActorInfo(const UpdateActorInfoRequest &request,
                                      UpdateActorInfoReply *reply,
                                      SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleAddActorCheckpoint(const AddActorCheckpointRequest &request,
+                                        AddActorCheckpointReply *reply,
+                                        SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetActorCheckpoint(const GetActorCheckpointRequest &request,
+                                        GetActorCheckpointReply *reply,
+                                        SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleAddActorCheckpointID(const AddActorCheckpointIDRequest &request,
+                                          AddActorCheckpointIDReply *reply,
+                                          SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetActorCheckpointID(const GetActorCheckpointIDRequest &request,
+                                          GetActorCheckpointIDReply *reply,
+                                          SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `ActorInfoGcsService`.
@@ -122,6 +138,10 @@ class ActorInfoGrpcService : public GrpcService {
     ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorInfo, 1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(RegisterActorInfo, 1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(UpdateActorInfo, 1);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(AddActorCheckpoint, 1);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorCheckpoint, 1);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(AddActorCheckpointID, 1);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(GetActorCheckpointID, 1);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This is the sixth pr of gcs server which add actor checkpoint methods to gcs server actor info handler.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/6401

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
