### PR TITLE
Disable HTTP proxy for gRPC connections

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -7,6 +7,7 @@ import collections
 import io
 import json
 import logging
+import os
 import re
 import string
 import sys
@@ -22,6 +23,19 @@ import ray.cluster_utils
 import ray.test_utils
 
 logger = logging.getLogger(__name__)
+
+
+# https://github.com/ray-project/ray/issues/6662
+def test_ignore_http_proxy(shutdown_only):
+    ray.init(num_cpus=1)
+    os.environ["http_proxy"] = "http://example.com"
+    os.environ["https_proxy"] = "http://example.com"
+
+    @ray.remote
+    def f():
+        return 1
+
+    assert ray.get(f.remote()) == 1
 
 
 def test_simple_serialization(ray_start_regular):

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -38,6 +38,7 @@ class GrpcClient {
  public:
   GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager)
       : client_call_manager_(call_manager) {
+    grpc::ChannelArguments argument;
     // Disable http proxy since it disrupts local connections. TODO(ekl) we should make
     // this configurable, or selectively set it for known local connections only.
     argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY, 0);

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -38,8 +38,12 @@ class GrpcClient {
  public:
   GrpcClient(const std::string &address, const int port, ClientCallManager &call_manager)
       : client_call_manager_(call_manager) {
-    std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
-        address + ":" + std::to_string(port), grpc::InsecureChannelCredentials());
+    // Disable http proxy since it disrupts local connections. TODO(ekl) we should make
+    // this configurable, or selectively set it for known local connections only.
+    argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY, 0);
+    std::shared_ptr<grpc::Channel> channel =
+        grpc::CreateCustomChannel(address + ":" + std::to_string(port),
+                                  grpc::InsecureChannelCredentials(), argument);
     stub_ = GrpcService::NewStub(channel);
   }
 
@@ -50,6 +54,7 @@ class GrpcClient {
     quota.SetMaxThreads(num_threads);
     grpc::ChannelArguments argument;
     argument.SetResourceQuota(quota);
+    argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY, 0);
     std::shared_ptr<grpc::Channel> channel =
         grpc::CreateCustomChannel(address + ":" + std::to_string(port),
                                   grpc::InsecureChannelCredentials(), argument);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Local gRPC connections will fail if the http_proxy or https_proxy env vars are set. Since we never supported HTTP proxying in previous versions of Ray, the simplest fix is to globally disable proxy support for all Ray gRPC connections.

In the future we can consider making this configurable, or disabling proxying for only local connections.

Closes https://github.com/ray-project/ray/issues/6662