### PR TITLE
Fix streaming code compile bug

### DIFF
--- a/streaming/src/test/mock_actor.cc
+++ b/streaming/src/test/mock_actor.cc
@@ -405,7 +405,7 @@ class StreamingWorker {
 
     STREAMING_LOG(INFO) << "Init message: " << message->ToString();
     std::string actor_handle_serialized = message->ActorHandleSerialized();
-    worker_->DeserializeAndRegisterActorHandle(actor_handle_serialized);
+    worker_->DeserializeAndRegisterActorHandle(actor_handle_serialized, ObjectID::Nil());
     std::shared_ptr<ActorHandle> actor_handle(new ActorHandle(actor_handle_serialized));
     STREAMING_CHECK(actor_handle != nullptr);
     STREAMING_LOG(INFO) << " actor id from handle: " << actor_handle->GetActorID();

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -154,7 +154,9 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
                   const std::vector<ObjectID> &rescale_queue_ids, std::string suite_name,
                   std::string test_name, uint64_t param) {
     std::string forked_serialized_str;
-    Status st = driver.SerializeActorHandle(peer_actor_id, &forked_serialized_str);
+    ObjectID actor_handle_id;
+    Status st = driver.SerializeActorHandle(peer_actor_id, &forked_serialized_str,
+                                            &actor_handle_id);
     STREAMING_CHECK(st.ok());
     STREAMING_LOG(INFO) << "forked_serialized_str: " << forked_serialized_str;
     TestInitMessage msg(role, self_actor_id, peer_actor_id, forked_serialized_str,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fix streaming code compile bug: use SerializeActorHandle miss arguments.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
