### PR TITLE
[Tune] logger.py: Relax TBX Summary ValueErrors with e.g. empty lists in lists (and all…

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -350,6 +350,7 @@ class TBXLogger(Logger):
         flat_result = flatten_dict(tmp, delimiter="/")
         path = ["ray", "tune"]
         valid_result = {}
+
         for attr, value in flat_result.items():
             full_attr = "/".join(path + [attr])
             if type(value) in VALID_SUMMARY_TYPES:
@@ -358,8 +359,16 @@ class TBXLogger(Logger):
                     full_attr, value, global_step=step)
             elif type(value) is list and len(value) > 0:
                 valid_result[full_attr] = value
-                self._file_writer.add_histogram(
-                    full_attr, value, global_step=step)
+                try:
+                    self._file_writer.add_histogram(
+                        full_attr, value, global_step=step)
+                # In case TensorboardX still doesn't think it's a valid value
+                # (e.g. `[[]]`), warn and move on.
+                except ValueError as e:
+                    logger.warning(
+                        "You are trying to log an invalid value ({}={}) "
+                        "via {}!".format(
+                            full_attr, value, type(self).__name__))
 
         self.last_result = valid_result
         self._file_writer.flush()

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -364,11 +364,11 @@ class TBXLogger(Logger):
                         full_attr, value, global_step=step)
                 # In case TensorboardX still doesn't think it's a valid value
                 # (e.g. `[[]]`), warn and move on.
-                except ValueError as e:
+                except ValueError:
                     logger.warning(
                         "You are trying to log an invalid value ({}={}) "
-                        "via {}!".format(
-                            full_attr, value, type(self).__name__))
+                        "via {}!".format(full_attr, value,
+                                         type(self).__name__))
 
         self.last_result = valid_result
         self._file_writer.flush()


### PR DESCRIPTION
… other invalid-value cases).

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Sometimes, training results to be logged contain TBX-invalid values (such as empty lists OR lists with other empty lists in them). As we are not constraining creating arbitrarily nested results dict (e.g. from RLlib train runs), this should not cause a hard error in tune/logger.py, but simply warn (only once?). 

<!-- Please give a short summary of the change and the problem this solves. -->


<!-- For example: "Closes #1234" -->


- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
