### PR TITLE
Remove serialized from_random object ids in tests

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import fnmatch
 import os
@@ -210,3 +211,27 @@ def generate_internal_config_map(**kwargs):
         "_internal_config": internal_config,
     }
     return ray_kwargs
+
+
+@ray.remote(num_cpus=0)
+class SignalActor:
+    def __init__(self):
+        self.ready_event = asyncio.Event()
+
+    def send(self):
+        self.ready_event.set()
+
+    async def wait(self, should_wait=True):
+        if should_wait:
+            await self.ready_event.wait()
+
+
+class RemoteSignal:
+    def __init__(self):
+        self.signal_actor = SignalActor.remote()
+
+    def send(self):
+        ray.get(self.signal_actor.send.remote())
+
+    def wait(self):
+        ray.get(self.signal_actor.wait.remote())

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import asyncio
 import collections
 import io
 import json
@@ -1313,19 +1312,7 @@ def test_get_dict(ray_start_regular):
 
 
 def test_get_with_timeout(ray_start_regular):
-    @ray.remote(num_cpus=0)
-    class Signal:
-        def __init__(self):
-            self.ready_event = asyncio.Event()
-
-        def send(self):
-            self.ready_event.set()
-
-        async def wait(self, should_wait=True):
-            if should_wait:
-                await self.ready_event.wait()
-
-    signal = Signal.remote()
+    signal = ray.test_utils.SignalActor.remote()
 
     # Check that get() returns early if object is ready.
     start = time.time()

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -371,7 +371,7 @@ def test_actor_worker_dying(ray_start_regular):
         pass
 
     a = Actor.remote()
-    [obj], _ = ray.wait([a.kill.remote()], timeout=5.0)
+    [obj], _ = ray.wait([a.kill.remote()], timeout=5)
     with pytest.raises(ray.exceptions.RayActorError):
         ray.get(obj)
     with pytest.raises(ray.exceptions.RayTaskError):
@@ -863,11 +863,11 @@ def test_connect_with_disconnected_node(shutdown_only):
     # This node is killed by SIGKILL, ray_monitor will mark it to dead.
     dead_node = cluster.add_node(num_cpus=0, _internal_config=config)
     cluster.remove_node(dead_node, allow_graceful=False)
-    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 1, timeout=2)
+    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 1)
     # This node is killed by SIGKILL, ray_monitor will mark it to dead.
     dead_node = cluster.add_node(num_cpus=0, _internal_config=config)
     cluster.remove_node(dead_node, allow_graceful=False)
-    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 2, timeout=2)
+    wait_for_errors(ray_constants.REMOVED_NODE_ERROR, 2)
     # This node is killed by SIGTERM, ray_monitor will not mark it again.
     removing_node = cluster.add_node(num_cpus=0, _internal_config=config)
     cluster.remove_node(removing_node, allow_graceful=True)

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -258,7 +258,6 @@ def test_apply_async(pool):
         ray.get(signal.wait.remote())
         return 10 / val
 
-    # Generate a random ObjectID that will be fulfilled later.
     signal = Signal.remote()
     result = pool.apply_async(ten_over, ([signal, 10], ))
     result.wait(timeout=0.01)
@@ -273,7 +272,6 @@ def test_apply_async(pool):
     assert result.successful()
     assert result.get() == 1
 
-    # Generate a random ObjectID that will be fulfilled later.
     signal = Signal.remote()
     result = pool.apply_async(ten_over, ([signal, 0], ))
     with pytest.raises(ValueError, match="not ready"):

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 import pytest
@@ -137,17 +138,29 @@ def test_initializer(shutdown_only):
 
 
 def test_close(pool_4_processes):
-    def f(object_id):
-        return ray.get(object_id)
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
 
-    object_id = ray.ObjectID.from_random()
-    result = pool_4_processes.map_async(f, [object_id for _ in range(4)])
+        def send(self):
+            self.ready_event.set()
+
+        async def wait(self):
+            await self.ready_event.wait()
+
+    def f(signal):
+        ray.get(signal.wait.remote())
+        return "hello"
+
+    signal = Signal.remote()
+    result = pool_4_processes.map_async(f, [signal for _ in range(4)])
     assert not result.ready()
     pool_4_processes.close()
     assert not result.ready()
 
-    # Fulfill the object_id, causing the head of line tasks to finish.
-    ray.worker.global_worker.put_object("hello", object_id=object_id)
+    # Signal the head of line tasks to finish.
+    ray.get(signal.send.remote())
     pool_4_processes.join()
 
     # close() shouldn't interrupt pending tasks, so check that they succeeded.
@@ -158,11 +171,22 @@ def test_close(pool_4_processes):
 
 
 def test_terminate(pool_4_processes):
-    def f(object_id):
-        return ray.get(object_id)
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
 
-    object_id = ray.ObjectID.from_random()
-    result = pool_4_processes.map_async(f, [object_id for _ in range(4)])
+        def send(self):
+            self.ready_event.set()
+
+        async def wait(self):
+            await self.ready_event.wait()
+
+    def f(signal):
+        return ray.get(signal.wait.remote())
+
+    signal = Signal.remote()
+    result = pool_4_processes.map_async(f, [signal for _ in range(4)])
     assert not result.ready()
     pool_4_processes.terminate()
 
@@ -197,6 +221,17 @@ def test_apply(pool):
 
 
 def test_apply_async(pool):
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
+
+        def send(self):
+            self.ready_event.set()
+
+        async def wait(self):
+            await self.ready_event.wait()
+
     def f(arg1, arg2, kwarg1=None, kwarg2=None):
         assert arg1 == 1
         assert arg2 == 2
@@ -218,32 +253,34 @@ def test_apply_async(pool):
         pool.apply_async(f, (1, 2), {"kwarg1": 3}).get()
 
     # Won't return until the input ObjectID is fulfilled.
-    def ten_over(input):
-        return 10 / ray.get(input[0])
+    def ten_over(args):
+        signal, val = args
+        ray.get(signal.wait.remote())
+        return 10 / val
 
     # Generate a random ObjectID that will be fulfilled later.
-    object_id = ray.ObjectID.from_random()
-    result = pool.apply_async(ten_over, ([object_id], ))
+    signal = Signal.remote()
+    result = pool.apply_async(ten_over, ([signal, 10], ))
     result.wait(timeout=0.01)
     assert not result.ready()
     with pytest.raises(TimeoutError):
         result.get(timeout=0.01)
 
     # Fulfill the ObjectID.
-    ray.worker.global_worker.put_object(10, object_id=object_id)
+    ray.get(signal.send.remote())
     result.wait(timeout=10)
     assert result.ready()
     assert result.successful()
     assert result.get() == 1
 
     # Generate a random ObjectID that will be fulfilled later.
-    object_id = ray.ObjectID.from_random()
-    result = pool.apply_async(ten_over, ([object_id], ))
+    signal = Signal.remote()
+    result = pool.apply_async(ten_over, ([signal, 0], ))
     with pytest.raises(ValueError, match="not ready"):
         result.successful()
 
     # Fulfill the ObjectID with 0, causing the task to fail (divide by zero).
-    ray.worker.global_worker.put_object(0, object_id=object_id)
+    ray.get(signal.send.remote())
     result.wait(timeout=10)
     assert result.ready()
     assert not result.successful()
@@ -275,22 +312,32 @@ def test_map(pool_4_processes):
 
 
 def test_map_async(pool_4_processes):
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
+
+        def send(self):
+            self.ready_event.set()
+
+        async def wait(self):
+            await self.ready_event.wait()
+
     def f(args):
-        index = args[0]
-        ray.get(args[1])
+        index, signal = args
+        ray.get(signal.wait.remote())
         return index, os.getpid()
 
-    # Generate a random ObjectID that will be fulfilled later.
-    object_id = ray.ObjectID.from_random()
+    signal = Signal.remote()
     async_result = pool_4_processes.map_async(
-        f, [(i, object_id) for i in range(1000)])
+        f, [(i, signal) for i in range(1000)])
     assert not async_result.ready()
     with pytest.raises(TimeoutError):
         async_result.get(timeout=0.01)
     async_result.wait(timeout=0.01)
 
-    # Fulfill the object ID, finishing the tasks.
-    ray.worker.global_worker.put_object(0, object_id=object_id)
+    # Send the signal to finish the tasks.
+    ray.get(signal.send.remote())
     async_result.wait(timeout=10)
     assert async_result.ready()
     assert async_result.successful()
@@ -439,24 +486,33 @@ def test_imap_unordered(pool_4_processes):
 
 
 def test_imap_timeout(pool_4_processes):
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self.ready_event = asyncio.Event()
+
+        def send(self):
+            self.ready_event.set()
+
+        async def wait(self):
+            await self.ready_event.wait()
+
     def f(args):
+        index, wait_index, signal = args
         time.sleep(0.1 * random.random())
-        index = args[0]
-        wait_index = args[1]
-        object_id = args[2]
         if index == wait_index:
-            ray.get(object_id)
+            ray.get(signal.wait.remote())
         return index
 
     wait_index = 23
-    object_id = ray.ObjectID.from_random()
+    signal = Signal.remote()
     result_iter = pool_4_processes.imap(
-        f, [(index, wait_index, object_id) for index in range(100)])
+        f, [(index, wait_index, signal) for index in range(100)])
     for i in range(100):
         if i == wait_index:
             with pytest.raises(TimeoutError):
                 result = result_iter.next(timeout=0.1)
-            ray.worker.global_worker.put_object(None, object_id=object_id)
+            ray.get(signal.send.remote())
 
         result = result_iter.next()
         assert result == i
@@ -465,16 +521,15 @@ def test_imap_timeout(pool_4_processes):
         result_iter.next()
 
     wait_index = 23
-    object_id = ray.ObjectID.from_random()
+    signal = Signal.remote()
     result_iter = pool_4_processes.imap_unordered(
-        f, [(index, wait_index, object_id) for index in range(100)],
-        chunksize=11)
+        f, [(index, wait_index, signal) for index in range(100)], chunksize=11)
     in_order = []
     for i in range(100):
         try:
             result = result_iter.next(timeout=1)
         except TimeoutError:
-            ray.worker.global_worker.put_object(None, object_id=object_id)
+            ray.get(signal.send.remote())
             result = result_iter.next()
 
         in_order.append(result == i)

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -159,7 +159,7 @@ def test_dependency_refcounts(ray_start_regular):
     check_refcounts({dep: (1, 1), result: (1, 0)})
     ray.get(signal.send.remote())
     # Reference count should be removed as soon as the dependency is inlined.
-    check_refcounts({dep: (1, 0), result: (1, 0)}, timeout=1)
+    check_refcounts({dep: (1, 0), result: (1, 0)})
     del dep, result
     check_refcounts({})
 
@@ -171,7 +171,7 @@ def test_dependency_refcounts(ray_start_regular):
     result = one_dep.remote(dep, signal=signal2)
     check_refcounts({dep: (1, 1), result: (1, 0)})
     ray.get(signal1.send.remote())
-    ray.get(dep, timeout=5.0)
+    ray.get(dep, timeout=10)
     # Reference count should remain because the dependency is in plasma.
     check_refcounts({dep: (1, 1), result: (1, 0)})
     ray.get(signal2.send.remote())
@@ -200,7 +200,7 @@ def test_dependency_refcounts(ray_start_regular):
     result = one_dep.remote(dep, signal=signal2, fail=True)
     check_refcounts({dep: (1, 1), result: (1, 0)})
     ray.get(signal1.send.remote())
-    ray.get(dep, timeout=5)
+    ray.get(dep, timeout=10)
     # Reference count should remain because the dependency is in plasma.
     check_refcounts({dep: (1, 1), result: (1, 0)})
     ray.get(signal2.send.remote())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`ObjectID.from_random` is not a supported API so we shouldn't use it in tests. This replaces it with asyncio actors for synchronization.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
