### PR TITLE
Use ray.kill() in multiprocessing.Pool

### DIFF
--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -660,7 +660,7 @@ class Pool:
         if not self._closed:
             self.close()
         for actor, _ in self._actor_pool:
-            actor.__ray_kill__()
+            ray.kill(actor)
 
     def join(self):
         """Wait for the actors in a closed pool to exit.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Changed ray API.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
