### PR TITLE
[Dashboard] Add profiling button to logical view

### DIFF
--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -150,3 +150,26 @@ export interface LogsResponse {
 
 export const getLogs = (hostname: string, pid: string | undefined) =>
   get<LogsResponse>("/api/logs", { hostname, pid: pid || "" });
+
+export type LaunchProfilingResponse = string;
+
+export const launchProfiling = (
+  nodeId: string,
+  pid: number,
+  duration: number
+) =>
+  get<LaunchProfilingResponse>("/api/launch_profiling", {
+    node_id: nodeId,
+    pid: pid,
+    duration: duration
+  });
+
+export type CheckProfilingStatusResponse =
+  | { status: "pending" }
+  | { status: "finished" }
+  | { status: "error"; error: string };
+
+export const checkProfilingStatus = (profilingId: string) =>
+  get<CheckProfilingStatusResponse>("/api/check_profiling_status", {
+    profiling_id: profilingId
+  });

--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -173,3 +173,8 @@ export const checkProfilingStatus = (profilingId: string) =>
   get<CheckProfilingStatusResponse>("/api/check_profiling_status", {
     profiling_id: profilingId
   });
+
+export const getProfilingResultURL = (profilingId: string) =>
+  `${base}/speedscope/index.html#profileURL=${encodeURIComponent(
+    `${base}/api/get_profiling_info?profiling_id=${profilingId}`
+  )}`;

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import {
   checkProfilingStatus,
   CheckProfilingStatusResponse,
+  getProfilingResultURL,
   launchProfiling,
   RayletInfoResponse
 } from "../../../api";
@@ -213,11 +214,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
                       ) : latestResponse.status === "finished" ? (
                         <a
                           className={classes.action}
-                          href={`${
-                            window.origin
-                          }/speedscope/index.html#profileURL=${encodeURIComponent(
-                            `${window.origin}/api/get_profiling_info?profiling_id=${profilingId}`
-                          )}`}
+                          href={getProfilingResultURL(profilingId)}
                           rel="noopener noreferrer"
                           target="_blank"
                         >

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -194,6 +194,8 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
                           }/speedscope/index.html#profileURL=${encodeURIComponent(
                             `${window.origin}/api/get_profiling_info?profiling_id=${profilingId}`
                           )}`}
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
                           {profilingStatus.status}
                         </a>

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -75,7 +75,6 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
         actor.pid,
         duration
       );
-      console.log("profilingId", profilingId);
       this.setState(state => ({
         profiling: { ...state.profiling, [profilingId]: null }
       }));
@@ -198,6 +197,8 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
                         >
                           {profilingStatus.status}
                         </a>
+                      ) : profilingStatus.status === "error" ? (
+                        profilingStatus.error
                       ) : (
                         profilingStatus.status
                       )}

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -198,7 +198,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
                           {profilingStatus.status}
                         </a>
                       ) : profilingStatus.status === "error" ? (
-                        profilingStatus.error
+                        profilingStatus.error.trim()
                       ) : (
                         profilingStatus.status
                       )}

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -182,7 +182,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
               >
                 Profile
               </span>
-              )
+              ){" "}
               {Object.entries(profiling).map(
                 ([profilingId, profilingStatus]) =>
                   profilingStatus !== null && (

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/LogicalView.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/LogicalView.tsx
@@ -2,12 +2,23 @@ import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import createStyles from "@material-ui/core/styles/createStyles";
 import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
 import Typography from "@material-ui/core/Typography";
+import WarningRoundedIcon from "@material-ui/icons/WarningRounded";
 import React from "react";
 import { connect } from "react-redux";
 import { StoreState } from "../../../store";
 import Actors from "./Actors";
 
-const styles = (theme: Theme) => createStyles({});
+const styles = (theme: Theme) =>
+  createStyles({
+    warning: {
+      fontSize: "0.8125rem",
+      marginBottom: theme.spacing(2)
+    },
+    warningIcon: {
+      fontSize: "1.25em",
+      verticalAlign: "text-bottom"
+    }
+  });
 
 const mapStateToProps = (state: StoreState) => ({
   rayletInfo: state.dashboard.rayletInfo
@@ -17,19 +28,20 @@ class LogicalView extends React.Component<
   WithStyles<typeof styles> & ReturnType<typeof mapStateToProps>
 > {
   render() {
-    const { rayletInfo } = this.props;
-
-    if (rayletInfo === null) {
-      return <Typography color="textSecondary">Loading...</Typography>;
-    }
-
-    if (Object.entries(rayletInfo.actors).length === 0) {
-      return <Typography color="textSecondary">No actors found.</Typography>;
-    }
-
+    const { classes, rayletInfo } = this.props;
     return (
       <div>
-        <Actors actors={rayletInfo.actors} />
+        <Typography className={classes.warning} color="textSecondary">
+          <WarningRoundedIcon className={classes.warningIcon} /> Note: This tab
+          is experimental.
+        </Typography>
+        {rayletInfo === null ? (
+          <Typography color="textSecondary">Loading...</Typography>
+        ) : Object.entries(rayletInfo.actors).length === 0 ? (
+          <Typography color="textSecondary">No actors found.</Typography>
+        ) : (
+          <Actors actors={rayletInfo.actors} />
+        )}
       </div>
     );
   }

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -257,11 +257,11 @@ class Dashboard(object):
             duration = int(req.query.get("duration"))
             profiling_id = self.raylet_stats.launch_profiling(
                 node_id=node_id, pid=pid, duration=duration)
-            return aiohttp.web.json_response(str(profiling_id))
+            return await json_response(str(profiling_id))
 
         async def check_profiling_status(req) -> aiohttp.web.Response:
             profiling_id = req.query.get("profiling_id")
-            return aiohttp.web.json_response(
+            return await json_response(
                 self.raylet_stats.check_profiling_status(profiling_id))
 
         async def get_profiling_info(req) -> aiohttp.web.Response:

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -193,7 +193,8 @@ def test_raylet_info_endpoint(shutdown_only):
         }).json()["result"]
     start_time = time.time()
     while True:
-        if time.time() - start_time > 10:
+        # Sometimes some startup time is required
+        if time.time() - start_time > 30:
             raise RayTestTimeoutException(
                 "Timed out while collecting profiling stats.")
         profiling_info = requests.get(

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -190,7 +190,7 @@ def test_raylet_info_endpoint(shutdown_only):
             "node_id": ray.nodes()[0]["NodeID"],
             "pid": actor_pid,
             "duration": 5
-        }).json()
+        }).json()["result"]
     start_time = time.time()
     while True:
         time.sleep(1)
@@ -200,7 +200,8 @@ def test_raylet_info_endpoint(shutdown_only):
                 params={
                     "profiling_id": profiling_id,
                 }).json()
-            assert profiling_info["status"] in ("finished", "pending", "error")
+            status = profiling_info["result"]["status"]
+            assert status in ("finished", "pending", "error")
             break
         except AssertionError:
             if time.time() - start_time + 10:

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -193,19 +193,19 @@ def test_raylet_info_endpoint(shutdown_only):
         }).json()["result"]
     start_time = time.time()
     while True:
-        time.sleep(1)
-        try:
-            profiling_info = requests.get(
-                webui_url + "/api/check_profiling_status",
-                params={
-                    "profiling_id": profiling_id,
-                }).json()
-            status = profiling_info["result"]["status"]
-            assert status in ("finished", "pending", "error")
+        if time.time() - start_time > 10:
+            raise RayTestTimeoutException(
+                "Timed out while collecting profiling stats.")
+        profiling_info = requests.get(
+            webui_url + "/api/check_profiling_status",
+            params={
+                "profiling_id": profiling_id,
+            }).json()
+        status = profiling_info["result"]["status"]
+        assert status in ("finished", "pending", "error")
+        if status in ("finished", "error"):
             break
-        except AssertionError:
-            if time.time() - start_time + 10:
-                raise Exception("Timed out while collecting profiling stats.")
+        time.sleep(1)
 
 
 def test_profiling_info_endpoint(shutdown_only):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR adds a profiling button to the logical view in order to allow users to interface with the profiling routes introduced in #6705.

**Note:** At the moment this only works if the password for sudo is empty.

You can try it out with
```python
import ray

ray.init()

def do_sum(n):
    total = 0
    for i in range(n):
        total += i
        return total

@ray.remote 
class C: 
    def local_sum(self, n): 
        return do_sum(n) 

c = C.remote()                                                                                                                                                                                                                                        
c.actor_sum.remote(int(1e10))
```

The dashboard has a profiling button:

<img width="481" alt="Screen Shot 2020-01-24 at 11 40 27 AM" src="https://user-images.githubusercontent.com/113316/73098608-998b0080-3e9e-11ea-881e-e13642ba9662.png">

And this is the profiling information that is being shown:

<img width="811" alt="Screen Shot 2020-01-24 at 11 46 27 AM" src="https://user-images.githubusercontent.com/113316/73098900-33eb4400-3e9f-11ea-9ea1-d116314b95f6.png">


## Related issue number

Adds frontend components corresponding to the backend logic added in #6705.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
