### PR TITLE
Decrease test_object_manager put size to avoid OOMs in CI

### DIFF
--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -50,11 +50,11 @@ def test_object_broadcast(ray_start_cluster_with_resource):
     def f(x):
         return
 
-    x = np.zeros(10 * 1024 * 1024, dtype=np.uint8)
+    x = np.zeros(1024 * 1024, dtype=np.uint8)
 
     @ray.remote
     def create_object():
-        return np.zeros(10 * 1024 * 1024, dtype=np.uint8)
+        return np.zeros(1024 * 1024, dtype=np.uint8)
 
     object_ids = []
 

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -151,7 +151,7 @@ def test_actor_broadcast(ray_start_cluster_with_resource):
 
     # Broadcast a large object to all actors.
     for _ in range(5):
-        x_id = ray.put(np.zeros(10**7, dtype=np.uint8))
+        x_id = ray.put(np.zeros(1024 * 1024, dtype=np.uint8))
         object_ids.append(x_id)
         # Pass the object into a method for every actor.
         ray.get([a.set_weights.remote(x_id) for a in actors])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Test is flaky:
https://travis-ci.com/ray-project/ray/jobs/291580641
https://travis-ci.com/ray-project/ray/jobs/291581053

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
