### PR TITLE
added _get_policy_class as a class variable of rllib.agents.trainer_t…

### DIFF
--- a/rllib/agents/ppo/ppo.py
+++ b/rllib/agents/ppo/ppo.py
@@ -68,7 +68,8 @@ DEFAULT_CONFIG = with_common_config({
     # the default optimizer.
     "simple_optimizer": False,
     # Use PyTorch as framework?
-    "use_pytorch": False
+    "use_pytorch": False,
+    "standardize": ["advantages"]
 })
 # __sphinx_doc_end__
 # yapf: enable
@@ -81,7 +82,7 @@ def choose_policy_optimizer(workers, config):
             num_sgd_iter=config["num_sgd_iter"],
             train_batch_size=config["train_batch_size"],
             sgd_minibatch_size=config["sgd_minibatch_size"],
-            standardize_fields=["advantages"])
+            standardize_fields=config["standardize"])
 
     return LocalMultiGPUOptimizer(
         workers,
@@ -91,7 +92,7 @@ def choose_policy_optimizer(workers, config):
         sample_batch_size=config["sample_batch_size"],
         num_envs_per_worker=config["num_envs_per_worker"],
         train_batch_size=config["train_batch_size"],
-        standardize_fields=["advantages"],
+        standardize_fields=config["standardize"],
         shuffle_sequences=config["shuffle_sequences"])
 
 


### PR DESCRIPTION
…emplate.trainer_cls

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Added a _get_policy_class class variable to trainer_cls, to facilitate getting the policy class. This is useful for getting the pytorch version of the policy.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
