### PR TITLE
Fix installation documentation on readthedocs

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -48,13 +48,13 @@ Installing from a specific commit
 
 You can install the Ray wheels of any particular commit on ``master`` with the following template. You need to specify the commit hash, Ray version, Operating System, and Python version:
 
-.. code-block::
+.. code-block:: bash
 
     pip install https://ray-wheels.s3-us-west-2.amazonaws.com/master/{COMMIT_HASH}/ray-{RAY_VERSION}-{PYTHON_VERSION}-{PYTHON_VERSION}m-{OS_VERSION}_intel.whl
 
 For example, here are the Ray 0.9.0.dev0 wheels for Python 3.5, MacOS for commit ``a0ba4499ac645c9d3e82e68f3a281e48ad57f873``:
 
-.. code-block::
+.. code-block:: bash
 
     pip install https://ray-wheels.s3-us-west-2.amazonaws.com/master/a0ba4499ac645c9d3e82e68f3a281e48ad57f873/ray-0.9.0.dev0-cp35-cp35m-macosx_10_13_intel.whl
 
@@ -168,7 +168,7 @@ If you are using Anaconda and have trouble installing ``psutil`` or
 The command ``ray.init()`` or ``ray start --head`` will print out the address of
 the dashboard. For example,
 
-.. code-block::
+.. code-block:: python
 
   >>> import ray
   >>> ray.init()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The installation instructions for installing the latest wheel on readthedocs is currently broken, this PR attempts to fix it. All the code blocks without a language don't show up, so this PR adds a language to those ones.

Broken version:

<img width="762" alt="Screen Shot 2020-03-03 at 10 31 15 AM" src="https://user-images.githubusercontent.com/113316/75807390-29438a80-5d3a-11ea-8d27-95f3db4ed92f.png">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
