### PR TITLE
[Java] Enable stress test

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/StressTest.java
+++ b/java/test/src/main/java/org/ray/api/test/StressTest.java
@@ -17,7 +17,7 @@ public class StressTest extends BaseTest {
     return x;
   }
 
-  @Test(enabled = false)
+  @Test
   public void testSubmittingTasks() {
     TestUtils.skipTestUnderSingleProcess();
     for (int numIterations : ImmutableList.of(1, 10, 100, 1000)) {
@@ -35,7 +35,7 @@ public class StressTest extends BaseTest {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void testDependency() {
     TestUtils.skipTestUnderSingleProcess();
     RayObject<Integer> x = Ray.call(StressTest::echo, 1);
@@ -74,7 +74,7 @@ public class StressTest extends BaseTest {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void testSubmittingManyTasksToOneActor() throws Exception {
     TestUtils.skipTestUnderSingleProcess();
     RayActor<Actor> actor = Ray.createActor(Actor::new);
@@ -89,7 +89,7 @@ public class StressTest extends BaseTest {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void testPuttingAndGettingManyObjects() {
     TestUtils.skipTestUnderSingleProcess();
     Integer objectToPut = 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
StressTests were disabled before because of CI failures. This can be enabled since issue was addressed.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
