### PR TITLE
[RLlib] TupleActions cannot be exported by Policy: Fixes issues 7231 and 5593.

### DIFF
--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -493,8 +493,10 @@ class TFPolicy(Policy):
 
         # build output signatures
         output_signature = self._extra_output_signature_def()
-        output_signature["actions"] = \
-            tf.saved_model.utils.build_tensor_info(self._sampled_action)
+        for i, a in enumerate(tf.nest.flatten(self._sampled_action)):
+            output_signature["actions_{}".format(i)] = \
+                tf.saved_model.utils.build_tensor_info(a)
+
         for state_output in self._state_outputs:
             output_signature[state_output.name] = \
                 tf.saved_model.utils.build_tensor_info(state_output)

--- a/rllib/tests/test_checkpoint_restore.py
+++ b/rllib/tests/test_checkpoint_restore.py
@@ -80,7 +80,7 @@ def test_ckpt_restore(use_object_store, alg_name, failures):
     else:
         alg2.restore(alg1.save())
 
-    for _ in range(10):
+    for _ in range(5):
         if "DDPG" in alg_name or "SAC" in alg_name:
             obs = np.clip(
                 np.random.uniform(size=3),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

TupleActions are not exportable by `Policy.export_model`. This PR fixes that restriction.

<!-- Please give a short summary of the change and the problem this solves. -->

#7231 and #5593 

<!-- For example: "Closes #1234" -->

Closes issues #7231 and #5593.

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
