### PR TITLE
[tune] Expose progress reporter to users

### DIFF
--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -711,7 +711,7 @@ Note that some behavior such as writing to files by depending on the current wor
 CLI Progress Reporting
 ----------------------
 
-By default, Tune reports experiment progress to the command-line at the end of each training iteration as follows.
+By default, Tune reports experiment progress periodically to the command-line as follows.
 
 .. code-block:: bash
 
@@ -747,11 +747,18 @@ Extending ``CLIReporter`` lets you control reporting frequency. For example:
 
 .. code-block:: python
 
+    class ExperimentTerminationReporter(CLIReporter):
+        def should_report(self, trials, done=False):
+            """Reports only on experiment termination."""
+            return done
+
+    tune.run(my_trainable, progress_reporter=ExperimentTerminationReporter())
+
     class TrialTerminationReporter(CLIReporter):
         def __init__(self):
             self.num_terminated = 0
 
-        def should_report(self, trials):
+        def should_report(self, trials, done=False):
             """Reports only on trial termination events."""
             old_num_terminated = self.num_terminated
             self.num_terminated = len([t for t in trials if t.status == Trial.TERMINATED])
@@ -767,7 +774,7 @@ The default reporting style can also be overriden more broadly by extending the 
 
     class CustomReporter(ProgressReporter):
 
-        def should_report(self, trials):
+        def should_report(self, trials, done=False):
             return True
 
         def report(self, trials, *sys_info):

--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -743,22 +743,15 @@ This output can be configured in various ways. Here are some examples:
     reporter.add_metric_column("custom_metric")
     tune.run(my_trainable, progress_reporter=reporter)
 
-    # Report only at the end of the experiment instead of periodically.
-    class ExperimentTerminationReporter(CLIReporter):
-        def should_report(self, trials):
-            return trial_runner.is_finished()
-
-    tune.run(my_trainable, progress_reporter=ExperimentTerminationReporter())
-
     # Report only on trial termination events.
     class TrialTerminationReporter(CLIReporter):
-      def __init__(self):
-        self.num_terminated = 0
+        def __init__(self):
+            self.num_terminated = 0
 
-      def should_report(self, trials):
-        old_num_terminated = self.num_terminated
-        self.num_terminated = len([t for t in trial_runner.get_trials() if t.status == Trial.TERMINATED])
-        return self.num_terminated > old_num_terminated
+        def should_report(self, trials):
+            old_num_terminated = self.num_terminated
+            self.num_terminated = len([t for t in trial_runner.get_trials() if t.status == Trial.TERMINATED])
+            return self.num_terminated > old_num_terminated
 
     tune.run(my_trainable, progress_reporter=TrialTerminationReporter())
 
@@ -775,7 +768,7 @@ The default reporting style can be overriden more broadly by extending the ``Pro
 
         def report(self, trials, *sys_info):
             print(*sys_info)
-            print(" ".join([str(trial) for trial in trials]))
+            print("\n".join([str(trial) for trial in trials]))
 
 Tune CLI (Experimental)
 -----------------------

--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -711,7 +711,7 @@ Note that some behavior such as writing to files by depending on the current wor
 CLI Progress Reporting
 ----------------------
 
-By default, Tune periodically reports experiment progress to command-line as follows:
+By default, Tune periodically reports experiment progress to command-line as follows. Columns are hidden if they are completely empty.
 
 .. code-block:: bash
 
@@ -738,7 +738,8 @@ This output can be configured in various ways. Here are some examples:
 
     # Limit the number of rows.
     reporter = CLIReporter(max_progress_rows=10)
-    # Add a custom metric column, in addition to accuracy, loss, total time and iterations.
+    # Add a custom metric column, in addition to the default metrics.
+    # Note that this must be a metric that is returned in your training results.
     reporter.add_metric_column("custom_metric")
     tune.run(my_trainable, progress_reporter=reporter)
 

--- a/python/ray/tune/__init__.py
+++ b/python/ray/tune/__init__.py
@@ -6,6 +6,8 @@ from ray.tune.registry import register_env, register_trainable
 from ray.tune.trainable import Trainable
 from ray.tune.durable_trainable import DurableTrainable
 from ray.tune.suggest import grid_search
+from ray.tune.progress_reporter import (ProgressReporter, CLIReporter,
+                                        JupyterNotebookReporter)
 from ray.tune.sample import (function, sample_from, uniform, choice, randint,
                              randn, loguniform)
 
@@ -29,4 +31,7 @@ __all__ = [
     "loguniform",
     "ExperimentAnalysis",
     "Analysis",
+    "CLIReporter",
+    "JupyterNotebookReporter",
+    "ProgressReporter",
 ]

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -65,6 +65,27 @@ class TuneReporterBase(ProgressReporter):
     def should_report(self, trial_runner):
         return True
 
+    def add_metric_column(self, metric, representation=None):
+        """Adds a metric to the existing columns.
+
+        Args:
+            metric (str): Metric to add.
+            representation (str): Representation to use in table. Defaults to
+                `metric`.
+        """
+        if metric in self._metric_columns:
+            raise ValueError("Column {} already exists.".format(metric))
+
+        if isinstance(self._metric_columns, collections.Mapping):
+            representation = representation or metric
+            self._metric_columns[metric] = representation
+        else:
+            if representation is not None and representation != metric:
+               raise ValueError("`representation` cannot differ from `metric` "
+                                "if this reporter was initialized with a list "
+                                "of metric columns.")
+            self._metric_columns.append(metric)
+
     def _progress_str(self, trial_runner, fmt="psql", delim="\n"):
         """Returns full progress string.
 

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -17,7 +17,10 @@ except ImportError:
 
 class ProgressReporter:
     def should_report(self, trials):
-        """Returns whether or not progress should be reported."""
+        """Returns whether or not progress should be reported.
+
+        This is called at the end of every execution step.
+        """
         raise NotImplementedError
 
     def report(self, trials, *sys_info):

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -48,7 +48,7 @@ class TuneReporterBase(ProgressReporter):
 
     # Truncated representations of column names (to accommodate small screens).
     DEFAULT_COLUMNS = {
-        EPISODE_REWARD_MEAN: "rew",
+        EPISODE_REWARD_MEAN: "reward",
         MEAN_ACCURACY: "acc",
         MEAN_LOSS: "loss",
         TIME_TOTAL_S: "total time (s)",

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -81,9 +81,10 @@ class TuneReporterBase(ProgressReporter):
             self._metric_columns[metric] = representation
         else:
             if representation is not None and representation != metric:
-               raise ValueError("`representation` cannot differ from `metric` "
-                                "if this reporter was initialized with a list "
-                                "of metric columns.")
+                raise ValueError(
+                    "`representation` cannot differ from `metric` "
+                    "if this reporter was initialized with a list "
+                    "of metric columns.")
             self._metric_columns.append(metric)
 
     def _progress_str(self, trial_runner, fmt="psql", delim="\n"):

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -50,7 +50,7 @@ class TuneReporterBase(ProgressReporter):
         """Initializes a new TableReporterBase.
 
         Args:
-            metric_columns (Dict[str,str]|List[str]): Names of metrics to
+            metric_columns (dict[str, str]|list[str]): Names of metrics to
                 include in progress table. If this is a dict, the keys should
                 be metric names and the values should be the displayed names.
                 If this is a list, the metric name is used directly.
@@ -103,7 +103,7 @@ class JupyterNotebookReporter(TuneReporterBase):
 
         Args:
             overwrite (bool): Flag for overwriting the last reported progress.
-            metric_columns (Dict[str,str]|List[str]): Names of metrics to
+            metric_columns (dict[str, str]|list[str]): Names of metrics to
                 include in progress table. If this is a dict, the keys should
                 be metric names and the values should be the displayed names.
                 If this is a list, the metric name is used directly.
@@ -135,7 +135,7 @@ class CLIReporter(TuneReporterBase):
         """Initializes a CLIReporter.
 
         Args:
-            metric_columns (Dict[str,str]|List[str]): Names of metrics to
+            metric_columns (dict[str, str]|list[str]): Names of metrics to
                 include in progress table. If this is a dict, the keys should
                 be metric names and the values should be the displayed names.
                 If this is a list, the metric name is used directly.
@@ -179,8 +179,8 @@ def trial_progress_str(trials, metric_columns, fmt="psql", max_rows=None):
     and the current values of its metrics.
 
     Args:
-        trials (List[Trial]): List of trials to get progress string for.
-        metric_columns (Dict[str,str]|List[str]): Names of metrics to include.
+        trials (list[Trial]): List of trials to get progress string for.
+        metric_columns (dict[str, str]|list[str]): Names of metrics to include.
             If this is a dict, the keys are metric names and the values are
             the names to use in the message. If this is a list, the metric
             name is used in the message directly.
@@ -245,7 +245,7 @@ def trial_errors_str(trials, fmt="psql", max_rows=None):
     """Returns a readable message regarding trial errors.
 
     Args:
-        trials (List[Trial]): List of trials to get progress string for.
+        trials (list[Trial]): List of trials to get progress string for.
         fmt (str): Output format (see tablefmt in tabulate API).
         max_rows (int): Maximum number of rows in the error table. Defaults to
             unlimited.
@@ -277,7 +277,7 @@ def _fair_filter_trials(trials_by_state, max_trials):
     The oldest trials are truncated if necessary.
 
     Args:
-        trials_by_state (Dict[str, List[Trial]]: Trials by state.
+        trials_by_state (dict[str, list[Trial]]: Trials by state.
         max_trials (int): Maximum number of trials to return.
     Returns:
         Dict mapping state to List of fairly represented trials.
@@ -315,8 +315,8 @@ def _get_trial_info(trial, parameters, metrics):
 
     Args:
         trial (Trial): Trial to get information for.
-        parameters (List[str]): Names of trial parameters to include.
-        metrics (List[str]): Names of metrics to include.
+        parameters (list[str]): Names of trial parameters to include.
+        metrics (list[str]): Names of metrics to include.
     """
     result = flatten_dict(trial.last_result)
     trial_info = [str(trial), trial.status, str(trial.location)]

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -116,8 +116,8 @@ class JupyterNotebookReporter(TuneReporterBase):
             max_error_rows (int): Maximum number of error rows to print in the
                 error table. Defaults to 20.
         """
-        super(JupyterNotebookReporter, self).__init__(
-            metric_columns, max_progress_rows, max_error_rows)
+        super(JupyterNotebookReporter,
+              self).__init__(metric_columns, max_progress_rows, max_error_rows)
         self._overwrite = overwrite
 
     def report(self, trial_runner):

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -73,7 +73,8 @@ class TuneReporterBase(ProgressReporter):
         """Adds a metric to the existing columns.
 
         Args:
-            metric (str): Metric to add.
+            metric (str): Metric to add. This must be a metric being returned
+                in training step results.
             representation (str): Representation to use in table. Defaults to
                 `metric`.
         """

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from ray.tune.trial import Trial
-from ray.tune.progress_reporter import _fair_filter_trials
+from ray.tune.progress_reporter import CLIReporter, _fair_filter_trials
 
 
 class ProgressReporterTest(unittest.TestCase):
@@ -48,3 +48,22 @@ class ProgressReporterTest(unittest.TestCase):
             for i in range(len(state_trials) - 1):
                 self.assertGreaterEqual(state_trials[i].start_time,
                                         state_trials[i + 1].start_time)
+
+    def testAddMetricColumn(self):
+        """Tests edge cases of add_metric_column."""
+
+        # Test list-initialized metric columns.
+        reporter = CLIReporter(metric_columns=["foo", "bar"])
+        with self.assertRaises(ValueError):
+            reporter.add_metric_column("bar")
+
+        with self.assertRaises(ValueError):
+            reporter.add_metric_column("baz", "qux")
+
+        reporter.add_metric_column("baz")
+        self.assertIn("baz", reporter._metric_columns)
+
+        # Test default-initialized (dict) metric columns.
+        reporter = CLIReporter()
+        reporter.add_metric_column("foo", "bar")
+        self.assertIn("foo", reporter._metric_columns)


### PR DESCRIPTION
Related features have been requested a couple times.

This PR allows users to use their own progress reporter. It also makes it easier to adjust the existing ones (different table sizes, more/less columns etc)

Closes #6270

Intended usage examples
```python
# add some custom columns
reporter = CLIReporter()
reporter.add_metric_column("cust_metric")
tune.run(..., progress_reporter=reporter)

######## report only on termination of any trial ########
class TrialTerminationReporter(CLIReporter):
  def __init__(self):
    self.num_terminated = 0

  def should_report(self, trials, done=False):
    old_num_terminated = self.num_terminated
    self.num_terminated = len([t for t in trials if t.status == Trial.TERMINATED])
    return done or self.num_terminated > old_num_terminated

tune.run(..., progress_reporter=TrialTerminationReporter())
```

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
