### PR TITLE
[tune] Higher timeout for progress reporter test

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -74,7 +74,7 @@ py_test(
 
 py_test(
     name = "test_progress_reporter",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_progress_reporter.py"],
     deps = [":tune_lib"],
 )

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -212,7 +212,6 @@ class ProgressReporterTest(unittest.TestCase):
         print(prog2)
         assert prog2 == EXPECTED_RESULT_2
 
-    @pytest.mark.skip("Very flaky in CI.")
     def testEndToEndReporting(self):
         with tempfile.NamedTemporaryFile(suffix=".py") as f:
             f.write(END_TO_END_COMMAND.encode("utf-8"))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

It seems this just needed a higher timeout.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
