### PR TITLE
[WIP] Try to parallelize task submission

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -15,7 +15,7 @@ namespace {
 // Duration between internal book-keeping heartbeats.
 const int kInternalHeartbeatMillis = 1000;
 
-const int kMaxSubmitParallelism = 2;
+const int kMaxSubmitParallelism = 8;
 
 void BuildCommonTaskSpec(
     ray::TaskSpecBuilder &builder, const JobID &job_id, const TaskID &task_id,
@@ -89,7 +89,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       core_worker_server_(WorkerTypeString(worker_type), 0 /* let grpc choose a port */),
       reference_counter_(std::make_shared<ReferenceCounter>()),
       rr_index_(0),
-      pool_(1),
+      pool_(kMaxSubmitParallelism),
       task_queue_length_(0),
       task_execution_service_work_(task_execution_service_),
       task_execution_callback_(task_execution_callback),

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -631,6 +631,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   // Interface to submit non-actor tasks directly to leased workers.
   std::unique_ptr<CoreWorkerDirectTaskSubmitter> direct_task_submitter_;
 
+  std::vector<std::unique_ptr<CoreWorkerDirectTaskSubmitter>> extra_task_submitters_;
+  std::atomic<unsigned int> rr_index_;
+  boost::asio::thread_pool pool_;
+
   /// The `actor_handles_` field could be mutated concurrently due to multi-threading, we
   /// need a mutex to protect it.
   mutable absl::Mutex actor_handles_mutex_;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -17,8 +17,8 @@ void ReferenceCounter::AddBorrowedObject(const ObjectID &object_id,
 void ReferenceCounter::AddOwnedObject(const ObjectID &object_id, const TaskID &owner_id,
                                       const rpc::Address &owner_address) {
   absl::MutexLock lock(&mutex_);
-  RAY_CHECK(object_id_refs_.count(object_id) == 0)
-      << "Tried to create an owned object that already exists: " << object_id;
+  //  RAY_CHECK(object_id_refs_.count(object_id) == 0)
+  //      << "Tried to create an owned object that already exists: " << object_id;
   // If the entry doesn't exist, we initialize the direct reference count to zero
   // because this corresponds to a submitted task whose return ObjectID will be created
   // in the frontend language, incrementing the reference count.


### PR DESCRIPTION
Using this test script:
```
import ray, time

@ray.remote
def f():
  return b"hi"

n = 30000
ray.init()
for _ in range(5):
  start = time.time()
  x = [f.remote() for _ in range(n)]
  print("submitted", n / (time.time() - start))
  ray.get(x)
  print("finish", n / (time.time() - start))

```

You get these results:
```

par = 1
submitted 17461.612735745388
finish 14836.20481873587
submitted 13246.058430527217
finish 12489.780577249872
submitted 13839.060553610727
finish 12983.325683920784
submitted 14229.594386550296
finish 13355.90064324985


par = 8
submitted 56628.4814405976
finish 17461.405555421872
submitted 53697.091746366845
finish 17603.496672345067
submitted 52963.62670244125
finish 18001.9753525582
submitted 55341.49189531532
finish 17915.928784517968
```