### PR TITLE
[RLlib] Exporting checkpoint and export model in eager model in eager_tf_policy

### DIFF
--- a/rllib/policy/eager_tf_policy.py
+++ b/rllib/policy/eager_tf_policy.py
@@ -471,19 +471,14 @@ def build_eager_tf_policy(name,
                     raise
 
             save_path = os.path.join(export_dir, filename_prefix)
-
+            # get the Keras model for checkpointing
             if hasattr(self.model, 'model'):
-                # self.model.base_model.save_weights(save_path)
-                ckpt = tf.train.Checkpoint(optimizer=self._optimizer,
-                                           model=self.model.model)
+                self.model.model.save_weights(save_path)
             elif hasattr(self.model, 'base_model'):
-                ckpt = tf.train.Checkpoint(optimizer=self._optimizer,
-                                           model=self.base_model.model)
+                self.model.base_model.save_weights(save_path)
             else:
                 raise AttributeError('Could not find model or base model in the '
                                      'model of the policy to export the checkpoint')
-
-            ckpt.save(save_path)
 
         def _get_is_training_placeholder(self):
             return tf.convert_to_tensor(self._is_training)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

@sven1977 Dear Mr Mika, this is my first PR if you want to make more tests, please help me to do it.

There is no implementation on exporting checkpoint and export model in eager model in eager_tf_policy.py

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/7674

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
