### PR TITLE
Remove misleading error prefix

### DIFF
--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -150,7 +150,7 @@ void CoreWorkerDirectTaskSubmitter::RetryLeaseRequest(
     // A local request failed. This shouldn't happen if the raylet is still alive
     // and we don't currently handle raylet failures, so treat it as a fatal
     // error.
-    RAY_LOG(FATAL) << "Lost connection with local raylet. Error: " << status.ToString();
+    RAY_LOG(FATAL) << status.ToString();
   }
 }
 


### PR DESCRIPTION
When a raylet IPC fails, we should not prefix it with a long message, since that can obscure the real cause.

https://github.com/ray-project/ray/issues/7263