### PR TITLE
Change CI to properly list Python 3.6 as tested version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ dist: xenial
 matrix:
   include:
     - os: linux
-      env: PYTHON=3.5 PYTHONWARNINGS=ignore
+      env: PYTHON=3.6 PYTHONWARNINGS=ignore
 
     - os: osx
       osx_image: xcode7
-      env: PYTHON=3.5 PYTHONWARNINGS=ignore
+      env: PYTHON=3.6 PYTHONWARNINGS=ignore
 
     - os: linux
       env:
         - JDK='Oracle JDK 8'
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
+        - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
         - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -32,7 +32,7 @@ matrix:
         - TESTSUITE=streaming
         - JDK='Oracle JDK 8'
         - RAY_INSTALL_JAVA=1
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
+        - PYTHON=3.6 PYTHONWARNINGS=ignore
       install:
         - python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py
         - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`
@@ -52,7 +52,7 @@ matrix:
         - TESTSUITE=gcs_service
         - JDK='Oracle JDK 8'
         - RAY_GCS_SERVICE_ENABLED=true
-        - PYTHON=3.5 PYTHONWARNINGS=ignore
+        - PYTHON=3.6 PYTHONWARNINGS=ignore
         - RAY_INSTALL_JAVA=1
       install:
         - eval `python $TRAVIS_BUILD_DIR/ci/travis/determine_tests_to_run.py`

--- a/ci/travis/install-cython-examples.sh
+++ b/ci/travis/install-cython-examples.sh
@@ -9,7 +9,7 @@ echo "PYTHON is $PYTHON"
 
 cython_examples="$ROOT_DIR/../../doc/examples/cython"
 
-if [[ "$PYTHON" == "3.5" ]]; then
+if [[ "$PYTHON" == "3.6" ]]; then
    export PATH="$HOME/miniconda/bin:$PATH"
 
    pushd $cython_examples

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -17,7 +17,7 @@ else
   exit 1
 fi
 
-if [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
+if [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y python-dev python-numpy build-essential curl unzip tmux gdb
   # Install miniconda.
@@ -28,7 +28,7 @@ if [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
     feather-format lxml openpyxl xlrd py-spy pytest-timeout networkx tabulate aiohttp \
     uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio \
     blist torch torchvision scikit-learn
-elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
+elif [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "macosx" ]]; then
   # Install miniconda.
   wget -q https://repo.continuum.io/miniconda/Miniconda3-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
   bash miniconda.sh -b -p $HOME/miniconda
@@ -56,7 +56,7 @@ else
   exit 1
 fi
 
-if [[ "$PYTHON" == "3.5" ]] || [[ "$MAC_WHEELS" == "1" ]]; then
+if [[ "$PYTHON" == "3.6" ]] || [[ "$MAC_WHEELS" == "1" ]]; then
   # Install the latest version of Node.js in order to build the dashboard.
   source $HOME/.nvm/nvm.sh
   nvm install node

--- a/ci/travis/install-ray.sh
+++ b/ci/travis/install-ray.sh
@@ -16,7 +16,7 @@ if [[ "$TRAVIS" == "true" ]]; then
   echo "build --jobs=50" >> $HOME/.bazelrc
 fi
 
-if [[ "$PYTHON" == "3.5" ]]; then
+if [[ "$PYTHON" == "3.6" ]]; then
   export PATH="$HOME/miniconda/bin:$PATH"
 
   pushd "$ROOT_DIR/../../python"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We've already been testing Python 3.6 in Travis, but it still displays 3.5.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
