### PR TITLE
Windows compatibility stubs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1093,15 +1093,28 @@ genrule(
         "redis-server",
         "redis-cli",
     ],
-    cmd = """
-        set -x &&
-        curl -sL \"https://github.com/antirez/redis/archive/5.0.3.tar.gz\" | tar -xzf - --strip-components=1 -C . &&
-        make &&
-        mv ./src/redis-server $(location redis-server) &&
-        chmod +x $(location redis-server) &&
-        mv ./src/redis-cli $(location redis-cli) &&
-        chmod +x $(location redis-cli)
-    """,
+    cmd = select({
+        # Windows is not supported yet, so make stubs for it
+        "@bazel_tools//src/conditions:windows": """
+            set -eu
+            for f in $(OUTS); do
+                {
+                    echo '#!/usr/bin/env bash'
+                    echo 'echo "$${0##*/} is unsupported on this platform" 1>&2 && false'
+                } > "$$f"
+                chmod +x "$$f"
+            done
+        """,
+        "//conditions:default": """
+            set -x &&
+            curl -sL \"https://github.com/antirez/redis/archive/5.0.3.tar.gz\" | tar -xzf - --strip-components=1 -C . &&
+            make &&
+            mv ./src/redis-server $(location redis-server) &&
+            chmod +x $(location redis-server) &&
+            mv ./src/redis-cli $(location redis-cli) &&
+            chmod +x $(location redis-cli)
+        """,
+    }),
     visibility = ["//java:__subpackages__"],
 )
 

--- a/src/shims/windows/sys/wait.cc
+++ b/src/shims/windows/sys/wait.cc
@@ -1,0 +1,27 @@
+#include <sys/wait.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#include <Windows.h>
+
+pid_t waitpid(pid_t pid, int *status, int options) {
+  int result;
+  if (pid <= 0) {
+    result = -1;
+    errno = ECHILD;
+  } else if (HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, pid)) {
+    DWORD timeout = status && *status == WNOHANG ? 0 : INFINITE;
+    if (WaitForSingleObject(process, timeout) != WAIT_FAILED) {
+      result = 0;
+    } else {
+      result = -1;
+      errno = ECHILD;
+    }
+    CloseHandle(process);
+  } else {
+    result = -1;
+    errno = ECHILD;
+  }
+  return result;
+}

--- a/src/shims/windows/sys/wait.h
+++ b/src/shims/windows/sys/wait.h
@@ -1,4 +1,15 @@
 #ifndef WAIT_H
 #define WAIT_H
 
+#include <unistd.h>  // pid_t
+
+#define WNOHANG 1
+
+__declspec(
+    deprecated("Waiting on a process by ID has an inherent race condition"
+               " on Windows and is discouraged. "
+               "Please use a wrapper that keeps the process handle alive"
+               " and waits on it directly as needed."
+               "")) pid_t waitpid(pid_t pid, int *status, int options);
+
 #endif /* WAIT_H */


### PR DESCRIPTION
## Why are these changes needed?

Some stubs to allow Windows builds to succeed. I plan to replace them later.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
