### PR TITLE
[RLlib] Update MADDPG example repo to maintained fork

### DIFF
--- a/doc/source/rllib-algorithms.rst
+++ b/doc/source/rllib-algorithms.rst
@@ -348,7 +348,7 @@ Tuned examples: `Two-step game <https://github.com/ray-project/ray/blob/master/r
 
 Multi-Agent Deep Deterministic Policy Gradient (contrib/MADDPG)
 ---------------------------------------------------------------
-`[paper] <https://arxiv.org/abs/1706.02275>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/contrib/maddpg/maddpg.py>`__ MADDPG is a specialized multi-agent algorithm. Code here is adapted from https://github.com/openai/maddpg to integrate with RLlib multi-agent APIs. Please check `wsjeon/maddpg-rllib <https://github.com/wsjeon/maddpg-rllib>`__ for examples and more information.
+`[paper] <https://arxiv.org/abs/1706.02275>`__ `[implementation] <https://github.com/ray-project/ray/blob/master/rllib/contrib/maddpg/maddpg.py>`__ MADDPG is a specialized multi-agent algorithm. Code here is adapted from https://github.com/openai/maddpg to integrate with RLlib multi-agent APIs. Please check `justinkterry/maddpg-rllib <https://github.com/justinkterry/maddpg-rllib>`__ for examples and more information.
 
 **MADDPG-specific configs** (see also `common configs <rllib-training.html#common-parameters>`__):
 

--- a/rllib/contrib/maddpg/README.md
+++ b/rllib/contrib/maddpg/README.md
@@ -1,4 +1,4 @@
 # Implementation of MADDPG in RLLib
 
-Please check [justinkterry/maddpg-rllib](https://github.com/wsjeon/justinkterry-rllib) for more information. 
+Please check [justinkterry/maddpg-rllib](https://github.com/justinkterry-rllib) for more information. 
 

--- a/rllib/contrib/maddpg/README.md
+++ b/rllib/contrib/maddpg/README.md
@@ -1,4 +1,4 @@
 # Implementation of MADDPG in RLLib
 
-Please check [wsjeon/maddpg-rllib](https://github.com/wsjeon/maddpg-rllib) for more information. 
+Please check [justinkterry/maddpg-rllib](https://github.com/wsjeon/justinkterry-rllib) for more information. 
 

--- a/rllib/contrib/maddpg/README.md
+++ b/rllib/contrib/maddpg/README.md
@@ -1,4 +1,4 @@
 # Implementation of MADDPG in RLLib
 
-Please check [justinkterry/maddpg-rllib](https://github.com/justinkterry-rllib) for more information. 
+Please check [justinkterry/maddpg-rllib](https://github.com/justinkterry/maddpg-rllib) for more information. 
 


### PR DESCRIPTION
Per issue #6803, the original MADDPG example repo isn't being maintained and can't be run. I've forked it, fixed it, and will maintain it. I've created this PR to change the official documentation to point to my repo per @ericl 's request.