### PR TITLE
[rllib] Fix multiagent example crash due to undefined abstract method

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1265,6 +1265,14 @@ py_test(
 )
 
 py_test(
+    name = "examples/rock_paper_scissors_multiagent", main = "examples/rock_paper_scissors_multiagent.py",
+    tags = ["examples", "examples_R"],
+    size = "large",
+    srcs = ["examples/rock_paper_scissors_multiagent.py"],
+    args = ["--stop=200"],
+)
+
+py_test(
     name = "examples/twostep_game_maddpg", main = "examples/twostep_game.py",
     tags = ["examples", "examples_T"],
     size = "large",

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -164,7 +164,7 @@ def run_heuristic_vs_learned(use_lstm=False, trainer="PG"):
         config={
             "env": RockPaperScissorsEnv,
             "gamma": 0.9,
-            "num_workers": 4,
+            "num_workers": 0,
             "num_envs_per_worker": 4,
             "sample_batch_size": 10,
             "train_batch_size": 200,

--- a/rllib/examples/rock_paper_scissors_multiagent.py
+++ b/rllib/examples/rock_paper_scissors_multiagent.py
@@ -7,6 +7,7 @@ This demonstrates running the following policies in competition:
     (4) LSTM policy with custom entropy loss
 """
 
+import argparse
 import random
 from gym.spaces import Discrete
 
@@ -22,6 +23,9 @@ tf = try_import_tf()
 ROCK = 0
 PAPER = 1
 SCISSORS = 2
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--stop", type=int, default=400000)
 
 
 class RockPaperScissorsEnv(MultiAgentEnv):
@@ -153,9 +157,10 @@ def run_heuristic_vs_learned(use_lstm=False, trainer="PG"):
         else:
             return random.choice(["always_same", "beat_last"])
 
+    args = parser.parse_args()
     tune.run(
         trainer,
-        stop={"timesteps_total": 400000},
+        stop={"timesteps_total": args.stop},
         config={
             "env": RockPaperScissorsEnv,
             "gamma": 0.9,

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -164,7 +164,6 @@ class Policy(metaclass=ABCMeta):
         return action, [s[0] for s in state_out], \
             {k: v[0] for k, v in info.items()}
 
-    @abstractmethod
     @DeveloperAPI
     def compute_log_likelihoods(self,
                                 actions,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We shouldn't require the log likelihood method to be defined. This fixes the example and adds a test.