### PR TITLE
[core] Fix leak for subscribing to object dependencies in NodeManager

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2254,9 +2254,7 @@ void NodeManager::AsyncResolveObjects(
     // HandleDirectCallUnblocked.
     auto &task_id = mark_worker_blocked ? current_task_id : worker->GetAssignedTaskId();
     if (!task_id.IsNil()) {
-      task_dependency_manager_.SubscribeGetDependencies(
-          task_id,
-          required_object_ids);
+      task_dependency_manager_.SubscribeGetDependencies(task_id, required_object_ids);
     }
   } else {
     task_dependency_manager_.SubscribeWaitDependencies(worker->WorkerId(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

I noticed when running test_array locally that there were sometimes assertion failures in the NodeManager. Unfortunately I think some of them were hidden in Travis because of task retries. I was able to recreate these errors locally by running:
```
taskset 1 python -m pytest -sv python/ray/tests/test_array.py::test_distributed_array_methods
```

This would result in a stacktrace like this:
```
(pid=raylet) F0316 12:28:09.223908 12495 node_manager.cc:2800]  Check failed: actor_registry_.count(id.ActorId()) > 0
(pid=raylet) *** Check failure stack trace: ***
(pid=raylet)     @     0x556ad0f42d7d  google::LogMessage::Fail()
(pid=raylet)     @     0x556ad0f442c4  google::LogMessage::SendToLog()
(pid=raylet)     @     0x556ad0f42a1d  google::LogMessage::Flush()
(pid=raylet)     @     0x556ad0f42c71  google::LogMessage::~LogMessage()
(pid=raylet)     @     0x556ad0bfd968  ray::RayLog::~RayLog()
(pid=raylet)     @     0x556ad09efd15  ray::raylet::NodeManager::HandleObjectLocal()
(pid=raylet)     @     0x556ad09eff65  _ZNSt17_Function_handlerIFvRKN3ray14object_manager8protocol11ObjectInfoTEEZNS0_6raylet11NodeManagerC4ERN5boost4asio10io_contextERKNS0_8ClientIDERKNS7_17NodeManagerConfigERNS0_13ObjectManagerESt10shared_ptrINS0_3gcs9GcsClientEESL_INS0_24ObjectDirectoryInterfaceEEEUlS5_E1_E9_M_invokeERKSt9_Any_dataS5_
(pid=raylet)     @     0x556ad0a30860  ray::ObjectStoreNotificationManager::ProcessStoreAdd()
(pid=raylet)     @     0x556ad0a341b6  ray::ObjectStoreNotificationManager::ProcessStoreNotification()
(pid=raylet)     @     0x556ad0a32c6b  boost::asio::detail::reactive_socket_recv_op<>::do_complete()
(pid=raylet)     @     0x556ad0ed32e1  boost::asio::detail::scheduler::do_run_one()
(pid=raylet)     @     0x556ad0ed38e1  boost::asio::detail::scheduler::run()
(pid=raylet)     @     0x556ad0ed6223  boost::asio::io_context::run()
(pid=raylet)     @     0x556ad096e1e4  main
(pid=raylet)     @     0x7f61fb62eb97  __libc_start_main
(pid=raylet)     @     0x556ad097d8ea  _start
```

It seems that the problem has to do with the accounting for which task IDs depend on which object IDs. When a task depends on an object ID, the NodeManager calls TaskDependencyManager::SubscribeGetDependencies to indicate this and is responsible for calling TaskDependencyManager::UnsubscribeGetDependencies once the object is no longer needed. The assertion check is to make sure that we know about all of the tasks that depend on an object. If it fails, then this means that there may be a leak; there are tasks that depend on the object that the NodeManager will never unsubscribe. This is a leak because we will continue trying to fetch that object even though no tasks depend on it.

This fixes the leak by:
1. Calling UnsubscribeGetDependencies when a task finishes.
2. Not calling SubscribeGetDependencies if the worker's currently assigned task ID is nil.

I believe both of these cases can happen when a task still has pending object resolution requests that aren't canceled yet by the time the task finishes, probably due to message reordering. This solution is not ideal since the dependency tracking in the NodeManager is pretty complicated right now. Long-term, I think we can simplify this by tracking object dependencies per worker instead of per task ID.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
