### PR TITLE
Remove asyncio try/except for python 2

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -5,11 +5,7 @@
 
 from cpython.exc cimport PyErr_CheckSignals
 
-try:
-    import asyncio
-except ImportError:
-    # Python2 doesn't have asyncio
-    asyncio = None
+import asyncio
 import numpy
 import gc
 import inspect


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Python 2 is deprecated.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
