### PR TITLE
[Java] Package binaries of all platforms in one jar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 env:
   DEBIAN_FRONTEND: noninteractive
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   iwyu:
@@ -89,3 +89,103 @@ jobs:
         bazel --batch build \
           --keep_going \
           "//:ray_pkg"  # TODO(mehrdadn): Should be "//:*", but we get a linking error with _streaming.so
+
+  build_jar_on_os_mac_osx:
+    runs-on: macOS-10.14
+#    on:
+#      # Should be changed to on_pull before checkin.
+#      pull_request:
+#        branches:
+#          - master
+    env:
+      PYTHON: 3.6
+      RAY_BUILD_JAVA: "YES"
+      OSS_ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
+      OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+    steps:
+      - name: use checkout@v2 action
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Upload native files
+        run: bash ./java/build_jars/build_and_upload_native_dependencies_with_platform.sh
+
+
+  build_jar_on_os_linux:
+    runs-on: ubuntu-latest
+    #    on:
+    #      # Should be changed to on_pull before checkin.
+    #      pull_request:
+    #        branches:
+    #          - master
+    env:
+      PYTHON: 3.6
+      RAY_BUILD_JAVA: "YES"
+      OSS_ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
+      OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+    steps:
+      - name: use checkout@v2 action
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Upload native files
+        run: bash ./java/build_jars/build_and_upload_native_dependencies_with_platform.sh
+
+  build_all_in_one_jar:
+    runs-on: macOS-10.14
+    #    on:
+    #      # Should be changed to on_pull before checkin.
+    #      pull_request:
+    #        branches:
+    #          - master
+    needs: [build_jar_on_os_mac_osx, build_jar_on_os_linux]
+    env:
+      PYTHON: 3.6
+      RAY_BUILD_JAVA: "YES"
+      OSS_ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
+      OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+    steps:
+      - name: use checkout@v2 action
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Build and upload jars.
+        run: bash ./java/build_jars/build_all_platform_dependencies_into_jar.sh
+#
+#  test_all_in_one_jar_on_os_mac_osx:
+#    runs-on: macOS-10.14
+#    on:
+#      # Should be changed to on_pull before checkin.
+#      pull_request:
+#        branches:
+#          - master
+#    needs: build_all_in_one_jar
+#    steps:
+#
+#  test_all_in_one_jar_on_os_linux:
+#    runs-on: ubuntu-16.04
+#    on:
+#      # Should be changed to on_pull before checkin.
+#      pull_request:
+#        branches:
+#          - master
+#    needs: build_all_in_one_jar
+#    steps:

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ set -x
 # Cause the script to exit if a single command fails.
 set -e
 
+pip install wheel
+
 # As the supported Python versions change, edit this array:
 SUPPORTED_PYTHONS=( "3.5" "3.6" "3.7" )
 
@@ -106,7 +108,7 @@ echo "Using Python executable $PYTHON_EXECUTABLE."
 
 # Find the bazel executable. The script ci/travis/install-bazel.sh doesn't
 # always put the bazel executable on the PATH.
-BAZEL_EXECUTABLE=$(PATH="$PATH:$HOME/.bazel/bin" which bazel)
+BAZEL_EXECUTABLE="$HOME/bin/bazel"
 echo "Using Bazel executable $BAZEL_EXECUTABLE."
 
 # Now we build everything.

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -21,7 +21,13 @@ unamestr="$(uname)"
 if [[ "$unamestr" == "Linux" ]]; then
   echo "Platform is linux."
   platform="linux"
+elif [[ "$unamestr" == "linux" ]]; then
+  echo "Platform is linux."
+  platform="linux"
 elif [[ "$unamestr" == "Darwin" ]]; then
+  echo "Platform is macosx."
+  platform="macosx"
+elif [[ "$unamestr" == "darwin" ]]; then
   echo "Platform is macosx."
   platform="macosx"
 else
@@ -53,7 +59,7 @@ if [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "linux" ]]; then
     opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy pytest pytest-timeout networkx tabulate aiohttp \
     uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio \
-    blist scikit-learn numba
+    blist scikit-learn numba oss2 wheel
 elif [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "macosx" ]]; then
   # Install miniconda.
   wget -q https://repo.continuum.io/miniconda/Miniconda3-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
@@ -64,7 +70,7 @@ elif [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "macosx" ]]; then
     opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy pytest pytest-timeout networkx tabulate aiohttp \
     uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio \
-    blist scikit-learn numba
+    blist scikit-learn numba oss2 wheel
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y build-essential curl unzip
@@ -106,11 +112,11 @@ if [[ "$RAY_CI_STREAMING_PYTHON_AFFECTED" == "1" ]]; then
   pip install -q msgpack>=0.6.2
 fi
 
-if [[ "$PYTHON" == "3.6" ]] || [[ "$MAC_WHEELS" == "1" ]]; then
-  # Install the latest version of Node.js in order to build the dashboard.
-  source "$HOME/.nvm/nvm.sh"
-  nvm install node
-fi
+#if [[ "$PYTHON" == "3.6" ]] || [[ "$MAC_WHEELS" == "1" ]]; then
+#  # Install the latest version of Node.js in order to build the dashboard.
+#  source "$HOME/.nvm/nvm.sh"
+#  nvm install node
+#fi
 
 pip install psutil setproctitle \
         --target="$ROOT_DIR/../../python/ray/thirdparty_files"

--- a/ci/travis/install-ray.sh
+++ b/ci/travis/install-ray.sh
@@ -7,6 +7,16 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 echo "PYTHON is $PYTHON"
 
+
+unamestr="$(uname)"
+if [[ "$unamestr" == "Linux" ]]; then
+  echo "Platform is linux."
+  source /home/runner/.bazel/bin/bazel-complete.bash
+elif [[ "$unamestr" == "linux" ]]; then
+  echo "Platform is linux."
+  source /home/runner/.bazel/bin/bazel-complete.bash
+fi
+
 # If we are in Travis, most of the compilation result will be cached.
 # This means we are I/O bounded. By default, Bazel set the number of concurrent
 # jobs to the the number cores on the machine, which are not efficient for
@@ -21,10 +31,10 @@ if [[ "$PYTHON" == "3.6" ]]; then
 
   pushd "$ROOT_DIR/../../python"
     pushd ray/dashboard/client
-      source $HOME/.nvm/nvm.sh
-      nvm use node
-      npm ci
-      npm run build
+#      source $HOME/.nvm/nvm.sh
+#      nvm use node
+#      npm ci
+#      npm run build
     popd
     pip install -e . --verbose
   popd
@@ -39,4 +49,3 @@ else
   echo "Unrecognized Python version."
   exit 1
 fi
-

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -180,7 +180,7 @@ genrule(
         for f in $(locations //java:all_java_proto); do
             unzip "$$f" -x META-INF/MANIFEST.MF -d "$$WORK_DIR/java/runtime/src/main/java"
         done
-        # Copy native dependecies.
+        # Copy native dependencies.
         NATIVE_DEPS_DIR="$$WORK_DIR/java/runtime/native_dependencies/"
         rm -rf "$$NATIVE_DEPS_DIR"
         mkdir -p "$$NATIVE_DEPS_DIR"
@@ -193,6 +193,8 @@ genrule(
     local = 1,
     tags = ["no-cache"],
 )
+
+
 
 genrule(
     name = "copy_pom_file",

--- a/java/build_jars/build_all_platform_dependencies_into_jar.sh
+++ b/java/build_jars/build_all_platform_dependencies_into_jar.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+pip install oss2
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+pushd $ROOT_DIR/../..
+
+# Ray root dir
+./ci/travis/install-bazel.sh
+./ci/travis/install-dependencies.sh
+
+BAZEL_EXECUTABLE="$HOME/bin/bazel"
+
+# Build Ray java for some dependencies ready.
+"$BAZEL_EXECUTABLE" build //java:all
+
+popd
+
+pushd java/
+
+# Remove unecessary native dependencies.
+rm -rf runtime/runtime/native_dependencies
+
+# Download the native depedencies with all platforms.
+COMMIT_ID=$(git rev-parse HEAD)
+python ./build_jars/oss_updater.py $COMMIT_ID download
+
+# Package to api and runtime jars.
+mvn clean package -DskipTests -Dcheckstyle.skip=true
+
+# Upload the api and runtime jars to oss.
+python ./build_jars/oss_updater.py $COMMIT_ID upload-jars
+
+popd

--- a/java/build_jars/build_and_upload_native_dependencies_with_platform.sh
+++ b/java/build_jars/build_and_upload_native_dependencies_with_platform.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+pip install oss2 wheel
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+pushd $ROOT_DIR/..
+
+pushd ../
+# Ray project root dir
+
+./ci/travis/install-bazel.sh
+./ci/travis/install-dependencies.sh
+./build.sh -l java
+echo "Build Java successfully."
+popd
+
+# Determine the platform suffix.
+unamestr="$(uname)"
+if [[ "$unamestr" == "Linux" ]]; then
+  PLATFORM_SUFFIX="os_linux"
+elif [[ "$unamestr" == "Darwin" ]]; then
+  PLATFORM_SUFFIX="os_mac_osx"
+else
+  echo "Unrecognized platform."
+  exit 1
+fi
+
+for filename in `ls ./runtime/native_dependencies/*`
+do
+  if [[ $filename == *.so ]];
+  then
+    mv $filename ${filename%.so}_$PLATFORM_SUFFIX.so
+  elif [[ $filename == *.dylib ]];
+  then
+    mv $filename ${filename%.dylib}_$PLATFORM_SUFFIX.dylib
+  else
+    mv $filename ${filename}_$PLATFORM_SUFFIX;
+  fi
+done
+
+# Upload the files to oss.
+COMMIT_ID=$(git rev-parse HEAD)
+python ./build_jars/oss_updater.py $COMMIT_ID upload
+
+popd

--- a/java/build_jars/docker/linux/Dockerfile
+++ b/java/build_jars/docker/linux/Dockerfile
@@ -1,0 +1,18 @@
+# The base-deps Docker image installs main libraries needed to run Ray
+
+FROM ubuntu:xenial
+RUN apt-get update \
+    && apt-get install -y \
+        git \
+        wget \
+        cmake \
+        build-essential \
+        curl \
+        unzip \
+    && apt-get clean
+
+# To avoid the following error on Jenkins:
+# AttributeError: 'numpy.ufunc' object has no attribute '__module__'
+RUN /opt/conda/bin/pip uninstall -y dask
+
+ENV PATH "/opt/conda/bin:$PATH"

--- a/java/build_jars/oss_updater.py
+++ b/java/build_jars/oss_updater.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+import sys
+import oss2
+import os
+import logging
+
+OSS_URL = "http://oss-cn-beijing.aliyuncs.com"
+OSS_BUCKET_NAME = "ray-jars"
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_oss_access_key():
+    return os.environ["OSS_ACCESS_KEY"]
+
+
+def get_oss_access_key_secret():
+    return os.environ["OSS_ACCESS_KEY_SECRET"]
+
+
+# A helper method to locate the current dir.
+def get_current_dir():
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    return this_dir
+
+
+# Get all files from the given directory.
+def get_all_files(dir):
+    all_files = []
+    list = os.listdir(dir)
+    for i in range(0, len(list)):
+        path = os.path.join(dir, list[i])
+        if os.path.isfile(path):
+            all_files.append(list[i])
+    return all_files
+
+
+def get_platform_sign():
+    if sys.platform == "darwin":
+        return "os_mac_osx"
+    elif sys.platform == "linux":
+        return "os_linux"
+
+
+def upload_native_files(commit_id):
+    auth = oss2.Auth(get_oss_access_key(), get_oss_access_key_secret())
+    bucket = oss2.Bucket(auth, OSS_URL, OSS_BUCKET_NAME)
+    native_files_dir = os.path.join(get_current_dir(), "../runtime/native_dependencies")
+    for native_filename in get_all_files(native_files_dir):
+        dest_filename = os.path.join(commit_id, get_platform_sign(), native_filename)
+        bucket.put_object_from_file(dest_filename, os.path.join(native_files_dir, native_filename))
+        logger.warning("Succeeded to upload [" + native_filename + "] to [" + dest_filename + "]")
+
+
+def get_all_files_from_oss(bucket, commit_id):
+    result = []
+    for obj in oss2.ObjectIterator(bucket, prefix="{}/".format(commit_id)):
+        if not obj.is_prefix():
+            # `obj` is a not a directory.
+            if not obj.key.endswith("/"):
+                result.append(obj.key)
+    return result
+
+# Prepare the directory of native native_dependencies to avoid no such file when downloading.
+def _prepare_native_dependencies_dir():
+    dir = os.path.join(get_current_dir(), "../runtime/native_dependencies")
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+
+def download_all_native_files(commit_id):
+    auth = oss2.Auth(get_oss_access_key(), get_oss_access_key_secret())
+    bucket = oss2.Bucket(auth, OSS_URL, OSS_BUCKET_NAME)
+    native_files = get_all_files_from_oss(bucket, commit_id)
+    _prepare_native_dependencies_dir()
+    for object_file in native_files:
+        dest_filename = os.path.join(get_current_dir(), "../runtime/native_dependencies", os.path.split(object_file)[1])
+        if dest_filename.endswith(".jar"):
+            # Skip downloading jars.
+            continue
+        bucket.get_object_to_file(object_file, dest_filename)
+        logger.warning("Succeeded to download [" + object_file + "] to [" + dest_filename +"]")
+
+def upload_all_in_one_jar(commit_id):
+    auth = oss2.Auth(get_oss_access_key(), get_oss_access_key_secret())
+    bucket = oss2.Bucket(auth, OSS_URL, OSS_BUCKET_NAME)
+    # TODO(qwang): Do not use fixed version here.
+    ray_api_jar_filename = "ray-api-0.1-SNAPSHOT.jar"
+    ray_runtime_jar_filename = "ray-runtime-0.1-SNAPSHOT.jar"
+    ray_api_jar_file = os.path.join(get_current_dir(), "../tutorial/lib", ray_api_jar_filename)
+    ray_runtime_jar_file = os.path.join(get_current_dir(), "../tutorial/lib", ray_runtime_jar_filename)
+    bucket.put_object_from_file(os.path.join(commit_id, ray_api_jar_filename), ray_api_jar_file)
+    bucket.put_object_from_file(os.path.join(commit_id, ray_runtime_jar_filename), ray_runtime_jar_file)
+    logger.info("Succeeded to update ray jars to oss.")
+
+def main(commit_id, command_name):
+    if command_name == "upload":
+        upload_native_files(commit_id)
+    elif command_name == "download":
+        download_all_native_files(commit_id)
+    elif command_name == "upload-jars":
+        upload_all_in_one_jar(commit_id)
+    else:
+        raise ValueError("Unknown command.")
+
+
+if __name__ == "__main__":
+    commit_id = sys.argv[1]
+    command_name = sys.argv[2]
+    main(commit_id, command_name)

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -19,7 +19,8 @@ def gen_java_deps():
             "org.slf4j:slf4j-log4j12:1.7.25",
             "org.testng:testng:6.9.10",
             "redis.clients:jedis:2.8.0",
-            "net.java.dev.jna:jna:5.5.0"
+            "net.java.dev.jna:jna:5.5.0",
+            "org.apache.commons:commons-lang3:3.9"
         ],
         repositories = [
             "https://repo1.maven.org/maven2/",

--- a/java/runtime/pom.xml
+++ b/java/runtime/pom.xml
@@ -60,7 +60,7 @@
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-lang3</artifactId>
-  <version>3.4</version>
+  <version>3.9</version>
 </dependency>
 <dependency>
   <groupId>org.ow2.asm</groupId>

--- a/java/test/pom.xml
+++ b/java/test/pom.xml
@@ -60,7 +60,7 @@
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-lang3</artifactId>
-  <version>3.4</version>
+  <version>3.9</version>
 </dependency>
 <dependency>
   <groupId>org.slf4j</groupId>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
1. Add 3 Github action jobs to build all in one jars:
`build_all_in_one_jars` job depends on `build_native_osx` and `build_native_linux`.(Use `needs` feature of Github action.)
2. Make Java Worker loads the corresponding native dependencies according to its platform.
3. We use the OSS to store our jars cached. Once CI succeeded to finish `build_all_in_one_jars`, it will upload the generated jars to the OSS.


#### This PR is not able to cover:
Deploying jars to maven central repository. Because we have not do any maven preparations yet.


## Related issue number
#7291
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
