### PR TITLE
[Java] Enable skipped direct call cases

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/ActorTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorTest.java
@@ -129,6 +129,8 @@ public class ActorTest extends BaseTest {
 
   public void testUnreconstructableActorObject() throws InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
+    // TODO (kfstorm): This should be supported by direct actor call.
+    TestUtils.skipTestIfDirectActorCallEnabled();
     RayActor<Counter> counter = Ray.createActor(Counter::new, 100);
     // Call an actor method.
     RayObject value = Ray.call(Counter::getValue, counter);

--- a/java/test/src/main/java/org/ray/api/test/ActorTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorTest.java
@@ -129,6 +129,7 @@ public class ActorTest extends BaseTest {
 
   public void testUnreconstructableActorObject() throws InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
+    // The UnreconstructableException is created by raylet.
     // TODO (kfstorm): This should be supported by direct actor call.
     TestUtils.skipTestIfDirectActorCallEnabled();
     RayActor<Counter> counter = Ray.createActor(Counter::new, 100);

--- a/java/test/src/main/java/org/ray/api/test/ActorTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorTest.java
@@ -129,9 +129,6 @@ public class ActorTest extends BaseTest {
 
   public void testUnreconstructableActorObject() throws InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
-    // The UnreconstructableException is created by raylet.
-    // TODO (kfstorm): This should be supported by direct actor call.
-    TestUtils.skipTestIfDirectActorCallEnabled();
     RayActor<Counter> counter = Ray.createActor(Counter::new, 100);
     // Call an actor method.
     RayObject value = Ray.call(Counter::getValue, counter);

--- a/java/test/src/main/java/org/ray/api/test/CrossLanguageInvocationTest.java
+++ b/java/test/src/main/java/org/ray/api/test/CrossLanguageInvocationTest.java
@@ -62,8 +62,6 @@ public class CrossLanguageInvocationTest extends BaseMultiLanguageTest {
 
   @Test
   public void testCallingPythonActor() {
-    // Python worker doesn't support direct call yet.
-    TestUtils.skipTestIfDirectActorCallEnabled();
     RayPyActor actor = Ray.createPyActor(PYTHON_MODULE, "Counter", "1".getBytes());
     RayObject res = Ray.callPy(actor, "increase", "1".getBytes());
     Assert.assertEquals(res.get(), "2".getBytes());

--- a/java/test/src/main/java/org/ray/api/test/FailureTest.java
+++ b/java/test/src/main/java/org/ray/api/test/FailureTest.java
@@ -120,9 +120,6 @@ public class FailureTest extends BaseTest {
   @Test
   public void testActorProcessDying() {
     TestUtils.skipTestUnderSingleProcess();
-    // This test case hangs if the worker to worker connection is implemented with grpc.
-    // TODO (kfstorm): Should be fixed.
-    TestUtils.skipTestIfDirectActorCallEnabled();
     RayActor<BadActor> actor = Ray.createActor(BadActor::new, false);
     try {
       Ray.call(BadActor::badMethod2, actor).get();


### PR DESCRIPTION

## Why are these changes needed?
Since some features are supported in direct call, enable the related skipped cases mentioned in #5559.
