### PR TITLE
[Dashboard] Add route for /favicon.ico to fix missing favicon

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -128,6 +128,12 @@ class Dashboard(object):
                     os.path.dirname(os.path.abspath(__file__)),
                     "client/build/index.html"))
 
+        async def get_favicon(req) -> aiohttp.web.Response:
+            return aiohttp.web.FileResponse(
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "client/build/favicon.ico"))
+
         async def json_response(result=None, error=None,
                                 ts=None) -> aiohttp.web.Response:
             if ts is None:
@@ -249,6 +255,7 @@ class Dashboard(object):
             return await json_response(result=result)
 
         self.app.router.add_get("/", get_index)
+        self.app.router.add_get("/favicon.ico", get_favicon)
 
         static_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "client/build/static")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR fixes the missing favicon in the browser tab for the Ray dashboard.

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
