### PR TITLE
Allow ray.wait() to wait for actors to be ready

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -95,7 +95,7 @@ import ray.projects  # noqa: E402
 # We import ray.actor because some code is run in actor.py which initializes
 # some functions in the worker.
 import ray.actor  # noqa: F401
-from ray.actor import method  # noqa: E402
+from ray.actor import ActorHandle, method  # noqa: E402
 from ray.runtime_context import _get_runtime_context  # noqa: E402
 from ray.cross_language import java_function, java_actor_class  # noqa: E402
 from ray import util  # noqa: E402
@@ -105,6 +105,7 @@ __commit__ = "{{RAY_COMMIT_SHA}}"
 __version__ = "0.9.0.dev0"
 
 __all__ = [
+    "ActorHandle",
     "jobs",
     "nodes",
     "actors",

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -718,7 +718,10 @@ class ActorHandle:
         if not self._ray_is_cross_language:
             raise AttributeError("'{}' object has no attribute '{}'".format(
                 type(self).__name__, item))
-        if item in ["__ray_terminate__", "__ray_checkpoint__"]:
+        if item in [
+                "__ray_terminate__", "__ray_ready_check__",
+                "__ray_checkpoint__"
+        ]:
 
             class FakeActorMethod(object):
                 def __call__(self, *args, **kwargs):
@@ -885,6 +888,9 @@ def modify_class(cls):
             worker = ray.worker.get_global_worker()
             if worker.mode != ray.LOCAL_MODE:
                 ray.actor.exit_actor()
+
+        def __ray_ready_check__(self):
+            pass
 
         def __ray_checkpoint__(self):
             """Save a checkpoint.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Often it's useful to know when actors have finished initializing and can execute tasks. We don't currently have an API for this, so users often resort to defining an "empty" method and calling that and waiting for the result.

This PR adds the ability to call `ray.wait()` on `ActorHandle` objects in the same way as `ObjectID`s.

A few design considerations:

- This currently overloads the same API call as the existing `ray.wait()` - should we instead add a new call?
- If we want to use the same API call, should we allow calling `ray.wait()` on a list containing both `ObjectID`s and `ActorHandle`s?
- This currently waits for an actor by defining an internal `__ray_ready_check__` method and calling it the first time each worker calls `ray.wait()` an actor. This is somewhat problematic as it might not return quickly if the actor is busy processing other tasks. We could instead modify the actor creation task to return an ID that is either exposed to the user or not exposed to the user and only used for `ray.wait()`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
