### PR TITLE
Removing unused Pyarrow Docs

### DIFF
--- a/doc/source/serialization.rst
+++ b/doc/source/serialization.rst
@@ -15,13 +15,13 @@ Overview
 
 Objects that are serialized for transfer among Ray processes go through three stages:
 
-**1. Serialize using pyarrow**: Below is the set of Python objects that Ray can serialize using ``pyarrow``:
+**1. Serialize directly**: Below is the set of Python objects that Ray can serialize using ``memcpy``:
 
 1. Primitive types: ints, floats, longs, bools, strings, unicode, and numpy arrays.
 
 2. Any list, dictionary, or tuple whose elements can be serialized by Ray.
 
-**2. ``__dict__`` serialization**: If a direct usage of PyArrow is not possible, Ray will recursively extract the object’s ``__dict__`` and serialize that using pyarrow. This behavior is not correct in all cases.
+**2. ``__dict__`` serialization**: If a direct usage is not possible, Ray will recursively extract the object’s ``__dict__`` and serialize that directly. This behavior is not correct in all cases.
 
 **3. Cloudpickle**:  Ray falls back to ``cloudpickle`` as a final attempt for serialization. This may be slow.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Serialization does not use pyarrow after  [PR7146](https://github.com/ray-project/ray/pull/7146)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Related to change #7146 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
