### PR TITLE
[Parallel Iterators] Allow for operator chaining after repartition

### DIFF
--- a/doc/source/iter.rst
+++ b/doc/source/iter.rst
@@ -1,4 +1,4 @@
-Distributed Iterators
+Parallel Iterators
 =====================
 
 .. _`issue on GitHub`: https://github.com/ray-project/ray/issues
@@ -204,4 +204,3 @@ API Reference
 .. automodule:: ray.util.iter
     :members:
     :show-inheritance:
-    :special-members:

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -158,7 +158,7 @@ class ParallelIterator(Generic[T]):
     def __init__(self, actor_sets: List["_ActorSet"], name: str,
                  parent_iterators: List["ParallelIterator[Any]"]):
         """Create a parallel iterator (this is an internal function)."""
-        
+
         # We track multiple sets of actors to support parallel .union().
         self.actor_sets = actor_sets
         self.name = name

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -195,7 +195,7 @@ class ParallelIterator(Generic[T]):
             ... [0, 2, 4, 8]
         """
         return self._add_transform(lambda local_it: local_it.for_each(fn),
-                                    ".for_each()")
+                                   ".for_each()")
 
     def filter(self, fn: Callable[[T], bool]) -> "ParallelIterator[T]":
         """Remotely filter items from this iterator.
@@ -209,7 +209,7 @@ class ParallelIterator(Generic[T]):
             ... [1, 2]
         """
         return self._add_transform(lambda local_it: local_it.filter(fn),
-                                    ".filter()")
+                                   ".filter()")
 
     def batch(self, n: int) -> "ParallelIterator[List[T]]":
         """Remotely batch together items in this iterator.
@@ -222,7 +222,7 @@ class ParallelIterator(Generic[T]):
             ... [0, 1, 2, 3]
         """
         return self._add_transform(lambda local_it: local_it.batch(n),
-                                    ".batch({})".format(n))
+                                   ".batch({})".format(n))
 
     def flatten(self) -> "ParallelIterator[T[0]]":
         """Flatten batches of items into individual items.
@@ -232,7 +232,7 @@ class ParallelIterator(Generic[T]):
             ... 0
         """
         return self._add_transform(lambda local_it: local_it.flatten(),
-                                    ".flatten()")
+                                   ".flatten()")
 
     def combine(self, fn: Callable[[T], List[U]]) -> "ParallelIterator[U]":
         """Transform and then combine items horizontally.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Currently for `repartition`, we need to keep an explicit reference to the source actors so that they do not die. However, other operations (`for_each`, `batch`, etc.) return *new* ParallelIterator instances. So, we need to make sure we pass the parent iterator explicit references to these new iterators to allow for transformations to be chained after a `repartition`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
