### PR TITLE
Fix async actor recursion limitation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ script:
 
   # ray tests
   - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then RAY_FORCE_DIRECT=0 python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then RAY_FORCE_DIRECT=0 python -m pytest -v --durations=5 --timeout=300 python/ray/tests/py3_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/tests/py3_test.py; fi
 
   - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/...
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -377,7 +377,7 @@ class ActorClass(object):
             is_direct_call: Use direct actor calls.
             max_concurrency: The max number of concurrent calls to allow for
                 this actor. This only works with direct actor calls. The max
-                concurrency defaults to 1 for threaded execution, and 100 for
+                concurrency defaults to 1 for threaded execution, and 1000 for
                 asyncio execution. Note that the execution order is not
                 guaranteed when max_concurrency > 1.
             name: The globally unique name for the actor.
@@ -397,7 +397,7 @@ class ActorClass(object):
             is_direct_call = ray_constants.direct_call_enabled()
         if max_concurrency is None:
             if is_asyncio:
-                max_concurrency = 100
+                max_concurrency = 1000
             else:
                 max_concurrency = 1
 

--- a/python/ray/tests/py3_test.py
+++ b/python/ray/tests/py3_test.py
@@ -193,7 +193,8 @@ def test_asyncio_actor_high_concurrency(ray_start_regular_shared):
 
     batch_size = sys.getrecursionlimit() * 4
     actor = AsyncConcurrencyBatcher.options(
-        is_asyncio=True, max_concurrency=batch_size * 2).remote(batch_size)
+        is_asyncio=True, max_concurrency=batch_size * 2,
+        is_direct_call=True).remote(batch_size)
     result = ray.get([actor.add.remote(i) for i in range(batch_size)])
     assert result[0] == list(range(batch_size))
     assert result[-1] == list(range(batch_size))

--- a/python/ray/tests/py3_test.py
+++ b/python/ray/tests/py3_test.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import asyncio
 import threading
 import pytest
+import sys
 
 import ray
 import ray.cluster_utils
@@ -170,6 +171,32 @@ def test_asyncio_actor_concurrency(ray_start_regular_shared):
             answer.append(status)
 
     assert history == answer
+
+
+def test_asyncio_actor_high_concurrency(ray_start_regular_shared):
+    # This tests actor can handle concurrency above recursionlimit.
+
+    @ray.remote
+    class AsyncConcurrencyBatcher:
+        def __init__(self, batch_size):
+            self.batch = []
+            self.event = asyncio.Event()
+            self.batch_size = batch_size
+
+        async def add(self, x):
+            self.batch.append(x)
+            if len(self.batch) >= self.batch_size:
+                self.event.set()
+            else:
+                await self.event.wait()
+            return sorted(self.batch)
+
+    batch_size = sys.getrecursionlimit() * 4
+    actor = AsyncConcurrencyBatcher.options(
+        is_asyncio=True, max_concurrency=batch_size * 2).remote(batch_size)
+    result = ray.get([actor.add.remote(i) for i in range(batch_size)])
+    assert result[0] == list(range(batch_size))
+    assert result[-1] == list(range(batch_size))
 
 
 @pytest.mark.asyncio

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -285,7 +285,7 @@ class FiberRateLimiter {
  private:
   boost::fibers::condition_variable cond_;
   boost::fibers::mutex mutex_;
-  int num_;
+  int num_ = 1;
 };
 
 /// Used to ensure serial order of task execution per actor handle.
@@ -472,7 +472,8 @@ class CoreWorkerDirectTaskReceiver {
   /// Set the max concurrency at runtime. It cannot be changed once set.
   void SetMaxActorConcurrency(int max_concurrency);
 
-  void SetActorAsAsync();
+  /// Set the max concurrency and start async actor context.
+  void SetActorAsAsync(int max_concurrency);
 
  private:
   // Worker context.


### PR DESCRIPTION
This PR resolves past issue where *async actor concurrency* is limited by python's recursion limit. Our previous approach makes python keep incrementing the stack count and mistakenly throws recursion error. 

Turning `function_executor` into a generator fix this issue. So the concurrency limit can be raised much higher like `int(1e8)`. 

This PR also fix a bug that we started threadpool in async mode where we shouldn't. 