### PR TITLE
[tune] [WIP] Function fault tolerance

### DIFF
--- a/python/ray/tune/examples/fault_tolerant_function_example.py
+++ b/python/ray/tune/examples/fault_tolerant_function_example.py
@@ -1,0 +1,94 @@
+import argparse
+import cloudpickle
+import numpy as np
+import time
+import logging
+
+import ray
+from ray import tune
+from ray.tune import track
+
+logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
+
+
+class OptimusFn(object):
+    def __init__(self, params, max_t=10000):
+        self.params = params
+        self.noise = np.random.normal(size=max_t) * 0.005
+
+    def eval(self, k, add_noise=True):
+        b0, b1, b2 = self.params
+        score = (b0 * k / 100 + 0.1 * b1 + 0.5)**(-1) + b2 * 0.01
+        if add_noise:
+            return score + abs(self.noise[k])
+        else:
+            return score
+
+
+CHECKPOINT_FREQ = 10
+TRAINING_ITERS = 1000
+
+
+def train(config):
+    if track.is_pending_restore():
+        # Handle restoration.
+        checkpoint = track.restore()
+        func = cloudpickle.loads(checkpoint["func"])
+        mock_data = checkpoint["data"]
+        cur_i = checkpoint["iter"]
+        np.random.set_state(checkpoint["seed"])
+    else:
+        # Handle initialization.
+        params = [config["param1"], config["param2"], config["param3"]]
+        func = OptimusFn(params=params)
+        mock_data = open("/dev/urandom", "rb").read(1024)
+        cur_i = 0
+
+    for i in range(cur_i, TRAINING_ITERS):
+        new_loss = func.eval(i)
+        time.sleep(0.5)
+
+        if i % CHECKPOINT_FREQ == 0:
+            checkpoint = {
+                "func": cloudpickle.dumps(func),
+                "seed": np.random.get_state(),
+                "data": mock_data,
+                "iter": i,
+            }
+        else:
+            checkpoint = None
+
+        track.log(
+            mean_loss=float(new_loss),
+            mean_accuracy=(2 - new_loss) / 2,
+            **{track.SAVE: checkpoint},
+        )
+
+
+def parse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local", action="store_true", default=False)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse()
+    address = None if args.local else "auto"
+    ray.init(address=address)
+
+    config = {
+        "param1": tune.sample_from(lambda spec: np.random.exponential(0.1)),
+        "param2": tune.sample_from(lambda _: np.random.rand()),
+        "param3": tune.sample_from(lambda _: np.random.rand()),
+    }
+
+    analysis = tune.run(
+        train,
+        name="durableTrainable" + str(time.time()),
+        config=config,
+        num_samples=1,
+        verbose=2,
+        queue_trials=True,
+        max_failures=-1,
+    )

--- a/python/ray/tune/examples/fault_tolerant_function_example.py
+++ b/python/ray/tune/examples/fault_tolerant_function_example.py
@@ -1,19 +1,16 @@
 import argparse
 import cloudpickle
 import numpy as np
-import os
 import time
-import logging
 
 import ray
 from ray import tune
 from ray.tune import track
 
-logger = logging.getLogger(__name__)
-logger.setLevel("INFO")
-
 
 class OptimusFn(object):
+    """Simulate learning."""
+
     def __init__(self, params, max_t=10000):
         self.params = params
         self.noise = np.random.normal(size=max_t) * 0.005
@@ -86,10 +83,10 @@ if __name__ == "__main__":
 
     analysis = tune.run(
         train,
-        name="durableTrainable" + str(time.time()),
+        name="ft_func" + str(time.time()),
         config=config,
-        num_samples=1,
-        verbose=2,
+        num_samples=4,
+        verbose=1,
         queue_trials=True,
         max_failures=-1,
     )

--- a/python/ray/tune/examples/fault_tolerant_function_example.py
+++ b/python/ray/tune/examples/fault_tolerant_function_example.py
@@ -1,6 +1,7 @@
 import argparse
 import cloudpickle
 import numpy as np
+import os
 import time
 import logging
 
@@ -17,7 +18,8 @@ class OptimusFn(object):
         self.params = params
         self.noise = np.random.normal(size=max_t) * 0.005
 
-    def eval(self, k, add_noise=True):
+    def __call__(self, k, add_noise=True):
+        time.sleep(0.5)
         b0, b1, b2 = self.params
         score = (b0 * k / 100 + 0.1 * b1 + 0.5)**(-1) + b2 * 0.01
         if add_noise:
@@ -46,8 +48,7 @@ def train(config):
         cur_i = 0
 
     for i in range(cur_i, TRAINING_ITERS):
-        new_loss = func.eval(i)
-        time.sleep(0.5)
+        new_loss = func(i)
 
         if i % CHECKPOINT_FREQ == 0:
             checkpoint = {

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -1,19 +1,19 @@
-import logging
-import time
 import inspect
+import logging
 import threading
+import time
 import traceback
 from six.moves import queue
 
 from ray.tune import track
 from ray.tune import TuneError
 from ray.tune.trainable import Trainable
-from ray.tune.result import TIME_THIS_ITER_S, RESULT_DUPLICATE
+from ray.tune.result import (FUNCTION_SAVE, RESULT_DUPLICATE, TIME_THIS_ITER_S)
 
 logger = logging.getLogger(__name__)
 
 # Time between FunctionRunner checks when fetching
-# new results after signaling the reporter to continue
+# new results after signaling the reporter to continue.
 RESULT_FETCH_TIMEOUT = 0.2
 
 ERROR_REPORT_TIMEOUT = 10
@@ -29,11 +29,23 @@ class StatusReporter:
         >>>     reporter(timesteps_this_iter=1)
     """
 
-    def __init__(self, result_queue, continue_semaphore, logdir=None):
+    def __init__(self,
+                 result_queue,
+                 continue_semaphore,
+                 logdir=None,
+                 restore=None):
+        """Initializes a StatusReporter.
+
+        Args:
+            result_queue (queue.Queue): Thread-safe message queue.
+            continue_semaphore (threading.Semaphore):
+            logdir (str): Trial logdir.
+        """
         self._queue = result_queue
         self._last_report_time = None
         self._continue_semaphore = continue_semaphore
         self._logdir = logdir
+        self._restore_from = restore
 
     def __call__(self, **kwargs):
         """Report updated training status.
@@ -51,32 +63,47 @@ class StatusReporter:
             StopIteration: A StopIteration exception is raised if the trial has
                 been signaled to stop.
         """
-
         assert self._last_report_time is not None, (
             "StatusReporter._start() must be called before the first "
             "report __call__ is made to ensure correct runtime metrics.")
 
-        # time per iteration is recorded directly in the reporter to ensure
-        # any delays in logging results aren't counted
+        # Time per iteration is recorded directly in the reporter to ensure
+        # any delays in logging results aren't counted.
         report_time = time.time()
         if TIME_THIS_ITER_S not in kwargs:
             kwargs[TIME_THIS_ITER_S] = report_time - self._last_report_time
         self._last_report_time = report_time
 
-        # add results to a thread-safe queue
+        # Add result to a thread-safe queue.
         self._queue.put(kwargs.copy(), block=True)
+        self._wait_for_notification()
 
-        # This blocks until notification from the FunctionRunner that the last
-        # result has been returned to Tune and that the function is safe to
-        # resume training.
-        self._continue_semaphore.acquire()
+    def on_result(self, result):
+        self.__call__(**result)
 
-    def _start(self):
+    def start(self):
         self._last_report_time = time.time()
+
+    def is_pending_restore(self):
+        return self._restore_from is not None
+
+    def pop_checkpoint(self):
+        checkpoint = self._restore_from
+        self._restore_from = None
+        return checkpoint
 
     @property
     def logdir(self):
         return self._logdir
+
+    def _wait_for_notification(self):
+        """Blocks until notification from FunctionRunner received.
+
+        This blocks until notification from the FunctionRunner that the last
+        result has been received by Tune and that the function is safe to
+        resume training.
+        """
+        self._continue_semaphore.acquire()
 
 
 class _RunnerThread(threading.Thread):
@@ -93,7 +120,7 @@ class _RunnerThread(threading.Thread):
             self._entrypoint()
         except StopIteration:
             logger.debug(
-                ("Thread runner raised StopIteration. Interperting it as a "
+                ("Thread runner raised StopIteration. Interpreting it as a "
                  "signal to terminate the thread without error."))
         except Exception as e:
             logger.exception("Runner Thread raised error.")
@@ -115,104 +142,107 @@ class _RunnerThread(threading.Thread):
 class FunctionRunner(Trainable):
     """Trainable that runs a user function reporting results.
 
-    This mode of execution does not support checkpoint/restore."""
+    Saves are triggered during training steps.
+    """
 
     _name = "func"
+
+    def train(self):
+        """Overrides Trainable.train to call `save()` if necessary."""
+        result = super(FunctionRunner, self).train()
+        if self._last_result.get(FUNCTION_SAVE) is not None:
+            result[FUNCTION_SAVE] = self.save()
+        return result
 
     def _setup(self, config):
         # Semaphore for notifying the reporter to continue with the computation
         # and to generate the next result.
         self._continue_semaphore = threading.Semaphore(0)
 
-        # Queue for passing results between threads
-        self._results_queue = queue.Queue(1)
+        # Queue for passing results between threads.
+        self._result_queue = queue.Queue(1)
 
         # Queue for passing errors back from the thread runner. The error queue
         # has a max size of one to prevent stacking error and force error
         # reporting to block until finished.
         self._error_queue = queue.Queue(1)
 
-        self._status_reporter = StatusReporter(
-            self._results_queue, self._continue_semaphore, self.logdir)
+        # Last training result.
         self._last_result = {}
-        config = config.copy()
+
+        # Thread in which function runs.
+        self._runner_thread = None
+
+    def _init_runner_thread(self, restore=None):
+        """Initializes the runner thread and its reporter."""
+        self._status_reporter = StatusReporter(
+            self._result_queue, self._continue_semaphore, self.logdir, restore)
 
         def entrypoint():
-            return self._trainable_func(config, self._status_reporter)
+            return self._trainable_func(self.config.copy(),
+                                        self._status_reporter)
 
-        # the runner thread is not started until the first call to _train
-        self._runner = _RunnerThread(entrypoint, self._error_queue)
+        # The runner thread is not started until the first call to _train.
+        self._runner_thread = _RunnerThread(entrypoint, self._error_queue)
 
-    def _trainable_func(self):
-        """Subclasses can override this to set the trainable func."""
-
+    def _trainable_func(self, config, reporter):
+        """Subclasses can override this to set the Trainable function."""
         raise NotImplementedError
 
     def _train(self):
         """Implements train() for a Function API.
 
+        Monitors queue for results.
+
         If the RunnerThread finishes without reporting "done",
         Tune will automatically provide a magic keyword __duplicate__
         along with a result with "done=True". The TrialRunner will handle the
         result accordingly (see tune/trial_runner.py).
+
+        Raises:
+            TuneError: This is raised if the Trainable ends up in a bad state.
         """
-        if self._runner.is_alive():
-            # if started and alive, inform the reporter to continue and
-            # generate the next result
+        if self._runner_thread is None:
+            # Initialize thread here at trial start time, rather than in
+            # `_setup` to avoid double-initialization during restores.
+            self._init_runner_thread()
+
+        if self._runner_thread.is_alive():
+            # If started and alive, inform the reporter to continue and
+            # generate the next result.
             self._continue_semaphore.release()
         else:
-            # if not alive, try to start
-            self._status_reporter._start()
+            # If not alive, try to start.
+            self._status_reporter.start()
             try:
-                self._runner.start()
+                self._runner_thread.start()
             except RuntimeError:
                 # If this is reached, it means the thread was started and is
                 # now done or has raised an exception.
                 pass
 
-        result = None
-        while result is None and self._runner.is_alive():
-            # fetch the next produced result
-            try:
-                result = self._results_queue.get(
-                    block=True, timeout=RESULT_FETCH_TIMEOUT)
-            except queue.Empty:
-                pass
+        result = self._fetch_result()
 
-        # if no result were found, then the runner must no longer be alive
+        # Check if error occurred inside the thread runner.
         if result is None:
-            # Try one last time to fetch results in case results were reported
-            # in between the time of the last check and the termination of the
-            # thread runner.
-            try:
-                result = self._results_queue.get(block=False)
-            except queue.Empty:
-                pass
-
-        # check if error occured inside the thread runner
-        if result is None:
-            # only raise an error from the runner if all results are consumed
+            # Only raise an error from the runner if all results are consumed.
             self._report_thread_runner_error(block=True)
-
             # Under normal conditions, this code should never be reached since
             # this branch should only be visited if the runner thread raised
-            # an exception. If no exception were raised, it means that the
+            # an exception. If no exception was raised, it means that the
             # runner thread never reported any results which should not be
             # possible when wrapping functions with `wrap_function`.
             raise TuneError(
-                ("Wrapped function ran until completion without reporting "
-                 "results or raising an exception."))
-
-        else:
-            if not self._error_queue.empty():
-                logger.warning(
-                    ("Runner error waiting to be raised in main thread. "
-                     "Logging all available results first."))
+                "Wrapped function ran until completion without reporting "
+                "results or raising an exception.")
+        elif not self._error_queue.empty():
+            logger.warning("Runner error waiting to be raised in main thread. "
+                           "Logging all available results first.")
 
         # This keyword appears if the train_func using the Function API
         # finishes without "done=True". This duplicates the last result, but
         # the TrialRunner will not log this result again.
-        if "__duplicate__" in result:
+        if RESULT_DUPLICATE in result:
             new_result = self._last_result.copy()
             new_result.update(result)
             result = new_result
@@ -220,15 +250,47 @@ class FunctionRunner(Trainable):
         self._last_result = result
         return result
 
-    def _stop(self):
-        # If everything stayed in synch properly, this should never happen.
-        if not self._results_queue.empty():
-            logger.warning(
-                ("Some results were added after the trial stop condition. "
-                 "These results won't be logged."))
+    def _save(self, checkpoint_dir):
+        """Returns the checkpoint last taken."""
+        return self._last_result.get(FUNCTION_SAVE)
 
+    def _restore(self, checkpoint):
+        """Prepares the runner thread for restoration."""
+        self._init_runner_thread(checkpoint)
+
+    def _stop(self):
+        if not self._result_queue.empty():
+            # If everything stayed in sync properly, this should never happen.
+            logger.warning("Some results were added after the trial stop "
+                           "condition. They will not be logged.")
         # Check for any errors that might have been missed.
         self._report_thread_runner_error()
+
+    def _fetch_result(self):
+        """Blocks and fetches a result from the queue.
+
+        Returns:
+            Result, or None if the runner is dead and the queue is empty.
+        """
+        result = None
+        while result is None and self._runner_thread.is_alive():
+            # Fetch the next result.
+            try:
+                result = self._result_queue.get(
+                    block=True, timeout=RESULT_FETCH_TIMEOUT)
+            except queue.Empty:
+                pass
+
+        # If no result received, then the runner must no longer be alive.
+        if result is None:
+            # Try one last time to fetch results, in case results were
+            # reported in between the time of the last check and the
+            # termination of the thread runner.
+            try:
+                result = self._result_queue.get(block=False)
+            except queue.Empty:
+                pass
+        return result
 
     def _report_thread_runner_error(self, block=False):
         try:

--- a/python/ray/tune/function_runner.py
+++ b/python/ray/tune/function_runner.py
@@ -85,9 +85,11 @@ class StatusReporter:
         self._last_report_time = time.time()
 
     def is_pending_restore(self):
+        """Whether the reporter was initialized with a checkpoint."""
         return self._restore_from is not None
 
     def pop_checkpoint(self):
+        """Returns the checkpoint the reporter was initialized with."""
         checkpoint = self._restore_from
         self._restore_from = None
         return checkpoint
@@ -300,6 +302,14 @@ class FunctionRunner(Trainable):
                              .format(err_tb_str)))
         except queue.Empty:
             pass
+
+    def _cleanup_object_restore(self):
+        """Do not cleanup checkpoint dir at the end of `restore_from_object`.
+
+        This prevents the temporary checkpoint dir from being deleted before
+        the runner thread has a chance to restore from it.
+        """
+        return False
 
 
 def wrap_function(train_func):

--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -5,7 +5,7 @@ import os
 # (Optional/Auto-filled) training is terminated. Filled only if not provided.
 DONE = "done"
 
-# (Optional) Enum for user controlled checkpoint
+# (Optional) Enum for user-controlled checkpoint
 SHOULD_CHECKPOINT = "should_checkpoint"
 
 # (Auto-filled) The hostname of the machine hosting the training process.
@@ -64,6 +64,10 @@ DEFAULT_RESULT_KEYS = (TRAINING_ITERATION, TIME_TOTAL_S, TIMESTEPS_TOTAL,
 # __duplicate__ is a magic keyword used internally to
 # avoid double-logging results when using the Function API.
 RESULT_DUPLICATE = "__duplicate__"
+
+# __func_save__ is a magic keyword used to save
+# checkpoints when using the Function API.
+FUNCTION_SAVE = "__func_save__"
 
 # Where Tune writes result files by default
 DEFAULT_RESULTS_DIR = (os.environ.get("TEST_TMPDIR")

--- a/python/ray/tune/track/__init__.py
+++ b/python/ray/tune/track/__init__.py
@@ -1,6 +1,8 @@
 import logging
+import os
 
-from ray.tune.track.session import TrackSession
+from ray.tune.result import FUNCTION_SAVE as SAVE
+from ray.tune.track.session import TrackSession, TuneSession
 
 logger = logging.getLogger(__name__)
 
@@ -31,18 +33,20 @@ def init(ignore_reinit_error=True, **session_kwargs):
         # info is helpful to keep around anyway.
         reinit_msg = "A session already exists in the current context."
         if ignore_reinit_error:
-            if not _session.is_tune_session:
+            if not isinstance(_session, TuneSession):
                 logger.warning(reinit_msg)
             return
         else:
             raise ValueError(reinit_msg)
 
-    _session = TrackSession(**session_kwargs)
+    if "_tune_reporter" in session_kwargs:
+        _session = TuneSession(**session_kwargs)
+    else:
+        _session = TrackSession(**session_kwargs)
 
 
 def shutdown():
     """Cleans up the trial and removes it from the global context."""
-
     global _session
     if _session:
         _session.close()
@@ -50,9 +54,52 @@ def shutdown():
 
 
 def log(**kwargs):
-    """Applies TrackSession.log to the trial in the current context."""
-    _session = get_session()
-    return _session.log(**kwargs)
+    """Applies TrackSession.log to the trial in the current context.
+
+    Checkpoints can be saved using the `tune.track.SAVE` parameter.
+
+    Examples:
+        >>> track.log({"mean_accuracy": acc, "mean_loss": loss})
+
+        >>> track.log(mean_accuracy=acc, mean_loss=loss)
+
+        >>> checkpoint = {"state": state}
+        >>> track.log(mean_accuracy=acc, **{tune.track.SAVE: checkpoint})
+    """
+    return get_session().log(**kwargs)
+
+
+def get_checkpoint_dir():
+    """Returns the checkpoint directory.
+
+    This is the directory in which the checkpoint corresponding to the next
+    reported result, if any, should be placed.
+
+    Examples:
+        >>> checkpoint_path = track.get_checkpoint_dir() + "/model.pkl")
+        >>> pickle.dump(model, open(checkpoint_path, "wb"))
+        >>> track.log({"mean_accuracy": acc, tune.track.SAVE: checkpoint_path})
+    """
+    checkpoint_dir = get_session().get_next_iter_checkpoint_dir()
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    return checkpoint_dir
+
+
+def is_pending_restore():
+    """Returns whether the trial can be restored from a checkpoint."""
+    return get_session().is_pending_restore
+
+
+def restore():
+    """Returns a checkpoint to restore from, if restorable.
+
+    Examples:
+        >>> if track.is_pending_restore():
+        >>>   checkpoint_path = track.restore()
+        >>>   model = pickle.load(open(checkpoint_path, "rb"))
+    """
+    chkpt = get_session().restore()
+    return chkpt
 
 
 def trial_dir():
@@ -60,8 +107,10 @@ def trial_dir():
 
     This includes json data containing the session's parameters and metrics.
     """
-    _session = get_session()
-    return _session.logdir
+    return get_session().logdir
 
 
-__all__ = ["TrackSession", "session", "log", "trial_dir", "init", "shutdown"]
+__all__ = [
+    "TrackSession", "init", "is_pending_restore", "log", "restore", "SAVE",
+    "session", "shutdown", "trial_dir"
+]

--- a/python/ray/tune/track/session.py
+++ b/python/ray/tune/track/session.py
@@ -1,3 +1,5 @@
+import logging
+import shutil
 import os
 from datetime import datetime
 
@@ -5,6 +7,8 @@ from ray.tune.logger import UnifiedLogger
 from ray.tune.result import DEFAULT_RESULTS_DIR, TRAINING_ITERATION
 from ray.tune.trainable import CHECKPOINT_DIR_FORMAT, TrainableUtil
 from ray.tune.trial import Trial
+
+logger = logging.getLogger(__name__)
 
 # TODO(ujvl): Refactor these classes.
 
@@ -99,7 +103,7 @@ class TrackSession:
 
 class TuneSession(TrackSession):
     def __init__(self, _tune_reporter):
-        """Initializes a Tune session.
+        """Initializes a Tune track session.
 
         Args:
             _tune_reporter (StatusReporter): Status reporter.
@@ -107,11 +111,22 @@ class TuneSession(TrackSession):
         super(TuneSession, self).__init__(init_logger=False)
         self._logger = _tune_reporter
         self._logdir = self._logger.logdir
+        self._restoring_from = None
 
     def log(self, **metrics):
         if self.is_pending_restore:
             raise ValueError("Trial is pending restore. `restore` must be "
                              "called before `log`.")
+        if self._restoring_from:
+            # Restoration is considered complete once `log` is called.
+            if isinstance(self._restoring_from, dict):
+                checkpoint_path = self._restoring_from["tune_checkpoint_path"]
+            else:
+                checkpoint_path = self._restoring_from
+            checkpoint_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
+            shutil.rmtree(checkpoint_dir)
+            self._restoring_from = None
+
         super(TuneSession, self).log(**metrics)
 
     def get_next_iter_checkpoint_dir(self):
@@ -121,22 +136,28 @@ class TuneSession(TrackSession):
         return checkpoint_dir
 
     def restore(self):
-        """Restores internal state.
+        """Restores session state.
+
+        `is_pending_restore` must return True before this is called.
 
         Returns:
-            Checkpoint to caller for processing.
+            Checkpoint for training function to restore from.
         """
         if not self.is_pending_restore:
-            raise ValueError("Trial is not restorable.")
-        checkpoint = self._logger.pop_checkpoint()
-        if isinstance(checkpoint, dict):
-            checkpoint_path = checkpoint["tune_checkpoint_path"]
+            raise ValueError("Trial is not pending restoration.")
+
+        self._restoring_from = self._logger.pop_checkpoint()
+
+        # Restore session state.
+        if isinstance(self._restoring_from, dict):
+            checkpoint_path = self._restoring_from["tune_checkpoint_path"]
         else:
-            checkpoint_path = checkpoint
+            checkpoint_path = self._restoring_from
         metadata = TrainableUtil.read_metadata(checkpoint_path)
         self._iteration = metadata["iteration"]
-        return checkpoint
+        return self._restoring_from
 
     @property
     def is_pending_restore(self):
+        """Whether the session and training function must be restored."""
         return self._logger.is_pending_restore()

--- a/python/ray/tune/track/session.py
+++ b/python/ray/tune/track/session.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from ray.tune.logger import UnifiedLogger
 from ray.tune.result import DEFAULT_RESULTS_DIR, TRAINING_ITERATION
-from ray.tune.trainable import CHECKPOINT_DIR_FORMAT, TrainableUtil
+from ray.tune.trainable import TrainableUtil
 from ray.tune.trial import Trial
 
 logger = logging.getLogger(__name__)
@@ -131,9 +131,8 @@ class TuneSession(TrackSession):
 
     def get_next_iter_checkpoint_dir(self):
         """Returns the next iteration's checkpoint directory."""
-        checkpoint_dir = CHECKPOINT_DIR_FORMAT.format(
-            root_dir=self.logdir, iteration=self._iteration + 1)
-        return checkpoint_dir
+        next_iter = self._iteration + 1
+        return TrainableUtil.get_checkpoint_dir(self.logdir, next_iter)
 
     def restore(self):
         """Restores session state.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -24,7 +24,6 @@ from ray.tune.utils import UtilMonitor
 logger = logging.getLogger(__name__)
 
 SETUP_TIME_THRESHOLD = 10
-CHECKPOINT_DIR_FORMAT = os.path.join("{root_dir}", "checkpoint_{iteration}")
 
 
 class TrainableUtil:
@@ -70,6 +69,10 @@ class TrainableUtil:
         return checkpoint_dir
 
     @staticmethod
+    def get_checkpoint_dir(root_dir, iteration):
+        return os.path.join(root_dir, "checkpoint_{}".format(iteration))
+
+    @staticmethod
     def make_checkpoint_dir(checkpoint_dir):
         """Creates a checkpoint directory at the provided path."""
         os.makedirs(checkpoint_dir, exist_ok=True)
@@ -98,6 +101,7 @@ class TrainableUtil:
         Raises:
             FileNotFoundError if the directory is not found.
         """
+        # TODO(ujvl): Fix this function for nested dirs.
         marker_paths = glob.glob(
             os.path.join(logdir, "checkpoint_*/.is_checkpoint"))
         iter_chkpt_pairs = []
@@ -342,8 +346,8 @@ class Trainable:
         Returns:
             Checkpoint path or prefix that may be passed to restore().
         """
-        checkpoint_dir = CHECKPOINT_DIR_FORMAT.format(
-            root_dir=checkpoint_dir or self.logdir, iteration=self._iteration)
+        checkpoint_dir = TrainableUtil.get_checkpoint_dir(
+            checkpoint_dir or self.logdir, self._iteration)
         TrainableUtil.make_checkpoint_dir(checkpoint_dir)
         checkpoint = self._save(checkpoint_dir)
         saved_as_dict = False

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -453,7 +453,8 @@ class Trainable:
                 f.write(file_contents)
 
         self.restore(checkpoint_path)
-        shutil.rmtree(tmpdir)
+        if self._cleanup_object_restore():
+            shutil.rmtree(tmpdir)
 
     def delete_checkpoint(self, checkpoint_path):
         """Deletes local copy of checkpoint.
@@ -550,7 +551,6 @@ class Trainable:
             A dict that describes training progress.
 
         """
-
         raise NotImplementedError
 
     def _save(self, tmp_checkpoint_dir):
@@ -586,7 +586,6 @@ class Trainable:
             >>> trainable._save("/tmp/bad_example")
             "/tmp/NEW_CHECKPOINT_PATH/my_checkpoint_file" # This will error.
         """
-
         raise NotImplementedError
 
     def _restore(self, checkpoint):
@@ -629,7 +628,6 @@ class Trainable:
                 The directory structure underneath the `checkpoint_dir`
                 `_save` is preserved.
         """
-
         raise NotImplementedError
 
     def _setup(self, config):
@@ -667,7 +665,14 @@ class Trainable:
             export_formats (list): List of formats that should be exported.
             export_dir (str): Directory to place exported models.
 
-        Return:
+        Returns:
             A dict that maps ExportFormats to successfully exported models.
         """
         return {}
+
+    def _cleanup_object_restore(self):
+        """Whether or not to cleanup checkpoint after `restore_from_object`.
+
+        This does not normally need to be overridden.
+        """
+        return True


### PR DESCRIPTION
Support save/restore functionality in the function-based API so that users who don't want to use the Trainable interface can still benefit from FT.

Closes #6162


**API**


`track.log({..., track.SAVE: checkpoint})`
Save checkpoint. We enforce that each checkpoint corresponds to a single result by having the user pass the checkpoint into the `log` call. This is for implementation simplicity. `track.SAVE` is a reserved result parameter (it might be nicer if we can just reserve "save" instead of having them use this variable).

The checkpoint can be either a path or a dict, just as in the Trainable case.  

`track.is_pending_restore() -> bool`
Check if we can restore from a checkpoint instead of starting from scratch.

`track.restore() -> dict|path`
Restores internal state and returns a checkpoint to restore from. If `log` is called before this function is called (in event of a restore), we raise an error.

`track.get_checkpoint_dir() -> str`
This can be called optionally to get the directory to store the checkpoint in, in the case where the checkpoint is a file or dir rather than a dict. Note that this must be called each time before a new checkpoint is taken since the directory changes with iteration.

Note: Nothing changes in the function API if no checkpoints are taken.

**Examples**

The general usage structure would be as follows:

```python
def train(config):
    if track.is_pending_restore():
        # Handle restoration.
        checkpoint = track.restore()
        model, cur_iter = ...
    else:
        # Handle initialization.
        model = ..., cur_iter = 0

    for i in range(cur_iter, TRAINING_ITERS):
        loss, acc = ...
        track.log({
            "mean_loss": loss, 
            "mean_accuracy": acc,
            track.SAVE: model.save_to_dict() if i % 100 == 0 else None. # can also be a path
        })
```

**TODO**
- [ ] add docs
- [ ] cleanup 
- [ ] tests 
- [x] fix GC bug
