### PR TITLE
[RLlib] Add cartpole PPO torch to regression (besides tf).

### DIFF
--- a/rllib/tuned_examples/regression_tests/cartpole-ppo-torch.yaml
+++ b/rllib/tuned_examples/regression_tests/cartpole-ppo-torch.yaml
@@ -1,0 +1,11 @@
+cartpole-ppo-tf:
+    env: CartPole-v0
+    run: PPO
+    stop:
+        episode_reward_mean: 150
+        timesteps_total: 100000
+    config:
+        num_workers: 1
+        batch_mode: complete_episodes
+        observation_filter: MeanStdFilter
+        use_pytorch: true


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

To have a more complete regression suite (at least test every Algo on CartPole using both frameworks). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
