### PR TITLE
[autoscaler] Increase limit for autoscaler keys

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -134,7 +134,7 @@ def _configure_key_pair(config):
     ec2 = _resource("ec2", config)
 
     # Try a few times to get or create a good key pair.
-    MAX_NUM_KEYS = 20
+    MAX_NUM_KEYS = 30
     for i in range(MAX_NUM_KEYS):
         key_name, key_path = key_pair(i, config["provider"]["region"])
         key = _get_key(key_name, config)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If many autoscaler users are sharing an EC2 account, we can run into the autoscaler's key limit. This increases the limit a bit as a stop gap solution.

Error:

```

File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/autoscaler/commands.py", line 41, in create_or_update_cluster
config = _bootstrap_config(config)
File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/autoscaler/commands.py", line 63, in _bootstrap_config
resolved_config = bootstrap_config(config)
File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/autoscaler/aws/config.py", line 43, in bootstrap_aws
config = _configure_key_pair(config)
File "/home/ubuntu/anaconda3/lib/python3.7/site-packages/ray/autoscaler/aws/config.py", line 144, in _configure_key_pair
"Private key file {} not found for {}".format(key_path, key_name)
AssertionError: Private key file /home/ubuntu/.ssh/ray-autoscaler_19_us-west-2.pem not found for ray-autoscaler_19_us-west-2
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
