### PR TITLE
setpgrp fix

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -283,10 +283,10 @@ def get_node_ip_address(address="8.8.8.8:53"):
         # connection.
         s.connect((ip_address, int(port)))
         node_ip_address = s.getsockname()[0]
-    except Exception as e:
+    except OSError as e:
         node_ip_address = "127.0.0.1"
         # [Errno 101] Network is unreachable
-        if e.errno == 101:
+        if e.errno == errno.ENETUNREACH:
             try:
                 # try get node ip address from host name
                 host_name = socket.getfqdn(socket.gethostname())

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -584,14 +584,14 @@ def start_reaper():
         os.setpgrp()
     except OSError as e:
         if e.errno == errno.EPERM and os.getpgrp() == os.getpid():
-            # Nothing to do; we're already a session leader
+            # Nothing to do; we're already a session leader.
             pass
         else:
             logger.warning("setpgrp failed, processes may not be "
                            "cleaned up properly: {}.".format(e))
             # Don't start the reaper in this case as it could result in killing
             # other user processes.
-        return None
+            return None
 
     reaper_filepath = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "ray_process_reaper.py")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`setpgrp` fails if the current process is already a session leader.

## Related issue number

Closes #6718

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
