### PR TITLE
Enhance the serialization refcount test for dynamic classes

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -468,7 +468,7 @@ def test_reducer_override_no_reference_cycle(ray_start_regular):
     wr = weakref.ref(f)
 
     bio = io.BytesIO()
-    from ray.cloudpickle import CloudPickler, loads
+    from ray.cloudpickle import CloudPickler, loads, dumps
     p = CloudPickler(bio, protocol=5)
     p.dump(f)
     new_f = loads(bio.getvalue())
@@ -484,13 +484,10 @@ def test_reducer_override_no_reference_cycle(ray_start_regular):
         def __del__(self):
             print("Went out of scope!")
 
-    bio = io.BytesIO()
     obj = ShortlivedObject()
     new_obj = weakref.ref(obj)
 
-    p = CloudPickler(bio, protocol=5)
-    p.dump(obj)
-    loads(bio.getvalue())
+    dumps(obj)
     del obj
     assert new_obj() is None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

It is reported that the refcount for dynamic generated objects seem incorrect using the new serializer. However, I failed to reproduce this issue locally. So I will add a related test to see if we can find test failure in the CI env.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
