### PR TITLE
[autoscaler] Add ``--all-nodes`` option to rsync-up

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -441,7 +441,8 @@ def _exec(updater, cmd, screen, tmux, port_forward=None):
             port_forward=port_forward)
 
 
-def rsync(config_file, source, target, override_cluster_name, down):
+def rsync(config_file, source, target, override_cluster_name, down,
+          sync_workers=False):
     """Rsyncs files.
 
     Arguments:
@@ -450,6 +451,7 @@ def rsync(config_file, source, target, override_cluster_name, down):
         target: target dir
         override_cluster_name: set the name of the cluster
         down: whether we're syncing remote -> local
+        sync_workers: whether to sync worker nodes in addition to the head node
     """
     assert bool(source) == bool(target), (
         "Must either provide both or neither source and target.")
@@ -458,32 +460,41 @@ def rsync(config_file, source, target, override_cluster_name, down):
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
     config = _bootstrap_config(config)
-    head_node = _get_head_node(
-        config, config_file, override_cluster_name, create_if_needed=False)
 
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:
-        updater = NodeUpdaterThread(
-            node_id=head_node,
-            provider_config=config["provider"],
-            provider=provider,
-            auth_config=config["auth"],
-            cluster_name=config["cluster_name"],
-            file_mounts=config["file_mounts"],
-            initialization_commands=[],
-            setup_commands=[],
-            ray_start_commands=[],
-            runtime_hash="",
-        )
-        if down:
-            rsync = updater.rsync_down
-        else:
-            rsync = updater.rsync_up
+        nodes = []
+        if sync_workers:
+            # technically we re-open the provider for no reason in get_worker_nodes
+            # but it's cleaner this way and _get_head_node does this too
+            nodes = _get_worker_nodes(config, override_cluster_name)
 
-        if source and target:
-            rsync(source, target)
-        else:
-            updater.sync_file_mounts(rsync)
+        nodes += [_get_head_node(
+            config, config_file, override_cluster_name,
+            create_if_needed=False)]
+
+        for node_id in nodes:
+            updater = NodeUpdaterThread(
+                node_id=node_id,
+                provider_config=config["provider"],
+                provider=provider,
+                auth_config=config["auth"],
+                cluster_name=config["cluster_name"],
+                file_mounts=config["file_mounts"],
+                initialization_commands=[],
+                setup_commands=[],
+                ray_start_commands=[],
+                runtime_hash="",
+            )
+            if down:
+                rsync = updater.rsync_down
+            else:
+                rsync = updater.rsync_up
+
+            if source and target:
+                rsync(source, target)
+            else:
+                updater.sync_file_mounts(rsync)
 
     finally:
         provider.cleanup()
@@ -526,6 +537,20 @@ def get_worker_node_ips(config_file, override_cluster_name):
             return [provider.internal_ip(node) for node in nodes]
         else:
             return [provider.external_ip(node) for node in nodes]
+    finally:
+        provider.cleanup()
+
+def _get_worker_nodes(config, override_cluster_name):
+    """Returns worker node ids for given configuration."""
+    # todo: technically could be reused in get_worker_node_ips
+    if override_cluster_name is not None:
+        config["cluster_name"] = override_cluster_name
+
+    provider = get_node_provider(config["provider"], config["cluster_name"])
+    try:
+        return provider.non_terminated_nodes({
+            TAG_RAY_NODE_TYPE: NODE_TYPE_WORKER
+        })
     finally:
         provider.cleanup()
 

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -446,7 +446,7 @@ def rsync(config_file,
           target,
           override_cluster_name,
           down,
-          sync_workers=False):
+          all_nodes=False):
     """Rsyncs files.
 
     Arguments:
@@ -455,7 +455,7 @@ def rsync(config_file,
         target: target dir
         override_cluster_name: set the name of the cluster
         down: whether we're syncing remote -> local
-        sync_workers: whether to sync worker nodes in addition to the head node
+        all_nodes: whether to sync worker nodes in addition to the head node
     """
     assert bool(source) == bool(target), (
         "Must either provide both or neither source and target.")
@@ -468,7 +468,7 @@ def rsync(config_file,
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:
         nodes = []
-        if sync_workers:
+        if all_nodes:
             # technically we re-open the provider for no reason
             # in get_worker_nodes but it's cleaner this way
             # and _get_head_node does this too

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -441,7 +441,11 @@ def _exec(updater, cmd, screen, tmux, port_forward=None):
             port_forward=port_forward)
 
 
-def rsync(config_file, source, target, override_cluster_name, down,
+def rsync(config_file,
+          source,
+          target,
+          override_cluster_name,
+          down,
           sync_workers=False):
     """Rsyncs files.
 
@@ -465,13 +469,18 @@ def rsync(config_file, source, target, override_cluster_name, down,
     try:
         nodes = []
         if sync_workers:
-            # technically we re-open the provider for no reason in get_worker_nodes
-            # but it's cleaner this way and _get_head_node does this too
+            # technically we re-open the provider for no reason
+            # in get_worker_nodes but it's cleaner this way
+            # and _get_head_node does this too
             nodes = _get_worker_nodes(config, override_cluster_name)
 
-        nodes += [_get_head_node(
-            config, config_file, override_cluster_name,
-            create_if_needed=False)]
+        nodes += [
+            _get_head_node(
+                config,
+                config_file,
+                override_cluster_name,
+                create_if_needed=False)
+        ]
 
         for node_id in nodes:
             updater = NodeUpdaterThread(
@@ -539,6 +548,7 @@ def get_worker_node_ips(config_file, override_cluster_name):
             return [provider.external_ip(node) for node in nodes]
     finally:
         provider.cleanup()
+
 
 def _get_worker_nodes(config, override_cluster_name):
     """Returns worker node ids for given configuration."""

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -654,7 +654,12 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     required=False,
     help="Upload to workers as well as the head node.")
 def rsync_up(cluster_config_file, source, target, cluster_name, sync_workers):
-    rsync(cluster_config_file, source, target, cluster_name, down=False,
+    rsync(
+        cluster_config_file,
+        source,
+        target,
+        cluster_name,
+        down=False,
         sync_workers=sync_workers)
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -647,8 +647,15 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     required=False,
     type=str,
     help="Override the configured cluster name.")
-def rsync_up(cluster_config_file, source, target, cluster_name):
-    rsync(cluster_config_file, source, target, cluster_name, down=False)
+@click.option(
+    "--sync-workers",
+    "-sw",
+    is_flag=True,
+    required=False,
+    help="Upload to workers as well as the head node.")
+def rsync_up(cluster_config_file, source, target, cluster_name, sync_workers):
+    rsync(cluster_config_file, source, target, cluster_name, down=False,
+        sync_workers=sync_workers)
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -648,19 +648,19 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     type=str,
     help="Override the configured cluster name.")
 @click.option(
-    "--sync-workers",
-    "-sw",
+    "--all-nodes",
+    "-A",
     is_flag=True,
     required=False,
-    help="Upload to workers as well as the head node.")
-def rsync_up(cluster_config_file, source, target, cluster_name, sync_workers):
+    help="Upload to all nodes (workers and head).")
+def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes):
     rsync(
         cluster_config_file,
         source,
         target,
         cluster_name,
         down=False,
-        sync_workers=sync_workers)
+        all_nodes=all_nodes)
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Added new flag `--all-nodes` (`-A`) to `rsync-up`. This will sync with workers in addition to the head node.

## Related issue number
Closes #6693 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
