### PR TITLE
[RLlib] Fix old exploration configs.

### DIFF
--- a/rllib/agents/dqn/apex.py
+++ b/rllib/agents/dqn/apex.py
@@ -22,7 +22,7 @@ APEX_DEFAULT_CONFIG = merge_dicts(
         "sample_batch_size": 50,
         "target_network_update_freq": 500000,
         "timesteps_per_iteration": 25000,
-        "exploration": {"type": "PerWorkerEpsilonGreedy"},
+        "exploration_config": {"type": "PerWorkerEpsilonGreedy"},
         "worker_side_prioritization": True,
         "min_iter_time_s": 30,
     },

--- a/rllib/tests/test_ignore_worker_failure.py
+++ b/rllib/tests/test_ignore_worker_failure.py
@@ -72,7 +72,7 @@ class IgnoresWorkerFailure(unittest.TestCase):
                 "timesteps_per_iteration": 1000,
                 "num_gpus": 0,
                 "min_iter_time_s": 1,
-                "exploration": False,
+                "explore": False,
                 "learning_starts": 1000,
                 "target_network_update_freq": 100,
                 "optimizer": {

--- a/rllib/tuned_examples/atari-apex.yaml
+++ b/rllib/tuned_examples/atari-apex.yaml
@@ -17,7 +17,7 @@ apex:
         adam_epsilon: .00015
         hiddens: [512]
         buffer_size: 1000000
-        exploration:
+        exploration_config:
           final_epsilon: 0.01
           epsilon_timesteps: 200000
         prioritized_replay_alpha: 0.5

--- a/rllib/tuned_examples/atari-dist-dqn.yaml
+++ b/rllib/tuned_examples/atari-dist-dqn.yaml
@@ -21,7 +21,7 @@ atari-dist-dqn:
         buffer_size: 1000000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: 0.01
         prioritized_replay_alpha: 0.5

--- a/rllib/tuned_examples/atari-dqn.yaml
+++ b/rllib/tuned_examples/atari-dqn.yaml
@@ -23,7 +23,7 @@ atari-basic-dqn:
         buffer_size: 1000000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: 0.01
         prioritized_replay_alpha: 0.5

--- a/rllib/tuned_examples/atari-duel-ddqn.yaml
+++ b/rllib/tuned_examples/atari-duel-ddqn.yaml
@@ -23,7 +23,7 @@ dueling-ddqn:
         buffer_size: 1000000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: 0.01
         prioritized_replay_alpha: 0.5

--- a/rllib/tuned_examples/compact-regression-test.yaml
+++ b/rllib/tuned_examples/compact-regression-test.yaml
@@ -85,7 +85,7 @@ apex:
         adam_epsilon: .00015
         hiddens: [512]
         buffer_size: 1000000
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: 0.01
         prioritized_replay_alpha: 0.5
@@ -135,7 +135,7 @@ atari-basic-dqn:
         buffer_size: 1000000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: 0.01
         prioritized_replay_alpha: 0.5

--- a/rllib/tuned_examples/pong-dqn.yaml
+++ b/rllib/tuned_examples/pong-dqn.yaml
@@ -13,7 +13,7 @@ pong-deterministic-dqn:
         buffer_size: 50000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 200000
           final_epsilon: .01
         model:

--- a/rllib/tuned_examples/pong-rainbow.yaml
+++ b/rllib/tuned_examples/pong-rainbow.yaml
@@ -13,7 +13,7 @@ pong-deterministic-rainbow:
         buffer_size: 50000
         sample_batch_size: 4
         train_batch_size: 32
-        exploration:
+        exploration_config:
           epsilon_timesteps: 2
           final_epsilon: 0.0
         target_network_update_freq: 500


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Some configs (in yaml and test files) in the repo are outdated exploration API configs.
This PR fixes these.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
