### PR TITLE
Use /var/run instead of /tmp where appropriate

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -210,8 +210,8 @@ To get information about the current nodes in your cluster, you can use ``ray.no
       'NodeManagerAddress': '192.168.19.108',
       'NodeManagerPort': 37428,
       'ObjectManagerPort': 43415,
-      'ObjectStoreSocketName': '/tmp/ray/session_2019-07-28_17-03-53_955034_24883/sockets/plasma_store',
-      'RayletSocketName': '/tmp/ray/session_2019-07-28_17-03-53_955034_24883/sockets/raylet',
+      'ObjectStoreSocketName': '/var/run/session_2019-07-28_17-03-53_955034_24883/sockets/plasma_store',
+      'RayletSocketName': '/var/run/session_2019-07-28_17-03-53_955034_24883/sockets/raylet',
       'Resources': {'CPU': 4.0},
       'alive': True}]
     """

--- a/doc/source/configure.rst
+++ b/doc/source/configure.rst
@@ -79,24 +79,27 @@ start a new worker with the given *root temporary directory*.
   /tmp
   └── ray
       └── session_{datetime}_{pid}
-          ├── logs  # for logging
-          │   ├── log_monitor.err
-          │   ├── log_monitor.out
-          │   ├── monitor.err
-          │   ├── monitor.out
-          │   ├── plasma_store.err  # outputs of the plasma store
-          │   ├── plasma_store.out
-          │   ├── raylet.err  # outputs of the raylet process
-          │   ├── raylet.out
-          │   ├── redis-shard_0.err   # outputs of redis shards
-          │   ├── redis-shard_0.out
-          │   ├── redis.err  # redis
-          │   ├── redis.out
-          │   ├── webui.err  # ipython notebook web ui
-          │   ├── webui.out
-          │   ├── worker-{worker_id}.err  # redirected output of workers
-          │   ├── worker-{worker_id}.out
-          │   └── {other workers}
+          └── logs  # for logging
+              ├── log_monitor.err
+              ├── log_monitor.out
+              ├── monitor.err
+              ├── monitor.out
+              ├── plasma_store.err  # outputs of the plasma store
+              ├── plasma_store.out
+              ├── raylet.err  # outputs of the raylet process
+              ├── raylet.out
+              ├── redis-shard_0.err   # outputs of redis shards
+              ├── redis-shard_0.out
+              ├── redis.err  # redis
+              ├── redis.out
+              ├── webui.err  # ipython notebook web ui
+              ├── webui.out
+              ├── worker-{worker_id}.err  # redirected output of workers
+              ├── worker-{worker_id}.out
+              └── {other workers}
+  /var/run
+  └── ray
+      └── session_{datetime}_{pid}
           └── sockets  # for sockets
               ├── plasma_store
               └── raylet  # this could be deleted by Ray's shutdown cleanup.

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -88,8 +88,8 @@ like so:
  #   'NodeManagerAddress': '1.2.3.4',
  #   'NodeManagerPort': 43280,
  #   'ObjectManagerPort': 38062,
- #   'ObjectStoreSocketName': '/tmp/ray/session_2019-01-21_16-28-05_4216/sockets/plasma_store',
- #   'RayletSocketName': '/tmp/ray/session_2019-01-21_16-28-05_4216/sockets/raylet',
+ #   'ObjectStoreSocketName': '/var/run/session_2019-01-21_16-28-05_4216/sockets/plasma_store',
+ #   'RayletSocketName': '/var/run/session_2019-01-21_16-28-05_4216/sockets/raylet',
  #   'Resources': {'CPU': 8.0, 'GPU': 1.0}}]
 
 To inspect the primary Redis shard manually, you can also query with commands

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -74,7 +74,7 @@ ray {
   // ----------------------------
   object-store {
     // RPC socket name of object store
-    socket-name: /tmp/ray/sockets/object_store
+    socket-name: /var/run/ray/sockets/object_store
     // Initial size of the object store.
     size: 10 MB
   }
@@ -84,7 +84,7 @@ ray {
   // ----------------------------
   raylet {
     // RPC socket name of Raylet
-    socket-name: /tmp/ray/sockets/raylet
+    socket-name: /var/run/ray/sockets/raylet
     // Listening port for node manager.
     node-manager-port: 0
 

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -203,11 +203,16 @@ class Node:
                 redis_client.get("session_dir"))
         session_symlink = os.path.join(self._temp_dir, SESSION_LATEST)
 
+        # /var/run is a POSIX-compatible tmpfs that gets cleaned on reboot.
+        # It should be used for run-time files that are useless and must be
+        # cleaned after reboot, such as UNIX domain sockets.
+        self._session_run_dir = os.path.join("/var/run/ray", self.session_name)
+
         # Send a warning message if the session exists.
         try_to_create_directory(self._session_dir)
         try_to_symlink(session_symlink, self._session_dir)
         # Create a directory to be used for socket files.
-        self._sockets_dir = os.path.join(self._session_dir, "sockets")
+        self._sockets_dir = os.path.join(self._session_run_dir, "sockets")
         try_to_create_directory(self._sockets_dir)
         # Create a directory to be used for process log files.
         self._logs_dir = os.path.join(self._session_dir, "logs")


### PR DESCRIPTION
## Why are these changes needed?

Some files (like UNIX domain socket files) shouldn't clutter the file system after the system has shut down. One way to help make this happen is to use `/var/run`, as this is generally a `tmpfs` mount by default.

Edit: Never mind, the directory requires root permissions and isn't `tmpfs` on Mac.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
