### PR TITLE
[core] Add long running regression test for distributed ref counting and fix memory leak

### DIFF
--- a/ci/long_running_tests/ray-project/project.yaml
+++ b/ci/long_running_tests/ray-project/project.yaml
@@ -29,6 +29,7 @@ commands:
             "node_failures",
             "pbt",
             "serve",
+            "many_tasks_serialized_ids",
           ]
     config:
       tmux: true

--- a/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -1,0 +1,71 @@
+# This workload tests submitting and getting many tasks over and over.
+
+import time
+
+import numpy as np
+
+import ray
+from ray.cluster_utils import Cluster
+
+num_redis_shards = 5
+redis_max_memory = 10**8
+object_store_memory = 10**8
+num_nodes = 10
+
+message = ("Make sure there is enough memory on this machine to run this "
+           "workload. We divide the system memory by 2 to provide a buffer.")
+assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
+        ray.utils.get_system_memory() / 2)
+
+# Simulate a cluster on one machine.
+
+cluster = Cluster()
+for i in range(num_nodes):
+    cluster.add_node(
+        redis_port=6379 if i == 0 else None,
+        num_redis_shards=num_redis_shards if i == 0 else None,
+        num_cpus=2,
+        num_gpus=0,
+        resources={str(i): 2},
+        object_store_memory=object_store_memory,
+        redis_max_memory=redis_max_memory,
+        webui_host="0.0.0.0")
+ray.init(address=cluster.address)
+
+# Run the workload.
+
+
+@ray.remote(max_retries=0)
+def child(*xs):
+    return np.zeros(1024, dtype=np.uint8)
+
+
+@ray.remote(max_retries=0)
+def f(xs):
+    return child.remote(*xs)
+
+
+iteration = 0
+ids = []
+start_time = time.time()
+previous_time = start_time
+while True:
+    for _ in range(50):
+        new_constrained_ids = [
+            f._remote(args=[[ids]], resources={str(i % num_nodes): 1})
+            for i in range(25)
+        ]
+        new_unconstrained_ids = [f.remote([ids]) for _ in range(25)]
+        ids = new_constrained_ids + new_unconstrained_ids
+
+    ray.get(ids)
+
+    new_time = time.time()
+    print("Iteration {}:\n"
+          "  - Iteration time: {}.\n"
+          "  - Absolute time: {}.\n"
+          "  - Total elapsed time: {}.".format(
+              iteration, new_time - previous_time, new_time,
+              new_time - start_time))
+    previous_time = new_time
+    iteration += 1

--- a/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -1,4 +1,5 @@
-# This workload tests submitting and getting many tasks over and over.
+# This workload stresses distributed reference counting by passing and
+# returning serialized ObjectIDs.
 
 import time
 


### PR DESCRIPTION
## Why are these changes needed?

#6945 introduced a memory leak when the feature flag for distributed ref counting is off. Even when ref counting is disabled, the owner of an object will send RPCs to borrowers, which respond once their ref goes out of scope. Unfortunately, the previous PR only clears the RPC reply callbacks when ref counting is enabled.

This PR fixes the leak by clearing the reply callback even when ref counting is disabled. It also adds a long-running regression test. When running the test locally, the memory usage for both the driver and workers grew steadily before this PR, probably because entries could never get removed from the local `ReferenceCounter`. With this PR, the memory usage stays stable.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
