### PR TITLE
bugfix - fixing first few failing training sessions due to deep_updat…

### DIFF
--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -168,7 +168,7 @@ def deep_update(original, new_dict, new_keys_allowed, whitelist):
         if k not in original:
             if not new_keys_allowed:
                 raise Exception("Unknown config parameter `{}` ".format(k))
-        if isinstance(original.get(k), dict):
+        if isinstance(value, dict):
             if k in whitelist:
                 deep_update(original[k], value, True, [])
             else:


### PR DESCRIPTION
…e looking for wrong types in config dict

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Using Tune with recursive config, one gets the following exception:

> 2020-01-28 15:30:18,878	ERROR trial_runner.py:487 -- Error processing event.
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/trial_runner.py", line 436, in _process_trial
>     result = self.trial_executor.fetch_result(trial)
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/ray_trial_executor.py", line 323, in fetch_result
>     result = ray.get(trial_future[0])
>   File "/usr/local/lib/python3.6/dist-packages/ray/worker.py", line 2195, in get
>     raise value
> ray.exceptions.RayTaskError: ray_worker (pid=1138, host=7e2ac1920dad)
>   File "/usr/local/lib/python3.6/dist-packages/ray/rllib/agents/trainer_template.py", line 87, in __init__
>     Trainer.__init__(self, config, env, logger_creator)
>   File "/usr/local/lib/python3.6/dist-packages/ray/rllib/agents/trainer.py", line 323, in __init__
>     Trainable.__init__(self, config, logger_creator)
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/trainable.py", line 87, in __init__
>     self._setup(copy.deepcopy(self.config))
>   File "/usr/local/lib/python3.6/dist-packages/ray/rllib/agents/trainer.py", line 424, in _setup
>     self._allow_unknown_subkeys)
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/util.py", line 94, in deep_update
>     deep_update(original[k], value, True, [])
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/util.py", line 96, in deep_update
>     deep_update(original[k], value, new_keys_allowed, [])
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/util.py", line 96, in deep_update
>     deep_update(original[k], value, new_keys_allowed, [])
>   File "/usr/local/lib/python3.6/dist-packages/ray/tune/util.py", line 88, in deep_update
>     for k, value in new_dict.items():
> AttributeError: 'str' object has no attribute 'items'

## Related issue number

Closes #6847

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
