### PR TITLE
Deprecate _remote function

### DIFF
--- a/ci/long_running_tests/workloads/many_actor_tasks.py
+++ b/ci/long_running_tests/workloads/many_actor_tasks.py
@@ -46,8 +46,9 @@ class Actor(object):
 
 
 actors = [
-    Actor._remote([], {}, num_cpus=0.1, resources={str(i % num_nodes): 0.1})
-    for i in range(num_nodes * 5)
+    Actor.options(num_cpus=0.1, resources={
+        str(i % num_nodes): 0.1
+    }).remote() for i in range(num_nodes * 5)
 ]
 
 iteration = 0

--- a/ci/long_running_tests/workloads/many_drivers.py
+++ b/ci/long_running_tests/workloads/many_drivers.py
@@ -57,8 +57,8 @@ class Actor(object):
 for _ in range(5):
     for i in range(num_nodes):
         assert (ray.get(
-            f._remote(args=[], kwargs={{}}, resources={{str(i): 1}})) == 1)
-        actor = Actor._remote(args=[], kwargs={{}}, resources={{str(i): 1}})
+            f.options(resources={{str(i): 1}})) == 1).remote()
+        actor = Actor.options(resources={{str(i): 1}}).remote()
         assert ray.get(actor.method.remote()) == 1
 
 print("success")
@@ -73,9 +73,9 @@ def run_driver():
 
 iteration = 0
 running_ids = [
-    run_driver._remote(
-        args=[], kwargs={}, num_cpus=0, resources={str(i): 0.01})
-    for i in range(num_nodes)
+    run_driver.options(num_cpus=0, resources={
+        str(i): 0.01
+    }).remote() for i in range(num_nodes)
 ]
 start_time = time.time()
 previous_time = start_time
@@ -85,11 +85,8 @@ while True:
     ray.get(ready_id)
 
     running_ids.append(
-        run_driver._remote(
-            args=[],
-            kwargs={},
-            num_cpus=0,
-            resources={str(iteration % num_nodes): 0.01}))
+        run_driver.options(
+            num_cpus=0, resources={str(iteration % num_nodes): 0.01})).remote()
 
     new_time = time.time()
     print("Iteration {}:\n"

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -47,8 +47,9 @@ previous_time = start_time
 while True:
     for _ in range(50):
         new_constrained_ids = [
-            f._remote(args=[*ids], resources={str(i % num_nodes): 1})
-            for i in range(25)
+            f.options(resources={
+                str(i % num_nodes): 1
+            }).remote(args=[*ids]) for i in range(25)
         ]
         new_unconstrained_ids = [f.remote(*ids) for _ in range(25)]
         ids = new_constrained_ids + new_unconstrained_ids

--- a/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -69,8 +69,9 @@ previous_time = start_time
 while True:
     for _ in range(50):
         new_constrained_ids = [
-            f._remote(args=ids, resources={str(i % num_nodes): 1})
-            for i in range(25)
+            f.options(resources={
+                str(i % num_nodes): 1
+            }).remote(ids) for i in range(25)
         ]
         new_unconstrained_ids = [f.remote(*ids) for _ in range(25)]
         ids = new_constrained_ids + new_unconstrained_ids
@@ -79,8 +80,9 @@ while True:
     for i in range(num_nodes):
         for _ in range(10):
             [
-                churn._remote(args=[], resources={str(i % num_nodes): 1})
-                for _ in range(10)
+                churn.options(resources={
+                    str(i % num_nodes): 1
+                }).remote() for _ in range(10)
             ]
 
     # Make sure that the objects are still available.

--- a/ci/performance_tests/test_performance.py
+++ b/ci/performance_tests/test_performance.py
@@ -138,7 +138,7 @@ def warm_up_cluster(num_nodes, object_store_memory):
         for i in range(num_nodes):
             for _ in range(num_objects):
                 object_ids += [
-                    create_array._remote(args=[size], resources={str(i): 1})
+                    create_array.options(args=[size], resources={str(i): 1})
                 ]
         size = size // 2
         num_objects = min(num_objects * 2, 1000)
@@ -164,7 +164,7 @@ def run_multiple_trials(f, num_trials):
 def test_tasks(num_nodes):
     def one_thousand_serial_tasks_local_node():
         for _ in range(1000):
-            ray.get(no_op._remote(resources={"0": 1}))
+            ray.get(no_op.options(resources={"0": 1}))
 
     durations = run_multiple_trials(one_thousand_serial_tasks_local_node, 10)
     logger.warning(
@@ -176,7 +176,7 @@ def test_tasks(num_nodes):
 
     def one_thousand_serial_tasks_remote_node():
         for _ in range(1000):
-            ray.get(no_op._remote(resources={"1": 1}))
+            ray.get(no_op.options(resources={"1": 1}))
 
     durations = run_multiple_trials(one_thousand_serial_tasks_remote_node, 10)
     logger.warning(
@@ -187,7 +187,7 @@ def test_tasks(num_nodes):
         np.std(durations))
 
     def ten_thousand_parallel_tasks_local():
-        ray.get([no_op._remote(resources={"0": 1}) for _ in range(10000)])
+        ray.get([no_op.options(resources={"0": 1}) for _ in range(10000)])
 
     durations = run_multiple_trials(ten_thousand_parallel_tasks_local, 5)
     logger.warning(
@@ -199,7 +199,7 @@ def test_tasks(num_nodes):
 
     def ten_thousand_parallel_tasks_load_balanced():
         ray.get([
-            no_op._remote(resources={str(i % num_nodes): 1})
+            no_op.options(resources={str(i % num_nodes): 1})
             for i in range(10000)
         ])
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -109,7 +109,7 @@ class ActorMethod:
                 num_return_vals=None,
                 internal_called=False):
         if not internal_called:
-            deprecation_warning("_remote", new=".options")
+            deprecation_warning("_remote", new="remote")
 
         if num_return_vals is None:
             num_return_vals = self._num_return_vals

--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -160,7 +160,7 @@ def main():
 
     n = 5000
     n_cpu = multiprocessing.cpu_count() // 2
-    actors = [Actor._remote() for _ in range(n_cpu)]
+    actors = [Actor.remote() for _ in range(n_cpu)]
     client = Client.remote(actors)
 
     def actor_async_direct():
@@ -181,7 +181,7 @@ def main():
     timeit("n:n actor calls async", actor_multi2, m * n)
 
     n = 1000
-    actors = [Actor._remote() for _ in range(n_cpu)]
+    actors = [Actor.remote() for _ in range(n_cpu)]
     clients = [Client.remote(a) for a in actors]
 
     def actor_multi2_direct_arg():

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -265,7 +265,7 @@ def create_backend(func_or_class,
         # arg list for a fn is function itself
         arg_list = [func_or_class]
         # ignore lint on lambda expression
-        creator = lambda kwrgs: TaskRunnerActor._remote(**kwrgs)  # noqa: E731
+        creator = lambda kwrgs: TaskRunnerActor.remote(**kwrgs)  # noqa: E731
     elif inspect.isclass(func_or_class):
         # Python inheritance order is right-to-left. We put RayServeMixin
         # on the left to make sure its methods are not overriden.
@@ -278,7 +278,7 @@ def create_backend(func_or_class,
 
         arg_list = actor_init_args
         # ignore lint on lambda expression
-        creator = lambda kwargs: CustomActor._remote(**kwargs)  # noqa: E731
+        creator = lambda kwargs: CustomActor.remote(**kwargs)  # noqa: E731
     else:
         raise TypeError(
             "Backend must be a function or class, it is {}.".format(

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -407,3 +407,11 @@ py_test(
     tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
+
+py_test(
+    name = "test_deprecate_remote",
+    size = "small",
+    srcs = ["test_deprecate_remote.py"],
+    tags = ["exclusive"],
+    deps = ["//:ray_lib"],
+)

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -659,11 +659,11 @@ def test_detached_actor(ray_start_regular):
             return "pong"
 
     with pytest.raises(Exception, match="Detached actors must be named"):
-        DetachedActor._remote(detached=True)
+        DetachedActor.options(detached=True)
 
     with pytest.raises(ValueError, match="Please use a different name"):
-        _ = DetachedActor._remote(name="d_actor")
-        DetachedActor._remote(name="d_actor")
+        _ = DetachedActor.options(name="d_actor")
+        DetachedActor.options(name="d_actor")
 
     redis_address = ray_start_regular["redis_address"]
 
@@ -677,7 +677,7 @@ class DetachedActor:
     def ping(self):
         return "pong"
 
-actor = DetachedActor._remote(name="{}", detached=True)
+actor = DetachedActor.options(name="{}", detached=True)
 ray.get(actor.ping.remote())
 """.format(redis_address, actor_name)
 

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -260,14 +260,17 @@ def test_object_transfer_dump(ray_start_cluster):
 
     # These objects will live on different nodes.
     object_ids = [
-        f._remote(args=[1], resources={str(i): 1}) for i in range(num_nodes)
+        f.options(resources={
+            str(i): 1
+        }).remote(1) for i in range(num_nodes)
     ]
 
     # Broadcast each object from each machine to each other machine.
     for object_id in object_ids:
         ray.get([
-            f._remote(args=[object_id], resources={str(i): 1})
-            for i in range(num_nodes)
+            f.options(resources={
+                str(i): 1
+            }).remote(object_id) for i in range(num_nodes)
         ])
 
     # The profiling information only flushes once every second.

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -288,17 +288,17 @@ def test_fractional_resources(shutdown_only):
             pass
 
     # Create an actor that requires 0.7 of the custom resource.
-    f1 = Foo2._remote([], {}, resources={"Custom": 0.7})
+    f1 = Foo2.options(resources={"Custom": 0.7}).remote()
     ray.get(f1.method.remote())
     # Make sure that we cannot create an actor that requires 0.7 of the
     # custom resource. TODO(rkn): Re-enable this once ray.wait is
     # implemented.
-    f2 = Foo2._remote([], {}, resources={"Custom": 0.7})
+    f2 = Foo2.options(resources={"Custom": 0.7}).remote()
     ready, _ = ray.wait([f2.method.remote()], timeout=0.5)
     assert len(ready) == 0
     # Make sure we can start an actor that requries only 0.3 of the custom
     # resource.
-    f3 = Foo2._remote([], {}, resources={"Custom": 0.3})
+    f3 = Foo2.options(resources={"Custom": 0.3}).remote()
     ray.get(f3.method.remote())
 
     del f1, f3
@@ -314,7 +314,7 @@ def test_fractional_resources(shutdown_only):
         test.remote()
 
     with pytest.raises(ValueError):
-        Foo2._remote([], {}, resources={"Custom": 1.5})
+        Foo2.options(resources={"Custom": 1.5}).remote()
 
 
 def test_multiple_raylets(ray_start_cluster):

--- a/python/ray/tests/test_deprecate_remote.py
+++ b/python/ray/tests/test_deprecate_remote.py
@@ -1,0 +1,61 @@
+import sys
+import pytest
+
+import ray
+
+def test_deprecate_remote_func(capsys):
+    ray.init(num_cpus=1)
+
+    @ray.remote
+    def f(n):
+        return list(range(n))
+
+    # Call options.
+    assert f.options(num_return_vals=0).remote([0]) is None
+    # Verify the warning message not show up when calling the `options` method.
+    captured = capsys.readouterr()
+    assert "DeprecationWarning" not in captured.err
+    assert "Use `.options` instead." not in captured.err
+
+    # Call _remote.
+    id1 = f._remote(args=[1], num_return_vals=1)
+    assert ray.get(id1) == [0]
+    # Verify the warning message showed up when calling the `_remote` method.
+    captured = capsys.readouterr()
+    assert "DeprecationWarning" in captured.err
+    assert "Use `.options` instead." in captured.err
+
+
+def test_deprecate_remote_actor(capsys):
+    @ray.remote
+    class Actor:
+        def __init__(self, x, y=0):
+            self.x = x
+            self.y = y
+
+        def method(self, a, b=0):
+            return self.x, self.y, a, b
+
+        def gpu_ids(self):
+            return ray.get_gpu_ids()
+
+    # Call _remote.
+    a = Actor._remote(
+        args=[0], kwargs={"y": 1}, num_gpus=1, resources={"Custom": 1})
+    # Verify the warning message showed up when calling the `_remote` method.
+    captured = capsys.readouterr()
+    assert "DeprecationWarning" in captured.err
+    assert "Use `.options` instead." in captured.err
+
+    # Call options.
+    a = Actor.options(
+        args=[0], kwargs={"y": 1}, num_gpus=1, resources={"Custom": 1})
+    print(a)
+    # Verify the warning message not show up when calling the `options` method.
+    captured = capsys.readouterr()
+    assert "DeprecationWarning" not in captured.err
+    assert "Use `.options` instead." not in captured.err
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -346,8 +346,9 @@ def test_dynamic_res_concurrent_res_increment(ray_start_cluster):
 
     # Launch the task with resource requirement of 4, thus the new available
     # capacity becomes 1
-    task = wait_func._remote(
-        args=[running_signal, finish_signal], resources={res_name: 4})
+    task = wait_func.options(resources={
+        res_name: 4
+    }).remote(running_signal, finish_signal)
     # Wait until wait_func is launched before updating resource
     ray.get(running_signal.wait.remote())
 
@@ -360,15 +361,17 @@ def test_dynamic_res_concurrent_res_increment(ray_start_cluster):
 
     # Check if scheduler state is consistent by launching a task requiring
     # updated capacity
-    task_2 = test_func._remote(args=[], resources={res_name: updated_capacity})
+    task_2 = test_func.options(resources={
+        res_name: updated_capacity
+    }).remote()
     successful, unsuccessful = ray.wait([task_2], timeout=TIMEOUT_DURATION)
     assert successful  # The task completed
 
     # Check if scheduler state is consistent by launching a task requiring
     # updated capacity + 1. This should not execute
-    task_3 = test_func._remote(
-        args=[], resources={res_name: updated_capacity + 1
-                            })  # This should be infeasible
+    task_3 = test_func.options(resources={
+        res_name: updated_capacity + 1
+    }).remote()  # This should be infeasible
     successful, unsuccessful = ray.wait([task_3], timeout=TIMEOUT_DURATION)
     assert unsuccessful  # The task did not complete because it's infeasible
     assert ray.available_resources()[res_name] == updated_capacity
@@ -432,8 +435,9 @@ def test_dynamic_res_concurrent_res_decrement(ray_start_cluster):
 
     # Launch the task with resource requirement of 4, thus the new available
     # capacity becomes 1
-    task = wait_func._remote(
-        args=[running_signal, finish_signal], resources={res_name: 4})
+    task = wait_func.options(resources={
+        res_name: 4
+    }).remote(running_signal, finish_signal)
     # Wait until wait_func is launched before updating resource
     ray.get(running_signal.wait.remote())
 
@@ -446,15 +450,17 @@ def test_dynamic_res_concurrent_res_decrement(ray_start_cluster):
 
     # Check if scheduler state is consistent by launching a task requiring
     # updated capacity
-    task_2 = test_func._remote(args=[], resources={res_name: updated_capacity})
+    task_2 = test_func.options(resources={
+        res_name: updated_capacity
+    }).remote()
     successful, unsuccessful = ray.wait([task_2], timeout=TIMEOUT_DURATION)
     assert successful  # The task completed
 
     # Check if scheduler state is consistent by launching a task requiring
     # updated capacity + 1. This should not execute
-    task_3 = test_func._remote(
-        args=[], resources={res_name: updated_capacity + 1
-                            })  # This should be infeasible
+    task_3 = test_func.options(resources={
+        res_name: updated_capacity + 1
+    }).remote()  # This should be infeasible
     successful, unsuccessful = ray.wait([task_3], timeout=TIMEOUT_DURATION)
     assert unsuccessful  # The task did not complete because it's infeasible
     assert ray.available_resources()[res_name] == updated_capacity
@@ -521,8 +527,9 @@ def test_dynamic_res_concurrent_res_delete(ray_start_cluster):
 
     # Launch the task with resource requirement of 4, thus the new available
     # capacity becomes 1
-    task = wait_func._remote(
-        args=[running_signal, finish_signal], resources={res_name: 4})
+    task = wait_func.options(resources={
+        res_name: 4
+    }).remote(running_signal, finish_signal)
     # Wait until wait_func is launched before updating resource
     ray.get(running_signal.wait.remote())
 
@@ -535,8 +542,9 @@ def test_dynamic_res_concurrent_res_delete(ray_start_cluster):
 
     # Check if scheduler state is consistent by launching a task requiring
     # the deleted resource  This should not execute
-    task_2 = test_func._remote(
-        args=[], resources={res_name: 1})  # This should be infeasible
+    task_2 = test_func.options(resources={
+        res_name: 1
+    }).remote()  # This should be infeasible
     successful, unsuccessful = ray.wait([task_2], timeout=TIMEOUT_DURATION)
     assert unsuccessful  # The task did not complete because it's infeasible
     assert res_name not in ray.available_resources()

--- a/python/ray/tests/test_memory_limits.py
+++ b/python/ray/tests/test_memory_limits.py
@@ -63,8 +63,8 @@ class TestMemoryLimits(unittest.TestCase):
                 object_store_memory=300 * MB,
                 driver_object_store_memory=driver_quota)
             z = ray.put("hi", weakref=True)
-            a = LightActor._remote(object_store_memory=a_quota)
-            b = GreedyActor._remote(object_store_memory=b_quota)
+            a = LightActor.options(object_store_memory=a_quota).remote()
+            b = GreedyActor.options(object_store_memory=b_quota).remote()
             for _ in range(5):
                 r_a = a.sample.remote()
                 for _ in range(20):

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -693,3 +693,24 @@ def try_to_symlink(symlink_path, target_path):
         os.symlink(target_path, symlink_path)
     except OSError:
         return
+
+
+def deprecation_warning(old, new=None, error=None):
+    """Logs (via the `logger` object) or throws a deprecation warning/error.
+
+    Args:
+        old (str): A description of the "thing" that is to be deprecated.
+        new (Optional[str]): A description of the new "thing" that replaces it.
+        error (Optional[bool,Exception]): Whether or which exception to throw.
+            If True, throw ValueError.
+    """
+    msg = "`{}` has been deprecated.{}".format(
+        old, (" Use `{}` instead.".format(new) if new else ""))
+
+    if error is True:
+        raise ValueError(msg)
+    elif error and issubclass(error, Exception):
+        raise error(msg)
+    else:
+        logger.warning("DeprecationWarning: " + msg +
+                       " This will raise an error in the future!")

--- a/streaming/python/tests/test_direct_transfer.py
+++ b/streaming/python/tests/test_direct_transfer.py
@@ -104,8 +104,8 @@ class Worker:
 
 def test_queue():
     ray.init()
-    writer = Worker._remote(is_direct_call=True)
-    reader = Worker._remote(is_direct_call=True)
+    writer = Worker.remote(is_direct_call=True)
+    reader = Worker.remote(is_direct_call=True)
     channel_id_str = transfer.ChannelID.gen_random_id()
     inits = [
         writer.init_writer.remote(channel_id_str, pickle.dumps(reader)),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Deprecate _remote function.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #7040
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
