### PR TITLE
[core] Make sure to unsubscribe get dependencies for direct task calls.

### DIFF
--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -132,7 +132,9 @@ Status CoreWorkerPlasmaStoreProvider::FetchAndGetFromPlasmaStore(
 Status UnblockIfNeeded(const std::shared_ptr<raylet::RayletClient> &client,
                        const WorkerContext &ctx) {
   if (ctx.CurrentTaskIsDirectCall()) {
-    if (ctx.ShouldReleaseResourcesOnBlockingCalls()) {
+    // NOTE: for direct call actors, we still need to issue an unblock IPC to release
+    // get subscriptions, even if the worker isn't blocked.
+    if (ctx.ShouldReleaseResourcesOnBlockingCalls() || ctx.CurrentActorIsDirectCall()) {
       return client->NotifyDirectCallTaskUnblocked();
     } else {
       return Status::OK();  // We don't need to release resources.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -642,6 +642,8 @@ void ObjectManager::WaitComplete(const UniqueID &wait_id) {
   // Unsubscribe to any objects that weren't found in the time allotted.
   for (const auto &object_id : wait_state.requested_objects) {
     RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(wait_id, object_id));
+    // Should have cancelled the pull request already.
+    RAY_CHECK(pull_requests_.find(object_id) == pull_requests_.end()) << object_id;
   }
   // Cancel the timer. This is okay even if the timer hasn't been started.
   // The timer handler will be given a non-zero error code. The handler

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -642,8 +642,6 @@ void ObjectManager::WaitComplete(const UniqueID &wait_id) {
   // Unsubscribe to any objects that weren't found in the time allotted.
   for (const auto &object_id : wait_state.requested_objects) {
     RAY_CHECK_OK(object_directory_->UnsubscribeObjectLocations(wait_id, object_id));
-    // Should have cancelled the pull request already.
-    RAY_CHECK(pull_requests_.find(object_id) == pull_requests_.end()) << object_id;
   }
   // Cancel the timer. This is okay even if the timer hasn't been started.
   // The timer handler will be given a non-zero error code. The handler


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We forgot to unsubscribe from objects for direct actor tasks, which causes leaks in the ObjectManager::pull_requests_ and TaskDependencyManager::required_objects_.

This leak only occurs in a multi-node environment. It can be reproduced by running `./train.py --ray-num-nodes=5 --run=IMPALA --env=PongNoFrameskip-v4 --config='{"num_workers": 4, "num_gpus": 0, "sample_batch_size": 2, "train_batch_size": 2}' --ray-object-store-memory=100000000 --ray-num-cpus=1 -v` and then checking `cat /tmp/ray/session_latest/debug_state.txt` for `req objects map size` and `num pull requests`. Before this fix, those counts increase without limit.

This may address https://github.com/ray-project/ray/issues/7154