### PR TITLE
adding context parameter for pool with a warning for not being supported

### DIFF
--- a/doc/source/multiprocessing.rst
+++ b/doc/source/multiprocessing.rst
@@ -9,7 +9,7 @@ multiprocessing.Pool API (Experimental)
   Contributions are always welcome!
   
 .. warning::
-  The 'context' argument passed to pool \_\_init\_\_ function is not supported using ray.
+  The ``context`` argument to the ``Pool`` constructor is not supported using ray.
 
 .. _`issue on GitHub`: https://github.com/ray-project/ray/issues
 

--- a/doc/source/multiprocessing.rst
+++ b/doc/source/multiprocessing.rst
@@ -7,6 +7,9 @@ multiprocessing.Pool API (Experimental)
   so it may be changed at any time without warning. If you encounter any
   bugs/shortcomings/incompatibilities, please file an `issue on GitHub`_.
   Contributions are always welcome!
+  
+.. warning::
+  The 'context' argument passed to pool \_\_init\_\_ function is not supported using ray.
 
 .. _`issue on GitHub`: https://github.com/ray-project/ray/issues
 

--- a/doc/source/multiprocessing.rst
+++ b/doc/source/multiprocessing.rst
@@ -7,9 +7,6 @@ multiprocessing.Pool API (Experimental)
   so it may be changed at any time without warning. If you encounter any
   bugs/shortcomings/incompatibilities, please file an `issue on GitHub`_.
   Contributions are always welcome!
-  
-.. warning::
-  The ``context`` argument to the ``Pool`` constructor is not supported using ray.
 
 .. _`issue on GitHub`: https://github.com/ray-project/ray/issues
 
@@ -42,6 +39,9 @@ instructions to run on a multi-node Ray cluster instead.
 
 The full ``multiprocessing.Pool`` API is currently supported. Please see the
 `multiprocessing documentation`_ for details.
+
+.. warning::
+  The ``context`` argument in the ``Pool`` constructor is ignored when using Ray.
 
 .. _`multiprocessing documentation`: https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool
 

--- a/python/ray/experimental/multiprocessing/pool.py
+++ b/python/ray/experimental/multiprocessing/pool.py
@@ -329,7 +329,9 @@ class Pool:
         self._actor_deletion_ids = []
 
         if context:
-            logger.warning("The 'context' argument is not supported using ray. Please refer to the documentation for how to control ray initialization.")
+            logger.warning("The 'context' argument is not supported using "
+                           "ray. Please refer to the documentation for how "
+                           "to control ray initialization.")
 
         processes = self._init_ray(processes, ray_address)
         self._start_actor_pool(processes)
@@ -344,12 +346,12 @@ class Pool:
 
             # Cluster mode.
             if ray_address is not None:
-                print("Connecting to ray cluster at address='{}'".format(
+                logger.info("Connecting to ray cluster at address='{}'".format(
                     ray_address))
                 ray.init(address=ray_address)
             # Local mode.
             else:
-                print("Starting local ray cluster")
+                logger.info("Starting local ray cluster")
                 ray.init(num_cpus=processes)
 
         ray_cpus = int(ray.state.cluster_resources()["CPU"])

--- a/python/ray/experimental/multiprocessing/pool.py
+++ b/python/ray/experimental/multiprocessing/pool.py
@@ -329,7 +329,7 @@ class Pool:
         self._actor_deletion_ids = []
 
         if context:
-            logger.warning("context argument is ignored")
+            logger.warning("The 'context' argument is not supported using ray. Please refer to the documentation for how to control ray initialization.")
 
         processes = self._init_ray(processes, ray_address)
         self._start_actor_pool(processes)

--- a/python/ray/experimental/multiprocessing/pool.py
+++ b/python/ray/experimental/multiprocessing/pool.py
@@ -1,3 +1,4 @@
+import logging
 from multiprocessing import TimeoutError
 import os
 import time
@@ -8,6 +9,8 @@ import queue
 import copy
 
 import ray
+
+logger = logging.getLogger(__name__)
 
 RAY_ADDRESS_ENV = "RAY_ADDRESS"
 
@@ -317,12 +320,16 @@ class Pool:
                  initializer=None,
                  initargs=None,
                  maxtasksperchild=None,
+                 context=None,
                  ray_address=None):
         self._closed = False
         self._initializer = initializer
         self._initargs = initargs
         self._maxtasksperchild = maxtasksperchild or -1
         self._actor_deletion_ids = []
+
+        if context:
+            logger.warning("context argument is ignored")
 
         processes = self._init_ray(processes, ray_address)
         self._start_actor_pool(processes)

--- a/python/ray/experimental/multiprocessing/pool.py
+++ b/python/ray/experimental/multiprocessing/pool.py
@@ -329,7 +329,9 @@ class Pool:
         self._actor_deletion_ids = []
 
         if context:
-            logger.warning("The 'context' argument is not supported using ray. Please refer to the documentation for how to control ray initialization.")
+            logger.warning("The 'context' argument is not supported using "
+                            "ray. Please refer to the documentation for how "
+                            "to control ray initialization.")
 
         processes = self._init_ray(processes, ray_address)
         self._start_actor_pool(processes)
@@ -344,12 +346,12 @@ class Pool:
 
             # Cluster mode.
             if ray_address is not None:
-                print("Connecting to ray cluster at address='{}'".format(
+                logger.info("Connecting to ray cluster at address='{}'".format(
                     ray_address))
                 ray.init(address=ray_address)
             # Local mode.
             else:
-                print("Starting local ray cluster")
+                logger.info("Starting local ray cluster")
                 ray.init(num_cpus=processes)
 
         ray_cpus = int(ray.state.cluster_resources()["CPU"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
for backward compatibility with original multiprocessing.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
