### PR TITLE
Revert accidental removal of OMP_NUM_THREADS=1, add test

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -13,6 +13,12 @@ if "pickle5" in sys.modules:
                       "requires a specific version of pickle5 (which is "
                       "packaged along with Ray).")
 
+if "OMP_NUM_THREADS" not in os.environ:
+    logger.debug("[ray] Forcing OMP_NUM_THREADS=1 to avoid performance "
+                 "degradation with many workers (issue #6998). You can "
+                 "override this by explicitly setting OMP_NUM_THREADS.")
+    os.environ["OMP_NUM_THREADS"] = "1"
+
 # Add the directory containing pickle5 to the Python path so that we find the
 # pickle5 version packaged with ray and not a pre-existing pickle5.
 pickle5_path = os.path.join(

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -38,6 +38,13 @@ def test_ignore_http_proxy(shutdown_only):
     assert ray.get(f.remote()) == 1
 
 
+# https://github.com/ray-project/ray/issues/7287
+def test_omp_threads_set(shutdown_only):
+    ray.init(num_cpus=1)
+    # Should have been auto set by ray init.
+    assert os.environ["OMP_NUM_THREADS"] == "1"
+
+
 def test_simple_serialization(ray_start_regular):
     primitive_objects = [
         # Various primitive types.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR unintentionally removed OMP_NUM_THREADS=1: https://github.com/ray-project/ray/pull/7254

Add it back, add a test.

## Related issue number

Closes https://github.com/ray-project/ray/issues/7287
