### PR TITLE
[iterators] Add duplicate() call and fix broken test case

### DIFF
--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -776,6 +776,46 @@ class LocalIterator(Generic[T]):
             if i >= n:
                 break
 
+    def duplicate(self, n) -> List["LocalIterator[T]"]:
+        """Copy this iterator `n` times, duplicating the data.
+
+        Returns:
+            List[LocalIterator[T]]: multiple iterators that each have a copy
+                of the data of this iterator.
+        """
+
+        if n < 2:
+            raise ValueError("Number of copies must be >= 2")
+
+        queues = []
+        for _ in range(n):
+            queues.append(collections.deque())
+
+        def fill_next(timeout):
+            self.timeout = timeout
+            item = next(self)
+            for q in queues:
+                q.append(item)
+
+        def make_next(i):
+            def gen(timeout):
+                while True:
+                    if len(queues[i]) == 0:
+                        fill_next(timeout)
+                    yield queues[i].popleft()
+
+            return gen
+
+        iterators = []
+        for i in range(n):
+            iterators.append(
+                LocalIterator(
+                    make_next(i),
+                    self.metrics, [],
+                    name=self.name + ".duplicate[{}]".format(i)))
+
+        return iterators
+
     def union(self, *others: "LocalIterator[T]",
               deterministic: bool = False) -> "LocalIterator[T]":
         """Return an iterator that is the union of this and the others.

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -854,7 +854,7 @@ class LocalIterator(Generic[T]):
                     # To avoid starvation, we yield at most max_yield items per
                     # iterator before switching.
                     if deterministic:
-                        max_yield = 1
+                        max_yield = 1  # Forces round robin.
                     else:
                         max_yield = 20
                     try:

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -851,15 +851,19 @@ class LocalIterator(Generic[T]):
                 for it in list(active):
                     # Yield items from the iterator until _NextValueNotReady is
                     # found, then switch to the next iterator.
+                    # To avoid starvation, we yield at most max_yield items per
+                    # iterator before switching.
+                    if deterministic:
+                        max_yield = 1
+                    else:
+                        max_yield = 20
                     try:
-                        while True:
+                        for _ in range(max_yield):
                             item = next(it)
                             if isinstance(item, _NextValueNotReady):
                                 break
                             else:
                                 yield item
-                            if deterministic:
-                                break
                     except StopIteration:
                         active.remove(it)
                 if not active:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Add a duplicate() call which can be used to copy a local iterator into two streams. This is intended for use with more complex RLlib workflows. Also fix a broken test case which was introduced in a rllib PR.


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
