### PR TITLE
[WIP] Get full command if shell flag set

### DIFF
--- a/python/ray/projects/projects.py
+++ b/python/ray/projects/projects.py
@@ -104,8 +104,12 @@ class ProjectDefinition:
             ValueError: This exception is raised if the given command is not
                 found in project.yaml.
         """
-        if shell or not command_name:
+        if not command_name:
             return command_name, {}, {}
+
+        if shell:
+            command_to_return = " ".join([command_name] + list(args))
+            return command_to_return, {}, {}
 
         command_to_run = None
         params = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently the `get_command_info` function returns only the `command_name`, ignoring the arguments if the shell flag is set. This is an issue because the `command_name` variable is only the first string of the actual command intended to be run. This PR returns the full concatenated command to run as the output instead of just the first string.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
