### PR TITLE
[operator] Use headless service for head node

### DIFF
--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.complete.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.complete.yaml
@@ -21,7 +21,7 @@ spec:
       type: worker
 
       # Command to start ray
-      command: ray start --block --node-ip-address=$MY_POD_IP --address=$RAYCLUSTER_SAMPLE_SERVICE_HOST:$RAYCLUSTER_SAMPLE_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
+      command: ray start --block --node-ip-address=$MY_POD_IP --address=$CLUSTER_NAME-head:6379 --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
 
       # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
       # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -112,7 +112,7 @@ spec:
         key: value
 
       # Command to start ray
-      command: ray start --block --node-ip-address=$MY_POD_IP --address=$RAYCLUSTER_SAMPLE_SERVICE_HOST:$RAYCLUSTER_SAMPLE_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
+      command: ray start --block --node-ip-address=$MY_POD_IP --address=$CLUSTER_NAME-head:6379 --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
 
       # use affinity to select nodes.Optional.
       # Refer to https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.heterogeneous.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.heterogeneous.yaml
@@ -26,7 +26,7 @@ spec:
         raycluster.group.name: small-group
 
       # Command to start ray
-      command: ray start --block --node-ip-address=$MY_POD_IP --address=$RAYCLUSTER_SAMPLE_SERVICE_HOST:$RAYCLUSTER_SAMPLE_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
+      command: ray start --block --node-ip-address=$MY_POD_IP --address=$CLUSTER_NAME-head:6379 --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
 
       # resource requirements
       # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
@@ -70,7 +70,7 @@ spec:
         raycluster.group.name: medium-group
 
       # Command to start ray
-      command: ray start --block --node-ip-address=$MY_POD_IP --address=$RAYCLUSTER_SAMPLE_SERVICE_HOST:$RAYCLUSTER_SAMPLE_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
+      command: ray start --block --node-ip-address=$MY_POD_IP --address=$CLUSTER_NAME-head:6379 --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
 
       # resource requirements
       # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/deploy/ray-operator/config/samples/ray_v1_raycluster.mini.yaml
+++ b/deploy/ray-operator/config/samples/ray_v1_raycluster.mini.yaml
@@ -26,7 +26,7 @@ spec:
         raycluster.group.name: small-group
 
       # Command to start ray
-      command: ray start --block --node-ip-address=$MY_POD_IP --address=$RAYCLUSTER_SAMPLE_SERVICE_HOST:$RAYCLUSTER_SAMPLE_SERVICE_PORT_REDIS --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
+      command: ray start --block --node-ip-address=$MY_POD_IP --address=$CLUSTER_NAME-head:6379 --object-manager-port=12345 --node-manager-port=12346 --object-store-memory=100000000 --num-cpus=1
 
       # resource requirements
       # Refer to https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/deploy/ray-operator/controllers/common/service.go
+++ b/deploy/ray-operator/controllers/common/service.go
@@ -36,9 +36,9 @@ func ServiceForPod(conf *ServiceConfig) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{Name: "redis", Port: int32(defaultRedisPort)}},
-			// TODO(edoakes): ClusterIPNone (headless service) should work but I wasn't
-			// able to get the environment variables for service discovery to work.
-			// ClusterIP: corev1.ClusterIPNone,
+			// Use a headless service, meaning that the DNS record for the service will
+			// point directly to the head node pod's IP address.
+			ClusterIP: corev1.ClusterIPNone,
 			// This selector must match the label of the head node.
 			Selector: map[string]string{
 				rayclusterComponent: conf.PodName,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Want worker -> head node connection to be direct, not proxied by k8s.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
