### PR TITLE
Make Cython rules more consistent for Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1058,10 +1058,10 @@ pyx_library(
     # Export ray ABI symbols, which can then be used by _streaming.so.
     # We need to dlopen this lib with RTLD_GLOBAL to use ABI in this
     # shared lib, see python/ray/__init__.py.
-    cc_kwargs = {
-        "linkstatic": 1,
+    cc_kwargs = dict(
+        copts = COPTS,
         # see https://github.com/tensorflow/tensorflow/blob/r2.1/tensorflow/lite/BUILD#L444
-        "linkopts": select({
+        linkopts = select({
             "@bazel_tools//src/conditions:darwin": [
                 "-Wl,-exported_symbols_list,$(location //:src/ray/ray_exported_symbols.lds)",
             ],
@@ -1071,8 +1071,8 @@ pyx_library(
                 "-Wl,--version-script,$(location //:src/ray/ray_version_script.lds)",
             ],
         }),
-    },
-    copts = COPTS,
+        linkstatic = 1,
+    ),
     deps = [
         "//:core_worker_lib",
         "//:raylet_lib",
@@ -1094,7 +1094,9 @@ pyx_library(
         "python/ray/streaming/includes/*.pxd",
         "python/ray/streaming/includes/*.pxi",
     ]),
-    copts = COPTS,
+    cc_kwargs = dict(
+        copts = COPTS,
+    ),
     deps = [
         "//streaming:streaming_lib",
     ],

--- a/streaming/BUILD.bazel
+++ b/streaming/BUILD.bazel
@@ -1,7 +1,6 @@
 # Bazel build
 # C/C++ documentation: https://docs.bazel.build/versions/master/be/c-cpp.html
 
-load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 load("@rules_proto_grpc//python:defs.bzl", "python_proto_compile")
 load("//bazel:ray.bzl", "COPTS")
 

--- a/thirdparty/patches/grpc-cython-copts.patch
+++ b/thirdparty/patches/grpc-cython-copts.patch
@@ -1,9 +1,9 @@
 diff --git bazel/cython_library.bzl bazel/cython_library.bzl
 --- bazel/cython_library.bzl
 +++ bazel/cython_library.bzl
-@@ -10,14 +10,16 @@
+@@ -10,15 +10,16 @@
 -def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
-+def pyx_library(name, deps=[], copts=[], cc_kwargs={}, py_deps=[], srcs=[], **kwargs):
++def pyx_library(name, deps=[], cc_kwargs={}, py_deps=[], srcs=[], **kwargs):
      """Compiles a group of .pyx / .pxd / .py files.
 
      First runs Cython to create .cpp files for each input .pyx or .py + .pxd
@@ -19,18 +19,19 @@ diff --git bazel/cython_library.bzl bazel/cython_library.bzl
      Args:
          name: Name for the rule.
          deps: C/C++ dependencies of the Cython (e.g. Numpy headers).
-+        copts: C/C++ compiler options for Cython
-+        cc_kwargs: cc_binary extra arguments such as linkstatic, linkopts, features
-         py_deps: Pure Python dependencies of the final library.
-         srcs: .py, .pyx, or .pxd files to either compile or pass through.
-@@ -58,6 +60,8 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
++        cc_kwargs: cc_binary extra arguments such as copts, linkstatic, linkopts, features
+@@ -57,7 +59,8 @@ def pyx_library(name, deps=[], py_deps=[], srcs=[], **kwargs):
+-        shared_object_name = stem + ".so"
++        shared_object_name = stem + ".so"
          native.cc_binary(
-             name=shared_object_name,
+-            name=shared_object_name,
++            name=cc_kwargs.pop("name", shared_object_name),
 -            srcs=[stem + ".cpp"],
 +            srcs=[stem + ".cpp"] + cc_kwargs.pop("srcs", []),
-+            copts=copts,
-             deps=deps + ["@local_config_python//:python_headers"],
-             linkshared=1,
+-            deps=deps + ["@local_config_python//:python_headers"],
++            deps=deps + ["@local_config_python//:python_headers"] + cc_kwargs.pop("deps", []),
+-            linkshared=1,
++            linkshared=cc_kwargs.pop("linkshared", 1),
 +            **cc_kwargs
          )
 --


### PR DESCRIPTION
## Why are these changes needed?

The `pyx_library` rules had inconsistent syntax for passing different `kwargs` to `cc_binary`.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
