### PR TITLE
Always set OMP_NUM_THREADS even on low core machines

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import multiprocessing
 from os.path import dirname
 import sys
 
@@ -14,7 +13,7 @@ if "pickle5" in sys.modules:
                       "requires a specific version of pickle5 (which is "
                       "packaged along with Ray).")
 
-if "OMP_NUM_THREADS" not in os.environ and multiprocessing.cpu_count() > 8:
+if "OMP_NUM_THREADS" not in os.environ:
     logger.warning("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
                    "degradation with many workers (issue #6998). You can "
                    "override this by explicitly setting OMP_NUM_THREADS.")


### PR DESCRIPTION
See last comment from https://github.com/ray-project/ray/pull/6998, there is still significant slowdown on low core machines.

This is probably more consistent behaviour anyways.