### PR TITLE
Make sure pre-push is executable.

### DIFF
--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-chmod 0755 $PWD/scripts/pre-push
+chmod +x $PWD/scripts/pre-push
 ln -s $PWD/scripts/pre-push $PWD/.git/hooks/pre-push

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+chmod 0755 $PWD/scripts/pre-push
 ln -s $PWD/scripts/pre-push $PWD/.git/hooks/pre-push


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

When pushing commits through PyCharm, no warning/error is shown when pre-push cannot be run (to auto-LINT all cadges made), b/c it's not executable. Add chmod to setup_hooks.sh

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
