### PR TITLE
[Serve] Add async, multi methods support for serve actors

### DIFF
--- a/python/ray/serve/queues.py
+++ b/python/ray/serve/queues.py
@@ -17,8 +17,12 @@ from ray.serve.utils import logger
 
 
 class Query:
-    def __init__(self, request_args, request_kwargs, request_context,
-                 request_slo_ms):
+    def __init__(self,
+                 request_args,
+                 request_kwargs,
+                 request_context,
+                 request_slo_ms,
+                 backend_method="__call__"):
         self.request_args = request_args
         self.request_kwargs = request_kwargs
         self.request_context = request_context
@@ -28,6 +32,8 @@ class Query:
         # Service level objective in milliseconds. This is expected to be the
         # absolute time since unix epoch.
         self.request_slo_ms = request_slo_ms
+
+        self.backend_method = backend_method
 
     def ray_serialize(self):
         # NOTE: this method is needed because Query need to be serialized and
@@ -175,8 +181,12 @@ class CentralizedQueues:
         else:
             request_slo_ms = request_in_object.adjust_relative_slo_ms()
         request_context = request_in_object.request_context
-        query = Query(request_args, request_kwargs, request_context,
-                      request_slo_ms)
+        query = Query(
+            request_args,
+            request_kwargs,
+            request_context,
+            request_slo_ms,
+            backend_method=request_in_object.call_method)
         await self.service_queues[service].put(query)
         await self.flush()
 

--- a/python/ray/serve/request_params.py
+++ b/python/ray/serve/request_params.py
@@ -19,12 +19,14 @@ class RequestMetadata:
                  service,
                  request_context,
                  relative_slo_ms=None,
-                 absolute_slo_ms=None):
+                 absolute_slo_ms=None,
+                 call_method="__call__"):
 
         self.service = service
         self.request_context = request_context
         self.relative_slo_ms = relative_slo_ms
         self.absolute_slo_ms = absolute_slo_ms
+        self.call_method = call_method
 
     def adjust_relative_slo_ms(self) -> float:
         """Normalize the input latency objective to absoluate timestamp.

--- a/python/ray/serve/task_runner.py
+++ b/python/ray/serve/task_runner.py
@@ -104,7 +104,7 @@ class RayServeMixin:
             self._ray_serve_self_handle)
 
     def _ray_serve_get_runner_method(self, request_item):
-        method_name = request_item.backend_method
+        method_name = request_item.call_method
         if not hasattr(self, method_name):
             raise RayServeException("Backend doesn't have method {} "
                                     "which is specified in the request. "

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -9,7 +9,7 @@ from ray import serve
 def test_new_driver(serve_instance):
     script = """
 import ray
-ray.init(address="auto")
+ray.init(address="{}")
 
 from ray import serve
 serve.init()
@@ -17,7 +17,7 @@ serve.init()
 @serve.route("/driver")
 def driver(flask_request):
     return "OK!"
-"""
+""".format(ray.worker._global_node._redis_address)
 
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         path = f.name

--- a/python/ray/serve/tests/test_task_runner.py
+++ b/python/ray/serve/tests/test_task_runner.py
@@ -175,10 +175,9 @@ async def test_task_runner_custom_method_batch(serve_instance):
         PRODUCER_NAME, context.TaskContext.Python, call_method="b")
 
     futures = [q.enqueue_request.remote(a_query_param) for _ in range(2)]
-    # force batching here
-    runner._ray_serve_fetch.remote()
-
     futures += [q.enqueue_request.remote(b_query_param) for _ in range(2)]
+
+    runner._ray_serve_fetch.remote()
 
     gathered = await asyncio.gather(*futures)
     assert gathered == ["a-0", "a-1", "b-0", "b-1"]

--- a/python/ray/serve/tests/test_task_runner.py
+++ b/python/ray/serve/tests/test_task_runner.py
@@ -1,11 +1,15 @@
+import asyncio
+
 import pytest
 
 import ray
+from ray import serve
 import ray.serve.context as context
 from ray.serve.policy import RoundRobinPolicyQueueActor
 from ray.serve.task_runner import (RayServeMixin, TaskRunner, TaskRunnerActor,
                                    wrap_to_ray_error)
 from ray.serve.request_params import RequestMetadata
+from ray.serve.backend_config import BackendConfig
 
 pytestmark = pytest.mark.asyncio
 
@@ -97,3 +101,84 @@ async def test_task_runner_check_context(serve_instance):
 
     with pytest.raises(ray.exceptions.RayTaskError):
         await result_oid
+
+
+async def test_task_runner_custom_method_single(serve_instance):
+    q = RoundRobinPolicyQueueActor.remote()
+
+    class NonBatcher:
+        def a(self, _):
+            return "a"
+
+        def b(self, _):
+            return "b"
+
+    @ray.remote
+    class CustomActor(NonBatcher, RayServeMixin):
+        pass
+
+    CONSUMER_NAME = "runner"
+    PRODUCER_NAME = "producer"
+
+    runner = CustomActor.remote()
+
+    runner._ray_serve_setup.remote(CONSUMER_NAME, q, runner)
+    runner._ray_serve_fetch.remote()
+
+    q.link.remote(PRODUCER_NAME, CONSUMER_NAME)
+
+    query_param = RequestMetadata(
+        PRODUCER_NAME, context.TaskContext.Python, call_method="a")
+    a_result = await q.enqueue_request.remote(query_param)
+    assert a_result == "a"
+
+    query_param = RequestMetadata(
+        PRODUCER_NAME, context.TaskContext.Python, call_method="b")
+    b_result = await q.enqueue_request.remote(query_param)
+    assert b_result == "b"
+
+    query_param = RequestMetadata(
+        PRODUCER_NAME, context.TaskContext.Python, call_method="non_exist")
+    with pytest.raises(ray.exceptions.RayTaskError):
+        await q.enqueue_request.remote(query_param)
+
+
+async def test_task_runner_custom_method_batch(serve_instance):
+    q = RoundRobinPolicyQueueActor.remote()
+
+    @serve.accept_batch
+    class Batcher:
+        def a(self, _):
+            return ["a-{}".format(i) for i in range(serve.context.batch_size)]
+
+        def b(self, _):
+            return ["b-{}".format(i) for i in range(serve.context.batch_size)]
+
+    @ray.remote
+    class CustomActor(Batcher, RayServeMixin):
+        pass
+
+    CONSUMER_NAME = "runner"
+    PRODUCER_NAME = "producer"
+
+    runner = CustomActor.remote()
+
+    runner._ray_serve_setup.remote(CONSUMER_NAME, q, runner)
+
+    q.link.remote(PRODUCER_NAME, CONSUMER_NAME)
+    q.set_backend_config.remote(
+        CONSUMER_NAME, BackendConfig(max_batch_size=2).__dict__)
+
+    a_query_param = RequestMetadata(
+        PRODUCER_NAME, context.TaskContext.Python, call_method="a")
+    b_query_param = RequestMetadata(
+        PRODUCER_NAME, context.TaskContext.Python, call_method="b")
+
+    futures = [q.enqueue_request.remote(a_query_param) for _ in range(2)]
+    # force batching here
+    runner._ray_serve_fetch.remote()
+
+    futures += [q.enqueue_request.remote(b_query_param) for _ in range(2)]
+
+    gathered = await asyncio.gather(*futures)
+    assert gathered == ["a-0", "a-1", "b-0", "b-1"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR adds the capability for async methods in serve actors as well as preliminary support for multiple methods. 

```python
class MyBackend:
    async __call__(self, flask_request):
        pass

    def other_method(self, _): pass
```

The `other_method` currently can only be invoked internally by constructing `call_method="other_method"` to the query parameter. It is planned for the future to expose this through `serve.route` decorator. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
