### PR TITLE
Fix crash in HandleObjectMissing when direct actor creation task is not found in local_queues_

### DIFF
--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -416,7 +416,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Implements gRPC server handler.
   void HandleWaitForObjectEviction(const rpc::WaitForObjectEvictionRequest &request,
                                    rpc::WaitForObjectEvictionReply *reply,
-                                   rpc::SendReplyCallback send_reply_callback);
+                                   rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
   void HandleKillActor(const rpc::KillActorRequest &request, rpc::KillActorReply *reply,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2688,21 +2688,70 @@ void NodeManager::HandleObjectLocal(const ObjectID &object_id) {
   }
 }
 
+bool NodeManager::IsDirectActorCreationTask(const TaskID &task_id) {
+  auto actor_id = task_id.ActorId();
+  if (!actor_id.IsNil() && task_id == TaskID::ForActorCreationTask(actor_id)) {
+    // This task ID corresponds to an actor creation task.
+    auto iter = actor_registry_.find(actor_id);
+    if (iter != actor_registry_.end() &&
+        iter->second.GetTableData().is_direct_call()) {
+      // This actor is direct call actor.
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void NodeManager::HandleObjectMissing(const ObjectID &object_id) {
   // Notify the task dependency manager that this object is no longer local.
   const auto waiting_task_ids = task_dependency_manager_.HandleObjectMissing(object_id);
-  RAY_LOG(DEBUG) << "Object missing " << object_id << ", "
-                 << " on " << self_node_id_ << waiting_task_ids.size()
-                 << " tasks waiting";
+  std::stringstream result;
+  result << "Object missing " << object_id << ", "
+         << " on " << self_node_id_ << ", " << waiting_task_ids.size()
+         << " tasks waiting";
+  if (waiting_task_ids.size() > 0) {
+    result << ", tasks: ";
+    for (const auto &task_id : waiting_task_ids) {
+      result << task_id << "  ";
+    }
+  }
+  RAY_LOG(DEBUG) << result.str();
+
   // Transition any tasks that were in the runnable state and are dependent on
   // this object to the waiting state.
   if (!waiting_task_ids.empty()) {
     std::unordered_set<TaskID> waiting_task_id_set(waiting_task_ids.begin(),
                                                    waiting_task_ids.end());
+    
+    // NOTE(zhijunfu): For actor creation task, we mark it as completed and remove it
+    // from local_queues_ when we're notified by worker via TaskDone message. This is
+    // required for actor reconstruction, as when we resbumit the actor creation task
+    // for reconstruction, it will be treated as duplicate and ignored if the same
+    // task ID is contained in local_queues_.
+    // Currently some applications like RLlib creates async threads in actor
+    // constructors, after the actor is created successfully, when these threads are
+    // blocked on ray.get, raylet will still receive `FetchOrReconstruct` messages
+    // with actor creation task id, and thus it's added to required_tasks_. Later
+    // when these objects get evicted, raylet will try to move the task that depends
+    // on these objects to WAITING queue, but the actor creation task has been removed
+    // when the actor is created, thus it would crash in MoveTask below.
+    // So we ignore actor creation task here to allow it to work.
+    auto iter = waiting_task_id_set.begin();
+    while (iter != waiting_task_id_set.end()) {
+      if (IsDirectActorCreationTask(*iter)) {
+        RAY_LOG(DEBUG) << "Ignoring direct actor creation task " << *iter
+                       << " when handling object missing for " << object_id;
+        iter = waiting_task_id_set.erase(iter);
+      } else {
+        ++iter;
+      }
+    }
+
     // First filter out any tasks that can't be transitioned to READY. These
     // are running workers or drivers, now blocked in a get.
     local_queues_.FilterState(waiting_task_id_set, TaskState::RUNNING);
-    local_queues_.FilterState(waiting_task_id_set, TaskState::DRIVER);
+    local_queues_.FilterState(waiting_task_id_set, TaskState::DRIVER);    
     // Transition the tasks back to the waiting state. They will be made
     // runnable once the deleted object becomes available again.
     local_queues_.MoveTasks(waiting_task_id_set, TaskState::READY, TaskState::WAITING);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2727,13 +2727,11 @@ void NodeManager::HandleObjectMissing(const ObjectID &object_id) {
     // creation task ID, which will not be reset after the task finishes. And later tasks
     // of this actor will reuse this task ID to require objects from plasma with
     // FetchOrReconstruct, since direct actor task IDs are not known to raylet.
-    // To support actor reconstruction for direct actors, raylet marks actor creation task
+    // To support actor reconstruction for direct actor, raylet marks actor creation task
     // as completed and removes it from `local_queues_` when it receives `TaskDone`
-    // message
-    // from worker. This is necessary because the actor creation task will be re-submitted
-    // during reconstruction, if the task is not removed previously, the new submitted
-    // task
-    // will be marked as duplicate and thus ignored.
+    // message from worker. This is necessary because the actor creation task will be
+    // re-submitted during reconstruction, if the task is not removed previously, the new
+    // submitted task will be marked as duplicate and thus ignored.
     // So here we check for direct actor creation task explicitly to allow this case.
     auto iter = waiting_task_id_set.begin();
     while (iter != waiting_task_id_set.end()) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2693,8 +2693,7 @@ bool NodeManager::IsDirectActorCreationTask(const TaskID &task_id) {
   if (!actor_id.IsNil() && task_id == TaskID::ForActorCreationTask(actor_id)) {
     // This task ID corresponds to an actor creation task.
     auto iter = actor_registry_.find(actor_id);
-    if (iter != actor_registry_.end() &&
-        iter->second.GetTableData().is_direct_call()) {
+    if (iter != actor_registry_.end() && iter->second.GetTableData().is_direct_call()) {
       // This actor is direct call actor.
       return true;
     }
@@ -2729,11 +2728,13 @@ void NodeManager::HandleObjectMissing(const ObjectID &object_id) {
     // of this actor will reuse this task ID to require objects from plasma with
     // FetchOrReconstruct, since direct actor task IDs are not known to raylet.
     // To support actor reconstruction for direct actors, raylet marks actor creation task
-    // as completed and removes it from `local_queues_` when it receives `TaskDone` message
+    // as completed and removes it from `local_queues_` when it receives `TaskDone`
+    // message
     // from worker. This is necessary because the actor creation task will be re-submitted
-    // during reconstruction, if the task is not removed previously, the new submitted task
+    // during reconstruction, if the task is not removed previously, the new submitted
+    // task
     // will be marked as duplicate and thus ignored.
-    // So here we check for direct actor creation task explicitly to allow this case.   
+    // So here we check for direct actor creation task explicitly to allow this case.
     auto iter = waiting_task_id_set.begin();
     while (iter != waiting_task_id_set.end()) {
       if (IsDirectActorCreationTask(*iter)) {
@@ -2748,7 +2749,7 @@ void NodeManager::HandleObjectMissing(const ObjectID &object_id) {
     // First filter out any tasks that can't be transitioned to READY. These
     // are running workers or drivers, now blocked in a get.
     local_queues_.FilterState(waiting_task_id_set, TaskState::RUNNING);
-    local_queues_.FilterState(waiting_task_id_set, TaskState::DRIVER);    
+    local_queues_.FilterState(waiting_task_id_set, TaskState::DRIVER);
     // Transition the tasks back to the waiting state. They will be made
     // runnable once the deleted object becomes available again.
     local_queues_.MoveTasks(waiting_task_id_set, TaskState::READY, TaskState::WAITING);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -571,6 +571,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// Repeat the process as long as we can schedule a task.
   void NewSchedulerSchedulePendingTasks();
 
+  /// Whether a task is an direct actor creation task.
+  bool IsDirectActorCreationTask(const TaskID &task_id);
+
   /// ID of this node.
   ClientID self_node_id_;
   boost::asio::io_service &io_service_;


### PR DESCRIPTION
## Why are these changes needed?

For direct actors, the worker is initially assigned actor creation task ID, which will not be reset after the task finishes. And later tasks of this actor will reuse this task ID to require objects from plasma with FetchOrReconstruct, since direct actor task IDs are not known to raylet.

To support actor reconstruction for direct actors, raylet marks actor creation task as completed and removes it from `local_queues_` when it receives `TaskDone` message from worker. This is necessary because the actor creation task will be re-submitted during reconstruction, if the task is not removed previously, the new submitted task will be marked as duplicate and thus ignored.  

This PR checks for direct actor creation task explicitly to allow this case.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
