### PR TITLE
fix#6722

### DIFF
--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -195,7 +195,7 @@ message CoreWorkerStats {
   // Number of object ids in local scope.
   int32 num_object_ids_in_scope = 3;
   // Function descriptor of the currently executing task.
-  repeated string current_task_func_desc = 4;
+  repeated bytes current_task_func_desc = 4;
   // IP address of the core worker.
   string ip_address = 6;
   // Port of the core worker.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Remove warning when serializing protocol buffer.

## Related issue number

 Fix for #6722 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
