### PR TITLE
Add internal_api.global_gc() method, which triggers gc.collect() on all workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -327,8 +327,8 @@ script:
 
   # ray operator tests
   - cd ./deploy/ray-operator/
-  - go build
-  - go test ./...
+  - ./ci/suppress_output go build
+  - ./ci/suppress_output go test ./...
   - cd ../..
 
   # random python tests TODO(ekl): these should be moved to bazel

--- a/.travis.yml
+++ b/.travis.yml
@@ -327,8 +327,8 @@ script:
 
   # ray operator tests
   - cd ./deploy/ray-operator/
-  - ./ci/suppress_output go build
-  - ./ci/suppress_output go test ./...
+  - ../../ci/suppress_output go build
+  - ../../ci/suppress_output go test ./...
   - cd ../..
 
   # random python tests TODO(ekl): these should be moved to bazel

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -772,7 +772,7 @@ cdef class CoreWorker:
 
     def global_gc(self):
         with nogil:
-            check_status(self.core_worker.get().GlobalGC())
+            self.core_worker.get().GlobalGC()
 
     def set_object_store_client_options(self, client_name,
                                         int64_t limit_bytes):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -772,7 +772,7 @@ cdef class CoreWorker:
 
     def global_gc(self):
         with nogil:
-            self.core_worker.get().GlobalGC()
+            self.core_worker.get().TriggerGlobalGC()
 
     def set_object_store_client_options(self, client_name,
                                         int64_t limit_bytes):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -562,6 +562,11 @@ cdef CRayStatus check_signals() nogil:
     return CRayStatus.OK()
 
 
+cdef void gc_collect() nogil:
+    with gil:
+        gc.collect()
+
+
 cdef shared_ptr[CBuffer] string_to_buffer(c_string& c_str):
     cdef shared_ptr[CBuffer] empty_metadata
     if c_str.size() == 0:
@@ -607,7 +612,7 @@ cdef class CoreWorker:
             raylet_socket.encode("ascii"), job_id.native(),
             gcs_options.native()[0], log_dir.encode("utf-8"),
             node_ip_address.encode("utf-8"), node_manager_port,
-            task_execution_handler, check_signals, True))
+            task_execution_handler, check_signals, gc_collect, True))
 
     def run_task_loop(self):
         with nogil:
@@ -759,6 +764,10 @@ cdef class CoreWorker:
         with nogil:
             check_status(self.core_worker.get().Delete(
                 free_ids, local_only, delete_creating_tasks))
+
+    def global_gc(self):
+        with nogil:
+            check_status(self.core_worker.get().GlobalGC())
 
     def set_object_store_client_options(self, client_name,
                                         int64_t limit_bytes):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -564,7 +564,12 @@ cdef CRayStatus check_signals() nogil:
 
 cdef void gc_collect() nogil:
     with gil:
-        gc.collect()
+        start = time.perf_counter()
+        num_freed = gc.collect()
+        end = time.perf_counter()
+        logger.info(
+            "gc.collect() freed {} refs in {} seconds".format(
+                num_freed, end - start))
 
 
 cdef shared_ptr[CBuffer] string_to_buffer(c_string& c_str):

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -177,7 +177,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                         int64_t timeout_ms, c_vector[c_bool] *results)
         CRayStatus Delete(const c_vector[CObjectID] &object_ids,
                           c_bool local_only, c_bool delete_creating_tasks)
-        CRayStatus GlobalGC()
+        CRayStatus TriggerGlobalGC()
         c_string MemoryUsageString()
 
         CWorkerContext &GetWorkerContext()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -97,6 +97,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                         c_vector[shared_ptr[CRayObject]] *returns,
                         const CWorkerID &worker_id) nogil,
                     CRayStatus() nogil,
+                    void() nogil,
                     c_bool ref_counting_enabled)
         CWorkerType &GetWorkerType()
         CLanguage &GetLanguage()
@@ -176,6 +177,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                         int64_t timeout_ms, c_vector[c_bool] *results)
         CRayStatus Delete(const c_vector[CObjectID] &object_ids,
                           c_bool local_only, c_bool delete_creating_tasks)
+        CRayStatus GlobalGC()
         c_string MemoryUsageString()
 
         CWorkerContext &GetWorkerContext()

--- a/python/ray/internal/internal_api.py
+++ b/python/ray/internal/internal_api.py
@@ -1,7 +1,14 @@
 import ray.worker
 from ray import profiling
 
-__all__ = ["free"]
+__all__ = ["free", "global_gc"]
+
+
+def global_gc():
+    """Trigger gc.collect() on all workers in the cluster."""
+
+    worker = ray.worker.get_global_worker()
+    worker.core_worker.global_gc()
 
 
 def free(object_ids, local_only=False, delete_creating_tasks=False):

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -81,15 +81,15 @@ def test_global_gc(shutdown_only):
         cluster.add_node(num_cpus=1, num_gpus=0)
     ray.init(address=cluster.address)
 
-    class Loop:
-        pass
+    class ObjectWithCyclicRef:
+        def __init__(self):
+            self.loop = self
 
     @ray.remote(num_cpus=1)
     class GarbageHolder:
         def __init__(self):
             gc.disable()
-            x = Loop()
-            x.cyclic_ref = x
+            x = ObjectWithCyclicRef()
             self.garbage = weakref.ref(x)
 
         def has_garbage(self):

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1368,8 +1368,13 @@ void CoreWorker::HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &
 void CoreWorker::HandleLocalGC(const rpc::LocalGCRequest &request,
                                rpc::LocalGCReply *reply,
                                rpc::SendReplyCallback send_reply_callback) {
-  gc_collect_();
-  send_reply_callback(Status::OK(), nullptr, nullptr);
+  if (gc_collect_ != nullptr) {
+    gc_collect_();
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  } else {
+    send_reply_callback(Status::NotImplemented("GC callback not defined"), nullptr,
+                        nullptr);
+  }
 }
 
 void CoreWorker::YieldCurrentFiber(FiberEvent &event) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -68,12 +68,14 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
                        const std::string &log_dir, const std::string &node_ip_address,
                        int node_manager_port,
                        const TaskExecutionCallback &task_execution_callback,
-                       std::function<Status()> check_signals, bool ref_counting_enabled)
+                       std::function<Status()> check_signals,
+                       std::function<void()> gc_collect, bool ref_counting_enabled)
     : worker_type_(worker_type),
       language_(language),
       log_dir_(log_dir),
       ref_counting_enabled_(ref_counting_enabled),
       check_signals_(check_signals),
+      gc_collect_(gc_collect),
       worker_context_(worker_type, job_id),
       io_work_(io_service_),
       client_call_manager_(new rpc::ClientCallManager(io_service_)),
@@ -673,6 +675,12 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
   RAY_RETURN_NOT_OK(plasma_store_provider_->Delete(plasma_object_ids, local_only,
                                                    delete_creating_tasks));
 
+  return Status::OK();
+}
+
+Status CoreWorker::GlobalGC() {
+  gc_collect_();
+  RAY_LOG(ERROR) << "TODO trigger global gc";
   return Status::OK();
 }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -680,8 +680,8 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
 
 Status CoreWorker::GlobalGC() {
   gc_collect_();
-  RAY_LOG(ERROR) << "TODO trigger global gc";
-  return Status::OK();
+  return local_raylet_client_->GlobalGC(
+      [](const Status &status, const rpc::GlobalGCReply &reply) {});
 }
 
 std::string CoreWorker::MemoryUsageString() {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -678,7 +678,7 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
   return Status::OK();
 }
 
-void CoreWorker::GlobalGC() {
+void CoreWorker::TriggerGlobalGC() {
   auto status = local_raylet_client_->GlobalGC(
       [](const Status &status, const rpc::GlobalGCReply &reply) {
         if (!status.ok()) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -290,9 +290,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                 bool delete_creating_tasks);
 
   /// Trigger garbage collection on each worker in the cluster.
-  ///
-  /// \return Status.
-  Status GlobalGC();
+  void GlobalGC();
 
   /// Get a string describing object store memory usage for debugging purposes.
   ///
@@ -495,6 +493,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   void HandleGetCoreWorkerStats(const rpc::GetCoreWorkerStatsRequest &request,
                                 rpc::GetCoreWorkerStatsReply *reply,
                                 rpc::SendReplyCallback send_reply_callback) override;
+
+  /// Trigger local GC on this worker.
+  void HandleLocalGC(const rpc::LocalGCRequest &request, rpc::LocalGCReply *reply,
+                     rpc::SendReplyCallback send_reply_callback) override;
 
   ///
   /// Public methods related to async actor call. This should only be used when

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -290,7 +290,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                 bool delete_creating_tasks);
 
   /// Trigger garbage collection on each worker in the cluster.
-  void GlobalGC();
+  void TriggerGlobalGC();
 
   /// Get a string describing object store memory usage for debugging purposes.
   ///

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -218,6 +218,12 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
+message LocalGCRequest {
+}
+
+message LocalGCReply {
+}
+
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
   rpc AssignTask(AssignTaskRequest) returns (AssignTaskReply);
@@ -238,4 +244,6 @@ service CoreWorkerService {
   rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
   // Wait for a borrower to finish using an object. Sent by the object's owner.
   rpc WaitForRefRemoved(WaitForRefRemovedRequest) returns (WaitForRefRemovedReply);
+  // Trigger local GC on the worker.
+  rpc LocalGC(LocalGCRequest) returns (LocalGCReply);
 }

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -211,6 +211,8 @@ message HeartbeatTableData {
   repeated double resource_load_capacity = 7;
   // Object IDs that are in use by workers on this node manager's node.
   repeated bytes active_object_id = 8;
+  // Whether this node manager is requesting global GC.
+  bool should_global_gc = 9;
 }
 
 message HeartbeatBatchTableData {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -75,6 +75,12 @@ message GetNodeStatsReply {
   repeated TaskSpec ready_tasks = 5;
 }
 
+message GlobalGCRequest {
+}
+
+message GlobalGCReply {
+}
+
 // Service for inter-node-manager communication.
 service NodeManagerService {
   // Request a worker from the raylet.
@@ -87,4 +93,6 @@ service NodeManagerService {
   rpc PinObjectIDs(PinObjectIDsRequest) returns (PinObjectIDsReply);
   // Get the current node stats.
   rpc GetNodeStats(GetNodeStatsRequest) returns (GetNodeStatsReply);
+  // Trigger garbage collection in all workers across the cluster.
+  rpc GlobalGC(GlobalGCRequest) returns (GlobalGCReply);
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -344,8 +344,11 @@ void NodeManager::Heartbeat() {
 }
 
 void NodeManager::DoLocalGC() {
-  RAY_LOG(ERROR) << "Sending local GC request to all workers.";
   auto all_workers = worker_pool_.GetAllWorkers();
+  for (const auto &driver : worker_pool_.GetAllDrivers()) {
+    all_workers.push_back(driver);
+  }
+  RAY_LOG(ERROR) << "Sending local GC request to " << all_workers.size() << " workers.";
   for (const auto &worker : all_workers) {
     rpc::LocalGCRequest request;
     auto status = worker->rpc_client()->LocalGC(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -304,6 +304,19 @@ void NodeManager::Heartbeat() {
     heartbeat_data->add_resource_load_capacity(resource_pair.second);
   }
 
+  // Set the global gc bit on the outgoing heartbeat message.
+  if (should_global_gc_) {
+    heartbeat_data->set_should_global_gc(true);
+    should_global_gc_ = false;
+  }
+
+  // Trigger local GC if needed. This throttles the frequency of local GC calls
+  // to at most once per heartbeat interval.
+  if (should_local_gc_) {
+    DoLocalGC();
+    should_local_gc_ = false;
+  }
+
   ray::Status status = gcs_client_->Nodes().AsyncReportHeartbeat(heartbeat_data,
                                                                  /*done*/ nullptr);
   RAY_CHECK_OK_PREPEND(status, "Heartbeat failed");
@@ -328,6 +341,23 @@ void NodeManager::Heartbeat() {
     RAY_CHECK(!error);
     Heartbeat();
   });
+}
+
+void NodeManager::DoLocalGC() {
+  RAY_LOG(ERROR) << "Sending local GC request to all workers.";
+  auto all_workers = worker_pool_.GetAllWorkers();
+  for (const auto &worker : all_workers) {
+    rpc::LocalGCRequest request;
+    auto status = worker->rpc_client()->LocalGC(
+        request, [](const ray::Status &status, const rpc::LocalGCReply &r) {
+          if (!status.ok()) {
+            RAY_LOG(ERROR) << "Failed to send local GC request: " << status.ToString();
+          }
+        });
+    if (!status.ok()) {
+      RAY_LOG(ERROR) << "Failed to send local GC request: " << status.ToString();
+    }
+  }
 }
 
 // TODO(edoakes): this function is problematic because it both sends warnings spuriously
@@ -650,6 +680,12 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
                   << client_id;
     return;
   }
+
+  // Trigger local GC at the next heartbeat interval.
+  if (heartbeat_data.should_global_gc()) {
+    should_local_gc_ = true;
+  }
+
   SchedulingResources &remote_resources = it->second;
 
   ResourceSet remote_total(VectorFromProtobuf(heartbeat_data.resources_total_label()),
@@ -3270,6 +3306,14 @@ void NodeManager::HandleGetNodeStats(const rpc::GetNodeStatsRequest &request,
                        << status.ToString();
     }
   }
+}
+
+void NodeManager::HandleGlobalGC(const rpc::GlobalGCRequest &request,
+                                 rpc::GlobalGCReply *reply,
+                                 rpc::SendReplyCallback send_reply_callback) {
+  RAY_LOG(ERROR) << "Broadcasting global GC request to all raylets.";
+  should_global_gc_ = true;
+  should_local_gc_ = true;
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3316,8 +3316,8 @@ void NodeManager::HandleGlobalGC(const rpc::GlobalGCRequest &request,
                                  rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(WARNING) << "Broadcasting global GC request to all raylets.";
   should_global_gc_ = true;
-  // We won't see our own request, so trigger local GC immediately too.
-  DoLocalGC();
+  // We won't see our own request, so trigger local GC in the next heartbeat.
+  should_local_gc_ = true;
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3316,7 +3316,8 @@ void NodeManager::HandleGlobalGC(const rpc::GlobalGCRequest &request,
                                  rpc::SendReplyCallback send_reply_callback) {
   RAY_LOG(WARNING) << "Broadcasting global GC request to all raylets.";
   should_global_gc_ = true;
-  should_local_gc_ = true;
+  // We won't see our own request, so trigger local GC immediately too.
+  DoLocalGC();
 }
 
 void NodeManager::RecordMetrics() {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -348,7 +348,7 @@ void NodeManager::DoLocalGC() {
   for (const auto &driver : worker_pool_.GetAllDrivers()) {
     all_workers.push_back(driver);
   }
-  RAY_LOG(ERROR) << "Sending local GC request to " << all_workers.size() << " workers.";
+  RAY_LOG(WARNING) << "Sending local GC request to " << all_workers.size() << " workers.";
   for (const auto &worker : all_workers) {
     rpc::LocalGCRequest request;
     auto status = worker->rpc_client()->LocalGC(
@@ -3314,7 +3314,7 @@ void NodeManager::HandleGetNodeStats(const rpc::GetNodeStatsRequest &request,
 void NodeManager::HandleGlobalGC(const rpc::GlobalGCRequest &request,
                                  rpc::GlobalGCReply *reply,
                                  rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(ERROR) << "Broadcasting global GC request to all raylets.";
+  RAY_LOG(WARNING) << "Broadcasting global GC request to all raylets.";
   should_global_gc_ = true;
   should_local_gc_ = true;
 }

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -563,6 +563,13 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
                           rpc::GetNodeStatsReply *reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle a `GlobalGC` request.
+  void HandleGlobalGC(const rpc::GlobalGCRequest &request, rpc::GlobalGCReply *reply,
+                      rpc::SendReplyCallback send_reply_callback) override;
+
+  /// Trigger local GC on each worker of this raylet.
+  void DoLocalGC();
+
   /// Push an error to the driver if this node is full of actors and so we are
   /// unable to schedule new tasks or actors at all.
   void WarnResourceDeadlock();
@@ -668,6 +675,14 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
 
   /// Whether new schedule is enabled.
   const bool new_scheduler_enabled_;
+
+  /// Whether to trigger global GC in the next heartbeat. This will broadcast
+  /// a global GC message to all raylets except for this one.
+  bool should_global_gc_ = false;
+
+  /// Whether to trigger local GC in the next heartbeat. This will trigger gc
+  /// on all local workers of this raylet.
+  bool should_local_gc_ = false;
 
   /// The new resource scheduler for direct task calls.
   std::shared_ptr<ClusterResourceScheduler> new_resource_scheduler_;

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -377,4 +377,10 @@ Status raylet::RayletClient::PinObjectIDs(
   return grpc_client_->PinObjectIDs(request, callback);
 }
 
+Status raylet::RayletClient::GlobalGC(
+    const rpc::ClientCallback<rpc::GlobalGCReply> &callback) {
+  rpc::GlobalGCRequest request;
+  return grpc_client_->GlobalGC(request, callback);
+}
+
 }  // namespace ray

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -257,6 +257,8 @@ class RayletClient : public WorkerLeaseInterface {
       const rpc::Address &caller_address, const std::vector<ObjectID> &object_ids,
       const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback);
 
+  ray::Status GlobalGC(const rpc::ClientCallback<rpc::GlobalGCReply> &callback);
+
   WorkerID GetWorkerID() const { return worker_id_; }
 
   JobID GetJobID() const { return job_id_; }

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -76,6 +76,9 @@ class NodeManagerWorkerClient
   /// Notify the raylet to pin the provided object IDs.
   RPC_CLIENT_METHOD(NodeManagerService, PinObjectIDs, grpc_client_, )
 
+  /// Trigger global GC across the cluster.
+  RPC_CLIENT_METHOD(NodeManagerService, GlobalGC, grpc_client_, )
+
  private:
   /// Constructor.
   ///

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -15,7 +15,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(NodeManagerService, ReturnWorker, 100)       \
   RPC_SERVICE_HANDLER(NodeManagerService, ForwardTask, 100)        \
   RPC_SERVICE_HANDLER(NodeManagerService, PinObjectIDs, 100)       \
-  RPC_SERVICE_HANDLER(NodeManagerService, GetNodeStats, 1)
+  RPC_SERVICE_HANDLER(NodeManagerService, GetNodeStats, 1)         \
+  RPC_SERVICE_HANDLER(NodeManagerService, GlobalGC, 1)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
 class NodeManagerServiceHandler {
@@ -50,6 +51,9 @@ class NodeManagerServiceHandler {
   virtual void HandleGetNodeStats(const GetNodeStatsRequest &request,
                                   GetNodeStatsReply *reply,
                                   SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGlobalGC(const GlobalGCRequest &request, GlobalGCReply *reply,
+                              SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `NodeManagerService`.

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -194,6 +194,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   RPC_CLIENT_METHOD(CoreWorkerService, GetCoreWorkerStats, grpc_client_, override)
 
+  RPC_CLIENT_METHOD(CoreWorkerService, LocalGC, grpc_client_, override)
+
   RPC_CLIENT_METHOD(CoreWorkerService, WaitForRefRemoved, grpc_client_, override)
 
   ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request,

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -149,6 +149,11 @@ class CoreWorkerClientInterface {
     return Status::NotImplemented("");
   }
 
+  virtual ray::Status LocalGC(const LocalGCRequest &request,
+                              const ClientCallback<LocalGCReply> &callback) {
+    return Status::NotImplemented("");
+  }
+
   virtual ray::Status WaitForRefRemoved(
       const WaitForRefRemovedRequest &request,
       const ClientCallback<WaitForRefRemovedReply> &callback) {

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -22,7 +22,8 @@ namespace rpc {
   RPC_SERVICE_HANDLER(CoreWorkerService, WaitForObjectEviction, 9999)         \
   RPC_SERVICE_HANDLER(CoreWorkerService, WaitForRefRemoved, 9999)             \
   RPC_SERVICE_HANDLER(CoreWorkerService, KillActor, 9999)                     \
-  RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats, 100)
+  RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats, 100)             \
+  RPC_SERVICE_HANDLER(CoreWorkerService, LocalGC, 100)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(AssignTask)                     \
@@ -32,7 +33,8 @@ namespace rpc {
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(WaitForObjectEviction)          \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(WaitForRefRemoved)              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(KillActor)                      \
-  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(GetCoreWorkerStats)
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(GetCoreWorkerStats)             \
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(LocalGC)
 
 /// Interface of the `CoreWorkerServiceHandler`, see `src/ray/protobuf/core_worker.proto`.
 class CoreWorkerServiceHandler {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This adds a `global_gc` method, which triggers gc.collect() on all workers to collect cyclic object references. This can be called when there is object store memory pressure to trigger the release of distributed object references.

It works like this:
- The GlobalGC() method of the core worker sends a RPC to the raylet to request global GC.
- The raylet sets a `should_global_gc` flag in its heartbeat, which is broadcast to all other raylets. When a raylet sees a heartbeat with should_global_gc set, it sets a local `should_local_gc` flag.
- When a raylet sees `should_local_gc` set, it will send a RPC to all workers in the next heartbeat.

This effectively throttles the frequency of worker GC to once per raylet heartbeat (100ms), no matter how often it is called across the cluster.