### PR TITLE
Use go1.12 in lint build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,8 +110,8 @@ matrix:
         - python setup.py check --restructuredtext --strict --metadata
         - cd ..
         # Run Bazel linter Buildifier.
-        - wget -q https://dl.google.com/go/go1.11.linux-amd64.tar.gz
-        - tar -xf go1.11.linux-amd64.tar.gz
+        - wget -q https://dl.google.com/go/go1.12.linux-amd64.tar.gz
+        - tar -xf go1.12.linux-amd64.tar.gz
         - mkdir $HOME/go_dir
         - export GOROOT=`pwd`/go
         - export GOPATH="$HOME/go_dir"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Lint is failing on master because one of our dependencies uses `strings.ReplaceAll`, which is introduced in go 1.12.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
