### PR TITLE
[Dashboard] Allow custom url prefix for dashboard server

### DIFF
--- a/python/ray/dashboard/client/package.json
+++ b/python/ray/dashboard/client/package.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "homepage": "REPLACE_HOMEPAGE_PREFIX",
   "dependencies": {
     "@material-ui/core": "^4.3.3",
     "@material-ui/icons": "^4.2.1",

--- a/python/ray/dashboard/client/public/index.html
+++ b/python/ray/dashboard/client/public/index.html
@@ -2,6 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+
+    <!-- Conditional content injection of base tag -->
+    <!-- https://github.com/facebook/create-react-app/issues/3112 -->
+    <% if (process.env.NODE_ENV === 'production') { %>
+    <!--This tag will be processed by dashboard.py to dynamically inject
+        base url for custon dashboard prefix.-->
+    <base href="HTML_BASE_REF" />
+    <% } %>
+
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!--

--- a/python/ray/dashboard/client/src/api.ts
+++ b/python/ray/dashboard/client/src/api.ts
@@ -1,11 +1,14 @@
 const base =
   process.env.NODE_ENV === "development"
-    ? "http://localhost:8265"
-    : window.location.origin;
+    ? "http://localhost:8265/"
+    : document.baseURI + "/";
 
 // TODO(mitchellstern): Add JSON schema validation for the responses.
 const get = async <T>(path: string, params: { [key: string]: any }) => {
-  const url = new URL(path, base);
+  // Need to construct url relative to baseURI so user can add
+  // path prefix to their dashboard.
+  const relativePath = "./" + path;
+  const url = new URL(relativePath, base);
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
@@ -127,7 +130,7 @@ export interface RayletInfoResponse {
           actorTitle: string;
           requiredResources: { [key: string]: number };
           state: -1;
-          invalidStateType?: 'infeasibleActor' | 'pendingActor';
+          invalidStateType?: "infeasibleActor" | "pendingActor";
         };
   };
 }

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -101,7 +101,7 @@ def find_and_replace_files(replacement_dict, path):
     for file_path in Path(path).rglob("*"):
         if not file_path.is_file():
             continue
-        if file_path.suffix not in {'.js', '.css', '.html'}:
+        if file_path.suffix not in {".js", ".css", ".html"}:
             continue
 
         # Use backup file if exists, create one otherwise
@@ -113,7 +113,7 @@ def find_and_replace_files(replacement_dict, path):
         try:
             with open(backup_file_path) as f:
                 data = f.read()
-            with open(file_path, 'w') as f:
+            with open(file_path, "w") as f:
                 for find, replace in replacement_dict.items():
                     data = data.replace(find, replace)
                 f.write(data)


### PR DESCRIPTION
This PR allows user to add arbitrary path prefix for their dashboard. For example, http://localhost:8265/ray_dashboard. This mode is required when dashboard is served behind a reverse proxy for path based proxying.

The implementation uses two template variable:
- `%PUBLIC URL%` is provided by react to inject path prefix for built assets and their relative linking. However this works only in build time. At dashboard startup time, we will replace with custom routes
- `<base>` tag is needed for other relative url based assets and HTTP API path. This is also replaced on dashboard server startup time.

Made sure the following works:
- [x] dev server, no prefix
- [x] production build, no prefix
- [x] production build, has prefix