### PR TITLE
Fix serve::test_api flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,8 +144,8 @@ script:
   - ./ci/suppress_output bazel test --build_tests_only --show_progress_rate_limit=100 --test_output=errors //:all
 
   # ray serve tests TODO(ekl): these should be moved to bazel
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
-  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then SERVE_LOG_DEBUG=1 python -m pytest -v --durations=5 --timeout=300 python/ray/experimental/serve/tests; fi
+  - if [ $RAY_CI_SERVE_AFFECTED == "1" ]; then SERVE_LOG_DEBUG=1 ./ci/suppress_output python python/ray/experimental/serve/examples/echo_full.py; fi
 
   # ray operator tests
   - cd ./deploy/ray-operator/
@@ -164,7 +164,7 @@ script:
 
 deploy:
   - provider: s3
-    edge: true  # This supposedly opts in to deploy v2.
+    edge: true # This supposedly opts in to deploy v2.
     access_key_id: AKIAU6DMUCJUFL3EX3SM
     secret_access_key:
       secure: J1sX71fKFPQhgWzColllxfzcF877ScBZ1cIl71krZ6SO0LKnwsCScpQck5eZOyQo/Iverwye0iKtE87qNsiRi3+V2D9iulSr18T09j7+FjPKfxAmXmjfrNafoMXTDQroSJblCri5vl+DysISPqImJkWTNaYhGJ9QakoSd5djnAopLNWj6PCR3S50baS49+nB5nSIY3jMhtUzlaBdniFPFC81Cxyuafr4pv6McGRfR/dK+ZnPhdGtMnVeIJXB+ooZKQ26mDJKBPka4jm3u1Oa72b/Atu2RO3MwxTg79LTrMxXKh2OcCqhtD2Z3lz1OltvNSunCuwY8AejCJsfSLbM9mGDoz+xhNUWmYNy48YFf+61OY8PXi8S/9Q817yb3GpLbb2l/P+KMgq9eSEiELIOwuYsDxPX5TuAg6dx0wCNgDEBJoThSQjYl6MgJrLrs7p+JBxp3giedHiy0TLa5hCVKTj3euONAXDArYnnT+DvUIOkaeTk5DClRZbZ0sUXhLy//HuT5WJvjFBJJZ0u0f4RLVb5D7DI4uMZr7+yJPDR2AXCyW9YMaBEbmEYbPaKi283jlEyn7R33+AZlnXv0THHwZ4xvjKKG3/fBSXsOUmv5wmUveEqVGDj1mKPGj9NF8iA5qMm2AaZuJpEEBVBZtSlTZt6ZG7rzAJZGNL52t7xuMo=
@@ -180,7 +180,7 @@ deploy:
       condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
 
   - provider: s3
-    edge: true  # This supposedly opts in to deploy v2.
+    edge: true # This supposedly opts in to deploy v2.
     access_key_id: AKIAU6DMUCJUFL3EX3SM
     secret_access_key:
       secure: J1sX71fKFPQhgWzColllxfzcF877ScBZ1cIl71krZ6SO0LKnwsCScpQck5eZOyQo/Iverwye0iKtE87qNsiRi3+V2D9iulSr18T09j7+FjPKfxAmXmjfrNafoMXTDQroSJblCri5vl+DysISPqImJkWTNaYhGJ9QakoSd5djnAopLNWj6PCR3S50baS49+nB5nSIY3jMhtUzlaBdniFPFC81Cxyuafr4pv6McGRfR/dK+ZnPhdGtMnVeIJXB+ooZKQ26mDJKBPka4jm3u1Oa72b/Atu2RO3MwxTg79LTrMxXKh2OcCqhtD2Z3lz1OltvNSunCuwY8AejCJsfSLbM9mGDoz+xhNUWmYNy48YFf+61OY8PXi8S/9Q817yb3GpLbb2l/P+KMgq9eSEiELIOwuYsDxPX5TuAg6dx0wCNgDEBJoThSQjYl6MgJrLrs7p+JBxp3giedHiy0TLa5hCVKTj3euONAXDArYnnT+DvUIOkaeTk5DClRZbZ0sUXhLy//HuT5WJvjFBJJZ0u0f4RLVb5D7DI4uMZr7+yJPDR2AXCyW9YMaBEbmEYbPaKi283jlEyn7R33+AZlnXv0THHwZ4xvjKKG3/fBSXsOUmv5wmUveEqVGDj1mKPGj9NF8iA5qMm2AaZuJpEEBVBZtSlTZt6ZG7rzAJZGNL52t7xuMo=
@@ -196,7 +196,7 @@ deploy:
       condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
 
   - provider: script
-    edge: true  # This supposedly opts in to deploy v2.
+    edge: true # This supposedly opts in to deploy v2.
     script: bash $TRAVIS_BUILD_DIR/ci/travis/build-autoscaler-images.sh || true
     skip_cleanup: true
     on:
@@ -204,8 +204,6 @@ deploy:
       all_branches: true
       condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
 
-
 cache:
   directories:
     - $HOME/ray-bazel-cache
-

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -106,7 +106,6 @@ def init(kv_store_connector=None,
 
     # Initialize ray if needed.
     if not ray.is_initialized():
-        logger.debug("Initializing ray with kwargs {}".format(ray_init_kwargs))
         ray.init(**ray_init_kwargs)
 
     # Try to get serve nursery if there exists

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -13,7 +13,7 @@ from ray.experimental.serve.global_state import (GlobalState,
 from ray.experimental.serve.kv_store_service import SQLiteKVStore
 from ray.experimental.serve.task_runner import RayServeMixin, TaskRunnerActor
 from ray.experimental.serve.utils import (block_until_http_ready,
-                                          get_random_letters, logger)
+                                          get_random_letters)
 from ray.experimental.serve.exceptions import RayServeException
 from ray.experimental.serve.backend_config import BackendConfig
 from ray.experimental.serve.policy import RoutePolicy

--- a/python/ray/experimental/serve/api.py
+++ b/python/ray/experimental/serve/api.py
@@ -408,8 +408,8 @@ def split(endpoint_name, traffic_policy_dictionary):
 
     global_state.policy_table.register_traffic_policy(
         endpoint_name, traffic_policy_dictionary)
-    global_state.init_or_get_router().set_traffic.remote(
-        endpoint_name, traffic_policy_dictionary)
+    ray.get(global_state.init_or_get_router().set_traffic.remote(
+        endpoint_name, traffic_policy_dictionary))
 
 
 @_ensure_connected

--- a/python/ray/experimental/serve/examples/echo_full.py
+++ b/python/ray/experimental/serve/examples/echo_full.py
@@ -33,7 +33,7 @@ backend_config_v1 = serve.get_backend_config("echo:v1")
 # goes to my_endpoint will now goes to echo:v1 backend.
 serve.link("my_endpoint", "echo:v1")
 
-print(requests.get("http://127.0.0.1:8000/echo").json())
+print(requests.get("http://127.0.0.1:8000/echo", timeout=0.5).json())
 # The service will be reachable from http
 
 print(ray.get(serve.get_handle("my_endpoint").remote(response="hello")))

--- a/python/ray/experimental/serve/global_state.py
+++ b/python/ray/experimental/serve/global_state.py
@@ -32,8 +32,7 @@ class ActorNursery:
     """
 
     def __init__(self):
-        # Dict: Actor handles -> tag
-        self.actor_handles = dict()
+        self.tag_to_actor_handles = dict()
 
         self.bootstrap_state = dict()
 
@@ -44,10 +43,14 @@ class ActorNursery:
                     init_kwargs={},
                     is_asyncio=False):
         """Start an actor and add it to the nursery"""
+        # Avoid double initialization
+        if tag in self.tag_to_actor_handles.keys():
+            return self.tag_to_actor_handles[tag]
+
         max_concurrency = ASYNC_CONCURRENCY if is_asyncio else None
         handle = (actor_cls.options(max_concurrency=max_concurrency).remote(
             *init_args, **init_kwargs))
-        self.actor_handles[handle] = tag
+        self.tag_to_actor_handles[tag] = handle
         return [handle]
 
     def start_actor_with_creator(self, creator, kwargs, tag):
@@ -58,19 +61,18 @@ class ActorNursery:
                 The kwargs input is passed to `ActorCls_remote` method.
         """
         handle = creator(kwargs)
-        self.actor_handles[handle] = tag
+        self.tag_to_actor_handles[tag] = handle
         return [handle]
 
     def get_all_handles(self):
-        return {tag: handle for handle, tag in self.actor_handles.items()}
+        return self.tag_to_actor_handles
 
     def get_handle(self, actor_tag):
-        return [self.get_all_handles()[actor_tag]]
+        return [self.tag_to_actor_handles[actor_tag]]
 
     def remove_handle(self, actor_tag):
-        [handle] = self.get_handle(actor_tag)
-        self.actor_handles.pop(handle)
-        del handle
+        if actor_tag in self.tag_to_actor_handles.keys():
+            self.tag_to_actor_handles.pop(actor_tag)
 
     def store_bootstrap_state(self, key, value):
         self.bootstrap_state[key] = value

--- a/python/ray/experimental/serve/global_state.py
+++ b/python/ray/experimental/serve/global_state.py
@@ -45,7 +45,7 @@ class ActorNursery:
         """Start an actor and add it to the nursery"""
         # Avoid double initialization
         if tag in self.tag_to_actor_handles.keys():
-            return self.tag_to_actor_handles[tag]
+            return [self.tag_to_actor_handles[tag]]
 
         max_concurrency = ASYNC_CONCURRENCY if is_asyncio else None
         handle = (actor_cls.options(max_concurrency=max_concurrency).remote(

--- a/python/ray/experimental/serve/tests/test_api.py
+++ b/python/ray/experimental/serve/tests/test_api.py
@@ -17,7 +17,7 @@ def test_e2e(serve_instance):
     timeout_sleep = 0.5
     while True:
         try:
-            resp = requests.get("http://127.0.0.1:8000/").json()
+            resp = requests.get("http://127.0.0.1:8000/", timeout=0.5).json()
             assert resp == result
             break
         except Exception:


### PR DESCRIPTION
This PR tries to fix the flaky test_api.py test in serve by:
- Making `serve.link` and `serve.split` blocking so the traffic policy is propagated through
- Impose a timeout on `requests.get` so the requests will try new TCP connection every 0.5 seconds instead of hanging on older connection