### PR TITLE
Ignore io.UnsupportedOperation error when "Enabling nice stack traces…" in `worker.py::connect()`.

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -4,6 +4,7 @@ import atexit
 import faulthandler
 import hashlib
 import inspect
+import io
 import json
 import logging
 import os
@@ -1104,8 +1105,11 @@ def connect(node,
     assert worker.cached_functions_to_run is not None, error_message
 
     # Enable nice stack traces on SIGSEGV etc.
-    if not faulthandler.is_enabled():
-        faulthandler.enable(all_threads=False)
+    try:
+        if not faulthandler.is_enabled():
+            faulthandler.enable(all_threads=False)
+    except io.UnsupportedOperation:
+        pass  # ignore
 
     ray._raylet.set_internal_config(internal_config)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fixes RLlib tf-eager test cases for all RLlib agents when run locally on Ubuntu and Mac.

<!-- Please give a short summary of the change and the problem this solves. -->



<!-- For example: "Closes #1234" -->



- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
