### PR TITLE
UI improvement for asyncio

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -818,8 +818,8 @@ cdef class CoreWorker:
     def get_actor_id(self):
         return ActorID(self.core_worker.get().GetActorId().Binary())
 
-    def set_webui_display(self, message):
-        self.core_worker.get().SetWebuiDisplay(message)
+    def set_webui_display(self, key, message):
+        self.core_worker.get().SetWebuiDisplay(key, message)
 
     def set_actor_title(self, title):
         self.core_worker.get().SetActorTitle(title)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -138,7 +138,8 @@ else:
     import cPickle as pickle
 
 if PY3:
-    from ray.async_compat import sync_to_async, AsyncGetResponse, AsyncMonitorState
+    from ray.async_compat import (sync_to_async,
+                                  AsyncGetResponse, AsyncMonitorState)
 
 
 def set_internal_config(dict options):
@@ -610,8 +611,10 @@ cdef execute_task(
                 coroutine = async_function(actor, *arguments, **kwarguments)
                 loop = core_worker.create_or_get_event_loop()
                 monitor_state = loop.monitor_state
-                monitor_state.register_coroutine(coroutine, str(function.method))
+                monitor_state.register_coroutine(coroutine,
+                                                 str(function.method))
                 future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+
                 def callback(future):
                     fiber_event.Notify()
                     monitor_state.unregister_coroutine(coroutine)
@@ -1191,7 +1194,7 @@ cdef class CoreWorker:
             # Delayed import due to async_api depends on _raylet.
             from ray.experimental.async_api import _async_init
             self.async_event_loop.run_until_complete(_async_init())
-            
+
             # Create and attach the monitor object
             monitor_state = AsyncMonitorState(self.async_event_loop)
             self.async_event_loop.monitor_state = monitor_state

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -359,8 +359,7 @@ class ActorClass:
                 is_direct_call=None,
                 max_concurrency=None,
                 name=None,
-                detached=False,
-                is_asyncio=False):
+                detached=False):
         """Create an actor.
 
         This method allows more flexibility than the remote method because
@@ -386,8 +385,6 @@ class ActorClass:
             name: The globally unique name for the actor.
             detached: Whether the actor should be kept alive after driver
                 exits.
-            is_asyncio: Turn on async actor calls. This only works with direct
-                actor calls.
 
         Returns:
             A handle to the newly created actor.
@@ -404,7 +401,7 @@ class ActorClass:
             inspect.getmembers(
                 meta.modified_class,
                 predicate=inspect.iscoroutinefunction)) > 0
-        is_asyncio = is_asyncio or actor_has_async_methods
+        is_asyncio = actor_has_async_methods
 
         if max_concurrency is None:
             if is_asyncio:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -398,6 +398,14 @@ class ActorClass:
             kwargs = {}
         if is_direct_call is None:
             is_direct_call = ray_constants.direct_call_enabled()
+
+        meta = self.__ray_metadata__
+        actor_has_async_methods = len(
+            inspect.getmembers(
+                meta.modified_class,
+                predicate=inspect.iscoroutinefunction)) > 0
+        is_asyncio = is_asyncio or actor_has_async_methods
+
         if max_concurrency is None:
             if is_asyncio:
                 max_concurrency = 1000
@@ -418,8 +426,6 @@ class ActorClass:
         if worker.mode is None:
             raise Exception("Actors cannot be created before ray.init() "
                             "has been called.")
-
-        meta = self.__ray_metadata__
 
         if detached and name is None:
             raise Exception("Detached actors must be named. "

--- a/python/ray/async_compat.py
+++ b/python/ray/async_compat.py
@@ -3,7 +3,7 @@ This file should only be imported from Python 3.
 It will raise SyntaxError when importing from Python 2.
 """
 import asyncio
-from collections import namedtuple
+from collections import namedtuple, Counter
 import time
 import threading
 
@@ -112,6 +112,12 @@ class AsyncMonitorState:
             start = time.time()
             await asyncio.sleep(self.sleep_time)
             self.real_sleep_time = time.time() - start
+
+            all_tasks = self.get_all_task_names()
+            ray.show_in_webui(str(len(all_tasks)), key="Number of concurrent task runing")
+            ray.show_in_webui(str(dict(Counter(all_tasks))), key="Concurrent tasks")
+            ray.show_in_webui("{:.2f}".format(self.get_loop_blocking_index()), key="Loop business (should be close to 1)")
+            
         
     def register_coroutine(self, coro, name):
         with self.names_lock:

--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -120,7 +120,7 @@ export interface RayletInfoResponse {
           usedResources: { [key: string]: number };
           currentTaskDesc?: string;
           numPendingTasks?: number;
-          webuiDisplay?: string;
+          webuiDisplay?: Record<string, string>;
         }
       | {
           actorId: string;

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -172,16 +172,18 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
           ];
 
     // Construct the custom message from the actor.
-    let actorCustomDisplay: JSX.Element[] = []
+    let actorCustomDisplay: JSX.Element[] = [];
     if (actor.state !== -1 && actor.webuiDisplay) {
-      Object.keys(actor.webuiDisplay).sort().forEach(key =>{
-        actorCustomDisplay.push(<Typography className={classes.webuiDisplay}>
-          &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
-          </Typography>)
-        actorCustomDisplay.push(<Divider></Divider>)
-      })
+      actorCustomDisplay = Object.keys(actor.webuiDisplay)
+        .sort()
+        .map((key, _, __) => {
+          return (
+            <Typography className={classes.webuiDisplay}>
+              &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
+            </Typography>
+          );
+        });
     }
-   
 
     return (
       <div className={classes.root}>
@@ -261,8 +263,19 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
         </Typography>
         {actor.state !== -1 && (
           <React.Fragment>
-              {actorCustomDisplay && <Typography className={classes.webuiDisplay}>Actor Custom Display</Typography>}
-              {actorCustomDisplay}
+            {
+              actorCustomDisplay.length > 0 && (
+                <React.Fragment>
+                  <Typography>
+                    <Typography className={classes.webuiDisplay}>
+                      Actor Custom Display
+                    </Typography>
+                  </Typography>
+                  {actorCustomDisplay}
+                </React.Fragment>
+              )
+            }
+
             <Collapse in={expanded}>
               <Actors actors={actor.children} />
             </Collapse>

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -171,6 +171,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
             }
           ];
 
+    // Construct the custom message from the actor.
     let actorCustomDisplay: JSX.Element[] = []
     if (actor.state !== -1 && actor.webuiDisplay) {
       Object.keys(actor.webuiDisplay).sort().forEach(key =>{

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -1,4 +1,3 @@
-import Collapse from "@material-ui/core/Collapse";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import createStyles from "@material-ui/core/styles/createStyles";
 import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
@@ -12,6 +11,7 @@ import {
   RayletInfoResponse
 } from "../../../api";
 import Actors from "./Actors";
+import Collapse from "@material-ui/core/Collapse";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -171,6 +171,17 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
             }
           ];
 
+    let actorCustomDisplay: JSX.Element[] = []
+    if (actor.state !== -1 && actor.webuiDisplay) {
+      Object.keys(actor.webuiDisplay).sort().forEach(key =>{
+        actorCustomDisplay.push(<Typography className={classes.webuiDisplay}>
+          &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
+          </Typography>)
+        actorCustomDisplay.push(<Divider></Divider>)
+      })
+    }
+   
+
     return (
       <div className={classes.root}>
         <Typography className={classes.title}>
@@ -249,11 +260,8 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
         </Typography>
         {actor.state !== -1 && (
           <React.Fragment>
-            {actor.webuiDisplay && (
-              <Typography className={classes.webuiDisplay}>
-                {actor.webuiDisplay}
-              </Typography>
-            )}
+              <Typography className={classes.webuiDisplay}>Actor Custom Display</Typography>
+              {actorCustomDisplay}
             <Collapse in={expanded}>
               <Actors actors={actor.children} />
             </Collapse>

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -261,7 +261,7 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
         </Typography>
         {actor.state !== -1 && (
           <React.Fragment>
-              <Typography className={classes.webuiDisplay}>Actor Custom Display</Typography>
+              {actorCustomDisplay && <Typography className={classes.webuiDisplay}>Actor Custom Display</Typography>}
               {actorCustomDisplay}
             <Collapse in={expanded}>
               <Actors actors={actor.children} />

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -177,11 +177,19 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
       actorCustomDisplay = Object.keys(actor.webuiDisplay)
         .sort()
         .map((key, _, __) => {
-          return (
-            <Typography className={classes.webuiDisplay}>
-              &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
-            </Typography>
-          );
+          if (key === "") {
+            return (
+              <Typography className={classes.webuiDisplay}>
+                &nbsp; &nbsp; {actor.webuiDisplay![key]}
+              </Typography>
+            );
+          } else {
+            return (
+              <Typography className={classes.webuiDisplay}>
+                &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
+              </Typography>
+            );
+          }
         });
     }
 
@@ -263,18 +271,9 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
         </Typography>
         {actor.state !== -1 && (
           <React.Fragment>
-            {
-              actorCustomDisplay.length > 0 && (
-                <React.Fragment>
-                  <Typography>
-                    <Typography className={classes.webuiDisplay}>
-                      Actor Custom Display
-                    </Typography>
-                  </Typography>
-                  {actorCustomDisplay}
-                </React.Fragment>
-              )
-            }
+            {actorCustomDisplay.length > 0 && (
+              <React.Fragment>{actorCustomDisplay}</React.Fragment>
+            )}
 
             <Collapse in={expanded}>
               <Actors actors={actor.children} />

--- a/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/logical-view/Actor.tsx
@@ -177,16 +177,27 @@ class Actor extends React.Component<Props & WithStyles<typeof styles>, State> {
       actorCustomDisplay = Object.keys(actor.webuiDisplay)
         .sort()
         .map((key, _, __) => {
+          // Construct the value from actor.
+          // Please refer to worker.py::show_in_webui for schema.
+          const valueEncoded = actor.webuiDisplay![key];
+          const valueParsed = JSON.parse(valueEncoded);
+          let valueRendered = valueParsed["message"];
+          if (valueParsed["dtype"] === "html") {
+            valueRendered = (
+              <div dangerouslySetInnerHTML={{ __html: valueRendered }}></div>
+            );
+          }
+
           if (key === "") {
             return (
               <Typography className={classes.webuiDisplay}>
-                &nbsp; &nbsp; {actor.webuiDisplay![key]}
+                &nbsp; &nbsp; {valueRendered}
               </Typography>
             );
           } else {
             return (
               <Typography className={classes.webuiDisplay}>
-                &nbsp; &nbsp; {key}: {actor.webuiDisplay![key]}
+                &nbsp; &nbsp; {key}: {valueRendered}
               </Typography>
             );
           }

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -113,8 +113,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CJobID GetCurrentJobId()
         CTaskID GetCurrentTaskId()
         const CActorID &GetActorId()
-        void SetWebuiDisplay(const c_string &message)
         void SetActorTitle(const c_string &title)
+        void SetWebuiDisplay(const c_string &key, const c_string &message)
         CTaskID GetCallerId()
         const ResourceMappingType &GetResourceIDs() const
         CActorID DeserializeAndRegisterActorHandle(const c_string &bytes)

--- a/python/ray/tests/py3_test.py
+++ b/python/ray/tests/py3_test.py
@@ -110,7 +110,7 @@ def test_asyncio_actor(ray_start_regular_shared):
                 await self.event.wait()
             return sorted(self.batch)
 
-    a = AsyncBatcher.options(is_direct_call=True, is_asyncio=True).remote()
+    a = AsyncBatcher.options(is_direct_call=True).remote()
     x1 = a.add.remote(1)
     x2 = a.add.remote(2)
     x3 = a.add.remote(3)
@@ -130,7 +130,7 @@ def test_asyncio_actor_same_thread(ray_start_regular_shared):
         async def async_thread_id(self):
             return threading.current_thread().ident
 
-    a = Actor.options(is_direct_call=True, is_asyncio=True).remote()
+    a = Actor.options(is_direct_call=True).remote()
     sync_id, async_id = ray.get(
         [a.sync_thread_id.remote(),
          a.async_thread_id.remote()])
@@ -154,8 +154,7 @@ def test_asyncio_actor_concurrency(ray_start_regular_shared):
 
     num_calls = 10
 
-    a = RecordOrder.options(
-        is_direct_call=True, max_concurrency=1, is_asyncio=True).remote()
+    a = RecordOrder.options(is_direct_call=True, max_concurrency=1).remote()
     ray.get([a.do_work.remote() for _ in range(num_calls)])
     history = ray.get(a.get_history.remote())
 
@@ -189,8 +188,7 @@ def test_asyncio_actor_high_concurrency(ray_start_regular_shared):
 
     batch_size = sys.getrecursionlimit() * 4
     actor = AsyncConcurrencyBatcher.options(
-        is_asyncio=True, max_concurrency=batch_size * 2,
-        is_direct_call=True).remote(batch_size)
+        max_concurrency=batch_size * 2, is_direct_call=True).remote(batch_size)
     result = ray.get([actor.add.remote(i) for i in range(batch_size)])
     assert result[0] == list(range(batch_size))
     assert result[-1] == list(range(batch_size))
@@ -264,6 +262,6 @@ def test_asyncio_actor_async_get(ray_start_regular_shared):
         async def plasma_get(self):
             return await plasma_object
 
-    getter = AsyncGetter.options(is_asyncio=True).remote()
+    getter = AsyncGetter.options().remote()
     assert ray.get(getter.get.remote()) == 1
     assert ray.get(getter.plasma_get.remote()) == 2

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -65,7 +65,7 @@ def test_worker_stats(shutdown_only):
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == '{"message": "", "dtype": "text"}'
+            assert stats.webui_display[""] == "" # Empty proto
     assert target_worker_present
 
     # Test show_in_webui for remote actors.
@@ -79,7 +79,7 @@ def test_worker_stats(shutdown_only):
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == '{"message": "", "dtype": "text"}'
+            assert stats.webui_display[""] == "" # Empty proto
     assert target_worker_present
 
     timeout_seconds = 20

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -61,11 +61,11 @@ def test_worker_stats(shutdown_only):
     target_worker_present = False
     for worker in reply.workers_stats:
         stats = worker.core_worker_stats
-        if stats.webui_display == "test":
+        if stats.webui_display[""] == "test":
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display == ""
+            assert stats.webui_display[""] == ""
     assert target_worker_present
 
     # Test show_in_webui for remote actors.
@@ -75,11 +75,11 @@ def test_worker_stats(shutdown_only):
     target_worker_present = False
     for worker in reply.workers_stats:
         stats = worker.core_worker_stats
-        if stats.webui_display == "test":
+        if stats.webui_display[""] == "test":
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display == ""
+            assert stats.webui_display[""] == ""
     assert target_worker_present
 
     timeout_seconds = 20

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -65,7 +65,7 @@ def test_worker_stats(shutdown_only):
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == "" # Empty proto
+            assert stats.webui_display[""] == ""  # Empty proto
     assert target_worker_present
 
     # Test show_in_webui for remote actors.
@@ -79,7 +79,7 @@ def test_worker_stats(shutdown_only):
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == "" # Empty proto
+            assert stats.webui_display[""] == ""  # Empty proto
     assert target_worker_present
 
     timeout_seconds = 20

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -61,11 +61,11 @@ def test_worker_stats(shutdown_only):
     target_worker_present = False
     for worker in reply.workers_stats:
         stats = worker.core_worker_stats
-        if stats.webui_display[""] == "test":
+        if stats.webui_display[""] == '{"message": "test", "dtype": "text"}':
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == ""
+            assert stats.webui_display[""] == '{"message": "", "dtype": "text"}'
     assert target_worker_present
 
     # Test show_in_webui for remote actors.
@@ -75,11 +75,11 @@ def test_worker_stats(shutdown_only):
     target_worker_present = False
     for worker in reply.workers_stats:
         stats = worker.core_worker_stats
-        if stats.webui_display[""] == "test":
+        if stats.webui_display[""] == '{"message": "test", "dtype": "text"}':
             target_worker_present = True
             assert worker.pid == worker_pid
         else:
-            assert stats.webui_display[""] == ""
+            assert stats.webui_display[""] == '{"message": "", "dtype": "text"}'
     assert target_worker_present
 
     timeout_seconds = 20

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1422,7 +1422,7 @@ def register_custom_serializer(cls,
         class_id=class_id)
 
 
-def show_in_webui(message, key=""):
+def show_in_webui(message, key="", dtype="text"):
     """Display message in dashboard.
 
     Display message for the current task or actor in the dashboard.
@@ -1431,10 +1431,23 @@ def show_in_webui(message, key=""):
 
     Args:
         message (str): Message to be displayed.
+        key (str): The key name for the message. Multiple message under
+            different keys will be displayed at the same time. Messages
+            under the same key will be overriden.
+        data_type (str): The type of message for rendering. One of the
+            following: text, html.
     """
     worker = global_worker
     worker.check_connected()
-    worker.core_worker.set_webui_display(key.encode(), message.encode())
+
+    acceptable_dtypes = {"text", "html"}
+    assert dtype in acceptable_dtypes, "dtype accepts only: {}".format(
+        acceptable_dtypes)
+
+    message_wrapped = {"message": message, "dtype": dtype}
+    message_encoded = json.dumps(message_wrapped).encode()
+
+    worker.core_worker.set_webui_display(key.encode(), message_encoded)
 
 
 def get(object_ids, timeout=None):

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1422,7 +1422,7 @@ def register_custom_serializer(cls,
         class_id=class_id)
 
 
-def show_in_webui(message):
+def show_in_webui(message, key=""):
     """Display message in dashboard.
 
     Display message for the current task or actor in the dashboard.
@@ -1434,7 +1434,7 @@ def show_in_webui(message):
     """
     worker = global_worker
     worker.check_connected()
-    worker.core_worker.set_webui_display(message.encode())
+    worker.core_worker.set_webui_display(key.encode(), message.encode())
 
 
 def get(object_ids, timeout=None):

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1188,8 +1188,11 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
     }
     (*used_resources_map)[it.first] = quantity;
   }
-  stats->set_webui_display(webui_display_);
   stats->set_actor_title(actor_title_);
+  google::protobuf::Map<std::string, std::string> webui_map(webui_display_.begin(),
+                                                            webui_display_.end());
+  (*stats->mutable_webui_display()) = webui_map;
+
   MemoryStoreStats memory_store_stats = memory_store_->GetMemoryStoreStatisticalData();
   stats->set_num_local_objects(memory_store_stats.num_local_objects);
   stats->set_used_object_store_memory(memory_store_stats.used_object_store_memory);
@@ -1221,9 +1224,9 @@ void CoreWorker::SetActorId(const ActorID &actor_id) {
   actor_id_ = actor_id;
 }
 
-void CoreWorker::SetWebuiDisplay(const std::string &message) {
+void CoreWorker::SetWebuiDisplay(const std::string &key, const std::string &message) {
   absl::MutexLock lock(&mutex_);
-  webui_display_ = message;
+  webui_display_[key] = message;
 }
 
 void CoreWorker::SetActorTitle(const std::string &title) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -97,7 +97,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   void SetActorId(const ActorID &actor_id);
 
-  void SetWebuiDisplay(const std::string &message);
+  void SetWebuiDisplay(const std::string &key, const std::string &message);
 
   void SetActorTitle(const std::string &title);
 
@@ -656,8 +656,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// we cannot access the thread-local worker contexts from GetCoreWorkerStats()
   TaskSpecification current_task_ GUARDED_BY(mutex_);
 
-  /// String to be displayed on Web UI.
-  std::string webui_display_ GUARDED_BY(mutex_);
+  /// Key value pairs to be displayed on Web UI.
+  std::unordered_map<std::string, std::string> webui_display_ GUARDED_BY(mutex_);
 
   /// Actor title that consists of class name, args, kwargs for actor construction.
   std::string actor_title_ GUARDED_BY(mutex_);

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -205,7 +205,7 @@ message CoreWorkerStats {
   // A map from the resource name (e.g. "CPU") to the amount of resource used.
   map<string, double> used_resources = 9;
   // A string displayed on Dashboard.
-  string webui_display = 10;
+  map<string, string> webui_display = 10;
   // Number of objects stored in local memory.
   int32 num_local_objects = 11;
   // Used local object store memory.


### PR DESCRIPTION
Add fews thing to clear the rough edges of asyncio

- [x] Display the number of tasks and their names in the dashboard
<img width="580" alt="Screen Shot 2020-01-23 at 1 16 36 PM" src="https://user-images.githubusercontent.com/21118851/73026081-9f70db00-3de5-11ea-99a5-1db2ac932aee.png">

- [x] `ray.show_in_webui(key, value)` instead of `ray.show_in_webui(key)`

- [x] No longer throw `_async_init` when running inside a loop

- [x] Autodetect is_asycnio flag for actors. No need to say is_asyncio=True

- [ ] Doc
