### PR TITLE
Show yapf download command if yapf is not downloaded.

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -8,18 +8,24 @@ set -eo pipefail
 FLAKE8_VERSION_REQUIRED="3.7.7"
 YAPF_VERSION_REQUIRED="0.23.0"
 
-YAPF_DOWNLOAD_COMMAND_MSG="pip install yapf==$YAPF_VERSION_REQUIRED"
-FLAKE8_DOWNLOAD_COMMAND_MSG="pip install flake8=$FLAKE8_VERSION_REQUIRED"
+check_command_exist() {
+    VERSION=""
+    case "$1" in
+        yapf)
+            VERSION=$YAPF_VERSION_REQUIRED
+            ;;
+        flake8)
+            VERSION=$FLAKE8_VERSION_REQUIRED
+            ;;
+    esac
+    if ! [ -x "$(command -v $1)" ]; then
+        echo "$1 not installed. pip install $1==$VERSION"
+        exit 1
+    fi 
+}
 
-if ! [ -x "$(command -v yapf)" ]; then
-  echo "YAPF not installed. $YAPF_DOWNLOAD_COMMAND_MSG"
-  exit 1
-fi
-
-if ! [ -x "$(command -v flake8)" ]; then
-  echo "Flake8 not installed. $FLAKE8_DOWNLOAD_COMMAND_MSG"
-  exit 1
-fi
+check_command_exist yapf
+check_command_exist flake8
 
 ver=$(yapf --version)
 if ! echo $ver | grep -q 0.23.0; then

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -5,9 +5,18 @@
 # Cause the script to exit if a single command fails
 set -eo pipefail
 
+FLAKE8_VERSION_REQUIRED="3.7.7"
+YAPF_VERSION_REQUIRED="0.23.0"
+
+YAPF_DOWNLOAD_COMMAND_MSG="Run pip install yapf==$YAPF_VERSION_REQUIRED Make sure you are using python 3 interpreter"
+if ! [ -x "$(command -v yapf)" ]; then
+  echo "YAPF not installed. $YAPF_DOWNLOAD_COMMAND_MSG"
+  exit 1
+fi
+
 ver=$(yapf --version)
 if ! echo $ver | grep -q 0.23.0; then
-    echo "Wrong YAPF version installed: 0.23.0 is required, not $ver"
+    echo "Wrong YAPF version installed: 0.23.0 is required, not $ver. $YAPF_DOWNLOAD_COMMAND_MSG"
     exit 1
 fi
 
@@ -32,8 +41,8 @@ tool_version_check() {
     fi
 }
 
-tool_version_check "flake8" $FLAKE8_VERSION "3.7.7"
-tool_version_check "yapf" $YAPF_VERSION "0.23.0"
+tool_version_check "flake8" $FLAKE8_VERSION $FLAKE8_VERSION_REQUIRED
+tool_version_check "yapf" $YAPF_VERSION $YAPF_VERSION_REQUIRED
 
 if which clang-format >/dev/null; then
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -8,9 +8,16 @@ set -eo pipefail
 FLAKE8_VERSION_REQUIRED="3.7.7"
 YAPF_VERSION_REQUIRED="0.23.0"
 
-YAPF_DOWNLOAD_COMMAND_MSG="Run pip install yapf==$YAPF_VERSION_REQUIRED Make sure you are using python 3 interpreter"
+YAPF_DOWNLOAD_COMMAND_MSG="pip install yapf==$YAPF_VERSION_REQUIRED"
+FLAKE8_DOWNLOAD_COMMAND_MSG="pip install flake8=$FLAKE8_VERSION_REQUIRED"
+
 if ! [ -x "$(command -v yapf)" ]; then
   echo "YAPF not installed. $YAPF_DOWNLOAD_COMMAND_MSG"
+  exit 1
+fi
+
+if ! [ -x "$(command -v flake8)" ]; then
+  echo "Flake8 not installed. $FLAKE8_DOWNLOAD_COMMAND_MSG"
   exit 1
 fi
 

--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -17,6 +17,9 @@ check_command_exist() {
         flake8)
             VERSION=$FLAKE8_VERSION_REQUIRED
             ;;
+        *)
+            echo "$1 is not a required dependency"
+            exit 1
     esac
     if ! [ -x "$(command -v $1)" ]; then
         echo "$1 not installed. pip install $1==$VERSION"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, `./ci/travis/format.sh` fails if `yapf` is not downloaded, and it does not properly instruct users what to do. I
- made it print proper commands to install yapf when it is not downloaded
- Refactored code to define expected `yapf` and `flake8` version in the beginning of the file. 

By this PR, if `yapf` is not downloaded, it shows
```
./ci/travis/format.sh
YAPF not installed. Run pip install yapf==0.23.0 Make sure you are using python 3 interpreter
```

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
