### PR TITLE
Fix error in shape calculation.

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -229,8 +229,8 @@ class ModelCatalog:
                 else:
                     all_discrete = False
                     size += np.product(action_space.spaces[i].shape)
-            return (tf.int64
-                    if all_discrete else tf.float32, (None, int(size)))
+            size = int(size)
+            return (tf.int64 if all_discrete else tf.float32, (None, size))
         elif isinstance(action_space, gym.spaces.Dict):
             raise NotImplementedError(
                 "Dict action spaces are not supported, consider using "

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -229,7 +229,7 @@ class ModelCatalog:
                 else:
                     all_discrete = False
                     size += np.product(action_space.spaces[i].shape)
-            return (tf.int64 if all_discrete else tf.float32, (None, size))
+            return (tf.int64 if all_discrete else tf.float32, (None, int(size)))
         elif isinstance(action_space, gym.spaces.Dict):
             raise NotImplementedError(
                 "Dict action spaces are not supported, consider using "

--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -229,7 +229,8 @@ class ModelCatalog:
                 else:
                     all_discrete = False
                     size += np.product(action_space.spaces[i].shape)
-            return (tf.int64 if all_discrete else tf.float32, (None, int(size)))
+            return (tf.int64
+                    if all_discrete else tf.float32, (None, int(size)))
         elif isinstance(action_space, gym.spaces.Dict):
             raise NotImplementedError(
                 "Dict action spaces are not supported, consider using "


### PR DESCRIPTION
This PR fixes the issue of the `size` variable being converted to a `float` due to the `np.product` operation. This issue causes an exception to be raised from `tensorflow` when the `compute_action_shape` method of the `ActionDistribution` class is run.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Convert the `size` variable to be an integer so that `shape` is a valid `tf.TensorShape`.

## Related issue number

No current issue for this.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
