### PR TITLE
[Tests] determine_tests_to_run.sh has a bug affecting RLlib testing to be skipped sometimes.

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import re
 import subprocess
 import sys
 from functools import partial
@@ -54,13 +55,13 @@ if __name__ == "__main__":
         ]
 
         for changed_file in files:
-            if changed_file.startswith("python/ray/tune/"):
+            if changed_file.startswith("python/ray/tune"):
                 RAY_CI_TUNE_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_RLLIB_FULL_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-            elif changed_file.startswith("python/ray/rllib/"):
+            elif re.match(r'^(python/ray/)?rllib/', changed_file):
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_RLLIB_FULL_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
                 RAY_CI_RLLIB_FULL_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-            elif re.match(r'^(python/ray/)?rllib/', changed_file):
+            elif re.match("^(python/ray/)?rllib/", changed_file):
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_RLLIB_FULL_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1

--- a/rllib/agents/a3c/__init__.py
+++ b/rllib/agents/a3c/__init__.py
@@ -7,6 +7,10 @@ A2CAgent = renamed_agent(A2CTrainer)
 A3CAgent = renamed_agent(A3CTrainer)
 
 __all__ = [
-    "A2CAgent", "A3CAgent", "A2CTrainer", "A3CTrainer", "DEFAULT_CONFIG",
+    "A2CAgent",
+    "A3CAgent",
+    "A2CTrainer",
+    "A3CTrainer",
+    "DEFAULT_CONFIG",
     "A2CPipeline"
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

If the PR'd RLlib file starts with "rllib/..." and not with "python/ray/rllib", the script will not force RLlib to be tested fully, only the tf.2x regression is run.
This PR fixes that.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
