### PR TITLE
Use 2xlarge instances in long running tests

### DIFF
--- a/ci/long_running_tests/ray-project/cluster.yaml
+++ b/ci/long_running_tests/ray-project/cluster.yaml
@@ -13,7 +13,7 @@ auth:
     ssh_user: ubuntu
 
 head_node:
-    InstanceType: m5.xlarge
+    InstanceType: m5.2xlarge
     ImageId: ami-0888a3b5189309429  # DLAMI 7/1/19
     BlockDeviceMappings:
         - DeviceName: /dev/sda1

--- a/ci/long_running_tests/ray-project/project.yaml
+++ b/ci/long_running_tests/ray-project/project.yaml
@@ -10,8 +10,7 @@ commands:
     command: |
       # Install nightly Ray wheels.
       source activate tensorflow_p36 && pip install -U {{wheel}}
-      source activate tensorflow_p36 && pip install ray[rllib] ray[debug] gym[atari]
-      source activate tensorflow_p36 && pip install ray[debug]
+      source activate tensorflow_p36 && pip install ray[dashboard,debug,rllib,tune] gym[atari]
       source activate tensorflow_p36 && python workloads/{{workload}}.py
     params:
       - name: wheel

--- a/ci/long_running_tests/workloads/actor_deaths.py
+++ b/ci/long_running_tests/workloads/actor_deaths.py
@@ -28,8 +28,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/actor_deaths.py
+++ b/ci/long_running_tests/workloads/actor_deaths.py
@@ -29,7 +29,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/apex.py
+++ b/ci/long_running_tests/workloads/apex.py
@@ -25,8 +25,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/apex.py
+++ b/ci/long_running_tests/workloads/apex.py
@@ -26,7 +26,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/impala.py
+++ b/ci/long_running_tests/workloads/impala.py
@@ -25,8 +25,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/impala.py
+++ b/ci/long_running_tests/workloads/impala.py
@@ -26,7 +26,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_actor_tasks.py
+++ b/ci/long_running_tests/workloads/many_actor_tasks.py
@@ -28,8 +28,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_actor_tasks.py
+++ b/ci/long_running_tests/workloads/many_actor_tasks.py
@@ -29,7 +29,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_drivers.py
+++ b/ci/long_running_tests/workloads/many_drivers.py
@@ -28,7 +28,7 @@ for i in range(num_nodes):
         resources={str(i): 5},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_drivers.py
+++ b/ci/long_running_tests/workloads/many_drivers.py
@@ -27,8 +27,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 5},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -28,8 +28,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -29,7 +29,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/node_failures.py
+++ b/ci/long_running_tests/workloads/node_failures.py
@@ -26,8 +26,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/node_failures.py
+++ b/ci/long_running_tests/workloads/node_failures.py
@@ -27,7 +27,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/pbt.py
+++ b/ci/long_running_tests/workloads/pbt.py
@@ -26,8 +26,9 @@ for i in range(num_nodes):
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address, webui_host="0.0.0.0")
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
 
 # Run the workload.
 

--- a/ci/long_running_tests/workloads/pbt.py
+++ b/ci/long_running_tests/workloads/pbt.py
@@ -27,7 +27,7 @@ for i in range(num_nodes):
         resources={str(i): 2},
         object_store_memory=object_store_memory,
         redis_max_memory=redis_max_memory)
-ray.init(address=cluster.address)
+ray.init(address=cluster.address, webui_host="0.0.0.0")
 
 # Run the workload.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Previously we were running very close to the 16GiB memory limit on the m4.xlarge instances in the long running tests. Recent changes have caused us to consume just over this limit, causing some of the tests to fail.

Also exposes the web ui for these tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
