### PR TITLE
Add kubectl to autoscaler docker image

### DIFF
--- a/docker/autoscaler/Dockerfile
+++ b/docker/autoscaler/Dockerfile
@@ -4,6 +4,11 @@ ARG WHEEL_NAME
 
 RUN apt update
 RUN apt install -y curl tmux screen rsync
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+RUN sudo touch /etc/apt/sources.list.d/kubernetes.list
+RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt update
+RUN apt install -y kubectl
 
 # We have to uninstall wrapt this way for Tensorflow compatibility
 RUN conda remove -y wrapt

--- a/docker/autoscaler/Dockerfile
+++ b/docker/autoscaler/Dockerfile
@@ -3,10 +3,10 @@ ARG WHEEL_PATH
 ARG WHEEL_NAME
 
 RUN apt update
-RUN apt install -y curl tmux screen rsync
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-RUN sudo touch /etc/apt/sources.list.d/kubernetes.list
-RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt install -y curl tmux screen rsync apt-transport-https
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN touch /etc/apt/sources.list.d/kubernetes.list
+RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 RUN apt update
 RUN apt install -y kubectl
 

--- a/docker/autoscaler/Dockerfile
+++ b/docker/autoscaler/Dockerfile
@@ -4,6 +4,8 @@ ARG WHEEL_NAME
 
 RUN apt update
 RUN apt install -y curl tmux screen rsync apt-transport-https
+
+# Install kubectl.
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN touch /etc/apt/sources.list.d/kubernetes.list
 RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Required for the autoscaler to run on kubernetes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
