### PR TITLE
Polish clang-format and let it run in a local repo

### DIFF
--- a/ci/travis/check-git-clang-format-output.sh
+++ b/ci/travis/check-git-clang-format-output.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
+if [ -z "${TRAVIS_PULL_REQUEST-}" ] || [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   # Not in a pull request, so compare against parent commit
   base_commit="HEAD^"
-  echo "Running clang-format against parent commit $(git rev-parse $base_commit)"
+  echo "Running clang-format against parent commit $(git rev-parse "$base_commit")"
 else
   base_commit="$TRAVIS_BRANCH"
-  echo "Running clang-format against branch $base_commit, with hash $(git rev-parse $base_commit)"
+  echo "Running clang-format against branch $base_commit, with hash $(git rev-parse "$base_commit")"
 fi
 exclude_regex="(.*thirdparty/|.*redismodule.h|.*.java|.*.jsx?|.*.tsx?)"
-output=$(ci/travis/git-clang-format --binary clang-format --commit $base_commit --diff --exclude "$exclude_regex")
-if [ "$output" == "no modified files to format" ] || [ "$output" == "clang-format did not modify any files" ] ; then
+output="$(ci/travis/git-clang-format --binary clang-format --commit "$base_commit" --diff --exclude "$exclude_regex")"
+if [ "$output" = "no modified files to format" ] || [ "$output" = "clang-format did not modify any files" ] ; then
   echo "clang-format passed."
   exit 0
 else


### PR DESCRIPTION
## Why are these changes needed?

`check-git-clang-format-output.sh` can't properly run locally.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
