### PR TITLE
Stop gap solution for cython functions breaking in memory monitor

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -569,7 +569,12 @@ cdef void get_py_stack(c_string* stack_out) nogil:
     """
 
     with gil:
-        frame = inspect.currentframe()
+        try:
+            frame = inspect.currentframe()
+        except ValueError:
+            stack_out[0] = "".encode("ascii")
+            return
+
         msg = ""
         while frame:
             filename = frame.f_code.co_filename

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -571,7 +571,7 @@ cdef void get_py_stack(c_string* stack_out) nogil:
     with gil:
         try:
             frame = inspect.currentframe()
-        except ValueError:
+        except ValueError:  # overhead of exception handling is about 20us
             stack_out[0] = "".encode("ascii")
             return
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR addresses part of #7684 by silencing the stack unwinding error during `get_py_stack`. The real problem is that we are doing raw ObjectID construction from bytes in cython. I have no idea how to change those. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
