### PR TITLE
[Asyncio] Increase recursion limit manually

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -3,6 +3,8 @@
 # cython: embedsignature = True
 # cython: language_level = 3
 
+from cpython.pystate cimport PyThreadState_Get
+
 from libcpp cimport bool as c_bool
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector as c_vector
@@ -23,6 +25,19 @@ from ray.includes.unique_ids cimport (
 from ray.includes.function_descriptor cimport (
     CFunctionDescriptor,
 )
+
+cdef extern from "Python.h":
+    # Note(simon): This is used to configure asyncio actor stack size.
+    # Cython made PyThreadState an opaque types. Saying that if the user wants
+    # specific attributes, they can be declared manually.
+
+    # You can find the cpython definition in Include/cpython/pystate.h#L59
+    ctypedef struct CPyThreadState "PyThreadState":
+        int recursion_depth
+
+    # From Include/ceveal.h#67
+    int Py_GetRecursionLimit()
+    void Py_SetRecursionLimit(int)
 
 cdef class Buffer:
     cdef:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -402,7 +402,7 @@ cdef execute_task(
                 # mistakenly count each callstack towards recusion limit.
                 # We don't need to worry about stackoverflow here because
                 # the max number of callstacks is limited in direct actor
-                # transport with max_concurreny flag.
+                # transport with max_concurrency flag.
                 increase_recursion_limit()
 
                 if inspect.iscoroutinefunction(function.method):
@@ -429,8 +429,7 @@ cdef execute_task(
                     (core_worker.core_worker.get()
                         .YieldCurrentFiber(fiber_event))
 
-                result = future.result()
-                return result
+                return future.result()
 
             return function(actor, *arguments, **kwarguments)
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -14,6 +14,7 @@ import threading
 import time
 import logging
 import os
+import pickle
 import sys
 
 from libc.stdint cimport (
@@ -76,6 +77,8 @@ from ray.includes.task cimport CTaskSpec
 from ray.includes.ray_config cimport RayConfig
 
 import ray
+from ray.async_compat import (sync_to_async,
+                              AsyncGetResponse, AsyncMonitorState)
 import ray.experimental.signal as ray_signal
 import ray.memory_monitor as memory_monitor
 import ray.ray_constants as ray_constants
@@ -117,17 +120,6 @@ include "includes/libcoreworker.pxi"
 logger = logging.getLogger(__name__)
 
 MEMCOPY_THREADS = 12
-PY3 = cpython.PY_MAJOR_VERSION >= 3
-
-
-if PY3:
-    import pickle
-else:
-    import cPickle as pickle
-
-if PY3:
-    from ray.async_compat import (sync_to_async,
-                                  AsyncGetResponse, AsyncMonitorState)
 
 
 def set_internal_config(dict options):
@@ -205,6 +197,21 @@ cdef c_vector[CObjectID] ObjectIDsToVector(object_ids):
 
 def compute_task_id(ObjectID object_id):
     return TaskID(object_id.native().TaskId().Binary())
+
+
+cdef increase_recursion_limit():
+    """Double the recusion limit if current depth is close to the limit"""
+    cdef:
+        CPyThreadState * s = <CPyThreadState *> PyThreadState_Get()
+        int current_depth = s.recursion_depth
+        int current_limit = Py_GetRecursionLimit()
+        int new_limit = current_limit * 2
+
+    if current_limit - current_depth < 500:
+        Py_SetRecursionLimit(new_limit)
+        logger.debug("Increasing Python recursion limit to {} "
+                     "current recursion depth is {}.".format(
+                         new_limit, current_depth))
 
 
 @cython.auto_pickle(False)
@@ -297,8 +304,9 @@ cdef void prepare_args(
             else:
                 args_vector.push_back(
                     CTaskArg.PassByReference(
-                        (CObjectID.FromBinary(core_worker.put_serialized_cobject(
-                            serialized_arg)))))
+                        (CObjectID.FromBinary(
+                            core_worker.put_serialized_cobject(
+                                serialized_arg)))))
 
 cdef deserialize_args(
         const c_vector[shared_ptr[CRayObject]] &c_args,
@@ -385,13 +393,18 @@ cdef execute_task(
                             c_resources.find(b"object_store_memory")).second)))
 
         def function_executor(*arguments, **kwarguments):
-            # function_executor is a generator to make sure python decrement
-            # stack counter on context switch for async mode. If it is not
-            # a generator, python will count the stacks of executor as part
-            # of the recursion limit, resulting in much lower concurrency.
             function = execution_info.function
 
-            if PY3 and core_worker.current_actor_is_asyncio():
+            if core_worker.current_actor_is_asyncio():
+                # Increase recursion limit if necessary. In asyncio mode,
+                # we have many parallel callstacks (represented in fibers)
+                # that's suspended for execution. Python interpreter will
+                # mistakenly count each callstack towards recusion limit.
+                # We don't need to worry about stackoverflow here because
+                # the max number of callstacks is limited in direct actor
+                # transport with max_concurreny flag.
+                increase_recursion_limit()
+
                 if inspect.iscoroutinefunction(function.method):
                     async_function = function
                 else:
@@ -412,14 +425,14 @@ cdef execute_task(
                     monitor_state.unregister_coroutine(coroutine)
 
                 future.add_done_callback(callback)
-
                 with nogil:
                     (core_worker.core_worker.get()
                         .YieldCurrentFiber(fiber_event))
 
-                yield future.result()
+                result = future.result()
+                return result
 
-            yield function(actor, *arguments, **kwarguments)
+            return function(actor, *arguments, **kwarguments)
 
     with core_worker.profile_event(b"task", extra_data=extra_data):
         try:
@@ -431,22 +444,17 @@ cdef execute_task(
 
             with core_worker.profile_event(b"task:deserialize_arguments"):
                 args, kwargs = deserialize_args(c_args, c_arg_reference_ids)
-
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
                 actor = worker.actors[core_worker.get_actor_id()]
                 class_name = actor.__class__.__name__
                 actor_title = "{}({}, {})".format(
                     class_name, repr(args), repr(kwargs))
                 core_worker.set_actor_title(actor_title.encode("utf-8"))
-
             # Execute the task.
             with ray.worker._changeproctitle(title, next_title):
                 with core_worker.profile_event(b"task:execute"):
                     task_exception = True
                     outputs = function_executor(*args, **kwargs)
-                    # The function_executor is a generator in actor mode.
-                    if inspect.isgenerator(outputs):
-                        outputs = next(outputs)
                     task_exception = False
                     if c_return_ids.size() == 1:
                         outputs = (outputs,)
@@ -680,11 +688,12 @@ cdef class CoreWorker:
     def put_serialized_object(self, serialized_object,
                               ObjectID object_id=None,
                               c_bool pin_object=True):
-        return ObjectID(self.put_serialized_cobject(serialized_object, object_id, pin_object))
+        return ObjectID(self.put_serialized_cobject(
+            serialized_object, object_id, pin_object))
 
     def put_serialized_cobject(self, serialized_object,
-                              ObjectID object_id=None,
-                              c_bool pin_object=True):
+                               ObjectID object_id=None,
+                               c_bool pin_object=True):
         cdef:
             CObjectID c_object_id
             shared_ptr[CBuffer] data


### PR DESCRIPTION
This PR address the issue that asyncio actor segfaulting in python 3.7. 

Previously, we used generators to make sure python doesn't mistakenly count our executor stack as part of their recursion limit. However, this approach will cause segfault in python3.7. Instead of relying on python internal implementation, we will manually double the recursion limit when we are close to the limit so Python won't error. The doubling only happens before the task execute. This means if user have an infinite recursive call, Python can still catch it and error with RecusionLimitExceeded.

To get the current recursion depth, we have to ping cpython internal API, there's no way around that. 