### PR TITLE
Restore setting OMP_NUM_THREADS=1 in autoscaler

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -29,7 +29,7 @@ KUBECTL_RSYNC = os.path.join(
 
 def with_interactive(cmd):
     force_interactive = ("true && source ~/.bashrc && "
-                         "export PYTHONWARNINGS=ignore && ")
+                         "export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ")
     return ["bash", "--login", "-c", "-i", quote(force_interactive + cmd)]
 
 


### PR DESCRIPTION
Though we don't need to with future ray versions, this is needed if the autoscaler version on the client is higher than then ray version on the cluster.