### PR TITLE
Add machinable to list of projects using Tune

### DIFF
--- a/doc/source/tune.rst
+++ b/doc/source/tune.rst
@@ -95,6 +95,7 @@ Here are some of the popular open source repositories and research projects that
  - `Population Based Augmentation <https://github.com/arcelien/pba>`_: Population Based Augmentation (PBA) is a algorithm that quickly and efficiently learns data augmentation functions for neural network training. PBA matches state-of-the-art results on CIFAR with one thousand times less compute.
  - `Fast AutoAugment by Kakao <https://github.com/kakaobrain/fast-autoaugment>`_: Fast AutoAugment (Accepted at NeurIPS 2019) learns augmentation policies using a more efficient search strategy based on density matching.
  - `Allentune <https://github.com/allenai/allentune>`_: Hyperparameter Search for AllenNLP from AllenAI.
+ - `machinable <https://github.com/frthjf/machinable>`_: A modular configuration system for machine learning research. See `machinable.org <machinable.org>`_.
 
 Citing Tune
 -----------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Adds link to open-source project *machinable* that builds on Ray and Ray Tune. machinable is a configuration system to support the development, execution and result analysis of ML experiments. You can find a quick overview of the features [here](https://machinable.org/guide/at-glance.html), in particular its integration with [Ray Tune](https://machinable.org/guide/tuning.html).

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
