### PR TITLE
Use our own implementation of parallel_memcopy

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1075,6 +1075,7 @@ pyx_library(
     ),
     deps = [
         "//:core_worker_lib",
+        "//:ray_util",
         "//:raylet_lib",
         "//:serialization_cc_proto",
         "//:src/ray/ray_exported_symbols.lds",

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -13,12 +13,6 @@ if "pickle5" in sys.modules:
                       "requires a specific version of pickle5 (which is "
                       "packaged along with Ray).")
 
-if "OMP_NUM_THREADS" not in os.environ:
-    logger.debug("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
-                 "degradation with many workers (issue #6998). You can "
-                 "override this by explicitly setting OMP_NUM_THREADS.")
-    os.environ["OMP_NUM_THREADS"] = "1"
-
 # Add the directory containing pickle5 to the Python path so that we find the
 # pickle5 version packaged with ray and not a pre-existing pickle5.
 pickle5_path = os.path.join(

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -112,7 +112,7 @@ include "includes/libcoreworker.pxi"
 
 logger = logging.getLogger(__name__)
 
-MEMCOPY_THREADS = 12
+MEMCOPY_THREADS = 6
 
 
 def set_internal_config(dict options):

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -10,7 +10,7 @@ DEF kMajorBufferSize = 2048
 DEF kMemcopyDefaultBlocksize = 64
 DEF kMemcopyDefaultThreshold = 1024 * 1024
 
-cdef extern from "arrow/util/memory.h" namespace "arrow::internal" nogil:
+cdef extern from "ray/util/memory.h" namespace "ray" nogil:
     void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
                           uintptr_t block_size, int num_threads)
 

--- a/src/ray/util/memory.cc
+++ b/src/ray/util/memory.cc
@@ -1,0 +1,47 @@
+#include "ray/util/memory.h"
+
+#include <thread>
+#include <vector>
+
+namespace ray {
+
+uint8_t* pointer_logical_and(const uint8_t* address, uintptr_t bits) {
+  uintptr_t value = reinterpret_cast<uintptr_t>(address);
+  return reinterpret_cast<uint8_t*>(value & bits);
+}
+
+void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
+                      uintptr_t block_size, int num_threads) {
+  std::vector<std::thread> threadpool(num_threads);
+  uint8_t* left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
+  uint8_t* right = pointer_logical_and(src + nbytes, ~(block_size - 1));
+  int64_t num_blocks = (right - left) / block_size;
+
+  // Update right address
+  right = right - (num_blocks % num_threads) * block_size;
+
+  // Now we divide these blocks between available threads. The remainder is
+  // handled on the main thread.
+  int64_t chunk_size = (right - left) / num_threads;
+  int64_t prefix = left - src;
+  int64_t suffix = src + nbytes - right;
+  // Now the data layout is | prefix | k * num_threads * block_size | suffix |.
+  // We have chunk_size = k * block_size, therefore the data layout is
+  // | prefix | num_threads * chunk_size | suffix |.
+  // Each thread gets a "chunk" of k blocks.
+
+  // Start all threads first and handle leftovers while threads run.
+  for (int i = 0; i < num_threads; i++) {
+    threadpool[i] = std::thread(memcpy, dst + prefix + i * chunk_size,
+        left + i * chunk_size, chunk_size);
+  }
+
+  memcpy(dst, src, prefix);
+  memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
+
+  for (auto& t : threadpool) {
+    if (t.joinable()) { t.join(); }
+  }
+}
+
+} // namespace ray

--- a/src/ray/util/memory.cc
+++ b/src/ray/util/memory.cc
@@ -5,16 +5,16 @@
 
 namespace ray {
 
-uint8_t* pointer_logical_and(const uint8_t* address, uintptr_t bits) {
+uint8_t *pointer_logical_and(const uint8_t *address, uintptr_t bits) {
   uintptr_t value = reinterpret_cast<uintptr_t>(address);
-  return reinterpret_cast<uint8_t*>(value & bits);
+  return reinterpret_cast<uint8_t *>(value & bits);
 }
 
-void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
+void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
                       uintptr_t block_size, int num_threads) {
   std::vector<std::thread> threadpool(num_threads);
-  uint8_t* left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
-  uint8_t* right = pointer_logical_and(src + nbytes, ~(block_size - 1));
+  uint8_t *left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
+  uint8_t *right = pointer_logical_and(src + nbytes, ~(block_size - 1));
   int64_t num_blocks = (right - left) / block_size;
 
   // Update right address
@@ -33,15 +33,17 @@ void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
   // Start all threads first and handle leftovers while threads run.
   for (int i = 0; i < num_threads; i++) {
     threadpool[i] = std::thread(memcpy, dst + prefix + i * chunk_size,
-        left + i * chunk_size, chunk_size);
+                                left + i * chunk_size, chunk_size);
   }
 
   memcpy(dst, src, prefix);
   memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
 
-  for (auto& t : threadpool) {
-    if (t.joinable()) { t.join(); }
+  for (auto &t : threadpool) {
+    if (t.joinable()) {
+      t.join();
+    }
   }
 }
 
-} // namespace ray
+}  // namespace ray

--- a/src/ray/util/memory.cc
+++ b/src/ray/util/memory.cc
@@ -1,5 +1,6 @@
 #include "ray/util/memory.h"
 
+#include <cstring>
 #include <thread>
 #include <vector>
 
@@ -32,12 +33,12 @@ void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
 
   // Start all threads first and handle leftovers while threads run.
   for (int i = 0; i < num_threads; i++) {
-    threadpool[i] = std::thread(memcpy, dst + prefix + i * chunk_size,
+    threadpool[i] = std::thread(std::memcpy, dst + prefix + i * chunk_size,
                                 left + i * chunk_size, chunk_size);
   }
 
-  memcpy(dst, src, prefix);
-  memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
+  std::memcpy(dst, src, prefix);
+  std::memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
 
   for (auto &t : threadpool) {
     if (t.joinable()) {

--- a/src/ray/util/memory.h
+++ b/src/ray/util/memory.h
@@ -7,9 +7,9 @@ namespace ray {
 
 // A helper function for doing memcpy with multiple threads. This is required
 // to saturate the memory bandwidth of modern cpus.
-void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
+void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
                       uintptr_t block_size, int num_threads);
 
-} // namespace ray
+}  // namespace ray
 
 #endif  // RAY_UTIL_MEMORY_H

--- a/src/ray/util/memory.h
+++ b/src/ray/util/memory.h
@@ -1,0 +1,15 @@
+#ifndef RAY_UTIL_MEMORY_H
+#define RAY_UTIL_MEMORY_H
+
+#include <stdint.h>
+
+namespace ray {
+
+// A helper function for doing memcpy with multiple threads. This is required
+// to saturate the memory bandwidth of modern cpus.
+void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
+                      uintptr_t block_size, int num_threads);
+
+} // namespace ray
+
+#endif  // RAY_UTIL_MEMORY_H


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We have been having issues with our parallel memcopy respecting `OMP_NUM_THREADS` causing performance degradation for some applications. This introduces our own version that doesn't pull in the environment variable but uses a constant in the code instead. Also sets the constant to 6 threads to align with the benchmarks we ran previously.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
