### PR TITLE
Fixed the bug where ray.remote reference is not shown in the document…

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,6 +74,7 @@ def fake_remote(*args, **kwargs):
     return _inner_wrapper
 
 
+fake_remote.__doc__ = ray.remote.__doc__
 ray.remote = fake_remote
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fixed the problem `ray.remote` is not visible in the document. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
