### PR TITLE
[Java] Remove singleton exceptions

### DIFF
--- a/java/api/src/main/java/org/ray/api/exception/RayActorException.java
+++ b/java/api/src/main/java/org/ray/api/exception/RayActorException.java
@@ -8,9 +8,8 @@ package org.ray.api.exception;
  */
 public class RayActorException extends RayException {
 
-  public static final RayActorException INSTANCE = new RayActorException();
-
-  private RayActorException() {
+  public RayActorException() {
     super("The actor died unexpectedly before finishing this task.");
   }
+
 }

--- a/java/api/src/main/java/org/ray/api/exception/RayWorkerException.java
+++ b/java/api/src/main/java/org/ray/api/exception/RayWorkerException.java
@@ -5,9 +5,8 @@ package org.ray.api.exception;
  */
 public class RayWorkerException extends RayException {
 
-  public static final RayWorkerException INSTANCE = new RayWorkerException();
-
-  private RayWorkerException() {
+  public RayWorkerException() {
     super("The worker died unexpectedly while executing this task.");
   }
+
 }

--- a/java/runtime/src/main/java/org/ray/runtime/object/ObjectSerializer.java
+++ b/java/runtime/src/main/java/org/ray/runtime/object/ObjectSerializer.java
@@ -45,9 +45,9 @@ public class ObjectSerializer {
       if (Arrays.equals(meta, RAW_TYPE_META)) {
         return data;
       } else if (Arrays.equals(meta, WORKER_EXCEPTION_META)) {
-        return RayWorkerException.INSTANCE;
+        return new RayWorkerException();
       } else if (Arrays.equals(meta, ACTOR_EXCEPTION_META)) {
-        return RayActorException.INSTANCE;
+        return new RayActorException();
       } else if (Arrays.equals(meta, UNRECONSTRUCTABLE_EXCEPTION_META)) {
         return new UnreconstructableException(objectId);
       } else if (Arrays.equals(meta, TASK_EXECUTION_EXCEPTION_META)) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Singleton exception is very confusing to users. When user throw a singleton exception in one place, then catch and throw same singleton exception in another place, stack trace is the stack trace of first throw. All stack trace of later exception throws won't exists. User will think these code doesn't get executed.

The PR remove all ray singleton exceptions.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
