### PR TITLE
Exclude test profiling info endpoint

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -245,8 +245,7 @@ def test_raylet_info_endpoint(shutdown_only):
 
 @pytest.mark.skipif(
     os.environ.get("TRAVIS") is None,
-    reason="This test is skipped when running locally because it requires sudo access"
-)
+    reason="Local env cannot satisfy its password requirement")
 def test_profiling_info_endpoint(shutdown_only):
     ray.init(num_cpus=1)
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -245,7 +245,7 @@ def test_raylet_info_endpoint(shutdown_only):
 
 @pytest.mark.skipif(
     os.environ.get("TRAVIS") is None,
-    reason="Local env cannot satisfy its password requirement")
+    reason="This test requires password-less sudo due to py-spy requirement.")
 def test_profiling_info_endpoint(shutdown_only):
     ray.init(num_cpus=1)
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -2,6 +2,7 @@ import os
 import json
 import grpc
 import psutil
+import pytest
 import requests
 import time
 
@@ -242,6 +243,10 @@ def test_raylet_info_endpoint(shutdown_only):
         time.sleep(1)
 
 
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS") is None,
+    reason="This test is skipped when running locally because it requires sudo access"
+)
 def test_profiling_info_endpoint(shutdown_only):
     ray.init(num_cpus=1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_profiling_info_endpoint` requires password-less sudo due to py-spy requirement. We decided not to run it in the local environment because it is tedious to setup for a little bit of gaining.

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
