### PR TITLE
Use standard EditorConfig file for editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.py]
+indent_style = space
+indent_size = 4
+wrap_width = 80
+
+[*.{hpp,hxx,h,cpp,cxx,cc,c}]
+indent_style = space
+indent_size = 2
+wrap_width = 90


### PR DESCRIPTION
## Why are these changes needed?

[EditorConfig](https://editorconfig.org/) is a standardized mechanism for specifying project-specific editor settings. This helps developers avoid having to constantly switch editor settings between codebases.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
