### PR TITLE
Fix fate_share not being passed to Redis shards

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -768,7 +768,8 @@ def start_redis(node_ip_address,
             redis_max_clients=redis_max_clients,
             redis_max_memory=redis_max_memory,
             stdout_file=redis_stdout_file,
-            stderr_file=redis_stderr_file)
+            stderr_file=redis_stderr_file,
+            fate_share=fate_share)
         processes.append(p)
 
         shard_address = address(node_ip_address, redis_shard_port)


### PR DESCRIPTION
## Why are these changes needed?

`fate_share` wasn't being propagated properly.

## Related issue number

Fixes bug in #7150.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
