### PR TITLE
[doc] Make doc pages wider

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,0 +1,5 @@
+/* Max window size */
+.wy-nav-content{
+    max-width: 1200px;
+}
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -393,5 +393,6 @@ def update_context(app, pagename, templatename, context, doctree):
 
 def setup(app):
     app.connect('html-page-context', update_context)
+    app.add_stylesheet('css/custom.css')
     # Custom directives
     app.add_directive('customgalleryitem', CustomGalleryItemDirective)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Default sphinx template has a very small screen width. This proposal
will significantly increase the width.
<!-- Please give a short summary of the change and the problem this solves. -->

<img width="1404" alt="Screenshot 2020-03-08 23 08 34" src="https://user-images.githubusercontent.com/4529381/76187177-e2b6bb80-6191-11ea-94b2-6eb689ebf071.png">


Tradeoffs:

* Text becomes wider, but images need to be resized.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)