### PR TITLE
[tune] Align scheduler mode with search algorithm in example of Ax

### DIFF
--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         outcome_constraints=["l2norm <= 1.25"],  # Optional.
     )
     algo = AxSearch(client, max_concurrent=4)
-    scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="max")
+    scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="min")
     run(easy_objective,
         name="ax",
         search_alg=algo,


### PR DESCRIPTION
There are two different modes used in the example of Ax. While the search algorithm's mode tells to minimize the objective, the scheduler wants to maximize it. I think this is a mistake, and both need to minimize the hartmann6 metric.
