### PR TITLE
Reduce memory usage per worker 200MB->50MB

### DIFF
--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -33,7 +33,7 @@ namespace rpc {
 #define WORKER_INFO_SERVICE_RPC_HANDLER(HANDLER, CONCURRENCY) \
   RPC_SERVICE_HANDLER(WorkerInfoGcsService, HANDLER, CONCURRENCY)
 
-#define SERVER_CALL_CONCURRENCY 9999
+#define SERVER_CALL_CONCURRENCY 100
 
 class JobInfoGcsServiceHandler {
  public:

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -16,12 +16,12 @@ namespace rpc {
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
 #define RAY_CORE_WORKER_RPC_HANDLERS                                          \
   RPC_SERVICE_HANDLER(CoreWorkerService, AssignTask, 5)                       \
-  RPC_SERVICE_HANDLER(CoreWorkerService, PushTask, 9999)                      \
+  RPC_SERVICE_HANDLER(CoreWorkerService, PushTask, 100)                       \
   RPC_SERVICE_HANDLER(CoreWorkerService, DirectActorCallArgWaitComplete, 100) \
-  RPC_SERVICE_HANDLER(CoreWorkerService, GetObjectStatus, 9999)               \
-  RPC_SERVICE_HANDLER(CoreWorkerService, WaitForObjectEviction, 9999)         \
-  RPC_SERVICE_HANDLER(CoreWorkerService, WaitForRefRemoved, 9999)             \
-  RPC_SERVICE_HANDLER(CoreWorkerService, KillActor, 9999)                     \
+  RPC_SERVICE_HANDLER(CoreWorkerService, GetObjectStatus, 100)                \
+  RPC_SERVICE_HANDLER(CoreWorkerService, WaitForObjectEviction, 100)          \
+  RPC_SERVICE_HANDLER(CoreWorkerService, WaitForRefRemoved, 100)              \
+  RPC_SERVICE_HANDLER(CoreWorkerService, KillActor, 100)                      \
   RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats, 100)             \
   RPC_SERVICE_HANDLER(CoreWorkerService, LocalGC, 100)
 


### PR DESCRIPTION
It turns out each `ServerCall` objects are pre-created given the max concurrency. So declarations like 
```
RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats, 9999)
```
will create 9999 ServerCall objects. This increase the memory consumptions. 

This PR reduce the number of max concurrent call per methods. I can file a follow up PR to lazily create more server call objects when the number of incoming requests going to exceeds the number of existing `ServerCall` objects.