### PR TITLE
Support configurable python executable in format.sh

### DIFF
--- a/ci/travis/format.sh
+++ b/ci/travis/format.sh
@@ -144,7 +144,10 @@ fi
 # Ensure import ordering
 # Make sure that for every import psutil; import setpproctitle
 # There's a import ray above it.
-python ci/travis/check_import_order.py . -s ci -s python/ray/pyarrow_files -s python/ray/thirdparty_files -s python/build -s lib
+
+PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
+
+$PYTHON_EXECUTABLE ci/travis/check_import_order.py . -s ci -s python/ray/pyarrow_files -s python/ray/thirdparty_files -s python/build -s lib
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted changed files. Please review and stage the changes.'


### PR DESCRIPTION
## Why are these changes needed?

Currently `scripts/format.sh` hardcode the python executable name as `python` where there is quite a lot settings named `python3`.

Although user can change the link to python executable at their environment, but it requires a global change. With this change user can easily configure the path to executable as

```bash
$ PYTHON_EXECUTABLE=/path/to/python_or_python3 scripts/format.sh
```

## Checks

Test manually.