### PR TITLE
Use --force_pic to prevent Bazel from compiling the same files twice

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,9 @@ build --action_env=USE_CLANG_CL=1
 build:linux   --compilation_mode=opt
 build:macos   --compilation_mode=opt
 build:windows --compilation_mode=fastbuild
+# This workaround is needed to prevent Bazel from compiling the same file twice (once PIC and once not).
+build:linux --force_pic
+build:macos --force_pic
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug
 #                 for compiling assembly files is fixed on Windows:
 #                 https://github.com/bazelbuild/bazel/issues/8924


### PR DESCRIPTION
# Why are these changes needed?

Bazel builds many files twice (e.g. `src/ray/gcs/gcs_server/gcs_server.cc`), which slows down the build considerably.

This seems to occur on POSIX systems due to a requirement of PIC (position-independent code) for dynamically-linked binaries. See:

- https://groups.google.com/forum/#!topic/bazel-discuss/agycffdH0R0
- https://docs.bazel.build/versions/1.2.0/user-manual.html#flag--force_pic

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
