### PR TITLE
Revert "New scheduler local node (#7441)"

### DIFF
--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -60,7 +60,6 @@ struct ResourceRequestWithId : ResourceRequest {
   int64_t id;
 };
 
-// Data structure specifying the capacity of each resource requested by a task.
 class TaskRequest {
  public:
   /// List of predefined resources required by the task.
@@ -73,11 +72,10 @@ class TaskRequest {
   /// nodes in this list can schedule this task.
   absl::flat_hash_set<int64_t> placement_hints;
   /// Returns human-readable string for this task request.
-  std::string DebugString() const;
+  std::string DebugString();
 };
 
-// Data structure specifying the capacity of each instance of each resource
-// allocated to a task.
+// Task request specifying instances for each resource.
 class TaskResourceInstances {
  public:
   /// The list of instances of each predifined resource allocated to a task.
@@ -85,20 +83,10 @@ class TaskResourceInstances {
   /// The list of instances of each custom resource allocated to a task.
   absl::flat_hash_map<int64_t, std::vector<double>> custom_resources;
   bool operator==(const TaskResourceInstances &other);
-  /// For each resource of this request aggregate its instances.
-  TaskRequest ToTaskRequest() const;
   /// Get CPU instances only.
-  std::vector<double> GetCPUInstances() const {
-    if (!this->predefined_resources.empty()) {
-      return this->predefined_resources[CPU];
-    } else {
-      return {};
-    }
-  };
-  /// Check whether there are no resource instances.
-  bool IsEmpty() const;
+  std::vector<double> GetCPUInstances() { return this->predefined_resources[CPU]; };
   /// Returns human-readable string for these resources.
-  std::string DebugString() const;
+  std::string DebugString();
 };
 
 /// Total and available capacities of each resource of a node.
@@ -112,7 +100,7 @@ class NodeResources {
   /// Returns if this equals another node resources.
   bool operator==(const NodeResources &other);
   /// Returns human-readable string for these resources.
-  std::string DebugString(StringIdMap string_to_int_map) const;
+  std::string DebugString();
 };
 
 /// Total and available capacities of each resource instance.
@@ -129,7 +117,7 @@ class NodeResourceInstances {
   /// Returns if this equals another node resources.
   bool operator==(const NodeResourceInstances &other);
   /// Returns human-readable string for these resources.
-  std::string DebugString(StringIdMap string_to_int_map) const;
+  std::string DebugString();
 };
 
 /// Class encapsulating the cluster resources and the logic to assign
@@ -161,19 +149,6 @@ class ClusterResourceScheduler {
       const absl::flat_hash_map<int64_t, ResourceCapacity> &new_custom_resources,
       absl::flat_hash_map<int64_t, ResourceCapacity> *old_custom_resources);
 
-  /// Subtract the resources required by a given task request (task_req) from
-  /// a given node (node_id).
-  ///
-  /// \param node_id Node whose resources we allocate. Can be the local or a remote node.
-  /// \param task_req Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity.
-  /// This is a return parameter.
-  ///
-  /// \return True if the node has enough resources to satisfy the task request.
-  /// False otherwise.
-  bool AllocateTaskResources(int64_t node_id, const TaskRequest &task_req,
-                             std::shared_ptr<TaskResourceInstances> task_allocation);
-
  public:
   ClusterResourceScheduler(void){};
 
@@ -187,9 +162,6 @@ class ClusterResourceScheduler {
   ClusterResourceScheduler(
       const std::string &local_node_id,
       const std::unordered_map<std::string, double> &local_node_resources);
-
-  // Mapping from predefined resource indexes to resource strings
-  std::string GetResourceNameFromIndex(int64_t res_idx);
 
   /// Add a new node or overwrite the resources of an existing node.
   ///
@@ -292,19 +264,24 @@ class ClusterResourceScheduler {
   /// Get number of nodes in the cluster.
   int64_t NumNodes();
 
-  /// Update total capacity of a given resource of a given node.
-  ///
-  /// \param node_name: Node whose resource we want to update.
-  /// \param resource_name: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource.
-  void UpdateResourceCapacity(const std::string &node_name,
+  /// Convert a map of resources to a TaskRequest data structure.
+  void ResourceMapToTaskRequest(
+      const std::unordered_map<std::string, double> &resource_map,
+      TaskRequest *task_request);
+
+  /// Convert a map of resources to a TaskRequest data structure.
+  void ResourceMapToNodeResources(
+      const std::unordered_map<std::string, double> &resource_map_total,
+      const std::unordered_map<std::string, double> &resource_map_available,
+      NodeResources *node_resources);
+
+  /// Update total capacity of resource resource_name at node client_id.
+  void UpdateResourceCapacity(const std::string &client_id,
                               const std::string &resource_name, int64_t resource_total);
 
-  /// Delete a given resource from a given node.
-  ///
-  /// \param node_name: Node whose resource we want to delete.
-  /// \param resource_name: Resource we want to delete
-  void DeleteResource(const std::string &node_name, const std::string &resource_name);
+  /// Delete resource resource_name from node cleint_id_string.
+  void DeleteResource(const std::string &client_id_string,
+                      const std::string &resource_name);
 
   /// Return local resources.
   NodeResourceInstances GetLocalResources() { return local_resources_; };
@@ -328,27 +305,25 @@ class ClusterResourceScheduler {
                              ResourceInstanceCapacities *instance_list);
 
   /// Allocate enough capacity across the instances of a resource to satisfy "demand".
-  /// If resource has multiple unit-capacity instances, we consider two cases.
+  /// If resource has multiple unit-capacity instance, we consider two cases.
   ///
   /// 1) If the constraint is hard, allocate full unit-capacity instances until
-  /// demand becomes fractional, and then satisfy the fractional demand using the
+  /// demand becomes fractional, and then satisfy the fractional deman using the
   /// instance with the smallest available capacity that can satisfy the fractional
   /// demand. For example, assume a resource conisting of 4 instances, with available
   /// capacities: (1., 1., .7, 0.5) and deman of 1.2. Then we allocate one full
   /// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
   /// with the smalest available capacity that can satisfy the remaining demand of 0.2).
-  /// As a result remaining available capacities will be (0., 1., .7, .3).
-  /// Thus, if the constraint is hard, we will allocate a bunch of full instances and
-  /// at most a fractional instance.
+  /// As a result remaining available capacities will be (0., 1., .7, .2).
+  /// Thus, if the constraint is hard, we will allocate at most a fractional resource.
   ///
   /// 2) If the constraint is soft, we can allocate multiple fractional resources,
   /// and even overallocate the resource. For example, in the previous case, if we
   /// have a demand of 1.8, we can allocate one full instance, the 0.5 instance, and
-  /// 0.3 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
+  /// 0.1 from the 0.7 instance. Furthermore, if the demand is 3.5, then we allocate
   /// all instances, and return success (true), despite the fact that the total
   /// available capacity of the rwsource is 3.2 (= 1. + 1. + .7 + .5), which is less
-  /// than the demand, 3.5. In this case, the remaining available resource is
-  /// (0., 0., 0., 0.)
+  /// than the demand, 3.5.
   ///
   /// \param demand: The resource amount to be allocated.
   /// \param soft: Specifies whether this demand has soft or hard constraints.
@@ -365,94 +340,45 @@ class ClusterResourceScheduler {
   ///
   /// \param task_req: Resources requested by a task.
   /// \param task_allocation: Local resources allocated to satsify task_req demand.
+  /// This is an output argument.
   ///
   /// \return true, if allocation successful. If false, the caller needs to free the
   /// allocated resources, i.e., task_allocation.
-  bool AllocateTaskResourceInstances(
-      const TaskRequest &task_req,
-      std::shared_ptr<TaskResourceInstances> task_allocation);
+  bool AllocateTaskResourceInstances(const TaskRequest &task_req,
+                                     TaskResourceInstances *task_allocation);
 
   /// Free resources which were allocated with a task. The freed resources are
   /// added back to the node's local available resources.
   ///
   /// \param task_allocation: Task's resources to be freed.
-  void FreeTaskResourceInstances(std::shared_ptr<TaskResourceInstances> task_allocation);
+  void FreeTaskResourceInstances(TaskResourceInstances &task_allocation);
 
   /// Increase the available capacities of the instances of a given resource.
   ///
   /// \param available A list of available capacities for resource's instances.
   /// \param resource_instances List of the resource instances being updated.
-  ///
-  /// \return Overflow capacities of "resource_instances" after adding instance
-  /// capacities in "available", i.e.,
-  /// min(available + resource_instances.available, resource_instances.total)
-  std::vector<double> AddAvailableResourceInstances(
-      std::vector<double> available, ResourceInstanceCapacities *resource_instances);
+  void AddAvailableResourceInstances(std::vector<double> available,
+                                     ResourceInstanceCapacities *resource_instances);
 
   /// Decrease the available capacities of the instances of a given resource.
   ///
   /// \param free A list of capacities for resource's instances to be freed.
   /// \param resource_instances List of the resource instances being updated.
-  /// \return Underflow of "resource_instances" after subtracting instance
-  /// capacities in "available", i.e.,.
-  /// max(available - reasource_instances.available, 0)
-  std::vector<double> SubtractAvailableResourceInstances(
-      std::vector<double> available, ResourceInstanceCapacities *resource_instances);
+  void SubtractAvailableResourceInstances(std::vector<double> free,
+                                          ResourceInstanceCapacities *resource_instances);
 
   /// Increase the available CPU instances of this node.
   ///
   /// \param cpu_instances CPU instances to be added to available cpus.
-  ///
-  /// \return Overflow capacities of CPU instances after adding CPU
-  /// capacities in cpu_instances.
-  std::vector<double> AddCPUResourceInstances(std::vector<double> &cpu_instances);
+  void AddCPUResourceInstances(std::vector<double> &cpu_instances);
 
-  /// Decrease the available CPU instances of this node.
+  /// Decrease the available cpu instances of this node.
   ///
-  /// \param cpu_instances CPU instances to be removed from available cpus.
-  ///
-  /// \return Underflow capacities of CPU instances after subtracting CPU
-  /// capacities in cpu_instances.
-  std::vector<double> SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
-
-  /// Subtract the resources required by a given task request (task_req) from the
-  /// local node. This function also updates the local node resources
-  /// at the instance granularity.
-  ///
-  /// \param task_req Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity.
-  /// This is a return parameter.
-  ///
-  /// \return True if local node has enough resources to satisfy the task request.
-  /// False otherwise.
-  bool AllocateLocalTaskResources(
-      const std::unordered_map<std::string, double> &task_resources,
-      std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  /// Subtract the resources required by a given task request (task_req) from a given
-  /// remote node.
-  ///
-  /// \param node_id Remote node whose resources we allocate.
-  /// \param task_req Task for which we allocate resources.
-  void AllocateRemoteTaskResources(
-      std::string &node_id,
-      const std::unordered_map<std::string, double> &task_resources);
-
-  void FreeLocalTaskResources(std::shared_ptr<TaskResourceInstances> task_allocation);
-
-  /// Update the available resources of the local node given
-  /// the available instances of each resource of the local node.
-  /// Basically, this means computing the available resources
-  /// by adding up the available quantities of each instance of that
-  /// resources.
-  ///
-  /// Example: Assume the local node has four GPU instances with the
-  /// following availabilities: 0.2, 0.3, 0.1, 1. Then the total GPU
-  // resources availabile at that node is 0.2 + 0.3 + 0.1 + 1. = 1.6
-  void UpdateLocalAvailableResourcesFromResourceInstances();
+  /// \param cpu_instances Cpu instances to be removed from available cpus.
+  void SubtractCPUResourceInstances(std::vector<double> &cpu_instances);
 
   /// Return human-readable string for this scheduler state.
-  std::string DebugString() const;
+  std::string DebugString();
 };
 
 #endif  // RAY_COMMON_SCHEDULING_SCHEDULING_H

--- a/src/ray/common/scheduling/scheduling_test.cc
+++ b/src/ray/common/scheduling/scheduling_test.cc
@@ -596,10 +596,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -622,10 +621,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((cluster_resources.GetLocalResources() == old_local_resources), true);
@@ -644,10 +642,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyBoolVector, EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -680,10 +677,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -710,10 +706,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, false);
     ASSERT_EQ((cluster_resources.GetLocalResources() == old_local_resources), true);
@@ -737,10 +732,9 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
                     EmptyIntVector);
 
     NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
+    TaskResourceInstances task_allocation;
     bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
+        cluster_resources.AllocateTaskResourceInstances(task_req, &task_allocation);
 
     ASSERT_EQ(success, true);
 
@@ -755,138 +749,6 @@ TEST_F(SchedulingTest, TaskResourceInstancesTest) {
         cluster_resources.GetLocalResources().GetAvailableResourceInstances();
 
     ASSERT_EQ((local_available_resources == expected_task_allocation), true);
-  }
-}
-
-TEST_F(SchedulingTest, TaskResourceInstancesTest2) {
-  {
-    NodeResources node_resources;
-    vector<int64_t> pred_capacities{4 /* CPU */, 4 /* MEM */, 5 /* GPU */};
-    vector<int64_t> cust_ids{1, 2};
-    vector<int64_t> cust_capacities{4, 4};
-    initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
-    ClusterResourceScheduler cluster_resources(0, node_resources);
-
-    TaskRequest task_req;
-    vector<double> pred_demands = {2. /* CPU */, 2. /* MEM */, 1.5 /* GPU */};
-    vector<bool> pred_soft = {false};
-    vector<double> cust_demands{3, 2};
-    vector<bool> cust_soft{false, false};
-    initTaskRequest(task_req, pred_demands, pred_soft, cust_ids, cust_demands, cust_soft,
-                    EmptyIntVector);
-
-    std::shared_ptr<TaskResourceInstances> task_allocation =
-        std::make_shared<TaskResourceInstances>();
-    bool success =
-        cluster_resources.AllocateTaskResourceInstances(task_req, task_allocation);
-
-    NodeResourceInstances old_local_resources = cluster_resources.GetLocalResources();
-    ASSERT_EQ(success, true);
-    std::vector<double> cpu_instances = task_allocation->GetCPUInstances();
-    cluster_resources.AddCPUResourceInstances(cpu_instances);
-    cluster_resources.SubtractCPUResourceInstances(cpu_instances);
-
-    ASSERT_EQ((cluster_resources.GetLocalResources() == old_local_resources), true);
-  }
-}
-
-TEST_F(SchedulingTest, TaskCPUResourceInstancesTest) {
-  {
-    NodeResources node_resources;
-    vector<int64_t> pred_capacities{4 /* CPU */, 1 /* MEM */, 1 /* GPU */};
-    vector<int64_t> cust_ids{1};
-    vector<int64_t> cust_capacities{8};
-    initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
-    ClusterResourceScheduler cluster_resources(0, node_resources);
-
-    std::vector<double> allocate_cpu_instances{0.5, 0.5, 0.5, 0.5};
-    cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
-                                                      .GetAvailableResourceInstances()
-                                                      .GetCPUInstances();
-    std::vector<double> expected_available_cpu_instances{0.5, 0.5, 0.5, 0.5};
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
-                           expected_available_cpu_instances.begin()));
-
-    cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-    available_cpu_instances = cluster_resources.GetLocalResources()
-                                  .GetAvailableResourceInstances()
-                                  .GetCPUInstances();
-    expected_available_cpu_instances = {1., 1., 1., 1.};
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
-                           expected_available_cpu_instances.begin()));
-
-    allocate_cpu_instances = {1.5, 1.5, .5, 1.5};
-    std::vector<double> underflow =
-        cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> expected_underflow{.5, .5, 0., .5};
-    ASSERT_TRUE(
-        std::equal(underflow.begin(), underflow.end(), expected_underflow.begin()));
-    available_cpu_instances = cluster_resources.GetLocalResources()
-                                  .GetAvailableResourceInstances()
-                                  .GetCPUInstances();
-    expected_available_cpu_instances = {0., 0., 0.5, 0.};
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
-                           expected_available_cpu_instances.begin()));
-
-    allocate_cpu_instances = {1.0, .5, 1., .5};
-    std::vector<double> overflow =
-        cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-    std::vector<double> expected_overflow{.0, .0, .5, 0.};
-    ASSERT_TRUE(std::equal(overflow.begin(), overflow.end(), expected_overflow.begin()));
-    available_cpu_instances = cluster_resources.GetLocalResources()
-                                  .GetAvailableResourceInstances()
-                                  .GetCPUInstances();
-    expected_available_cpu_instances = {1., .5, 1., .5};
-    ASSERT_TRUE(std::equal(available_cpu_instances.begin(), available_cpu_instances.end(),
-                           expected_available_cpu_instances.begin()));
-  }
-}
-
-TEST_F(SchedulingTest, UpdateLocalAvailableResourcesFromResourceInstancesTest) {
-  {
-    NodeResources node_resources;
-    vector<int64_t> pred_capacities{4 /* CPU */, 1 /* MEM */, 1 /* GPU */};
-    vector<int64_t> cust_ids{1};
-    vector<int64_t> cust_capacities{8};
-    initNodeResources(node_resources, pred_capacities, cust_ids, cust_capacities);
-    ClusterResourceScheduler cluster_resources(0, node_resources);
-
-    {
-      std::vector<double> allocate_cpu_instances{0.5, 0.5, 2, 0.5};
-      // SubtractCPUResourceInstances() calls
-      // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
-      cluster_resources.SubtractCPUResourceInstances(allocate_cpu_instances);
-      std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
-                                                        .GetAvailableResourceInstances()
-                                                        .GetCPUInstances();
-      std::vector<double> expected_available_cpu_instances{0.5, 0.5, 0., 0.5};
-      ASSERT_TRUE(std::equal(available_cpu_instances.begin(),
-                             available_cpu_instances.end(),
-                             expected_available_cpu_instances.begin()));
-
-      NodeResources nr;
-      cluster_resources.GetNodeResources(0, &nr);
-      ASSERT_TRUE(nr.predefined_resources[0].available == 1.5);
-    }
-
-    {
-      std::vector<double> allocate_cpu_instances{1.5, 0.5, 2, 0.3};
-      // SubtractCPUResourceInstances() calls
-      // UpdateLocalAvailableResourcesFromResourceInstances() under the hood.
-      cluster_resources.AddCPUResourceInstances(allocate_cpu_instances);
-      std::vector<double> available_cpu_instances = cluster_resources.GetLocalResources()
-                                                        .GetAvailableResourceInstances()
-                                                        .GetCPUInstances();
-      std::vector<double> expected_available_cpu_instances{1., 1., 1., 0.8};
-      ASSERT_TRUE(std::equal(available_cpu_instances.begin(),
-                             available_cpu_instances.end(),
-                             expected_available_cpu_instances.begin()));
-
-      NodeResources nr;
-      cluster_resources.GetNodeResources(0, &nr);
-      ASSERT_TRUE(nr.predefined_resources[0].available == 3.8);
-    }
   }
 }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -84,41 +84,6 @@ namespace ray {
 
 namespace raylet {
 
-// A helper function to print the leased workers.
-std::string LeasedWorkersSring(
-    const std::unordered_map<WorkerID, std::shared_ptr<Worker>> &leased_workers) {
-  std::stringstream buffer;
-  buffer << "  @leased_workers: (";
-  for (const auto &pair : leased_workers) {
-    auto &worker = pair.second;
-    buffer << worker->WorkerId() << ", ";
-  }
-  buffer << ")";
-  return buffer.str();
-}
-
-// A helper function to print the workers in worker_pool_.
-std::string WorkerPoolString(const std::vector<std::shared_ptr<Worker>> &worker_pool) {
-  std::stringstream buffer;
-  buffer << "   @worker_pool: (";
-  for (const auto &worker : worker_pool) {
-    buffer << worker->WorkerId() << ", ";
-  }
-  buffer << ")";
-  return buffer.str();
-}
-
-// Helper function to print the worker's owner worker and and node owner.
-std::string WorkerOwnerString(std::shared_ptr<Worker> &worker) {
-  std::stringstream buffer;
-  const auto owner_worker_id =
-      WorkerID::FromBinary(worker->GetOwnerAddress().worker_id());
-  const auto owner_node_id = WorkerID::FromBinary(worker->GetOwnerAddress().raylet_id());
-  buffer << "leased_worker Lease " << worker->WorkerId() << " owned by "
-         << owner_worker_id << " / " << owner_node_id;
-  return buffer.str();
-}
-
 NodeManager::NodeManager(boost::asio::io_service &io_service,
                          const ClientID &self_node_id, const NodeManagerConfig &config,
                          ObjectManager &object_manager,
@@ -702,6 +667,7 @@ void NodeManager::ResourceDeleted(const ClientID &client_id,
       new_resource_scheduler_->DeleteResource(client_id.Binary(), resource_label);
     }
   }
+  RAY_LOG(DEBUG) << "[ResourceDeleted] Updated cluster_resource_map.";
   return;
 }
 
@@ -735,6 +701,7 @@ void NodeManager::HeartbeatAdded(const ClientID &client_id,
                   << client_id;
     return;
   }
+
   // Trigger local GC at the next heartbeat interval.
   if (heartbeat_data.should_global_gc()) {
     should_local_gc_ = true;
@@ -909,7 +876,6 @@ void NodeManager::DispatchTasks(
   // one class of tasks become stuck behind others in the queue, causing Ray to start
   // many workers. See #3644 for a more detailed description of this issue.
   std::vector<const std::pair<const SchedulingClass, ordered_set<TaskID>> *> fair_order;
-  RAY_CHECK(new_scheduler_enabled_ == false);
   for (auto &it : tasks_by_class) {
     fair_order.emplace_back(&it);
   }
@@ -966,7 +932,6 @@ void NodeManager::ProcessClientMessage(
                  << (registered_worker
                          ? std::to_string(registered_worker->GetProcess().GetId())
                          : "nil");
-
   if (registered_worker && registered_worker->IsDead()) {
     // For a worker that is marked as dead (because the job has died already),
     // all the messages are ignored except DisconnectClient.
@@ -1081,6 +1046,8 @@ void NodeManager::ProcessRegisterClientRequestMessage(
       static_cast<int64_t>(protocol::MessageType::RegisterClientReply), fbb.GetSize(),
       fbb.GetBufferPointer(), [this, client](const ray::Status &status) {
         if (!status.ok()) {
+          RAY_LOG(WARNING)
+              << "Failed to send RegisterClientReply to client, so disconnecting";
           ProcessDisconnectClientMessage(client);
         }
       });
@@ -1179,7 +1146,6 @@ void NodeManager::HandleWorkerAvailable(
 void NodeManager::HandleWorkerAvailable(const std::shared_ptr<Worker> &worker) {
   RAY_CHECK(worker);
   bool worker_idle = true;
-
   // If the worker was assigned a task, mark it as finished.
   if (!worker->GetAssignedTaskId().IsNil()) {
     worker_idle = FinishAssignedTask(*worker);
@@ -1190,10 +1156,10 @@ void NodeManager::HandleWorkerAvailable(const std::shared_ptr<Worker> &worker) {
     worker_pool_.PushWorker(worker);
   }
 
-  // Local resource availability changed: invoke scheduling policy for local node.
   if (new_scheduler_enabled_) {
-    NewSchedulerSchedulePendingTasks();
+    DispatchScheduledTasksToWorkers();
   } else {
+    // Local resource availability changed: invoke scheduling policy for local node.
     cluster_resource_map_[self_node_id_].SetLoadResources(
         local_queues_.GetResourceLoad());
     // Call task dispatch to assign work to the new worker.
@@ -1216,10 +1182,10 @@ void NodeManager::ProcessDisconnectClientMessage(
     } else {
       RAY_LOG(INFO) << "Ignoring client disconnect because the client has already "
                     << "been disconnected.";
-      return;
     }
   }
   RAY_CHECK(!(is_worker && is_driver));
+
   // If the client has any blocked tasks, mark them as unblocked. In
   // particular, we are no longer waiting for their dependencies.
   if (worker) {
@@ -1238,7 +1204,6 @@ void NodeManager::ProcessDisconnectClientMessage(
       // Clean up any open ray.wait calls that the worker made.
       task_dependency_manager_.UnsubscribeWaitDependencies(worker->WorkerId());
     }
-
     // Erase any lease metadata.
     leased_workers_.erase(worker->WorkerId());
 
@@ -1296,34 +1261,24 @@ void NodeManager::ProcessDisconnectClientMessage(
     worker_pool_.DisconnectWorker(worker);
 
     // Return the resources that were being used by this worker.
-    if (new_scheduler_enabled_) {
-      new_resource_scheduler_->SubtractCPUResourceInstances(
-          worker->GetBorrowedCPUInstances());
-      new_resource_scheduler_->FreeLocalTaskResources(worker->GetAllocatedInstances());
-      worker->ClearAllocatedInstances();
-      new_resource_scheduler_->FreeLocalTaskResources(
-          worker->GetLifetimeAllocatedInstances());
-      worker->ClearLifetimeAllocatedInstances();
-    } else {
-      auto const &task_resources = worker->GetTaskResourceIds();
-      local_available_resources_.ReleaseConstrained(
-          task_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
-      cluster_resource_map_[self_node_id_].Release(task_resources.ToResourceSet());
-      worker->ResetTaskResourceIds();
+    auto const &task_resources = worker->GetTaskResourceIds();
+    local_available_resources_.ReleaseConstrained(
+        task_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
+    cluster_resource_map_[self_node_id_].Release(task_resources.ToResourceSet());
+    worker->ResetTaskResourceIds();
 
-      auto const &lifetime_resources = worker->GetLifetimeResourceIds();
-      local_available_resources_.ReleaseConstrained(
-          lifetime_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
-      cluster_resource_map_[self_node_id_].Release(lifetime_resources.ToResourceSet());
-      worker->ResetLifetimeResourceIds();
-    }
+    auto const &lifetime_resources = worker->GetLifetimeResourceIds();
+    local_available_resources_.ReleaseConstrained(
+        lifetime_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
+    cluster_resource_map_[self_node_id_].Release(lifetime_resources.ToResourceSet());
+    worker->ResetLifetimeResourceIds();
 
-    // Since some resources may have been released, we can try to dispatch more tasks. YYY
-    if (new_scheduler_enabled_) {
-      NewSchedulerSchedulePendingTasks();
-    } else {
-      DispatchTasks(local_queues_.GetReadyTasksByClass());
-    }
+    RAY_LOG(DEBUG) << "Worker (pid=" << worker->GetProcess().GetId()
+                   << ") is disconnected. "
+                   << "job_id: " << worker->GetAssignedJobId();
+
+    // Since some resources may have been released, we can try to dispatch more tasks.
+    DispatchTasks(local_queues_.GetReadyTasksByClass());
   } else if (is_driver) {
     // The client is a driver.
     const auto job_id = worker->GetAssignedJobId();
@@ -1335,7 +1290,7 @@ void NodeManager::ProcessDisconnectClientMessage(
 
     RAY_LOG(DEBUG) << "Driver (pid=" << worker->GetProcess().GetId()
                    << ") is disconnected. "
-                   << "job_id: " << worker->GetAssignedJobId();
+                   << "job_id: " << job_id;
   }
 
   client->Close();
@@ -1421,6 +1376,9 @@ void NodeManager::ProcessWaitRequestMessage(
           }
         } else {
           // We failed to write to the client, so disconnect the client.
+          RAY_LOG(WARNING)
+              << "Failed to send WaitReply to client, so disconnecting client";
+          // We failed to send the reply to the client, so disconnect the worker.
           ProcessDisconnectClientMessage(client);
         }
       });
@@ -1449,7 +1407,7 @@ void NodeManager::ProcessWaitForDirectActorCallArgsRequestMessage(
       [this, client, tag](std::vector<ObjectID> found, std::vector<ObjectID> remaining) {
         RAY_CHECK(remaining.empty());
         std::shared_ptr<Worker> worker = worker_pool_.GetRegisteredWorker(client);
-        if (!worker) {
+        if (worker == nullptr) {
           RAY_LOG(ERROR) << "Lost worker for wait request " << client;
         } else {
           worker->DirectActorCallArgWaitComplete(tag);
@@ -1535,67 +1493,38 @@ void NodeManager::ProcessSubmitTaskMessage(const uint8_t *message_data) {
 
 void NodeManager::DispatchScheduledTasksToWorkers() {
   RAY_CHECK(new_scheduler_enabled_);
-
-  // Check every task in task_to_dispatch queue to see
-  // whether it can be dispatched and ran. This avoids head-of-line
-  // blocking where a task which cannot be dispatched because
-  // there are not enough available resources blocks other
-  // tasks from being dispatched.
-  for (size_t queue_size = tasks_to_dispatch_.size(); queue_size > 0; queue_size--) {
+  while (!tasks_to_dispatch_.empty()) {
     auto task = tasks_to_dispatch_.front();
     auto reply = task.first;
     auto spec = task.second.GetTaskSpecification();
-    tasks_to_dispatch_.pop_front();
-
     std::shared_ptr<Worker> worker = worker_pool_.PopWorker(spec);
-    if (!worker) {
-      // No worker available to schedule this task.
-      // Put the task back in the dispatch queue.
-      tasks_to_dispatch_.push_front(task);
+    if (worker == nullptr) {
       return;
     }
 
-    std::shared_ptr<TaskResourceInstances> allocated_instances(
-        new TaskResourceInstances());
-    bool schedulable = new_resource_scheduler_->AllocateLocalTaskResources(
-        spec.GetRequiredResources().GetResourceMap(), allocated_instances);
+    bool schedulable = new_resource_scheduler_->SubtractNodeAvailableResources(
+        self_node_id_.Binary(), spec.GetRequiredResources().GetResourceMap());
     if (!schedulable) {
-      // Not enough resources to schedule this task.
-      // Put it back at the end of the dispatch queue.
-      tasks_to_dispatch_.push_back(task);
-      worker_pool_.PushWorker(worker);
-      // Try next task in the dispatch queue.
-      continue;
+      return;
     }
-    worker->SetOwnerAddress(spec.CallerAddress());
+    // Handle the allocation to specific resource IDs.
+    auto acquired_resources =
+        local_available_resources_.Acquire(spec.GetRequiredResources());
+    cluster_resource_map_[self_node_id_].Acquire(spec.GetRequiredResources());
     if (spec.IsActorCreationTask()) {
-      worker->SetLifetimeAllocatedInstances(allocated_instances);
+      worker->SetLifetimeResourceIds(acquired_resources);
     } else {
-      worker->SetAllocatedInstances(allocated_instances);
+      worker->SetTaskResourceIds(acquired_resources);
     }
-    worker->AssignTaskId(spec.TaskId());
-    worker->AssignJobId(spec.JobId());
-    worker->SetAssignedTask(task.second);
 
     reply(worker, ClientID::Nil(), "", -1);
+    tasks_to_dispatch_.pop_front();
   }
 }
 
 void NodeManager::NewSchedulerSchedulePendingTasks() {
   RAY_CHECK(new_scheduler_enabled_);
-  size_t queue_size = tasks_to_schedule_.size();
-
-  // Check every task in task_to_schedule queue to see
-  // whether it can be scheduled. This avoids head-of-line
-  // blocking where a task which cannot be scheduled because
-  // there are not enough available resources blocks other
-  // tasks from being scheduled.
-  while (queue_size > 0) {
-    if (queue_size == 0) {
-      return;
-    } else {
-      queue_size--;
-    }
+  while (!tasks_to_schedule_.empty()) {
     auto work = tasks_to_schedule_.front();
     auto task = work.second;
     auto request_resources =
@@ -1605,16 +1534,13 @@ void NodeManager::NewSchedulerSchedulePendingTasks() {
         new_resource_scheduler_->GetBestSchedulableNode(request_resources, &violations);
     if (node_id_string.empty()) {
       /// There is no node that has available resources to run the request.
-      tasks_to_schedule_.pop_front();
-      tasks_to_schedule_.push_back(work);
-      continue;
+      break;
     } else {
       if (node_id_string == self_node_id_.Binary()) {
         WaitForTaskArgsRequests(work);
       } else {
-        new_resource_scheduler_->AllocateRemoteTaskResources(node_id_string,
-                                                             request_resources);
-
+        new_resource_scheduler_->SubtractNodeAvailableResources(node_id_string,
+                                                                request_resources);
         ClientID node_id = ClientID::FromBinary(node_id_string);
         auto node_info_opt = gcs_client_->Nodes().Get(node_id);
         RAY_CHECK(node_info_opt)
@@ -1631,19 +1557,17 @@ void NodeManager::NewSchedulerSchedulePendingTasks() {
 
 void NodeManager::WaitForTaskArgsRequests(std::pair<ScheduleFn, Task> &work) {
   RAY_CHECK(new_scheduler_enabled_);
-  const Task &task = work.second;
-  std::vector<ObjectID> object_ids = task.GetTaskSpecification().GetDependencies();
+  std::vector<ObjectID> object_ids = work.second.GetTaskSpecification().GetDependencies();
 
   if (object_ids.size() > 0) {
-    bool args_ready = task_dependency_manager_.SubscribeGetDependencies(
-        task.GetTaskSpecification().TaskId(), task.GetDependencies());
-    if (args_ready) {
-      task_dependency_manager_.UnsubscribeGetDependencies(
-          task.GetTaskSpecification().TaskId());
-      tasks_to_dispatch_.push_back(work);
-    } else {
-      waiting_tasks_[task.GetTaskSpecification().TaskId()] = work;
-    }
+    ray::Status status = object_manager_.Wait(
+        object_ids, -1, object_ids.size(), false,
+        [this, work](std::vector<ObjectID> found, std::vector<ObjectID> remaining) {
+          RAY_CHECK(remaining.empty());
+          tasks_to_dispatch_.push_back(work);
+          DispatchScheduledTasksToWorkers();
+        });
+    RAY_CHECK_OK(status);
   } else {
     tasks_to_dispatch_.push_back(work);
   }
@@ -1657,7 +1581,6 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
   Task task(task_message);
   bool is_actor_creation_task = task.GetTaskSpecification().IsActorCreationTask();
   ActorID actor_id = ActorID::Nil();
-
   if (is_actor_creation_task) {
     actor_id = task.GetTaskSpecification().ActorCreationId();
 
@@ -1670,11 +1593,11 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
   }
 
   if (new_scheduler_enabled_) {
-    auto task_spec = task.GetTaskSpecification();
+    auto request_resources = task.GetTaskSpecification().GetRequiredResources();
     auto work = std::make_pair(
-        [this, task_spec, reply, send_reply_callback](std::shared_ptr<Worker> worker,
-                                                      ClientID spillback_to,
-                                                      std::string address, int port) {
+        [this, request_resources, reply, send_reply_callback](
+            std::shared_ptr<Worker> worker, ClientID spillback_to, std::string address,
+            int port) {
           if (worker != nullptr) {
             reply->mutable_worker_address()->set_ip_address(
                 initial_config_.node_manager_address);
@@ -1683,52 +1606,7 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
             reply->mutable_worker_address()->set_raylet_id(self_node_id_.Binary());
             RAY_CHECK(leased_workers_.find(worker->WorkerId()) == leased_workers_.end());
             leased_workers_[worker->WorkerId()] = worker;
-// TODO (Ion): Fix handling floating point errors, maybe by moving to integers.
-#define ZERO_CAPACITY 1.0e-5
-            std::shared_ptr<TaskResourceInstances> allocated_resources;
-            if (task_spec.IsActorCreationTask()) {
-              allocated_resources = worker->GetLifetimeAllocatedInstances();
-            } else {
-              allocated_resources = worker->GetAllocatedInstances();
-            }
-            auto predefined_resources = allocated_resources->predefined_resources;
-            ::ray::rpc::ResourceMapEntry *resource;
-            for (size_t res_idx = 0; res_idx < predefined_resources.size(); res_idx++) {
-              bool first = true;  // Set resource name only if at least one of its
-                                  // instances has available capacity.
-              for (size_t inst_idx = 0; inst_idx < predefined_resources[res_idx].size();
-                   inst_idx++) {
-                if (std::abs(predefined_resources[res_idx][inst_idx]) > ZERO_CAPACITY) {
-                  if (first) {
-                    resource = reply->add_resource_mapping();
-                    resource->set_name(
-                        new_resource_scheduler_->GetResourceNameFromIndex(res_idx));
-                    first = false;
-                  }
-                  auto rid = resource->add_resource_ids();
-                  rid->set_index(inst_idx);
-                  rid->set_quantity(predefined_resources[res_idx][inst_idx]);
-                }
-              }
-            }
-            auto custom_resources = allocated_resources->custom_resources;
-            for (auto it = custom_resources.begin(); it != custom_resources.end(); ++it) {
-              bool first = true;  // Set resource name only if at least one of its
-                                  // instances has available capacity.
-              for (size_t inst_idx = 0; inst_idx < it->second.size(); inst_idx++) {
-                if (std::abs(it->second[inst_idx]) > ZERO_CAPACITY) {
-                  if (first) {
-                    resource = reply->add_resource_mapping();
-                    resource->set_name(
-                        new_resource_scheduler_->GetResourceNameFromIndex(it->first));
-                    first = false;
-                  }
-                  auto rid = resource->add_resource_ids();
-                  rid->set_index(inst_idx);
-                  rid->set_quantity(it->second[inst_idx]);
-                }
-              }
-            }
+            leased_worker_resources_[worker->WorkerId()] = request_resources;
           } else {
             reply->mutable_retry_at_raylet_address()->set_ip_address(address);
             reply->mutable_retry_at_raylet_address()->set_port(port);
@@ -1771,6 +1649,7 @@ void NodeManager::HandleRequestWorkerLease(const rpc::RequestWorkerLeaseRequest 
           }
         }
         send_reply_callback(Status::OK(), nullptr, nullptr);
+
         RAY_CHECK(leased_workers_.find(worker_id) == leased_workers_.end())
             << "Worker is already leased out " << worker_id;
 
@@ -1794,12 +1673,47 @@ void NodeManager::HandleReturnWorker(const rpc::ReturnWorkerRequest &request,
                                      rpc::SendReplyCallback send_reply_callback) {
   // Read the resource spec submitted by the client.
   auto worker_id = WorkerID::FromBinary(request.worker_id());
+  RAY_LOG(DEBUG) << "Return worker " << worker_id;
   std::shared_ptr<Worker> worker = leased_workers_[worker_id];
 
+  if (new_scheduler_enabled_) {
+    if (worker->IsBlocked()) {
+      // If worker blocked, unblock it to return the cpu resources back to the worker.
+      HandleDirectCallTaskUnblocked(worker);
+    }
+    auto it = leased_worker_resources_.find(worker_id);
+    RAY_CHECK(it != leased_worker_resources_.end());
+
+    new_resource_scheduler_->AddNodeAvailableResources(self_node_id_.Binary(),
+                                                       it->second.GetResourceMap());
+
+    if (worker->borrowed_cpu_resources_.GetResourceMap().size()) {
+      // This machine is oversubscribed, so the worker didn't get back cpus when
+      // unblocked. Thus we need to substract these cpus, as the previous
+      // "AddNodeAvailableResources" call assumed they were allocated to this worker.
+      new_resource_scheduler_->SubtractNodeAvailableResources(
+          self_node_id_.Binary(), worker->borrowed_cpu_resources_.GetResourceMap());
+      worker->borrowed_cpu_resources_ = ResourceSet();
+    }
+    leased_worker_resources_.erase(it);
+
+    // Update resource ids.
+    auto const &task_resources = worker->GetTaskResourceIds();
+    local_available_resources_.ReleaseConstrained(
+        task_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
+    cluster_resource_map_[self_node_id_].Release(task_resources.ToResourceSet());
+    worker->ResetTaskResourceIds();
+
+    // TODO (ion): Handle ProcessDisconnectClientMessage()
+    HandleWorkerAvailable(worker);
+    leased_workers_.erase(worker_id);
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+    return;
+  }
+
+  leased_workers_.erase(worker_id);
   Status status;
   if (worker) {
-    leased_workers_.erase(worker_id);
-
     if (request.disconnect_worker()) {
       ProcessDisconnectClientMessage(worker->Connection());
     } else {
@@ -1807,12 +1721,6 @@ void NodeManager::HandleReturnWorker(const rpc::ReturnWorkerRequest &request,
       // unblock RPC by unblocking it immediately (unblock is idempotent).
       if (worker->IsBlocked()) {
         HandleDirectCallTaskUnblocked(worker);
-      }
-      if (new_scheduler_enabled_) {
-        new_resource_scheduler_->SubtractCPUResourceInstances(
-            worker->GetBorrowedCPUInstances());
-        new_resource_scheduler_->FreeLocalTaskResources(worker->GetAllocatedInstances());
-        worker->ClearAllocatedInstances();
       }
       HandleWorkerAvailable(worker);
     }
@@ -2192,16 +2100,14 @@ void NodeManager::HandleDirectCallTaskBlocked(const std::shared_ptr<Worker> &wor
     if (!worker) {
       return;
     }
-    std::vector<double> cpu_instances;
-    if (worker->GetAllocatedInstances() != nullptr) {
-      cpu_instances = worker->GetAllocatedInstances()->GetCPUInstances();
-    }
-    if (cpu_instances.size() > 0) {
-      std::vector<double> borrowed_cpu_instances =
-          new_resource_scheduler_->AddCPUResourceInstances(cpu_instances);
-      worker->SetBorrowedCPUInstances(borrowed_cpu_instances);
-      worker->MarkBlocked();
-    }
+    auto const cpu_resource_ids = worker->ReleaseTaskCpuResources();
+    local_available_resources_.Release(cpu_resource_ids);
+    cluster_resource_map_[self_node_id_].Release(cpu_resource_ids.ToResourceSet());
+    new_resource_scheduler_->AddNodeAvailableResources(
+        self_node_id_.Binary(),  // A
+        cpu_resource_ids.ToResourceSet().GetResourceMap());
+
+    worker->MarkBlocked();
     NewSchedulerSchedulePendingTasks();
     return;
   }
@@ -2221,23 +2127,43 @@ void NodeManager::HandleDirectCallTaskUnblocked(const std::shared_ptr<Worker> &w
     if (!worker) {
       return;
     }
-    std::vector<double> cpu_instances;
-    if (worker->GetAllocatedInstances() != nullptr) {
-      cpu_instances = worker->GetAllocatedInstances()->GetCPUInstances();
+    auto it = leased_worker_resources_.find(worker->WorkerId());
+    RAY_CHECK(it != leased_worker_resources_.end());
+    const auto cpu_resources = it->second.GetNumCpus();
+    bool oversubscribed = !local_available_resources_.Contains(cpu_resources);
+    if (!oversubscribed) {
+      // Reacquire the CPU resources for the worker. Note that care needs to be
+      // taken if the user is using the specific CPU IDs since the IDs that we
+      // reacquire here may be different from the ones that the task started with.
+      auto const resource_ids = local_available_resources_.Acquire(cpu_resources);
+      worker->AcquireTaskCpuResources(resource_ids);
+      cluster_resource_map_[self_node_id_].Acquire(cpu_resources);
+      new_resource_scheduler_->SubtractNodeAvailableResources(
+          self_node_id_.Binary(), cpu_resources.GetResourceMap());
+      worker->borrowed_cpu_resources_ = ResourceSet();
+    } else {
+      // Remember these are borrowed cpus resources, i.e., we did not return then to the
+      // worker.
+      worker->borrowed_cpu_resources_ = cpu_resources;
     }
-    if (cpu_instances.size() > 0) {
-      new_resource_scheduler_->SubtractCPUResourceInstances(cpu_instances);
-      new_resource_scheduler_->AddCPUResourceInstances(worker->GetBorrowedCPUInstances());
-      worker->MarkUnblocked();
-    }
+    worker->MarkUnblocked();
     NewSchedulerSchedulePendingTasks();
     return;
   }
 
-  if (!worker || worker->GetAssignedTaskId().IsNil() || !worker->IsBlocked()) {
+  if (!worker || worker->GetAssignedTaskId().IsNil()) {
     return;  // The worker may have died or is no longer processing the task.
   }
   TaskID task_id = worker->GetAssignedTaskId();
+
+  // First, always release task dependencies. This ensures we don't leak resources even
+  // if we don't need to unblock the worker below.
+  task_dependency_manager_.UnsubscribeGetDependencies(task_id);
+
+  if (!worker->IsBlocked()) {
+    return;  // Don't need to unblock the worker.
+  }
+
   Task task = local_queues_.GetTaskOfState(task_id, TaskState::RUNNING);
   const auto required_resources = task.GetTaskSpecification().GetRequiredResources();
   const ResourceSet cpu_resources = required_resources.GetNumCpus();
@@ -2258,7 +2184,6 @@ void NodeManager::HandleDirectCallTaskUnblocked(const std::shared_ptr<Worker> &w
         << cluster_resource_map_[self_node_id_].GetAvailableResources().ToString();
   }
   worker->MarkUnblocked();
-  task_dependency_manager_.UnsubscribeGetDependencies(task_id);
 }
 
 void NodeManager::AsyncResolveObjects(
@@ -2488,29 +2413,18 @@ bool NodeManager::FinishAssignedTask(Worker &worker) {
   TaskID task_id = worker.GetAssignedTaskId();
   RAY_LOG(DEBUG) << "Finished task " << task_id;
 
+  // (See design_docs/task_states.rst for the state transition diagram.)
   Task task;
-  if (new_scheduler_enabled_) {
-    task = worker.GetAssignedTask();
-    // leased_workers_.erase(worker.WorkerId()); // Maybe RAY_CHECK ???
-    if (worker.GetAllocatedInstances() != nullptr) {
-      new_resource_scheduler_->SubtractCPUResourceInstances(
-          worker.GetBorrowedCPUInstances());
-      new_resource_scheduler_->FreeLocalTaskResources(worker.GetAllocatedInstances());
-      worker.ClearAllocatedInstances();
-    }
-  } else {
-    // (See design_docs/task_states.rst for the state transition diagram.)
-    RAY_CHECK(local_queues_.RemoveTask(task_id, &task));
+  RAY_CHECK(local_queues_.RemoveTask(task_id, &task));
 
-    // Release task's resources. The worker's lifetime resources are still held.
-    auto const &task_resources = worker.GetTaskResourceIds();
-    local_available_resources_.ReleaseConstrained(
-        task_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
-    cluster_resource_map_[self_node_id_].Release(task_resources.ToResourceSet());
-    worker.ResetTaskResourceIds();
-  }
+  // Release task's resources. The worker's lifetime resources are still held.
+  auto const &task_resources = worker.GetTaskResourceIds();
+  local_available_resources_.ReleaseConstrained(
+      task_resources, cluster_resource_map_[self_node_id_].GetTotalResources());
+  cluster_resource_map_[self_node_id_].Release(task_resources.ToResourceSet());
+  worker.ResetTaskResourceIds();
 
-  const auto &spec = task.GetTaskSpecification();  //
+  const auto &spec = task.GetTaskSpecification();
   if ((spec.IsActorCreationTask() || spec.IsActorTask())) {
     // If this was an actor or actor creation task, handle the actor's new
     // state.
@@ -2843,43 +2757,31 @@ void NodeManager::HandleObjectLocal(const ObjectID &object_id) {
                  << " on " << self_node_id_ << ", " << ready_task_ids.size()
                  << " tasks ready";
   // Transition the tasks whose dependencies are now fulfilled to the ready state.
-  if (new_scheduler_enabled_) {
-    for (auto task_id : ready_task_ids) {
-      auto it = waiting_tasks_.find(task_id);
-      if (it != waiting_tasks_.end()) {
-        task_dependency_manager_.UnsubscribeGetDependencies(task_id);
-        tasks_to_dispatch_.push_back(it->second);
-        waiting_tasks_.erase(it);
-      }
+  if (ready_task_ids.size() > 0) {
+    std::unordered_set<TaskID> ready_task_id_set(ready_task_ids.begin(),
+                                                 ready_task_ids.end());
+
+    // First filter out the tasks that should not be moved to READY.
+    local_queues_.FilterState(ready_task_id_set, TaskState::BLOCKED);
+    local_queues_.FilterState(ready_task_id_set, TaskState::RUNNING);
+    local_queues_.FilterState(ready_task_id_set, TaskState::DRIVER);
+    local_queues_.FilterState(ready_task_id_set, TaskState::WAITING_FOR_ACTOR_CREATION);
+
+    // Make sure that the remaining tasks are all WAITING or direct call
+    // actors.
+    auto ready_task_id_set_copy = ready_task_id_set;
+    local_queues_.FilterState(ready_task_id_set_copy, TaskState::WAITING);
+    // Filter out direct call actors. These are not tracked by the raylet and
+    // their assigned task ID is the actor ID.
+    for (const auto &id : ready_task_id_set_copy) {
+      RAY_CHECK(actor_registry_.count(id.ActorId()) > 0);
+      ready_task_id_set.erase(id);
     }
-    NewSchedulerSchedulePendingTasks();
-  } else {
-    if (ready_task_ids.size() > 0) {
-      std::unordered_set<TaskID> ready_task_id_set(ready_task_ids.begin(),
-                                                   ready_task_ids.end());
 
-      // First filter out the tasks that should not be moved to READY.
-      local_queues_.FilterState(ready_task_id_set, TaskState::BLOCKED);
-      local_queues_.FilterState(ready_task_id_set, TaskState::RUNNING);
-      local_queues_.FilterState(ready_task_id_set, TaskState::DRIVER);
-      local_queues_.FilterState(ready_task_id_set, TaskState::WAITING_FOR_ACTOR_CREATION);
-
-      // Make sure that the remaining tasks are all WAITING or direct call
-      // actors.
-      auto ready_task_id_set_copy = ready_task_id_set;
-      local_queues_.FilterState(ready_task_id_set_copy, TaskState::WAITING);
-      // Filter out direct call actors. These are not tracked by the raylet and
-      // their assigned task ID is the actor ID.
-      for (const auto &id : ready_task_id_set_copy) {
-        RAY_CHECK(actor_registry_.count(id.ActorId()) > 0);
-        ready_task_id_set.erase(id);
-      }
-
-      // Queue and dispatch the tasks that are ready to run (i.e., WAITING).
-      auto ready_tasks = local_queues_.RemoveTasks(ready_task_id_set);
-      local_queues_.QueueTasks(ready_tasks, TaskState::READY);
-      DispatchTasks(MakeTasksByClass(ready_tasks));
-    }
+    // Queue and dispatch the tasks that are ready to run (i.e., WAITING).
+    auto ready_tasks = local_queues_.RemoveTasks(ready_task_id_set);
+    local_queues_.QueueTasks(ready_tasks, TaskState::READY);
+    DispatchTasks(MakeTasksByClass(ready_tasks));
   }
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -720,6 +720,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
 
   /// The new resource scheduler for direct task calls.
   std::shared_ptr<ClusterResourceScheduler> new_resource_scheduler_;
+  /// Map of leased workers to their current resource usage.
+  /// TODO(ion): Check whether we can track these resources in the worker.
+  std::unordered_map<WorkerID, ResourceSet> leased_worker_resources_;
 
   typedef std::function<void(std::shared_ptr<Worker>, ClientID spillback_to,
                              std::string address, int port)>
@@ -730,8 +733,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_schedule_;
   /// Queue of lease requests that should be scheduled onto workers.
   std::deque<std::pair<ScheduleFn, Task>> tasks_to_dispatch_;
-  /// Queue tasks waiting for arguments to be transferred locally.
-  absl::flat_hash_map<TaskID, std::pair<ScheduleFn, Task>> waiting_tasks_;
 
   /// Cache of gRPC clients to workers (not necessarily running on this node).
   /// Also includes the number of inflight requests to each worker - when this

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -19,8 +19,6 @@
 
 #include "ray/common/client_connection.h"
 #include "ray/common/id.h"
-#include "ray/common/scheduling/cluster_resource_scheduler.h"
-#include "ray/common/scheduling/scheduling_ids.h"
 #include "ray/common/task/scheduling_resources.h"
 #include "ray/common/task/task.h"
 #include "ray/common/task/task_common.h"
@@ -87,40 +85,11 @@ class Worker {
   void DirectActorCallArgWaitComplete(int64_t tag);
   void WorkerLeaseGranted(const std::string &address, int port);
 
-  // Setter, geter, and clear methods  for allocated_instances_.
-  void SetAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
-    allocated_instances_ = allocated_instances;
-  };
-
-  std::shared_ptr<TaskResourceInstances> GetAllocatedInstances() {
-    return allocated_instances_;
-  };
-
-  void ClearAllocatedInstances() { allocated_instances_ = nullptr; };
-
-  void SetLifetimeAllocatedInstances(
-      std::shared_ptr<TaskResourceInstances> &allocated_instances) {
-    lifetime_allocated_instances_ = allocated_instances;
-  };
-
-  std::shared_ptr<TaskResourceInstances> GetLifetimeAllocatedInstances() {
-    return lifetime_allocated_instances_;
-  };
-
-  void ClearLifetimeAllocatedInstances() { lifetime_allocated_instances_ = nullptr; };
-
-  void SetBorrowedCPUInstances(std::vector<double> &cpu_instances) {
-    borrowed_cpu_instances_ = cpu_instances;
-  };
-
-  std::vector<double> &GetBorrowedCPUInstances() { return borrowed_cpu_instances_; };
-
-  void ClearBorrowedCPUInstances() { return borrowed_cpu_instances_.clear(); };
-
-  Task &GetAssignedTask() { return assigned_task_; };
-
-  void SetAssignedTask(Task &assigned_task) { assigned_task_ = assigned_task; };
+  /// Cpus borrowed by the worker. This happens when the machine is oversubscribed
+  /// and the worker does not get back the cpu resources when unblocked.
+  /// TODO (ion): Add methods to access this variable.
+  /// TODO (ion): Investigate a more intuitive alternative to track these Cpus.
+  ResourceSet borrowed_cpu_resources_;
 
   rpc::CoreWorkerClient *rpc_client() { return rpc_client_.get(); }
 
@@ -165,22 +134,6 @@ class Worker {
   /// The address of this worker's owner. The owner is the worker that
   /// currently holds the lease on this worker, if any.
   rpc::Address owner_address_;
-  /// The capacity of each resource instance allocated to this worker in order
-  /// to satisfy the resource requests of the task is currently running.
-  std::shared_ptr<TaskResourceInstances> allocated_instances_;
-  /// The capacity of each resource instance allocated to this worker
-  /// when running as an actor.
-  std::shared_ptr<TaskResourceInstances> lifetime_allocated_instances_;
-  /// CPUs borrowed by the worker. This happens in the following scenario:
-  /// 1) Worker A is blocked, so it donates its CPUs back to the node.
-  /// 2) Other workers are scheduled and are allocated some of the CPUs donated by A.
-  /// 3) Task A is unblocked, but it cannot get all CPUs back. At this point,
-  /// the node is oversubscribed. borrowed_cpu_instances_ represents the number
-  /// of CPUs this node is oversubscribed by.
-  /// TODO (Ion): Investigate a more intuitive alternative to track these Cpus.
-  std::vector<double> borrowed_cpu_instances_;
-  /// Task being assigned to this worker.
-  Task assigned_task_;
 };
 
 }  // namespace raylet


### PR DESCRIPTION
This reverts commit 6141fdab955926229f3c20581771ac3a1c0819c5.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR appears to be causing some segfaults in Travis. Running locally, I got stacktraces like this:
```
PC: @                0x0 (unknown)
*** SIGSEGV (@0x158) received by PID 10773 (TID 0x7fe40ddda800) from PID 344; stack trace: ***
    @     0x7fe40d2a6890 (unknown)
    @     0x5556eca5b18e ray::raylet::NodeManager::HandleUnexpectedWorkerFailure()
    @     0x5556ecb52658 _ZNSt17_Function_handlerIFvPN3ray3gcs14RedisGcsClientERKNS0_8WorkerIDERKSt6vectorINS0_3rpc17WorkerFailureDataESaIS9_EEEZNS1_20SubscriptionExecutorIS4_S9_NS1_18WorkerFailureTableEE17AsyncSubscribeAllERKNS0_8ClientIDERKSt8functionIFvS6_RKS9_EERKSL_IFvNS0_6StatusEEEEUlS3_S6_SD_E_E9_M_invokeERKSt9_Any_dataOS3_S6_SD_
    @     0x5556ecb457dd _ZNSt17_Function_handlerIFvPN3ray3gcs14RedisGcsClientERKNS0_8WorkerIDENS0_3rpc13GcsChangeModeERKSt6vectorINS7_17WorkerFailureDataESaISA_EEEZNS1_3LogIS4_SA_E9SubscribeERKNS0_5JobIDERKNS0_8ClientIDERKSt8functionIFvS3_S6_SE_EERKSO_IFvS3_EEEUlS3_S6_S8_SE_E_E9_M_invokeERKSt9_Any_dataOS3_S6_OS8_SE_
    @     0x5556ecb2355a _ZNSt17_Function_handlerIFvSt10shared_ptrIN3ray3gcs13CallbackReplyEEEZNS2_3LogINS1_8WorkerIDENS1_3rpc17WorkerFailureDataEE9SubscribeERKNS1_5JobIDERKNS1_8ClientIDERKSt8functionIFvPNS2_14RedisGcsClientERKS7_NS8_13GcsChangeModeERKSt6vectorIS9_SaIS9_EEEERKSH_IFvSJ_EEEUlS4_E_E9_M_invokeERKSt9_Any_dataOS4_
    @     0x5556ecb5b4c4 _ZN5boost4asio6detail18completion_handlerIZN3ray3gcs20RedisCallbackManager12CallbackItem8DispatchERSt10shared_ptrINS4_13CallbackReplyEEEUlvE_E11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm
    @     0x5556ecf5ebe1 boost::asio::detail::scheduler::do_run_one()
    @     0x5556ecf5f1e1 boost::asio::detail::scheduler::run()
    @     0x5556ecf61b23 boost::asio::io_context::run()
    @     0x5556ec9e408a main
    @     0x7fe40caa4b97 __libc_start_main
    @     0x5556ec9f391a _start
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
