### PR TITLE
fix issue 6762:  delete pods associated with the project when running ray session stop

### DIFF
--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -326,6 +326,10 @@ def attach(screen, tmux):
 @click.option("--name", help="Name of the session to stop", default=None)
 def stop(name):
     project_definition = load_project_or_throw()
+
+    if not name:
+        name = project_definition.config["name"]
+
     teardown_cluster(
         project_definition.cluster_yaml(),
         yes=True,


### PR DESCRIPTION
delete pods associated with the project when running ray session stop

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fix bug when delete pods associated with the project when running ```ray session stop```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

close #6762

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
