### PR TITLE
Fix flaky multiprocessing tests

### DIFF
--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -71,8 +71,6 @@ def test_ray_init(shutdown_only):
     with pytest.raises(ValueError):
         Pool(processes=2)
     assert int(ray.state.cluster_resources()["CPU"]) == 1
-    pool.terminate()
-    pool.join()
     ray.shutdown()
 
 
@@ -134,8 +132,6 @@ def test_connect_to_ray(ray_start_cluster):
     with pytest.raises(Exception):
         Pool(processes=start_cpus + 1)
     assert int(ray.state.cluster_resources()["CPU"]) == start_cpus
-    pool.terminate()
-    pool.join()
     ray.shutdown()
 
 

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -466,10 +466,8 @@ def test_imap_timeout(pool_4_processes):
 
     wait_index = 23
     signal = SignalActor.remote()
-    print("1", flush=True)
     result_iter = pool_4_processes.imap(
         f, [(index, wait_index, signal) for index in range(100)])
-    print("2", flush=True)
     for i in range(100):
         if i == wait_index:
             with pytest.raises(TimeoutError):
@@ -478,18 +476,15 @@ def test_imap_timeout(pool_4_processes):
 
         result = result_iter.next()
         assert result == i
-    print("3", flush=True)
 
     with pytest.raises(StopIteration):
         result_iter.next()
 
     wait_index = 23
     signal = SignalActor.remote()
-    print("4", flush=True)
     result_iter = pool_4_processes.imap_unordered(
         f, [(index, wait_index, signal) for index in range(100)], chunksize=11)
     in_order = []
-    print("5", flush=True)
     for i in range(100):
         try:
             result = result_iter.next(timeout=1)
@@ -498,17 +493,14 @@ def test_imap_timeout(pool_4_processes):
             result = result_iter.next()
 
         in_order.append(result == i)
-    print("6", flush=True)
 
     # Check that the results didn't come back all in order.
     # NOTE: this could be flaky if the calls happened to finish in order due
     # to the random sleeps, but it's very unlikely.
     assert not all(in_order)
 
-    print("7", flush=True)
     with pytest.raises(StopIteration):
         result_iter.next()
-    print("8", flush=True)
 
 
 def test_maxtasksperchild(shutdown_only):

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -660,7 +660,7 @@ class Pool:
         if not self._closed:
             self.close()
         for actor, _ in self._actor_pool:
-            actor.__ray_kill__()
+            ray.kill(actor)
 
     def join(self):
         """Wait for the actors in a closed pool to exit.

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -232,13 +232,14 @@ class OrderedIMapIterator(IMapIterator):
             if self._next_chunk_index == self._total_chunks:
                 raise StopIteration
 
-            while timeout is None or timeout > 0:
+            # This loop will break when the next index in order is ready or
+            # self._result_thread.next_ready_index() raises a timeout.
+            index = -1
+            while index != self._next_chunk_index:
                 start = time.time()
                 index = self._result_thread.next_ready_index(timeout=timeout)
                 self._submit_next_chunk()
                 self._submitted_chunks[index] = True
-                if index == self._next_chunk_index:
-                    break
                 if timeout is not None:
                     timeout = max(0, timeout - (time.time() - start))
 

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -31,7 +31,7 @@ class ResultThread(threading.Thread):
                  callback=None,
                  error_callback=None,
                  total_object_ids=None):
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self._got_error = False
         self._object_ids = []
         self._num_ready = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_multiprocessing.py` has been failing periodically on master due to an issue where the pools were not shut down properly.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
