### PR TITLE
`ray memory` should collect statistics from all nodes

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -221,7 +221,7 @@ py_test(
 
 py_test(
     name = "test_global_gc",
-    size = "small",
+    size = "medium",
     srcs = ["test_global_gc.py"],
     tags = ["exclusive"],
     deps = ["//:ray_lib"],

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -191,7 +191,7 @@ def test_pinned_object_call_site(ray_start_regular):
     assert num_objects(info) == 0, info
 
 
-def test_multi_node_stats(call_ray_stop_only):
+def test_multi_node_stats(shutdown_only):
     cluster = Cluster()
     for _ in range(2):
         cluster.add_node(num_cpus=1)

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3380,12 +3380,11 @@ void NodeManager::HandleGetNodeStats(const rpc::GetNodeStatsRequest &node_stats_
   }
 }
 
-std::string FormatMemoryInfo(
-    std::vector<std::shared_ptr<rpc::GetNodeStatsReply>> node_stats) {
+std::string FormatMemoryInfo(std::vector<rpc::GetNodeStatsReply> node_stats) {
   // First pass to compute object sizes.
   absl::flat_hash_map<ObjectID, int64_t> object_sizes;
   for (const auto &reply : node_stats) {
-    for (const auto &worker_stats : reply->workers_stats()) {
+    for (const auto &worker_stats : reply.workers_stats()) {
       for (const auto &object_ref : worker_stats.core_worker_stats().object_refs()) {
         auto obj_id = ObjectID::FromBinary(object_ref.object_id());
         if (object_ref.object_size() > 0) {
@@ -3408,7 +3407,8 @@ std::string FormatMemoryInfo(
 
   // Second pass builds the summary string for each node.
   for (const auto &reply : node_stats) {
-    for (const auto &worker_stats : reply->workers_stats()) {
+    RAY_LOG(ERROR) << " num stats " << reply.DebugString();
+    for (const auto &worker_stats : reply.workers_stats()) {
       bool pid_printed = false;
       for (const auto &object_ref : worker_stats.core_worker_stats().object_refs()) {
         if (!object_ref.pinned_in_memory() && object_ref.local_ref_count() == 0 &&
@@ -3459,23 +3459,42 @@ std::string FormatMemoryInfo(
 void NodeManager::HandleFormatGlobalMemoryInfo(
     const rpc::FormatGlobalMemoryInfoRequest &request,
     rpc::FormatGlobalMemoryInfoReply *reply, rpc::SendReplyCallback send_reply_callback) {
-  std::vector<std::shared_ptr<rpc::GetNodeStatsReply>> replies;
-
+  auto replies = std::make_shared<std::vector<rpc::GetNodeStatsReply>>();
   auto local_request = std::make_shared<rpc::GetNodeStatsRequest>();
   auto local_reply = std::make_shared<rpc::GetNodeStatsReply>();
   local_request->set_include_memory_info(true);
 
-  // TODO(ekl): for (const auto &entry : remote_node_manager_clients_) {}
-  // to handle remote nodes
+  unsigned int num_nodes = remote_node_manager_clients_.size() + 1;
 
-  HandleGetNodeStats(*local_request, local_reply.get(),
-                     [local_request, local_reply, replies, reply, send_reply_callback](
-                         Status status, std::function<void()> success,
-                         std::function<void()> failure) mutable {
-                       replies.push_back(local_reply);
-                       reply->set_memory_summary(FormatMemoryInfo(replies));
-                       send_reply_callback(Status::OK(), nullptr, nullptr);
-                     });
+  auto store_reply = [replies, reply, num_nodes,
+                      send_reply_callback](const rpc::GetNodeStatsReply &local_reply) {
+    replies->push_back(local_reply);
+    if (replies->size() >= num_nodes) {
+      reply->set_memory_summary(FormatMemoryInfo(*replies));
+      send_reply_callback(Status::OK(), nullptr, nullptr);
+    }
+  };
+
+  // Fetch from remote nodes.
+  for (const auto &entry : remote_node_manager_clients_) {
+    rpc::GetNodeStatsRequest remote_req;
+    remote_req.set_include_memory_info(true);
+    entry.second->GetNodeStats(
+        remote_req, [replies, store_reply](const ray::Status &status,
+                                           const rpc::GetNodeStatsReply &r) {
+          if (!status.ok()) {
+            RAY_LOG(ERROR) << "Failed to get remote node stats: " << status.ToString();
+          }
+          store_reply(r);
+        });
+  }
+
+  // Fetch from the local node.
+  HandleGetNodeStats(
+      *local_request, local_reply.get(),
+      [local_request, local_reply, &replies, store_reply](
+          Status status, std::function<void()> success,
+          std::function<void()> failure) mutable { store_reply(*local_reply); });
 }
 
 void NodeManager::HandleGlobalGC(const rpc::GlobalGCRequest &request,

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3407,7 +3407,6 @@ std::string FormatMemoryInfo(std::vector<rpc::GetNodeStatsReply> node_stats) {
 
   // Second pass builds the summary string for each node.
   for (const auto &reply : node_stats) {
-    RAY_LOG(ERROR) << " num stats " << reply.DebugString();
     for (const auto &worker_stats : reply.workers_stats()) {
       bool pid_printed = false;
       for (const auto &object_ref : worker_stats.core_worker_stats().object_refs()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This fixes the TODO to collect reference statistics from all nodes, not just the local one.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
