### PR TITLE
Treat static methods as class methods instead of instance methods in actors

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -218,9 +218,9 @@ class ActorClassMetadata:
             # Whether or not this method requires binding of its first
             # argument. For class and static methods, we do not want to bind
             # the first argument, but we do for instance methods
-            is_bound = (
-                ray.utils.is_class_method(method) or
-                ray.utils.is_static_method(self.modified_class, method_name))
+            is_bound = (ray.utils.is_class_method(method)
+                        or ray.utils.is_static_method(self.modified_class,
+                                                      method_name))
 
             # Print a warning message if the method signature is not
             # supported. We don't raise an exception because if the actor

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -215,6 +215,9 @@ class ActorClassMetadata:
         self.method_signatures = {}
         self.actor_method_num_return_vals = {}
         for method_name, method in self.actor_methods:
+            # Whether or not this method requires binding of its first
+            # argument. For class and static methods, we do not want to bind
+            # the first argument, but we do for instance methods
             is_bound = (
                 ray.utils.is_class_method(method) or
                 ray.utils.is_static_method(self.modified_class, method_name))

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -215,6 +215,13 @@ class ActorClassMetadata:
         self.method_signatures = {}
         self.actor_method_num_return_vals = {}
         for method_name, method in self.actor_methods:
+            # Check if this method is static, and if so treat it like a class
+            # method by mocking the `__self__` attribute to look bound.
+            for cls in inspect.getmro(self.modified_class):
+                if method_name in cls.__dict__:
+                    if isinstance(cls.__dict__[method_name], staticmethod):
+                        method.__self__ = self.modified_class
+
             # Print a warning message if the method signature is not
             # supported. We don't raise an exception because if the actor
             # inherits from a class that has a method whose signature we

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -758,8 +758,8 @@ class FunctionActorManager:
 
             # Execute the assigned method and save a checkpoint if necessary.
             try:
-                is_bound = (is_class_method(method) or
-                            is_static_method(type(actor), method_name))
+                is_bound = (is_class_method(method)
+                            or is_static_method(type(actor), method_name))
                 if is_bound:
                     method_returns = method(*args, **kwargs)
                 else:

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -25,6 +25,7 @@ from ray.utils import (
     binary_to_hex,
     is_function_or_method,
     is_class_method,
+    is_static_method,
     check_oversized_pickle,
     decode,
     ensure_str,
@@ -757,7 +758,9 @@ class FunctionActorManager:
 
             # Execute the assigned method and save a checkpoint if necessary.
             try:
-                if is_class_method(method):
+                is_bound = (is_class_method(method) or
+                            is_static_method(type(actor), method_name))
+                if is_bound:
                     method_returns = method(*args, **kwargs)
                 else:
                     method_returns = method(actor, *args, **kwargs)

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1,23 +1,19 @@
-from __future__ import absolute_import, division, print_function
-
-import os
 import random
-import sys
-import time
-
 import numpy as np
+import os
 import pytest
-
-import ray
-import ray.cluster_utils
-import ray.test_utils
-from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
-from ray.test_utils import run_string_as_driver
-
 try:
     import pytest_timeout
 except ImportError:
     pytest_timeout = None
+import sys
+import time
+
+import ray
+import ray.test_utils
+import ray.cluster_utils
+from ray.test_utils import run_string_as_driver
+from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
 
 
 def test_actor_init_error_propagated(ray_start_regular):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import random
 import numpy as np
 import os

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -131,6 +131,14 @@ def is_class_method(f):
     return hasattr(f, "__self__") and f.__self__ is not None
 
 
+def is_static_method(cls, f_name):
+    """Returns whether the gclass has a static method with the given name."""
+    for cls in inspect.getmro(cls):
+        if f_name in cls.__dict__:
+            return isinstance(cls.__dict__[f_name], staticmethod)
+    return False
+
+
 def random_string():
     """Generate a random string to use as an ID.
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -132,7 +132,14 @@ def is_class_method(f):
 
 
 def is_static_method(cls, f_name):
-    """Returns whether the gclass has a static method with the given name."""
+    """Returns whether the class has a static method with the given name.
+
+    Args:
+        cls: The Python class (i.e. object of type `type`) to
+            search for the method in.
+        f_name: The name of the method to look up in this class
+            and check whether or not it is static.
+    """
     for cls in inspect.getmro(cls):
         if f_name in cls.__dict__:
             return isinstance(cls.__dict__[f_name], staticmethod)


### PR DESCRIPTION
## Why are these changes needed?
See #4687 for more info on the issue. Essentially static methods were being treated as instance methods that should be bound on actor creation which shouldn't be the case. This change introduces a simple trick to treat static methods (that shouldn't be bound) as bound-at-_class_-creation-time class methods. Even though the static methods actually do not have any reference to the class they are in, this trick allows us to not worry about binding these static methods throughout the framework.

This change is a little bit hacky, it spoofs the `__self__` attribute of the static method to make it seem like it is already bound (i.e. like a class method); however, this might be brittle in the case where the technique used to check the class methods changes.

Also, there might be some overhead to checking the entire MRO of a class for the static method reference, but we need to do this because the underlying `staticmethod` function is only shown in the `__dict__` of each class, and the `__dict__` attribute is not inherited or extended.

## Related issue number
Closes #4687.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
