### PR TITLE
Force OMP_NUM_THREADS=1 if unset

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -4,10 +4,10 @@ import multiprocessing
 from os.path import dirname
 import sys
 
+logger = logging.getLogger(__name__)
+
 # MUST add pickle5 to the import path because it will be imported by some
 # raylet modules.
-
-logger = logging.getLogger(__name__)
 
 if "pickle5" in sys.modules:
     raise ImportError("Ray must be imported before pickle5 because Ray "

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -16,7 +16,7 @@ if "pickle5" in sys.modules:
 
 if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
     logger.warning("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
-                   "degradation with many CPUs. You can override this by "
+                   "degradation with many workers. You can override this by "
                    "explicitly setting OMP_NUM_THREADS.")
     os.environ["OMP_NUM_THREADS"] = "1"
 

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -16,8 +16,8 @@ if "pickle5" in sys.modules:
 
 if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
     logger.warning("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
-                   "degradation with many workers. You can override this by "
-                   "explicitly setting OMP_NUM_THREADS.")
+                   "degradation with many workers (issue #6998). You can "
+                   "override this by explicitly setting OMP_NUM_THREADS.")
     os.environ["OMP_NUM_THREADS"] = "1"
 
 # Add the directory containing pickle5 to the Python path so that we find the

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,14 +1,24 @@
 import os
+import logging
+import multiprocessing
 from os.path import dirname
 import sys
 
 # MUST add pickle5 to the import path because it will be imported by some
 # raylet modules.
 
+logger = logging.getLogger(__name__)
+
 if "pickle5" in sys.modules:
     raise ImportError("Ray must be imported before pickle5 because Ray "
                       "requires a specific version of pickle5 (which is "
                       "packaged along with Ray).")
+
+if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
+    logger.warning("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
+                   "degradation with many CPUs. You can override this by "
+                   "explicitly setting OMP_NUM_THREADS.")
+    os.environ["OMP_NUM_THREADS"] = "1"
 
 # Add the directory containing pickle5 to the Python path so that we find the
 # pickle5 version packaged with ray and not a pre-existing pickle5.

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -29,7 +29,7 @@ KUBECTL_RSYNC = os.path.join(
 
 def with_interactive(cmd):
     force_interactive = ("true && source ~/.bashrc && "
-                         "export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ")
+                         "export PYTHONWARNINGS=ignore && ")
     return ["bash", "--login", "-c", "-i", quote(force_interactive + cmd)]
 
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -290,7 +290,7 @@ class Worker:
             delta = time.perf_counter() - start
             if delta > 0.1:
                 logger.warning("OMP_NUM_THREADS=1 is set, this may slow down "
-                               "ray.put() for large objects.")
+                               "ray.put() for large objects (issue #6998).")
                 should_warn_of_slow_puts = False
         return result
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -68,6 +68,12 @@ try:
 except ImportError:
     setproctitle = None
 
+# Whether we should warn about slow put performance.
+if os.environ.get("OMP_NUM_THREADS") == "1":
+    should_warn_of_slow_puts = True
+else:
+    should_warn_of_slow_puts = False
+
 
 class ActorCheckpointInfo:
     """Information used to maintain actor checkpoints."""
@@ -272,9 +278,21 @@ class Worker:
                 "do this, you can wrap the ray.ObjectID in a list and "
                 "call 'put' on it (or return it).")
 
+        global should_warn_of_slow_puts
+        if should_warn_of_slow_puts:
+            start = time.perf_counter()
+
         serialized_value = self.get_serialization_context().serialize(value)
-        return self.core_worker.put_serialized_object(
+        result = self.core_worker.put_serialized_object(
             serialized_value, object_id=object_id, pin_object=pin_object)
+
+        if should_warn_of_slow_puts:
+            delta = time.perf_counter() - start
+            if delta > 0.1:
+                logger.warning("OMP_NUM_THREADS=1 is set, this may slow down "
+                               "ray.put() for large objects.")
+                should_warn_of_slow_puts = False
+        return result
 
     def deserialize_objects(self,
                             data_metadata_pairs,
@@ -671,11 +689,6 @@ def init(address=None,
         driver_mode = LOCAL_MODE
     else:
         driver_mode = SCRIPT_MODE
-
-    if "OMP_NUM_THREADS" in os.environ:
-        logger.warning("OMP_NUM_THREADS={} is set, this may impact "
-                       "object transfer performance.".format(
-                           os.environ["OMP_NUM_THREADS"]))
 
     if setproctitle is None:
         logger.warning(

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import logging
 import os
 
@@ -87,14 +86,6 @@ def try_import_torch(error=False):
     if "RLLIB_TEST_NO_TORCH_IMPORT" in os.environ:
         logger.warning("Not importing Torch for test purposes.")
         return None, None
-
-    if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
-        logger.warning(
-            "WARNING framework.py -- Force setting OMP_NUM_THREADS=1 before "
-            "torch import to avoid performance degradation with many CPUs "
-            "(issue #6962). You can override this by explicitly setting "
-            "OMP_NUM_THREADS.")
-        os.environ["OMP_NUM_THREADS"] = "1"
 
     try:
         import torch

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import logging
 import os
 
@@ -86,6 +87,14 @@ def try_import_torch(error=False):
     if "RLLIB_TEST_NO_TORCH_IMPORT" in os.environ:
         logger.warning("Not importing Torch for test purposes.")
         return None, None
+
+    if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
+        logger.warning(
+            "WARNING framework.py -- Force setting OMP_NUM_THREADS=1 before "
+            "torch import to avoid performance degradation with many CPUs "
+            "(issue #6962). You can override this by explicitly setting "
+            "OMP_NUM_THREADS.")
+        os.environ["OMP_NUM_THREADS"] = "1"
 
     try:
         import torch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

PyTorch will get much slower if OMP_NUM_THREADS isn't set on many core machines. This has been an issue for other applications as well.

This PR:
- Always sets OMP_NUM_THREADS=1 on large machines (>8 cores). This prints a warning.
- If OMP_NUM_THREADS=1, warns that puts may be slow.
- Removes the auto setting of OMP_NUM_THREADS=1 in the autoscaler, since it is now done on ray import.

## Related issue number

Closes https://github.com/ray-project/ray/issues/6962