### PR TITLE
Bazel mirrors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 env:
+  GITHUB: true
   DEBIAN_FRONTEND: noninteractive
 
 on: [push, pull_request]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,6 @@ jobs:
           --compilation_mode=fastbuild \
           --config=iwyu \
           --keep_going \
-          --show_progress_rate_limit=5 \
-          --show_task_finish \
-          --verbose_failures \
           "//:*"
   build:
     name: ${{ matrix.name }}
@@ -92,7 +89,4 @@ jobs:
         . ./ci/travis/build-helper.sh prep_build_env
         bazel --batch build \
           --keep_going \
-          --show_progress_rate_limit=5 \
-          --show_task_finish \
-          --verbose_failures \
           "//:ray_pkg"  # TODO(mehrdadn): Should be "//:*", but we get a linking error with _streaming.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  LLVM_VERSION_WINDOWS: 9.0.0
   DEBIAN_FRONTEND: noninteractive
 
 on: [push, pull_request]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  GITHUB: true
   DEBIAN_FRONTEND: noninteractive
 
 on: [push, pull_request]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             compiler: clang
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - name: Setup Bazel
@@ -69,9 +69,7 @@ jobs:
             compiler: clang-cl
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+      uses: actions/checkout@v2
     - name: Setup Bazel
       shell: bash
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
           --keep_going \
           --show_progress_rate_limit=5 \
           --show_task_finish \
-          --show_timestamps \
           --verbose_failures \
           "//:*"
   build:
@@ -95,6 +94,5 @@ jobs:
           --keep_going \
           --show_progress_rate_limit=5 \
           --show_task_finish \
-          --show_timestamps \
           --verbose_failures \
           "//:ray_pkg"  # TODO(mehrdadn): Should be "//:*", but we get a linking error with _streaming.so

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -56,46 +56,43 @@ def auto_http_archive(*, name=None, url=None, urls=None,
     return http_archive(name=name, url=url, urls=urls, build_file=build_file,
                         build_file_content=build_file_content, strip_prefix=strip_prefix, **kwargs)
 
-def github_repository(*, name=None, remote=None, commit=None, tag=None,
-                      branch=None, build_file=None, build_file_content=None,
-                      sha256=None, archive_suffix=".tar.gz", shallow_since=None,
-                      strip_prefix=True, url=None, urls=None, path=None, **kwargs):
+def github_repository(*, name=None, build_file=None, build_file_content=None,
+                      sha256=None, shallow_since=None, strip_prefix=True,
+                      url=None, urls=None, path=None, **kwargs):
     """
     Conveniently chooses between archive, git, etc. GitHub repositories.
     Prefer archives, as they're smaller and faster due to the lack of history.
 
-    One of {commit, tag, branch} must also be provided (as usual).
+    url must be of the form: https://github.com/{username}/{project}/archive/...
 
-    sha256 should be omitted (or None) when the archive hash is unknown, then
-    updated ASAP to allow caching & avoid repeated downloads on every build.
-
-    If remote       == None , it is an error.
     If name         == None , it is auto-deduced, but this is NOT recommended.
     If build_file   == True , it is auto-deduced.
     If strip_prefix == True , it is auto-deduced.
-    If url          == None , it is auto-deduced, unless urls is provided.
     If sha256       != False, uses archive download (recommended; fast).
     If sha256       == False, uses git clone (NOT recommended; slow).
     If path         != None , local repository is assumed at the given path.
     """
-    GIT_SUFFIX = ".git"
+    GITHUB_URL_PREFIX = "https://github.com/"
+    if not url.startswith(GITHUB_URL_PREFIX):
+        fail("URL passed to github_repository() is not a GitHub URL: " + url)
 
-    treeish = commit or tag or branch
-    if path == None and not treeish: fail("Missing commit, tag, or branch argument")
-    if path == None and remote == None: fail("Missing remote argument")
+    (username, project, archive, filename) = url[len(GITHUB_URL_PREFIX):].split("/", 3)
+    if archive != "archive": fail("Expected GitHub archive URL: " + url)
 
-    if path == None and remote.endswith(GIT_SUFFIX):
-        remote_no_suffix = remote[:len(remote) - len(GIT_SUFFIX)]
-    else:
-        remote_no_suffix = remote
-    project = remote_no_suffix.split("//", 1)[1].split("/")[2] if remote_no_suffix else None
+    remote = username + "/" + project
+    tag = None
+    for suffix in (".tar.gz", ".zip"):
+        if filename.endswith(suffix):
+            tag = filename[:len(filename) - len(suffix)]
+    if tag == None: fail("Could not extract ref from GitHub URL: " + url)
+
+    commit = None
+    if len(tag) in (40, 64): (commit, tag) = (tag, commit)  # Looks like a commit SHA, not a tag
 
     if project != None and name == None:
-        name = project.replace("-", "_")
+        name = ["com", "github", username, project.replace("-", "_")].join("_")
     if project != None and strip_prefix == True:
-        strip_prefix = "%s-%s" % (project, treeish)
-    if url == None and urls == None:
-        url = "%s/archive/%s%s" % (remote_no_suffix, treeish, archive_suffix)
+        strip_prefix = "%s-%s" % (project, commit or tag)
     if name != None and build_file == True:
         build_file = "@//%s:%s" % ("bazel", "BUILD." + name)
 
@@ -110,14 +107,12 @@ def github_repository(*, name=None, remote=None, commit=None, tag=None,
     elif sha256 == False:
         if build_file or build_file_content:
             new_git_repository(name=name, remote=remote, build_file=build_file,
-                               commit=commit, tag=tag, branch=branch,
-                               shallow_since=shallow_since,
+                               commit=commit, tag=tag, shallow_since=shallow_since,
                                build_file_content=build_file_content,
                                strip_prefix=strip_prefix, **kwargs)
         else:
             git_repository(name=name, remote=remote, strip_prefix=strip_prefix,
-                           commit=commit, tag=tag, branch=branch,
-                           shallow_since=shallow_since, **kwargs)
+                           commit=commit, tag=tag, shallow_since=shallow_since, **kwargs)
     else:
         auto_http_archive(name=name, url=url, urls=urls, sha256=sha256,
                           build_file=build_file, strip_prefix=strip_prefix,
@@ -127,8 +122,7 @@ def ray_deps_setup():
     github_repository(
         name = "redis",
         build_file = True,
-        tag = "5.0.3",
-        remote = "https://github.com/antirez/redis",
+        url = "https://github.com/antirez/redis/archive/5.0.3.tar.gz",
         sha256 = "7084e8bd9e5dedf2dbb2a1e1d862d0c46e66cc0872654bdc677f4470d28d84c5",
         patches = [
             "//thirdparty/patches:hiredis-async-include-dict.patch",
@@ -156,22 +150,19 @@ def ray_deps_setup():
 
     github_repository(
         name = "rules_jvm_external",
-        tag = "2.10",
-        remote = "https://github.com/bazelbuild/rules_jvm_external",
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/2.10.tar.gz",
         sha256 = "5c1b22eab26807d5286ada7392d796cbc8425d3ef9a57d114b79c5f8ef8aca7c",
     )
 
     github_repository(
         name = "bazel_common",
-        commit = "f1115e0f777f08c3cdb115526c4e663005bec69b",
-        remote = "https://github.com/google/bazel-common",
+        url = "https://github.com/google/bazel-common/archive/f1115e0f777f08c3cdb115526c4e663005bec69b.tar.gz",
         sha256 = "50dea89af2e1334e18742f18c91c860446de8d1596947fe87e3cdb0d27b6f8f3",
     )
 
     github_repository(
         name = "com_github_checkstyle_java",
-        commit = "ef367030d1433877a3360bbfceca18a5d0791bdd",
-        remote = "https://github.com/ray-project/checkstyle_java",
+        url = "https://github.com/ray-project/checkstyle_java/archive/ef367030d1433877a3360bbfceca18a5d0791bdd.tar.gz",
         sha256 = "847d391156d7dcc9424e6a8ba06ff23ea2914c725b18d92028074b2ed8de3da9",
     )
 
@@ -190,8 +181,7 @@ def ray_deps_setup():
     github_repository(
         name = "com_github_nelhage_rules_boost",
         # If you update the Boost version, remember to update the 'boost' rule.
-        commit = "5b53112431ef916381d6969f114727cc4f83960b",
-        remote = "https://github.com/nelhage/rules_boost",
+        url = "https://github.com/nelhage/rules_boost/archive/5b53112431ef916381d6969f114727cc4f83960b.tar.gz",
         sha256 = "32080749fdb8e4015815694a5c7d009f479e5f6a4da443d262bd7f28b8bd1b55",
         patches = [
             "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
@@ -201,29 +191,25 @@ def ray_deps_setup():
 
     github_repository(
         name = "com_github_google_flatbuffers",
-        commit = "63d51afd1196336a7d1f56a988091ef05deb1c62",
-        remote = "https://github.com/google/flatbuffers",
+        url = "https://github.com/google/flatbuffers/archive/63d51afd1196336a7d1f56a988091ef05deb1c62.tar.gz",
         sha256 = "3f469032571d324eabea88d7014c05fec8565a5877dbe49b2a52d8d1a0f18e63",
     )
 
     github_repository(
         name = "com_google_googletest",
-        commit = "3306848f697568aacf4bcca330f6bdd5ce671899",
-        remote = "https://github.com/google/googletest",
+        url = "https://github.com/google/googletest/archive/3306848f697568aacf4bcca330f6bdd5ce671899.tar.gz",
         sha256 = "79ae337dab8e9ee6bd97a9f7134929bb1ddc7f83be9a564295b895865efe7dba",
     )
 
     github_repository(
         name = "com_github_gflags_gflags",
-        commit = "e171aa2d15ed9eb17054558e0b3a6a413bb01067",
-        remote = "https://github.com/gflags/gflags",
+        url = "https://github.com/gflags/gflags/archive/e171aa2d15ed9eb17054558e0b3a6a413bb01067.tar.gz",
         sha256 = "b20f58e7f210ceb0e768eb1476073d0748af9b19dfbbf53f4fd16e3fb49c5ac8",
     )
 
     github_repository(
         name = "com_github_google_glog",
-        commit = "925858d9969d8ee22aabc3635af00a37891f4e25",
-        remote = "https://github.com/google/glog",
+        url = "https://github.com/google/glog/archive/925858d9969d8ee22aabc3635af00a37891f4e25.tar.gz",
         sha256 = "fb86eca661497ac6f9ce2a106782a30215801bb8a7c8724c6ec38af05a90acf3",
         patches = [
             "//thirdparty/patches:glog-stack-trace.patch",
@@ -233,8 +219,7 @@ def ray_deps_setup():
     github_repository(
         name = "plasma",
         build_file = True,
-        commit = "86f34aa07e611787d9cc98c6a33b0a0a536dce57",
-        remote = "https://github.com/apache/arrow",
+        url = "https://github.com/apache/arrow/archive/86f34aa07e611787d9cc98c6a33b0a0a536dce57.tar.gz",
         sha256 = "6b5f55d10681a3938bbf8f07eee52c4eb6e761da6ba27490f55ccb89ce645ac8",
         patches = [
             "//thirdparty/patches:arrow-headers-unused.patch",
@@ -249,15 +234,13 @@ def ray_deps_setup():
     github_repository(
         name = "cython",
         build_file = True,
-        commit = "49414dbc7ddc2ca2979d6dbe1e44714b10d72e7e",
-        remote = "https://github.com/cython/cython",
+        url = "https://github.com/cython/cython/archive/49414dbc7ddc2ca2979d6dbe1e44714b10d72e7e.tar.gz",
         sha256 = "0b697ac90d1e46842c7cbbf5f4a1bde5b7b41037c611167417115337e3756eaa",
     )
 
     github_repository(
         name = "io_opencensus_cpp",
-        commit = "3aa11f20dd610cb8d2f7c62e58d1e69196aadf11",
-        remote = "https://github.com/census-instrumentation/opencensus-cpp",
+        url = "https://github.com/census-instrumentation/opencensus-cpp/archive/3aa11f20dd610cb8d2f7c62e58d1e69196aadf11.tar.gz",
         sha256 = "a0b4e2d3c4479cc343c003f0c31f48e9e05461cb232815e348fc0358bfa8bb79",
     )
 
@@ -265,16 +248,14 @@ def ray_deps_setup():
     # This is how diamond dependencies are prevented.
     github_repository(
         name = "com_google_absl",
-        commit = "aa844899c937bde5d2b24f276b59997e5b668bde",
-        remote = "https://github.com/abseil/abseil-cpp",
+        url = "https://github.com/abseil/abseil-cpp/archive/aa844899c937bde5d2b24f276b59997e5b668bde.tar.gz",
         sha256 = "327a3883d24cf5d81954b8b8713867ecf2289092c7a39a9dc25a9947cf5b8b78",
     )
 
     # OpenCensus depends on jupp0r/prometheus-cpp
     github_repository(
         name = "com_github_jupp0r_prometheus_cpp",
-        commit = "60eaa4ea47b16751a8e8740b05fe70914c68a480",
-        remote = "https://github.com/jupp0r/prometheus-cpp",
+        url = "https://github.com/jupp0r/prometheus-cpp/archive/60eaa4ea47b16751a8e8740b05fe70914c68a480.tar.gz",
         sha256 = "ec825b802487ac18b0d98e2e8b7961487b12562f8f82e424521d0a891d9e1373",
         patches = [
             # https://github.com/jupp0r/prometheus-cpp/pull/225
@@ -286,8 +267,7 @@ def ray_deps_setup():
     github_repository(
         name = "com_github_grpc_grpc",
         # NOTE: If you update this, also update @boringssl's hash.
-        commit = "4790ab6d97e634a1ede983be393f3bb3c132b2f7",
-        remote = "https://github.com/grpc/grpc",
+        url = "https://github.com/grpc/grpc/archive/4790ab6d97e634a1ede983be393f3bb3c132b2f7.tar.gz",
         sha256 = "df83bd8a08975870b8b254c34afbecc94c51a55198e6e3a5aab61d62f40b7274",
         patches = [
             "//thirdparty/patches:grpc-command-quoting.patch",
@@ -301,14 +281,12 @@ def ray_deps_setup():
         # https://github.com/grpc/grpc/blob/4790ab6d97e634a1ede983be393f3bb3c132b2f7/bazel/grpc_deps.bzl#L102
         name = "boringssl",
         # Ensure this matches the commit used by grpc's bazel/grpc_deps.bzl
-        commit = "83da28a68f32023fd3b95a8ae94991a07b1f6c62",
-        remote = "https://github.com/google/boringssl",
+        url = "https://github.com/google/boringssl/archive/83da28a68f32023fd3b95a8ae94991a07b1f6c62.tar.gz",
         sha256 = "781fa39693ec2984c71213cd633e9f6589eaaed75e3a9ac413237edec96fd3b9",
     )
 
     github_repository(
         name = "rules_proto_grpc",
-        commit = "a74fef39c5fe636580083545f76d1eab74f6450d",
-        remote = "https://github.com/rules-proto-grpc/rules_proto_grpc",
+        url = "https://github.com/rules-proto-grpc/rules_proto_grpc/archive/a74fef39c5fe636580083545f76d1eab74f6450d.tar.gz",
         sha256 = "2f6606151ec042e23396f07de9e7dcf6ca9a5db1d2b09f0cc93a7fc7f4008d1b",
     )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -96,7 +96,7 @@ def ray_deps_setup():
     http_file(
         name = "redis-src",
         sha256 = "7084e8bd9e5dedf2dbb2a1e1d862d0c46e66cc0872654bdc677f4470d28d84c5",
-        urls = ["https://github.com/antirez/redis/archive/5.0.3.tar.bz2"],
+        urls = ["https://github.com/antirez/redis/archive/5.0.3.tar.gz"],
     )
 
     auto_http_archive(

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -58,7 +58,7 @@ def auto_http_archive(*, name=None, url=None, urls=None,
 
 def github_repository(*, name=None, remote=None, commit=None, tag=None,
                       branch=None, build_file=None, build_file_content=None,
-                      sha256=None, archive_suffix=".zip", shallow_since=None,
+                      sha256=None, archive_suffix=".tar.gz", shallow_since=None,
                       strip_prefix=True, url=None, urls=None, path=None, **kwargs):
     """
     Conveniently chooses between archive, git, etc. GitHub repositories.
@@ -129,7 +129,7 @@ def ray_deps_setup():
         build_file = True,
         tag = "5.0.3",
         remote = "https://github.com/antirez/redis",
-        sha256 = "8e5997b447b1afdd1efd33731968484d2fe71c271fa7f1cd6b2476367e964e0e",
+        sha256 = "7084e8bd9e5dedf2dbb2a1e1d862d0c46e66cc0872654bdc677f4470d28d84c5",
         patches = [
             "//thirdparty/patches:hiredis-async-include-dict.patch",
             "//thirdparty/patches:hiredis-casts.patch",
@@ -158,21 +158,21 @@ def ray_deps_setup():
         name = "rules_jvm_external",
         tag = "2.10",
         remote = "https://github.com/bazelbuild/rules_jvm_external",
-        sha256 = "1bbf2e48d07686707dd85357e9a94da775e1dbd7c464272b3664283c9c716d26",
+        sha256 = "5c1b22eab26807d5286ada7392d796cbc8425d3ef9a57d114b79c5f8ef8aca7c",
     )
 
     github_repository(
         name = "bazel_common",
         commit = "f1115e0f777f08c3cdb115526c4e663005bec69b",
         remote = "https://github.com/google/bazel-common",
-        sha256 = "1e05a4791cc3470d3ecf7edb556f796b1d340359f1c4d293f175d4d0946cf84c",
+        sha256 = "50dea89af2e1334e18742f18c91c860446de8d1596947fe87e3cdb0d27b6f8f3",
     )
 
     github_repository(
         name = "com_github_checkstyle_java",
         commit = "ef367030d1433877a3360bbfceca18a5d0791bdd",
         remote = "https://github.com/ray-project/checkstyle_java",
-        sha256 = "2fc33ec804011a03106e76ae77d7f1b09091b0f830f8e2a0408f079a032ed716",
+        sha256 = "847d391156d7dcc9424e6a8ba06ff23ea2914c725b18d92028074b2ed8de3da9",
     )
 
     auto_http_archive(
@@ -192,7 +192,7 @@ def ray_deps_setup():
         # If you update the Boost version, remember to update the 'boost' rule.
         commit = "5b53112431ef916381d6969f114727cc4f83960b",
         remote = "https://github.com/nelhage/rules_boost",
-        sha256 = "4481db75d1d25b4f043f17a6c2d5f963782e659ad5049e027146b5248d37bf6b",
+        sha256 = "32080749fdb8e4015815694a5c7d009f479e5f6a4da443d262bd7f28b8bd1b55",
         patches = [
             "//thirdparty/patches:rules_boost-undefine-boost_fallthrough.patch",
             "//thirdparty/patches:rules_boost-windows-linkopts.patch",
@@ -203,28 +203,28 @@ def ray_deps_setup():
         name = "com_github_google_flatbuffers",
         commit = "63d51afd1196336a7d1f56a988091ef05deb1c62",
         remote = "https://github.com/google/flatbuffers",
-        sha256 = "dd87be0acf932c9b0d9b5d7bb49aec23e1c98bbd3327254bd90cb4af198f9332",
+        sha256 = "3f469032571d324eabea88d7014c05fec8565a5877dbe49b2a52d8d1a0f18e63",
     )
 
     github_repository(
         name = "com_google_googletest",
         commit = "3306848f697568aacf4bcca330f6bdd5ce671899",
         remote = "https://github.com/google/googletest",
-        sha256 = "2625a1d301cd658514e297002170c2fc83a87beb0f495f943601df17d966511d",
+        sha256 = "79ae337dab8e9ee6bd97a9f7134929bb1ddc7f83be9a564295b895865efe7dba",
     )
 
     github_repository(
         name = "com_github_gflags_gflags",
         commit = "e171aa2d15ed9eb17054558e0b3a6a413bb01067",
         remote = "https://github.com/gflags/gflags",
-        sha256 = "da72f0dce8e3422d0ab2fea8d03a63a64227b0376b3558fd9762e88de73b780b",
+        sha256 = "b20f58e7f210ceb0e768eb1476073d0748af9b19dfbbf53f4fd16e3fb49c5ac8",
     )
 
     github_repository(
         name = "com_github_google_glog",
         commit = "925858d9969d8ee22aabc3635af00a37891f4e25",
         remote = "https://github.com/google/glog",
-        sha256 = "dbe787f2a7cf1146f748a191c99ae85d6b931dd3ebdcc76aa7ccae3699149c67",
+        sha256 = "fb86eca661497ac6f9ce2a106782a30215801bb8a7c8724c6ec38af05a90acf3",
         patches = [
             "//thirdparty/patches:glog-stack-trace.patch",
         ],
@@ -235,7 +235,7 @@ def ray_deps_setup():
         build_file = True,
         commit = "86f34aa07e611787d9cc98c6a33b0a0a536dce57",
         remote = "https://github.com/apache/arrow",
-        sha256 = "4f1956e74188fa15078c8ad560bbc298624320d2aafd21fe7a2511afee7ea841",
+        sha256 = "6b5f55d10681a3938bbf8f07eee52c4eb6e761da6ba27490f55ccb89ce645ac8",
         patches = [
             "//thirdparty/patches:arrow-headers-unused.patch",
             "//thirdparty/patches:arrow-windows-export.patch",
@@ -251,14 +251,14 @@ def ray_deps_setup():
         build_file = True,
         commit = "49414dbc7ddc2ca2979d6dbe1e44714b10d72e7e",
         remote = "https://github.com/cython/cython",
-        sha256 = "aaee5dec23165ee10c189d8b40f19861e2c6929c015cee3d2b4e56d8a1bdc422",
+        sha256 = "0b697ac90d1e46842c7cbbf5f4a1bde5b7b41037c611167417115337e3756eaa",
     )
 
     github_repository(
         name = "io_opencensus_cpp",
         commit = "3aa11f20dd610cb8d2f7c62e58d1e69196aadf11",
         remote = "https://github.com/census-instrumentation/opencensus-cpp",
-        sha256 = "92eef77c44d01e8472f68a2f1329919a1bb59317a4bb1e4d76081ab5c13a56d6",
+        sha256 = "a0b4e2d3c4479cc343c003f0c31f48e9e05461cb232815e348fc0358bfa8bb79",
     )
 
     # OpenCensus depends on Abseil so we have to explicitly pull it in.
@@ -267,7 +267,7 @@ def ray_deps_setup():
         name = "com_google_absl",
         commit = "aa844899c937bde5d2b24f276b59997e5b668bde",
         remote = "https://github.com/abseil/abseil-cpp",
-        sha256 = "f1a959a2144f0482b9bd61e67a9897df02234fff6edf82294579a4276f2f4b97",
+        sha256 = "327a3883d24cf5d81954b8b8713867ecf2289092c7a39a9dc25a9947cf5b8b78",
     )
 
     # OpenCensus depends on jupp0r/prometheus-cpp
@@ -275,7 +275,7 @@ def ray_deps_setup():
         name = "com_github_jupp0r_prometheus_cpp",
         commit = "60eaa4ea47b16751a8e8740b05fe70914c68a480",
         remote = "https://github.com/jupp0r/prometheus-cpp",
-        sha256 = "9756bd2d573e7722f97dbe6d35934e43b9a79e6a87fc5e1da79774a621cddd8e",
+        sha256 = "ec825b802487ac18b0d98e2e8b7961487b12562f8f82e424521d0a891d9e1373",
         patches = [
             # https://github.com/jupp0r/prometheus-cpp/pull/225
             "//thirdparty/patches:prometheus-windows-zlib.patch",
@@ -288,7 +288,7 @@ def ray_deps_setup():
         # NOTE: If you update this, also update @boringssl's hash.
         commit = "4790ab6d97e634a1ede983be393f3bb3c132b2f7",
         remote = "https://github.com/grpc/grpc",
-        sha256 = "723853c36ea6d179d32a4f9f2f8691dbe0e28d5bbc521c954b34355a1c952ba5",
+        sha256 = "df83bd8a08975870b8b254c34afbecc94c51a55198e6e3a5aab61d62f40b7274",
         patches = [
             "//thirdparty/patches:grpc-command-quoting.patch",
             "//thirdparty/patches:grpc-cython-copts.patch",
@@ -303,12 +303,12 @@ def ray_deps_setup():
         # Ensure this matches the commit used by grpc's bazel/grpc_deps.bzl
         commit = "83da28a68f32023fd3b95a8ae94991a07b1f6c62",
         remote = "https://github.com/google/boringssl",
-        sha256 = "58bdaf1fa305d42142c0c1aa7a84aa2e5df12f581c13a606b20242e1d037210c",
+        sha256 = "781fa39693ec2984c71213cd633e9f6589eaaed75e3a9ac413237edec96fd3b9",
     )
 
     github_repository(
         name = "rules_proto_grpc",
         commit = "a74fef39c5fe636580083545f76d1eab74f6450d",
         remote = "https://github.com/rules-proto-grpc/rules_proto_grpc",
-        sha256 = "53561ecacaebe58916dfdb962d889a56394d3fae6956e0bcd63c4353f813284a",
+        sha256 = "2f6606151ec042e23396f07de9e7dcf6ca9a5db1d2b09f0cc93a7fc7f4008d1b",
     )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -58,7 +58,7 @@ def auto_http_archive(*, name=None, url=None, urls=None,
 
 def github_repository(*, name=None, build_file=None, build_file_content=None,
                       sha256=None, shallow_since=None, strip_prefix=True,
-                      url=None, urls=None, path=None, **kwargs):
+                      url=None, urls=None, path=None, patches=None, **kwargs):
     """
     Conveniently chooses between archive, git, etc. GitHub repositories.
     Prefer archives, as they're smaller and faster due to the lack of history.
@@ -97,6 +97,8 @@ def github_repository(*, name=None, build_file=None, build_file_content=None,
         build_file = "@//%s:%s" % ("bazel", "BUILD." + name)
 
     if path != None:
+        if patches != None and len(patches) > 0:
+            print("patches ignored for local repository: " + path)
         if build_file or build_file_content:
             native.new_local_repository(name=name, path=path,
                                         build_file=build_file,
@@ -109,14 +111,16 @@ def github_repository(*, name=None, build_file=None, build_file_content=None,
             new_git_repository(name=name, remote=remote, build_file=build_file,
                                commit=commit, tag=tag, shallow_since=shallow_since,
                                build_file_content=build_file_content,
-                               strip_prefix=strip_prefix, **kwargs)
+                               patches=patches, strip_prefix=strip_prefix, **kwargs)
         else:
             git_repository(name=name, remote=remote, strip_prefix=strip_prefix,
-                           commit=commit, tag=tag, shallow_since=shallow_since, **kwargs)
+                           commit=commit, tag=tag, shallow_since=shallow_since,
+                           patches=patches, **kwargs)
     else:
         auto_http_archive(name=name, url=url, urls=urls, sha256=sha256,
                           build_file=build_file, strip_prefix=strip_prefix,
-                          build_file_content=build_file_content, **kwargs)
+                          build_file_content=build_file_content,
+                          patches=patches, **kwargs)
 
 def ray_deps_setup():
     github_repository(

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -43,6 +43,7 @@ if [ "${TRAVIS-}" = true ]; then
   mkdir -p "${HOME}/ray-bazel-cache"
   cat <<EOF >> "${HOME}/.bazelrc"
 build --disk_cache="${HOME}/ray-bazel-cache"
+build --show_timestamps  # Travis doesn't have an option to show timestamps, but GitHub Actions does
 EOF
 fi
 if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
@@ -53,7 +54,6 @@ build --progress_report_interval=60
 # Use ray google cloud cache
 build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 build --show_progress_rate_limit=15
-build --show_timestamps
 build --ui_actions_shown=1024
 EOF
   # If we are in master build, we can write to the cache as well.

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -45,7 +45,7 @@ if [ "${TRAVIS-}" = true ]; then
 build --disk_cache="${HOME}/ray-bazel-cache"
 EOF
 fi
-if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_TOKEN-}" ]; then
+if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
   cat <<EOF >> "${HOME}/.bazelrc"
 # CI output doesn't scroll, so don't use curses
 build --curses=no

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -54,7 +54,9 @@ build --progress_report_interval=60
 # Use ray google cloud cache
 build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"
 build --show_progress_rate_limit=15
+build --show_task_finish
 build --ui_actions_shown=1024
+build --verbose_failures
 EOF
   # If we are in master build, we can write to the cache as well.
   upload=0

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -46,12 +46,12 @@ build --disk_cache="${HOME}/ray-bazel-cache"
 build --show_timestamps  # Travis doesn't have an option to show timestamps, but GitHub Actions does
 EOF
 fi
-if [ "${GITHUB-}" = true ]; then
+if [ -n "${GITHUB_WORKFLOW-}" ]; then
   cat <<EOF >> "${HOME}/.bazelrc"
 --output_base=".bazel-out"  # On GitHub Actions, staying on the same volume seems to be faster
 EOF
 fi
-if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
+if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_WORKFLOW-}" ]; then
   cat <<EOF >> "${HOME}/.bazelrc"
 # CI output doesn't scroll, so don't use curses
 build --curses=no

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -46,6 +46,11 @@ build --disk_cache="${HOME}/ray-bazel-cache"
 build --show_timestamps  # Travis doesn't have an option to show timestamps, but GitHub Actions does
 EOF
 fi
+if [ "${GITHUB-}" = true ]; then
+  cat <<EOF >> "${HOME}/.bazelrc"
+--output_base=".bazel-out"  # On GitHub Actions, staying on the same volume seems to be faster
+EOF
+fi
 if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
   cat <<EOF >> "${HOME}/.bazelrc"
 # CI output doesn't scroll, so don't use curses

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -33,7 +33,7 @@ fi
 pip install --upgrade pip # setuptools cloudpickle urllib3
 
 # If we're in a CI environment, do some configuration
-if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_TOKEN-}" ]; then
+if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
   pip config --user set global.disable-pip-version-check True
   pip config --user set global.no-color True
   pip config --user set global.progress_bar off

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -33,7 +33,7 @@ fi
 pip install --upgrade pip # setuptools cloudpickle urllib3
 
 # If we're in a CI environment, do some configuration
-if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
+if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_WORKFLOW-}" ]; then
   pip config --user set global.disable-pip-version-check True
   pip config --user set global.no-color True
   pip config --user set global.progress_bar off

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -22,7 +22,7 @@ install_clang() {
         curl -s -L -R -o "${target}" "http://releases.llvm.org/${version}/${target##*/}"
         chmod +x "${target}"
       fi
-      if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
+      if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_WORKFLOW-}" ]; then
         7z x "${target}" -o"${target_dir}"  # 7-zip is faster than the self-extracting installer; good for CI
       else
         "${target}" /S  # for normal users we should install properly

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 LLVM_VERSION_WINDOWS="9.0.0"
 

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -22,7 +22,7 @@ install_clang() {
         curl -s -L -R -o "${target}" "http://releases.llvm.org/${version}/${target##*/}"
         chmod +x "${target}"
       fi
-      if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_TOKEN}" ]; then
+      if [ "${TRAVIS-}" = true ] || [ "${GITHUB-}" = true ]; then
         7z x "${target}" -o"${target_dir}"  # 7-zip is faster than the self-extracting installer; good for CI
       else
         "${target}" /S  # for normal users we should install properly

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+LLVM_VERSION_WINDOWS="9.0.0"
+
 install_clang() {
   if [ "${OSTYPE}" = "msys" ]; then
     export MSYS2_ARG_CONV_EXCL="*"  # Don't let MSYS2 attempt to auto-translate arguments that look like paths

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -8,16 +8,25 @@ install_clang() {
     # Ideally we should be able to use the Chocolatey package manager:
     #   choco install --no-progress llvm
     # However, it frequently gives HTTP 503 errors, so we just download and install manually.
-    urldir="https://releases.llvm.org"
-    arch=64
-    if [ "${HOSTTYPE}" = "${HOSTTYPE%64}" ]; then arch=32; fi
-    local version
-    version="${LLVM_VERSION_WINDOWS}"
-    target="./LLVM-${version}-win${arch}.exe"
-    curl -s -L -R -o "${target}" "http://releases.llvm.org/${version}/${target##*/}"
-    chmod +x "${target}"
-    "${target}" /S
-    rm -f -- "${target}"
+    local target_dir="${PROGRAMFILES}\LLVM"
+    if ! command -v clang "${target_dir}/clang" > /dev/null; then
+      local urldir="https://releases.llvm.org"
+      local arch=64
+      if [ "${HOSTTYPE}" = "${HOSTTYPE%64}" ]; then arch=32; fi
+      local version="${LLVM_VERSION_WINDOWS}"
+      local target="./LLVM-${version}-win${arch}.exe"
+      if [ ! -f "${target}" ]; then
+        mkdir -p -- "${target%/*}"
+        curl -s -L -R -o "${target}" "http://releases.llvm.org/${version}/${target##*/}"
+        chmod +x "${target}"
+      fi
+      if [ "${TRAVIS-}" = true ] || [ -n "${GITHUB_TOKEN}" ]; then
+        7z x "${target}" -o"${target_dir}"  # 7-zip is faster than the self-extracting installer; good for CI
+      else
+        "${target}" /S  # for normal users we should install properly
+        rm -f -- "${target}"
+      fi
+    fi
   elif 1>&- command -v pacman; then
     sudo pacman -S --needed --noconfirm --noprogressbar clang
   elif 1>&- command -v apt-get; then


### PR DESCRIPTION
## Why are these changes needed?

- `dl.bintray.com` keeps returning forbidden, so we want to be able to use a mirror

- Improve build performance

- Make build rules clearer and more succinct

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
