### PR TITLE
fix symbols conflict and add symbols check

### DIFF
--- a/streaming/BUILD.bazel
+++ b/streaming/BUILD.bazel
@@ -306,7 +306,5 @@ cc_binary(
     deps = [
         ":jni",
         ":streaming_lib",
-        "//:core_worker_lib",
-        "//:ray_util",
     ],
 )

--- a/streaming/java/test.sh
+++ b/streaming/java/test.sh
@@ -7,33 +7,37 @@ set -x
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
-run_testng() {
-    "$@" || exit_code=$?
-    # exit_code == 2 means there are skipped tests.
-    if [ $exit_code -ne 2 ] && [ $exit_code -ne 0 ] ; then
-        exit $exit_code
-    fi
-}
-
 echo "build ray streaming"
 bazel build //streaming/java:all
+
+# Check that ray libstreaming_java doesn't include symbols from ray by accident.
+# Otherwise the symbols may conflict.
+symbols_conflict=$(nm bazel-bin/streaming/libstreaming_java.so | grep TaskFinisherInterface || true)
+if [[ -n "${symbols_conflict}" ]]; then
+    echo "found ray symbol streaming: ${symbols_conflict}"
+    exit 1
+fi
 
 echo "Linting Java code with checkstyle."
 bazel test //streaming/java:all --test_tag_filters="checkstyle" --build_tests_only
 
 echo "Running streaming tests."
-run_testng java -cp $ROOT_DIR/../../bazel-bin/streaming/java/all_streaming_tests_deploy.jar\
+java -cp $ROOT_DIR/../../bazel-bin/streaming/java/all_streaming_tests_deploy.jar\
  org.testng.TestNG -d /tmp/ray_streaming_java_test_output $ROOT_DIR/testng.xml
-
+exit_code=$?
 echo "Streaming TestNG results"
 cat /tmp/ray_streaming_java_test_output/testng-results.xml
+# exit_code == 2 means there are skipped tests.
+if [ $exit_code -ne 2 ] && [ $exit_code -ne 0 ] ; then
+    exit $exit_code
+fi
 
 echo "Testing maven install."
-cd $ROOT_DIR/../../java
+cd "$ROOT_DIR"/../../java
 echo "build ray maven deps"
 bazel build gen_maven_deps
 echo "maven install ray"
 mvn clean install -DskipTests
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 echo "maven install ray streaming"
 mvn clean install -DskipTests

--- a/streaming/java/test.sh
+++ b/streaming/java/test.sh
@@ -13,8 +13,8 @@ bazel build //streaming/java:all
 # Check that ray libstreaming_java doesn't include symbols from ray by accident.
 # Otherwise the symbols may conflict.
 symbols_conflict=$(nm bazel-bin/streaming/libstreaming_java.so | grep TaskFinisherInterface || true)
-if [[ -n "${symbols_conflict}" ]]; then
-    echo "found ray symbol streaming: ${symbols_conflict}"
+if [ -n "${symbols_conflict}" ]; then
+    echo "streaming should not include symbols from ray: ${symbols_conflict}"
     exit 1
 fi
 
@@ -22,8 +22,8 @@ echo "Linting Java code with checkstyle."
 bazel test //streaming/java:all --test_tag_filters="checkstyle" --build_tests_only
 
 echo "Running streaming tests."
-java -cp $ROOT_DIR/../../bazel-bin/streaming/java/all_streaming_tests_deploy.jar\
- org.testng.TestNG -d /tmp/ray_streaming_java_test_output $ROOT_DIR/testng.xml
+java -cp "$ROOT_DIR"/../../bazel-bin/streaming/java/all_streaming_tests_deploy.jar\
+ org.testng.TestNG -d /tmp/ray_streaming_java_test_output "$ROOT_DIR"/testng.xml
 exit_code=$?
 echo "Streaming TestNG results"
 cat /tmp/ray_streaming_java_test_output/testng-results.xml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fix symbol conflict introduced in #6811, and add symbols check.

Symbol conflict can result in some very tricky runtime memory errors. For example, I serialize some data using`protobuf` in python, then deserialize data in c++, the result will be just corrupt and runtime behaviour is undefined.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#6811
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
