### PR TITLE
[tune] Better warm-start support

### DIFF
--- a/doc/source/tune-usage.rst
+++ b/doc/source/tune-usage.rst
@@ -407,6 +407,25 @@ The checkpoint will be saved at a path that looks like ``local_dir/exp_name/tria
         config={"env": "CartPole-v0"},
     )
 
+Additionally, Tune sampling operators (``tune.choice``, ``tune.grid_search``) can be used. For initialization-sensitive problems, you can use this to *warmstart* one or more trials from an existing, favorably-initialized population.
+
+.. code-block:: python
+
+    # Paths to checkpoints that have favorable training dynamics
+    known_good_checkpoints = [
+        "~/ray_results/Original/PG_<xxx>/checkpoint_15/checkpoint-15",
+        "~/ray_results/Original/PG_<yyy>/checkpoint_5/checkpoint-5",
+        "~/ray_results/Original/PG_<zzz>/checkpoint_10/checkpoint-10",
+    ]
+    tune.run(
+        "PG",
+        num_samples=64, # train a population
+        name="SomeDifficultProblem",
+        stop={"training_iteration": 20},
+        restore=tune.choice(known_good_checkpoints), # sample randomly
+        config={"env": "CartPole-v0"},
+    )
+
 Fault Tolerance
 ---------------
 

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -170,6 +170,9 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
     if "resources_per_trial" in spec:
         trial_kwargs["resources"] = json_to_resources(
             spec["resources_per_trial"])
+    restore_path = spec.get("restore")
+    if restore_path:
+        restore_path = os.path.abspath(os.path.expanduser(restore))
     return Trial(
         # Submitting trial via server in py2.7 creates Unicode, which does not
         # convert to string in a straightforward manner.
@@ -187,7 +190,7 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
         checkpoint_score_attr=args.checkpoint_score_attr,
         export_formats=spec.get("export_formats", []),
         # str(None) doesn't create None
-        restore_path=spec.get("restore"),
+        restore_path=restore_path,
         trial_name_creator=spec.get("trial_name_creator"),
         loggers=spec.get("loggers"),
         # str(None) doesn't create None

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -172,7 +172,7 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
             spec["resources_per_trial"])
     restore_path = spec.get("restore")
     if restore_path:
-        restore_path = os.path.abspath(os.path.expanduser(restore))
+        restore_path = os.path.abspath(os.path.expanduser(restore_path))
     return Trial(
         # Submitting trial via server in py2.7 creates Unicode, which does not
         # convert to string in a straightforward manner.

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -155,8 +155,7 @@ class Experiment:
             "checkpoint_score_attr": checkpoint_score_attr,
             "export_formats": export_formats or [],
             "max_failures": max_failures,
-            "restore": os.path.abspath(os.path.expanduser(restore))
-            if restore else None
+            "restore": restore,
         }
         self.spec = spec
 

--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -73,7 +73,7 @@ class WarmStartTest(unittest.TestCase):
             checkpoint_path = os.path.join(trial.logdir,
                                            "checkpoint_1/checkpoint-1")
             self.assertTrue(os.path.isfile(checkpoint_path))
-            checkpoint_path.append(checkpoint_path)
+            checkpoint_paths.append(checkpoint_path)
 
         return trials, checkpoint_paths
 

--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -57,6 +57,7 @@ class WarmStartTest(unittest.TestCase):
                 "training_iteration": 1
             },
             checkpoint_freq=1,
+            checkpoint_at_end=True,
             local_dir=absolute_local_dir,
             config={
                 "env": "CartPole-v0",

--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -11,6 +11,123 @@ from ray.rllib import _register_all
 from ray.tune import Trainable
 
 
+class WarmStartTest(unittest.TestCase):
+    local_mode = True
+
+    class MockTrainable(Trainable):
+        _name = "MockTrainable"
+
+        def _setup(self, config):
+            self.state = {"hi": 1}
+
+        def _train(self):
+            return {"timesteps_this_iter": 1, "done": True}
+
+        def _save(self, checkpoint_dir):
+            checkpoint_path = os.path.join(
+                checkpoint_dir, "checkpoint-{}".format(self._iteration))
+            with open(checkpoint_path, "wb") as f:
+                pickle.dump(self.state, f)
+            return checkpoint_path
+
+        def _restore(self, checkpoint_path):
+            with open(checkpoint_path, "rb") as f:
+                extra_data = pickle.load(f)
+            self.state.update(extra_data)
+
+    def setUp(self):
+        ray.init(num_cpus=1, num_gpus=0, local_mode=self.local_mode)
+
+    def tearDown(self):
+        shutil.rmtree(self.absolute_local_dir, ignore_errors=True)
+        self.absolute_local_dir = None
+        ray.shutdown()
+        # Without this line, test_tune_server.testAddTrial would fail.
+        _register_all()
+
+    def _train(self,
+               exp_name,
+               local_dir,
+               absolute_local_dir,
+               num_samples=1,
+               restore=None):
+        trials = tune.run(
+            self.MockTrainable,
+            num_samples=num_samples,
+            restore=restore,
+            name=exp_name,
+            stop={
+                "training_iteration": 1
+            },
+            checkpoint_freq=1,
+            local_dir=local_dir,
+            config={
+                "env": "CartPole-v0",
+                "log_level": "DEBUG"
+            }).trials
+
+        exp_dir = os.path.join(absolute_local_dir, exp_name)
+
+        checkpoint_paths = []
+
+        for trial in trials:
+            self.assertIsNone(trial.error_file)
+            self.assertEqual(trial.local_dir, exp_dir)
+            checkpoint_path = os.path.join(trial.logdir,
+                                           "checkpoint_1/checkpoint-1")
+            self.assertTrue(os.path.isfile(checkpoint_path))
+            checkpoint_path.append(checkpoint_path)
+
+        return trials, checkpoint_paths
+
+    def testSimpleRestore(self):
+        # test base functionality of restore=<path_to_checkpoint>
+        exp_name = self.prefix + "SimpleRestore"
+        local_dir = "./test_simple_restore"
+        absolute_local_dir = os.path.abspath(local_dir)
+        self.assertFalse(os.path.exists(absolute_local_dir))
+        trials, paths_to_checkpoints = self._train(
+            exp_name,
+            local_dir=local_dir,
+            absolute_local_dir=absolute_local_dir)
+        new_trials, new_paths_to_checkpoints = self._train(
+            exp_name,
+            local_dir=local_dir,
+            absolute_local_dir=absolute_local_dir,
+            restore=paths_to_checkpoints[0])
+        # ensure the restored trial was given a new ID
+        self.assertNotEqual(trials[0].trial_id, new_trials[0].trial_id)
+        # the new trial's name should have restore=<reference_to_restored_trial>
+        self.assertTrue('restore=' in new_paths_to_checkpoints[0])
+        self.assertTrue(trials[0].trial_id in new_paths_to_checkpoints[0])
+
+    def testWarmStartGridSearch(self):
+        exp_name = self.prefix + "WarmStartGridSearch"
+        local_dir = "./warm_start_grid_search"
+        absolute_local_dir = os.path.abspath(local_dir)
+        self.assertFalse(os.path.exists(absolute_local_dir))
+        # train a small number of trials
+        trials, paths_to_checkpoints = self._train(
+            exp_name,
+            local_dir=local_dir,
+            absolute_local_dir=absolute_local_dir,
+            num_samples=4)
+        # start a new set of trials using the checkpoints
+        # as a starting point
+        new_trials, new_checkpoints = self._train(
+            exp_name, restore=tune.grid_search(paths_to_checkpoints))
+        for old_trial, old_checkpoint in zip(trials, paths_to_checkpoints):
+            used = False
+            for new_trial, new_checkpoint in zip(new_trials, new_checkpoints):
+                self.assertNotEqual(old_trial.trial_id, new_trial.trial_id)
+                self.assertTrue('restore=' in new_checkpoint)
+                if old_trial.trial_id in new_checkpoint:
+                    used = True
+                    break
+            self.assertTrue(
+                used, 'checkpoint {} not used in grid_search' % old_checkpoint)
+
+
 class SerialTuneRelativeLocalDirTest(unittest.TestCase):
     local_mode = True
     prefix = "Serial"

--- a/python/ray/tune/tests/test_tune_save_restore.py
+++ b/python/ray/tune/tests/test_tune_save_restore.py
@@ -93,7 +93,8 @@ class WarmStartTest(unittest.TestCase):
             restore=paths_to_checkpoints[0])
         # ensure the restored trial was given a new ID
         self.assertNotEqual(trials[0].trial_id, new_trials[0].trial_id)
-        # the new trial's name should have restore=<reference_to_restored_trial>
+        # the new trial's name should have
+        # restore=<reference_to_restored_trial>
         self.assertTrue("restore=" in new_paths_to_checkpoints[0])
         self.assertTrue(trials[0].trial_id in new_paths_to_checkpoints[0])
 

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -174,8 +174,8 @@ def run(run_or_experiment,
             Ray will recover from the latest checkpoint if present.
             Setting to -1 will lead to infinite recovery retries.
             Setting to 0 will disable retries. Defaults to 3.
-        restore (str): Path to checkpoint. Only makes sense to set if
-            running 1 trial. Defaults to None.
+        restore (str): Path to checkpoint. Used to initialize state for new trials.
+            Can be used with tune.choice() to initialize a population. Defaults to None.
         search_alg (SearchAlgorithm): Search Algorithm. Defaults to
             BasicVariantGenerator.
         scheduler (TrialScheduler): Scheduler for executing

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -175,7 +175,8 @@ def run(run_or_experiment,
             Setting to -1 will lead to infinite recovery retries.
             Setting to 0 will disable retries. Defaults to 3.
         restore (str): Path to checkpoint. Used to initialize state for new trials.
-            Can be used with tune.choice() to initialize a population. Defaults to None.
+            Can be used with Tune sampling operators (``tune.choice``, 
+            ``tune.grid_search``). Defaults to None.
         search_alg (SearchAlgorithm): Search Algorithm. Defaults to
             BasicVariantGenerator.
         scheduler (TrialScheduler): Scheduler for executing

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -174,9 +174,9 @@ def run(run_or_experiment,
             Ray will recover from the latest checkpoint if present.
             Setting to -1 will lead to infinite recovery retries.
             Setting to 0 will disable retries. Defaults to 3.
-        restore (str): Path to checkpoint. Used to initialize state for new trials.
-            Can be used with Tune sampling operators (``tune.choice``, 
-            ``tune.grid_search``). Defaults to None.
+        restore (str): Path to checkpoint. Used to initialize state for
+            new trials. Can be used with Tune sampling operators
+            (``tune.choice``, ``tune.grid_search``). Defaults to None.
         search_alg (SearchAlgorithm): Search Algorithm. Defaults to
             BasicVariantGenerator.
         scheduler (TrialScheduler): Scheduler for executing


### PR DESCRIPTION
## Why are these changes needed?
Currently, the `restore` argument of `tune.run` only takes a single trial. When the training task is sensitive to initialization, it can be useful to initialize a population's weights from a population of working models. This is to avoid scenarios where a significant portion of trials are "dead" right from the beginning due to poor initialization. This change permits the use of `tune.run(restore=tune.choice(my_list_of_checkpoints))`, as per @richardliaw's suggestion (thanks!)

The work entailed removing the path resolution from `restore`, which required it be a string. I have only tested with absolute paths, and this removal may prevent use of relative paths. This concern needs addressing.

### Additional notes
New trials created with particularly ugly names:
```
~/ray_results/PPO$ ls
experiment_state-2020-02-05_22-28-43.json
experiment_state-2020-02-05_23-13-23.json
experiment_state-2020-02-06_14-42-39.json
experiment_state-2020-02-06_15-33-35.json
PPO_MyEnv_09b61f96_0_restore=_restore_PPO_PPO_MyEnv_4b3d3a46_2020-02-04_22-47-17x1p6dcm6_checkpoint_200_checkpoint-200_2020-02-06_15-33-36umu05v_h
PPO_MyEnv_09b8c4bc_1_restore=_restore_PPO_PPO_MyEnv_4b46f572_2020-02-05_05-49-14kfpsvc1v_checkpoint_200_checkpoint-200_2020-02-06_15-33-36rxrol44w
PPO_MyEnv_09b97f38_2_restore=_restore_PPO_PPO_MyEnv_4b489422_2020-02-05_12-52-415hjqghl6_checkpoint_200_checkpoint-200_2020-02-06_15-33-36lw64jt7x
PPO_MyEnv_09ba13c6_3_restore=_restore_PPO_PPO_MyEnv_4b4913de_2020-02-05_12-55-12kzzf6dcn_checkpoint_200_checkpoint-200_2020-02-06_15-33-37b7trculd
PPO_MyEnv_09bcbc84_4_restore=_restore_PPO_PPO_MyEnv_4b403caa_2020-02-04_22-47-179k2l_6a3_checkpoint_200_checkpoint-200_2020-02-06_15-33-37qfzb169_
```

Presumably, the name will grow every time this process is repeated. I personally do not like that the restore path is inserted into the trial name, and would much prefer this information be available in a json file. Please inform.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
*I'm having difficulty with this one on MacOS.*

- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
*Inline comments are changed for `tune.run`, will make changes to docs upon request.*

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
*Currently running - meant to create this PR on my master but created it on the official.*
