### PR TITLE
[docs] Fix import breaking docs build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,10 +23,11 @@ from custom_directives import CustomGalleryItemDirective
 # These lines added to enable Sphinx to work without installing Ray.
 import mock
 MOCK_MODULES = [
-    "blist", "gym", "gym.spaces", "psutil". "ray._raylet", "ray.core.generated",
-    "ray.core.generated.gcs_pb2", "ray.core.generated.ray.protocol.Task",
-    "scipy", "scipy.signal", "scipy.stats", "tensorflow_probability",
-    "tensorflow", "tensorflow.contrib", "tensorflow.contrib.all_reduce",
+    "blist", "gym", "gym.spaces", "psutil", "ray._raylet",
+    "ray.core.generated", "ray.core.generated.gcs_pb2",
+    "ray.core.generated.ray.protocol.Task", "scipy", "scipy.signal",
+    "scipy.stats", "tensorflow_probability", "tensorflow",
+    "tensorflow.contrib", "tensorflow.contrib.all_reduce",
     "tensorflow.contrib.all_reduce.python", "tensorflow.contrib.layers",
     "tensorflow.contrib.rnn", "tensorflow.contrib.slim", "tensorflow.core",
     "tensorflow.core.util", "tensorflow.python", "tensorflow.python.client",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,7 +23,7 @@ from custom_directives import CustomGalleryItemDirective
 # These lines added to enable Sphinx to work without installing Ray.
 import mock
 MOCK_MODULES = [
-    "blist", "gym", "gym.spaces", "ray._raylet", "ray.core.generated",
+    "blist", "gym", "gym.spaces", "psutil". "ray._raylet", "ray.core.generated",
     "ray.core.generated.gcs_pb2", "ray.core.generated.ray.protocol.Task",
     "scipy", "scipy.signal", "scipy.stats", "tensorflow_probability",
     "tensorflow", "tensorflow.contrib", "tensorflow.contrib.all_reduce",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Docs are broken on a `psutil` line.

```
python /home/docs/checkouts/readthedocs.org/user_builds/ray/envs/latest/bin/sphinx-build -T -E -b readthedocs -d _build/doctrees-readthedocs -D language=en . _build/html
Running Sphinx v1.8.5

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/envs/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/checkouts/latest/doc/source/conf.py", line 47, in <module>
    import ray
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/checkouts/latest/python/ray/__init__.py", line 62, in <module>
    from ray.state import (jobs, nodes, actors, tasks, objects, timeline,
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/checkouts/latest/python/ray/state.py", line 9, in <module>
    from ray import (
  File "/home/docs/checkouts/readthedocs.org/user_builds/ray/checkouts/latest/python/ray/services.py", line 18, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)