### PR TITLE
[WIP] Attempt to retry pending requests on actor restart

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -218,12 +218,14 @@ class SignalActor:
     def __init__(self):
         self.ready_event = asyncio.Event()
 
-    def send(self):
+    async def send(self):
         self.ready_event.set()
 
-    async def wait(self, should_wait=True):
+    async def wait(self, should_wait=True, clear=True):
         if should_wait:
             await self.ready_event.wait()
+            if clear:
+                self.ready_event.clear()
 
 
 class RemoteSignal:

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -43,7 +43,7 @@ py_test(
     size = "medium",
     srcs = ["test_actor_failures.py"],
     # TODO(ekl) enable this once we support actor reconstruction again
-    tags = ["exclusive", "manual"],
+    tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -127,8 +127,7 @@ class TaskSpecBuilder {
   /// \return Reference to the builder object itself.
   TaskSpecBuilder &SetActorTaskSpec(const ActorID &actor_id,
                                     const ObjectID &actor_creation_dummy_object_id,
-                                    const ObjectID &previous_actor_task_dummy_object_id,
-                                    uint64_t actor_counter) {
+                                    const ObjectID &previous_actor_task_dummy_object_id) {
     message_->set_type(TaskType::ACTOR_TASK);
     auto actor_spec = message_->mutable_actor_task_spec();
     actor_spec->set_actor_id(actor_id.Binary());
@@ -136,6 +135,11 @@ class TaskSpecBuilder {
         actor_creation_dummy_object_id.Binary());
     actor_spec->set_previous_actor_task_dummy_object_id(
         previous_actor_task_dummy_object_id.Binary());
+    return *this;
+  }
+
+  TaskSpecBuilder &SetActorCounter(uint64_t actor_counter) {
+    auto actor_spec = message_->mutable_actor_task_spec();
     actor_spec->set_actor_counter(actor_counter);
     return *this;
   }

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -62,7 +62,6 @@ void ActorHandle::Serialize(std::string *output) { inner_.SerializeToString(outp
 
 void ActorHandle::Reset() {
   absl::MutexLock guard(&mutex_);
-  task_counter_ = 0;
   actor_cursor_ = ObjectID::FromBinary(inner_.actor_cursor());
 }
 

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -53,8 +53,7 @@ void ActorHandle::SetActorTaskSpec(TaskSpecBuilder &builder,
       ObjectID::ForTaskReturn(actor_creation_task_id, /*index=*/1,
                               /*transport_type=*/static_cast<int>(transport_type));
   builder.SetActorTaskSpec(GetActorID(), actor_creation_dummy_object_id,
-                           /*previous_actor_task_dummy_object_id=*/actor_cursor_,
-                           task_counter_++);
+                           /*previous_actor_task_dummy_object_id=*/actor_cursor_);
   actor_cursor_ = new_cursor;
 }
 

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -69,16 +69,6 @@ class ActorHandle {
     return state_ == rpc::ActorTableData::DEAD;
   }
 
-  void CompleteNextTask() {
-    absl::MutexLock lock(&mutex_);
-    ++complete_task_counter_;
-  }
-
-  uint64_t NumCompletedTasks() const {
-    absl::MutexLock lock(&mutex_);
-    return complete_task_counter_;
-  }
-
  private:
   // Protobuf-defined persistent state of the actor handle.
   const ray::rpc::ActorHandle inner_;
@@ -92,11 +82,6 @@ class ActorHandle {
   /// only.
   // TODO: Save this state in the core worker.
   ObjectID actor_cursor_ GUARDED_BY(mutex_);
-  /// Number of tasks that have been submitted on this handle.
-  uint64_t task_counter_ GUARDED_BY(mutex_) = 0;
-
-  /// Nuber of tasks submitted to this handle that have been completed by the actor.
-  uint64_t complete_task_counter_ GUARDED_BY(mutex_) = 0;
 
   /// Mutex to protect fields in the actor handle.
   mutable absl::Mutex mutex_;

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -69,6 +69,16 @@ class ActorHandle {
     return state_ == rpc::ActorTableData::DEAD;
   }
 
+  void CompleteNextTask() {
+    absl::MutexLock lock(&mutex_);
+    ++complete_task_counter_;
+  }
+
+  uint64_t NumCompletedTasks() const {
+    absl::MutexLock lock(&mutex_);
+    return complete_task_counter_;
+  }
+
  private:
   // Protobuf-defined persistent state of the actor handle.
   const ray::rpc::ActorHandle inner_;
@@ -82,8 +92,11 @@ class ActorHandle {
   /// only.
   // TODO: Save this state in the core worker.
   ObjectID actor_cursor_ GUARDED_BY(mutex_);
-  // Number of tasks that have been submitted on this handle.
+  /// Number of tasks that have been submitted on this handle.
   uint64_t task_counter_ GUARDED_BY(mutex_) = 0;
+
+  /// Nuber of tasks submitted to this handle that have been completed by the actor.
+  uint64_t complete_task_counter_ GUARDED_BY(mutex_) = 0;
 
   /// Mutex to protect fields in the actor handle.
   mutable absl::Mutex mutex_;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -919,8 +919,7 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle) {
         absl::MutexLock lock(&mutex_);
         auto task_it = pending_kill_for_actor_.find(actor_id);
         if (task_it != pending_kill_for_actor_.end()) {
-          auto it = task_it->second;
-          pending_actor_kills_.erase(it);
+          pending_actor_kills_.erase(task_it->second);
         }
       };
       if (actor_data.state() == gcs::ActorTableData::RECONSTRUCTING) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -368,9 +368,10 @@ void CoreWorker::InternalHeartbeat() {
   while (!to_resubmit_.empty() && current_time_ms() > to_resubmit_.front().first) {
     auto& spec = to_resubmit_.front().second;
     if (spec.IsActorTask()) {
-      ActorHandle* handle = nullptr;
+      ActorHandle *handle = nullptr;
       RAY_CHECK_OK(GetActorHandle(spec.ActorId(), &handle));
       if (handle->IsDead()) {
+        task_manager_->SetRemainingRetries(spec.TaskId(), 0);
         task_manager_->PendingTaskFailed(spec.TaskId(), rpc::ErrorType::ACTOR_DIED);
       } else {
         RAY_CHECK_OK(direct_actor_submitter_->SubmitTask(std::move(spec)));

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -799,6 +799,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   // Plasma notification manager
   std::unique_ptr<ObjectStoreNotificationManager> plasma_notifier_;
 
+  // Plasma Callback
+  PlasmaSubscriptionCallback plasma_done_callback_;
+
   friend class CoreWorkerTest;
 };
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -796,14 +796,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   // Queue of tasks to resubmit when the specified time passes.
   std::deque<std::pair<int64_t, TaskSpecification>> to_resubmit_ GUARDED_BY(mutex_);
 
-  // Plasma Callback
-  PlasmaSubscriptionCallback plasma_done_callback_;
-  // List of deadlines for delayed actor kill requests.
-  std::list<std::pair<int64_t, ActorID>> pending_actor_kills_ GUARDED_BY(mutex_);
-
-  // Contains iterators to entries in pending_actor_kills_ for each actor.  Useful for cancelling pending kills.
-  absl::flat_hash_map<ActorID, std::list<std::pair<int64_t, ActorID>>::iterator> pending_kill_for_actor_ GUARDED_BY(mutex_);
-
   // Plasma notification manager
   std::unique_ptr<ObjectStoreNotificationManager> plasma_notifier_;
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -798,6 +798,14 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   // Plasma Callback
   PlasmaSubscriptionCallback plasma_done_callback_;
+  // List of deadlines for delayed actor kill requests.
+  std::list<std::pair<int64_t, ActorID>> pending_actor_kills_ GUARDED_BY(mutex_);
+
+  // Contains iterators to entries in pending_actor_kills_ for each actor.  Useful for cancelling pending kills.
+  absl::flat_hash_map<ActorID, std::list<std::pair<int64_t, ActorID>>::iterator> pending_kill_for_actor_ GUARDED_BY(mutex_);
+
+  // Plasma notification manager
+  std::unique_ptr<ObjectStoreNotificationManager> plasma_notifier_;
 
   friend class CoreWorkerTest;
 };

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -79,10 +79,11 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     auto it = pending_tasks_.find(task_id);
     RAY_CHECK(it != pending_tasks_.end())
         << "Tried to complete task that was not pending " << task_id;
-    spec = it->second.first;
+    spec = std::move(it->second.first);
     pending_tasks_.erase(it);
   }
 
+  complete_task_callback_(spec);
   RemoveFinishedTaskReferences(spec, worker_addr, reply.borrowed_refs());
 
   for (int i = 0; i < reply.return_objects_size(); i++) {
@@ -114,7 +115,6 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
           object_id));
     }
   }
-
   ShutdownIfNeeded();
 }
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -12,7 +12,7 @@ const int64_t kTaskFailureLoggingFrequencyMillis = 5000;
 
 void TaskManager::AddPendingTask(const TaskID &caller_id,
                                  const rpc::Address &caller_address,
-                                 TaskSpecification &spec, uint64_t max_retries) {
+                                 const TaskSpecification &spec, uint64_t max_retries) {
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId();
   absl::MutexLock lock(&mu_);
   std::pair<TaskSpecification, uint64_t> entry = {spec, max_retries};

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -245,4 +245,11 @@ TaskSpecification TaskManager::GetTaskSpec(const TaskID &task_id) const {
   return it->second.first;
 }
 
+void TaskManager::SetRemainingRetries(const TaskID &task_id, uint64_t retries) {
+  absl::MutexLock lock(&mu_);
+  auto it = pending_tasks_.find(task_id);
+  RAY_CHECK(it != pending_tasks_.end());
+  it->second.second = retries;
+}
+
 }  // namespace ray

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -12,10 +12,10 @@ const int64_t kTaskFailureLoggingFrequencyMillis = 5000;
 
 void TaskManager::AddPendingTask(const TaskID &caller_id,
                                  const rpc::Address &caller_address,
-                                 const TaskSpecification &spec, int max_retries) {
+                                 const TaskSpecification &spec, uint64_t max_retries) {
   RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId();
   absl::MutexLock lock(&mu_);
-  std::pair<TaskSpecification, int> entry = {spec, max_retries};
+  std::pair<TaskSpecification, uint64_t> entry = {spec, max_retries};
   RAY_CHECK(pending_tasks_.emplace(spec.TaskId(), std::move(entry)).second);
 
   // Add references for the dependencies to the task.
@@ -124,7 +124,7 @@ void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_
   // loudly with ERROR here.
   RAY_LOG(DEBUG) << "Task " << task_id << " failed with error "
                  << rpc::ErrorType_Name(error_type);
-  int num_retries_left = 0;
+  uint64_t num_retries_left = 0;
   TaskSpecification spec;
   {
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -29,17 +29,20 @@ class TaskFinisherInterface {
 };
 
 using RetryTaskCallback = std::function<void(const TaskSpecification &spec)>;
+using CompleteTaskCallback = std::function<void(const TaskSpecification &spec)>;
 
 class TaskManager : public TaskFinisherInterface {
  public:
   TaskManager(std::shared_ptr<CoreWorkerMemoryStore> in_memory_store,
               std::shared_ptr<ReferenceCounter> reference_counter,
               std::shared_ptr<ActorManagerInterface> actor_manager,
-              RetryTaskCallback retry_task_callback)
+              RetryTaskCallback retry_task_callback,
+              CompleteTaskCallback complete_task_callback)
       : in_memory_store_(in_memory_store),
         reference_counter_(reference_counter),
         actor_manager_(actor_manager),
-        retry_task_callback_(retry_task_callback) {}
+        retry_task_callback_(retry_task_callback),
+        complete_task_callback_(complete_task_callback) {}
 
   /// Add a task that is pending execution.
   ///
@@ -129,6 +132,9 @@ class TaskManager : public TaskFinisherInterface {
 
   /// Called when a task should be retried.
   const RetryTaskCallback retry_task_callback_;
+
+  /// Called when a task is completed.
+  const CompleteTaskCallback complete_task_callback_;
 
   // The number of task failures we have logged total.
   int64_t num_failure_logs_ GUARDED_BY(mu_) = 0;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -33,6 +33,8 @@ using CompleteTaskCallback = std::function<void(const TaskSpecification &spec)>;
 
 class TaskManager : public TaskFinisherInterface {
  public:
+  static constexpr uint64_t kInfiniteRetries = std::numeric_limits<uint64_t>::max();
+
   TaskManager(std::shared_ptr<CoreWorkerMemoryStore> in_memory_store,
               std::shared_ptr<ReferenceCounter> reference_counter,
               std::shared_ptr<ActorManagerInterface> actor_manager,
@@ -53,7 +55,7 @@ class TaskManager : public TaskFinisherInterface {
   /// on failure.
   /// \return Void.
   void AddPendingTask(const TaskID &caller_id, const rpc::Address &caller_address,
-                      const TaskSpecification &spec, int max_retries = 0);
+                      const TaskSpecification &spec, uint64_t max_retries = 0);
 
   /// Wait for all pending tasks to finish, and then shutdown.
   ///
@@ -153,7 +155,7 @@ class TaskManager : public TaskFinisherInterface {
   /// the worker fails. We could avoid this by either not caching the full
   /// TaskSpec for tasks that cannot be retried (e.g., actor tasks), or by
   /// storing a shared_ptr to a PushTaskRequest protobuf for all tasks.
-  absl::flat_hash_map<TaskID, std::pair<TaskSpecification, int>> pending_tasks_
+  absl::flat_hash_map<TaskID, std::pair<TaskSpecification, uint64_t>> pending_tasks_
       GUARDED_BY(mu_);
 
   /// Optional shutdown hook to call when pending tasks all finish.

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -47,12 +47,12 @@ class TaskManager : public TaskFinisherInterface {
   ///
   /// \param[in] caller_id The TaskID of the calling task.
   /// \param[in] caller_address The rpc address of the calling task.
-  /// \param[in,out] spec The spec of the pending task.
+  /// \param[in] spec The spec of the pending task.
   /// \param[in] max_retries Number of times this task may be retried
   /// on failure.
   /// \return Void.
   void AddPendingTask(const TaskID &caller_id, const rpc::Address &caller_address,
-                      TaskSpecification &spec, uint64_t max_retries = 0);
+                      const TaskSpecification &spec, uint64_t max_retries = 0);
 
   /// Wait for all pending tasks to finish, and then shutdown.
   ///
@@ -98,8 +98,10 @@ class TaskManager : public TaskFinisherInterface {
   /// Return the spec for a pending task.
   TaskSpecification GetTaskSpec(const TaskID &task_id) const;
 
+  /// Sets the actor counter in the task spec being built.
   void SetActorCounter(TaskSpecBuilder &builder, const ActorID &actor_id);
 
+  /// Resets the number of retries remaining for a pending task to the given value.
   void SetRemainingRetries(const TaskID &task_id, uint64_t retries);
 
   /// Return the number of pending tasks.

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -101,6 +101,8 @@ class TaskManager : public TaskFinisherInterface {
   /// Return the spec for a pending task.
   TaskSpecification GetTaskSpec(const TaskID &task_id) const;
 
+  void SetRemainingRetries(const TaskID &task_id, uint64_t retries);
+
   /// Return the number of pending tasks.
   int NumPendingTasks() const { return pending_tasks_.size(); }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -122,7 +122,6 @@ class CoreWorkerDirectActorTaskSubmitter {
   /// Set of actor ids that should be force killed once a client is available.
   absl::flat_hash_set<ActorID> pending_force_kills_ GUARDED_BY(mu_);
 
-  // TODO(apaszke): Get rid of those
   /// Map from actor id to the actor's pending requests. Each actor's requests
   /// are ordered by the task number in the request.
   absl::flat_hash_map<ActorID, std::vector<std::unique_ptr<rpc::PushTaskRequest>>>

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -37,7 +37,7 @@ const int kMaxReorderWaitSeconds = 30;
 class CoreWorkerDirectActorTaskSubmitter {
  public:
   CoreWorkerDirectActorTaskSubmitter(rpc::Address rpc_address,
-                                     rpc::ClientFactoryFn client_factory,
+                                     rpc::ClientWithOffsetFactoryFn client_factory,
                                      std::shared_ptr<CoreWorkerMemoryStore> store,
                                      std::shared_ptr<TaskFinisherInterface> task_finisher)
       : rpc_address_(rpc_address),
@@ -61,7 +61,7 @@ class CoreWorkerDirectActorTaskSubmitter {
   ///
   /// \param[in] actor_id Actor ID.
   /// \param[in] address The new address of the actor.
-  void ConnectActor(const ActorID &actor_id, const rpc::Address &address);
+  void ConnectActor(const ActorID &actor_id, const rpc::Address &address, uint64_t actor_counter);
 
   /// Disconnect from a failed actor.
   ///
@@ -99,7 +99,7 @@ class CoreWorkerDirectActorTaskSubmitter {
   bool IsActorAlive(const ActorID &actor_id) const;
 
   /// Factory for producing new core worker clients.
-  rpc::ClientFactoryFn client_factory_;
+  rpc::ClientWithOffsetFactoryFn client_factory_;
 
   /// Mutex to proect the various maps below.
   mutable absl::Mutex mu_;
@@ -122,6 +122,7 @@ class CoreWorkerDirectActorTaskSubmitter {
   /// Set of actor ids that should be force killed once a client is available.
   absl::flat_hash_set<ActorID> pending_force_kills_ GUARDED_BY(mu_);
 
+  // TODO(apaszke): Get rid of those
   /// Map from actor id to the actor's pending requests. Each actor's requests
   /// are ordered by the task number in the request.
   absl::flat_hash_map<ActorID, std::map<int64_t, std::unique_ptr<rpc::PushTaskRequest>>>

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -296,6 +296,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   /// The max sequence number we have processed responses for.
   int64_t max_finished_seq_no_ GUARDED_BY(mutex_) = -1;
 
+  /// An offset subtracted from every sequence number before the request is sent.
   uint64_t sequence_nr_offset_;
 
   /// The task id we are currently sending requests for. When this changes,


### PR DESCRIPTION
Previously any actor failure would cause all outstanding actor tasks to
get marked as failed, leading to an exception in the user program.
This patch changes the behavior such that as long as the actor has
remaining reconstructions, all tasks which haven't been completed previously
will get resubmitted to the new instance automatically.

The new semantics allow to handle failures in a more transparent way, but
also requiresthe user to make sure that the actor will always restart in a
state in which the repeated calls are still valid. If this is not the desired
behavior the workaround is to disallow automatic reconstruction and implement
manual handling of actor failures in the user program.

## Related issue numbers

#6670, #6773

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
