### PR TITLE
Disable Travis Disk Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -377,6 +377,3 @@ deploy:
       all_branches: true
       condition: $LINUX_WHEELS = 1 || $MAC_WHEELS = 1
 
-cache:
-  directories:
-    - $HOME/ray-bazel-cache


### PR DESCRIPTION
There are some file sizes and memory issue with bazel disk cache
we will disable the cache and use remote cache exclusively for now

This doesn't impact build performance

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [n/a] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
