### PR TITLE
bug fix about usage of absl::flat_hash_map::erase and absl::flat_hash_set::erase

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -515,11 +515,12 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids, const int64_t timeout_m
 
   // Erase any objects that were promoted to plasma from the results. These get
   // requests will be retried at the plasma store.
-  for (auto it = result_map.begin(); it != result_map.end(); it++) {
-    if (it->second->IsInPlasmaError()) {
-      RAY_LOG(DEBUG) << it->first << " in plasma, doing fetch-and-get";
-      plasma_object_ids.insert(it->first);
-      result_map.erase(it);
+  for (auto it = result_map.begin(); it != result_map.end();) {
+    auto current = it++;
+    if (current->second->IsInPlasmaError()) {
+      RAY_LOG(DEBUG) << current->first << " in plasma, doing fetch-and-get";
+      plasma_object_ids.insert(current->first);
+      result_map.erase(current);
     }
   }
 
@@ -585,16 +586,19 @@ void RetryObjectInPlasmaErrors(std::shared_ptr<CoreWorkerMemoryStore> &memory_st
                                absl::flat_hash_set<ObjectID> &memory_object_ids,
                                absl::flat_hash_set<ObjectID> &plasma_object_ids,
                                absl::flat_hash_set<ObjectID> &ready) {
-  for (const auto &mem_id : memory_object_ids) {
-    if (ready.find(mem_id) != ready.end()) {
+  for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end();) {
+    auto current = iter++;
+    const auto &mem_id = *current;
+    auto ready_iter = ready.find(mem_id);
+    if (ready_iter != ready.end()) {
       std::vector<std::shared_ptr<RayObject>> found;
       RAY_CHECK_OK(memory_store->Get({mem_id}, /*num_objects=*/1, /*timeout=*/0,
                                      worker_context,
                                      /*remote_after_get=*/false, &found));
       if (found.size() == 1 && found[0]->IsInPlasmaError()) {
-        memory_object_ids.erase(mem_id);
-        ready.erase(mem_id);
         plasma_object_ids.insert(mem_id);
+        ready.erase(ready_iter);
+        memory_object_ids.erase(current);
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
It is wrong to use absl::flat_hash_map::erase or absl::flat_hash_set::erase like this:
```
for (const auto &entry : flat_hash_set) {
   .....
   flat_hash_set.erase(entry);
}

for (auto iter = flat_hash_set.begin(); iter != flat_hash_set.end(); ++iter) {
   .....
   flat_hash_set.erase(iter);
}
```
The tow above codes will lead to exception.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
