### PR TITLE
Do not expose task argument ObjectIDs to python to avoid early GC

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -303,8 +303,8 @@ cdef void prepare_args(
             else:
                 args_vector.push_back(
                     CTaskArg.PassByReference(
-                        (<ObjectID>core_worker.put_serialized_object(
-                            serialized_arg)).native()))
+                        (CObjectID.FromBinary(core_worker.put_serialized_cobject(
+                            serialized_arg)))))
 
 cdef deserialize_args(
         const c_vector[shared_ptr[CRayObject]] &c_args,
@@ -689,6 +689,11 @@ cdef class CoreWorker:
     def put_serialized_object(self, serialized_object,
                               ObjectID object_id=None,
                               c_bool pin_object=True):
+        return ObjectID(self.put_serialized_cobject(serialized_object, object_id, pin_object))
+
+    def put_serialized_cobject(self, serialized_object,
+                              ObjectID object_id=None,
+                              c_bool pin_object=True):
         cdef:
             CObjectID c_object_id
             shared_ptr[CBuffer] data
@@ -710,7 +715,7 @@ cdef class CoreWorker:
                     self.core_worker.get().Seal(
                         c_object_id, pin_object and object_id is None))
 
-        return ObjectID(c_object_id.Binary())
+        return c_object_id.Binary()
 
     def wait(self, object_ids, int num_returns, int64_t timeout_ms,
              TaskID current_task_id):

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -195,17 +195,13 @@ def test_pending_task_dependency_pinning(shutdown_only):
     def pending(input1, input2):
         return
 
-    @ray.remote
-    def slow(dep):
-        pass
-
     # The object that is ray.put here will go out of scope immediately, so if
     # pending task dependencies aren't considered, it will be evicted before
     # the ray.get below due to the subsequent ray.puts that fill up the object
     # store.
     np_array = np.zeros(40 * 1024 * 1024, dtype=np.uint8)
     random_id = ray.ObjectID.from_random()
-    oid = pending.remote(np_array, slow.remote(random_id))
+    oid = pending.remote(np_array, random_id)
 
     for _ in range(2):
         ray.put(np_array)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When preparing the arguments for a task submission, any large objects will be `ray.put()` and then attached as an ObjectID. Normally, we want to pin these objects until we are sure that the submitted task has finished. We do this by incrementing their ref count on task submission and decrementing when the task finishes.

When attaching the arg to the task spec, the code currently creates a Python reference to the ObjectID and immediately destroys it. This happens before we increment the ref count during task submission, so we end up with a ref count of 0, and we evict the object before the task has been submitted.

This PR fixes it so that we do not create the temporary Python reference when attaching the arg.

## Related issue number

No related issue open, but this should fix the flaky test `test_reference_counting.py::test_pending_task_dependency_pinning`. Confirmed the bug and fix by adding a gc.collect() call after attaching the task arguments.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
