### PR TITLE
[README] Center-align RLlib logo in README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,7 @@ RLlib Quick Start
 -----------------
 
 .. image:: https://github.com/ray-project/ray/raw/master/doc/source/images/rllib-wide.jpg
+    :align: center
 
 `RLlib`_ is an open-source library for reinforcement learning built on top of Ray that offers both high scalability and a unified API for a variety of applications.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The RLlib logo was not centered in the README (like all other logos are).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
