### PR TITLE
[GCS]Add job id when operating gcs table

### DIFF
--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -106,11 +106,12 @@ class ActorInfoAccessor {
 
   /// Get actor checkpoint data from GCS asynchronously.
   ///
+  /// \param actor_id The ID of actor to look up in the GCS.
   /// \param checkpoint_id The ID of checkpoint to lookup in GCS.
   /// \param callback The callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id,
+      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
       const OptionalItemCallback<rpc::ActorCheckpointData> &callback) = 0;
 
   /// Get actor checkpoint id data from GCS asynchronously.

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -106,12 +106,12 @@ class ActorInfoAccessor {
 
   /// Get actor checkpoint data from GCS asynchronously.
   ///
-  /// \param actor_id The ID of actor to look up in the GCS.
   /// \param checkpoint_id The ID of checkpoint to lookup in GCS.
+  /// \param actor_id The ID of actor that this checkpoint belongs to.
   /// \param callback The callback that will be called after lookup finishes.
   /// \return Status
   virtual Status AsyncGetCheckpoint(
-      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
+      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
       const OptionalItemCallback<rpc::ActorCheckpointData> &callback) = 0;
 
   /// Get actor checkpoint id data from GCS asynchronously.

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -216,7 +216,7 @@ Status ServiceBasedActorInfoAccessor::AsyncAddCheckpoint(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
+    const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
     const OptionalItemCallback<rpc::ActorCheckpointData> &callback) {
   RAY_LOG(DEBUG) << "Getting actor checkpoint, checkpoint id = " << checkpoint_id;
   rpc::GetActorCheckpointRequest request;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -216,10 +216,11 @@ Status ServiceBasedActorInfoAccessor::AsyncAddCheckpoint(
 }
 
 Status ServiceBasedActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorCheckpointID &checkpoint_id,
+    const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
     const OptionalItemCallback<rpc::ActorCheckpointData> &callback) {
   RAY_LOG(DEBUG) << "Getting actor checkpoint, checkpoint id = " << checkpoint_id;
   rpc::GetActorCheckpointRequest request;
+  request.set_actor_id(actor_id.Binary());
   request.set_checkpoint_id(checkpoint_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorCheckpoint(
       request, [checkpoint_id, callback](const Status &status,

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -82,7 +82,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
                             const StatusCallback &callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
+      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
       const OptionalItemCallback<rpc::ActorCheckpointData> &callback) override;
 
   Status AsyncGetCheckpointID(

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -82,7 +82,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
                             const StatusCallback &callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id,
+      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
       const OptionalItemCallback<rpc::ActorCheckpointData> &callback) override;
 
   Status AsyncGetCheckpointID(

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -122,7 +122,7 @@ class ServiceBasedGcsGcsClientTest : public RedisServiceManagerForTest {
     std::promise<bool> promise;
     rpc::ActorCheckpointData actor_checkpoint_data;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpoint(
-        actor_id, checkpoint_id,
+        checkpoint_id, actor_id,
         [&actor_checkpoint_data, &promise](
             Status status, const boost::optional<rpc::ActorCheckpointData> &result) {
           assert(result);

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -117,11 +117,12 @@ class ServiceBasedGcsGcsClientTest : public RedisServiceManagerForTest {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::ActorCheckpointData GetCheckpoint(const ActorCheckpointID &checkpoint_id) {
+  rpc::ActorCheckpointData GetCheckpoint(const ActorID &actor_id,
+                                         const ActorCheckpointID &checkpoint_id) {
     std::promise<bool> promise;
     rpc::ActorCheckpointData actor_checkpoint_data;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpoint(
-        checkpoint_id,
+        actor_id, checkpoint_id,
         [&actor_checkpoint_data, &promise](
             Status status, const boost::optional<rpc::ActorCheckpointData> &result) {
           assert(result);
@@ -428,7 +429,7 @@ TEST_F(ServiceBasedGcsGcsClientTest, TestActorCheckpoint) {
   ASSERT_TRUE(AddCheckpoint(checkpoint));
 
   // Get Checkpoint
-  auto get_checkpoint_result = GetCheckpoint(checkpoint_id);
+  auto get_checkpoint_result = GetCheckpoint(actor_id, checkpoint_id);
   ASSERT_TRUE(get_checkpoint_result.actor_id() == actor_id.Binary());
 
   // Get CheckpointID

--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
@@ -22,7 +22,8 @@ void DefaultActorInfoHandler::HandleGetActorInfo(
     const rpc::GetActorInfoRequest &request, rpc::GetActorInfoReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
-  RAY_LOG(DEBUG) << "Getting actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Getting actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
 
   auto on_done = [actor_id, reply, send_reply_callback](
                      Status status, const boost::optional<ActorTableData> &result) {
@@ -32,7 +33,7 @@ void DefaultActorInfoHandler::HandleGetActorInfo(
       }
     } else {
       RAY_LOG(ERROR) << "Failed to get actor info: " << status.ToString()
-                     << ", actor id = " << actor_id;
+                     << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -41,20 +42,22 @@ void DefaultActorInfoHandler::HandleGetActorInfo(
   if (!status.ok()) {
     on_done(status, boost::none);
   }
-  RAY_LOG(DEBUG) << "Finished getting actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Finished getting actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
 }
 
 void DefaultActorInfoHandler::HandleRegisterActorInfo(
     const rpc::RegisterActorInfoRequest &request, rpc::RegisterActorInfoReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_table_data().actor_id());
-  RAY_LOG(DEBUG) << "Registering actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Registering actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
   auto actor_table_data = std::make_shared<ActorTableData>();
   actor_table_data->CopyFrom(request.actor_table_data());
   auto on_done = [actor_id, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to register actor info: " << status.ToString()
-                     << ", actor id = " << actor_id;
+                     << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -63,20 +66,22 @@ void DefaultActorInfoHandler::HandleRegisterActorInfo(
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished registering actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Finished registering actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
 }
 
 void DefaultActorInfoHandler::HandleUpdateActorInfo(
     const rpc::UpdateActorInfoRequest &request, rpc::UpdateActorInfoReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
-  RAY_LOG(DEBUG) << "Updating actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Updating actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
   auto actor_table_data = std::make_shared<ActorTableData>();
   actor_table_data->CopyFrom(request.actor_table_data());
   auto on_done = [actor_id, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to update actor info: " << status.ToString()
-                     << ", actor id = " << actor_id;
+                     << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -85,7 +90,8 @@ void DefaultActorInfoHandler::HandleUpdateActorInfo(
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished updating actor info, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Finished updating actor info, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
 }
 
 void DefaultActorInfoHandler::HandleAddActorCheckpoint(
@@ -94,14 +100,14 @@ void DefaultActorInfoHandler::HandleAddActorCheckpoint(
   ActorID actor_id = ActorID::FromBinary(request.checkpoint_data().actor_id());
   ActorCheckpointID checkpoint_id =
       ActorCheckpointID::FromBinary(request.checkpoint_data().checkpoint_id());
-  RAY_LOG(DEBUG) << "Adding actor checkpoint, actor id = " << actor_id
-                 << ", checkpoint id = " << checkpoint_id;
+  RAY_LOG(DEBUG) << "Adding actor checkpoint, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id << ", checkpoint id = " << checkpoint_id;
   auto actor_checkpoint_data = std::make_shared<ActorCheckpointData>();
   actor_checkpoint_data->CopyFrom(request.checkpoint_data());
   auto on_done = [actor_id, checkpoint_id, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add actor checkpoint: " << status.ToString()
-                     << ", actor id = " << actor_id
+                     << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id
                      << ", checkpoint id = " << checkpoint_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
@@ -111,41 +117,46 @@ void DefaultActorInfoHandler::HandleAddActorCheckpoint(
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished adding actor checkpoint, actor id = " << actor_id
-                 << ", checkpoint id = " << checkpoint_id;
+  RAY_LOG(DEBUG) << "Finished adding actor checkpoint, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id << ", checkpoint id = " << checkpoint_id;
 }
 
 void DefaultActorInfoHandler::HandleGetActorCheckpoint(
     const GetActorCheckpointRequest &request, GetActorCheckpointReply *reply,
     SendReplyCallback send_reply_callback) {
+  ActorID actor_id = ActorID::FromBinary(request.actor_id());
   ActorCheckpointID checkpoint_id =
       ActorCheckpointID::FromBinary(request.checkpoint_id());
-  RAY_LOG(DEBUG) << "Getting actor checkpoint, checkpoint id = " << checkpoint_id;
-  auto on_done = [checkpoint_id, reply, send_reply_callback](
+  RAY_LOG(DEBUG) << "Getting actor checkpoint, job id = " << actor_id.JobId()
+                 << ", checkpoint id = " << checkpoint_id;
+  auto on_done = [actor_id, checkpoint_id, reply, send_reply_callback](
                      Status status, const boost::optional<ActorCheckpointData> &result) {
     if (status.ok()) {
       RAY_DCHECK(result);
       reply->mutable_checkpoint_data()->CopyFrom(*result);
     } else {
       RAY_LOG(ERROR) << "Failed to get actor checkpoint: " << status.ToString()
+                     << ", job id = " << actor_id.JobId()
                      << ", checkpoint id = " << checkpoint_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
 
-  Status status = gcs_client_.Actors().AsyncGetCheckpoint(checkpoint_id, on_done);
+  Status status =
+      gcs_client_.Actors().AsyncGetCheckpoint(actor_id, checkpoint_id, on_done);
   if (!status.ok()) {
     on_done(status, boost::none);
   }
-  RAY_LOG(DEBUG) << "Finished getting actor checkpoint, checkpoint id = "
-                 << checkpoint_id;
+  RAY_LOG(DEBUG) << "Finished getting actor checkpoint, job id = " << actor_id.JobId()
+                 << ", checkpoint id = " << checkpoint_id;
 }
 
 void DefaultActorInfoHandler::HandleGetActorCheckpointID(
     const GetActorCheckpointIDRequest &request, GetActorCheckpointIDReply *reply,
     SendReplyCallback send_reply_callback) {
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
-  RAY_LOG(DEBUG) << "Getting actor checkpoint id, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Getting actor checkpoint id, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
   auto on_done = [actor_id, reply, send_reply_callback](
                      Status status,
                      const boost::optional<ActorCheckpointIdData> &result) {
@@ -154,7 +165,7 @@ void DefaultActorInfoHandler::HandleGetActorCheckpointID(
       reply->mutable_checkpoint_id_data()->CopyFrom(*result);
     } else {
       RAY_LOG(ERROR) << "Failed to get actor checkpoint id: " << status.ToString()
-                     << ", actor id = " << actor_id;
+                     << ", job id = " << actor_id.JobId() << ", actor id = " << actor_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -163,7 +174,8 @@ void DefaultActorInfoHandler::HandleGetActorCheckpointID(
   if (!status.ok()) {
     on_done(status, boost::none);
   }
-  RAY_LOG(DEBUG) << "Finished getting actor checkpoint id, actor id = " << actor_id;
+  RAY_LOG(DEBUG) << "Finished getting actor checkpoint id, job id = " << actor_id.JobId()
+                 << ", actor id = " << actor_id;
 }
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/actor_info_handler_impl.cc
@@ -143,7 +143,7 @@ void DefaultActorInfoHandler::HandleGetActorCheckpoint(
   };
 
   Status status =
-      gcs_client_.Actors().AsyncGetCheckpoint(actor_id, checkpoint_id, on_done);
+      gcs_client_.Actors().AsyncGetCheckpoint(checkpoint_id, actor_id, on_done);
   if (!status.ok()) {
     on_done(status, boost::none);
   }

--- a/src/ray/gcs/gcs_server/object_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/object_info_handler_impl.cc
@@ -22,7 +22,8 @@ void DefaultObjectInfoHandler::HandleGetObjectLocations(
     const GetObjectLocationsRequest &request, GetObjectLocationsReply *reply,
     SendReplyCallback send_reply_callback) {
   ObjectID object_id = ObjectID::FromBinary(request.object_id());
-  RAY_LOG(DEBUG) << "Getting object locations, object id = " << object_id;
+  RAY_LOG(DEBUG) << "Getting object locations, job id = " << object_id.TaskId().JobId()
+                 << ", object id = " << object_id;
 
   auto on_done = [reply, object_id, send_reply_callback](
                      Status status, const std::vector<rpc::ObjectTableData> &result) {
@@ -32,6 +33,7 @@ void DefaultObjectInfoHandler::HandleGetObjectLocations(
       }
     } else {
       RAY_LOG(ERROR) << "Failed to get object locations: " << status.ToString()
+                     << ", job id = " << object_id.TaskId().JobId()
                      << ", object id = " << object_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
@@ -42,7 +44,8 @@ void DefaultObjectInfoHandler::HandleGetObjectLocations(
     on_done(status, std::vector<rpc::ObjectTableData>());
   }
 
-  RAY_LOG(DEBUG) << "Finished getting object locations, object id = " << object_id;
+  RAY_LOG(DEBUG) << "Finished getting object locations, job id = "
+                 << object_id.TaskId().JobId() << ", object id = " << object_id;
 }
 
 void DefaultObjectInfoHandler::HandleAddObjectLocation(
@@ -50,12 +53,13 @@ void DefaultObjectInfoHandler::HandleAddObjectLocation(
     SendReplyCallback send_reply_callback) {
   ObjectID object_id = ObjectID::FromBinary(request.object_id());
   ClientID node_id = ClientID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "Adding object location, object id = " << object_id
-                 << ", node id = " << node_id;
+  RAY_LOG(DEBUG) << "Adding object location, job id = " << object_id.TaskId().JobId()
+                 << ", object id = " << object_id << ", node id = " << node_id;
 
   auto on_done = [object_id, node_id, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to add object location: " << status.ToString()
+                     << ", job id = " << object_id.TaskId().JobId()
                      << ", object id = " << object_id << ", node id = " << node_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
@@ -66,7 +70,8 @@ void DefaultObjectInfoHandler::HandleAddObjectLocation(
     on_done(status);
   }
 
-  RAY_LOG(DEBUG) << "Finished adding object location, object id = " << object_id
+  RAY_LOG(DEBUG) << "Finished adding object location, job id = "
+                 << object_id.TaskId().JobId() << ", object id = " << object_id
                  << ", node id = " << node_id;
 }
 
@@ -75,12 +80,13 @@ void DefaultObjectInfoHandler::HandleRemoveObjectLocation(
     SendReplyCallback send_reply_callback) {
   ObjectID object_id = ObjectID::FromBinary(request.object_id());
   ClientID node_id = ClientID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "Removing object location, object id = " << object_id
-                 << ", node id = " << node_id;
+  RAY_LOG(DEBUG) << "Removing object location, job id = " << object_id.TaskId().JobId()
+                 << ", object id = " << object_id << ", node id = " << node_id;
 
   auto on_done = [object_id, node_id, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
       RAY_LOG(ERROR) << "Failed to remove object location: " << status.ToString()
+                     << ", job id = " << object_id.TaskId().JobId()
                      << ", object id = " << object_id << ", node id = " << node_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
@@ -91,7 +97,8 @@ void DefaultObjectInfoHandler::HandleRemoveObjectLocation(
     on_done(status);
   }
 
-  RAY_LOG(DEBUG) << "Finished removing object location, object id = " << object_id
+  RAY_LOG(DEBUG) << "Finished removing object location, job id = "
+                 << object_id.TaskId().JobId() << ", object id = " << object_id
                  << ", node id = " << node_id;
 }
 

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.cc
@@ -22,13 +22,13 @@ void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest &request,
                                            SendReplyCallback send_reply_callback) {
   JobID job_id = JobID::FromBinary(request.task_data().task().task_spec().job_id());
   TaskID task_id = TaskID::FromBinary(request.task_data().task().task_spec().task_id());
-  RAY_LOG(DEBUG) << "Adding task, task id = " << task_id << ", job id = " << job_id;
+  RAY_LOG(DEBUG) << "Adding task, job id = " << job_id << ", task id = " << task_id;
   auto task_table_data = std::make_shared<TaskTableData>();
   task_table_data->CopyFrom(request.task_data());
   auto on_done = [job_id, task_id, request, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to add task, task id = " << task_id
-                     << ", job id = " << job_id;
+      RAY_LOG(ERROR) << "Failed to add task, job id = " << job_id
+                     << ", task id = " << task_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -37,22 +37,24 @@ void DefaultTaskInfoHandler::HandleAddTask(const AddTaskRequest &request,
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished adding task, task id = " << task_id
-                 << ", job id = " << job_id;
+  RAY_LOG(DEBUG) << "Finished adding task, job id = " << job_id
+                 << ", task id = " << task_id;
 }
 
 void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest &request,
                                            GetTaskReply *reply,
                                            SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_id());
-  RAY_LOG(DEBUG) << "Getting task, task id = " << task_id;
+  RAY_LOG(DEBUG) << "Getting task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id;
   auto on_done = [task_id, request, reply, send_reply_callback](
                      Status status, const boost::optional<TaskTableData> &result) {
     if (status.ok()) {
       RAY_DCHECK(result);
       reply->mutable_task_data()->CopyFrom(*result);
     } else {
-      RAY_LOG(ERROR) << "Failed to get task, task id = " << task_id;
+      RAY_LOG(ERROR) << "Failed to get task, job id = " << task_id.JobId()
+                     << ", task id = " << task_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -61,17 +63,21 @@ void DefaultTaskInfoHandler::HandleGetTask(const GetTaskRequest &request,
   if (!status.ok()) {
     on_done(status, boost::none);
   }
-  RAY_LOG(DEBUG) << "Finished getting task, task id = " << task_id;
+  RAY_LOG(DEBUG) << "Finished getting task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id;
 }
 
 void DefaultTaskInfoHandler::HandleDeleteTasks(const DeleteTasksRequest &request,
                                                DeleteTasksReply *reply,
                                                SendReplyCallback send_reply_callback) {
   std::vector<TaskID> task_ids = IdVectorFromProtobuf<TaskID>(request.task_id_list());
-  RAY_LOG(DEBUG) << "Deleting tasks, task id list size = " << task_ids.size();
-  auto on_done = [task_ids, request, reply, send_reply_callback](Status status) {
+  JobID job_id = task_ids.empty() ? JobID::Nil() : task_ids[0].JobId();
+  RAY_LOG(DEBUG) << "Deleting tasks, job id = " << job_id
+                 << ", task id list size = " << task_ids.size();
+  auto on_done = [job_id, task_ids, request, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to delete tasks, task id list size = " << task_ids.size();
+      RAY_LOG(ERROR) << "Failed to delete tasks, job id = " << job_id
+                     << ", task id list size = " << task_ids.size();
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -80,7 +86,8 @@ void DefaultTaskInfoHandler::HandleDeleteTasks(const DeleteTasksRequest &request
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished deleting tasks, task id list size = " << task_ids.size();
+  RAY_LOG(DEBUG) << "Finished deleting tasks, job id = " << job_id
+                 << ", task id list size = " << task_ids.size();
 }
 
 void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &request,
@@ -88,14 +95,14 @@ void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &reque
                                                 SendReplyCallback send_reply_callback) {
   TaskID task_id = TaskID::FromBinary(request.task_lease_data().task_id());
   ClientID node_id = ClientID::FromBinary(request.task_lease_data().node_manager_id());
-  RAY_LOG(DEBUG) << "Adding task lease, task id = " << task_id
-                 << ", node id = " << node_id;
+  RAY_LOG(DEBUG) << "Adding task lease, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", node id = " << node_id;
   auto task_lease_data = std::make_shared<TaskLeaseData>();
   task_lease_data->CopyFrom(request.task_lease_data());
   auto on_done = [task_id, node_id, request, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to add task lease, task id = " << task_id
-                     << ", node id = " << node_id;
+      RAY_LOG(ERROR) << "Failed to add task lease, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", node id = " << node_id;
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
@@ -104,23 +111,26 @@ void DefaultTaskInfoHandler::HandleAddTaskLease(const AddTaskLeaseRequest &reque
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished adding task lease, task id = " << task_id
-                 << ", node id = " << node_id;
+  RAY_LOG(DEBUG) << "Finished adding task lease, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", node id = " << node_id;
 }
 
 void DefaultTaskInfoHandler::HandleAttemptTaskReconstruction(
     const AttemptTaskReconstructionRequest &request,
     AttemptTaskReconstructionReply *reply, SendReplyCallback send_reply_callback) {
+  TaskID task_id = TaskID::FromBinary(request.task_reconstruction().task_id());
   ClientID node_id =
       ClientID::FromBinary(request.task_reconstruction().node_manager_id());
-  RAY_LOG(DEBUG) << "Reconstructing task, reconstructions num = "
+  RAY_LOG(DEBUG) << "Reconstructing task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", reconstructions num = "
                  << request.task_reconstruction().num_reconstructions()
                  << ", node id = " << node_id;
   auto task_reconstruction_data = std::make_shared<TaskReconstructionData>();
   task_reconstruction_data->CopyFrom(request.task_reconstruction());
-  auto on_done = [node_id, request, reply, send_reply_callback](Status status) {
+  auto on_done = [task_id, node_id, request, reply, send_reply_callback](Status status) {
     if (!status.ok()) {
-      RAY_LOG(ERROR) << "Failed to reconstruct task, reconstructions num = "
+      RAY_LOG(ERROR) << "Failed to reconstruct task, job id = " << task_id.JobId()
+                     << ", task id = " << task_id << ", reconstructions num = "
                      << request.task_reconstruction().num_reconstructions()
                      << ", node id = " << node_id;
     }
@@ -132,7 +142,8 @@ void DefaultTaskInfoHandler::HandleAttemptTaskReconstruction(
   if (!status.ok()) {
     on_done(status);
   }
-  RAY_LOG(DEBUG) << "Finished reconstructing task, reconstructions num = "
+  RAY_LOG(DEBUG) << "Finished reconstructing task, job id = " << task_id.JobId()
+                 << ", task id = " << task_id << ", reconstructions num = "
                  << request.task_reconstruction().num_reconstructions()
                  << ", node id = " << node_id;
 }

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -129,8 +129,10 @@ class GcsServerTest : public RedisServiceManagerForTest {
     return WaitReady(promise.get_future(), timeout_ms_);
   }
 
-  rpc::ActorCheckpointData GetActorCheckpoint(const std::string &checkpoint_id) {
+  rpc::ActorCheckpointData GetActorCheckpoint(const std::string &actor_id,
+                                              const std::string &checkpoint_id) {
     rpc::GetActorCheckpointRequest request;
+    request.set_actor_id(actor_id);
     request.set_checkpoint_id(checkpoint_id);
     rpc::ActorCheckpointData checkpoint_data;
     std::promise<bool> promise;
@@ -394,11 +396,10 @@ class GcsServerTest : public RedisServiceManagerForTest {
     return job_table_data;
   }
 
-  rpc::ActorTableData GenActorTableData(const JobID &job_id) {
+  rpc::ActorTableData GenActorTableData(const ActorID &actor_id) {
     rpc::ActorTableData actor_table_data;
-    ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
     actor_table_data.set_actor_id(actor_id.Binary());
-    actor_table_data.set_job_id(job_id.Binary());
+    actor_table_data.set_job_id(actor_id.JobId().Binary());
     actor_table_data.set_state(
         rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
     actor_table_data.set_max_reconstructions(1);
@@ -451,7 +452,8 @@ class GcsServerTest : public RedisServiceManagerForTest {
 TEST_F(GcsServerTest, TestActorInfo) {
   // Create actor_table_data
   JobID job_id = JobID::FromInt(1);
-  rpc::ActorTableData actor_table_data = GenActorTableData(job_id);
+  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  rpc::ActorTableData actor_table_data = GenActorTableData(actor_id);
 
   // Register actor
   rpc::RegisterActorInfoRequest register_actor_info_request;
@@ -482,7 +484,8 @@ TEST_F(GcsServerTest, TestActorInfo) {
   rpc::AddActorCheckpointRequest add_actor_checkpoint_request;
   add_actor_checkpoint_request.mutable_checkpoint_data()->CopyFrom(checkpoint);
   ASSERT_TRUE(AddActorCheckpoint(add_actor_checkpoint_request));
-  rpc::ActorCheckpointData checkpoint_result = GetActorCheckpoint(checkpoint_id.Binary());
+  rpc::ActorCheckpointData checkpoint_result =
+      GetActorCheckpoint(actor_id.Binary(), checkpoint_id.Binary());
   ASSERT_TRUE(checkpoint_result.actor_id() == actor_table_data.actor_id());
   ASSERT_TRUE(checkpoint_result.checkpoint_id() == checkpoint_id.Binary());
   rpc::ActorCheckpointIdData checkpoint_id_result =

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -144,7 +144,7 @@ Status RedisActorInfoAccessor::AsyncAddCheckpoint(
 }
 
 Status RedisActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
+    const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
     const OptionalItemCallback<ActorCheckpointData> &callback) {
   RAY_CHECK(callback != nullptr);
   auto on_success = [callback](RedisGcsClient *client,

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -37,7 +37,7 @@ Status RedisActorInfoAccessor::AsyncGet(
     callback(Status::OK(), result);
   };
 
-  return client_impl_->actor_table().Lookup(JobID::Nil(), actor_id, on_done);
+  return client_impl_->actor_table().Lookup(actor_id.JobId(), actor_id, on_done);
 }
 
 Status RedisActorInfoAccessor::AsyncRegister(
@@ -57,7 +57,7 @@ Status RedisActorInfoAccessor::AsyncRegister(
   };
 
   ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
-  return client_impl_->actor_table().AppendAt(JobID::Nil(), actor_id, data_ptr,
+  return client_impl_->actor_table().AppendAt(actor_id.JobId(), actor_id, data_ptr,
                                               on_success, on_failure,
                                               /*log_length*/ 0);
 }
@@ -100,7 +100,7 @@ Status RedisActorInfoAccessor::AsyncUpdate(
     }
   };
 
-  return client_impl_->actor_table().AppendAt(JobID::Nil(), actor_id, data_ptr,
+  return client_impl_->actor_table().AppendAt(actor_id.JobId(), actor_id, data_ptr,
                                               on_success, on_failure, log_length);
 }
 
@@ -126,11 +126,11 @@ Status RedisActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
 Status RedisActorInfoAccessor::AsyncAddCheckpoint(
     const std::shared_ptr<ActorCheckpointData> &data_ptr,
     const StatusCallback &callback) {
-  auto on_add_data_done = [callback, data_ptr, this](
+  ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
+  auto on_add_data_done = [actor_id, callback, data_ptr, this](
                               RedisGcsClient *client,
                               const ActorCheckpointID &checkpoint_id,
                               const ActorCheckpointData &data) {
-    ActorID actor_id = ActorID::FromBinary(data_ptr->actor_id());
     Status status = AsyncAddCheckpointID(actor_id, checkpoint_id, callback);
     if (!status.ok()) {
       callback(status);
@@ -140,11 +140,11 @@ Status RedisActorInfoAccessor::AsyncAddCheckpoint(
   ActorCheckpointID checkpoint_id =
       ActorCheckpointID::FromBinary(data_ptr->checkpoint_id());
   ActorCheckpointTable &actor_cp_table = client_impl_->actor_checkpoint_table();
-  return actor_cp_table.Add(JobID::Nil(), checkpoint_id, data_ptr, on_add_data_done);
+  return actor_cp_table.Add(actor_id.JobId(), checkpoint_id, data_ptr, on_add_data_done);
 }
 
 Status RedisActorInfoAccessor::AsyncGetCheckpoint(
-    const ActorCheckpointID &checkpoint_id,
+    const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
     const OptionalItemCallback<ActorCheckpointData> &callback) {
   RAY_CHECK(callback != nullptr);
   auto on_success = [callback](RedisGcsClient *client,
@@ -161,7 +161,7 @@ Status RedisActorInfoAccessor::AsyncGetCheckpoint(
   };
 
   ActorCheckpointTable &actor_cp_table = client_impl_->actor_checkpoint_table();
-  return actor_cp_table.Lookup(JobID::Nil(), checkpoint_id, on_success, on_failure);
+  return actor_cp_table.Lookup(actor_id.JobId(), checkpoint_id, on_success, on_failure);
 }
 
 Status RedisActorInfoAccessor::AsyncGetCheckpointID(
@@ -180,7 +180,7 @@ Status RedisActorInfoAccessor::AsyncGetCheckpointID(
   };
 
   ActorCheckpointIdTable &cp_id_table = client_impl_->actor_checkpoint_id_table();
-  return cp_id_table.Lookup(JobID::Nil(), actor_id, on_success, on_failure);
+  return cp_id_table.Lookup(actor_id.JobId(), actor_id, on_success, on_failure);
 }
 
 Status RedisActorInfoAccessor::AsyncAddCheckpointID(
@@ -193,7 +193,7 @@ Status RedisActorInfoAccessor::AsyncAddCheckpointID(
   }
 
   ActorCheckpointIdTable &cp_id_table = client_impl_->actor_checkpoint_id_table();
-  return cp_id_table.AddCheckpointId(JobID::Nil(), actor_id, checkpoint_id, on_done);
+  return cp_id_table.AddCheckpointId(actor_id.JobId(), actor_id, checkpoint_id, on_done);
 }
 
 RedisJobInfoAccessor::RedisJobInfoAccessor(RedisGcsClient *client_impl)
@@ -250,7 +250,7 @@ Status RedisTaskInfoAccessor::AsyncAdd(const std::shared_ptr<TaskTableData> &dat
 
   TaskID task_id = TaskID::FromBinary(data_ptr->task().task_spec().task_id());
   raylet::TaskTable &task_table = client_impl_->raylet_task_table();
-  return task_table.Add(JobID::Nil(), task_id, data_ptr, on_done);
+  return task_table.Add(task_id.JobId(), task_id, data_ptr, on_done);
 }
 
 Status RedisTaskInfoAccessor::AsyncGet(
@@ -268,13 +268,14 @@ Status RedisTaskInfoAccessor::AsyncGet(
   };
 
   raylet::TaskTable &task_table = client_impl_->raylet_task_table();
-  return task_table.Lookup(JobID::Nil(), task_id, on_success, on_failure);
+  return task_table.Lookup(task_id.JobId(), task_id, on_success, on_failure);
 }
 
 Status RedisTaskInfoAccessor::AsyncDelete(const std::vector<TaskID> &task_ids,
                                           const StatusCallback &callback) {
   raylet::TaskTable &task_table = client_impl_->raylet_task_table();
-  task_table.Delete(JobID::Nil(), task_ids);
+  JobID job_id = task_ids.empty() ? JobID::Nil() : task_ids[0].JobId();
+  task_table.Delete(job_id, task_ids);
   if (callback) {
     callback(Status::OK());
   }
@@ -304,7 +305,7 @@ Status RedisTaskInfoAccessor::AsyncAddTaskLease(
   }
   TaskID task_id = TaskID::FromBinary(data_ptr->task_id());
   TaskLeaseTable &task_lease_table = client_impl_->task_lease_table();
-  return task_lease_table.Add(JobID::Nil(), task_id, data_ptr, on_done);
+  return task_lease_table.Add(task_id.JobId(), task_id, data_ptr, on_done);
 }
 
 Status RedisTaskInfoAccessor::AsyncSubscribeTaskLease(
@@ -340,7 +341,7 @@ Status RedisTaskInfoAccessor::AttemptTaskReconstruction(
   int reconstruction_attempt = data_ptr->num_reconstructions();
   TaskReconstructionLog &task_reconstruction_log =
       client_impl_->task_reconstruction_log();
-  return task_reconstruction_log.AppendAt(JobID::Nil(), task_id, data_ptr, on_success,
+  return task_reconstruction_log.AppendAt(task_id.JobId(), task_id, data_ptr, on_success,
                                           on_failure, reconstruction_attempt);
 }
 
@@ -356,7 +357,7 @@ Status RedisObjectInfoAccessor::AsyncGetLocations(
   };
 
   ObjectTable &object_table = client_impl_->object_table();
-  return object_table.Lookup(JobID::Nil(), object_id, on_done);
+  return object_table.Lookup(object_id.TaskId().JobId(), object_id, on_done);
 }
 
 Status RedisObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_id,
@@ -374,7 +375,7 @@ Status RedisObjectInfoAccessor::AsyncAddLocation(const ObjectID &object_id,
   data_ptr->set_manager(node_id.Binary());
 
   ObjectTable &object_table = client_impl_->object_table();
-  return object_table.Add(JobID::Nil(), object_id, data_ptr, on_done);
+  return object_table.Add(object_id.TaskId().JobId(), object_id, data_ptr, on_done);
 }
 
 Status RedisObjectInfoAccessor::AsyncRemoveLocation(const ObjectID &object_id,
@@ -392,7 +393,7 @@ Status RedisObjectInfoAccessor::AsyncRemoveLocation(const ObjectID &object_id,
   data_ptr->set_manager(node_id.Binary());
 
   ObjectTable &object_table = client_impl_->object_table();
-  return object_table.Remove(JobID::Nil(), object_id, data_ptr, on_done);
+  return object_table.Remove(object_id.TaskId().JobId(), object_id, data_ptr, on_done);
 }
 
 Status RedisObjectInfoAccessor::AsyncSubscribeToLocations(

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -59,7 +59,7 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
                             const StatusCallback &callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
+      const ActorCheckpointID &checkpoint_id, const ActorID &actor_id,
       const OptionalItemCallback<ActorCheckpointData> &callback) override;
 
   Status AsyncGetCheckpointID(

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -59,7 +59,7 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
                             const StatusCallback &callback) override;
 
   Status AsyncGetCheckpoint(
-      const ActorCheckpointID &checkpoint_id,
+      const ActorID &actor_id, const ActorCheckpointID &checkpoint_id,
       const OptionalItemCallback<ActorCheckpointData> &callback) override;
 
   Status AsyncGetCheckpointID(

--- a/src/ray/gcs/test/redis_actor_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_actor_info_accessor_test.cc
@@ -166,8 +166,8 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
         --pending_count_;
       };
       ++pending_count_;
-      Status status =
-          actor_accessor.AsyncGetCheckpoint(ActorID::Nil(), checkpoint_id, on_get_done);
+      Status status = actor_accessor.AsyncGetCheckpoint(
+          ActorID::FromBinary(checkpoint->actor_id()), checkpoint_id, on_get_done);
       RAY_CHECK_OK(status);
     }
   }

--- a/src/ray/gcs/test/redis_actor_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_actor_info_accessor_test.cc
@@ -167,7 +167,7 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
       };
       ++pending_count_;
       Status status = actor_accessor.AsyncGetCheckpoint(
-          ActorID::FromBinary(checkpoint->actor_id()), checkpoint_id, on_get_done);
+          checkpoint_id, ActorID::FromBinary(checkpoint->actor_id()), on_get_done);
       RAY_CHECK_OK(status);
     }
   }

--- a/src/ray/gcs/test/redis_actor_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_actor_info_accessor_test.cc
@@ -166,7 +166,8 @@ TEST_F(ActorInfoAccessorTest, GetActorCheckpointTest) {
         --pending_count_;
       };
       ++pending_count_;
-      Status status = actor_accessor.AsyncGetCheckpoint(checkpoint_id, on_get_done);
+      Status status =
+          actor_accessor.AsyncGetCheckpoint(ActorID::Nil(), checkpoint_id, on_get_done);
       RAY_CHECK_OK(status);
     }
   }

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -87,7 +87,8 @@ message AddActorCheckpointReply {
 }
 
 message GetActorCheckpointRequest {
-  bytes checkpoint_id = 1;
+  bytes actor_id = 1;
+  bytes checkpoint_id = 2;
 }
 
 message GetActorCheckpointReply {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2651,7 +2651,7 @@ void NodeManager::FinishAssignedActorCreationTask(const ActorID &parent_actor_id
     RAY_LOG(DEBUG) << "Looking up checkpoint " << checkpoint_id << " for actor "
                    << actor_id;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpoint(
-        checkpoint_id,
+        actor_id, checkpoint_id,
         [this, checkpoint_id, actor_id, new_actor_info, update_callback](
             Status status, const boost::optional<ActorCheckpointData> &checkpoint_data) {
           RAY_CHECK(checkpoint_data) << "Couldn't find checkpoint " << checkpoint_id

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2651,7 +2651,7 @@ void NodeManager::FinishAssignedActorCreationTask(const ActorID &parent_actor_id
     RAY_LOG(DEBUG) << "Looking up checkpoint " << checkpoint_id << " for actor "
                    << actor_id;
     RAY_CHECK_OK(gcs_client_->Actors().AsyncGetCheckpoint(
-        actor_id, checkpoint_id,
+        checkpoint_id, actor_id,
         [this, checkpoint_id, actor_id, new_actor_info, update_callback](
             Status status, const boost::optional<ActorCheckpointData> &checkpoint_data) {
           RAY_CHECK(checkpoint_data) << "Couldn't find checkpoint " << checkpoint_id


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
In order to support multi tenancy in the future, we need to logically separate gcs table according to Job ID, so we add Job ID when operating GCS table.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
