### PR TITLE
Fix flaky test test_feature_flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,42 +12,6 @@ matrix:
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
 
     - os: linux
-      env:
-        - JDK='Oracle JDK 8'
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
-        - RAY_INSTALL_JAVA=1
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./ci/travis/install-bazel.sh
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
-      script:
-        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
-        - ./java/test.sh
-
-    - os: linux
-      env:
-        - TESTSUITE=streaming
-        - JDK='Oracle JDK 8'
-        - RAY_INSTALL_JAVA=1
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
-      install:
-        - python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [[ $RAY_CI_STREAMING_PYTHON_AFFECTED != "1" && $RAY_CI_STREAMING_JAVA_AFFECTED != "1" ]]; then exit; fi
-        - ./ci/travis/install-bazel.sh
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
-      script:
-        # Streaming cpp test.
-        - if [ $RAY_CI_STREAMING_CPP_AFFECTED == "1" ]; then ./ci/suppress_output bazel test //streaming:all && bash streaming/src/test/run_streaming_queue_test.sh; fi
-        - if [ $RAY_CI_STREAMING_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 streaming/python/tests/; fi
-        - if [ $RAY_CI_STREAMING_JAVA_AFFECTED == "1" ]; then ./streaming/java/test.sh; fi
-
-    - os: linux
       env: LINT=1 PYTHONWARNINGS=ignore
       before_install:
         - sudo apt-get update -qq
@@ -80,62 +44,6 @@ matrix:
         - go get github.com/bazelbuild/buildtools/buildifier
         - ./ci/travis/bazel-format.sh
 
-    - os: linux
-      env: SANITIZER=1 CC=clang PYTHON=3.5 PYTHONWARNINGS=ignore
-
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/suppress_output ./ci/travis/install-bazel.sh
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - ./ci/suppress_output ./ci/travis/install-ray.sh
-
-      script:
-        # Run core worker tests with thread sanitizer
-        - RAY_BAZEL_CONFIG="--config=tsan" TSAN_OPTIONS="report_atomic_races=0" ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-
-    # Build Linux wheels.
-    - os: linux
-      env: LINUX_WHEELS=1 PYTHONWARNINGS=ignore RAY_INSTALL_JAVA=1
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-
-        # Mount bazel cache dir to the docker container.
-        # For the linux wheel build, we use a shared cache between all
-        # wheels, but not between different travis runs, because that
-        # caused timeouts in the past. See the "cache: false" line below.
-        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e encrypted_1c30b31fe1ee_key=$encrypted_1c30b31fe1ee_key -e encrypted_1c30b31fe1ee_iv=$encrypted_1c30b31fe1ee_iv"
-
-        # This command should be kept in sync with ray/python/README-building-wheels.md,
-        # except the `$MOUNT_BAZEL_CACHE` part.
-
-        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
-
-      script:
-        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/travis/test-wheels.sh
-      cache: false
-
-    # Build MacOS wheels.
-    - os: osx
-      osx_image: xcode7
-      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore RAY_INSTALL_JAVA=1
-      install:
-        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
-        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
-        # This command should be kept in sync with ray/python/README-building-wheels.md.
-        - ./ci/suppress_output ./python/build-wheel-macos.sh
-      script:
-        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
-
-        - ./ci/travis/test-wheels.sh
 
 install:
   - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -151,30 +59,7 @@ install:
 
 script:
   - export PATH="$HOME/miniconda/bin:$PATH"
-
-  # raylet integration tests
-  - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-  - ./ci/suppress_output bash src/ray/test/run_object_manager_tests.sh
-
-  # cc bazel tests
-  - ./ci/suppress_output bazel test --build_tests_only --show_progress_rate_limit=100 --test_output=errors //:all
-
-  # ray serve tests
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
-
-  # ray operator tests
-  - cd ./deploy/ray-operator/
-  - go build
-  - go test ./...
-  - cd ../..
-
-  # bazel python tests. This should be run last to keep its logs at the end of travis logs.
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then RAY_FORCE_DIRECT=0 python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
-  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/tests/py3_test.py; fi
-
-  - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/...
-  # NO MORE TESTS BELOW, keep them above.
+  - for i in {1..100}; do python -m pytest python/ray/tests/test_reference_counting.py; done
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,42 @@ matrix:
       env: PYTHON=3.5 PYTHONWARNINGS=ignore
 
     - os: linux
+      env:
+        - JDK='Oracle JDK 8'
+        - PYTHON=3.5 PYTHONWARNINGS=ignore
+        - RAY_INSTALL_JAVA=1
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
+        - ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+      script:
+        - if [ $RAY_CI_JAVA_AFFECTED != "1" ]; then exit; fi
+        - ./java/test.sh
+
+    - os: linux
+      env:
+        - TESTSUITE=streaming
+        - JDK='Oracle JDK 8'
+        - RAY_INSTALL_JAVA=1
+        - PYTHON=3.5 PYTHONWARNINGS=ignore
+      install:
+        - python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [[ $RAY_CI_STREAMING_PYTHON_AFFECTED != "1" && $RAY_CI_STREAMING_JAVA_AFFECTED != "1" ]]; then exit; fi
+        - ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+      script:
+        # Streaming cpp test.
+        - if [ $RAY_CI_STREAMING_CPP_AFFECTED == "1" ]; then ./ci/suppress_output bazel test //streaming:all && bash streaming/src/test/run_streaming_queue_test.sh; fi
+        - if [ $RAY_CI_STREAMING_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 streaming/python/tests/; fi
+        - if [ $RAY_CI_STREAMING_JAVA_AFFECTED == "1" ]; then ./streaming/java/test.sh; fi
+
+    - os: linux
       env: LINT=1 PYTHONWARNINGS=ignore
       before_install:
         - sudo apt-get update -qq
@@ -44,6 +80,62 @@ matrix:
         - go get github.com/bazelbuild/buildtools/buildifier
         - ./ci/travis/bazel-format.sh
 
+    - os: linux
+      env: SANITIZER=1 CC=clang PYTHON=3.5 PYTHONWARNINGS=ignore
+
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/suppress_output ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+
+      script:
+        # Run core worker tests with thread sanitizer
+        - RAY_BAZEL_CONFIG="--config=tsan" TSAN_OPTIONS="report_atomic_races=0" ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+
+    # Build Linux wheels.
+    - os: linux
+      env: LINUX_WHEELS=1 PYTHONWARNINGS=ignore RAY_INSTALL_JAVA=1
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+
+        # Mount bazel cache dir to the docker container.
+        # For the linux wheel build, we use a shared cache between all
+        # wheels, but not between different travis runs, because that
+        # caused timeouts in the past. See the "cache: false" line below.
+        - export MOUNT_BAZEL_CACHE="-v $HOME/ray-bazel-cache:/root/ray-bazel-cache -e TRAVIS=true -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e encrypted_1c30b31fe1ee_key=$encrypted_1c30b31fe1ee_key -e encrypted_1c30b31fe1ee_iv=$encrypted_1c30b31fe1ee_iv"
+
+        # This command should be kept in sync with ray/python/README-building-wheels.md,
+        # except the `$MOUNT_BAZEL_CACHE` part.
+
+        - ./ci/suppress_output docker run --rm -w /ray -v `pwd`:/ray $MOUNT_BAZEL_CACHE -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+
+      script:
+        - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/travis/test-wheels.sh
+      cache: false
+
+    # Build MacOS wheels.
+    - os: osx
+      osx_image: xcode7
+      env: MAC_WHEELS=1 PYTHONWARNINGS=ignore RAY_INSTALL_JAVA=1
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        # This command should be kept in sync with ray/python/README-building-wheels.md.
+        - ./ci/suppress_output ./python/build-wheel-macos.sh
+      script:
+        - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
+
+        - ./ci/travis/test-wheels.sh
 
 install:
   - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -59,7 +151,30 @@ install:
 
 script:
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - for i in {1..100}; do python -m pytest python/ray/tests/test_reference_counting.py; done
+
+  # raylet integration tests
+  - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+  - ./ci/suppress_output bash src/ray/test/run_object_manager_tests.sh
+
+  # cc bazel tests
+  - ./ci/suppress_output bazel test --build_tests_only --show_progress_rate_limit=100 --test_output=errors //:all
+
+  # ray serve tests
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
+
+  # ray operator tests
+  - cd ./deploy/ray-operator/
+  - go build
+  - go test ./...
+  - cd ../..
+
+  # bazel python tests. This should be run last to keep its logs at the end of travis logs.
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then RAY_FORCE_DIRECT=0 python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/test/async_test.py; fi
+  - if [ $RAY_CI_PYTHON_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/tests/py3_test.py; fi
+
+  - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/...
+  # NO MORE TESTS BELOW, keep them above.
 
 deploy:
   - provider: s3

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -231,10 +231,14 @@ def test_feature_flag(shutdown_only):
             self.large_object = ray.put(
                 np.zeros(25 * 1024 * 1024, dtype=np.uint8))
 
+        def wait_for_actor_to_start(self):
+            pass
+
         def get_large_object(self):
             return ray.get(self.large_object)
 
     actor = Actor.remote()
+    ray.get(actor.wait_for_actor_to_start.remote())
 
     for batch in range(10):
         intermediate_result = f.remote(


### PR DESCRIPTION
We're creating an initial big object in an actor, then creating a bunch of other objects and expecting the initial object to get evicted. Sometimes that isn't happening.

Still validating this hypothesis, but I suspect what is happening is that the actor is taking a while to start up so it isn't actually the first object to get created, so LRU doesn't evict it.

I'm fixing this by waiting for the actor to start up and create the object.