### PR TITLE
[Serve] Horizontal Scalability for HTTP (on a single machine)

### DIFF
--- a/python/ray/serve/http_util.py
+++ b/python/ray/serve/http_util.py
@@ -41,9 +41,15 @@ def build_wsgi_environ(scope, body):
     }
 
     # Get server name and port - required in WSGI, not in ASGI
-    environ["SERVER_NAME"] = scope["server"][0]
-    environ["SERVER_PORT"] = str(scope["server"][1])
-    environ["REMOTE_ADDR"] = scope["client"][0]
+    # scope["server"] and scope["client"] can default to None
+    environ["SERVER_NAME"] = ""
+    environ["SERVER_PORT"] = ""
+    environ["REMOTE_ADDR"] = ""
+    if scope["server"]:
+        environ["SERVER_NAME"] = scope["server"][0]
+        environ["SERVER_PORT"] = str(scope["server"][1])
+    if scope["client"]:
+        environ["REMOTE_ADDR"] = scope["client"][0]
 
     # Transforms headers into environ entries.
     for name, value in scope.get("headers", []):

--- a/python/ray/serve/server.py
+++ b/python/ray/serve/server.py
@@ -189,7 +189,7 @@ class HTTPProxy:
 
 
 def run_uvicorn_server(socket: socket.socket):
-    config = uvicorn.Config(HTTPProxy(), lifespan="on", access_log=True)
+    config = uvicorn.Config(HTTPProxy(), lifespan="on", access_log=False)
     server = uvicorn.Server(config=config)
     server.run(sockets=[socket])
 

--- a/python/ray/serve/server.py
+++ b/python/ray/serve/server.py
@@ -9,7 +9,8 @@ import ray
 from ray.experimental.async_api import _async_init
 from ray.serve.constants import HTTP_ROUTER_CHECKER_INTERVAL_S
 from ray.serve.context import TaskContext
-from ray.serve.utils import BytesEncoder, UnixFileDescriptTransport
+from ray.serve.utils import (BytesEncoder, UnixFileDescriptTransport,
+                             ensure_open_files_limit)
 from ray.serve.request_params import RequestMetadata
 
 from urllib.parse import parse_qs
@@ -189,6 +190,10 @@ class HTTPProxy:
 
 
 def run_uvicorn_server(socket: socket.socket):
+    # Make sure we have enough file descriptors
+    # to support concurrent connections.
+    ensure_open_files_limit()
+
     config = uvicorn.Config(HTTPProxy(), lifespan="on", access_log=False)
     server = uvicorn.Server(config=config)
     server.run(sockets=[socket])

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import random
+import resource
 import string
 import time
 import io
@@ -155,3 +156,9 @@ class UnixFileDescriptTransport:
                 cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
         fds = list(fds)
         return fds[0]
+
+
+def ensure_open_files_limit(soft_limit=1024 * 80):
+    _, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    soft = soft_limit if soft_limit <= hard else hard
+    resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -115,7 +115,7 @@ def get_random_letters(length=6):
 
 
 class UnixFileDescriptTransport:
-    """This class faciliate sending file descriptors among processes."""
+    """This class faciliates sending file descriptors among processes."""
 
     def __init__(self, unix_domain_path):
         self.unix_domain_path = unix_domain_path


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR enable ray serve HTTP server to run multiple HTTP workers binding listening on the same port. This enables horizontal scalability for the HTTP component on a single node. The followings are not in scope for this PR:
- Scaling HTTP servers across multiple node (will be done by starting at least one worker on each node)
- Scaling routers, inlining routers, other optimization.

This PR, when combined with horizontal scalability of the router, can improve the QPS.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
