### PR TITLE
[operator] Small bugfixes

### DIFF
--- a/deploy/ray-operator/config/manager/kustomization.yaml
+++ b/deploy/ray-operator/config/manager/kustomization.yaml
@@ -1,2 +1,6 @@
+images:
+ - name: controller
+   newTag: latest
+   newName: eoakes/controller
 resources:
 - manager.yaml

--- a/deploy/ray-operator/config/manager/kustomization.yaml
+++ b/deploy/ray-operator/config/manager/kustomization.yaml
@@ -1,6 +1,6 @@
 images:
  - name: controller
    newTag: latest
-   newName: eoakes/controller
+   newName: controller
 resources:
 - manager.yaml

--- a/deploy/ray-operator/config/manager/manager.yaml
+++ b/deploy/ray-operator/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: controller:latest
+        image: controller
         name: manager
         resources:
           limits:

--- a/deploy/ray-operator/config/rbac/role.yaml
+++ b/deploy/ray-operator/config/rbac/role.yaml
@@ -57,7 +57,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - RayClusters
+  - rayclusters
   verbs:
   - create
   - delete
@@ -69,7 +69,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - RayClusters/status
+  - rayclusters/status
   verbs:
   - get
   - patch

--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.complete.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.complete.yaml
@@ -9,7 +9,7 @@ spec:
   # An unique identifier for the head node and workers of this cluster.
   clusterName: raycluster-sample
   images:
-    defaultImage: "docker-image"
+    defaultImage: rayproject/autoscaler
   imagePullPolicy: "Always"
 
   extensions:

--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.heterogeneous.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.heterogeneous.yaml
@@ -9,7 +9,7 @@ spec:
   # An unique identifier for the head node and workers of this cluster.
   clusterName: raycluster-sample
   images:
-    defaultImage: "docker-image"
+    defaultImage: rayproject/autoscaler
   imagePullPolicy: "Always"
 
   extensions:

--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.mini.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.mini.yaml
@@ -9,7 +9,7 @@ spec:
   # An unique identifier for the head node and workers of this cluster.
   clusterName: raycluster-sample
   images:
-    defaultImage: "docker-image"
+    defaultImage: rayproject/autoscaler
   imagePullPolicy: "Always"
 
   extensions:

--- a/deploy/ray-operator/controllers/common/pod.go
+++ b/deploy/ray-operator/controllers/common/pod.go
@@ -70,15 +70,6 @@ func buildContainer(conf *PodConfig) corev1.Container {
 	httpServerPort := defaultHTTPServerPort
 	jobManagerPort := defaultRedisPort
 
-	// get pod file path to check if the pod container ready or not
-	var podReadyFilepath string
-	for _, env := range conf.Extension.ContainerEnv {
-		if strings.EqualFold(env.Name, PodReadyFilepath) {
-			podReadyFilepath = env.Value
-			break
-		}
-	}
-
 	// assign image by typeName
 	image := conf.RayCluster.Spec.Images.DefaultImage
 	if conf.Extension.Image != "" {
@@ -116,13 +107,6 @@ func buildContainer(conf *PodConfig) corev1.Container {
 				ContainerPort: int32(jobManagerPort),
 				Name:          "job-manager",
 			},
-		},
-		ReadinessProbe: &corev1.Probe{
-			Handler: corev1.Handler{
-				Exec: &corev1.ExecAction{Command: []string{"cat", podReadyFilepath}},
-			},
-			InitialDelaySeconds: 15,
-			SuccessThreshold:    2,
 		},
 	}
 	return container

--- a/deploy/ray-operator/controllers/common/service.go
+++ b/deploy/ray-operator/controllers/common/service.go
@@ -33,6 +33,7 @@ func ServiceForPod(conf *ServiceConfig) *corev1.Service {
 			Namespace: conf.RayCluster.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: "redis", Port: int32(defaultRedisPort)}},
 			ClusterIP: "None",
 			// select this raycluster's component
 			Selector: map[string]string{

--- a/deploy/ray-operator/controllers/raycluster_controller.go
+++ b/deploy/ray-operator/controllers/raycluster_controller.go
@@ -45,8 +45,8 @@ type RayClusterReconciler struct {
 // Reconcile reads that state of the cluster for a RayCluster object and makes changes based on it
 // and what is in the RayCluster.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write workloads
-// +kubebuilder:rbac:groups=ray.io,resources=RayClusters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ray.io,resources=RayClusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ray.io,resources=rayclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixes some small issues encountered while trying to run the kubernetes operator:

- Allow controller image to be specified via kustomize
- Rename RayClusters to rayclusters in RBAC specification
- Use rayproject/autoscaler image in examples
- Remove non-working readiness probe
- Add ServicePort to head node service

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
