### PR TITLE
[rllib] Fix rock paper scissors MADRL example

### DIFF
--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -15,7 +15,7 @@ from gym.spaces import Discrete
 
 from ray import tune
 from ray.rllib.agents.pg.pg import PGTrainer
-from ray.rllib.agents.pg.pg_tf_policy import PGTFPolicy
+from ray.rllib.agents.pg.pg_policy import PGTFPolicy
 from ray.rllib.policy.policy import Policy
 from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from ray.rllib.utils import try_import_tf


### PR DESCRIPTION
This example uses an older version of the api. As of ray 0.8.0, pg_tf_policy was renamed to pg_policy, and this code won't run without the fix.

## Checks

- [* ] I've run `scripts/format.sh` to lint the changes in this PR.
- [* ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [* ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
