### PR TITLE
[Dashboard] Refactor dialogs to use parent component state instead of routes

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter, Route } from "react-router-dom";
 import Dashboard from "./pages/dashboard/Dashboard";
-import Errors from "./pages/dashboard/dialogs/errors/Errors";
-import Logs from "./pages/dashboard/dialogs/logs/Logs";
 import { store } from "./store";
 
 class App extends React.Component {
@@ -13,9 +11,7 @@ class App extends React.Component {
       <Provider store={store}>
         <BrowserRouter>
           <CssBaseline />
-          <Dashboard />
-          <Route component={Logs} path="/logs/:hostname/:pid?" />
-          <Route component={Errors} path="/errors/:hostname/:pid?" />
+          <Route component={Dashboard} exact path="/" />
         </BrowserRouter>
       </Provider>
     );

--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -143,15 +143,21 @@ export interface ErrorsResponse {
   }>;
 }
 
-export const getErrors = (hostname: string, pid: string | undefined) =>
-  get<ErrorsResponse>("/api/errors", { hostname, pid: pid || "" });
+export const getErrors = (hostname: string, pid: number | null) =>
+  get<ErrorsResponse>("/api/errors", {
+    hostname,
+    pid: pid === null ? "" : pid
+  });
 
 export interface LogsResponse {
   [pid: string]: string[];
 }
 
-export const getLogs = (hostname: string, pid: string | undefined) =>
-  get<LogsResponse>("/api/logs", { hostname, pid: pid || "" });
+export const getLogs = (hostname: string, pid: number | null) =>
+  get<LogsResponse>("/api/logs", {
+    hostname,
+    pid: pid === null ? "" : pid
+  });
 
 export type LaunchProfilingResponse = string;
 

--- a/python/ray/dashboard/client/src/common/SpanButton.tsx
+++ b/python/ray/dashboard/client/src/common/SpanButton.tsx
@@ -1,0 +1,26 @@
+import { Theme } from "@material-ui/core/styles/createMuiTheme";
+import createStyles from "@material-ui/core/styles/createStyles";
+import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
+import React, { HTMLAttributes } from "react";
+
+const styles = (theme: Theme) =>
+  createStyles({
+    button: {
+      color: theme.palette.primary.main,
+      "&:hover": {
+        cursor: "pointer",
+        textDecoration: "underline"
+      }
+    }
+  });
+
+class SpanButton extends React.Component<
+  HTMLAttributes<HTMLSpanElement> & WithStyles<typeof styles>
+> {
+  render() {
+    const { classes, ...otherProps } = this.props;
+    return <span className={classes.button} {...otherProps} />;
+  }
+}
+
+export default withStyles(styles)(SpanButton);

--- a/python/ray/dashboard/client/src/pages/dashboard/Dashboard.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/Dashboard.tsx
@@ -43,6 +43,8 @@ class Dashboard extends React.Component<
     ReturnType<typeof mapStateToProps> &
     typeof mapDispatchToProps
 > {
+  timeoutId = 0;
+
   refreshNodeAndRayletInfo = async () => {
     try {
       const [nodeInfo, rayletInfo, tuneAvailability] = await Promise.all([
@@ -56,12 +58,16 @@ class Dashboard extends React.Component<
     } catch (error) {
       this.props.setError(error.toString());
     } finally {
-      setTimeout(this.refreshNodeAndRayletInfo, 1000);
+      this.timeoutId = window.setTimeout(this.refreshNodeAndRayletInfo, 1000);
     }
   };
 
   async componentDidMount() {
     await this.refreshNodeAndRayletInfo();
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeoutId);
   }
 
   handleTabChange = (event: React.ChangeEvent<{}>, value: number) => {

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeRowGroup.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/NodeRowGroup.tsx
@@ -56,6 +56,8 @@ interface Props {
     perWorker: { [pid: string]: number };
     total: number;
   };
+  setLogDialog: (hostname: string, pid: number | null) => void;
+  setErrorDialog: (hostname: string, pid: number | null) => void;
   initialExpanded: boolean;
 }
 
@@ -78,7 +80,15 @@ class NodeRowGroup extends React.Component<
   };
 
   render() {
-    const { classes, node, raylet, logCounts, errorCounts } = this.props;
+    const {
+      classes,
+      node,
+      raylet,
+      logCounts,
+      errorCounts,
+      setLogDialog,
+      setErrorDialog
+    } = this.props;
     const { expanded } = this.state;
 
     const features = [
@@ -91,12 +101,12 @@ class NodeRowGroup extends React.Component<
       { NodeFeature: NodeSent, WorkerFeature: WorkerSent },
       { NodeFeature: NodeReceived, WorkerFeature: WorkerReceived },
       {
-        NodeFeature: makeNodeLogs(logCounts),
-        WorkerFeature: makeWorkerLogs(logCounts)
+        NodeFeature: makeNodeLogs(logCounts, setLogDialog),
+        WorkerFeature: makeWorkerLogs(logCounts, setLogDialog)
       },
       {
-        NodeFeature: makeNodeErrors(errorCounts),
-        WorkerFeature: makeWorkerErrors(errorCounts)
+        NodeFeature: makeNodeErrors(errorCounts, setErrorDialog),
+        WorkerFeature: makeWorkerErrors(errorCounts, setErrorDialog)
       }
     ];
 

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/dialogs/errors/Errors.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/dialogs/errors/Errors.tsx
@@ -4,10 +4,9 @@ import createStyles from "@material-ui/core/styles/createStyles";
 import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
 import Typography from "@material-ui/core/Typography";
 import React from "react";
-import { RouteComponentProps } from "react-router";
-import { ErrorsResponse, getErrors } from "../../../../api";
-import DialogWithTitle from "../../../../common/DialogWithTitle";
-import NumberedLines from "../../../../common/NumberedLines";
+import { ErrorsResponse, getErrors } from "../../../../../api";
+import DialogWithTitle from "../../../../../common/DialogWithTitle";
+import NumberedLines from "../../../../../common/NumberedLines";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -30,29 +29,26 @@ const styles = (theme: Theme) =>
     }
   });
 
+interface Props {
+  clearErrorDialog: () => void;
+  hostname: string;
+  pid: number | null;
+}
+
 interface State {
   result: ErrorsResponse | null;
   error: string | null;
 }
 
-class Errors extends React.Component<
-  WithStyles<typeof styles> &
-    RouteComponentProps<{ hostname: string; pid: string | undefined }>,
-  State
-> {
+class Errors extends React.Component<Props & WithStyles<typeof styles>, State> {
   state: State = {
     result: null,
     error: null
   };
 
-  handleClose = () => {
-    this.props.history.push("/");
-  };
-
   async componentDidMount() {
     try {
-      const { match } = this.props;
-      const { hostname, pid } = match.params;
+      const { hostname, pid } = this.props;
       const result = await getErrors(hostname, pid);
       this.setState({ result, error: null });
     } catch (error) {
@@ -61,13 +57,11 @@ class Errors extends React.Component<
   }
 
   render() {
-    const { classes, match } = this.props;
+    const { classes, clearErrorDialog, hostname } = this.props;
     const { result, error } = this.state;
 
-    const { hostname } = match.params;
-
     return (
-      <DialogWithTitle handleClose={this.handleClose} title="Errors">
+      <DialogWithTitle handleClose={clearErrorDialog} title="Errors">
         {error !== null ? (
           <Typography color="error">{error}</Typography>
         ) : result === null ? (

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/dialogs/logs/Logs.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/dialogs/logs/Logs.tsx
@@ -4,10 +4,9 @@ import createStyles from "@material-ui/core/styles/createStyles";
 import withStyles, { WithStyles } from "@material-ui/core/styles/withStyles";
 import Typography from "@material-ui/core/Typography";
 import React from "react";
-import { RouteComponentProps } from "react-router";
-import { getLogs, LogsResponse } from "../../../../api";
-import DialogWithTitle from "../../../../common/DialogWithTitle";
-import NumberedLines from "../../../../common/NumberedLines";
+import { getLogs, LogsResponse } from "../../../../../api";
+import DialogWithTitle from "../../../../../common/DialogWithTitle";
+import NumberedLines from "../../../../../common/NumberedLines";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -25,29 +24,26 @@ const styles = (theme: Theme) =>
     }
   });
 
+interface Props {
+  clearLogDialog: () => void;
+  hostname: string;
+  pid: number | null;
+}
+
 interface State {
   result: LogsResponse | null;
   error: string | null;
 }
 
-class Logs extends React.Component<
-  WithStyles<typeof styles> &
-    RouteComponentProps<{ hostname: string; pid: string | undefined }>,
-  State
-> {
+class Logs extends React.Component<Props & WithStyles<typeof styles>, State> {
   state: State = {
     result: null,
     error: null
   };
 
-  handleClose = () => {
-    this.props.history.push("/");
-  };
-
   async componentDidMount() {
     try {
-      const { match } = this.props;
-      const { hostname, pid } = match.params;
+      const { hostname, pid } = this.props;
       const result = await getLogs(hostname, pid);
       this.setState({ result, error: null });
     } catch (error) {
@@ -56,13 +52,11 @@ class Logs extends React.Component<
   }
 
   render() {
-    const { classes, match } = this.props;
+    const { classes, clearLogDialog, hostname } = this.props;
     const { result, error } = this.state;
 
-    const { hostname } = match.params;
-
     return (
-      <DialogWithTitle handleClose={this.handleClose} title="Logs">
+      <DialogWithTitle handleClose={clearLogDialog} title="Logs">
         {error !== null ? (
           <Typography color="error">{error}</Typography>
         ) : result === null ? (

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Errors.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Errors.tsx
@@ -1,7 +1,6 @@
-import Link from "@material-ui/core/Link";
 import Typography from "@material-ui/core/Typography";
 import React from "react";
-import { Link as RouterLink } from "react-router-dom";
+import SpanButton from "../../../../common/SpanButton";
 import {
   ClusterFeatureComponent,
   NodeFeatureComponent,
@@ -34,30 +33,36 @@ export const makeClusterErrors = (errorCounts: {
   );
 };
 
-export const makeNodeErrors = (errorCounts: {
-  perWorker: { [pid: string]: number };
-  total: number;
-}): NodeFeatureComponent => ({ node }) =>
+export const makeNodeErrors = (
+  errorCounts: {
+    perWorker: { [pid: string]: number };
+    total: number;
+  },
+  setErrorDialog: (hostname: string, pid: number | null) => void
+): NodeFeatureComponent => ({ node }) =>
   errorCounts.total === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No errors
     </Typography>
   ) : (
-    <Link component={RouterLink} to={`/errors/${node.hostname}`}>
+    <SpanButton onClick={() => setErrorDialog(node.hostname, null)}>
       View all errors ({errorCounts.total.toLocaleString()})
-    </Link>
+    </SpanButton>
   );
 
-export const makeWorkerErrors = (errorCounts: {
-  perWorker: { [pid: string]: number };
-  total: number;
-}): WorkerFeatureComponent => ({ node, worker }) =>
+export const makeWorkerErrors = (
+  errorCounts: {
+    perWorker: { [pid: string]: number };
+    total: number;
+  },
+  setErrorDialog: (hostname: string, pid: number | null) => void
+): WorkerFeatureComponent => ({ node, worker }) =>
   errorCounts.perWorker[worker.pid] === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No errors
     </Typography>
   ) : (
-    <Link component={RouterLink} to={`/errors/${node.hostname}/${worker.pid}`}>
+    <SpanButton onClick={() => setErrorDialog(node.hostname, worker.pid)}>
       View errors ({errorCounts.perWorker[worker.pid].toLocaleString()})
-    </Link>
+    </SpanButton>
   );

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/Logs.tsx
@@ -1,7 +1,6 @@
-import Link from "@material-ui/core/Link";
 import Typography from "@material-ui/core/Typography";
 import React from "react";
-import { Link as RouterLink } from "react-router-dom";
+import SpanButton from "../../../../common/SpanButton";
 import {
   ClusterFeatureComponent,
   NodeFeatureComponent,
@@ -33,32 +32,38 @@ export const makeClusterLogs = (logCounts: {
   );
 };
 
-export const makeNodeLogs = (logCounts: {
-  perWorker: { [pid: string]: number };
-  total: number;
-}): NodeFeatureComponent => ({ node }) =>
+export const makeNodeLogs = (
+  logCounts: {
+    perWorker: { [pid: string]: number };
+    total: number;
+  },
+  setLogDialog: (hostname: string, pid: number | null) => void
+): NodeFeatureComponent => ({ node }) =>
   logCounts.total === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No logs
     </Typography>
   ) : (
-    <Link component={RouterLink} to={`/logs/${node.hostname}`}>
+    <SpanButton onClick={() => setLogDialog(node.hostname, null)}>
       View all logs ({logCounts.total.toLocaleString()}{" "}
       {logCounts.total === 1 ? "line" : "lines"})
-    </Link>
+    </SpanButton>
   );
 
-export const makeWorkerLogs = (logCounts: {
-  perWorker: { [pid: string]: number };
-  total: number;
-}): WorkerFeatureComponent => ({ node, worker }) =>
+export const makeWorkerLogs = (
+  logCounts: {
+    perWorker: { [pid: string]: number };
+    total: number;
+  },
+  setLogDialog: (hostname: string, pid: number | null) => void
+): WorkerFeatureComponent => ({ node, worker }) =>
   logCounts.perWorker[worker.pid] === 0 ? (
     <Typography color="textSecondary" component="span" variant="inherit">
       No logs
     </Typography>
   ) : (
-    <Link component={RouterLink} to={`/logs/${node.hostname}/${worker.pid}`}>
+    <SpanButton onClick={() => setLogDialog(node.hostname, worker.pid)}>
       View log ({logCounts.perWorker[worker.pid].toLocaleString()}{" "}
       {logCounts.perWorker[worker.pid] === 1 ? "line" : "lines"})
-    </Link>
+    </SpanButton>
   );


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR refactors the code for the log and error dialogs so that their state is managed by the `NodeInfo` component rather than at the top level as independent routes. This is a precursor to future PRs that will introduce other top-level routes for the dashboard.

CC @rkooo567 

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
