### PR TITLE
[RLlib] Fix issue with torch PPO not handling action spaces of shape=(>1,).

### DIFF
--- a/rllib/models/torch/torch_action_dist.py
+++ b/rllib/models/torch/torch_action_dist.py
@@ -71,7 +71,15 @@ class TorchDiagGaussian(TorchDistributionWrapper):
 
     @override(TorchDistributionWrapper)
     def logp(self, actions):
-        return TorchDistributionWrapper.logp(self, actions).sum(-1)
+        return super().logp(actions).sum(-1)
+
+    @override(TorchDistributionWrapper)
+    def entropy(self):
+        return super().entropy().sum(-1)
+
+    @override(TorchDistributionWrapper)
+    def kl(self, other):
+        return super().kl(other).sum(-1)
 
     @staticmethod
     @override(ActionDistribution)

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -11,6 +11,8 @@ from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.agents.registry import get_agent_class
 from ray.rllib.models.tf.fcnet_v2 import FullyConnectedNetwork as FCNetV2
 from ray.rllib.models.tf.visionnet_v2 import VisionNetwork as VisionNetV2
+from ray.rllib.models.torch.visionnet import VisionNetwork as TorchVisionNetV2
+from ray.rllib.models.torch.fcnet import FullyConnectedNetwork as TorchFCNetV2
 from ray.rllib.tests.test_multi_agent_env import MultiCartpole, \
     MultiMountainCar
 from ray.rllib.utils.error import UnsupportedSpaceException
@@ -75,10 +77,11 @@ def check_support(alg, config, stats, check_bounds=False, name=None):
     covered_o = set()
     config["log_level"] = "ERROR"
     first_error = None
+    torch = config.get("use_pytorch", False)
     for a_name, action_space in ACTION_SPACES_TO_TEST.items():
         for o_name, obs_space in OBSERVATION_SPACES_TO_TEST.items():
-            print("=== Testing {} A={} S={} ===".format(
-                alg, action_space, obs_space))
+            print("=== Testing {} (torch={}) A={} S={} ===".format(
+                alg, torch, action_space, obs_space))
             stub_env = make_stub_env(action_space, obs_space, check_bounds)
             register_env("stub_env", lambda c: stub_env())
             stat = "ok"
@@ -86,14 +89,26 @@ def check_support(alg, config, stats, check_bounds=False, name=None):
             try:
                 if a_name in covered_a and o_name in covered_o:
                     stat = "skip"  # speed up tests by avoiding full grid
+                # TODO(sven): Add necessary torch distributions.
+                elif torch and a_name in ["tuple", "multidiscrete"]:
+                    stat = "unsupported"
                 else:
                     a = get_agent_class(alg)(config=config, env="stub_env")
                     if alg not in ["DDPG", "ES", "ARS", "SAC"]:
                         if o_name in ["atari", "image"]:
-                            assert isinstance(a.get_policy().model,
-                                              VisionNetV2)
+                            if torch:
+                                assert isinstance(
+                                    a.get_policy().model, TorchVisionNetV2)
+                            else:
+                                assert isinstance(
+                                    a.get_policy().model, VisionNetV2)
                         elif o_name in ["vector", "vector2"]:
-                            assert isinstance(a.get_policy().model, FCNetV2)
+                            if torch:
+                                assert isinstance(
+                                    a.get_policy().model, TorchFCNetV2)
+                            else:
+                                assert isinstance(
+                                    a.get_policy().model, FCNetV2)
                     a.train()
                     covered_a.add(a_name)
                     covered_o.add(o_name)
@@ -144,15 +159,15 @@ class ModelSupportedSpaces(unittest.TestCase):
         ray.shutdown()
 
     def test_a3c(self):
-        check_support(
-            "A3C", {
-                "num_workers": 1,
-                "optimizer": {
-                    "grads_per_step": 1
-                }
-            },
-            self.stats,
-            check_bounds=True)
+        config = {
+            "num_workers": 1,
+            "optimizer": {
+                "grads_per_step": 1
+            }
+        }
+        check_support("A3C", config, self.stats, check_bounds=True)
+        config["use_pytorch"] = True
+        check_support("A3C", config, self.stats, check_bounds=True)
 
     def test_appo(self):
         check_support("APPO", {"num_gpus": 0, "vtrace": False}, self.stats)
@@ -201,25 +216,25 @@ class ModelSupportedSpaces(unittest.TestCase):
         check_support("IMPALA", {"num_gpus": 0}, self.stats)
 
     def test_ppo(self):
-        check_support(
-            "PPO", {
-                "num_workers": 1,
-                "num_sgd_iter": 1,
-                "train_batch_size": 10,
-                "sample_batch_size": 10,
-                "sgd_minibatch_size": 1,
-            },
-            self.stats,
-            check_bounds=True)
+        config = {
+            "num_workers": 1,
+            "num_sgd_iter": 1,
+            "train_batch_size": 10,
+            "sample_batch_size": 10,
+            "sgd_minibatch_size": 1,
+        }
+        check_support("PPO", config, self.stats, check_bounds=True)
+        config["use_pytorch"] = True
+        check_support("PPO", config, self.stats, check_bounds=True)
 
     def test_pg(self):
-        check_support(
-            "PG", {
-                "num_workers": 1,
-                "optimizer": {}
-            },
-            self.stats,
-            check_bounds=True)
+        config = {
+            "num_workers": 1,
+            "optimizer": {}
+        }
+        check_support("PG", config, self.stats, check_bounds=True)
+        config["use_pytorch"] = True
+        check_support("PG", config, self.stats, check_bounds=True)
 
     def test_sac(self):
         check_support("SAC", {}, self.stats, check_bounds=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The `kl` and `entropy` methods of TorchDiagGaussian do not properly handle reducing over the individual action-components.

<!-- Please give a short summary of the change and the problem this solves. -->

See issue https://github.com/ray-project/ray/issues/7397

<!-- For example: "Closes #1234" -->

Closes #7397

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
