### PR TITLE
Fix for #7106 - TaskPool.completed_prefetch() no longer returns stale object ids after an error

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -48,3 +48,14 @@ py_test(
     size = "small",
     srcs = ["utils/schedules/tests/test_schedules.py"]
 )
+
+# ---------------------------------------
+# Utilities and Internals
+# ---------------------------------------
+
+# TaskPool
+py_test(
+    name = "test_schedules",
+    size = "small",
+    srcs = ["utils/tests/test_taskpool.py"]
+)

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -55,7 +55,7 @@ py_test(
 
 # TaskPool
 py_test(
-    name = "test_schedules",
+    name = "test_taskpool",
     size = "small",
     srcs = ["utils/tests/test_taskpool.py"]
 )

--- a/rllib/utils/actors.py
+++ b/rllib/utils/actors.py
@@ -52,8 +52,8 @@ class TaskPool:
                 del self._tasks[obj_id]
                 del self._objects[obj_id]
 
-        # We want to keep the same deque reference so that we don't suffer from stale references
-        # in generators that are still in flight
+        # We want to keep the same deque reference so that we don't suffer from
+        # stale references in generators that are still in flight
         for _ in range(len(self._fetching)):
             ev, obj_id = self._fetching.popleft()
             if ev in workers:

--- a/rllib/utils/actors.py
+++ b/rllib/utils/actors.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import ray
+from collections import deque
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ class TaskPool:
     def __init__(self):
         self._tasks = {}
         self._objects = {}
-        self._fetching = []
+        self._fetching = deque()
 
     def add(self, worker, all_obj_ids):
         if isinstance(all_obj_ids, list):
@@ -38,15 +39,11 @@ class TaskPool:
         for worker, obj_id in self.completed(blocking_wait=blocking_wait):
             self._fetching.append((worker, obj_id))
 
-        remaining = []
-        num_yielded = 0
-        for worker, obj_id in self._fetching:
-            if num_yielded < max_yield:
-                yield (worker, obj_id)
-                num_yielded += 1
-            else:
-                remaining.append((worker, obj_id))
-        self._fetching = remaining
+        for _ in range(max_yield):
+            if not self._fetching:
+                break
+
+            yield self._fetching.popleft()
 
     def reset_workers(self, workers):
         """Notify that some workers may be removed."""
@@ -54,11 +51,14 @@ class TaskPool:
             if ev not in workers:
                 del self._tasks[obj_id]
                 del self._objects[obj_id]
-        ok = []
-        for ev, obj_id in self._fetching:
+
+        # We want to keep the same deque reference so that we don't suffer from stale references
+        # in generators that are still in flight
+        for _ in range(len(self._fetching)):
+            ev, obj_id = self._fetching.popleft()
             if ev in workers:
-                ok.append((ev, obj_id))
-        self._fetching = ok
+                # Re-queue items that are still valid
+                self._fetching.append((ev, obj_id))
 
     @property
     def count(self):

--- a/rllib/utils/tests/test_taskpool.py
+++ b/rllib/utils/tests/test_taskpool.py
@@ -10,7 +10,7 @@ def createMockWorkerAndObjectId(obj_id):
 
 
 class TaskPoolTest(unittest.TestCase):
-    @patch("ray.wait")
+    @patch('ray.wait')
     def test_completed_prefetch_yieldsAllComplete(self, rayWaitMock):
         task1 = createMockWorkerAndObjectId(1)
         task2 = createMockWorkerAndObjectId(2)
@@ -24,7 +24,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [task2])
 
-    @patch("ray.wait")
+    @patch('ray.wait')
     def test_completed_prefetch_yieldsAllCompleteUpToDefaultLimit(
             self, rayWaitMock):
         # Load the pool with 1000 tasks, mock them all as complete and then
@@ -45,7 +45,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [999])
 
-    @patch("ray.wait")
+    @patch('ray.wait')
     def test_completed_prefetch_yieldsAllCompleteUpToSpecifiedLimit(
             self, rayWaitMock):
         # Load the pool with 1000 tasks, mock them all as complete and then
@@ -67,7 +67,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [i for i in range(500, 1000)])
 
-    @patch("ray.wait")
+    @patch('ray.wait')
     def test_completed_prefetch_yieldsRemainingIfIterationStops(
             self, rayWaitMock):
         # Test for issue #7106
@@ -93,7 +93,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [i for i in range(1, 10)])
 
-    @patch("ray.wait")
+    @patch('ray.wait')
     def test_reset_workers_pendingFetchesFromFailedWorkersRemoved(
             self, rayWaitMock):
         pool = TaskPool()
@@ -134,5 +134,5 @@ class TaskPoolTest(unittest.TestCase):
         self.assertListEqual(fetched, [2, 3, 5])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/rllib/utils/tests/test_taskpool.py
+++ b/rllib/utils/tests/test_taskpool.py
@@ -21,7 +21,7 @@ class TaskPoolTest(unittest.TestCase):
         pool.add(*task1)
         pool.add(*task2)
 
-        fetched = [pair for pair in pool.completed_prefetch()]
+        fetched = list(pool.completed_prefetch())
         self.assertListEqual(fetched, [task2])
 
     @patch("ray.wait")
@@ -35,11 +35,11 @@ class TaskPoolTest(unittest.TestCase):
             task = createMockWorkerAndObjectId(i)
             pool.add(*task)
 
-        rayWaitMock.return_value = ([i for i in range(1000)], [])
+        rayWaitMock.return_value = (list(range(1000)), [])
 
         # For this test, we're only checking the object ids
         fetched = [pair[1] for pair in pool.completed_prefetch()]
-        self.assertListEqual(fetched, [i for i in range(999)])
+        self.assertListEqual(fetched, list(range(999)))
 
         # Finally, check the next iteration returns the final taks
         fetched = [pair[1] for pair in pool.completed_prefetch()]
@@ -56,16 +56,16 @@ class TaskPoolTest(unittest.TestCase):
             task = createMockWorkerAndObjectId(i)
             pool.add(*task)
 
-        rayWaitMock.return_value = ([i for i in range(1000)], [])
+        rayWaitMock.return_value = (list(range(1000)), [])
 
         # Verify that only the first 500 tasks are returned, this should leave
         # some tasks in the _fetching deque for later
         fetched = [pair[1] for pair in pool.completed_prefetch(max_yield=500)]
-        self.assertListEqual(fetched, [i for i in range(500)])
+        self.assertListEqual(fetched, list(range(500)))
 
         # Finally, check the next iteration returns the remaining tasks
         fetched = [pair[1] for pair in pool.completed_prefetch()]
-        self.assertListEqual(fetched, [i for i in range(500, 1000)])
+        self.assertListEqual(fetched, list(range(500, 1000)))
 
     @patch("ray.wait")
     def test_completed_prefetch_yieldsRemainingIfIterationStops(
@@ -79,7 +79,7 @@ class TaskPoolTest(unittest.TestCase):
             task = createMockWorkerAndObjectId(i)
             pool.add(*task)
 
-        rayWaitMock.return_value = ([i for i in range(10)], [])
+        rayWaitMock.return_value = (list(range(10)), [])
 
         # This should fetch just the first item in the list
         try:
@@ -91,7 +91,7 @@ class TaskPoolTest(unittest.TestCase):
 
         # This fetch should return the remaining pre-fetched tasks
         fetched = [pair[1] for pair in pool.completed_prefetch()]
-        self.assertListEqual(fetched, [i for i in range(1, 10)])
+        self.assertListEqual(fetched, list(range(1, 10)))
 
     @patch("ray.wait")
     def test_reset_workers_pendingFetchesFromFailedWorkersRemoved(

--- a/rllib/utils/tests/test_taskpool.py
+++ b/rllib/utils/tests/test_taskpool.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import ray
+from ray.rllib.utils.actors import TaskPool
+
+def createMockWorkerAndObjectId(obj_id):
+    return ({
+        obj_id: 1
+    }, obj_id)
+
+
+class TaskPoolTest(unittest.TestCase):
+    @patch("ray.wait")
+    def test_completed_prefetch_yieldsAllComplete(self, rayWaitMock):
+        task1 = createMockWorkerAndObjectId(1)
+        task2 = createMockWorkerAndObjectId(2)
+        # Return the second task as complete and the first as pending
+        rayWaitMock.return_value = ([2], [1])
+
+        pool = TaskPool()
+        pool.add(*task1)
+        pool.add(*task2)
+
+        fetched = [pair for pair in pool.completed_prefetch()]
+        self.assertListEqual(fetched, [task2])
+
+    @patch("ray.wait")
+    def test_completed_prefetch_yieldsAllCompleteUpToDefaultLimit(self, rayWaitMock):
+        # Load the pool with 1000 tasks, mock them all as complete and then check
+        # that the first call to completed_prefetch only yield 999 items and the
+        # second call yields the final one
+        pool = TaskPool()
+        for i in range(1000):
+            task = createMockWorkerAndObjectId(i)
+            pool.add(*task)
+
+        rayWaitMock.return_value = ([i for i in range(1000)], [])
+
+        # For this test, we're only checking the object ids
+        fetched = [pair[1] for pair in pool.completed_prefetch()]
+        self.assertListEqual(fetched, [i for i in range(999)])
+
+        # Finally, check the next iteration returns the final taks
+        fetched = [pair[1] for pair in pool.completed_prefetch()]
+        self.assertListEqual(fetched, [999])
+
+    @patch("ray.wait")
+    def test_completed_prefetch_yieldsAllCompleteUpToSpecifiedLimit(self, rayWaitMock):
+        # Load the pool with 1000 tasks, mock them all as complete and then check
+        # that the first call to completed_prefetch only yield 999 items and the
+        # second call yields the final one
+        pool = TaskPool()
+        for i in range(1000):
+            task = createMockWorkerAndObjectId(i)
+            pool.add(*task)
+
+        rayWaitMock.return_value = ([i for i in range(1000)], [])
+
+        # For this test, we're only checking the object ids
+        fetched = [pair[1] for pair in pool.completed_prefetch(max_yield=500)]
+        self.assertListEqual(fetched, [i for i in range(500)])
+
+        # Finally, check the next iteration returns the final taks
+        fetched = [pair[1] for pair in pool.completed_prefetch()]
+        self.assertListEqual(fetched, [i for i in range(500, 1000)])
+
+    @patch("ray.wait")
+    def test_completed_prefetch_yieldsRemainingIfIterationStops(self, rayWaitMock):
+        # Test for issue #7106
+        # In versions of Ray up to 0.8.1, if the pre-fetch generator failed to run to
+        # completion, then the TaskPool would fail to clear up already fetched tasks
+        # resulting in stale object ids being returned
+        pool = TaskPool()
+        for i in range(10):
+            task = createMockWorkerAndObjectId(i)
+            pool.add(*task)
+        
+        rayWaitMock.return_value = ([i for i in range(10)], [])
+
+        # This should fetch just the first item in the list
+        try:
+            for _ in pool.completed_prefetch():
+                # Simulate a worker failure returned by ray.get()
+                raise ray.exceptions.RayError
+        except ray.exceptions.RayError:
+            pass
+
+        # This fetch should return the remaining pre-fetched tasks
+        fetched = [pair[1] for pair in pool.completed_prefetch()]
+        self.assertListEqual(fetched, [i for i in range(1, 10)])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/rllib/utils/tests/test_taskpool.py
+++ b/rllib/utils/tests/test_taskpool.py
@@ -10,7 +10,7 @@ def createMockWorkerAndObjectId(obj_id):
 
 
 class TaskPoolTest(unittest.TestCase):
-    @patch('ray.wait')
+    @patch("ray.wait")
     def test_completed_prefetch_yieldsAllComplete(self, rayWaitMock):
         task1 = createMockWorkerAndObjectId(1)
         task2 = createMockWorkerAndObjectId(2)
@@ -24,7 +24,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [task2])
 
-    @patch('ray.wait')
+    @patch("ray.wait")
     def test_completed_prefetch_yieldsAllCompleteUpToDefaultLimit(
             self, rayWaitMock):
         # Load the pool with 1000 tasks, mock them all as complete and then
@@ -45,7 +45,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [999])
 
-    @patch('ray.wait')
+    @patch("ray.wait")
     def test_completed_prefetch_yieldsAllCompleteUpToSpecifiedLimit(
             self, rayWaitMock):
         # Load the pool with 1000 tasks, mock them all as complete and then
@@ -67,7 +67,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [i for i in range(500, 1000)])
 
-    @patch('ray.wait')
+    @patch("ray.wait")
     def test_completed_prefetch_yieldsRemainingIfIterationStops(
             self, rayWaitMock):
         # Test for issue #7106
@@ -93,7 +93,7 @@ class TaskPoolTest(unittest.TestCase):
         fetched = [pair[1] for pair in pool.completed_prefetch()]
         self.assertListEqual(fetched, [i for i in range(1, 10)])
 
-    @patch('ray.wait')
+    @patch("ray.wait")
     def test_reset_workers_pendingFetchesFromFailedWorkersRemoved(
             self, rayWaitMock):
         pool = TaskPool()
@@ -134,5 +134,5 @@ class TaskPoolTest(unittest.TestCase):
         self.assertListEqual(fetched, [2, 3, 5])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Why are these changes needed?

`TaskPool.completed_prefetch()` is using a list internally to store prefetched completed tasks. However, it is relying on its generator to run to completion in order to clean up this list of tasks. If any error occurs actually fetching one of the returned object ids, then the generator won't complete and the `TaskPool._fetching` list will contain stale object ids for objects that have already been fetched and freed.

This change updates `TaskPool._fetching` to use a deque rather than a list so that tasks can be yielded and removed while iteration is happening. This also ensures that the `_fetching` list is always up to date so that even if an error is raised, object ids that have already been yielded won't be yielded again.

I've also added a new test file  `/rllib/utils/tests/test_taskpool.py` to verify expected behaviour of these changes. Running these tests on the master version of 'TaskPool' will produce a test failure in `TaskPoolTest.test_completed_prefetch_yieldsRemainingIfIterationStops()` which proves the presence of the original issue in master.

## Related issue number

Closes #7106.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
