### PR TITLE
Make it possible to use authentication token for Dashboard

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -114,7 +114,7 @@ class Dashboard(object):
         """Initialize the dashboard object."""
         self.host = host
         self.port = port
-        # This is passed through an environment line variable
+        # This is passed through an environment variable
         # instead of an argument, to make sure it does not show up
         # in any logs.
         self.token = os.environ.get("RAY_DASHBOARD_TOKEN")

--- a/python/ray/parameter.py
+++ b/python/ray/parameter.py
@@ -109,7 +109,7 @@ class RayParams:
                  worker_path=None,
                  huge_pages=False,
                  include_webui=None,
-                 webui_host="localhost",
+                 webui_host=None,
                  logging_level=logging.INFO,
                  logging_format=ray_constants.LOGGER_FORMAT,
                  plasma_store_socket_name=None,

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1080,7 +1080,8 @@ def start_dashboard(require_webui,
         dashboard_url = "{}:{}".format(
             host if host != "0.0.0.0" else get_node_ip_address(), port)
         if os.environ.get("RAY_DASHBOARD_TOKEN"):
-            dashboard_url += "/?token={}".format(os.environ["RAY_DASHBOARD_TOKEN"])
+            dashboard_url += "/?token={}".format(
+                os.environ["RAY_DASHBOARD_TOKEN"])
         logger.info("View the Ray dashboard at {}{}{}{}{}".format(
             colorama.Style.BRIGHT, colorama.Fore.GREEN, dashboard_url,
             colorama.Fore.RESET, colorama.Style.NORMAL))

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -1053,6 +1053,8 @@ def start_dashboard(require_webui,
     ]
     if redis_password:
         command += ["--redis-password", redis_password]
+    if os.environ.get("RAY_DASHBOARD_TOKEN"):
+        command += ["--token", os.environ["RAY_DASHBOARD_TOKEN"]]
 
     webui_dependencies_present = True
     try:
@@ -1077,6 +1079,8 @@ def start_dashboard(require_webui,
 
         dashboard_url = "{}:{}".format(
             host if host != "0.0.0.0" else get_node_ip_address(), port)
+        if os.environ.get("RAY_DASHBOARD_TOKEN"):
+            dashboard_url += "/?token={}".format(os.environ["RAY_DASHBOARD_TOKEN"])
         logger.info("View the Ray dashboard at {}{}{}{}{}".format(
             colorama.Style.BRIGHT, colorama.Fore.GREEN, dashboard_url,
             colorama.Fore.RESET, colorama.Style.NORMAL))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR brings back some of the capabilities from https://github.com/ray-project/ray/pull/5888. Back then we removed the token since it was annoying for users. We now bring it back in a way that should be safe and convenient for most users. There are three modes:

- By default (`webui_host=None`), the dashboard listens to `127.0.0.1` which is the safe default, the same way as it currently is. If you define `RAY_DASHBOARD_TOKEN` on the head node to a token (a UUID
that was generated in a cryptographically safe way), the dashboard listens to `0.0.0.0` (i.e. it is public to the outside), but will need the token to access.

- If you want the webui to listen on localhost irrespective of whether `RAY_DASHBOARD_TOKEN` is set, use `webui_host="127.0.0.1"`, in which case the dashboard will always listen on localhost.

- If you specify `webui_host="0.0.0.0"` without setting `RAY_DASHBOARD_TOKEN`, the WebUI is public without a token. In this case you are responsible to secure it in some other way. **You should not run the Dashboard in an open way without proper authentication, especially because going forward we will expose more functionality in the Dashboard that can modify your cluster.**

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
