### PR TITLE
Fixes empty `state` argument in compute_single_action method

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -136,9 +136,12 @@ class Policy(metaclass=ABCMeta):
             info_batch = [info]
         if episode is not None:
             episodes = [episode]
+        state_batch = None
+        if state is not None:
+            state_batch = [[s] for s in state]
 
         [action], state_out, info = self.compute_actions(
-            [obs], [[s] for s in state],
+            [obs], state_batch,
             prev_action_batch=prev_action_batch,
             prev_reward_batch=prev_reward_batch,
             info_batch=info_batch,

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -128,6 +128,7 @@ class Policy(metaclass=ABCMeta):
         prev_reward_batch = None
         info_batch = None
         episodes = None
+        state_batch = None
         if prev_action is not None:
             prev_action_batch = [prev_action]
         if prev_reward is not None:
@@ -136,7 +137,6 @@ class Policy(metaclass=ABCMeta):
             info_batch = [info]
         if episode is not None:
             episodes = [episode]
-        state_batch = None
         if state is not None:
             state_batch = [[s] for s in state]
 


### PR DESCRIPTION
## Why are these changes needed?
The `compute_single_action` method allows for a default `None` value assignment to the `state` argument. However, the method body did not check if `state` was `None`, and instead performed an operation on the argument value. 

This fix includes the check that if `state == None`, then do not perform the aforementioned operation on the argument. The check is performed for all of the other arguments except for `state`.

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.