### PR TITLE
New scheduler local node

### DIFF
--- a/src/ray/common/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.cc
@@ -26,7 +26,8 @@ std::string UnorderedMapToString(const std::unordered_map<std::string, double> &
 }
 
 /// Convert a map of resources to a TaskRequest data structure.
-TaskRequest ResourceMapToTaskRequest(StringIdMap &string_to_int_map, 
+TaskRequest ResourceMapToTaskRequest(
+    StringIdMap &string_to_int_map,
     const std::unordered_map<std::string, double> &resource_map) {
   size_t i = 0;
 
@@ -92,12 +93,11 @@ TaskRequest TaskResourceInstances::ToTaskRequest() const {
 /// \param resource_map_total: Total capacities of resources we want to convert.
 /// \param resource_map_available: Available capacities of resources we want to convert.
 ///
-/// \request Conversion result to a TaskRequest data structure. 
+/// \request Conversion result to a TaskRequest data structure.
 NodeResources ResourceMapToNodeResources(
-    StringIdMap& string_to_int_map,
+    StringIdMap &string_to_int_map,
     const std::unordered_map<std::string, double> &resource_map_total,
     const std::unordered_map<std::string, double> &resource_map_available) {
-
   NodeResources node_resources;
   node_resources.predefined_resources.resize(PredefinedResources_MAX);
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
@@ -105,7 +105,7 @@ NodeResources ResourceMapToNodeResources(
         node_resources.predefined_resources[i].available = 0;
   }
 
-  for (auto const &resource : resource_map_total) {   
+  for (auto const &resource : resource_map_total) {
     ResourceCapacity resource_capacity;
     resource_capacity.total = (int64_t)resource.second;
     auto it = resource_map_available.find(resource.first);
@@ -174,12 +174,12 @@ std::string NodeResources::DebugString(StringIdMap string_to_in_map) const {
   buffer << "  {";
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
-    buffer << string_to_in_map.Get(it->first) << ":(" << it->second.total << ":" << it->second.available << ") ";
+    buffer << string_to_in_map.Get(it->first) << ":(" << it->second.total << ":"
+           << it->second.available << ") ";
   }
   buffer << "}" << std::endl;
   return buffer.str();
 }
-
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) {
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
@@ -225,9 +225,8 @@ std::string NodeResourceInstances::DebugString(StringIdMap string_to_int_map) co
   buffer << " {";
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
-    buffer << string_to_int_map.Get(it->first) 
-           << ":(" << VectorToString(it->second.total) << ":"
-           << VectorToString(it->second.available) << ") ";
+    buffer << string_to_int_map.Get(it->first) << ":(" << VectorToString(it->second.total)
+           << ":" << VectorToString(it->second.available) << ") ";
   }
   buffer << "}" << std::endl;
   return buffer.str();
@@ -276,7 +275,7 @@ bool TaskResourceInstances::IsEmpty() const {
       }
     }
   }
- 
+
   for (const auto custom_resource : custom_resources) {
     for (const auto custom_resource_instances : custom_resource.second) {
       if (custom_resource_instances != 0) {
@@ -333,7 +332,6 @@ bool TaskResourceInstances::operator==(const TaskResourceInstances &other) {
   return true;
 }
 
-
 ClusterResourceScheduler::ClusterResourceScheduler(
     int64_t local_node_id, const NodeResources &local_node_resources)
     : local_node_id_(local_node_id) {
@@ -344,11 +342,9 @@ ClusterResourceScheduler::ClusterResourceScheduler(
 ClusterResourceScheduler::ClusterResourceScheduler(
     const std::string &local_node_id,
     const std::unordered_map<std::string, double> &local_node_resources) {
-
   local_node_id_ = string_to_int_map_.Insert(local_node_id);
-  NodeResources node_resources = 
-      ResourceMapToNodeResources(string_to_int_map_, 
-          local_node_resources, local_node_resources);
+  NodeResources node_resources = ResourceMapToNodeResources(
+      string_to_int_map_, local_node_resources, local_node_resources);
 
   AddOrUpdateNode(local_node_id_, node_resources);
   InitLocalResources(node_resources);
@@ -358,8 +354,8 @@ void ClusterResourceScheduler::AddOrUpdateNode(
     const std::string &node_id,
     const std::unordered_map<std::string, double> &resources_total,
     const std::unordered_map<std::string, double> &resources_available) {
-  NodeResources node_resources = ResourceMapToNodeResources(string_to_int_map_, 
-      resources_total, resources_available);
+  NodeResources node_resources = ResourceMapToNodeResources(
+      string_to_int_map_, resources_total, resources_available);
   AddOrUpdateNode(string_to_int_map_.Insert(node_id), node_resources);
 }
 
@@ -419,12 +415,12 @@ int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
     if (task_req.predefined_resources[i].demand >
         resources.predefined_resources[i].available) {
       if (task_req.predefined_resources[i].soft) {
-        // A soft constraint has been violated. 
+        // A soft constraint has been violated.
         // Just remember this as soft violations do not preclude a task
         // from being scheduled.
         violations++;
       } else {
-        // A hard constraint has been violated, so we cannot schedule 
+        // A hard constraint has been violated, so we cannot schedule
         // this task request.
         return -1;
       }
@@ -432,7 +428,7 @@ int64_t ClusterResourceScheduler::IsSchedulable(const TaskRequest &task_req,
   }
 
   // No check custom resources.
-  for (const auto task_req_custom_resource : task_req.custom_resources) { 
+  for (const auto task_req_custom_resource : task_req.custom_resources) {
     auto it = resources.custom_resources.find(task_req_custom_resource.id);
 
     if (it == resources.custom_resources.end()) {
@@ -478,7 +474,7 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
   int64_t best_node = -1;
   *total_violations = 0;
 
- // Check whether local node is schedulable. We return immediately
+  // Check whether local node is schedulable. We return immediately
   // the local node only if there are zero violations.
   auto it = nodes_.find(local_node_id_);
   if (it != nodes_.end()) {
@@ -524,8 +520,7 @@ int64_t ClusterResourceScheduler::GetBestSchedulableNode(const TaskRequest &task
 std::string ClusterResourceScheduler::GetBestSchedulableNode(
     const std::unordered_map<std::string, double> &task_resources,
     int64_t *total_violations) {
-  TaskRequest task_request = 
-      ResourceMapToTaskRequest(string_to_int_map_, task_resources);
+  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
   int64_t node_id = GetBestSchedulableNode(task_request, total_violations);
 
   std::string id_string;
@@ -569,8 +564,7 @@ bool ClusterResourceScheduler::SubtractNodeAvailableResources(
 bool ClusterResourceScheduler::SubtractNodeAvailableResources(
     const std::string &node_id,
     const std::unordered_map<std::string, double> &resource_map) {
-  TaskRequest task_request = 
-      ResourceMapToTaskRequest(string_to_int_map_, resource_map);
+  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, resource_map);
   return SubtractNodeAvailableResources(string_to_int_map_.Get(node_id), task_request);
 }
 
@@ -602,8 +596,7 @@ bool ClusterResourceScheduler::AddNodeAvailableResources(int64_t node_id,
 bool ClusterResourceScheduler::AddNodeAvailableResources(
     const std::string &node_id,
     const std::unordered_map<std::string, double> &resource_map) {
-  TaskRequest task_request = 
-      ResourceMapToTaskRequest(string_to_int_map_, resource_map);
+  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, resource_map);
   return AddNodeAvailableResources(string_to_int_map_.Get(node_id), task_request);
 }
 
@@ -618,14 +611,11 @@ bool ClusterResourceScheduler::GetNodeResources(int64_t node_id,
   }
 }
 
-int64_t ClusterResourceScheduler::NumNodes() { 
-  return nodes_.size(); 
-}
-
+int64_t ClusterResourceScheduler::NumNodes() { return nodes_.size(); }
 
 void ClusterResourceScheduler::UpdateResourceCapacity(const std::string &client_id_string,
                                                       const std::string &resource_name,
-                                                      int64_t resource_total) {     
+                                                      int64_t resource_total) {
   int64_t client_id = string_to_int_map_.Get(client_id_string);
 
   auto it = nodes_.find(client_id);
@@ -721,8 +711,7 @@ std::string ClusterResourceScheduler::DebugString(void) const {
 }
 
 void ClusterResourceScheduler::InitResourceInstances(
-    double total, bool unit_instances,
-    ResourceInstanceCapacities *instance_list) {
+    double total, bool unit_instances, ResourceInstanceCapacities *instance_list) {
   if (unit_instances) {
     size_t num_instances = static_cast<size_t>(total);
     instance_list->total.resize(num_instances);
@@ -764,32 +753,30 @@ void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_reso
 }
 
 std::vector<double> ClusterResourceScheduler::AddAvailableResourceInstances(
-    std::vector<double> available,
-    ResourceInstanceCapacities *resource_instances) {
-  std::vector<double> overflow(available.size(), 0.);  
+    std::vector<double> available, ResourceInstanceCapacities *resource_instances) {
+  std::vector<double> overflow(available.size(), 0.);
   for (size_t i = 0; i < available.size(); i++) {
     resource_instances->available[i] = resource_instances->available[i] + available[i];
     if (resource_instances->available[i] > resource_instances->total[i]) {
       overflow[i] = resource_instances->available[i] - resource_instances->total[i];
       resource_instances->available[i] = resource_instances->total[i];
-    } 
+    }
   }
 
   return overflow;
 }
 
 std::vector<double> ClusterResourceScheduler::SubtractAvailableResourceInstances(
-    std::vector<double> available,
-    ResourceInstanceCapacities *resource_instances) {
+    std::vector<double> available, ResourceInstanceCapacities *resource_instances) {
   RAY_CHECK(available.size() == resource_instances->available.size());
 
-  std::vector<double> underflow(available.size(), 0.);      
+  std::vector<double> underflow(available.size(), 0.);
   for (size_t i = 0; i < available.size(); i++) {
     resource_instances->available[i] = resource_instances->available[i] - available[i];
     if (resource_instances->available[i] < 0) {
       underflow[i] = -resource_instances->available[i];
       resource_instances->available[i] = 0;
-    }  
+    }
   }
   return underflow;
 }
@@ -886,9 +873,8 @@ bool ClusterResourceScheduler::AllocateResourceInstances(
 }
 
 bool ClusterResourceScheduler::AllocateTaskResourceInstances(
-    const TaskRequest &task_req, 
-    std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);  
+    const TaskRequest &task_req, std::shared_ptr<TaskResourceInstances> task_allocation) {
+  RAY_CHECK(task_allocation != nullptr);
   if (nodes_.find(local_node_id_) == nodes_.end()) {
     return false;
   }
@@ -939,14 +925,15 @@ void ClusterResourceScheduler::UpdateLocalAvailableResourcesFromResourceInstance
 
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     it_local_node->second.predefined_resources[i].available = 0;
-    for (size_t j = 0; j < local_resources_.predefined_resources[i].available.size(); j++) {
-      it_local_node->second.predefined_resources[i].available += 
-          local_resources_.predefined_resources[i].available[j]; 
+    for (size_t j = 0; j < local_resources_.predefined_resources[i].available.size();
+         j++) {
+      it_local_node->second.predefined_resources[i].available +=
+          local_resources_.predefined_resources[i].available[j];
     }
   }
 
   for (auto &custom_resource : it_local_node->second.custom_resources) {
-    auto it = local_resources_.custom_resources.find(custom_resource.first); 
+    auto it = local_resources_.custom_resources.find(custom_resource.first);
     if (it != local_resources_.custom_resources.end()) {
       custom_resource.second.available = 0;
       for (const auto available : it->second.available) {
@@ -958,14 +945,15 @@ void ClusterResourceScheduler::UpdateLocalAvailableResourcesFromResourceInstance
 
 void ClusterResourceScheduler::FreeTaskResourceInstances(
     std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);    
+  RAY_CHECK(task_allocation != nullptr);
   for (size_t i = 0; i < PredefinedResources_MAX; i++) {
     AddAvailableResourceInstances(task_allocation->predefined_resources[i],
                                   &local_resources_.predefined_resources[i]);
   }
 
   for (const auto task_allocation_custom_resource : task_allocation->custom_resources) {
-    auto it = local_resources_.custom_resources.find(task_allocation_custom_resource.first);
+    auto it =
+        local_resources_.custom_resources.find(task_allocation_custom_resource.first);
     if (it != local_resources_.custom_resources.end()) {
       AddAvailableResourceInstances(task_allocation_custom_resource.second, &it->second);
     }
@@ -975,41 +963,40 @@ void ClusterResourceScheduler::FreeTaskResourceInstances(
 std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
     std::vector<double> &cpu_instances) {
   if (cpu_instances.size() == 0) {
-    return cpu_instances; // No oveerflow.
-  }    
+    return cpu_instances;  // No oveerflow.
+  }
   RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
 
-  auto overflow = AddAvailableResourceInstances(cpu_instances,
-      &local_resources_.predefined_resources[CPU]);
+  auto overflow = AddAvailableResourceInstances(
+      cpu_instances, &local_resources_.predefined_resources[CPU]);
   UpdateLocalAvailableResourcesFromResourceInstances();
 
-  return overflow; 
+  return overflow;
 }
 
 std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
     std::vector<double> &cpu_instances) {
   if (cpu_instances.size() == 0) {
-    return cpu_instances; // No underflow.
-  }    
+    return cpu_instances;  // No underflow.
+  }
   RAY_CHECK(nodes_.find(local_node_id_) != nodes_.end());
 
-  auto underflow = SubtractAvailableResourceInstances(cpu_instances,
-      &local_resources_.predefined_resources[CPU]);
+  auto underflow = SubtractAvailableResourceInstances(
+      cpu_instances, &local_resources_.predefined_resources[CPU]);
   UpdateLocalAvailableResourcesFromResourceInstances();
 
-  return underflow; 
+  return underflow;
 }
 
 bool ClusterResourceScheduler::AllocateTaskResources(
-    int64_t node_id, const TaskRequest &task_req, 
+    int64_t node_id, const TaskRequest &task_req,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
-
   if (node_id == local_node_id_) {
     RAY_CHECK(task_allocation != nullptr);
     if (AllocateTaskResourceInstances(task_req, task_allocation)) {
       UpdateLocalAvailableResourcesFromResourceInstances();
       return true;
-    } 
+    }
   } else {
     if (SubtractNodeAvailableResources(node_id, task_req)) {
       return true;
@@ -1019,12 +1006,11 @@ bool ClusterResourceScheduler::AllocateTaskResources(
 }
 
 bool ClusterResourceScheduler::AllocateLocalTaskResources(
-    const std::unordered_map<std::string, double> &task_resources, 
+    const std::unordered_map<std::string, double> &task_resources,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
-  RAY_CHECK(task_allocation != nullptr);    
-  TaskRequest task_request = 
-      ResourceMapToTaskRequest(string_to_int_map_, task_resources);
-  return AllocateTaskResources(local_node_id_, task_request, task_allocation);    
+  RAY_CHECK(task_allocation != nullptr);
+  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
+  return AllocateTaskResources(local_node_id_, task_request, task_allocation);
 }
 
 std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) {
@@ -1044,14 +1030,14 @@ std::string ClusterResourceScheduler::GetResourceNameFromIndex(int64_t res_idx) 
 void ClusterResourceScheduler::AllocateRemoteTaskResources(
     std::string &node_string,
     const std::unordered_map<std::string, double> &task_resources) {
-  TaskRequest task_request = 
-      ResourceMapToTaskRequest(string_to_int_map_, task_resources);
+  TaskRequest task_request = ResourceMapToTaskRequest(string_to_int_map_, task_resources);
   auto node_id = string_to_int_map_.Insert(node_string);
   RAY_CHECK(node_id != local_node_id_);
-  AllocateTaskResources(node_id, task_request, nullptr);    
+  AllocateTaskResources(node_id, task_request, nullptr);
 }
 
-void ClusterResourceScheduler::FreeLocalTaskResources(std::shared_ptr<TaskResourceInstances> task_allocation) {
+void ClusterResourceScheduler::FreeLocalTaskResources(
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
   if (task_allocation == nullptr || task_allocation->IsEmpty()) {
     return;
   }

--- a/src/ray/common/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.cc
@@ -953,7 +953,7 @@ std::vector<double> ClusterResourceScheduler::AddCPUResourceInstances(
   auto it = nodes_.find(local_node_id_);
   RAY_CHECK(it != nodes_.end());
   double cpus = 0;
-  for(int v : cpu_instances) {
+  for (double v : cpu_instances) {
     cpus += v;
   } 
   it->second.predefined_resources[CPU].available = 
@@ -971,7 +971,7 @@ std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
   auto it = nodes_.find(local_node_id_);
   RAY_CHECK(it != nodes_.end());
   double cpus = 0;
-  for(int v : cpu_instances) {
+  for (double v : cpu_instances) {
     cpus += v;
   } 
   it->second.predefined_resources[CPU].available = 

--- a/src/ray/common/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.cc
@@ -722,7 +722,7 @@ std::string ClusterResourceScheduler::DebugString(void) const {
 
 void ClusterResourceScheduler::InitResourceInstances(
     double total, bool unit_instances,
-    ResourceInstanceCapacities *instance_list /* return */) {
+    ResourceInstanceCapacities *instance_list) {
   if (unit_instances) {
     size_t num_instances = static_cast<size_t>(total);
     instance_list->total.resize(num_instances);
@@ -765,7 +765,7 @@ void ClusterResourceScheduler::InitLocalResources(const NodeResources &node_reso
 
 std::vector<double> ClusterResourceScheduler::AddAvailableResourceInstances(
     std::vector<double> available,
-    ResourceInstanceCapacities *resource_instances /* return */) {
+    ResourceInstanceCapacities *resource_instances) {
   std::vector<double> overflow(available.size(), 0.);  
   for (size_t i = 0; i < available.size(); i++) {
     resource_instances->available[i] = resource_instances->available[i] + available[i];
@@ -780,7 +780,7 @@ std::vector<double> ClusterResourceScheduler::AddAvailableResourceInstances(
 
 std::vector<double> ClusterResourceScheduler::SubtractAvailableResourceInstances(
     std::vector<double> available,
-    ResourceInstanceCapacities *resource_instances /* return */) {
+    ResourceInstanceCapacities *resource_instances) {
   RAY_CHECK(available.size() == resource_instances->available.size());
 
   std::vector<double> underflow(available.size(), 0.);      
@@ -796,7 +796,7 @@ std::vector<double> ClusterResourceScheduler::SubtractAvailableResourceInstances
 
 bool ClusterResourceScheduler::AllocateResourceInstances(
     double demand, bool soft, std::vector<double> &available,
-    std::vector<double> *allocation /* return */) {
+    std::vector<double> *allocation) {
   allocation->resize(available.size());
   double remaining_demand = demand;
 
@@ -887,7 +887,7 @@ bool ClusterResourceScheduler::AllocateResourceInstances(
 
 bool ClusterResourceScheduler::AllocateTaskResourceInstances(
     const TaskRequest &task_req, 
-    std::shared_ptr<TaskResourceInstances> task_allocation /* return */) {
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);  
   if (nodes_.find(local_node_id_) == nodes_.end()) {
     return false;
@@ -1002,7 +1002,7 @@ std::vector<double> ClusterResourceScheduler::SubtractCPUResourceInstances(
 
 bool ClusterResourceScheduler::AllocateTaskResources(
     int64_t node_id, const TaskRequest &task_req, 
-    std::shared_ptr<TaskResourceInstances> task_allocation /* return */) {
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
 
   if (node_id == local_node_id_) {
     RAY_CHECK(task_allocation != nullptr);
@@ -1020,7 +1020,7 @@ bool ClusterResourceScheduler::AllocateTaskResources(
 
 bool ClusterResourceScheduler::AllocateLocalTaskResources(
     const std::unordered_map<std::string, double> &task_resources, 
-    std::shared_ptr<TaskResourceInstances> task_allocation /* return */) {
+    std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);    
   TaskRequest task_request = 
       ResourceMapToTaskRequest(string_to_int_map_, task_resources);
@@ -1052,10 +1052,7 @@ void ClusterResourceScheduler::AllocateRemoteTaskResources(
 }
 
 void ClusterResourceScheduler::FreeLocalTaskResources(std::shared_ptr<TaskResourceInstances> task_allocation) {
-  if (task_allocation == nullptr) {
-    return;
-  }
-  if (task_allocation->IsEmpty()) {
+  if (task_allocation == nullptr || task_allocation->IsEmpty()) {
     return;
   }
   FreeTaskResourceInstances(task_allocation);

--- a/src/ray/common/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.cc
@@ -162,7 +162,7 @@ bool NodeResources::operator==(const NodeResources &other) {
   return true;
 }
 
-std::string NodeResources::DebugString() const {
+std::string NodeResources::DebugString(StringIdMap string_to_in_map) const {
   std::stringstream buffer;
   buffer << " {";
   for (size_t i = 0; i < static_cast<size_t>(this->predefined_resources.size()); i++) {
@@ -174,7 +174,7 @@ std::string NodeResources::DebugString() const {
   buffer << "  {";
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
-    buffer << it->first << ":(" << it->second.total << ":" << it->second.available << ") ";
+    buffer << string_to_in_map.Get(it->first) << ":(" << it->second.total << ":" << it->second.available << ") ";
   }
   buffer << "}" << std::endl;
   return buffer.str();
@@ -213,7 +213,7 @@ bool NodeResourceInstances::operator==(const NodeResourceInstances &other) {
   return true;
 }
 
-std::string NodeResourceInstances::DebugString() const {
+std::string NodeResourceInstances::DebugString(StringIdMap string_to_int_map) const {
   std::stringstream buffer;
   buffer << " {";
   for (size_t i = 0; i < this->predefined_resources.size(); i++) {
@@ -225,7 +225,8 @@ std::string NodeResourceInstances::DebugString() const {
   buffer << " {";
   for (auto it = this->custom_resources.begin(); it != this->custom_resources.end();
        ++it) {
-    buffer << it->first << ":(" << VectorToString(it->second.total) << ":"
+    buffer << string_to_int_map.Get(it->first) 
+           << ":(" << VectorToString(it->second.total) << ":"
            << VectorToString(it->second.available) << ") ";
   }
   buffer << "}" << std::endl;
@@ -711,10 +712,10 @@ void ClusterResourceScheduler::DeleteResource(const std::string &client_id_strin
 std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\n Local id: " << local_node_id_;
-  buffer << " Local resources: " << local_resources_.DebugString();
+  buffer << " Local resources: " << local_resources_.DebugString(string_to_int_map_);
   for (auto &node : nodes_) {
     buffer << "   node id: " << node.first;
-    buffer << node.second.DebugString();
+    buffer << node.second.DebugString(string_to_int_map_);
   }
   return buffer.str();
 }

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -278,8 +278,7 @@ class ClusterResourceScheduler {
   /// Get number of nodes in the cluster.
   int64_t NumNodes();
 
-  /// Update total capacity of a given resource (resource_name) of a give node 
-  /// (node_name).
+  /// Update total capacity of a given resource of a given node.
   ///
   /// \param node_name: Node whose resource we want to update.
   /// \param resource_name: Resource which we want to update.

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -427,6 +427,17 @@ class ClusterResourceScheduler {
 
   void FreeLocalTaskResources(TaskResourceInstances& task_allocation);
 
+  /// Update the available resources of the local node given 
+  /// the available instances of each resource of the local node.
+  /// Basically, this means computing the available resources
+  /// by adding up the available quantities of each instance of that
+  /// resources.
+  /// 
+  /// Example: Assume the local node has four GPU instances with the 
+  /// following availabilities: 0.2, 0.3, 0.1, 1. Then the total GPU 
+  // resources availabile at that node is 0.2 + 0.3 + 0.1 + 1. = 1.6
+  void UpdateLocalAvailableResourcesFromResourceInstances();
+
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 };

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -372,7 +372,7 @@ class ClusterResourceScheduler {
   ///
   /// \return Overflow capacities of "resource_instances" after adding instance 
   /// capacities in "available", i.e., 
-  /// min(available + reasource_instances.available, resource_instances.total) 
+  /// min(available + resource_instances.available, resource_instances.total) 
   std::vector<double> AddAvailableResourceInstances(std::vector<double> available,
                                                     ResourceInstanceCapacities *resource_instances);
 

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -380,7 +380,7 @@ class ClusterResourceScheduler {
   ///
   /// \param free A list of capacities for resource's instances to be freed.
   /// \param resource_instances List of the resource instances being updated.
-  /// \return Underflow of "resource_instances" after substracting instance 
+  /// \return Underflow of "resource_instances" after subtracting instance 
   /// capacities in "available", i.e.,.
   /// max(available - reasource_instances.available, 0)
   std::vector<double> SubtractAvailableResourceInstances(std::vector<double> available,

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -46,7 +46,7 @@ struct ResourceRequestWithId : ResourceRequest {
   int64_t id;
 };
 
-// Data structure specifying the capacity of each resource requested by a task. 
+// Data structure specifying the capacity of each resource requested by a task.
 class TaskRequest {
  public:
   /// List of predefined resources required by the task.
@@ -62,7 +62,7 @@ class TaskRequest {
   std::string DebugString() const;
 };
 
-// Data structure specifying the capacity of each instance of each resource 
+// Data structure specifying the capacity of each instance of each resource
 // allocated to a task.
 class TaskResourceInstances {
  public:
@@ -74,9 +74,9 @@ class TaskResourceInstances {
   /// For each resource of this request aggregate its instances.
   TaskRequest ToTaskRequest() const;
   /// Get CPU instances only.
-  std::vector<double> GetCPUInstances() const {  
+  std::vector<double> GetCPUInstances() const {
     if (!this->predefined_resources.empty()) {
-      return this->predefined_resources[CPU]; 
+      return this->predefined_resources[CPU];
     } else {
       return {};
     }
@@ -147,18 +147,18 @@ class ClusterResourceScheduler {
       const absl::flat_hash_map<int64_t, ResourceCapacity> &new_custom_resources,
       absl::flat_hash_map<int64_t, ResourceCapacity> *old_custom_resources);
 
-  /// Subtract the resources required by a given task request (task_req) from 
-  /// a given node (node_id). 
+  /// Subtract the resources required by a given task request (task_req) from
+  /// a given node (node_id).
   ///
   /// \param node_id Node whose resources we allocate. Can be the local or a remote node.
   /// \param task_req Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity. 
+  /// \param task_allocation Resources allocated to the task at instance granularity.
   /// This is a return parameter.
   ///
-  /// \return True if the node has enough resources to satisfy the task request. 
-  /// False otherwise. 
-  bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req, 
-                            std::shared_ptr<TaskResourceInstances> task_allocation);
+  /// \return True if the node has enough resources to satisfy the task request.
+  /// False otherwise.
+  bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req,
+                             std::shared_ptr<TaskResourceInstances> task_allocation);
 
  public:
   ClusterResourceScheduler(void){};
@@ -282,7 +282,7 @@ class ClusterResourceScheduler {
   ///
   /// \param node_name: Node whose resource we want to update.
   /// \param resource_name: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource. 
+  /// \param resource_total: New capacity of the resource.
   void UpdateResourceCapacity(const std::string &node_name,
                               const std::string &resource_name, int64_t resource_total);
 
@@ -290,8 +290,7 @@ class ClusterResourceScheduler {
   ///
   /// \param node_name: Node whose resource we want to delete.
   /// \param resource_name: Resource we want to delete
-  void DeleteResource(const std::string &node_name,
-                      const std::string &resource_name);
+  void DeleteResource(const std::string &node_name, const std::string &resource_name);
 
   /// Return local resources.
   NodeResourceInstances GetLocalResources() { return local_resources_; };
@@ -325,7 +324,7 @@ class ClusterResourceScheduler {
   /// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
   /// with the smalest available capacity that can satisfy the remaining demand of 0.2).
   /// As a result remaining available capacities will be (0., 1., .7, .3).
-  /// Thus, if the constraint is hard, we will allocate a bunch of full instances and 
+  /// Thus, if the constraint is hard, we will allocate a bunch of full instances and
   /// at most a fractional instance.
   ///
   /// 2) If the constraint is soft, we can allocate multiple fractional resources,
@@ -334,7 +333,7 @@ class ClusterResourceScheduler {
   /// 0.3 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
   /// all instances, and return success (true), despite the fact that the total
   /// available capacity of the rwsource is 3.2 (= 1. + 1. + .7 + .5), which is less
-  /// than the demand, 3.5. In this case, the remaining available resource is 
+  /// than the demand, 3.5. In this case, the remaining available resource is
   /// (0., 0., 0., 0.)
   ///
   /// \param demand: The resource amount to be allocated.
@@ -352,12 +351,12 @@ class ClusterResourceScheduler {
   ///
   /// \param task_req: Resources requested by a task.
   /// \param task_allocation: Local resources allocated to satsify task_req demand.
-  /// This is an output argument.
   ///
   /// \return true, if allocation successful. If false, the caller needs to free the
   /// allocated resources, i.e., task_allocation.
-  bool AllocateTaskResourceInstances(const TaskRequest &task_req,
-                                     std::shared_ptr<TaskResourceInstances> task_allocation);
+  bool AllocateTaskResourceInstances(
+      const TaskRequest &task_req,
+      std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Free resources which were allocated with a task. The freed resources are
   /// added back to the node's local available resources.
@@ -370,71 +369,71 @@ class ClusterResourceScheduler {
   /// \param available A list of available capacities for resource's instances.
   /// \param resource_instances List of the resource instances being updated.
   ///
-  /// \return Overflow capacities of "resource_instances" after adding instance 
-  /// capacities in "available", i.e., 
-  /// min(available + resource_instances.available, resource_instances.total) 
-  std::vector<double> AddAvailableResourceInstances(std::vector<double> available,
-                                                    ResourceInstanceCapacities *resource_instances);
+  /// \return Overflow capacities of "resource_instances" after adding instance
+  /// capacities in "available", i.e.,
+  /// min(available + resource_instances.available, resource_instances.total)
+  std::vector<double> AddAvailableResourceInstances(
+      std::vector<double> available, ResourceInstanceCapacities *resource_instances);
 
   /// Decrease the available capacities of the instances of a given resource.
   ///
   /// \param free A list of capacities for resource's instances to be freed.
   /// \param resource_instances List of the resource instances being updated.
-  /// \return Underflow of "resource_instances" after subtracting instance 
+  /// \return Underflow of "resource_instances" after subtracting instance
   /// capacities in "available", i.e.,.
   /// max(available - reasource_instances.available, 0)
-  std::vector<double> SubtractAvailableResourceInstances(std::vector<double> available,
-                                                         ResourceInstanceCapacities *resource_instances);
+  std::vector<double> SubtractAvailableResourceInstances(
+      std::vector<double> available, ResourceInstanceCapacities *resource_instances);
 
   /// Increase the available CPU instances of this node.
   ///
   /// \param cpu_instances CPU instances to be added to available cpus.
   ///
-  /// \return Overflow capacities of CPU instances after adding CPU 
-  /// capacities in cpu_instances. 
+  /// \return Overflow capacities of CPU instances after adding CPU
+  /// capacities in cpu_instances.
   std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
 
   /// Decrease the available CPU instances of this node.
   ///
   /// \param cpu_instances CPU instances to be removed from available cpus.
   ///
-  /// \return Underflow capacities of CPU instances after subtracting CPU 
-  /// capacities in cpu_instances. 
+  /// \return Underflow capacities of CPU instances after subtracting CPU
+  /// capacities in cpu_instances.
   std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
 
-  
-  /// Subtract the resources required by a given task request (task_req) from the 
+  /// Subtract the resources required by a given task request (task_req) from the
   /// local node. This function also updates the local node resources
-  /// at the instance granularity. 
+  /// at the instance granularity.
   ///
   /// \param task_req Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity. 
+  /// \param task_allocation Resources allocated to the task at instance granularity.
   /// This is a return parameter.
   ///
-  /// \return True if local node has enough resources to satisfy the task request. 
-  /// False otherwise. 
-  bool AllocateLocalTaskResources(const std::unordered_map<std::string, double> &task_resources, 
-                                  std::shared_ptr<TaskResourceInstances> task_allocation);  
+  /// \return True if local node has enough resources to satisfy the task request.
+  /// False otherwise.
+  bool AllocateLocalTaskResources(
+      const std::unordered_map<std::string, double> &task_resources,
+      std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Subtract the resources required by a given task request (task_req) from a given
-  /// remote node. 
+  /// remote node.
   ///
-  /// \param node_id Remote node whose resources we allocate. 
+  /// \param node_id Remote node whose resources we allocate.
   /// \param task_req Task for which we allocate resources.
-  void AllocateRemoteTaskResources(std::string &node_id,
-                                  const std::unordered_map<std::string, double> &task_resources);
+  void AllocateRemoteTaskResources(
+      std::string &node_id,
+      const std::unordered_map<std::string, double> &task_resources);
 
+  void FreeLocalTaskResources(std::shared_ptr<TaskResourceInstances> task_allocation);
 
-  void FreeLocalTaskResources(std::shared_ptr <TaskResourceInstances> task_allocation);
-
-  /// Update the available resources of the local node given 
+  /// Update the available resources of the local node given
   /// the available instances of each resource of the local node.
   /// Basically, this means computing the available resources
   /// by adding up the available quantities of each instance of that
   /// resources.
-  /// 
-  /// Example: Assume the local node has four GPU instances with the 
-  /// following availabilities: 0.2, 0.3, 0.1, 1. Then the total GPU 
+  ///
+  /// Example: Assume the local node has four GPU instances with the
+  /// following availabilities: 0.2, 0.3, 0.1, 1. Then the total GPU
   // resources availabile at that node is 0.2 + 0.3 + 0.1 + 1. = 1.6
   void UpdateLocalAvailableResourcesFromResourceInstances();
 

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -158,7 +158,7 @@ class ClusterResourceScheduler {
   /// \return True if the node has enough resources to satisfy the task request. 
   /// False otherwise. 
   bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req, 
-                            TaskResourceInstances *task_allocation);
+                            std::shared_ptr<TaskResourceInstances> task_allocation);
 
  public:
   ClusterResourceScheduler(void){};
@@ -357,13 +357,13 @@ class ClusterResourceScheduler {
   /// \return true, if allocation successful. If false, the caller needs to free the
   /// allocated resources, i.e., task_allocation.
   bool AllocateTaskResourceInstances(const TaskRequest &task_req,
-                                     TaskResourceInstances *task_allocation);
+                                     std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Free resources which were allocated with a task. The freed resources are
   /// added back to the node's local available resources.
   ///
   /// \param task_allocation: Task's resources to be freed.
-  void FreeTaskResourceInstances(TaskResourceInstances &task_allocation);
+  void FreeTaskResourceInstances(std::shared_ptr<TaskResourceInstances> task_allocation);
 
   /// Increase the available capacities of the instances of a given resource.
   ///
@@ -414,7 +414,7 @@ class ClusterResourceScheduler {
   /// \return True if local node has enough resources to satisfy the task request. 
   /// False otherwise. 
   bool AllocateLocalTaskResources(const std::unordered_map<std::string, double> &task_resources, 
-                                  TaskResourceInstances *task_allocation);  
+                                  std::shared_ptr<TaskResourceInstances> task_allocation);  
 
   /// Subtract the resources required by a given task request (task_req) from a given
   /// remote node. 
@@ -425,7 +425,7 @@ class ClusterResourceScheduler {
                                   const std::unordered_map<std::string, double> &task_resources);
 
 
-  void FreeLocalTaskResources(TaskResourceInstances& task_allocation);
+  void FreeLocalTaskResources(std::shared_ptr <TaskResourceInstances> task_allocation);
 
   /// Update the available resources of the local node given 
   /// the available instances of each resource of the local node.

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -14,8 +14,7 @@
 /// List of predefined resources.
 enum PredefinedResources { CPU, MEM, GPU, TPU, PredefinedResources_MAX };
 // Specify resources that consists of unit-size instances.
-// static std::unordered_set<int64_t> UnitInstanceResources{CPU, GPU, TPU};
-static std::unordered_set<int64_t> UnitInstanceResources{};
+static std::unordered_set<int64_t> UnitInstanceResources{CPU, GPU, TPU};
 
 // Helper function to compare two vectors with double values.
 bool EqualVectors(const std::vector<double> &v1, const std::vector<double> &v2);

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -69,8 +69,18 @@ class TaskResourceInstances {
   /// The list of instances of each custom resource allocated to a task.
   absl::flat_hash_map<int64_t, std::vector<double>> custom_resources;
   bool operator==(const TaskResourceInstances &other);
+  /// For each resource of this request aggregate its instances.
+  TaskRequest ToTaskRequest();
   /// Get CPU instances only.
-  std::vector<double> GetCPUInstances() { return this->predefined_resources[CPU]; };
+  std::vector<double> GetCPUInstances() {  
+    if (this->predefined_resources.size()) {
+      return this->predefined_resources[CPU]; 
+    } else {
+      return {};
+    }
+  };
+  /// Check whether there are no resource instances.
+  bool IsEmpty();
   /// Returns human-readable string for these resources.
   std::string DebugString();
 };
@@ -148,6 +158,9 @@ class ClusterResourceScheduler {
   ClusterResourceScheduler(
       const std::string &local_node_id,
       const std::unordered_map<std::string, double> &local_node_resources);
+
+  // Mapping from predefined resource indexes to resource strings
+  std::string GetResourceNameFromIndex(int64_t res_idx);
 
   /// Add a new node or overwrite the resources of an existing node.
   ///
@@ -251,15 +264,13 @@ class ClusterResourceScheduler {
   int64_t NumNodes();
 
   /// Convert a map of resources to a TaskRequest data structure.
-  void ResourceMapToTaskRequest(
-      const std::unordered_map<std::string, double> &resource_map,
-      TaskRequest *task_request);
+  TaskRequest ResourceMapToTaskRequest(
+      const std::unordered_map<std::string, double> &resource_map);
 
   /// Convert a map of resources to a TaskRequest data structure.
-  void ResourceMapToNodeResources(
+  NodeResources ResourceMapToNodeResources(
       const std::unordered_map<std::string, double> &resource_map_total,
-      const std::unordered_map<std::string, double> &resource_map_available,
-      NodeResources *node_resources);
+      const std::unordered_map<std::string, double> &resource_map_available);
 
   /// Update total capacity of resource resource_name at node client_id.
   void UpdateResourceCapacity(const std::string &client_id,
@@ -291,25 +302,27 @@ class ClusterResourceScheduler {
                              ResourceInstanceCapacities *instance_list);
 
   /// Allocate enough capacity across the instances of a resource to satisfy "demand".
-  /// If resource has multiple unit-capacity instance, we consider two cases.
+  /// If resource has multiple unit-capacity instances, we consider two cases.
   ///
   /// 1) If the constraint is hard, allocate full unit-capacity instances until
-  /// demand becomes fractional, and then satisfy the fractional deman using the
+  /// demand becomes fractional, and then satisfy the fractional demand using the
   /// instance with the smallest available capacity that can satisfy the fractional
   /// demand. For example, assume a resource conisting of 4 instances, with available
   /// capacities: (1., 1., .7, 0.5) and deman of 1.2. Then we allocate one full
   /// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
   /// with the smalest available capacity that can satisfy the remaining demand of 0.2).
-  /// As a result remaining available capacities will be (0., 1., .7, .2).
-  /// Thus, if the constraint is hard, we will allocate at most a fractional resource.
+  /// As a result remaining available capacities will be (0., 1., .7, .3).
+  /// Thus, if the constraint is hard, we will allocate a bunch of full instances and 
+  /// at most a fractional instance.
   ///
   /// 2) If the constraint is soft, we can allocate multiple fractional resources,
   /// and even overallocate the resource. For example, in the previous case, if we
   /// have a demand of 1.8, we can allocate one full instance, the 0.5 instance, and
-  /// 0.1 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
+  /// 0.3 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
   /// all instances, and return success (true), despite the fact that the total
   /// available capacity of the rwsource is 3.2 (= 1. + 1. + .7 + .5), which is less
-  /// than the demand, 3.5.
+  /// than the demand, 3.5. In this case, the remaining available resource is 
+  /// (0., 0., 0., 0.)
   ///
   /// \param demand: The resource amount to be allocated.
   /// \param soft: Specifies whether this demand has soft or hard constraints.
@@ -343,25 +356,46 @@ class ClusterResourceScheduler {
   ///
   /// \param available A list of available capacities for resource's instances.
   /// \param resource_instances List of the resource instances being updated.
-  void AddAvailableResourceInstances(std::vector<double> available,
-                                     ResourceInstanceCapacities *resource_instances);
+  ///
+  /// \return Overflow capacities of "resource_instances" after adding instance 
+  /// capacities in "available". 
+  std::vector<double> AddAvailableResourceInstances(std::vector<double> available,
+                                                    ResourceInstanceCapacities *resource_instances);
 
   /// Decrease the available capacities of the instances of a given resource.
   ///
   /// \param free A list of capacities for resource's instances to be freed.
   /// \param resource_instances List of the resource instances being updated.
-  void SubtractAvailableResourceInstances(std::vector<double> free,
-                                          ResourceInstanceCapacities *resource_instances);
+  /// \return Under capacities of "resource_instances" after substracting instance 
+  /// capacities in "free". 
+  std::vector<double> SubtractAvailableResourceInstances(std::vector<double> free,
+                                                         ResourceInstanceCapacities *resource_instances);
 
   /// Increase the available CPU instances of this node.
   ///
   /// \param cpu_instances CPU instances to be added to available cpus.
-  void AddCPUResourceInstances(std::vector<double> &cpu_instances);
-
-  /// Decrease the available cpu instances of this node.
   ///
-  /// \param cpu_instances Cpu instances to be removed from available cpus.
-  void SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
+  /// \return Overflow capacities of CPU instances after adding CPU 
+  /// capacities in cpu_instances. 
+  std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
+
+  /// Decrease the available CPU instances of this node.
+  ///
+  /// \param cpu_instances CPU instances to be removed from available cpus.
+  ///
+  /// \return Underflow capacities of CPU instances after subtracting CPU 
+  /// capacities in cpu_instances. 
+  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
+
+  bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req, 
+                            TaskResourceInstances *task_allocation /* return */);
+  bool AllocateLocalTaskResources(const std::unordered_map<std::string, double> &task_resources, 
+                                  TaskResourceInstances *task_allocation /* return */);                              
+  void AllocateRemoteTaskResources(std::string &node_id,
+                                  const std::unordered_map<std::string, double> &task_resources);
+
+
+  void FreeLocalTaskResources(TaskResourceInstances& task_allocation);
 
   /// Return human-readable string for this scheduler state.
   std::string DebugString();

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -14,7 +14,8 @@
 /// List of predefined resources.
 enum PredefinedResources { CPU, MEM, GPU, TPU, PredefinedResources_MAX };
 // Specify resources that consists of unit-size instances.
-static std::unordered_set<int64_t> UnitInstanceResources{CPU, GPU, TPU};
+// static std::unordered_set<int64_t> UnitInstanceResources{CPU, GPU, TPU};
+static std::unordered_set<int64_t> UnitInstanceResources{};
 
 // Helper function to compare two vectors with double values.
 bool EqualVectors(const std::vector<double> &v1, const std::vector<double> &v2);
@@ -98,7 +99,7 @@ class NodeResources {
   /// Returns if this equals another node resources.
   bool operator==(const NodeResources &other);
   /// Returns human-readable string for these resources.
-  std::string DebugString() const;
+  std::string DebugString(StringIdMap string_to_int_map) const;
 };
 
 /// Total and available capacities of each resource instance.
@@ -115,7 +116,7 @@ class NodeResourceInstances {
   /// Returns if this equals another node resources.
   bool operator==(const NodeResourceInstances &other);
   /// Returns human-readable string for these resources.
-  std::string DebugString() const;
+  std::string DebugString(StringIdMap string_to_int_map) const;
 };
 
 /// Class encapsulating the cluster resources and the logic to assign

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -286,7 +286,7 @@ class ClusterResourceScheduler {
   void UpdateResourceCapacity(const std::string &node_name,
                               const std::string &resource_name, int64_t resource_total);
 
-  /// Delete a given resource (resource_name) from a given node c(node_name).
+  /// Delete a given resource from a given node.
   ///
   /// \param node_name: Node whose resource we want to delete.
   /// \param resource_name: Resource we want to delete

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -582,9 +582,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -607,9 +608,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((cluster_resources.GetLocalResources() == old_local_resources), true);
@@ -628,9 +630,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -663,9 +666,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -692,9 +696,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((cluster_resources.GetLocalResources() == old_local_resources), true);
@@ -718,9 +723,10 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -755,13 +761,14 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest2) {
     initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
                     EmptyIntVector);
 
-    TaskResourceInstances task_allocation;
+    std::shared_ptr<TaskResourceInstances> task_allocation =
+        std::make_shared<TaskResourceInstances>();
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
     ASSERT_EQ(success, true);
-    std::vector<double> cpu_instances = task_allocation.GetCPUInstances();
+    std::vector<double> cpu_instances = task_allocation->GetCPUInstances();
     cluster_resources.AddCPUResourceInstances(cpu_instances);
     cluster_resources.SubtractCPUResourceInstances(cpu_instances);
 
@@ -778,43 +785,46 @@ TEST_F(SchedulingTest, TaskCPUResourceInstancesTest) {
     initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
     ClusterResourceScheduler cluster_resources(0, node_resources);
 
-    std::vector<double> allocate_cpu_instances {0.5, 0.5, 0.5, 0.5};    
+    std::vector<double> allocate_cpu_instances{0.5, 0.5, 0.5, 0.5};
     cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> available_cpu_instances =
-        cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-    std::vector<double> expected_available_cpu_instances {0.5, 0.5, 0.5, 0.5};    
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                           available_cpu_instances.end(), 
+    std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
+                                                      .GetAvailableResourceInstances()
+                                                      .GetCPUInstances();
+    std::vector<double> expected_available_cpu_instances{0.5, 0.5, 0.5, 0.5};
+    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
                            expected_available_cpu_instances.begin()));
 
     cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-    available_cpu_instances =
-        cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-    expected_available_cpu_instances = {1., 1., 1., 1.};    
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                           available_cpu_instances.end(), 
+    available_cpu_instances = cluster_resources.GetLocalResources()
+                                  .GetAvailableResourceInstances()
+                                  .GetCPUInstances();
+    expected_available_cpu_instances = {1., 1., 1., 1.};
+    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
                            expected_available_cpu_instances.begin()));
 
-    allocate_cpu_instances = {1.5, 1.5, .5, 1.5};    
-    std::vector<double> underflow = cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> expected_underflow {.5, .5, 0., .5};    
-    ASSERT_TRUE(std::equal(underflow.begin(), underflow.end(), expected_underflow.begin()));
-    available_cpu_instances =
-        cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-    expected_available_cpu_instances = {0., 0., 0.5, 0.};    
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                           available_cpu_instances.end(), 
+    allocate_cpu_instances = {1.5, 1.5, .5, 1.5};
+    std::vector<double> underflow =
+        cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
+    std::vector<double> expected_underflow{.5, .5, 0., .5};
+    ASSERT_TRUE(
+        std::equal(underflow.begin(), underflow.end(), expected_underflow.begin()));
+    available_cpu_instances = cluster_resources.GetLocalResources()
+                                  .GetAvailableResourceInstances()
+                                  .GetCPUInstances();
+    expected_available_cpu_instances = {0., 0., 0.5, 0.};
+    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
                            expected_available_cpu_instances.begin()));
 
-    allocate_cpu_instances = {1.0, .5, 1., .5};    
-    std::vector<double> overflow = cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> expected_overflow {.0, .0, .5, 0.};    
+    allocate_cpu_instances = {1.0, .5, 1., .5};
+    std::vector<double> overflow =
+        cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
+    std::vector<double> expected_overflow{.0, .0, .5, 0.};
     ASSERT_TRUE(std::equal(overflow.begin(), overflow.end(), expected_overflow.begin()));
-    available_cpu_instances =
-        cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-    expected_available_cpu_instances = {1., .5, 1., .5};    
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                           available_cpu_instances.end(), 
+    available_cpu_instances = cluster_resources.GetLocalResources()
+                                  .GetAvailableResourceInstances()
+                                  .GetCPUInstances();
+    expected_available_cpu_instances = {1., .5, 1., .5};
+    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
                            expected_available_cpu_instances.begin()));
   }
 }
@@ -829,15 +839,16 @@ TEST_F(SchedulingTest, UpdateLocalAvailableResourcesFromResourceInstancesTest) {
     ClusterResourceScheduler cluster_resources(0, node_resources);
 
     {
-      std::vector<double> allocate_cpu_instances {0.5, 0.5, 2, 0.5};    
-      // SubtractCPUResourceInstances() calls UpdateLocalAvailableResourcesFromResourceInstances()
-      // under the hood.
+      std::vector<double> allocate_cpu_instances{0.5, 0.5, 2, 0.5};
+      // SubtractCPUResourceInstances() calls
+      // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
       cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-      std::vector<double> available_cpu_instances =
-          cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-      std::vector<double> expected_available_cpu_instances {0.5, 0.5, 0., 0.5};    
-      ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                             available_cpu_instances.end(), 
+      std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
+                                                        .GetAvailableResourceInstances()
+                                                        .GetCPUInstances();
+      std::vector<double> expected_available_cpu_instances{0.5, 0.5, 0., 0.5};
+      ASSERT_TRUE(std::equal(available_cpu_instances.begin(),
+                             available_cpu_instances.end(),
                              expected_available_cpu_instances.begin()));
 
       NodeResources nr;
@@ -846,15 +857,16 @@ TEST_F(SchedulingTest, UpdateLocalAvailableResourcesFromResourceInstancesTest) {
     }
 
     {
-      std::vector<double> allocate_cpu_instances {1.5, 0.5, 2, 0.3};    
-      // SubtractCPUResourceInstances() calls UpdateLocalAvailableResourcesFromResourceInstances()
-      // under the hood.
+      std::vector<double> allocate_cpu_instances{1.5, 0.5, 2, 0.3};
+      // SubtractCPUResourceInstances() calls
+      // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
       cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-      std::vector<double> available_cpu_instances =
-          cluster_resources.GetLocalResources().GetAvailableResourceInstances().GetCPUInstances();
-      std::vector<double> expected_available_cpu_instances {1., 1., 1., 0.8};    
-      ASSERT_TRUE(std::equal(available_cpu_instances.begin(), 
-                             available_cpu_instances.end(), 
+      std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
+                                                        .GetAvailableResourceInstances()
+                                                        .GetCPUInstances();
+      std::vector<double> expected_available_cpu_instances{1., 1., 1., 0.8};
+      ASSERT_TRUE(std::equal(available_cpu_instances.begin(),
+                             available_cpu_instances.end(),
                              expected_available_cpu_instances.begin()));
 
       NodeResources nr;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1534,7 +1534,12 @@ void NodeManager::DispatchScheduledTasksToWorkers() {
   RAY_CHECK(new_scheduler_enabled_);
   size_t queue_size = tasks_to_dispatch_.size(); 
 
-  while (queue_size > 0) { //
+  // Check every task in task_to_dispatch queue to see
+  // whether it can be dispatched and ran. This avoids head-of-line
+  // blocking where a task which cannot be dispatches because
+  // there are not enough available resources blocks other
+  // tasks from being dispatched.
+  while (queue_size > 0) { 
     auto task = tasks_to_dispatch_.front(); 
     auto reply = task.first;
     auto spec = task.second.GetTaskSpecification();
@@ -1578,9 +1583,13 @@ void NodeManager::DispatchScheduledTasksToWorkers() {
 
 void NodeManager::NewSchedulerSchedulePendingTasks() {
   RAY_CHECK(new_scheduler_enabled_);
-
   size_t queue_size = tasks_to_schedule_.size();
 
+  // Check every task in task_to_schedule queue to see
+  // whether it can be scheduled. This avoids head-of-line
+  // blocking where a task which cannot be scheduled because
+  // there are not enough available resources blocks other
+  // tasks from being scheduled.
   while (queue_size > 0) {
     if (queue_size == 0) {
       return;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1744,7 +1744,8 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
                   << new_resource_scheduler_->GetResourceNameFromIndex(res_idx) 
                   << ", Resource idx = " << res_idx;
               resource->set_name(new_resource_scheduler_->GetResourceNameFromIndex(res_idx));
-	            for (size_t inst_idx = 0; inst_idx < predefined_resources.size(); inst_idx++) {
+	            for (size_t inst_idx = 0; inst_idx < predefined_resources[res_idx].size(); inst_idx++) {
+                RAY_LOG(WARNING) << "HandleRequestWorkerLease quantity, inst_idx = " << inst_idx; 
 	              if (std::abs(predefined_resources[res_idx][inst_idx]) > ZERO_CAPACITY) {
                   auto rid = resource->add_resource_ids();
                   RAY_LOG(WARNING) << "HandleRequestWorkerLease quantity[" 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1662,16 +1662,17 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
               allocated_resources = worker->GetAllocatedInstances();                                                   
             }
             auto predefined_resources = allocated_resources.predefined_resources;
+            ::ray::rpc::ResourceMapEntry *resource;
             for (size_t res_idx = 0; res_idx < predefined_resources.size(); res_idx++) {
-              auto resource = reply->add_resource_mapping();
               bool first = true; // Set resource name only if at least one of its instances has available capacity.
 	            for (size_t inst_idx = 0; inst_idx < predefined_resources[res_idx].size(); inst_idx++) {
 	              if (std::abs(predefined_resources[res_idx][inst_idx]) > ZERO_CAPACITY) {
-                  auto rid = resource->add_resource_ids();
                   if (first) {
+                    resource = reply->add_resource_mapping();
                     resource->set_name(new_resource_scheduler_->GetResourceNameFromIndex(res_idx));
                     first = false;
                   }     
+                  auto rid = resource->add_resource_ids();
                   rid->set_index(inst_idx);
                   rid->set_quantity(predefined_resources[res_idx][inst_idx]);
                 }
@@ -1679,15 +1680,15 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
             }
             auto custom_resources = allocated_resources.custom_resources;
             for (auto it = custom_resources.begin(); it != custom_resources.end(); ++it) {
-              auto resource = reply->add_resource_mapping();
               bool first = true; // Set resource name only if at least one of its instances has available capacity.
 	            for (size_t inst_idx = 0; inst_idx < it->second.size(); inst_idx++) {
 	              if (std::abs(it->second[inst_idx]) < ZERO_CAPACITY) {
-                  auto rid = resource->add_resource_ids();
                   if (first) {
+                    resource = reply->add_resource_mapping();
                     resource->set_name(new_resource_scheduler_->GetResourceNameFromIndex(it->first));
                     first = false;
                   }     
+                  auto rid = resource->add_resource_ids();
                   rid->set_index(inst_idx);
                   rid->set_quantity(it->second[inst_idx]);
                 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1682,7 +1682,7 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
             for (auto it = custom_resources.begin(); it != custom_resources.end(); ++it) {
               bool first = true; // Set resource name only if at least one of its instances has available capacity.
 	            for (size_t inst_idx = 0; inst_idx < it->second.size(); inst_idx++) {
-	              if (std::abs(it->second[inst_idx]) < ZERO_CAPACITY) {
+	              if (std::abs(it->second[inst_idx]) > ZERO_CAPACITY) {
                   if (first) {
                     resource = reply->add_resource_mapping();
                     resource->set_name(new_resource_scheduler_->GetResourceNameFromIndex(it->first));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1532,7 +1532,7 @@ void NodeManager::ProcessSubmitTaskMessage(const uint8_t *message_data) {
 
 void NodeManager::DispatchScheduledTasksToWorkers() {
   RAY_CHECK(new_scheduler_enabled_);
-  size_t queue_size = tasks_to_dispatch_.size(); // XXX
+  size_t queue_size = tasks_to_dispatch_.size(); 
   while (queue_size > 0) { //
     auto task = tasks_to_dispatch_.front(); 
     auto reply = task.first;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -709,7 +709,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_schedule_;
   /// Queue of lease requests that should be scheduled onto workers.
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_dispatch_;
-  /// Queue storing the tasks waiting for their arguments to be transferred locally.
+  /// Queue tasks waiting for arguments to be transferred locally.
   absl::flat_hash_map<TaskID, std::pair<ScheduleFn, Task>> waiting_tasks_;
 
   /// Cache of gRPC clients to workers (not necessarily running on this node).

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -742,11 +742,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// free_objects_batch_size, or if objects have been in the cache for longer
   /// than the config's free_objects_period, whichever occurs first.
   std::vector<ObjectID> objects_to_free_;
-
-  /// XXX
-  std::string PrintLeasedWorkers();
-  /// XXX
-  std::string PrintWorkerPool();
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -699,9 +699,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
 
   /// The new resource scheduler for direct task calls.
   std::shared_ptr<ClusterResourceScheduler> new_resource_scheduler_;
-  /// Map of leased workers to their current resource usage.
-  /// TODO(ion): Check whether we can track these resources in the worker.
-  std::unordered_map<WorkerID, ResourceSet> leased_worker_resources_;
 
   typedef std::function<void(std::shared_ptr<Worker>, ClientID spillback_to,
                              std::string address, int port)>
@@ -712,6 +709,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_schedule_;
   /// Queue of lease requests that should be scheduled onto workers.
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_dispatch_;
+  /// Queue storing the tasks waiting for their arguments to be transferred locally.
+  absl::flat_hash_map<TaskID, std::pair<ScheduleFn, Task>> waiting_tasks_;
 
   /// Cache of gRPC clients to workers (not necessarily running on this node).
   /// Also includes the number of inflight requests to each worker - when this
@@ -743,6 +742,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// free_objects_batch_size, or if objects have been in the cache for longer
   /// than the config's free_objects_period, whichever occurs first.
   std::vector<ObjectID> objects_to_free_;
+
+  /// XXX
+  std::string PrintLeasedWorkers();
+  /// XXX
+  std::string PrintWorkerPool();
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -83,24 +83,26 @@ class Worker {
     allocated_instances_ = nothing; // Clear allocated instances.
   };    
 
- // Setter, geter, and clear methods  for lifetime_allocated_instances_.
-   void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
-      lifetime_allocated_instances_ = allocated_instances;
+  void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+    lifetime_allocated_instances_ = allocated_instances;
   };                                                   
+  
   TaskResourceInstances &GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
+  
   void ClearLifetimeAllocatedInstances() {
     TaskResourceInstances nothing;  
     lifetime_allocated_instances_ = nothing; // Clear allocated instances.
   };    
 
- // Setter, geter, and clear methods  for borrowed_cpu_instances_.
   void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) { 
     borrowed_cpu_instances_ = cpu_instances; 
   };
+  
   std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }; 
   void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };   
 
   Task &GetAssignedTask() { return assigned_task_; };
+  
   void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
 
   rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -74,7 +74,7 @@ class Worker {
   void WorkerLeaseGranted(const std::string &address, int port);
 
   // Setter, geter, and clear methods  for allocated_instances_.
-  void SetAllocatedInstances(std::shared_ptr<TaskResourceInstances> allocated_instances) { 
+  void SetAllocatedInstances(std::shared_ptr<TaskResourceInstances> &allocated_instances) { 
       allocated_instances_ = allocated_instances;
   };                            
 
@@ -82,7 +82,7 @@ class Worker {
   
   void ClearAllocatedInstances() { allocated_instances_ = nullptr; };
 
-  void SetLifetimeAllocatedInstances(std::shared_ptr<TaskResourceInstances> allocated_instances) { 
+  void SetLifetimeAllocatedInstances(std::shared_ptr<TaskResourceInstances> &allocated_instances) { 
     lifetime_allocated_instances_ = allocated_instances;
   };                                                   
   

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -10,6 +10,8 @@
 #include "ray/common/task/task_common.h"
 #include "ray/rpc/worker/core_worker_client.h"
 #include "ray/util/process.h"
+#include "ray/common/scheduling/scheduling_ids.h"
+#include "ray/common/scheduling/cluster_resource_scheduler.h"
 
 namespace ray {
 
@@ -75,7 +77,36 @@ class Worker {
   /// and the worker does not get back the cpu resources when unblocked.
   /// TODO (ion): Add methods to access this variable.
   /// TODO (ion): Investigate a more intuitive alternative to track these Cpus.
-  ResourceSet borrowed_cpu_resources_;
+  /// XXX
+  TaskResourceInstances allocated_instances_;
+  void SetAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+      allocated_instances_ = allocated_instances;
+  };                                                   
+  TaskResourceInstances &GetAllocatedInstances() {return allocated_instances_; };    
+  void ClearAllocatedInstances() {
+    TaskResourceInstances nothing;  
+    allocated_instances_ = nothing; // Clear allocated instances.
+  };    
+  TaskResourceInstances lifetime_allocated_instances_;
+  void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+      lifetime_allocated_instances_ = allocated_instances;
+  };                                                   
+  TaskResourceInstances &GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
+  void ClearLifetimeAllocatedInstances() {
+    TaskResourceInstances nothing;  
+    lifetime_allocated_instances_ = nothing; // Clear allocated instances.
+  };    
+  std::vector<double> borrowed_cpu_instances_;
+  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) { 
+    borrowed_cpu_instances_ = cpu_instances; 
+  };
+  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }; 
+  void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };   
+
+  Task assigned_task_;
+  Task &GetAssignedTask() { return assigned_task_; };
+  void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
+  /// XXX                                               
 
   rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }
 

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -73,12 +73,7 @@ class Worker {
   void DirectActorCallArgWaitComplete(int64_t tag);
   void WorkerLeaseGranted(const std::string &address, int port);
 
-  /// Cpus borrowed by the worker. This happens when the machine is oversubscribed
-  /// and the worker does not get back the cpu resources when unblocked.
-  /// TODO (ion): Add methods to access this variable.
-  /// TODO (ion): Investigate a more intuitive alternative to track these Cpus.
-  /// XXX
-  TaskResourceInstances allocated_instances_;
+  // Setter, geter, and clear methods  for allocated_instances_.
   void SetAllocatedInstances(TaskResourceInstances &allocated_instances) { 
       allocated_instances_ = allocated_instances;
   };                                                   
@@ -87,8 +82,9 @@ class Worker {
     TaskResourceInstances nothing;  
     allocated_instances_ = nothing; // Clear allocated instances.
   };    
-  TaskResourceInstances lifetime_allocated_instances_;
-  void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+
+ // Setter, geter, and clear methods  for lifetime_allocated_instances_.
+   void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
       lifetime_allocated_instances_ = allocated_instances;
   };                                                   
   TaskResourceInstances &GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
@@ -96,17 +92,16 @@ class Worker {
     TaskResourceInstances nothing;  
     lifetime_allocated_instances_ = nothing; // Clear allocated instances.
   };    
-  std::vector<double> borrowed_cpu_instances_;
+
+ // Setter, geter, and clear methods  for borrowed_cpu_instances_.
   void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) { 
     borrowed_cpu_instances_ = cpu_instances; 
   };
   std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }; 
   void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };   
 
-  Task assigned_task_;
   Task &GetAssignedTask() { return assigned_task_; };
   void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
-  /// XXX                                               
 
   rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }
 
@@ -151,6 +146,22 @@ class Worker {
   /// The address of this worker's owner. The owner is the worker that
   /// currently holds the lease on this worker, if any.
   rpc::Address owner_address_;
+  /// The capacity of each resource instance allocated to this worker in order
+  /// to satisfy the resource requests of the task is currently running. 
+  TaskResourceInstances allocated_instances_;
+  /// The capacity of each resource instance allocated to this worker 
+  /// when running as an actor. 
+  TaskResourceInstances lifetime_allocated_instances_;
+  /// CPUs borrowed by the worker. This happens in the following scenario:
+  /// 1) Worker A is blocked, so it donates its CPUs back to the node.
+  /// 2) Other workers are scheduled and are allocated some of the CPUs donated by A.
+  /// 3) Task A is unblocked, but it cannot get all CPUs back. At this point,
+  /// the node is oversubscribed. borrowed_cpu_instances_ represents the number
+  /// of CPUs this node is iversubscribed by.
+  /// TODO (Ion): Investigate a more intuitive alternative to track these Cpus.
+  std::vector<double> borrowed_cpu_instances_;
+  /// Task being assigned to this worker.
+  Task assigned_task_;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -157,7 +157,7 @@ class Worker {
   /// 2) Other workers are scheduled and are allocated some of the CPUs donated by A.
   /// 3) Task A is unblocked, but it cannot get all CPUs back. At this point,
   /// the node is oversubscribed. borrowed_cpu_instances_ represents the number
-  /// of CPUs this node is iversubscribed by.
+  /// of CPUs this node is oversubscribed by.
   /// TODO (Ion): Investigate a more intuitive alternative to track these Cpus.
   std::vector<double> borrowed_cpu_instances_;
   /// Task being assigned to this worker.

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -5,13 +5,13 @@
 
 #include "ray/common/client_connection.h"
 #include "ray/common/id.h"
+#include "ray/common/scheduling/cluster_resource_scheduler.h"
+#include "ray/common/scheduling/scheduling_ids.h"
 #include "ray/common/task/scheduling_resources.h"
 #include "ray/common/task/task.h"
 #include "ray/common/task/task_common.h"
 #include "ray/rpc/worker/core_worker_client.h"
 #include "ray/util/process.h"
-#include "ray/common/scheduling/scheduling_ids.h"
-#include "ray/common/scheduling/cluster_resource_scheduler.h"
 
 namespace ray {
 
@@ -74,32 +74,38 @@ class Worker {
   void WorkerLeaseGranted(const std::string &address, int port);
 
   // Setter, geter, and clear methods  for allocated_instances_.
-  void SetAllocatedInstances(std::shared_ptr<TaskResourceInstances> &allocated_instances) { 
-      allocated_instances_ = allocated_instances;
-  };                            
+  void SetAllocatedInstances(
+      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
+    allocated_instances_ = allocated_instances;
+  };
 
-  std::shared_ptr<TaskResourceInstances> GetAllocatedInstances() {return allocated_instances_; };    
-  
+  std::shared_ptr<TaskResourceInstances> GetAllocatedInstances() {
+    return allocated_instances_;
+  };
+
   void ClearAllocatedInstances() { allocated_instances_ = nullptr; };
 
-  void SetLifetimeAllocatedInstances(std::shared_ptr<TaskResourceInstances> &allocated_instances) { 
+  void SetLifetimeAllocatedInstances(
+      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
     lifetime_allocated_instances_ = allocated_instances;
-  };                                                   
-  
-  std::shared_ptr<TaskResourceInstances> GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
-  
+  };
+
+  std::shared_ptr<TaskResourceInstances> GetLifetimeAllocatedInstances() {
+    return lifetime_allocated_instances_;
+  };
+
   void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
 
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) { 
-    borrowed_cpu_instances_ = cpu_instances; 
+  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
+    borrowed_cpu_instances_ = cpu_instances;
   };
-  
-  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }; 
 
-  void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };   
+  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; };
+
+  void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };
 
   Task &GetAssignedTask() { return assigned_task_; };
-  
+
   void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
 
   rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }
@@ -146,10 +152,10 @@ class Worker {
   /// currently holds the lease on this worker, if any.
   rpc::Address owner_address_;
   /// The capacity of each resource instance allocated to this worker in order
-  /// to satisfy the resource requests of the task is currently running. 
+  /// to satisfy the resource requests of the task is currently running.
   std::shared_ptr<TaskResourceInstances> allocated_instances_;
-  /// The capacity of each resource instance allocated to this worker 
-  /// when running as an actor. 
+  /// The capacity of each resource instance allocated to this worker
+  /// when running as an actor.
   std::shared_ptr<TaskResourceInstances> lifetime_allocated_instances_;
   /// CPUs borrowed by the worker. This happens in the following scenario:
   /// 1) Worker A is blocked, so it donates its CPUs back to the node.

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -74,31 +74,28 @@ class Worker {
   void WorkerLeaseGranted(const std::string &address, int port);
 
   // Setter, geter, and clear methods  for allocated_instances_.
-  void SetAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+  void SetAllocatedInstances(std::shared_ptr<TaskResourceInstances> allocated_instances) { 
       allocated_instances_ = allocated_instances;
-  };                                                   
-  TaskResourceInstances &GetAllocatedInstances() {return allocated_instances_; };    
-  void ClearAllocatedInstances() {
-    TaskResourceInstances nothing;  
-    allocated_instances_ = nothing; // Clear allocated instances.
-  };    
+  };                            
 
-  void SetLifetimeAllocatedInstances(TaskResourceInstances &allocated_instances) { 
+  std::shared_ptr<TaskResourceInstances> GetAllocatedInstances() {return allocated_instances_; };    
+  
+  void ClearAllocatedInstances() { allocated_instances_ = nullptr; };
+
+  void SetLifetimeAllocatedInstances(std::shared_ptr<TaskResourceInstances> allocated_instances) { 
     lifetime_allocated_instances_ = allocated_instances;
   };                                                   
   
-  TaskResourceInstances &GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
+  std::shared_ptr<TaskResourceInstances> GetLifetimeAllocatedInstances() {return lifetime_allocated_instances_; };    
   
-  void ClearLifetimeAllocatedInstances() {
-    TaskResourceInstances nothing;  
-    lifetime_allocated_instances_ = nothing; // Clear allocated instances.
-  };    
+  void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
 
   void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) { 
     borrowed_cpu_instances_ = cpu_instances; 
   };
   
   std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; }; 
+
   void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };   
 
   Task &GetAssignedTask() { return assigned_task_; };
@@ -150,10 +147,10 @@ class Worker {
   rpc::Address owner_address_;
   /// The capacity of each resource instance allocated to this worker in order
   /// to satisfy the resource requests of the task is currently running. 
-  TaskResourceInstances allocated_instances_;
+  std::shared_ptr<TaskResourceInstances> allocated_instances_;
   /// The capacity of each resource instance allocated to this worker 
   /// when running as an actor. 
-  TaskResourceInstances lifetime_allocated_instances_;
+  std::shared_ptr<TaskResourceInstances> lifetime_allocated_instances_;
   /// CPUs borrowed by the worker. This happens in the following scenario:
   /// 1) Worker A is blocked, so it donates its CPUs back to the node.
   /// 2) Other workers are scheduled and are allocated some of the CPUs donated by A.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Compared with previous merge, this PR adds:
- Support for multiple resource instances in the new scheduler.
- Handle correctly tasks waiting for their arguments, worker becoming available, and workers getting disconnected.
- Numerous fixes. 

All tests pass `test_basic.py` with the new scheduler except `test_submit_api` and `test_many_fractional_resources`. These will be fixed in a next PR.

Note: The new scheduler is dependent of removing the old scheduler codepath to reconstruct the actors. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
