### PR TITLE
[rllib] [tune] fix some nan warnings

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -203,7 +203,7 @@ class TBXLogger(Logger):
 
         for attr, value in flat_result.items():
             full_attr = "/".join(path + [attr])
-            if type(value) in VALID_SUMMARY_TYPES:
+            if type(value) in VALID_SUMMARY_TYPES and not np.isnan(value):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)

--- a/python/ray/util/timer.py
+++ b/python/ray/util/timer.py
@@ -48,15 +48,19 @@ class _Timer:
 
     @property
     def mean(self):
-        return np.mean(self._samples)
+        if not self._samples:
+            return 0.0
+        return float(np.mean(self._samples))
 
     @property
     def mean_units_processed(self):
+        if not self._units_processed:
+            return 0.0
         return float(np.mean(self._units_processed))
 
     @property
     def mean_throughput(self):
-        time_total = sum(self._samples)
+        time_total = float(sum(self._samples))
         if not time_total:
             return 0.0
-        return sum(self._units_processed) / time_total
+        return float(sum(self._units_processed)) / time_total

--- a/rllib/evaluation/metrics.py
+++ b/rllib/evaluation/metrics.py
@@ -117,11 +117,15 @@ def summarize_episodes(episodes, new_episodes=None):
     if episode_rewards:
         min_reward = min(episode_rewards)
         max_reward = max(episode_rewards)
+        avg_reward = np.mean(episode_rewards)
     else:
         min_reward = float("nan")
         max_reward = float("nan")
-    avg_reward = np.mean(episode_rewards)
-    avg_length = np.mean(episode_lengths)
+        avg_reward = float("nan")
+    if episode_lengths:
+        avg_length = np.mean(episode_lengths)
+    else:
+        avg_length = float("nan")
 
     # Show as histogram distributions.
     hist_stats["episode_reward"] = episode_rewards


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

In some configurations, NaN warnings get printed to the console. These are not errors, they are normal if the no episodes have completed or offline mode is used.

## Related issue number

Closes https://github.com/ray-project/ray/issues/5509
Closes https://github.com/ray-project/ray/issues/7606

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

Tested manually, no NaNs warnings.