### PR TITLE
Use exit() in __kill_actor__

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1413,12 +1413,12 @@ def test_kill(ray_start_regular):
     @ray.remote
     class Actor:
         def hang(self):
-            # Never returns.
-            ray.get(ray.ObjectID.from_random())
+            while True:
+                time.sleep(1)
 
     actor = Actor.remote()
     result = actor.hang.remote()
-    ready, _ = ray.wait([result], timeout=0.1)
+    ready, _ = ray.wait([result], timeout=0.5)
     assert len(ready) == 0
     actor.__ray_kill__()
     with pytest.raises(ray.exceptions.RayActorError):

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1153,8 +1153,11 @@ void CoreWorker::HandleKillActor(const rpc::KillActorRequest &request,
     send_reply_callback(Status::Invalid(msg), nullptr, nullptr);
     return;
   }
-  RAY_LOG(INFO) << "Got KillActor, shutting down...";
-  Shutdown();
+  RAY_LOG(INFO) << "Got KillActor, exiting immediately...";
+  if (log_dir_ != "") {
+    RayLog::ShutDownRayLog();
+  }
+  exit(1);
 }
 
 void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Related issue number

Closes #6751

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
