### PR TITLE
[Streaming] use GET-SET macro to reduce duplicated code

### DIFF
--- a/streaming/src/config/streaming_config.cc
+++ b/streaming/src/config/streaming_config.cc
@@ -45,45 +45,5 @@ void StreamingConfig::SetRingBufferCapacity(uint32_t ring_buffer_capacity) {
   StreamingConfig::ring_buffer_capacity_ =
       std::min(ring_buffer_capacity, StreamingConfig::MESSAGE_BUNDLE_MAX_SIZE);
 }
-
-uint32_t StreamingConfig::GetEmptyMessageTimeInterval() const {
-  return empty_message_time_interval_;
-}
-
-void StreamingConfig::SetEmptyMessageTimeInterval(uint32_t empty_message_time_interval) {
-  StreamingConfig::empty_message_time_interval_ = empty_message_time_interval;
-}
-
-streaming::proto::OperatorType StreamingConfig::GetOperatorType() const {
-  return operator_type_;
-}
-
-void StreamingConfig::SetOperatorType(streaming::proto::OperatorType type) {
-  StreamingConfig::operator_type_ = type;
-}
-
-const std::string &StreamingConfig::GetJobName() const { return job_name_; }
-
-void StreamingConfig::SetJobName(const std::string &job_name) {
-  StreamingConfig::job_name_ = job_name;
-}
-
-const std::string &StreamingConfig::GetOpName() const { return op_name_; }
-
-void StreamingConfig::SetOpName(const std::string &op_name) {
-  StreamingConfig::op_name_ = op_name;
-}
-
-const std::string &StreamingConfig::GetWorkerName() const { return worker_name_; }
-void StreamingConfig::SetWorkerName(const std::string &worker_name) {
-  StreamingConfig::worker_name_ = worker_name;
-}
-
-const std::string &StreamingConfig::GetTaskJobId() const { return task_job_id_; }
-
-void StreamingConfig::SetTaskJobId(const std::string &task_job_id) {
-  StreamingConfig::task_job_id_ = task_job_id;
-}
-
 }  // namespace streaming
 }  // namespace ray

--- a/streaming/src/config/streaming_config.h
+++ b/streaming/src/config/streaming_config.h
@@ -36,33 +36,21 @@ class StreamingConfig {
  public:
   void FromProto(const uint8_t *, uint32_t size);
 
-  const std::string &GetTaskJobId() const;
+#define DECL_GET_SET_PROPERTY(TYPE, NAME, VALUE) \
+  TYPE Get##NAME() const { return VALUE; }       \
+  void Set##NAME(TYPE value) { VALUE = value; }
 
-  void SetTaskJobId(const std::string &task_job_id);
-
-  const std::string &GetWorkerName() const;
-
-  void SetWorkerName(const std::string &worker_name);
-
-  const std::string &GetOpName() const;
-
-  void SetOpName(const std::string &op_name);
-
-  uint32_t GetEmptyMessageTimeInterval() const;
-
-  void SetEmptyMessageTimeInterval(uint32_t empty_message_time_interval);
+  DECL_GET_SET_PROPERTY(const std::string &, TaskJobId, task_job_id_)
+  DECL_GET_SET_PROPERTY(const std::string &, WorkerName, worker_name_)
+  DECL_GET_SET_PROPERTY(const std::string &, OpName, op_name_)
+  DECL_GET_SET_PROPERTY(uint32_t, EmptyMessageTimeInterval, empty_message_time_interval_)
+  DECL_GET_SET_PROPERTY(streaming::proto::OperatorType, OperatorType, operator_type_)
+  DECL_GET_SET_PROPERTY(const std::string &, JobName, job_name_)
 
   uint32_t GetRingBufferCapacity() const;
-
+  /// Note(lingxuan.zlx), RingBufferCapacity's valid range is from 1 to
+  /// MESSAGE_BUNDLE_MAX_SIZE, so we don't use DECL_GET_SET_PROPERTY for it.
   void SetRingBufferCapacity(uint32_t ring_buffer_capacity);
-
-  streaming::proto::OperatorType GetOperatorType() const;
-
-  void SetOperatorType(streaming::proto::OperatorType type);
-
-  const std::string &GetJobName() const;
-
-  void SetJobName(const std::string &job_name);
 };
 }  // namespace streaming
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Streaming job will be conducted with many configs (more than these we defined now).
So it's better to define a simple GET-SET macro for config property to reduce duplicated generated codes.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
