### PR TITLE
[Java] Show the exit code if RunManager failed to start a process

### DIFF
--- a/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/org/ray/runtime/runner/RunManager.java
@@ -146,7 +146,8 @@ public class RunManager {
       e.printStackTrace();
     }
     if (!p.isAlive()) {
-      throw new RuntimeException("Failed to start " + name);
+      throw new RuntimeException(
+          String.format("Failed to start %s. Exit code: %d.", name, p.exitValue()));
     }
     processes.add(Pair.of(name, p));
     if (LOGGER.isInfoEnabled()) {


### PR DESCRIPTION
The exit code can provide useful information about the reason of failure.