### PR TITLE
[tune] Fix an example for _Brackets of async hyperband scheduler

### DIFF
--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -124,12 +124,12 @@ class _Bracket():
     the correct rung corresponding to the current iteration of the result.
 
     Example:
-        >>> b = _Bracket(1, 10, 2, 3)
+        >>> b = _Bracket(1, 10, 2, 0)
         >>> b.on_result(trial1, 1, 2)  # CONTINUE
         >>> b.on_result(trial2, 1, 4)  # CONTINUE
         >>> b.cutoff(b._rungs[-1][1]) == 3.0  # rungs are reversed
         >>> b.on_result(trial3, 1, 1)  # STOP
-        >>> b.cutoff(b._rungs[0][1]) == 2.0
+        >>> b.cutoff(b._rungs[3][1]) == 2.0
     """
 
     def __init__(self, min_t, max_t, reduction_factor, s):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

In the middle of understanding `AsyncHyperBandScheduler`, I found that the example of `_Bracket` is different from what I got when I actually ran it.

The problem is that the bracket in the example makes rungs from 8 milestone so following trials could not be recorded at the first step.

```python
b = _Bracket(1, 10, 2, 3)
b.on_result(trial1, 1, 2)  # CONTINUE but the trial is not recorded
b.on_result(trial2, 1, 4)  # CONTINUE but the trial is not recorded
b.cutoff(b._rungs[-1][1]) == 3.0  # it actually gives None
b.on_result(trial3, 1, 1)  # it doesn't stop
b.cutoff(b._rungs[0][1]) == 2.0 # it actually gives  None
```

I changed the last parameter `s` when creating `_Bracket` to be set to `0` so that following trials can be recorded.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
