### PR TITLE
[autoscaler] Auto-replace "DEFAULT" with most recent DLAMI

### DIFF
--- a/doc/source/autoscaling.rst
+++ b/doc/source/autoscaling.rst
@@ -34,6 +34,8 @@ Test that it works by running the following commands from your local machine:
     # Tear down the cluster.
     $ ray down ray/python/ray/autoscaler/aws/example-full.yaml
 
+.. tip:: For the AWS node configuration, you can set ``"ImageId: DEFAULT"`` to automatically use the newest `Deep Learning AMI <https://aws.amazon.com/machine-learning/amis/>`_ for your region. For example, ``head_node: {InstanceType: c5.xlarge, ImageId: DEFAULT}``.
+
 GCP
 ~~~
 

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -65,6 +65,9 @@ def bootstrap_aws(config):
     # the group, and also SSH access from outside.
     config = _configure_security_group(config)
 
+    # Provide a helpful message for missing AMI.
+    _check_ami(config)
+
     return config
 
 
@@ -272,6 +275,7 @@ def _check_ami(config):
     region = config["provider"]["region"]
     default_ami = DEFAULT_AMI.get(region)
     if not default_ami:
+        # If we do not provide a default AMI for the given region, noop.
         return
 
     if "ImageId" not in config["head_node"]:

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -278,7 +278,7 @@ def _check_ami(config):
         # If we do not provide a default AMI for the given region, noop.
         return
 
-    if config["head_node"].get("ImageId") == "DEFAULT":
+    if config["head_node"].get("ImageId", "").lower() == "DEFAULT":
         config["head_node"]["ImageId"] = default_ami
         logger.info("_check_ami: head node ImageId specified as 'DEFAULT'. "
                     "Using '{ami_id}', which is the default {ami_name} "
@@ -287,7 +287,7 @@ def _check_ami(config):
                         ami_name=DEFAULT_AMI_NAME,
                         region=region))
 
-    if config["worker_nodes"].get("ImageId") == "DEFAULT":
+    if config["worker_nodes"].get("ImageId", "").lower() == "DEFAULT":
         config["worker_nodes"]["ImageId"] = default_ami
         logger.info("_check_ami: worker nodes ImageId specified as 'DEFAULT'. "
                     "Using '{ami_id}', which is the default {ami_name} "

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -278,19 +278,23 @@ def _check_ami(config):
         # If we do not provide a default AMI for the given region, noop.
         return
 
-    if "ImageId" not in config["head_node"]:
-        logger.info(
-            "_check_ami: head node ImageId not specified, please consider "
-            "using '{ami_id}', which is the default {ami_name} "
-            "for your region ({region}).".format(
-                ami_id=default_ami, ami_name=DEFAULT_AMI_NAME, region=region))
+    if config["head_node"].get("ImageId") == "DEFAULT":
+        config["head_node"]["ImageId"] = default_ami
+        logger.info("_check_ami: head node ImageId specified as 'DEFAULT'. "
+                    "Using '{ami_id}', which is the default {ami_name} "
+                    "for your region ({region}).".format(
+                        ami_id=default_ami,
+                        ami_name=DEFAULT_AMI_NAME,
+                        region=region))
 
-    if "ImageId" not in config["worker_nodes"]:
-        logger.info(
-            "_check_ami: worker nodes ImageId not specified, please consider "
-            "using '{ami_id}', which is the default {ami_name} "
-            "for your region ({region}).".format(
-                ami_id=default_ami, ami_name=DEFAULT_AMI_NAME, region=region))
+    if config["worker_nodes"].get("ImageId") == "DEFAULT":
+        config["worker_nodes"]["ImageId"] = default_ami
+        logger.info("_check_ami: worker nodes ImageId specified as 'DEFAULT'. "
+                    "Using '{ami_id}', which is the default {ami_name} "
+                    "for your region ({region}).".format(
+                        ami_id=default_ami,
+                        ami_name=DEFAULT_AMI_NAME,
+                        region=region))
 
 
 def _get_vpc_id_or_die(config, subnet_id):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

I really dislike moving regions because it forces me to look for the
right DLAMI string. A helpful macro like done in this PR will allow me
to avoid making multiple round trips to the AWS console.

Comments welcome (not sure if there is a better way to do this).
![image](https://user-images.githubusercontent.com/4529381/72690518-0171cd80-3ad2-11ea-9984-c86b7d8ac17d.png)



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.