### PR TITLE
num_cpus=1 by default in Pool

### DIFF
--- a/python/ray/experimental/multiprocessing/pool.py
+++ b/python/ray/experimental/multiprocessing/pool.py
@@ -270,7 +270,7 @@ class UnorderedIMapIterator(IMapIterator):
         return self._ready_objects.popleft()
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 class PoolActor:
     """Actor used to process tasks submitted to a Pool."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Not setting this seems to have some adverse impact on scheduling. Will follow up on that but for now manually setting it in Pool.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
