### PR TITLE
Fix build.sh hard-coded python version support message and dead code removal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,17 +25,6 @@ Options:
 EOF
 }
 
-# Determine how many parallel jobs to use for make based on the number of cores
-unamestr="$(uname)"
-if [[ "$unamestr" == "Linux" ]]; then
-  PARALLEL=1
-elif [[ "$unamestr" == "Darwin" ]]; then
-  PARALLEL=$(sysctl -n hw.ncpu)
-else
-  echo "Unrecognized platform."
-  exit 1
-fi
-
 RAY_BUILD_PYTHON="YES"
 RAY_BUILD_JAVA="NO"
 PYTHON_EXECUTABLE=""
@@ -97,7 +86,8 @@ if [[ -z $found ]]
 then
   cat <<EOF
 ERROR: Detected Python version $PYTHON_VERSION, which is not supported.
-       Please use version 3.6 or 3.7.
+       Please use one of the following Python versions:
+       $(printf ", %s" "${SUPPORTED_PYTHONS[@]}" | cut -c3-)
 EOF
   exit 1
 fi


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Simple build script refactor to remove dead code to improve maintainability/readability, and to fix now-incorrect hard-coded supported python versions error message (via re-use of existing SUPPORTED_PYTHONS variable).

## Related issue number
Unknown/None

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [N/A] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)

Manually validated that a properly formatted error message is emitted when using an unsupported python version that enumerates all supported python versions, and ensured that builds still complete successfully using expected Bazel-managed job concurrency.