### PR TITLE
Apply cpython patch bpo-39492 for the reference counting issue in pickle5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,7 +130,7 @@ WORK_DIR=`mktemp -d`
 pushd $WORK_DIR
 git clone https://github.com/suquark/pickle5-backport
 pushd pickle5-backport
-  git checkout 43551fbb9add8ac2e8551b96fdaf2fe5a3b5997d
+  git checkout 8ffe41ceba9d5e2ce8a98190f6b3d2f3325e5a72
   "$PYTHON_EXECUTABLE" setup.py bdist_wheel
   unzip -o dist/*.whl -d "$ROOT_DIR/python/ray/pickle5_files"
 popd

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -464,10 +464,10 @@ def test_reducer_override_no_reference_cycle(ray_start_regular):
     wr = weakref.ref(f)
 
     bio = io.BytesIO()
-    from ray.cloudpickle import CloudPickler
+    from ray.cloudpickle import CloudPickler, loads
     p = CloudPickler(bio, protocol=5)
     p.dump(f)
-    new_f = pickle.loads(bio.getvalue())
+    new_f = loads(bio.getvalue())
     assert new_f == 5
 
     del p

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -458,8 +458,7 @@ def test_reducer_override_no_reference_cycle(ray_start_regular):
     # bpo-39492: reducer_override used to induce a spurious reference cycle
     # inside the Pickler object, that could prevent all serialized objects
     # from being garbage-collected without explicity invoking gc.collect.
-    def f():
-        pass
+    f = lambda: 4669201609102990671853203821578
 
     wr = weakref.ref(f)
 
@@ -468,7 +467,7 @@ def test_reducer_override_no_reference_cycle(ray_start_regular):
     p = CloudPickler(bio, protocol=5)
     p.dump(f)
     new_f = loads(bio.getvalue())
-    assert new_f == 5
+    assert new_f() == 4669201609102990671853203821578
 
     del p
     del f


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This should fix https://github.com/cloudpipe/cloudpickle/issues/343 for python3.5, 3.6 and 3.7
It doesn't fix python3.8, but there will be official python3.8.2 fix

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
