### PR TITLE
[RLlib] Fix LSTM + no-shared-vf NN crash; add `RandomEnv` example to examples folder.

### DIFF
--- a/rllib/examples/random_env.py
+++ b/rllib/examples/random_env.py
@@ -1,0 +1,68 @@
+"""
+Example of a custom gym environment and model. Run this for a demo.
+
+This example shows:
+  - using a custom environment
+  - using a custom model
+  - using Tune for grid search
+
+You can visualize experiment results in ~/ray_results using TensorBoard.
+"""
+
+import gym
+from gym.spaces import Tuple, Discrete
+import numpy as np
+
+from ray.rllib.agents.ppo import PPOTrainer
+from ray.rllib.utils import try_import_tf
+
+tf = try_import_tf()
+
+
+class RandomEnv(gym.Env):
+    """
+    A randomly acting environment that can be instantiated with arbitrary
+    action and observation spaces.
+    """
+    def __init__(self, config):
+        # Action space.
+        self.action_space = config["action_space"]
+        # Observation space from which to sample.
+        self.observation_space = config["observation_space"]
+        # Reward space from which to sample.
+        self.reward_space = config.get(
+            "reward_space",
+            gym.spaces.Box(low=-1.0, high=1.0, shape=(), dtype=np.float32)
+        )
+        # Chance that an episode ends at any step.
+        self.p_done = config.get("p_done", 0.1)
+
+    def reset(self):
+        return self.observation_space.sample()
+
+    def step(self, action):
+        return self.observation_space.sample(), float(self.reward_space.sample()), \
+            bool(np.random.choice(
+                [True, False], p=[self.p_done, 1.0 - self.p_done]
+            )), {}
+
+
+if __name__ == "__main__":
+    trainer = PPOTrainer(
+        config={
+            "model": {
+                "use_lstm": True,
+            },
+            "vf_share_layers": False,
+            "num_workers": 0,  # no parallelism
+            "env_config": {
+                "action_space": Discrete(2),
+                # Test a simple Tuple observation space.
+                "observation_space": Tuple([Discrete(3), Discrete(2)])
+            }
+        },
+        env=RandomEnv,
+    )
+    for _ in range(2):
+        results = trainer.train()
+        print(results)

--- a/rllib/examples/random_env.py
+++ b/rllib/examples/random_env.py
@@ -24,6 +24,7 @@ class RandomEnv(gym.Env):
     A randomly acting environment that can be instantiated with arbitrary
     action and observation spaces.
     """
+
     def __init__(self, config):
         # Action space.
         self.action_space = config["action_space"]
@@ -32,8 +33,7 @@ class RandomEnv(gym.Env):
         # Reward space from which to sample.
         self.reward_space = config.get(
             "reward_space",
-            gym.spaces.Box(low=-1.0, high=1.0, shape=(), dtype=np.float32)
-        )
+            gym.spaces.Box(low=-1.0, high=1.0, shape=(), dtype=np.float32))
         # Chance that an episode ends at any step.
         self.p_done = config.get("p_done", 0.1)
 
@@ -41,7 +41,8 @@ class RandomEnv(gym.Env):
         return self.observation_space.sample()
 
     def step(self, action):
-        return self.observation_space.sample(), float(self.reward_space.sample()), \
+        return self.observation_space.sample(), \
+            float(self.reward_space.sample()), \
             bool(np.random.choice(
                 [True, False], p=[self.p_done, 1.0 - self.p_done]
             )), {}
@@ -58,7 +59,8 @@ if __name__ == "__main__":
             "env_config": {
                 "action_space": Discrete(2),
                 # Test a simple Tuple observation space.
-                "observation_space": Tuple([Discrete(3), Discrete(2)])
+                "observation_space": Tuple([Discrete(3),
+                                            Discrete(2)])
             }
         },
         env=RandomEnv,

--- a/rllib/models/tf/modelv1_compat.py
+++ b/rllib/models/tf/modelv1_compat.py
@@ -130,8 +130,7 @@ def make_v1_wrapper(legacy_model_cls):
                             "it to True). If you want to not share "
                             "layers, you can implement a custom LSTM "
                             "model that overrides the value_function() "
-                            "method."
-                            )
+                            "method.")
                     branch_instance = self.legacy_model_cls(
                         self.cur_instance.input_dict,
                         self.obs_space,

--- a/rllib/models/tf/modelv1_compat.py
+++ b/rllib/models/tf/modelv1_compat.py
@@ -6,7 +6,6 @@ from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.models.tf.misc import linear, normc_initializer
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils import try_import_tf
-from ray.rllib.utils.debug import log_once
 from ray.rllib.utils.tf_ops import scope_vars
 
 tf = try_import_tf()
@@ -125,15 +124,14 @@ def make_v1_wrapper(legacy_model_cls):
                     branch_model_config = self.model_config.copy()
                     branch_model_config["free_log_std"] = False
                     if branch_model_config["use_lstm"]:
-                        branch_model_config["use_lstm"] = False
-                        if log_once("vf_warn"):
-                            logger.warning(
-                                "It is not recommended to use a LSTM model "
-                                "with vf_share_layers=False (consider setting "
-                                "it to True). If you want to not share "
-                                "layers, you can implement a custom LSTM "
-                                "model that overrides the value_function() "
-                                "method.")
+                        raise ValueError(
+                            "It is not allowed to use an LSTM model "
+                            "with vf_share_layers=False (consider setting "
+                            "it to True). If you want to not share "
+                            "layers, you can implement a custom LSTM "
+                            "model that overrides the value_function() "
+                            "method."
+                            )
                     branch_instance = self.legacy_model_cls(
                         self.cur_instance.input_dict,
                         self.obs_space,


### PR DESCRIPTION
Convert warning into Error message when using an LSTM in a non-shared-vf network (after the warning, the program would crash).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Closes a bug issue.

<!-- Please give a short summary of the change and the problem this solves. -->

#6884 

<!-- For example: "Closes #1234" -->

Closes #6884

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
