### PR TITLE
[RLlib] Move distributions tests from PPO to models/.

### DIFF
--- a/ci/jenkins_tests/run_rllib_tests.sh
+++ b/ci/jenkins_tests/run_rllib_tests.sh
@@ -490,6 +490,3 @@ docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
 
 docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
     /ray/ci/suppress_output python /ray/rllib/examples/custom_keras_rnn_model.py --run=PPO --stop=50 --env=RepeatInitialEnv
-
-docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
-    /ray/ci/suppress_output python /ray/rllib/tests/test_env_with_subprocess.py

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -48,6 +48,7 @@ py_test(
 
 py_binary(
     name = "test_env_with_subprocess",
-    srcs = "tests/test_env_with_subprocess.py"
+    main = "tests/test_env_with_subprocess.py",
+    srcs = ["tests/test_env_with_subprocess.py"]
 
 )

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -41,3 +41,13 @@ py_test(
 #    size = "small",
 #    srcs = ["models/tests/test_distributions.py"]
 #)
+
+# ----------------------------------------
+# rllib/tests/ directory
+# ----------------------------------------
+
+py_binary(
+    name = "test_env_with_subprocess",
+    srcs = "tests/test_env_with_subprocess.py"
+
+)

--- a/rllib/agents/ppo/tests/test.py
+++ b/rllib/agents/ppo/tests/test.py
@@ -2,32 +2,13 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ray.rllib.models.tf.tf_action_dist import Categorical
 from ray.rllib.agents.ppo.utils import flatten, concatenate
 from ray.rllib.utils import try_import_tf
 
 tf = try_import_tf()
 
 
-# TODO(ekl): move to rllib/models dir
-class DistributionsTest(unittest.TestCase):
-    def testCategorical(self):
-        num_samples = 100000
-        logits = tf.placeholder(tf.float32, shape=(None, 10))
-        z = 8 * (np.random.rand(10) - 0.5)
-        data = np.tile(z, (num_samples, 1))
-        c = Categorical(logits, {})  # dummy config dict
-        sample_op = c.sample()
-        sess = tf.Session()
-        sess.run(tf.global_variables_initializer())
-        samples = sess.run(sample_op, feed_dict={logits: data})
-        counts = np.zeros(10)
-        for sample in samples:
-            counts[sample] += 1.0
-        probs = np.exp(z) / np.sum(np.exp(z))
-        self.assertTrue(np.sum(np.abs(probs - counts / num_samples)) <= 0.01)
-
-
+# TODO(sven): Move to utils/tests/.
 class UtilsTest(unittest.TestCase):
     def testFlatten(self):
         d = {

--- a/rllib/models/tests/test_distributions.py
+++ b/rllib/models/tests/test_distributions.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+
+from ray.rllib.models.tf.tf_action_dist import Categorical
+from ray.rllib.utils import try_import_tf
+
+tf = try_import_tf()
+
+
+class TestDistributions(unittest.TestCase):
+    def test_categorical(self):
+        num_samples = 100000
+        logits = tf.placeholder(tf.float32, shape=(None, 10))
+        z = 8 * (np.random.rand(10) - 0.5)
+        data = np.tile(z, (num_samples, 1))
+        c = Categorical(logits, {})  # dummy config dict
+        sample_op = c.sample()
+        sess = tf.Session()
+        sess.run(tf.global_variables_initializer())
+        samples = sess.run(sample_op, feed_dict={logits: data})
+        counts = np.zeros(10)
+        for sample in samples:
+            counts[sample] += 1.0
+        probs = np.exp(z) / np.sum(np.exp(z))
+        self.assertTrue(np.sum(np.abs(probs - counts / num_samples)) <= 0.01)

--- a/rllib/tests_to_be_moved_to_bazel.txt
+++ b/rllib/tests_to_be_moved_to_bazel.txt
@@ -1,3 +1,0 @@
-# This one fails here and there on Jenkins.
-#docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
-#    /ray/ci/suppress_output python /ray/rllib/tests/test_env_with_subprocess.py

--- a/rllib/tests_to_be_moved_to_bazel.txt
+++ b/rllib/tests_to_be_moved_to_bazel.txt
@@ -1,0 +1,3 @@
+# This one fails here and there on Jenkins.
+#docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} $DOCKER_SHA \
+#    /ray/ci/suppress_output python /ray/rllib/tests/test_env_with_subprocess.py

--- a/rllib/utils/tests/test_schedules.py
+++ b/rllib/utils/tests/test_schedules.py
@@ -1,0 +1,110 @@
+import numpy as np
+import unittest
+
+from ray.rllib.utils.schedules import Schedule, ConstantSchedule, \
+    LinearSchedule, ExponentialSchedule
+from ray.rllib.utils import check
+
+
+# TODO(sven): Fix these test cases for framework-agnostic Schedule-components.
+class TestSchedules(unittest.TestCase):
+    """
+    Tests all time-step/time-percentage dependent Schedule classes.
+    """
+    def test_constant_schedule(self):
+        value = 2.3
+        constant = ConstantSchedule.from_config(value)
+        # Time-percentages.
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = constant(input_)
+        check(out, [value] * len(input_))
+
+    def test_linear_schedule(self):
+        linear = LinearSchedule.from_config({
+            "initial_value": 2.1,
+            "final_value": 0.6
+        })
+        # Time-percentages.
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = linear(input_)
+        check(out, 2.1 - input_ * (2.1 - 0.6))
+
+    def test_linear_schedule_with_step_function(self):
+        linear = LinearSchedule.from_config({
+            "initial_value": 2.0,
+            "final_value": 0.5,
+            "begin_time_percentage": 0.5,
+            "end_time_percentage": 0.6
+        })
+        # Time-percentages.
+        input_ = np.array([
+            0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23, 0.51, 0.52, 0.55, 0.59
+        ])
+        out = linear(input_)
+        check(
+            out,
+            np.array([
+                2.0, 2.0, 0.5, 0.5, 2.0, 2.0, 0.5, 2.0, 1.85, 1.7, 1.25, 0.65
+            ]))
+
+    def test_linear_parameter_using_global_time_step(self):
+        max_time_steps = 100
+        linear = Schedule.from_config(
+            "linear", initial_value=2.0, final_value=0.5, max_t=max_time_steps)
+        # Call without any parameters -> force component to use GLOBAL_STEP,
+        # which should be 0 right now -> no decay.
+        for time_step in range(30):
+            out = linear()
+            check(out, 2.0 - (time_step / max_time_steps) * (2.0 - 0.5))
+
+    def test_polynomial_schedule(self):
+        polynomial = Schedule.from_config(
+            type="polynomial", initial_value=2.0, final_value=0.5, power=2.0)
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = polynomial(input_)
+        check(out, (2.0 - 0.5) * (1.0 - input_)**2 + 0.5)
+
+    def test_polynomial_schedule_using_global_time_step(self):
+        max_time_steps = 10
+        polynomial = Schedule.from_config(
+            "polynomial",
+            initial_value=3.0,
+            final_value=0.5,
+            max_t=max_time_steps)
+        # Call without any parameters -> force component to use internal
+        # `current_time_step`.
+        # Go over the max time steps and expect time_percentage to be capped
+        # at 1.0.
+        for time_step in range(50):
+            out = polynomial()
+            check(out,
+                  (3.0 - 0.5) * (1.0 - min(time_step / max_time_steps, 1.0))**2
+                  + 0.5)
+
+    def test_exponential_schedule(self):
+        exponential = Schedule.from_config(
+            type="exponential",
+            initial_value=2.0,
+            final_value=0.5,
+            decay_rate=0.5)
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = exponential(input_)
+        check(out, 0.5 + (2.0 - 0.5) * 0.5**input_)
+
+    def test_exponential_schedule_using_global_time_step(self):
+        max_time_steps = 10
+        decay_rate = 0.1
+        exponential = ExponentialSchedule.from_config(
+            initial_value=3.0,
+            final_value=0.5,
+            max_t=max_time_steps,
+            decay_rate=decay_rate)
+        # Call without any parameters -> force component to use internal
+        # `current_time_step`.
+        # Go over the max time steps and expect time_percentage to be capped
+        # at 1.0.
+        for time_step in range(100):
+            out = exponential()
+            check(
+                out, 0.5 +
+                (3.0 - 0.5) * decay_rate**min(time_step / max_time_steps, 1.0))

--- a/rllib/utils/tests/test_schedules.py
+++ b/rllib/utils/tests/test_schedules.py
@@ -1,0 +1,111 @@
+import numpy as np
+import unittest
+
+from ray.rllib.utils.schedules import Schedule, ConstantSchedule, \
+    LinearSchedule, ExponentialSchedule
+from ray.rllib.utils import check
+
+
+# TODO(sven): Fix these test cases for framework-agnostic Schedule-components.
+class TestSchedules(unittest.TestCase):
+    """
+    Tests all time-step/time-percentage dependent Schedule classes.
+    """
+
+    def test_constant_schedule(self):
+        value = 2.3
+        constant = ConstantSchedule.from_config(value)
+        # Time-percentages.
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = constant(input_)
+        check(out, [value] * len(input_))
+
+    def test_linear_schedule(self):
+        linear = LinearSchedule.from_config({
+            "initial_value": 2.1,
+            "final_value": 0.6
+        })
+        # Time-percentages.
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = linear(input_)
+        check(out, 2.1 - input_ * (2.1 - 0.6))
+
+    def test_linear_schedule_with_step_function(self):
+        linear = LinearSchedule.from_config({
+            "initial_value": 2.0,
+            "final_value": 0.5,
+            "begin_time_percentage": 0.5,
+            "end_time_percentage": 0.6
+        })
+        # Time-percentages.
+        input_ = np.array([
+            0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23, 0.51, 0.52, 0.55, 0.59
+        ])
+        out = linear(input_)
+        check(
+            out,
+            np.array([
+                2.0, 2.0, 0.5, 0.5, 2.0, 2.0, 0.5, 2.0, 1.85, 1.7, 1.25, 0.65
+            ]))
+
+    def test_linear_parameter_using_global_time_step(self):
+        max_time_steps = 100
+        linear = Schedule.from_config(
+            "linear", initial_value=2.0, final_value=0.5, max_t=max_time_steps)
+        # Call without any parameters -> force component to use GLOBAL_STEP,
+        # which should be 0 right now -> no decay.
+        for time_step in range(30):
+            out = linear()
+            check(out, 2.0 - (time_step / max_time_steps) * (2.0 - 0.5))
+
+    def test_polynomial_schedule(self):
+        polynomial = Schedule.from_config(
+            type="polynomial", initial_value=2.0, final_value=0.5, power=2.0)
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = polynomial(input_)
+        check(out, (2.0 - 0.5) * (1.0 - input_)**2 + 0.5)
+
+    def test_polynomial_schedule_using_global_time_step(self):
+        max_time_steps = 10
+        polynomial = Schedule.from_config(
+            "polynomial",
+            initial_value=3.0,
+            final_value=0.5,
+            max_t=max_time_steps)
+        # Call without any parameters -> force component to use internal
+        # `current_time_step`.
+        # Go over the max time steps and expect time_percentage to be capped
+        # at 1.0.
+        for time_step in range(50):
+            out = polynomial()
+            check(out,
+                  (3.0 - 0.5) * (1.0 - min(time_step / max_time_steps, 1.0))**2
+                  + 0.5)
+
+    def test_exponential_schedule(self):
+        exponential = Schedule.from_config(
+            type="exponential",
+            initial_value=2.0,
+            final_value=0.5,
+            decay_rate=0.5)
+        input_ = np.array([0.5, 0.1, 1.0, 0.9, 0.02, 0.01, 0.99, 0.23])
+        out = exponential(input_)
+        check(out, 0.5 + (2.0 - 0.5) * 0.5**input_)
+
+    def test_exponential_schedule_using_global_time_step(self):
+        max_time_steps = 10
+        decay_rate = 0.1
+        exponential = ExponentialSchedule.from_config(
+            initial_value=3.0,
+            final_value=0.5,
+            max_t=max_time_steps,
+            decay_rate=decay_rate)
+        # Call without any parameters -> force component to use internal
+        # `current_time_step`.
+        # Go over the max time steps and expect time_percentage to be capped
+        # at 1.0.
+        for time_step in range(100):
+            out = exponential()
+            check(
+                out, 0.5 +
+                (3.0 - 0.5) * decay_rate**min(time_step / max_time_steps, 1.0))


### PR DESCRIPTION
Move distributions tests from PPO to models/.
Add Schedules-tests to utils directory (utils/tests/test_schedules.py).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

To establish the structure of having test cases where the tested components are, we are starting to add and/or move tests into the respective directories:
e.g. tests for the Model classes go into rllib/models/tests/...
tests for the Schedule classes go into rllib/utils/tests/test_schedules.py ... 

<!-- Please give a short summary of the change and the problem this solves. -->


<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
