### PR TITLE
[Tests] Change 2 dot diff to 3 dot diff

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -44,8 +44,7 @@ if __name__ == "__main__":
 
     if os.environ["TRAVIS_EVENT_TYPE"] == "pull_request":
 
-        files = list_changed_files(os.environ["TRAVIS_COMMIT_RANGE"].replace(
-            "...", ".."))
+        files = list_changed_files(os.environ["TRAVIS_COMMIT_RANGE"])
 
         print(pformat(files), file=sys.stderr)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Currently a 2 dot diff is used to determine which files have changed for a PR and thus which tests to run. However, this runs unnecessary tests. Instead a 3 dot diff would be better since it only looks at the changes between the feature branch and the last time it was synced with the master branch.

[Difference between 2 dot diff and 3dot diff](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
