### PR TITLE
Allocate a buffer of 100 calls for each RPC handler

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -66,7 +66,12 @@ void GrpcServer::Run() {
   // Create calls for all the server call factories.
   for (auto &entry : server_call_factories_) {
     for (int i = 0; i < num_threads_; i++) {
-      entry->CreateCall();
+      // Create a buffer of 100 calls for each RPC handler.
+      // TODO(edoakes): a small buffer should be fine and seems to have better
+      // performance, but we don't currently handle backpressure on the client.
+      for (int j = 0; j < 100; j++) {
+        entry->CreateCall();
+      }
     }
   }
   // Start threads that polls incoming requests.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Removing the buffer of gRPC server "calls" in https://github.com/ray-project/ray/pull/7544 seems to have caused issues as we now actually have backpressure on the clients, causing check failures in `ray microbenchmark` (see https://github.com/ray-project/ray/pull/7572 for more details).

Merging this as a temporary fix before https://github.com/ray-project/ray/pull/7572 is sorted out. Prefer this over reverting the change as we don't want to go back to the CI failures due to OOMing.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
