### PR TITLE
Fix global state actors() call

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -318,9 +318,9 @@ class GlobalState:
             return {}
         gcs_entries = gcs_utils.GcsEntry.FromString(message)
 
-        assert len(gcs_entries.entries) == 1
+        assert len(gcs_entries.entries) > 0
         actor_table_data = gcs_utils.ActorTableData.FromString(
-            gcs_entries.entries[0])
+            gcs_entries.entries[-1])
 
         actor_info = {
             "ActorID": binary_to_hex(actor_table_data.actor_id),

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -93,16 +93,17 @@ def test_global_state_actor_table(ray_start_regular):
     # actor table should contain only this entry
     # even when the actor goes out of scope
     del a
-    get_state = lambda : list(ray.actors().values())[0]["State"]
+
+    def get_state():
+        return list(ray.actors().values())[0]["State"]
+
     dead_state = ray.gcs_utils.ActorTableData.DEAD
-    passed = False
     for _ in range(10):
         if get_state() == dead_state:
             break
         else:
             time.sleep(0.5)
     assert get_state() == dead_state
-
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -93,7 +93,16 @@ def test_global_state_actor_table(ray_start_regular):
     # actor table should contain only this entry
     # even when the actor goes out of scope
     del a
-    assert len(ray.actors()) == 1
+    get_state = lambda : list(ray.actors().values())[0]["State"]
+    dead_state = ray.gcs_utils.ActorTableData.DEAD
+    passed = False
+    for _ in range(10):
+        if get_state() == dead_state:
+            break
+        else:
+            time.sleep(0.5)
+    assert get_state() == dead_state
+
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -76,6 +76,26 @@ def test_add_remove_cluster_resources(ray_start_cluster_head):
     assert ray.cluster_resources()["CPU"] == 6
 
 
+def test_global_state_actor_table(ray_start_regular):
+    @ray.remote
+    class Actor:
+        def ready(self):
+            pass
+
+    # actor table should be empty at first
+    assert len(ray.actors()) == 0
+
+    # actor table should contain only one entry
+    a = Actor.remote()
+    ray.get(a.ready.remote())
+    assert len(ray.actors()) == 1
+
+    # actor table should contain only this entry
+    # even when the actor goes out of scope
+    del a
+    assert len(ray.actors()) == 1
+
+
 if __name__ == "__main__":
     import pytest
     import sys


### PR DESCRIPTION
There are can be multiple entries per actor. We just need to the
most recent on.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #7566
Closes #7310
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
