### PR TITLE
Compile Boost.Asio separately (BOOST_ASIO_SEPARATE_COMPILATION)

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -133,6 +133,7 @@ def ray_deps_setup():
         remote = "https://github.com/nelhage/rules_boost",
         sha256 = "3775c5ab217e0c9cc380f56e243a4d75fe6fee8eaee1447899eaa04c5d582cf1",
         patches = [
+            "//thirdparty/patches:rules_boost-asio-src.patch",
             "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",
         ],

--- a/thirdparty/patches/rules_boost-asio-src.patch
+++ b/thirdparty/patches/rules_boost-asio-src.patch
@@ -1,0 +1,20 @@
+diff --git BUILD.boost BUILD.boost
+--- BUILD.boost
++++ BUILD.boost
+@@ -305,7 +305,13 @@ boost_library(
+ boost_library(
+     name = "asio",
++    srcs = [
++        "boost/asio/impl/src.cpp",
++        "boost/asio/impl/src.hpp",
++    ],
+-    defines = select({
++    defines = [
++        "BOOST_ASIO_SEPARATE_COMPILATION",
++    ] + select({
+         ":osx_x86_64": [
+             "BOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW",
+         ],
+         "//conditions:default": [],
+     }),
+--


### PR DESCRIPTION
## Why are these changes needed?

Boost.Asio is used everywhere and it's better to compile its implementation separately once.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
