### PR TITLE
[RLlib] Fix SAC bug (twin Q not used for min'ing over both Q-nets in loss func).

### DIFF
--- a/rllib/agents/sac/sac_policy.py
+++ b/rllib/agents/sac/sac_policy.py
@@ -160,7 +160,7 @@ def actor_critic_loss(policy, model, _, train_batch):
     # Q-values for current policy (no noise) in given current state
     q_t_det_policy = model.get_q_values(model_out_t, policy_t)
     if policy.config["twin_q"]:
-        twin_q_t_det_policy = model.get_q_values(model_out_t, policy_t)
+        twin_q_t_det_policy = model.get_twin_q_values(model_out_t, policy_t)
         q_t_det_policy = tf.reduce_min(
             (q_t_det_policy, twin_q_t_det_policy), axis=0)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

In the SAC loss function, we do not use the twin-Q net's output to minimize over Q/twin-Q values (as described in the paper).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
