### PR TITLE
[tune] IP Check, Flatten Results for TBX

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -250,9 +250,10 @@ class TBXLogger(Logger):
 
     def _try_log_hparams(self, result):
         # TBX currently errors if the hparams value is None.
+        flat_params = flatten_dict(self.trial.evaluated_params)
         scrubbed_params = {
             k: v
-            for k, v in self.trial.evaluated_params.items() if v is not None
+            for k, v in flat_params.items() if v is not None
         }
         from tensorboardX.summary import hparams
         experiment_tag, session_start_tag, session_end_tag = hparams(

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -239,9 +239,10 @@ class TBXLogger(Logger):
     def close(self):
         if self._file_writer is not None:
             if self.trial and self.trial.evaluated_params and self.last_result:
+                flat_result = flatten_dict(self.last_result, delimiter="/")
                 scrubbed_result = {
                     k: value
-                    for k, value in self.last_result.items()
+                    for k, value in flat_result.items()
                     if type(value) in VALID_SUMMARY_TYPES
                 }
                 self._try_log_hparams(scrubbed_result)

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -54,6 +54,7 @@ class LoggerSuite(unittest.TestCase):
         logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
         logger.close()
 
+
 if __name__ == "__main__":
     import pytest
     import sys

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -28,32 +28,31 @@ class LoggerSuite(unittest.TestCase):
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def testCSV(self):
-        config = {"a": 2, "b": 5}
+        config = {"a": 2, "b": 5, "c": {"c": {"D": 123}, "e": None}}
         t = Trial(evaluated_params=config, trial_id="csv")
         logger = CSVLogger(config=config, logdir=self.test_dir, trial=t)
         logger.on_result(result(2, 4))
         logger.on_result(result(2, 4))
-        logger.on_result(result(2, 4, score=[1, 2, 3]))
+        logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
         logger.close()
 
     def testJSON(self):
-        config = {"a": 2, "b": 5}
+        config = {"a": 2, "b": 5, "c": {"c": {"D": 123}, "e": None}}
         t = Trial(evaluated_params=config, trial_id="json")
         logger = JsonLogger(config=config, logdir=self.test_dir, trial=t)
         logger.on_result(result(0, 4))
         logger.on_result(result(1, 4))
-        logger.on_result(result(2, 4, score=[1, 2, 3]))
+        logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
         logger.close()
 
     def testTBX(self):
-        config = {"a": 2, "b": 5}
+        config = {"a": 2, "b": 5, "c": {"c": {"D": 123}, "e": None}}
         t = Trial(evaluated_params=config, trial_id="tbx")
         logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)
         logger.on_result(result(0, 4))
         logger.on_result(result(1, 4))
-        logger.on_result(result(2, 4, score=[1, 2, 3]))
+        logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
         logger.close()
-
 
 if __name__ == "__main__":
     import pytest

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -178,7 +178,7 @@ class Trainable:
                         "slow to initialize, consider setting "
                         "reuse_actors=True to reduce actor creation "
                         "overheads.".format(setup_time))
-        self._local_ip = ray.services.get_node_ip_address()
+        self._local_ip = self.get_current_ip()
         log_sys_usage = self.config.get("log_sys_usage", False)
         self._monitor = UtilMonitor(start=log_sys_usage)
 
@@ -213,7 +213,7 @@ class Trainable:
         """
         return ""
 
-    def current_ip(self):
+    def get_current_ip(self):
         logger.info("Getting current IP.")
         self._local_ip = ray.services.get_node_ip_address()
         return self._local_ip
@@ -419,7 +419,7 @@ class Trainable:
         self._timesteps_since_restore = 0
         self._iterations_since_restore = 0
         self._restored = True
-        logger.info("Restored on %s from checkpoint: %s", self.current_ip(),
+        logger.info("Restored on %s from checkpoint: %s", self.get_current_ip(),
                     checkpoint_path)
         state = {
             "_iteration": self._iteration,

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -419,8 +419,8 @@ class Trainable:
         self._timesteps_since_restore = 0
         self._iterations_since_restore = 0
         self._restored = True
-        logger.info("Restored on %s from checkpoint: %s", self.get_current_ip(),
-                    checkpoint_path)
+        logger.info("Restored on %s from checkpoint: %s",
+                    self.get_current_ip(), checkpoint_path)
         state = {
             "_iteration": self._iteration,
             "_timesteps_total": self._timesteps_total,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Sometimes, people have IP address conflicts. Centralizing the IP check retrieval in one command (get_ip_address) allows people to override the retrieval process if needed.

The other part of this PR fixes #7695 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)