### PR TITLE
Mention that calling some_function.remote() is non-blocking

### DIFF
--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -83,7 +83,7 @@ This causes a few changes in behavior:
            remote_function.remote()
 
 The invocations are executed in parallel because the call to ``remote_function.remote()`` doesn't block.
-All I/O is performed in the background using Ray's internal event loop.
+All computation is performed in the background, driven by Ray's internal event loop.
 
 See the `ray.remote package reference <package-ref.html>`__ page for specific documentation on how to use ``ray.remote``.
 

--- a/doc/source/walkthrough.rst
+++ b/doc/source/walkthrough.rst
@@ -82,6 +82,9 @@ This causes a few changes in behavior:
        for _ in range(4):
            remote_function.remote()
 
+The invocations are executed in parallel because the call to ``remote_function.remote()`` doesn't block.
+All I/O is performed in the background using Ray's internal event loop.
+
 See the `ray.remote package reference <package-ref.html>`__ page for specific documentation on how to use ``ray.remote``.
 
 **Object IDs** can also be passed into remote functions. When the function actually gets executed, **the argument will be a retrieved as a regular Python object**. For example, take this function:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

It is not clear from the documentation that invoking a remote function or actor is non-blocking.
This PR specifies that fact in the walkthrough

## Related issue number

Fixes #7229

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
