### PR TITLE
fix test_worker_stats

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -240,7 +240,7 @@ def put_object(obj, use_ray_put):
 def wait_until_server_available(address,
                                 timeout_ms=5000,
                                 retry_interval_ms=100):
-    ip_port = address.split(':')
+    ip_port = address.split(":")
     ip = ip_port[0]
     port = int(ip_port[1])
     time_elapsed = 0

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -237,7 +237,8 @@ def put_object(obj, use_ray_put):
         return _put.remote(obj)
 
 
-def wait_until_server_available(address, timeout_ms=1000,
+def wait_until_server_available(address,
+                                timeout_ms=5000,
                                 retry_interval_ms=100):
     ip_port = address.split(':')
     ip = ip_port[0]

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -11,7 +11,8 @@ from ray.core.generated import node_manager_pb2_grpc
 from ray.core.generated import reporter_pb2
 from ray.core.generated import reporter_pb2_grpc
 from ray.test_utils import (RayTestTimeoutException,
-                            wait_until_succeeded_without_exception)
+                            wait_until_succeeded_without_exception,
+                            wait_until_server_available)
 
 import psutil  # We must import psutil after ray because we bundle it with ray.
 
@@ -125,6 +126,8 @@ def test_worker_stats(shutdown_only):
         else:
             return False
 
+    assert (wait_until_server_available(addresses["webui_url"]) is True)
+
     webui_url = addresses["webui_url"]
     webui_url = webui_url.replace("localhost", "http://127.0.0.1")
     for worker in reply.workers_stats:
@@ -184,6 +187,8 @@ def test_raylet_info_endpoint(shutdown_only):
     actor_pid = ray.get(c.getpid.remote())
     c.local_store.remote()
     c.remote_store.remote()
+
+    assert (wait_until_server_available(addresses["webui_url"]) is True)
 
     start_time = time.time()
     while True:
@@ -267,6 +272,7 @@ def test_raylet_infeasible_tasks(shutdown_only):
     ActorRequiringGPU.remote()
 
     def test_infeasible_actor(ray_addresses):
+        assert (wait_until_server_available(addresses["webui_url"]) is True)
         webui_url = ray_addresses["webui_url"].replace("localhost",
                                                        "http://127.0.0.1")
         raylet_info = requests.get(webui_url + "/api/raylet_info").json()
@@ -306,6 +312,7 @@ def test_raylet_pending_tasks(shutdown_only):
     assert parent_actor is not None
 
     def test_pending_actor(ray_addresses):
+        assert (wait_until_server_available(addresses["webui_url"]) is True)
         webui_url = ray_addresses["webui_url"].replace("localhost",
                                                        "http://127.0.0.1")
         raylet_info = requests.get(webui_url + "/api/raylet_info").json()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The http server may be not ready when requests.get, so we need to wait the http server ready before requests.get

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
