### PR TITLE
Fix test_raylet_pending_tasks test case failed

### DIFF
--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -301,6 +301,7 @@ def test_raylet_pending_tasks(shutdown_only):
             self.a = [ActorRequiringGPU.remote() for i in range(4)]
 
     parent_actor = ParentActor.remote()
+    assert parent_actor is not None
 
     def test_pending_actor(ray_addresses):
         webui_url = ray_addresses["webui_url"].replace("localhost",

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -300,6 +300,8 @@ def test_raylet_pending_tasks(shutdown_only):
         def __init__(self):
             self.a = [ActorRequiringGPU.remote() for i in range(4)]
 
+    # If we do not get ParentActor actor handler, reference counter will
+    # terminate ParentActor.
     parent_actor = ParentActor.remote()
     assert parent_actor is not None
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -300,7 +300,7 @@ def test_raylet_pending_tasks(shutdown_only):
         def __init__(self):
             self.a = [ActorRequiringGPU.remote() for i in range(4)]
 
-    ParentActor.remote()
+    parent_actor = ParentActor.remote()
 
     def test_pending_actor(ray_addresses):
         webui_url = ray_addresses["webui_url"].replace("localhost",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Test case of test_raylet_pending_tasks will create ParentActor first, then ParentActor will create ActorRequiringGPU actor. Now reference counter will terminate ParentActor because we do not get ParentActor actor handler in the driver code.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
