### PR TITLE
[minor][core] fix gpu ids for SLURM

### DIFF
--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -263,7 +263,7 @@ def get_cuda_visible_devices():
 
     Returns:
         if CUDA_VISIBLE_DEVICES is set, this returns a list of integers with
-            the IDs of the GPUs. If it is not set or is set incorrectly,
+            the IDs of the GPUs. If it is not set or is set to NoDevFiles,
             this returns None.
     """
     gpu_ids_str = os.environ.get("CUDA_VISIBLE_DEVICES", None)
@@ -274,16 +274,10 @@ def get_cuda_visible_devices():
     if gpu_ids_str == "":
         return []
 
-    try:
-        gpu_ids = [int(i) for i in gpu_ids_str.split(",")]
-        return gpu_ids
-    except ValueError:
-        # SLURM sets CUDA_VISIBLE_DEVICES to NoDevFiles.
-        # https://github.com/ray-project/ray/issues/6978
-        logger.debug(
-            "Unable to parse GPU IDs, returning empty list. "
-            "Expected a comma separated string, got {}".format(gpu_ids_str))
+    if gpu_ids_str == "NoDevFiles":
         return []
+
+    return [int(i) for i in gpu_ids_str.split(",")]
 
 
 last_set_gpu_ids = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The option "SBATCH -C TitanX" specifies a node with a TitanX GPU, while the option "SBATCH --gres=gpu:1" lets SLURM allocate the GPU for the job by setting environment parameter CUDA_VISIBLE_DEVICES to 0. Note that without the "--gres" option, SLURM by default sets CUDA_VISIBLE_DEVICES to value NoDevFiles, which causes the CUDA runtime system to ignore the GPU.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.