### PR TITLE
Capture output for commands run by the autoscaler

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -351,7 +351,8 @@ def exec_cluster(config_file,
                  stop=False,
                  start=False,
                  override_cluster_name=None,
-                 port_forward=None):
+                 port_forward=None,
+                 with_output=False):
     """Runs a command on the specified cluster.
 
     Arguments:
@@ -408,7 +409,8 @@ def exec_cluster(config_file,
                     shutdown_cmd = wrap_docker(shutdown_cmd)
                 cmd += ("; {}; sudo shutdown -h now".format(shutdown_cmd))
 
-        result = _exec(updater, cmd, screen, tmux, port_forward=port_forward)
+        result = _exec(updater, cmd, screen, tmux,
+                       port_forward=port_forward, with_output=with_output)
 
         if tmux or screen:
             attach_command_parts = ["ray attach", config_file]
@@ -429,7 +431,7 @@ def exec_cluster(config_file,
         provider.cleanup()
 
 
-def _exec(updater, cmd, screen, tmux, port_forward=None):
+def _exec(updater, cmd, screen, tmux, port_forward=None, with_output=False):
     if cmd:
         if screen:
             cmd = [
@@ -445,7 +447,8 @@ def _exec(updater, cmd, screen, tmux, port_forward=None):
             ]
             cmd = " ".join(cmd)
     return updater.cmd_runner.run(
-        cmd, allocate_tty=True, exit_on_fail=True, port_forward=port_forward)
+        cmd, allocate_tty=True, exit_on_fail=True,
+        port_forward=port_forward, with_output=with_output)
 
 
 def rsync(config_file,

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -424,9 +424,7 @@ def exec_cluster(config_file,
             attach_info = "Use `{}` to check on command status.".format(
                 attach_command)
             logger.info(attach_info)
-
         return result
-
     finally:
         provider.cleanup()
 
@@ -446,7 +444,6 @@ def _exec(updater, cmd, screen, tmux, port_forward=None):
                 quote(cmd + "; exec bash")
             ]
             cmd = " ".join(cmd)
-
     return updater.cmd_runner.run(
         cmd, allocate_tty=True, exit_on_fail=True, port_forward=port_forward)
 

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -409,8 +409,13 @@ def exec_cluster(config_file,
                     shutdown_cmd = wrap_docker(shutdown_cmd)
                 cmd += ("; {}; sudo shutdown -h now".format(shutdown_cmd))
 
-        result = _exec(updater, cmd, screen, tmux,
-                       port_forward=port_forward, with_output=with_output)
+        result = _exec(
+            updater,
+            cmd,
+            screen,
+            tmux,
+            port_forward=port_forward,
+            with_output=with_output)
 
         if tmux or screen:
             attach_command_parts = ["ray attach", config_file]
@@ -447,8 +452,11 @@ def _exec(updater, cmd, screen, tmux, port_forward=None, with_output=False):
             ]
             cmd = " ".join(cmd)
     return updater.cmd_runner.run(
-        cmd, allocate_tty=True, exit_on_fail=True,
-        port_forward=port_forward, with_output=with_output)
+        cmd,
+        allocate_tty=True,
+        exit_on_fail=True,
+        port_forward=port_forward,
+        with_output=with_output)
 
 
 def rsync(config_file,

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -408,7 +408,7 @@ def exec_cluster(config_file,
                     shutdown_cmd = wrap_docker(shutdown_cmd)
                 cmd += ("; {}; sudo shutdown -h now".format(shutdown_cmd))
 
-        _exec(updater, cmd, screen, tmux, port_forward=port_forward)
+        result = _exec(updater, cmd, screen, tmux, port_forward=port_forward)
 
         if tmux or screen:
             attach_command_parts = ["ray attach", config_file]
@@ -424,6 +424,9 @@ def exec_cluster(config_file,
             attach_info = "Use `{}` to check on command status.".format(
                 attach_command)
             logger.info(attach_info)
+
+        return result
+
     finally:
         provider.cleanup()
 
@@ -443,7 +446,8 @@ def _exec(updater, cmd, screen, tmux, port_forward=None):
                 quote(cmd + "; exec bash")
             ]
             cmd = " ".join(cmd)
-    updater.cmd_runner.run(
+
+    return updater.cmd_runner.run(
         cmd, allocate_tty=True, exit_on_fail=True, port_forward=port_forward)
 
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -48,7 +48,8 @@ class KubernetesCommandRunner:
             timeout=120,
             allocate_tty=False,
             exit_on_fail=False,
-            port_forward=None):
+            port_forward=None,
+            with_output=False):
         if cmd and port_forward:
             raise Exception(
                 "exec with Kubernetes can't forward ports and execute"
@@ -82,8 +83,11 @@ class KubernetesCommandRunner:
                 "--",
             ] + with_interactive(cmd)
             try:
-                return self.process_runner.check_output(
-                    " ".join(final_cmd), shell=True)
+                if with_output:
+                    return self.process_runner.check_output(
+                        " ".join(final_cmd), shell=True)
+                else:
+                    self.process_runner.check_call(" ".join(final_cmd), shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +
@@ -233,7 +237,8 @@ class SSHCommandRunner:
             timeout=120,
             allocate_tty=False,
             exit_on_fail=False,
-            port_forward=None):
+            port_forward=None,
+            with_output=False):
 
         self.set_ssh_ip_if_required()
 
@@ -261,7 +266,10 @@ class SSHCommandRunner:
             # still create an interactive shell in some ssh versions.
             final_cmd.append("while true; do sleep 86400; done")
         try:
-            return self.process_runner.check_output(final_cmd)
+            if with_output:
+                return self.process_runner.check_output(final_cmd)
+            else:
+                self.process_runner.check_call(final_cmd)
         except subprocess.CalledProcessError:
             if exit_on_fail:
                 quoted_cmd = " ".join(final_cmd[:-1] + [quote(final_cmd[-1])])
@@ -403,7 +411,6 @@ class NodeUpdater:
     def do_update(self):
         self.provider.set_node_tags(
             self.node_id, {TAG_RAY_NODE_STATUS: STATUS_WAITING_FOR_SSH})
-
         deadline = time.time() + NODE_START_WAIT_S
         self.wait_ready(deadline)
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -82,7 +82,8 @@ class KubernetesCommandRunner:
                 "--",
             ] + with_interactive(cmd)
             try:
-                return self.process_runner.check_output(" ".join(final_cmd), shell=True)
+                return self.process_runner.check_output(
+                    " ".join(final_cmd), shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -49,7 +49,6 @@ class KubernetesCommandRunner:
             allocate_tty=False,
             exit_on_fail=False,
             port_forward=None):
-
         if cmd and port_forward:
             raise Exception(
                 "exec with Kubernetes can't forward ports and execute"
@@ -83,8 +82,8 @@ class KubernetesCommandRunner:
                 "--",
             ] + with_interactive(cmd)
             try:
-                return self.process_runner.check_output(" ".join(final_cmd), shell=True)
-
+                return self.process_runner.check_output(
+                    " ".join(final_cmd), shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +
@@ -263,7 +262,6 @@ class SSHCommandRunner:
             final_cmd.append("while true; do sleep 86400; done")
         try:
             return self.process_runner.check_output(final_cmd)
-
         except subprocess.CalledProcessError:
             if exit_on_fail:
                 quoted_cmd = " ".join(final_cmd[:-1] + [quote(final_cmd[-1])])

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -87,7 +87,8 @@ class KubernetesCommandRunner:
                     return self.process_runner.check_output(
                         " ".join(final_cmd), shell=True)
                 else:
-                    self.process_runner.check_call(" ".join(final_cmd), shell=True)
+                    self.process_runner.check_call(
+                        " ".join(final_cmd), shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -82,8 +82,7 @@ class KubernetesCommandRunner:
                 "--",
             ] + with_interactive(cmd)
             try:
-                return self.process_runner.check_output(
-                    " ".join(final_cmd), shell=True)
+                return self.process_runner.check_output(" ".join(final_cmd), shell=True)
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -49,6 +49,7 @@ class KubernetesCommandRunner:
             allocate_tty=False,
             exit_on_fail=False,
             port_forward=None):
+
         if cmd and port_forward:
             raise Exception(
                 "exec with Kubernetes can't forward ports and execute"
@@ -82,7 +83,8 @@ class KubernetesCommandRunner:
                 "--",
             ] + with_interactive(cmd)
             try:
-                self.process_runner.check_call(" ".join(final_cmd), shell=True)
+                return self.process_runner.check_output(" ".join(final_cmd), shell=True)
+
             except subprocess.CalledProcessError:
                 if exit_on_fail:
                     quoted_cmd = " ".join(final_cmd[:-1] +
@@ -260,7 +262,8 @@ class SSHCommandRunner:
             # still create an interactive shell in some ssh versions.
             final_cmd.append("while true; do sleep 86400; done")
         try:
-            self.process_runner.check_call(final_cmd)
+            return self.process_runner.check_output(final_cmd)
+
         except subprocess.CalledProcessError:
             if exit_on_fail:
                 quoted_cmd = " ".join(final_cmd[:-1] + [quote(final_cmd[-1])])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Make it possible for users to capture the output of a command run through the autoscaler. With this PR, users can  get the output from `exec_cluster` by passing in `with_output=True`.

## Related issue number

N/A

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
