### PR TITLE
[Dashboard] Add actor task counter

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -336,6 +336,7 @@ class GlobalState:
             },
             "IsDirectCall": actor_table_data.is_direct_call,
             "State": actor_table_data.state,
+            "Timestamp": actor_table_data.timestamp,
         }
 
         return actor_info

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -168,6 +168,7 @@ def test_raylet_info_endpoint(shutdown_only):
                     "Timed out while waiting for dashboard to start.")
 
     assert parent_actor_info["usedResources"]["CPU"] == 2
+    assert parent_actor_info["numExecutedTasks"] == 3
     for _, child_actor_info in children.items():
         if child_actor_info["state"] == -1:
             assert child_actor_info["requiredResources"]["CustomResource"] == 1

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -660,6 +660,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Number of tasks that have been pushed to the actor but not executed.
   std::atomic<int64_t> task_queue_length_;
 
+  /// Number of executed tasks.
+  std::atomic<int64_t> num_executed_tasks_;
+
   /// Event loop where tasks are processed.
   boost::asio::io_service task_execution_service_;
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -212,4 +212,6 @@ message CoreWorkerStats {
   int64 used_object_store_memory = 12;
   // Length of the task queue.
   int32 task_queue_length = 13;
+  // Number of executed tasks.
+  int32 num_executed_tasks = 14;
 }

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -117,6 +117,8 @@ message ActorTableData {
   bool is_direct_call = 11;
   // Whether the actor is persistent.
   bool is_detached = 12;
+  // Timestamp that the actor is created or reconstructed.
+  double timestamp = 13;
 }
 
 message ErrorTableData {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2445,6 +2445,7 @@ std::shared_ptr<ActorTableData> NodeManager::CreateActorTableDataFromCreationTas
   actor_info_ptr->mutable_address()->set_raylet_id(self_node_id_.Binary());
   actor_info_ptr->mutable_address()->set_worker_id(worker_id.Binary());
   actor_info_ptr->set_state(ActorTableData::ALIVE);
+  actor_info_ptr->set_timestamp(current_time_ms());
   return actor_info_ptr;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR adds a counter for the number of tasks executed by an actor and tracks the time stamp an actor starts. The information is used to compute task execution speed of the actor. 
The PR fixes b64 decoding of task function descriptor. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
