### PR TITLE
rename ActorTable to LogBasedActorTable and add new ActorTable

### DIFF
--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -51,7 +51,9 @@ void RedisServiceManagerForTest::FlushAll() {
   std::string flush_all_redis_command =
       REDIS_CLIENT_EXEC_PATH + " -p " + std::to_string(REDIS_SERVER_PORT) + " flushall";
   RAY_LOG(INFO) << "Cleaning up redis with command: " << flush_all_redis_command;
-  system(flush_all_redis_command.c_str());
+  if (system(flush_all_redis_command.c_str()) != 0) {
+    RAY_LOG(WARNING) << "Failed to flush redis. The redis process may no longer exist.";
+  }
   usleep(100 * 1000);
 }
 

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -50,7 +50,7 @@ void RedisServiceManagerForTest::TearDownTestCase() {
 void RedisServiceManagerForTest::FlushAll() {
   std::string flush_all_redis_command =
       REDIS_CLIENT_EXEC_PATH + " -p " + std::to_string(REDIS_SERVER_PORT) + " flushall";
-  RAY_LOG(INFO) << "Clear redis command is: " << flush_all_redis_command;
+  RAY_LOG(INFO) << "Cleaning up redis with command: " << flush_all_redis_command;
   RAY_CHECK(system(flush_all_redis_command.c_str()) == 0);
   usleep(100 * 1000);
 }

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -51,7 +51,7 @@ void RedisServiceManagerForTest::FlushAll() {
   std::string flush_all_redis_command =
       REDIS_CLIENT_EXEC_PATH + " -p " + std::to_string(REDIS_SERVER_PORT) + " flushall";
   RAY_LOG(INFO) << "Cleaning up redis with command: " << flush_all_redis_command;
-  RAY_CHECK(system(flush_all_redis_command.c_str()) == 0);
+  system(flush_all_redis_command.c_str());
   usleep(100 * 1000);
 }
 

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -47,6 +47,14 @@ void RedisServiceManagerForTest::TearDownTestCase() {
   usleep(100 * 1000);
 }
 
+void RedisServiceManagerForTest::FlushAll() {
+  std::string flush_all_redis_command =
+      REDIS_CLIENT_EXEC_PATH + " -p " + std::to_string(REDIS_SERVER_PORT) + " flushall";
+  RAY_LOG(INFO) << "Clear redis command is: " << flush_all_redis_command;
+  RAY_CHECK(system(flush_all_redis_command.c_str()) == 0);
+  usleep(100 * 1000);
+}
+
 bool WaitForCondition(std::function<bool()> condition, int timeout_ms) {
   int wait_time = 0;
   while (true) {

--- a/src/ray/common/test_util.h
+++ b/src/ray/common/test_util.h
@@ -62,6 +62,7 @@ class RedisServiceManagerForTest : public ::testing::Test {
  public:
   static void SetUpTestCase();
   static void TearDownTestCase();
+  static void FlushAll();
 };
 
 }  // namespace ray

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -32,6 +32,12 @@ class ActorInfoAccessor {
  public:
   virtual ~ActorInfoAccessor() = default;
 
+  /// Get all actor specification from GCS synchronously.
+  ///
+  /// \param actor_table_data_list The container to hold the actor specification.
+  /// \return Status
+  virtual Status GetAll(std::vector<rpc::ActorTableData> *actor_table_data_list) = 0;
+
   /// Get actor specification from GCS asynchronously.
   ///
   /// \param actor_id The ID of actor to look up in the GCS.

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -79,8 +79,7 @@ ServiceBasedActorInfoAccessor::ServiceBasedActorInfoAccessor(
     ServiceBasedGcsClient *client_impl)
     : subscribe_id_(ClientID::FromRandom()),
       client_impl_(client_impl),
-      log_based_actor_sub_executor_(
-          client_impl->GetRedisGcsClient().log_based_actor_table()) {}
+      actor_sub_executor_(client_impl->GetRedisGcsClient().log_based_actor_table()) {}
 
 Status ServiceBasedActorInfoAccessor::GetAll(
     std::vector<ActorTableData> *actor_table_data_list) {
@@ -164,8 +163,7 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribeAll(
     const StatusCallback &done) {
   RAY_LOG(DEBUG) << "Subscribing register or update operations of actors.";
   RAY_CHECK(subscribe != nullptr);
-  auto status =
-      log_based_actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
+  auto status = actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
   RAY_LOG(DEBUG) << "Finished subscribing register or update operations of actors.";
   return status;
 }
@@ -176,8 +174,8 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
     const StatusCallback &done) {
   RAY_LOG(DEBUG) << "Subscribing update operations of actor, actor id = " << actor_id;
   RAY_CHECK(subscribe != nullptr) << "Failed to subscribe actor, actor id = " << actor_id;
-  auto status = log_based_actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id,
-                                                             subscribe, done);
+  auto status =
+      actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id, subscribe, done);
   RAY_LOG(DEBUG) << "Finished subscribing update operations of actor, actor id = "
                  << actor_id;
   return status;
@@ -186,8 +184,7 @@ Status ServiceBasedActorInfoAccessor::AsyncSubscribe(
 Status ServiceBasedActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
                                                        const StatusCallback &done) {
   RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id;
-  auto status =
-      log_based_actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, done);
+  auto status = actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, done);
   RAY_LOG(DEBUG) << "Finished cancelling subscription to an actor, actor id = "
                  << actor_id;
   return status;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -263,12 +263,12 @@ Status ServiceBasedActorInfoAccessor::AsyncGetCheckpointID(
   return Status::OK();
 }
 
-ServiceBasedRawActorInfoAccessor::ServiceBasedRawActorInfoAccessor(
+ServiceBasedNewActorInfoAccessor::ServiceBasedNewActorInfoAccessor(
     ServiceBasedGcsClient *client_impl)
     : ServiceBasedActorInfoAccessor(client_impl),
       raw_actor_sub_executor_(client_impl->GetRedisGcsClient().raw_actor_table()) {}
 
-Status ServiceBasedRawActorInfoAccessor::AsyncSubscribeAll(
+Status ServiceBasedNewActorInfoAccessor::AsyncSubscribeAll(
     const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
     const StatusCallback &done) {
   RAY_LOG(DEBUG) << "Subscribing register or update operations of actors.";
@@ -279,7 +279,7 @@ Status ServiceBasedRawActorInfoAccessor::AsyncSubscribeAll(
   return status;
 }
 
-Status ServiceBasedRawActorInfoAccessor::AsyncSubscribe(
+Status ServiceBasedNewActorInfoAccessor::AsyncSubscribe(
     const ActorID &actor_id,
     const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
     const StatusCallback &done) {
@@ -292,7 +292,7 @@ Status ServiceBasedRawActorInfoAccessor::AsyncSubscribe(
   return status;
 }
 
-Status ServiceBasedRawActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
+Status ServiceBasedNewActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
                                                           const StatusCallback &done) {
   RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id;
   auto status = raw_actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, done);

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -276,8 +276,8 @@ ServiceBasedNodeInfoAccessor::ServiceBasedNodeInfoAccessor(
 
 Status ServiceBasedNodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info) {
   auto node_id = ClientID::FromBinary(local_node_info.node_id());
-  RAY_LOG(INFO) << "Registering node info, node id = " << node_id
-                << ", address is = " << local_node_info.node_manager_address();
+  RAY_LOG(DEBUG) << "Registering node info, node id = " << node_id
+                 << ", address is = " << local_node_info.node_manager_address();
   RAY_CHECK(local_node_id_.IsNil()) << "This node is already connected.";
   RAY_CHECK(local_node_info.state() == GcsNodeInfo::ALIVE);
   rpc::RegisterNodeRequest request;
@@ -289,8 +289,8 @@ Status ServiceBasedNodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_
           local_node_info_.CopyFrom(local_node_info);
           local_node_id_ = ClientID::FromBinary(local_node_info.node_id());
         }
-        RAY_LOG(INFO) << "Finished registering node info, status = " << status
-                      << ", node id = " << node_id;
+        RAY_LOG(DEBUG) << "Finished registering node info, status = " << status
+                       << ", node id = " << node_id;
       });
   return Status::OK();
 }

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -266,43 +266,6 @@ Status ServiceBasedActorInfoAccessor::AsyncGetCheckpointID(
   return Status::OK();
 }
 
-ServiceBasedNewActorInfoAccessor::ServiceBasedNewActorInfoAccessor(
-    ServiceBasedGcsClient *client_impl)
-    : ServiceBasedActorInfoAccessor(client_impl),
-      actor_sub_executor_(client_impl->GetRedisGcsClient().actor_table()) {}
-
-Status ServiceBasedNewActorInfoAccessor::AsyncSubscribeAll(
-    const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-    const StatusCallback &done) {
-  RAY_LOG(DEBUG) << "Subscribing register or update operations of actors.";
-  RAY_CHECK(subscribe != nullptr);
-  auto status = actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
-  RAY_LOG(DEBUG) << "Finished subscribing register or update operations of actors.";
-  return status;
-}
-
-Status ServiceBasedNewActorInfoAccessor::AsyncSubscribe(
-    const ActorID &actor_id,
-    const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-    const StatusCallback &done) {
-  RAY_LOG(DEBUG) << "Subscribing update operations of actor, actor id = " << actor_id;
-  RAY_CHECK(subscribe != nullptr) << "Failed to subscribe actor, actor id = " << actor_id;
-  auto status =
-      actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id, subscribe, done);
-  RAY_LOG(DEBUG) << "Finished subscribing update operations of actor, actor id = "
-                 << actor_id;
-  return status;
-}
-
-Status ServiceBasedNewActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
-                                                          const StatusCallback &done) {
-  RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id;
-  auto status = actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, done);
-  RAY_LOG(DEBUG) << "Finished cancelling subscription to an actor, actor id = "
-                 << actor_id;
-  return status;
-}
-
 ServiceBasedNodeInfoAccessor::ServiceBasedNodeInfoAccessor(
     ServiceBasedGcsClient *client_impl)
     : client_impl_(client_impl),

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -97,9 +97,9 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
  private:
   ServiceBasedGcsClient *client_impl_;
 
-  typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, LogBasedActorTable>
       ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor actor_sub_executor_;
+  ActorSubscriptionExecutor log_based_actor_sub_executor_;
 
   Sequencer<ActorID> sequencer_;
 };
@@ -121,9 +121,9 @@ class ServiceBasedNewActorInfoAccessor : public ServiceBasedActorInfoAccessor {
   Status AsyncUnsubscribe(const ActorID &actor_id, const StatusCallback &done) override;
 
  private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
       ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor raw_actor_sub_executor_;
+  ActorSubscriptionExecutor actor_sub_executor_;
 };
 
 /// \class ServiceBasedNodeInfoAccessor

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -104,11 +104,11 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   Sequencer<ActorID> sequencer_;
 };
 
-class ServiceBasedRawActorInfoAccessor : public ServiceBasedActorInfoAccessor {
+class ServiceBasedNewActorInfoAccessor : public ServiceBasedActorInfoAccessor {
  public:
-  explicit ServiceBasedRawActorInfoAccessor(ServiceBasedGcsClient *client_impl);
+  explicit ServiceBasedNewActorInfoAccessor(ServiceBasedGcsClient *client_impl);
 
-  virtual ~ServiceBasedRawActorInfoAccessor() = default;
+  virtual ~ServiceBasedNewActorInfoAccessor() = default;
 
   Status AsyncSubscribeAll(
       const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
@@ -121,7 +121,7 @@ class ServiceBasedRawActorInfoAccessor : public ServiceBasedActorInfoAccessor {
   Status AsyncUnsubscribe(const ActorID &actor_id, const StatusCallback &done) override;
 
  private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, RawActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>
       ActorSubscriptionExecutor;
   ActorSubscriptionExecutor raw_actor_sub_executor_;
 };

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -99,7 +99,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
 
   typedef SubscriptionExecutor<ActorID, ActorTableData, LogBasedActorTable>
       ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor log_based_actor_sub_executor_;
+  ActorSubscriptionExecutor actor_sub_executor_;
 
   Sequencer<ActorID> sequencer_;
 };

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -104,28 +104,6 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
   Sequencer<ActorID> sequencer_;
 };
 
-class ServiceBasedNewActorInfoAccessor : public ServiceBasedActorInfoAccessor {
- public:
-  explicit ServiceBasedNewActorInfoAccessor(ServiceBasedGcsClient *client_impl);
-
-  virtual ~ServiceBasedNewActorInfoAccessor() = default;
-
-  Status AsyncSubscribeAll(
-      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-      const StatusCallback &done) override;
-
-  Status AsyncSubscribe(const ActorID &actor_id,
-                        const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
-                        const StatusCallback &done) override;
-
-  Status AsyncUnsubscribe(const ActorID &actor_id, const StatusCallback &done) override;
-
- private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
-      ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor actor_sub_executor_;
-};
-
 /// \class ServiceBasedNodeInfoAccessor
 /// ServiceBasedNodeInfoAccessor is an implementation of `NodeInfoAccessor`
 /// that uses GCS Service as the backend.

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -50,7 +50,12 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
                                               *client_call_manager_, get_server_address));
 
   job_accessor_.reset(new ServiceBasedJobInfoAccessor(this));
-  actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
+  if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
+    RAY_CHECK(getenv("RAY_GCS_SERVICE_ENABLED") != nullptr);
+    actor_accessor_.reset(new ServiceBasedRawActorInfoAccessor(this));
+  } else {
+    actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
+  }
   node_accessor_.reset(new ServiceBasedNodeInfoAccessor(this));
   task_accessor_.reset(new ServiceBasedTaskInfoAccessor(this));
   object_accessor_.reset(new ServiceBasedObjectInfoAccessor(this));

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -52,7 +52,7 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   job_accessor_.reset(new ServiceBasedJobInfoAccessor(this));
   if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
     RAY_CHECK(getenv("RAY_GCS_SERVICE_ENABLED") != nullptr);
-    actor_accessor_.reset(new ServiceBasedRawActorInfoAccessor(this));
+    actor_accessor_.reset(new ServiceBasedNewActorInfoAccessor(this));
   } else {
     actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
   }

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -50,12 +50,7 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
                                               *client_call_manager_, get_server_address));
 
   job_accessor_.reset(new ServiceBasedJobInfoAccessor(this));
-  if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
-    RAY_CHECK(getenv("RAY_GCS_SERVICE_ENABLED") != nullptr);
-    actor_accessor_.reset(new ServiceBasedNewActorInfoAccessor(this));
-  } else {
-    actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
-  }
+  actor_accessor_.reset(new ServiceBasedActorInfoAccessor(this));
   node_accessor_.reset(new ServiceBasedNodeInfoAccessor(this));
   task_accessor_.reset(new ServiceBasedTaskInfoAccessor(this));
   object_accessor_.reset(new ServiceBasedObjectInfoAccessor(this));

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -64,6 +64,7 @@ class ServiceBasedGcsGcsClientTest : public RedisServiceManagerForTest {
     thread_io_service_->join();
     thread_gcs_server_->join();
     gcs_client_->Disconnect();
+    FlushAll();
   }
 
   bool AddJob(const std::shared_ptr<rpc::JobTableData> &job_table_data) {
@@ -313,6 +314,7 @@ class ServiceBasedGcsGcsClientTest : public RedisServiceManagerForTest {
     rpc::GcsNodeInfo gcs_node_info;
     gcs_node_info.set_node_id(node_id);
     gcs_node_info.set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
+    gcs_node_info.set_node_manager_address("127.0.0.1");
     return gcs_node_info;
   }
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -649,13 +649,13 @@ TEST_F(ServiceBasedGcsGcsClientTest, TestDetectGcsAvailability) {
   promise.get_future().get();
 }
 
-TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
-  // Stop redis.
-  TearDownTestCase();
-
-  // Check if gcs server has exited.
-  RAY_CHECK(gcs_server_->IsStopped());
-}
+// TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
+//  // Stop redis.
+//  TearDownTestCase();
+//
+//  // Check if gcs server has exited.
+//  RAY_CHECK(gcs_server_->IsStopped());
+//}
 
 }  // namespace ray
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -649,13 +649,13 @@ TEST_F(ServiceBasedGcsGcsClientTest, TestDetectGcsAvailability) {
   promise.get_future().get();
 }
 
-// TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
-//  // Stop redis.
-//  TearDownTestCase();
-//
-//  // Check if gcs server has exited.
-//  RAY_CHECK(gcs_server_->IsStopped());
-//}
+TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
+  // Stop redis.
+  TearDownTestCase();
+
+  // Check if gcs server has exited.
+  RAY_CHECK(gcs_server_->IsStopped());
+}
 
 }  // namespace ray
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -410,6 +410,8 @@ class GcsServerTest : public RedisServiceManagerForTest {
   rpc::GcsNodeInfo GenGcsNodeInfo(const std::string &node_id) {
     rpc::GcsNodeInfo gcs_node_info;
     gcs_node_info.set_node_id(node_id);
+    gcs_node_info.set_node_manager_address("127.0.0.1");
+    gcs_node_info.set_node_manager_port(6000);
     gcs_node_info.set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
     return gcs_node_info;
   }

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -29,8 +29,8 @@ std::vector<ActorID> RedisActorInfoAccessor::GetAllActorID() const {
   return client_impl_->actor_table().GetAllActorID();
 }
 
-Status RedisActorInfoAccessor::GetActorData(const ActorID &actor_id,
-                                            ActorTableData *actor_table_data) const {
+Status RedisActorInfoAccessor::Get(const ActorID &actor_id,
+                                   ActorTableData *actor_table_data) const {
   return client_impl_->actor_table().Get(actor_id, actor_table_data);
 }
 
@@ -40,7 +40,7 @@ Status RedisActorInfoAccessor::GetAll(
   auto actor_id_list = GetAllActorID();
   actor_table_data_list->resize(actor_id_list.size());
   for (size_t i = 0; i < actor_id_list.size(); ++i) {
-    RAY_CHECK_OK(GetActorData(actor_id_list[i], &(*actor_table_data_list)[i]));
+    RAY_CHECK_OK(Get(actor_id_list[i], &(*actor_table_data_list)[i]));
   }
   return Status::OK();
 }
@@ -224,8 +224,8 @@ std::vector<ActorID> RedisRawActorInfoAccessor::GetAllActorID() const {
   return client_impl_->raw_actor_table().GetAllActorID();
 }
 
-Status RedisRawActorInfoAccessor::GetActorData(const ActorID &actor_id,
-                                               ActorTableData *actor_table_data) const {
+Status RedisRawActorInfoAccessor::Get(const ActorID &actor_id,
+                                      ActorTableData *actor_table_data) const {
   return client_impl_->raw_actor_table().Get(actor_id, actor_table_data);
 }
 

--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -216,20 +216,20 @@ Status RedisActorInfoAccessor::AsyncAddCheckpointID(
   return cp_id_table.AddCheckpointId(actor_id.JobId(), actor_id, checkpoint_id, on_done);
 }
 
-RedisRawActorInfoAccessor::RedisRawActorInfoAccessor(RedisGcsClient *client_impl)
+RedisNewActorInfoAccessor::RedisNewActorInfoAccessor(RedisGcsClient *client_impl)
     : RedisActorInfoAccessor(client_impl),
       raw_actor_sub_executor_(client_impl_->raw_actor_table()) {}
 
-std::vector<ActorID> RedisRawActorInfoAccessor::GetAllActorID() const {
+std::vector<ActorID> RedisNewActorInfoAccessor::GetAllActorID() const {
   return client_impl_->raw_actor_table().GetAllActorID();
 }
 
-Status RedisRawActorInfoAccessor::Get(const ActorID &actor_id,
+Status RedisNewActorInfoAccessor::Get(const ActorID &actor_id,
                                       ActorTableData *actor_table_data) const {
   return client_impl_->raw_actor_table().Get(actor_id, actor_table_data);
 }
 
-Status RedisRawActorInfoAccessor::AsyncGet(
+Status RedisNewActorInfoAccessor::AsyncGet(
     const ActorID &actor_id, const OptionalItemCallback<ActorTableData> &callback) {
   RAY_CHECK(callback != nullptr);
   auto on_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
@@ -245,7 +245,7 @@ Status RedisRawActorInfoAccessor::AsyncGet(
                                                 on_failure);
 }
 
-Status RedisRawActorInfoAccessor::AsyncRegister(
+Status RedisNewActorInfoAccessor::AsyncRegister(
     const std::shared_ptr<ActorTableData> &data_ptr, const StatusCallback &callback) {
   auto on_register_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
                                      const ActorTableData &data) {
@@ -258,7 +258,7 @@ Status RedisRawActorInfoAccessor::AsyncRegister(
                                              on_register_done);
 }
 
-Status RedisRawActorInfoAccessor::AsyncUpdate(
+Status RedisNewActorInfoAccessor::AsyncUpdate(
     const ActorID &actor_id, const std::shared_ptr<ActorTableData> &data_ptr,
     const StatusCallback &callback) {
   auto on_update_done = [callback](RedisGcsClient *client, const ActorID &actor_id,
@@ -271,21 +271,21 @@ Status RedisRawActorInfoAccessor::AsyncUpdate(
                                              on_update_done);
 }
 
-Status RedisRawActorInfoAccessor::AsyncSubscribeAll(
+Status RedisNewActorInfoAccessor::AsyncSubscribeAll(
     const SubscribeCallback<ActorID, ActorTableData> &subscribe,
     const StatusCallback &done) {
   RAY_CHECK(subscribe != nullptr);
   return raw_actor_sub_executor_.AsyncSubscribeAll(ClientID::Nil(), subscribe, done);
 }
 
-Status RedisRawActorInfoAccessor::AsyncSubscribe(
+Status RedisNewActorInfoAccessor::AsyncSubscribe(
     const ActorID &actor_id, const SubscribeCallback<ActorID, ActorTableData> &subscribe,
     const StatusCallback &done) {
   RAY_CHECK(subscribe != nullptr);
   return raw_actor_sub_executor_.AsyncSubscribe(subscribe_id_, actor_id, subscribe, done);
 }
 
-Status RedisRawActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
+Status RedisNewActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id,
                                                    const StatusCallback &done) {
   return raw_actor_sub_executor_.AsyncUnsubscribe(subscribe_id_, actor_id, done);
 }

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -70,8 +70,7 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
 
  protected:
   virtual std::vector<ActorID> GetAllActorID() const;
-  virtual Status GetActorData(const ActorID &actor_id,
-                              ActorTableData *actor_table_data) const;
+  virtual Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const;
 
  private:
   /// Add checkpoint id to GCS asynchronously.
@@ -129,8 +128,7 @@ class RedisRawActorInfoAccessor : public RedisActorInfoAccessor {
 
  protected:
   std::vector<ActorID> GetAllActorID() const override;
-  Status GetActorData(const ActorID &actor_id,
-                      ActorTableData *actor_table_data) const override;
+  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const override;
 
  private:
   typedef SubscriptionExecutor<ActorID, ActorTableData, RawActorTable>

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -98,14 +98,14 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
   ActorSubscriptionExecutor actor_sub_executor_;
 };
 
-/// \class RedisRawActorInfoAccessor
-/// `RedisRawActorInfoAccessor` is an implementation of `ActorInfoAccessor`
+/// \class RedisNewActorInfoAccessor
+/// `RedisNewActorInfoAccessor` is an implementation of `ActorInfoAccessor`
 /// that uses Redis as the backend storage.
-class RedisRawActorInfoAccessor : public RedisActorInfoAccessor {
+class RedisNewActorInfoAccessor : public RedisActorInfoAccessor {
  public:
-  explicit RedisRawActorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisNewActorInfoAccessor(RedisGcsClient *client_impl);
 
-  virtual ~RedisRawActorInfoAccessor() {}
+  virtual ~RedisNewActorInfoAccessor() {}
 
   Status AsyncGet(const ActorID &actor_id,
                   const OptionalItemCallback<ActorTableData> &callback) override;
@@ -131,7 +131,7 @@ class RedisRawActorInfoAccessor : public RedisActorInfoAccessor {
   Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const override;
 
  private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, RawActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>
       ActorSubscriptionExecutor;
   ActorSubscriptionExecutor raw_actor_sub_executor_;
 };

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -93,9 +93,9 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
   ClientID subscribe_id_{ClientID::FromRandom()};
 
  private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, LogBasedActorTable>
       ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor actor_sub_executor_;
+  ActorSubscriptionExecutor log_based_actor_sub_executor_;
 };
 
 /// \class RedisNewActorInfoAccessor
@@ -131,9 +131,9 @@ class RedisNewActorInfoAccessor : public RedisActorInfoAccessor {
   Status Get(const ActorID &actor_id, ActorTableData *actor_table_data) const override;
 
  private:
-  typedef SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>
+  typedef SubscriptionExecutor<ActorID, ActorTableData, ActorTable>
       ActorSubscriptionExecutor;
-  ActorSubscriptionExecutor raw_actor_sub_executor_;
+  ActorSubscriptionExecutor actor_sub_executor_;
 };
 
 /// \class RedisJobInfoAccessor

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -27,14 +27,14 @@ namespace gcs {
 
 class RedisGcsClient;
 
-/// \class RedisActorInfoAccessor
-/// `RedisActorInfoAccessor` is an implementation of `ActorInfoAccessor`
+/// \class RedisLogBasedActorInfoAccessor
+/// `RedisLogBasedActorInfoAccessor` is an implementation of `ActorInfoAccessor`
 /// that uses Redis as the backend storage.
-class RedisActorInfoAccessor : public ActorInfoAccessor {
+class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
  public:
-  explicit RedisActorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisLogBasedActorInfoAccessor(RedisGcsClient *client_impl);
 
-  virtual ~RedisActorInfoAccessor() {}
+  virtual ~RedisLogBasedActorInfoAccessor() {}
 
   Status GetAll(std::vector<ActorTableData> *actor_table_data_list) override;
 
@@ -98,14 +98,14 @@ class RedisActorInfoAccessor : public ActorInfoAccessor {
   ActorSubscriptionExecutor log_based_actor_sub_executor_;
 };
 
-/// \class RedisNewActorInfoAccessor
-/// `RedisNewActorInfoAccessor` is an implementation of `ActorInfoAccessor`
+/// \class RedisActorInfoAccessor
+/// `RedisActorInfoAccessor` is an implementation of `ActorInfoAccessor`
 /// that uses Redis as the backend storage.
-class RedisNewActorInfoAccessor : public RedisActorInfoAccessor {
+class RedisActorInfoAccessor : public RedisLogBasedActorInfoAccessor {
  public:
-  explicit RedisNewActorInfoAccessor(RedisGcsClient *client_impl);
+  explicit RedisActorInfoAccessor(RedisGcsClient *client_impl);
 
-  virtual ~RedisNewActorInfoAccessor() {}
+  virtual ~RedisActorInfoAccessor() {}
 
   Status AsyncGet(const ActorID &actor_id,
                   const OptionalItemCallback<ActorTableData> &callback) override;

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -297,9 +297,9 @@ std::unique_ptr<CallbackReply> RedisContext::RunArgvSync(
     RAY_LOG(ERROR) << "Failed to send redis command (sync).";
     return nullptr;
   }
-  auto callback_reply = new CallbackReply(redis_reply);
+  std::unique_ptr<CallbackReply> callback_reply(new CallbackReply(redis_reply));
   freeReplyObject(redis_reply);
-  return std::unique_ptr<CallbackReply>(callback_reply);
+  return callback_reply;
 }
 
 Status RedisContext::RunArgvAsync(const std::vector<std::string> &args) {

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -80,10 +80,11 @@ class CallbackReply {
   /// Reply data if reply_type_ is REDIS_REPLY_STATUS.
   Status status_reply_;
 
-  /// Reply data if reply_type_ is REDIS_REPLY_STRING or REDIS_REPLY_ARRAY.
-  /// Note that REDIS_REPLY_ARRAY is only used for pub-sub data.
+  /// Reply data if reply_type_ is REDIS_REPLY_STRING.
   std::string string_reply_;
 
+  /// Reply data if reply_type_ is REDIS_REPLY_ARRAY.
+  /// Note this is used when get actor table data.
   std::vector<std::string> string_array_reply_;
 };
 

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -62,10 +62,13 @@ class CallbackReply {
   ///
   /// Note that this will return an empty string if
   /// the type of this reply is `nil` or `status`.
-  std::string ReadAsString() const;
+  const std::string &ReadAsString() const;
 
   /// Read this reply data as pub-sub data.
-  std::string ReadAsPubsubData() const;
+  const std::string &ReadAsPubsubData() const;
+
+  /// Read this reply data as a string array.
+  const std::vector<std::string> &ReadAsStringArray() const;
 
  private:
   /// Flag indicating the type of reply this represents.
@@ -80,6 +83,8 @@ class CallbackReply {
   /// Reply data if reply_type_ is REDIS_REPLY_STRING or REDIS_REPLY_ARRAY.
   /// Note that REDIS_REPLY_ARRAY is only used for pub-sub data.
   std::string string_reply_;
+
+  std::vector<std::string> string_array_reply_;
 };
 
 /// Every callback should take in a vector of the results from the Redis
@@ -167,6 +172,12 @@ class RedisContext {
                                          const TablePrefix prefix,
                                          const TablePubsub pubsub_channel,
                                          int log_length = -1);
+
+  /// Run an arbitrary Redis command synchronously.
+  ///
+  /// \param args The vector of command args to pass to Redis.
+  /// \return CallbackReply(The reply from redis).
+  std::unique_ptr<CallbackReply> RunArgvSync(const std::vector<std::string> &args);
 
   /// Run an operation on some table key.
   ///

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -157,11 +157,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   resource_table_.reset(new DynamicResourceTable({primary_context_}, this));
   worker_failure_table_.reset(new WorkerFailureTable(shard_contexts_, this));
 
-  if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
-    actor_accessor_.reset(new RedisActorInfoAccessor(this));
-  } else {
-    actor_accessor_.reset(new RedisLogBasedActorInfoAccessor(this));
-  }
+  actor_accessor_.reset(new RedisLogBasedActorInfoAccessor(this));
   job_accessor_.reset(new RedisJobInfoAccessor(this));
   object_accessor_.reset(new RedisObjectInfoAccessor(this));
   node_accessor_.reset(new RedisNodeInfoAccessor(this));

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -133,8 +133,8 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
 
   Attach(io_service);
 
+  log_based_actor_table_.reset(new LogBasedActorTable({primary_context_}, this));
   actor_table_.reset(new ActorTable({primary_context_}, this));
-  raw_actor_table_.reset(new NewActorTable({primary_context_}, this));
 
   // TODO(micafan) Modify ClientTable' Constructor(remove ClientID) in future.
   // We will use NodeID instead of ClientID.
@@ -203,8 +203,8 @@ std::string RedisGcsClient::DebugString() const {
   std::stringstream result;
   result << "RedisGcsClient:";
   result << "\n- TaskTable: " << raylet_task_table_->DebugString();
+  result << "\n- LogBasedActorTable: " << log_based_actor_table_->DebugString();
   result << "\n- ActorTable: " << actor_table_->DebugString();
-  result << "\n- NewActorTable: " << raw_actor_table_->DebugString();
   result << "\n- TaskReconstructionLog: " << task_reconstruction_log_->DebugString();
   result << "\n- TaskLeaseTable: " << task_lease_table_->DebugString();
   result << "\n- HeartbeatTable: " << heartbeat_table_->DebugString();
@@ -219,9 +219,11 @@ ObjectTable &RedisGcsClient::object_table() { return *object_table_; }
 
 raylet::TaskTable &RedisGcsClient::raylet_task_table() { return *raylet_task_table_; }
 
-ActorTable &RedisGcsClient::actor_table() { return *actor_table_; }
+LogBasedActorTable &RedisGcsClient::log_based_actor_table() {
+  return *log_based_actor_table_;
+}
 
-NewActorTable &RedisGcsClient::raw_actor_table() { return *raw_actor_table_; }
+ActorTable &RedisGcsClient::actor_table() { return *actor_table_; }
 
 WorkerFailureTable &RedisGcsClient::worker_failure_table() {
   return *worker_failure_table_;

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -134,7 +134,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   Attach(io_service);
 
   actor_table_.reset(new ActorTable({primary_context_}, this));
-  raw_actor_table_.reset(new RawActorTable({primary_context_}, this));
+  raw_actor_table_.reset(new NewActorTable({primary_context_}, this));
 
   // TODO(micafan) Modify ClientTable' Constructor(remove ClientID) in future.
   // We will use NodeID instead of ClientID.
@@ -158,7 +158,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   worker_failure_table_.reset(new WorkerFailureTable(shard_contexts_, this));
 
   if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
-    actor_accessor_.reset(new RedisRawActorInfoAccessor(this));
+    actor_accessor_.reset(new RedisNewActorInfoAccessor(this));
   } else {
     actor_accessor_.reset(new RedisActorInfoAccessor(this));
   }
@@ -204,7 +204,7 @@ std::string RedisGcsClient::DebugString() const {
   result << "RedisGcsClient:";
   result << "\n- TaskTable: " << raylet_task_table_->DebugString();
   result << "\n- ActorTable: " << actor_table_->DebugString();
-  result << "\n- RawActorTable: " << raw_actor_table_->DebugString();
+  result << "\n- NewActorTable: " << raw_actor_table_->DebugString();
   result << "\n- TaskReconstructionLog: " << task_reconstruction_log_->DebugString();
   result << "\n- TaskLeaseTable: " << task_lease_table_->DebugString();
   result << "\n- HeartbeatTable: " << heartbeat_table_->DebugString();
@@ -221,7 +221,7 @@ raylet::TaskTable &RedisGcsClient::raylet_task_table() { return *raylet_task_tab
 
 ActorTable &RedisGcsClient::actor_table() { return *actor_table_; }
 
-RawActorTable &RedisGcsClient::raw_actor_table() { return *raw_actor_table_; }
+NewActorTable &RedisGcsClient::raw_actor_table() { return *raw_actor_table_; }
 
 WorkerFailureTable &RedisGcsClient::worker_failure_table() {
   return *worker_failure_table_;

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -134,6 +134,7 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   Attach(io_service);
 
   actor_table_.reset(new ActorTable({primary_context_}, this));
+  raw_actor_table_.reset(new RawActorTable({primary_context_}, this));
 
   // TODO(micafan) Modify ClientTable' Constructor(remove ClientID) in future.
   // We will use NodeID instead of ClientID.
@@ -156,7 +157,11 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   resource_table_.reset(new DynamicResourceTable({primary_context_}, this));
   worker_failure_table_.reset(new WorkerFailureTable(shard_contexts_, this));
 
-  actor_accessor_.reset(new RedisActorInfoAccessor(this));
+  if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
+    actor_accessor_.reset(new RedisRawActorInfoAccessor(this));
+  } else {
+    actor_accessor_.reset(new RedisActorInfoAccessor(this));
+  }
   job_accessor_.reset(new RedisJobInfoAccessor(this));
   object_accessor_.reset(new RedisObjectInfoAccessor(this));
   node_accessor_.reset(new RedisNodeInfoAccessor(this));
@@ -199,6 +204,7 @@ std::string RedisGcsClient::DebugString() const {
   result << "RedisGcsClient:";
   result << "\n- TaskTable: " << raylet_task_table_->DebugString();
   result << "\n- ActorTable: " << actor_table_->DebugString();
+  result << "\n- RawActorTable: " << raw_actor_table_->DebugString();
   result << "\n- TaskReconstructionLog: " << task_reconstruction_log_->DebugString();
   result << "\n- TaskLeaseTable: " << task_lease_table_->DebugString();
   result << "\n- HeartbeatTable: " << heartbeat_table_->DebugString();
@@ -214,6 +220,8 @@ ObjectTable &RedisGcsClient::object_table() { return *object_table_; }
 raylet::TaskTable &RedisGcsClient::raylet_task_table() { return *raylet_task_table_; }
 
 ActorTable &RedisGcsClient::actor_table() { return *actor_table_; }
+
+RawActorTable &RedisGcsClient::raw_actor_table() { return *raw_actor_table_; }
 
 WorkerFailureTable &RedisGcsClient::worker_failure_table() {
   return *worker_failure_table_;

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -158,9 +158,9 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   worker_failure_table_.reset(new WorkerFailureTable(shard_contexts_, this));
 
   if (getenv("RAY_GCS_SERVICE_ACTOR_MANAGEMENT_ENABLED") != nullptr) {
-    actor_accessor_.reset(new RedisNewActorInfoAccessor(this));
-  } else {
     actor_accessor_.reset(new RedisActorInfoAccessor(this));
+  } else {
+    actor_accessor_.reset(new RedisLogBasedActorInfoAccessor(this));
   }
   job_accessor_.reset(new RedisJobInfoAccessor(this));
   object_accessor_.reset(new RedisObjectInfoAccessor(this));

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -79,6 +79,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   /// The following xxx_table methods implement the Accessor interfaces.
   /// Implements the Actors() interface.
   ActorTable &actor_table();
+  RawActorTable &raw_actor_table();
   ActorCheckpointTable &actor_checkpoint_table();
   ActorCheckpointIdTable &actor_checkpoint_id_table();
   /// Implements the Jobs() interface.
@@ -114,6 +115,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   std::unique_ptr<ObjectTable> object_table_;
   std::unique_ptr<raylet::TaskTable> raylet_task_table_;
   std::unique_ptr<ActorTable> actor_table_;
+  std::unique_ptr<RawActorTable> raw_actor_table_;
   std::unique_ptr<TaskReconstructionLog> task_reconstruction_log_;
   std::unique_ptr<TaskLeaseTable> task_lease_table_;
   std::unique_ptr<HeartbeatTable> heartbeat_table_;

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -78,8 +78,8 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
 
   /// The following xxx_table methods implement the Accessor interfaces.
   /// Implements the Actors() interface.
+  LogBasedActorTable &log_based_actor_table();
   ActorTable &actor_table();
-  NewActorTable &raw_actor_table();
   ActorCheckpointTable &actor_checkpoint_table();
   ActorCheckpointIdTable &actor_checkpoint_id_table();
   /// Implements the Jobs() interface.
@@ -114,8 +114,8 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
 
   std::unique_ptr<ObjectTable> object_table_;
   std::unique_ptr<raylet::TaskTable> raylet_task_table_;
+  std::unique_ptr<LogBasedActorTable> log_based_actor_table_;
   std::unique_ptr<ActorTable> actor_table_;
-  std::unique_ptr<NewActorTable> raw_actor_table_;
   std::unique_ptr<TaskReconstructionLog> task_reconstruction_log_;
   std::unique_ptr<TaskLeaseTable> task_lease_table_;
   std::unique_ptr<HeartbeatTable> heartbeat_table_;

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -79,7 +79,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   /// The following xxx_table methods implement the Accessor interfaces.
   /// Implements the Actors() interface.
   ActorTable &actor_table();
-  RawActorTable &raw_actor_table();
+  NewActorTable &raw_actor_table();
   ActorCheckpointTable &actor_checkpoint_table();
   ActorCheckpointIdTable &actor_checkpoint_id_table();
   /// Implements the Jobs() interface.
@@ -115,7 +115,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   std::unique_ptr<ObjectTable> object_table_;
   std::unique_ptr<raylet::TaskTable> raylet_task_table_;
   std::unique_ptr<ActorTable> actor_table_;
-  std::unique_ptr<RawActorTable> raw_actor_table_;
+  std::unique_ptr<NewActorTable> raw_actor_table_;
   std::unique_ptr<TaskReconstructionLog> task_reconstruction_log_;
   std::unique_ptr<TaskLeaseTable> task_lease_table_;
   std::unique_ptr<HeartbeatTable> heartbeat_table_;

--- a/src/ray/gcs/subscription_executor.cc
+++ b/src/ray/gcs/subscription_executor.cc
@@ -199,7 +199,7 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncUnsubscribe(
 }
 
 template class SubscriptionExecutor<ActorID, ActorTableData, ActorTable>;
-template class SubscriptionExecutor<ActorID, ActorTableData, RawActorTable>;
+template class SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>;
 template class SubscriptionExecutor<JobID, JobTableData, JobTable>;
 template class SubscriptionExecutor<TaskID, TaskTableData, raylet::TaskTable>;
 template class SubscriptionExecutor<ObjectID, ObjectChangeNotification, ObjectTable>;

--- a/src/ray/gcs/subscription_executor.cc
+++ b/src/ray/gcs/subscription_executor.cc
@@ -199,6 +199,7 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncUnsubscribe(
 }
 
 template class SubscriptionExecutor<ActorID, ActorTableData, ActorTable>;
+template class SubscriptionExecutor<ActorID, ActorTableData, RawActorTable>;
 template class SubscriptionExecutor<JobID, JobTableData, JobTable>;
 template class SubscriptionExecutor<TaskID, TaskTableData, raylet::TaskTable>;
 template class SubscriptionExecutor<ObjectID, ObjectChangeNotification, ObjectTable>;

--- a/src/ray/gcs/subscription_executor.cc
+++ b/src/ray/gcs/subscription_executor.cc
@@ -198,8 +198,8 @@ Status SubscriptionExecutor<ID, Data, Table>::AsyncUnsubscribe(
   return table_.CancelNotifications(JobID::Nil(), id, client_id, on_done);
 }
 
+template class SubscriptionExecutor<ActorID, ActorTableData, LogBasedActorTable>;
 template class SubscriptionExecutor<ActorID, ActorTableData, ActorTable>;
-template class SubscriptionExecutor<ActorID, ActorTableData, NewActorTable>;
 template class SubscriptionExecutor<JobID, JobTableData, JobTable>;
 template class SubscriptionExecutor<TaskID, TaskTableData, raylet::TaskTable>;
 template class SubscriptionExecutor<ObjectID, ObjectChangeNotification, ObjectTable>;

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -746,6 +746,81 @@ Status TaskLeaseTable::Subscribe(const JobID &job_id, const ClientID &client_id,
   return Table<TaskID, TaskLeaseData>::Subscribe(job_id, client_id, on_subscribe, done);
 }
 
+std::vector<ActorID> SyncGetAllActorID(redisContext *redis_context,
+                                       const std::string &table_prefix) {
+  std::vector<ActorID> actor_id_list;
+  size_t cursor = 0;
+  do {
+    auto r = redisCommand(redis_context, "SCAN %d match %s* count 100", cursor,
+                          table_prefix.c_str());
+    auto reply = reinterpret_cast<redisReply *>(r);
+    RAY_CHECK(reply != nullptr && reply->type == REDIS_REPLY_ARRAY);
+    RAY_CHECK(reply->elements == 2);
+
+    // current cursor
+    redisReply *cursor_reply = reply->element[0];
+    RAY_CHECK(cursor_reply != nullptr && cursor_reply->type == REDIS_REPLY_STRING);
+    cursor = std::stoi(std::string(cursor_reply->str, cursor_reply->len));
+
+    // actor ids
+    redisReply *array_reply = reply->element[1];
+    RAY_CHECK(array_reply != nullptr && array_reply->type == REDIS_REPLY_ARRAY);
+    for (size_t i = 0; i < array_reply->elements; ++i) {
+      redisReply *id_reply = array_reply->element[i];
+      RAY_CHECK(id_reply != nullptr && id_reply->type == REDIS_REPLY_STRING);
+      auto id_with_prefix = std::string(id_reply->str, id_reply->len);
+      // The key of actor_checkpoint table and actor_checkpoint_id table have the same
+      // prefix of `ACTOR`, so we should check the length of the key to filter them.
+      if (id_with_prefix.size() == table_prefix.size() + ActorID::Size()) {
+        auto id = ActorID::FromBinary(id_with_prefix.substr(table_prefix.size()));
+        actor_id_list.emplace_back(id);
+      }
+    }
+  } while (cursor != 0);
+  return actor_id_list;
+}
+
+std::vector<ActorID> ActorTable::GetAllActorID() {
+  auto redis_context = client_->primary_context()->sync_context();
+  return SyncGetAllActorID(redis_context, TablePrefix_Name(prefix_));
+}
+
+Status ActorTable::Get(const ray::ActorID &actor_id,
+                       ray::rpc::ActorTableData *actor_table_data) {
+  RAY_CHECK(actor_table_data != nullptr);
+  auto key = TablePrefix_Name(prefix_) + actor_id.Binary();
+  auto reply = GetRedisContext(actor_id)->RunArgvSync({"LRANGE", key, "-1", "-1"});
+  if (!reply || reply->IsNil()) {
+    return Status::IOError("Failed to get actor data by actor_id " + actor_id.Hex());
+  }
+
+  const auto &data_list = reply->ReadAsStringArray();
+  if (data_list.empty()) {
+    return Status::IOError("Failed to get actor data by actor_id " + actor_id.Hex());
+  }
+
+  RAY_CHECK(data_list.size() == 1);
+  actor_table_data->ParseFromString(data_list.front());
+  return Status::OK();
+}
+
+std::vector<ActorID> RawActorTable::GetAllActorID() {
+  auto redis_context = client_->primary_context()->sync_context();
+  return SyncGetAllActorID(redis_context, TablePrefix_Name(prefix_));
+}
+
+Status RawActorTable::Get(const ray::ActorID &actor_id,
+                          ray::rpc::ActorTableData *actor_table_data) {
+  RAY_CHECK(actor_table_data != nullptr);
+  auto key = TablePrefix_Name(prefix_) + actor_id.Binary();
+  auto reply = GetRedisContext(actor_id)->RunArgvSync({"GET", key});
+  if (!reply || reply->IsNil()) {
+    return Status::IOError("Failed to get actor data by actor_id " + actor_id.Hex());
+  }
+  actor_table_data->ParseFromString(reply->ReadAsString());
+  return Status::OK();
+}
+
 Status ActorCheckpointIdTable::AddCheckpointId(const JobID &job_id,
                                                const ActorID &actor_id,
                                                const ActorCheckpointID &checkpoint_id,
@@ -795,6 +870,7 @@ template class Log<UniqueID, ProfileTableData>;
 template class Table<ActorCheckpointID, ActorCheckpointData>;
 template class Table<ActorID, ActorCheckpointIdData>;
 template class Table<WorkerID, WorkerFailureData>;
+template class Table<ActorID, ActorTableData>;
 
 template class Log<ClientID, ResourceTableData>;
 template class Hash<ClientID, ResourceTableData>;

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -783,13 +783,13 @@ std::vector<ActorID> SyncGetAllActorID(redisContext *redis_context,
   return actor_id_list;
 }
 
-std::vector<ActorID> ActorTable::GetAllActorID() {
+std::vector<ActorID> LogBasedActorTable::GetAllActorID() {
   auto redis_context = client_->primary_context()->sync_context();
   return SyncGetAllActorID(redis_context, TablePrefix_Name(prefix_));
 }
 
-Status ActorTable::Get(const ray::ActorID &actor_id,
-                       ray::rpc::ActorTableData *actor_table_data) {
+Status LogBasedActorTable::Get(const ray::ActorID &actor_id,
+                               ray::rpc::ActorTableData *actor_table_data) {
   RAY_CHECK(actor_table_data != nullptr);
   auto key = TablePrefix_Name(prefix_) + actor_id.Binary();
   auto reply = GetRedisContext(actor_id)->RunArgvSync({"LRANGE", key, "-1", "-1"});
@@ -807,13 +807,13 @@ Status ActorTable::Get(const ray::ActorID &actor_id,
   return Status::OK();
 }
 
-std::vector<ActorID> NewActorTable::GetAllActorID() {
+std::vector<ActorID> ActorTable::GetAllActorID() {
   auto redis_context = client_->primary_context()->sync_context();
   return SyncGetAllActorID(redis_context, TablePrefix_Name(prefix_));
 }
 
-Status NewActorTable::Get(const ray::ActorID &actor_id,
-                          ray::rpc::ActorTableData *actor_table_data) {
+Status ActorTable::Get(const ray::ActorID &actor_id,
+                       ray::rpc::ActorTableData *actor_table_data) {
   RAY_CHECK(actor_table_data != nullptr);
   auto key = TablePrefix_Name(prefix_) + actor_id.Binary();
   auto reply = GetRedisContext(actor_id)->RunArgvSync({"GET", key});

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -807,12 +807,12 @@ Status ActorTable::Get(const ray::ActorID &actor_id,
   return Status::OK();
 }
 
-std::vector<ActorID> RawActorTable::GetAllActorID() {
+std::vector<ActorID> NewActorTable::GetAllActorID() {
   auto redis_context = client_->primary_context()->sync_context();
   return SyncGetAllActorID(redis_context, TablePrefix_Name(prefix_));
 }
 
-Status RawActorTable::Get(const ray::ActorID &actor_id,
+Status NewActorTable::Get(const ray::ActorID &actor_id,
                           ray::rpc::ActorTableData *actor_table_data) {
   RAY_CHECK(actor_table_data != nullptr);
   auto key = TablePrefix_Name(prefix_) + actor_id.Binary();

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -729,6 +729,29 @@ class ActorTable : public Log<ActorID, ActorTableData> {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
     prefix_ = TablePrefix::ACTOR;
   }
+
+  /// Get all actor id synchronously.
+  std::vector<ActorID> GetAllActorID();
+
+  /// Get actor table data by actor id synchronously.
+  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
+};
+
+/// Raw actor table.
+class RawActorTable : public Table<ActorID, ActorTableData> {
+ public:
+  RawActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
+                RedisGcsClient *client)
+      : Table(contexts, client) {
+    pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
+    prefix_ = TablePrefix::ACTOR;
+  }
+
+  /// Get all actor id synchronously.
+  std::vector<ActorID> GetAllActorID();
+
+  /// Get actor table data by actor id synchronously.
+  Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
 };
 
 class WorkerFailureTable : public Table<WorkerID, WorkerFailureData> {

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -716,15 +716,15 @@ class JobTable : public Log<JobID, JobTableData> {
   virtual ~JobTable() {}
 };
 
-/// Actor table starts with an ALIVE entry, which represents the first time the actor
-/// is created. This may be followed by 0 or more pairs of RECONSTRUCTING, ALIVE entries,
-/// which represent each time the actor fails (RECONSTRUCTING) and gets recreated (ALIVE).
-/// These may be followed by a DEAD entry, which means that the actor has failed and will
-/// not be reconstructed.
-class ActorTable : public Log<ActorID, ActorTableData> {
+/// Log-based Actor table starts with an ALIVE entry, which represents the first time the
+/// actor is created. This may be followed by 0 or more pairs of RECONSTRUCTING, ALIVE
+/// entries, which represent each time the actor fails (RECONSTRUCTING) and gets recreated
+/// (ALIVE). These may be followed by a DEAD entry, which means that the actor has failed
+/// and will not be reconstructed.
+class LogBasedActorTable : public Log<ActorID, ActorTableData> {
  public:
-  ActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-             RedisGcsClient *client)
+  LogBasedActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
+                     RedisGcsClient *client)
       : Log(contexts, client) {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
     prefix_ = TablePrefix::ACTOR;
@@ -737,13 +737,13 @@ class ActorTable : public Log<ActorID, ActorTableData> {
   Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
 };
 
-/// New actor table.
+/// Actor table.
 /// This table is only used for GCS-based actor management. And when completely migrate to
-/// GCS service, the old actor table could be removed.
-class NewActorTable : public Table<ActorID, ActorTableData> {
+/// GCS service, the log-based actor table could be removed.
+class ActorTable : public Table<ActorID, ActorTableData> {
  public:
-  NewActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
-                RedisGcsClient *client)
+  ActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
+             RedisGcsClient *client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;
     prefix_ = TablePrefix::ACTOR;

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -738,6 +738,8 @@ class ActorTable : public Log<ActorID, ActorTableData> {
 };
 
 /// Raw actor table.
+/// This table is only used for GCS-based actor management. And when completely migrate to
+/// GCS service, the old actor table could be removed.
 class RawActorTable : public Table<ActorID, ActorTableData> {
  public:
   RawActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -737,12 +737,12 @@ class ActorTable : public Log<ActorID, ActorTableData> {
   Status Get(const ActorID &actor_id, ActorTableData *actor_table_data);
 };
 
-/// Raw actor table.
+/// New actor table.
 /// This table is only used for GCS-based actor management. And when completely migrate to
 /// GCS service, the old actor table could be removed.
-class RawActorTable : public Table<ActorID, ActorTableData> {
+class NewActorTable : public Table<ActorID, ActorTableData> {
  public:
-  RawActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
+  NewActorTable(const std::vector<std::shared_ptr<RedisContext>> &contexts,
                 RedisGcsClient *client)
       : Table(contexts, client) {
     pubsub_channel_ = TablePubsub::ACTOR_PUBSUB;

--- a/src/ray/gcs/test/redis_actor_info_accessor_test.cc
+++ b/src/ray/gcs/test/redis_actor_info_accessor_test.cc
@@ -79,7 +79,7 @@ TEST_F(ActorInfoAccessorTest, RegisterAndGet) {
 
   WaitPendingDone(wait_pending_timeout_);
 
-  // get
+  // async get
   for (const auto &elem : id_to_data_) {
     ++pending_count_;
     RAY_CHECK_OK(actor_accessor.AsyncGet(
@@ -93,6 +93,15 @@ TEST_F(ActorInfoAccessorTest, RegisterAndGet) {
   }
 
   WaitPendingDone(wait_pending_timeout_);
+
+  // sync get
+  std::vector<ActorTableData> actor_table_data_list;
+  RAY_CHECK_OK(actor_accessor.GetAll(&actor_table_data_list));
+  ASSERT_EQ(id_to_data_.size(), actor_table_data_list.size());
+  for (auto &data : actor_table_data_list) {
+    ActorID actor_id = ActorID::FromBinary(data.actor_id());
+    ASSERT_TRUE(id_to_data_.count(actor_id) != 0);
+  }
 }
 
 TEST_F(ActorInfoAccessorTest, Subscribe) {

--- a/src/ray/gcs/test/subscription_executor_test.cc
+++ b/src/ray/gcs/test/subscription_executor_test.cc
@@ -31,8 +31,7 @@ class SubscriptionExecutorTest : public AccessorTestBase<ActorID, ActorTableData
   virtual void SetUp() {
     AccessorTestBase<ActorID, ActorTableData>::SetUp();
 
-    log_based_actor_sub_executor_.reset(
-        new ActorSubExecutor(gcs_client_->log_based_actor_table()));
+    actor_sub_executor_.reset(new ActorSubExecutor(gcs_client_->log_based_actor_table()));
 
     subscribe_ = [this](const ActorID &id, const ActorTableData &data) {
       const auto it = id_to_data_.find(id);
@@ -89,7 +88,7 @@ class SubscriptionExecutorTest : public AccessorTestBase<ActorID, ActorTableData
   }
 
  protected:
-  std::unique_ptr<ActorSubExecutor> log_based_actor_sub_executor_;
+  std::unique_ptr<ActorSubExecutor> actor_sub_executor_;
 
   std::atomic<int> sub_pending_count_{0};
   std::atomic<int> do_sub_pending_count_{0};
@@ -102,14 +101,13 @@ class SubscriptionExecutorTest : public AccessorTestBase<ActorID, ActorTableData
 
 TEST_F(SubscriptionExecutorTest, SubscribeAllTest) {
   ++do_sub_pending_count_;
-  Status status = log_based_actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(),
-                                                                   subscribe_, sub_done_);
+  Status status =
+      actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(), subscribe_, sub_done_);
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   ASSERT_TRUE(status.ok());
   sub_pending_count_ = id_to_data_.size();
   AsyncRegisterActorToGcs();
-  status = log_based_actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(), subscribe_,
-                                                            sub_done_);
+  status = actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(), subscribe_, sub_done_);
   ASSERT_TRUE(status.IsInvalid());
   WaitPendingDone(sub_pending_count_, wait_pending_timeout_);
 }
@@ -118,14 +116,14 @@ TEST_F(SubscriptionExecutorTest, SubscribeOneWithClientIDTest) {
   const auto &item = id_to_data_.begin();
   ++do_sub_pending_count_;
   ++sub_pending_count_;
-  Status status = log_based_actor_sub_executor_->AsyncSubscribe(
-      ClientID::FromRandom(), item->first, subscribe_, sub_done_);
+  Status status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item->first,
+                                                      subscribe_, sub_done_);
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   ASSERT_TRUE(status.ok());
   AsyncRegisterActorToGcs();
   WaitPendingDone(sub_pending_count_, wait_pending_timeout_);
-  status = log_based_actor_sub_executor_->AsyncSubscribe(
-      ClientID::FromRandom(), item->first, subscribe_, sub_done_);
+  status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item->first,
+                                               subscribe_, sub_done_);
   ASSERT_TRUE(status.IsInvalid());
 }
 
@@ -134,25 +132,25 @@ TEST_F(SubscriptionExecutorTest, SubscribeOneAfterActorRegistrationWithClientIDT
   ++do_sub_pending_count_;
   ++sub_pending_count_;
   AsyncRegisterActorToGcs();
-  Status status = log_based_actor_sub_executor_->AsyncSubscribe(
-      ClientID::FromRandom(), item->first, subscribe_, sub_done_);
+  Status status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item->first,
+                                                      subscribe_, sub_done_);
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   ASSERT_TRUE(status.ok());
   WaitPendingDone(sub_pending_count_, wait_pending_timeout_);
-  status = log_based_actor_sub_executor_->AsyncSubscribe(
-      ClientID::FromRandom(), item->first, subscribe_, sub_done_);
+  status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item->first,
+                                               subscribe_, sub_done_);
   ASSERT_TRUE(status.IsInvalid());
 }
 
 TEST_F(SubscriptionExecutorTest, SubscribeAllAndSubscribeOneTest) {
   ++do_sub_pending_count_;
-  Status status = log_based_actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(),
-                                                                   subscribe_, sub_done_);
+  Status status =
+      actor_sub_executor_->AsyncSubscribeAll(ClientID::Nil(), subscribe_, sub_done_);
   ASSERT_TRUE(status.ok());
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   for (const auto &item : id_to_data_) {
-    status = log_based_actor_sub_executor_->AsyncSubscribe(
-        ClientID::FromRandom(), item.first, subscribe_, sub_done_);
+    status = actor_sub_executor_->AsyncSubscribe(ClientID::FromRandom(), item.first,
+                                                 subscribe_, sub_done_);
     ASSERT_FALSE(status.ok());
   }
   sub_pending_count_ = id_to_data_.size();
@@ -164,49 +162,45 @@ TEST_F(SubscriptionExecutorTest, UnsubscribeTest) {
   ClientID client_id = ClientID::FromRandom();
   Status status;
   for (const auto &item : id_to_data_) {
-    status = log_based_actor_sub_executor_->AsyncUnsubscribe(client_id, item.first,
-                                                             unsub_done_);
+    status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.IsInvalid());
   }
 
   for (const auto &item : id_to_data_) {
     ++do_sub_pending_count_;
-    status = log_based_actor_sub_executor_->AsyncSubscribe(client_id, item.first,
-                                                           subscribe_, sub_done_);
+    status =
+        actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   for (const auto &item : id_to_data_) {
     ++do_unsub_pending_count_;
-    status = log_based_actor_sub_executor_->AsyncUnsubscribe(client_id, item.first,
-                                                             unsub_done_);
+    status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_unsub_pending_count_, wait_pending_timeout_);
   for (const auto &item : id_to_data_) {
-    status = log_based_actor_sub_executor_->AsyncUnsubscribe(client_id, item.first,
-                                                             unsub_done_);
+    status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(!status.ok());
   }
 
   for (const auto &item : id_to_data_) {
     ++do_sub_pending_count_;
-    status = log_based_actor_sub_executor_->AsyncSubscribe(client_id, item.first,
-                                                           subscribe_, sub_done_);
+    status =
+        actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);
   for (const auto &item : id_to_data_) {
     ++do_unsub_pending_count_;
-    status = log_based_actor_sub_executor_->AsyncUnsubscribe(client_id, item.first,
-                                                             unsub_done_);
+    status = actor_sub_executor_->AsyncUnsubscribe(client_id, item.first, unsub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_unsub_pending_count_, wait_pending_timeout_);
   for (const auto &item : id_to_data_) {
     ++do_sub_pending_count_;
-    status = log_based_actor_sub_executor_->AsyncSubscribe(client_id, item.first,
-                                                           subscribe_, sub_done_);
+    status =
+        actor_sub_executor_->AsyncSubscribe(client_id, item.first, subscribe_, sub_done_);
     ASSERT_TRUE(status.ok());
   }
   WaitPendingDone(do_sub_pending_count_, wait_pending_timeout_);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Because the PR #6763 is quite large, I split it into 2 small PR, this PR is one of them.

The main function of this PR is to add a `RawActorTable` and it's `Accessor`, as well as the `GetAll` interface to get all actor table data synchronously, which is used when GCS Server restart (this logic will show in another PR). 

The difference between RawActorTable and ActorTable is that RawActorTable is inherit from `Table`, while the ActorTable is inherit from `Log` as the new GCS based actor management no longer need to record ActorTableData in form of log.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
