### PR TITLE
Enable GCS server when running python unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=master bash)"
       script:
-        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
-        - ./java/test.sh
+#        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+#        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
+#        - ./java/test.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/tests/...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
 
     - os: linux
       env:
-        - TESTSUITE=gcs service python testcase
+        - TESTSUITE=gcs_service_python_testcase
         - JDK='Oracle JDK 8'
         - RAY_GCS_SERVICE_ENABLED=true
         - PYTHON=3.6 PYTHONWARNINGS=ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,13 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-dependencies.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/suppress_output ./ci/travis/install-ray.sh
+        - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=master bash)"
       script:
 #        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
 #        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
 #        - ./java/test.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/tests/...
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,23 @@ matrix:
         - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
         - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
         - ./java/test.sh
+
+    - os: linux
+      env:
+        - TESTSUITE=gcs service python testcase
+        - JDK='Oracle JDK 8'
+        - RAY_GCS_SERVICE_ENABLED=true
+        - PYTHON=3.6 PYTHONWARNINGS=ignore
+        - RAY_INSTALL_JAVA=1
+      install:
+        - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
+        - ./ci/travis/install-bazel.sh
+        - ./ci/suppress_output ./ci/travis/install-dependencies.sh
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - ./ci/suppress_output ./ci/travis/install-ray.sh
+        - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
+        - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=master bash)"
+      script:
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/tests/...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
         - ./ci/suppress_output ./ci/travis/install-cython-examples.sh
         - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=master bash)"
       script:
-#        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-#        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
-#        - ./java/test.sh
+        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
+        - ./java/test.sh
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/tests/...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,10 @@ matrix:
         - export PATH="$HOME/miniconda/bin:$PATH"
         - ./ci/suppress_output ./ci/travis/install-ray.sh
       script:
-        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
-        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
-        - ./java/test.sh
+#        - ./ci/suppress_output bash src/ray/test/run_core_worker_tests.sh
+#        - ./ci/suppress_output bash streaming/src/test/run_streaming_queue_test.sh
+#        - ./java/test.sh
+        - ./ci/keep_alive bazel test --spawn_strategy=local --flaky_test_attempts=3 --nocache_test_results --test_verbose_timeout_warnings --progress_report_interval=100 --show_progress_rate_limit=100 --show_timestamps --test_output=errors --test_tag_filters=-jenkins_only python/ray/tests/...
 
     - os: linux
       env: LINT=1 PYTHONWARNINGS=ignore

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -609,7 +609,7 @@ class Node:
         # If this is the head node, start the relevant head node processes.
         self.start_redis()
 
-        if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+        if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
             self.start_gcs_server()
 
         self.start_monitor()

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -205,5 +205,5 @@ NODE_DEFAULT_IP = "127.0.0.1"
 MACH_PAGE_SIZE_BYTES = 4096
 
 # RAY_GCS_SERVICE_ENABLED only set in ci job.
-#TODO(ffbin): Once we entirely migrate to service-based GCS, we should remove it.
+# TODO(ffbin): Once we entirely migrate to service-based GCS, we should remove it.
 RAY_GCS_SERVICE_ENABLED = "RAY_GCS_SERVICE_ENABLED"

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -205,5 +205,6 @@ NODE_DEFAULT_IP = "127.0.0.1"
 MACH_PAGE_SIZE_BYTES = 4096
 
 # RAY_GCS_SERVICE_ENABLED only set in ci job.
-# TODO(ffbin): Once we entirely migrate to service-based GCS, we should remove it.
+# TODO(ffbin): Once we entirely migrate to service-based GCS, we should
+# remove it.
 RAY_GCS_SERVICE_ENABLED = "RAY_GCS_SERVICE_ENABLED"

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -203,3 +203,7 @@ NODE_DEFAULT_IP = "127.0.0.1"
 
 # The Mach kernel page size in bytes.
 MACH_PAGE_SIZE_BYTES = 4096
+
+# RAY_GCS_SERVICE_ENABLED only set in ci job.
+#TODO(ffbin): Once we entirely migrate to service-based GCS, we should remove it.
+RAY_GCS_SERVICE_ENABLED = "RAY_GCS_SERVICE_ENABLED"

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -83,6 +83,7 @@ def test_driver_lives_sequential(ray_start_regular):
     ray.worker._global_node.kill_log_monitor()
     ray.worker._global_node.kill_monitor()
     ray.worker._global_node.kill_raylet_monitor()
+    ray.worker._global_node.kill_gcs_server()
 
     # If the driver can reach the tearDown method, then it is still alive.
 
@@ -93,11 +94,12 @@ def test_driver_lives_sequential(ray_start_regular):
 def test_driver_lives_parallel(ray_start_regular):
     all_processes = ray.worker._global_node.all_processes
     process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
+                     all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +
                      all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
                      all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
                      all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
                      all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
-    assert len(process_infos) == 5
+    assert len(process_infos) == 6
 
     # Kill all the components in parallel.
     for process_info in process_infos:

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -83,7 +83,9 @@ def test_driver_lives_sequential(ray_start_regular):
     ray.worker._global_node.kill_log_monitor()
     ray.worker._global_node.kill_monitor()
     ray.worker._global_node.kill_raylet_monitor()
-    ray.worker._global_node.kill_gcs_server()
+
+    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+        ray.worker._global_node.kill_gcs_server()
 
     # If the driver can reach the tearDown method, then it is still alive.
 
@@ -95,19 +97,21 @@ def test_driver_lives_parallel(ray_start_regular):
     all_processes = ray.worker._global_node.all_processes
 
     if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
-        process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
-                         all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +
-                         all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
-                         all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
-                         all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
-                         all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
+        process_infos = (
+            all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
+            all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +
+            all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
+            all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
+            all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
+            all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
         assert len(process_infos) == 6
     else:
-        process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
-                         all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
-                         all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
-                         all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
-                         all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
+        process_infos = (
+            all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
+            all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
+            all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
+            all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
+            all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
         assert len(process_infos) == 5
 
     # Kill all the components in parallel.

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -93,13 +93,22 @@ def test_driver_lives_sequential(ray_start_regular):
     reason="Hanging with new GCS API.")
 def test_driver_lives_parallel(ray_start_regular):
     all_processes = ray.worker._global_node.all_processes
-    process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
-                     all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +
-                     all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
-                     all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
-                     all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
-                     all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
-    assert len(process_infos) == 6
+
+    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+        process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
+                         all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +
+                         all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
+                         all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
+                         all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
+                         all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
+        assert len(process_infos) == 6
+    else:
+        process_infos = (all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
+                         all_processes[ray_constants.PROCESS_TYPE_RAYLET] +
+                         all_processes[ray_constants.PROCESS_TYPE_LOG_MONITOR] +
+                         all_processes[ray_constants.PROCESS_TYPE_MONITOR] +
+                         all_processes[ray_constants.PROCESS_TYPE_RAYLET_MONITOR])
+        assert len(process_infos) == 5
 
     # Kill all the components in parallel.
     for process_info in process_infos:

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -84,7 +84,7 @@ def test_driver_lives_sequential(ray_start_regular):
     ray.worker._global_node.kill_monitor()
     ray.worker._global_node.kill_raylet_monitor()
 
-    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+    if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
         ray.worker._global_node.kill_gcs_server()
 
     # If the driver can reach the tearDown method, then it is still alive.
@@ -96,7 +96,7 @@ def test_driver_lives_sequential(ray_start_regular):
 def test_driver_lives_parallel(ray_start_regular):
     all_processes = ray.worker._global_node.all_processes
 
-    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+    if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
         process_infos = (
             all_processes[ray_constants.PROCESS_TYPE_PLASMA_STORE] +
             all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER] +

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -102,7 +102,8 @@ def test_raylet_tempfiles(shutdown_only):
         "log_monitor.out", "log_monitor.err", "plasma_store.out",
         "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
         "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-        "redis.out", "redis.err", "raylet.out", "raylet.err"
+        "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
+        "gcs_server.err"
     })  # with raylet logs
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
     assert socket_files == {"plasma_store", "raylet"}
@@ -118,7 +119,8 @@ def test_raylet_tempfiles(shutdown_only):
         "log_monitor.out", "log_monitor.err", "plasma_store.out",
         "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
         "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-        "redis.out", "redis.err", "raylet.out", "raylet.err"
+        "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
+        "gcs_server.err"
     })  # with raylet logs
 
     # Check numbers of worker log file.

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -99,23 +99,18 @@ def test_raylet_tempfiles(shutdown_only):
     top_levels = set(os.listdir(node.get_session_dir_path()))
     assert top_levels.issuperset({"sockets", "logs"})
     log_files = set(os.listdir(node.get_logs_dir_path()))
+    log_files_expected = {
+        "log_monitor.out", "log_monitor.err", "plasma_store.out",
+        "plasma_store.err", "monitor.out", "monitor.err",
+        "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
+        "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
+        "raylet.err"
+    }
 
     if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
-        assert log_files.issuperset({
-            "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err",
-            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
-            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
-            "raylet.err", "gcs_server.out", "gcs_server.err"
-        })  # with raylet logs
-    else:
-        assert log_files.issuperset({
-            "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err",
-            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
-            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
-            "raylet.err"
-        })  # with raylet logs
+        log_files_expected.update({"gcs_server.out", "gcs_server.err"})
+
+    assert log_files.issuperset(log_files_expected)
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
     assert socket_files == {"plasma_store", "raylet"}

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -102,17 +102,18 @@ def test_raylet_tempfiles(shutdown_only):
     if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-            "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
-            "gcs_server.err"
+            "plasma_store.err", "monitor.out", "monitor.err",
+            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
+            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
+            "raylet.err", "gcs_server.out", "gcs_server.err"
         })  # with raylet logs
     else:
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-            "redis.out", "redis.err", "raylet.out", "raylet.err"
+            "plasma_store.err", "monitor.out", "monitor.err",
+            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
+            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
+            "raylet.err"
         })  # with raylet logs
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
@@ -129,17 +130,18 @@ def test_raylet_tempfiles(shutdown_only):
     if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-            "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
-            "gcs_server.err"
+            "plasma_store.err", "monitor.out", "monitor.err",
+            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
+            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
+            "raylet.err", "gcs_server.out", "gcs_server.err"
         })  # with raylet logs
     else:
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-            "redis.out", "redis.err", "raylet.out", "raylet.err"
+            "plasma_store.err", "monitor.out", "monitor.err",
+            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
+            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
+            "raylet.err"
         })  # with raylet logs
 
     # Check numbers of worker log file.

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -3,6 +3,7 @@ import shutil
 import time
 import pytest
 import ray
+import ray.ray_constants as ray_constants
 from ray.cluster_utils import Cluster
 
 
@@ -99,7 +100,7 @@ def test_raylet_tempfiles(shutdown_only):
     assert top_levels.issuperset({"sockets", "logs"})
     log_files = set(os.listdir(node.get_logs_dir_path()))
 
-    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+    if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
             "plasma_store.err", "monitor.out", "monitor.err",
@@ -127,7 +128,7 @@ def test_raylet_tempfiles(shutdown_only):
     time.sleep(3)  # wait workers to start
     log_files = set(os.listdir(node.get_logs_dir_path()))
 
-    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+    if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
         assert log_files.issuperset({
             "log_monitor.out", "log_monitor.err", "plasma_store.out",
             "plasma_store.err", "monitor.out", "monitor.err",

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -101,10 +101,9 @@ def test_raylet_tempfiles(shutdown_only):
     log_files = set(os.listdir(node.get_logs_dir_path()))
     log_files_expected = {
         "log_monitor.out", "log_monitor.err", "plasma_store.out",
-        "plasma_store.err", "monitor.out", "monitor.err",
-        "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
-        "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
-        "raylet.err"
+        "plasma_store.err", "monitor.out", "monitor.err","raylet_monitor.out",
+        "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
+        "redis.out", "redis.err", "raylet.out", "raylet.err"
     }
 
     if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -101,7 +101,7 @@ def test_raylet_tempfiles(shutdown_only):
     log_files = set(os.listdir(node.get_logs_dir_path()))
     log_files_expected = {
         "log_monitor.out", "log_monitor.err", "plasma_store.out",
-        "plasma_store.err", "monitor.out", "monitor.err","raylet_monitor.out",
+        "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
         "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
         "redis.out", "redis.err", "raylet.out", "raylet.err"
     }

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -122,22 +122,7 @@ def test_raylet_tempfiles(shutdown_only):
     time.sleep(3)  # wait workers to start
     log_files = set(os.listdir(node.get_logs_dir_path()))
 
-    if os.environ.get(ray_constants.RAY_GCS_SERVICE_ENABLED, None):
-        assert log_files.issuperset({
-            "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err",
-            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
-            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
-            "raylet.err", "gcs_server.out", "gcs_server.err"
-        })  # with raylet logs
-    else:
-        assert log_files.issuperset({
-            "log_monitor.out", "log_monitor.err", "plasma_store.out",
-            "plasma_store.err", "monitor.out", "monitor.err",
-            "raylet_monitor.out", "raylet_monitor.err", "redis-shard_0.out",
-            "redis-shard_0.err", "redis.out", "redis.err", "raylet.out",
-            "raylet.err"
-        })  # with raylet logs
+    assert log_files.issuperset(log_files_expected)
 
     # Check numbers of worker log file.
     assert sum(

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -98,13 +98,23 @@ def test_raylet_tempfiles(shutdown_only):
     top_levels = set(os.listdir(node.get_session_dir_path()))
     assert top_levels.issuperset({"sockets", "logs"})
     log_files = set(os.listdir(node.get_logs_dir_path()))
-    assert log_files.issuperset({
-        "log_monitor.out", "log_monitor.err", "plasma_store.out",
-        "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-        "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-        "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
-        "gcs_server.err"
-    })  # with raylet logs
+
+    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+        assert log_files.issuperset({
+            "log_monitor.out", "log_monitor.err", "plasma_store.out",
+            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
+            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
+            "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
+            "gcs_server.err"
+        })  # with raylet logs
+    else:
+        assert log_files.issuperset({
+            "log_monitor.out", "log_monitor.err", "plasma_store.out",
+            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
+            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
+            "redis.out", "redis.err", "raylet.out", "raylet.err"
+        })  # with raylet logs
+
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
     assert socket_files == {"plasma_store", "raylet"}
     ray.shutdown()
@@ -115,13 +125,22 @@ def test_raylet_tempfiles(shutdown_only):
     assert top_levels.issuperset({"sockets", "logs"})
     time.sleep(3)  # wait workers to start
     log_files = set(os.listdir(node.get_logs_dir_path()))
-    assert log_files.issuperset({
-        "log_monitor.out", "log_monitor.err", "plasma_store.out",
-        "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
-        "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
-        "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
-        "gcs_server.err"
-    })  # with raylet logs
+
+    if os.environ.get("RAY_GCS_SERVICE_ENABLED", None):
+        assert log_files.issuperset({
+            "log_monitor.out", "log_monitor.err", "plasma_store.out",
+            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
+            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
+            "redis.out", "redis.err", "raylet.out", "raylet.err", "gcs_server.out",
+            "gcs_server.err"
+        })  # with raylet logs
+    else:
+        assert log_files.issuperset({
+            "log_monitor.out", "log_monitor.err", "plasma_store.out",
+            "plasma_store.err", "monitor.out", "monitor.err", "raylet_monitor.out",
+            "raylet_monitor.err", "redis-shard_0.out", "redis-shard_0.err",
+            "redis.out", "redis.err", "raylet.out", "raylet.err"
+        })  # with raylet logs
 
     # Check numbers of worker log file.
     assert sum(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Enable GCS server when running python unit tests.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
