### PR TITLE
Fix TestGcsRedisFailureDetector

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -656,7 +656,7 @@ TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
   // Sleep 3 times of gcs_redis_heartbeat_interval_milliseconds to make sure gcs_server
   // detects that the redis is failure and then stop itself.
   auto interval_ms = RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds();
-  std::this_thread::sleep_for(std::chrono::milliseconds(5 * interval_ms));
+  std::this_thread::sleep_for(std::chrono::milliseconds(3 * interval_ms));
 
   // Check if gcs server has exited.
   RAY_CHECK(gcs_server_->IsStopped());

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -653,6 +653,11 @@ TEST_F(ServiceBasedGcsGcsClientTest, TestGcsRedisFailureDetector) {
   // Stop redis.
   TearDownTestCase();
 
+  // Sleep 3 times of gcs_redis_heartbeat_interval_milliseconds to make sure gcs_server
+  // detects that the redis is failure and then stop itself.
+  auto interval_ms = RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds();
+  std::this_thread::sleep_for(std::chrono::milliseconds(5 * interval_ms));
+
   // Check if gcs server has exited.
   RAY_CHECK(gcs_server_->IsStopped());
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- GCS Server detects the failure of redis via heartbeat which is 100ms by default, while the TestGcsRedisFailureDetector stop the redis and check the GCS Server is stopped after sleep 100ms, which can easily lead to check failure.
- Just sleep more to make sure the GCS Server detects that the redis is failure.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
