### PR TITLE
Fix github_repository(path=...)

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -26,22 +26,22 @@ def github_repository(*, name=None, remote=None, commit=None, tag=None,
     GIT_SUFFIX = ".git"
 
     treeish = commit or tag or branch
-    if not treeish: fail("Missing commit, tag, or branch argument")
-    if remote == None: fail("Missing remote argument")
+    if path == None and not treeish: fail("Missing commit, tag, or branch argument")
+    if path == None and remote == None: fail("Missing remote argument")
 
-    if remote.endswith(GIT_SUFFIX):
+    if path == None and remote.endswith(GIT_SUFFIX):
         remote_no_suffix = remote[:len(remote) - len(GIT_SUFFIX)]
     else:
         remote_no_suffix = remote
-    project = remote_no_suffix.split("//", 1)[1].split("/")[2]
+    project = remote_no_suffix.split("//", 1)[1].split("/")[2] if remote_no_suffix else None
 
-    if name == None:
+    if project != None and name == None:
         name = project.replace("-", "_")
-    if strip_prefix == True:
+    if project != None and strip_prefix == True:
         strip_prefix = "%s-%s" % (project, treeish)
     if url == None:
         url = "%s/archive/%s%s" % (remote_no_suffix, treeish, archive_suffix)
-    if build_file == True:
+    if name != None and build_file == True:
         build_file = "@//%s:%s" % ("bazel", "BUILD." + name)
 
     if path != None:


### PR DESCRIPTION
## Why are these changes needed?

`github_repository(path=...)` accidentally requires other fields that shouldn't be necessary

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
