### PR TITLE
Remove duplicate jsonschema from setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -180,7 +180,6 @@ requires = [
     "packaging",
     "pytest",
     "pyyaml",
-    "jsonschema",
     "redis>=3.3.2",
     # NOTE: Don't upgrade the version of six! Doing so causes installation
     # problems. See https://github.com/ray-project/ray/issues/4169.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixes a duplication of `jsonschema` in the setup.py `requires` list.  Duplicating setup.py requirements apparently breaks the usage of the Ray Python library within an external Bazel context (see the linked issue.)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #7663 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

The only testing required should be the building and installation of the Python package.  That would probably be overkill too, given that this should be a no-op for all Python packaging considerations except for an external Bazel context, which can't be easily tested until the wheel is built off of master.