### PR TITLE
Fix the problem that ray.remote reference is not visible at a document.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,17 +65,6 @@ sys.path.insert(0, os.path.abspath("../../python/"))
 
 import ray
 
-
-# Avoid @ray.remote run when doc generating
-def fake_remote(*args, **kwargs):
-    def _inner_wrapper(cls_or_func):
-        return cls_or_func
-
-    return _inner_wrapper
-
-
-ray.remote = fake_remote
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`ray.remote` document is not visible at the latest document. It is because we use `fake_ray.remote` for doc generation. 

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
