### PR TITLE
Support setting extra_envs for remote function and Actor

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -314,12 +314,12 @@ cdef deserialize_args(
     return ray.signature.recover_args(args)
 
 
-cdef void prepare_extra_envs(
+cdef int prepare_extra_envs(
         dict extra_envs,
-        unordered_map[c_string, c_string] &c_extra_envs):
+        unordered_map[c_string, c_string] &c_extra_envs) except -1:
 
     if not extra_envs:
-        return
+        return 0
 
     if "CUDA_VISIBLE_DEVICES" in extra_envs:
         raise ValueError(
@@ -328,6 +328,8 @@ cdef void prepare_extra_envs(
         if not (isinstance(value, str) and isinstance(value, str)):
             raise ValueError("Extra envs key and value must be str.")
         c_extra_envs[key.encode("ascii")] = value.encode("ascii")
+
+    return 0
 
 
 cdef dict deserialize_extra_envs(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -317,10 +317,9 @@ class ActorClass:
                             self.__ray_metadata__.class_name))
 
     @classmethod
-    def _ray_from_modified_class(cls, modified_class, class_id,
-                                 max_reconstructions, num_cpus, num_gpus,
-                                 memory, object_store_memory, resources,
-                                 extra_envs):
+    def _ray_from_modified_class(
+            cls, modified_class, class_id, max_reconstructions, num_cpus,
+            num_gpus, memory, object_store_memory, resources, extra_envs):
         for attribute in [
                 "remote", "_remote", "_ray_from_modified_class",
                 "_ray_from_function_descriptor"
@@ -355,16 +354,16 @@ class ActorClass:
         return self
 
     @classmethod
-    def _ray_from_function_descriptor(cls, language,
-                                      actor_creation_function_descriptor,
-                                      max_reconstructions, num_cpus, num_gpus,
-                                      memory, object_store_memory, resources):
+    def _ray_from_function_descriptor(
+            cls, language, actor_creation_function_descriptor,
+            max_reconstructions, num_cpus, num_gpus, memory,
+            object_store_memory, resources, extra_envs):
         self = ActorClass.__new__(ActorClass)
 
         self.__ray_metadata__ = ActorClassMetadata(
             language, None, actor_creation_function_descriptor, None,
             max_reconstructions, num_cpus, num_gpus, memory,
-            object_store_memory, resources)
+            object_store_memory, resources, extra_envs)
 
         return self
 
@@ -477,7 +476,7 @@ class ActorClass:
             raise ValueError("Detached actors must be named. "
                              "Please use Actor._remote(name='some_name') "
                              "to associate the name.")
-        
+
         if extra_envs is None:
             extra_envs = meta.extra_envs
 
@@ -518,6 +517,8 @@ class ActorClass:
         if worker.mode == ray.LOCAL_MODE:
             assert not meta.is_cross_language, \
                 "Cross language ActorClass cannot be executed locally."
+            assert not extra_envs, \
+                "Set extra envs is not allowed for locally mode."
             actor_id = ActorID.from_random()
             worker.actors[actor_id] = meta.modified_class(
                 *copy.deepcopy(args), **copy.deepcopy(kwargs))

--- a/python/ray/cross_language.py
+++ b/python/ray/cross_language.py
@@ -68,7 +68,8 @@ def java_function(class_name, function_name):
         None,  # resources,
         None,  # num_return_vals,
         None,  # max_calls,
-        None)  # max_retries)
+        None,  # max_retries,
+        None)  # extra_envs)
 
 
 def java_actor_class(class_name):
@@ -81,4 +82,5 @@ def java_actor_class(class_name):
         None,  # num_gpus,
         None,  # memory,
         None,  # object_store_memory,
-        None)  # resources,
+        None,  # resources,
+        None)  # extra_envs

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -93,6 +93,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                         const unordered_map[c_string, double] &resources,
                         const c_vector[shared_ptr[CRayObject]] &args,
                         const c_vector[CObjectID] &arg_reference_ids,
+                        const unordered_map[c_string, c_string] &extra_envs,
                         const c_vector[CObjectID] &return_ids,
                         c_vector[shared_ptr[CRayObject]] *returns,
                         const CWorkerID &worker_id) nogil,
@@ -108,11 +109,13 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus SubmitTask(
             const CRayFunction &function, const c_vector[CTaskArg] &args,
             const CTaskOptions &options, c_vector[CObjectID] *return_ids,
-            int max_retries)
+            int max_retries, unordered_map[c_string, c_string] &extra_envs)
         CRayStatus CreateActor(
             const CRayFunction &function, const c_vector[CTaskArg] &args,
             const CActorCreationOptions &options,
-            const c_string &extension_data, CActorID *actor_id)
+            const c_string &extension_data,
+            unordered_map[c_string, c_string] &extra_envs,
+            CActorID *actor_id)
         CRayStatus SubmitActorTask(
             const CActorID &actor_id, const CRayFunction &function,
             const c_vector[CTaskArg] &args, const CTaskOptions &options,

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -207,9 +207,11 @@ class RemoteFunction:
                 assert not self._is_cross_language, \
                     "Cross language remote function " \
                     "cannot be executed locally."
+                assert not extra_envs, \
+                    "Set extra envs is not allowed for locally mode."
                 object_ids = worker.local_mode_manager.execute(
                     self._function, self._function_descriptor, args, kwargs,
-                    num_return_vals, extra_envs)
+                    num_return_vals)
             else:
                 object_ids = worker.core_worker.submit_task(
                     self._language, self._function_descriptor, list_args,

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -407,3 +407,11 @@ py_test(
     tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
+
+py_test(
+    name = "test_extra_envs",
+    size = "small",
+    srcs = ["test_extra_envs.py"],
+    tags = ["exclusive"],
+    deps = ["//:ray_lib"],
+)

--- a/python/ray/tests/test_extra_envs.py
+++ b/python/ray/tests/test_extra_envs.py
@@ -1,0 +1,93 @@
+import os
+import pytest
+import sys
+
+import ray
+
+
+def test_normal_remote_task():
+    @ray.remote(num_cpus=1, extra_envs={"key2", "value1"})
+    def f1(key):
+        return os.environ.get(key, "error")
+
+    @ray.remote(num_cpus=1, extra_envs={"key2": "value2"})
+    def f2(key):
+        return os.environ.get(key, "error")
+
+    ray.init(num_cpus=1)
+
+    assert ray.get(f1.remote("key1")) == "value1"
+    assert ray.get(f1.remote("key3")) == "error"
+    v = ray.get(f1.options(extra_envs={"key1", "value3"}).remote("key"))
+    assert v == "value3"
+    v = ray.get(f1.options(extra_envs={}).remote("key1"))
+    assert v == "error"
+    assert ray.get(f2.remote("key2")) == "value2"
+    assert ray.get(f2.remote("key1")) == "error"
+
+    with pytest.raises(ValueError) as excinfo:
+        f1.options(extra_envs={"CUDA_VISIBLE_DEVICES": "1"}).remote()
+    assert str(excinfo.value) == \
+        '"CUDA_VISIBLE_DEVICES" should not be set by user.'
+
+    with pytest.raises(ValueError) as excinfo:
+        f1.options(extra_envs={"key": 1.0}).remote()
+    assert str(excinfo.value) == \
+        "Extra envs key and value must be str."
+
+    ray.shutdown()
+
+
+def test_actor():
+    @ray.remote(num_cpus=1, extra_envs={"actor1": "value1"})
+    class Actor1:
+        def get(self, key):
+            return os.environ.get(key, "error")
+
+    @ray.remote(num_cpus=1, extra_envs={"actor2": "value2"})
+    class Actor2:
+        def get(self, key):
+            return os.environ.get(key, "error")
+
+    @ray.remote(num_cpus=1, extra_envs={"actor3": "value3"})
+    class Actor3:
+        def get(self, key):
+            return os.environ.get(key, "error")
+
+    ray.init(num_cpus=2)
+
+    actor1 = Actor1.remote()
+    actor2 = Actor2.remote()
+
+    assert ray.get(actor1.get.remote("actor1")) == "value1"
+    assert ray.get(actor1.get.remote("actor3")) == "error"
+    assert ray.get(actor1.get.remote("actor1")) == "value1"
+
+    assert ray.get(actor2.get.remote("actor2")) == "value2"
+    assert ray.get(actor2.get.remote("actor3")) == "error"
+    assert ray.get(actor2.get.remote("actor2")) == "value2"
+
+    del actor1
+
+    actor3 = Actor3.remote()
+    assert ray.get(actor3.get.remote("actor3")) == "value3"
+    assert ray.get(actor3.get.remote("actor4")) == "error"
+    assert ray.get(actor3.get.remote("actor3")) == "value3"
+
+    del actor2
+
+    with pytest.raises(ValueError) as excinfo:
+        Actor1.options(extra_envs={"CUDA_VISIBLE_DEVICES": "1"}).remote()
+    assert str(excinfo.value) == \
+        '"CUDA_VISIBLE_DEVICES" should not be set by user.'
+
+    with pytest.raises(ValueError) as excinfo:
+        Actor1.options(extra_envs={"key": 1.0}).remote()
+    assert str(excinfo.value) == \
+        "Extra envs key and value must be str."
+
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_extra_envs.py
+++ b/python/ray/tests/test_extra_envs.py
@@ -16,7 +16,7 @@ def test_normal_remote_task(ray_start_2_cpus):
 
     assert ray.get(f1.remote("key1")) == "value1"
     assert ray.get(f1.remote("key3")) == "error"
-    v = ray.get(f1.options(extra_envs={"key1", "value3"}).remote("key1"))
+    v = ray.get(f1.options(extra_envs={"key1": "value3"}).remote("key1"))
     assert v == "value3"
     v = ray.get(f1.options(extra_envs={}).remote("key1"))
     assert v == "error"
@@ -24,12 +24,12 @@ def test_normal_remote_task(ray_start_2_cpus):
     assert ray.get(f2.remote("key1")) == "error"
 
     with pytest.raises(ValueError) as excinfo:
-        f1.options(extra_envs={"CUDA_VISIBLE_DEVICES": "1"}).remote()
+        f1.options(extra_envs={"CUDA_VISIBLE_DEVICES": "1"}).remote("key")
     assert str(excinfo.value) == \
         '"CUDA_VISIBLE_DEVICES" should not be set by user.'
 
     with pytest.raises(ValueError) as excinfo:
-        f1.options(extra_envs={"key": 1.0}).remote()
+        f1.options(extra_envs={"key": 1.0}).remote("key")
     assert str(excinfo.value) == \
         "Extra envs key and value must be str."
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -288,6 +288,7 @@ def get_cuda_visible_devices():
 
 
 last_set_gpu_ids = None
+previous_extra_envs = None
 
 
 def set_cuda_visible_devices(gpu_ids):
@@ -303,6 +304,31 @@ def set_cuda_visible_devices(gpu_ids):
 
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join([str(i) for i in gpu_ids])
     last_set_gpu_ids = gpu_ids
+
+def prepare_envs(extra_envs, gpu_ids):
+    global previous_extra_envs
+    if extra_envs:
+        previous_extra_envs = {}
+        for k, v in extra_envs:
+            if k == "CUDA_VISIBLE_DEVICES":
+                logger.error(
+                    '"CUDA_VISIBLE_DEVICES" env should not be set by user')
+                continue
+            previous_extra_envs[k] = os.environ.get(k, None)
+            os.environ[k] = v
+
+    set_cuda_visible_devices(gpu_ids)
+
+
+def reset_envs():
+    global previous_extra_envs
+    if previous_extra_envs:
+        for k, v in previous_extra_envs:
+            if v is None:
+                del os.environ[k]
+            else:
+                os.environ[k] = v
+
 
 
 def resources_from_resource_arguments(

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -310,7 +310,7 @@ def prepare_envs(extra_envs):
     global previous_extra_envs
     if extra_envs:
         previous_extra_envs = {}
-        for k, v in extra_envs:
+        for k, v in extra_envs.items():
             if k == "CUDA_VISIBLE_DEVICES":
                 logger.error(
                     '"CUDA_VISIBLE_DEVICES" env should not be set by user')
@@ -322,11 +322,12 @@ def prepare_envs(extra_envs):
 def reset_envs():
     global previous_extra_envs
     if previous_extra_envs:
-        for k, v in previous_extra_envs:
+        for k, v in previous_extra_envs.items():
             if v is None:
                 del os.environ[k]
             else:
                 os.environ[k] = v
+        previous_extra_envs = None
 
 
 def resources_from_resource_arguments(

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -305,7 +305,8 @@ def set_cuda_visible_devices(gpu_ids):
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join([str(i) for i in gpu_ids])
     last_set_gpu_ids = gpu_ids
 
-def prepare_envs(extra_envs, gpu_ids):
+
+def prepare_envs(extra_envs):
     global previous_extra_envs
     if extra_envs:
         previous_extra_envs = {}
@@ -317,8 +318,6 @@ def prepare_envs(extra_envs, gpu_ids):
             previous_extra_envs[k] = os.environ.get(k, None)
             os.environ[k] = v
 
-    set_cuda_visible_devices(gpu_ids)
-
 
 def reset_envs():
     global previous_extra_envs
@@ -328,7 +327,6 @@ def reset_envs():
                 del os.environ[k]
             else:
                 os.environ[k] = v
-
 
 
 def resources_from_resource_arguments(

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1688,7 +1688,8 @@ def make_decorator(num_return_vals=None,
                    max_calls=None,
                    max_retries=None,
                    max_reconstructions=None,
-                   worker=None):
+                   worker=None,
+                   extra_envs=None):
     def decorator(function_or_class):
         if (inspect.isfunction(function_or_class)
                 or is_cython(function_or_class)):
@@ -1700,7 +1701,7 @@ def make_decorator(num_return_vals=None,
             return ray.remote_function.RemoteFunction(
                 Language.PYTHON, function_or_class, None, num_cpus, num_gpus,
                 memory, object_store_memory, resources, num_return_vals,
-                max_calls, max_retries)
+                max_calls, max_retries, extra_envs)
 
         if inspect.isclass(function_or_class):
             if num_return_vals is not None:
@@ -1712,7 +1713,7 @@ def make_decorator(num_return_vals=None,
 
             return ray.actor.make_actor(function_or_class, num_cpus, num_gpus,
                                         memory, object_store_memory, resources,
-                                        max_reconstructions)
+                                        max_reconstructions, extra_envs)
 
         raise TypeError("The @ray.remote decorator must be applied to "
                         "either a function or to a class.")
@@ -1764,6 +1765,7 @@ def remote(*args, **kwargs):
       process executing it crashes unexpectedly. The minimum valid value is 0,
       the default is 4 (default), and the maximum valid value is
       ray.ray_constants.INFINITE_RECONSTRUCTION.
+    * **extra_envs**: The extra envs setting for *remote functions* or *actors*
 
     This can be done as follows:
 
@@ -1827,6 +1829,7 @@ def remote(*args, **kwargs):
             "max_calls",
             "max_reconstructions",
             "max_retries",
+            "extra_envs"
         ], error_string
 
     num_cpus = kwargs["num_cpus"] if "num_cpus" in kwargs else None
@@ -1847,6 +1850,7 @@ def remote(*args, **kwargs):
     memory = kwargs.get("memory")
     object_store_memory = kwargs.get("object_store_memory")
     max_retries = kwargs.get("max_retries")
+    extra_envs = kwargs.get("extra_envs")
 
     return make_decorator(
         num_return_vals=num_return_vals,
@@ -1858,4 +1862,5 @@ def remote(*args, **kwargs):
         max_calls=max_calls,
         max_reconstructions=max_reconstructions,
         max_retries=max_retries,
-        worker=worker)
+        worker=worker,
+        extra_envs=extra_envs)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1820,16 +1820,9 @@ def remote(*args, **kwargs):
     assert len(args) == 0 and len(kwargs) > 0, error_string
     for key in kwargs:
         assert key in [
-            "num_return_vals",
-            "num_cpus",
-            "num_gpus",
-            "memory",
-            "object_store_memory",
-            "resources",
-            "max_calls",
-            "max_reconstructions",
-            "max_retries",
-            "extra_envs"
+            "num_return_vals", "num_cpus", "num_gpus", "memory",
+            "object_store_memory", "resources", "max_calls",
+            "max_reconstructions", "max_retries", "extra_envs"
         ], error_string
 
     num_cpus = kwargs["num_cpus"] if "num_cpus" in kwargs else None

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -148,6 +148,10 @@ const ResourceSet &TaskSpecification::GetRequiredPlacementResources() const {
   return *required_placement_resources_;
 }
 
+const std::unordered_map<std::string, std::string> &GetExtraEnvs() const {
+  return *MapFromProtobuf(message_->extra_envs());
+}
+
 bool TaskSpecification::IsDriverTask() const {
   return message_->type() == TaskType::DRIVER_TASK;
 }

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -148,8 +148,9 @@ const ResourceSet &TaskSpecification::GetRequiredPlacementResources() const {
   return *required_placement_resources_;
 }
 
-const std::unordered_map<std::string, std::string> &GetExtraEnvs() const {
-  return *MapFromProtobuf(message_->extra_envs());
+const std::unordered_map<std::string, std::string> TaskSpecification::GetExtraEnvs()
+    const {
+  return MapFromProtobuf(message_->extra_envs());
 }
 
 bool TaskSpecification::IsDriverTask() const {

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -116,6 +116,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// \return The resources that are required to place a task on a node.
   const ResourceSet &GetRequiredPlacementResources() const;
 
+  const std::unordered_map<std::string, std::string> &GetExtraEnvs() const;
+
   /// Return the dependencies of this task. This is recomputed each time, so it can
   /// be used if the task spec is mutated.
   ///

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -116,7 +116,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// \return The resources that are required to place a task on a node.
   const ResourceSet &GetRequiredPlacementResources() const;
 
-  const std::unordered_map<std::string, std::string> &GetExtraEnvs() const;
+  const std::unordered_map<std::string, std::string> GetExtraEnvs() const;
 
   /// Return the dependencies of this task. This is recomputed each time, so it can
   /// be used if the task spec is mutated.

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -29,7 +29,8 @@ class TaskSpecBuilder {
       const TaskID &parent_task_id, uint64_t parent_counter, const TaskID &caller_id,
       const rpc::Address &caller_address, uint64_t num_returns,
       const std::unordered_map<std::string, double> &required_resources,
-      const std::unordered_map<std::string, double> &required_placement_resources) {
+      const std::unordered_map<std::string, double> &required_placement_resources,
+      const std::shared_ptr<RayObject> &extra_envs) {
     message_->set_type(TaskType::NORMAL_TASK);
     message_->set_language(language);
     *message_->mutable_function_descriptor() = function_descriptor->GetMessage();
@@ -44,6 +45,7 @@ class TaskSpecBuilder {
                                                    required_resources.end());
     message_->mutable_required_placement_resources()->insert(
         required_placement_resources.begin(), required_placement_resources.end());
+    message_->mutable_extra_envs()->insert(extra_envs.begin(), extra_envs.end());
     return *this;
   }
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -30,7 +30,7 @@ class TaskSpecBuilder {
       const rpc::Address &caller_address, uint64_t num_returns,
       const std::unordered_map<std::string, double> &required_resources,
       const std::unordered_map<std::string, double> &required_placement_resources,
-      const std::shared_ptr<RayObject> &extra_envs) {
+      const std::unordered_map<std::string, std::string> &extra_envs) {
     message_->set_type(TaskType::NORMAL_TASK);
     message_->set_language(language);
     *message_->mutable_function_descriptor() = function_descriptor->GetMessage();

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -41,8 +41,7 @@ void BuildCommonTaskSpec(
   builder.SetCommonTaskSpec(task_id, function.GetLanguage(),
                             function.GetFunctionDescriptor(), job_id, current_task_id,
                             task_index, caller_id, address, num_returns,
-                            required_resources, extra_envs,
-                            required_placement_resources);
+                            required_resources, required_placement_resources, extra_envs);
   // Set task arguments.
   for (const auto &arg : args) {
     if (arg.IsPassedByReference()) {
@@ -799,13 +798,10 @@ Status CoreWorker::SetResource(const std::string &resource_name, const double ca
   return local_raylet_client_->SetResource(resource_name, capacity, client_id);
 }
 
-Status CoreWorker::SubmitTask(const RayFunction &function,
-                              const std::vector<TaskArg> &args,
-                              const TaskOptions &task_options,
-                              std::vector<ObjectID> *return_ids,
-                              int max_retries,
-                              const std::unordered_map<std::string, std::string>
-                                 &extra_envs) {
+Status CoreWorker::SubmitTask(
+    const RayFunction &function, const std::vector<TaskArg> &args,
+    const TaskOptions &task_options, std::vector<ObjectID> *return_ids, int max_retries,
+    const std::unordered_map<std::string, std::string> &extra_envs) {
   TaskSpecBuilder builder;
   const int next_task_index = worker_context_.GetNextTaskIndex();
   const auto task_id =
@@ -817,8 +813,7 @@ Status CoreWorker::SubmitTask(const RayFunction &function,
   BuildCommonTaskSpec(builder, worker_context_.GetCurrentJobID(), task_id,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, task_options.num_returns,
-                      task_options.resources, required_resources, extra_envs,
-                      return_ids);
+                      task_options.resources, required_resources, extra_envs, return_ids);
 
   TaskSpecification task_spec = builder.Build();
   task_manager_->AddPendingTask(GetCallerId(), rpc_address_, task_spec, CurrentCallSite(),
@@ -826,13 +821,11 @@ Status CoreWorker::SubmitTask(const RayFunction &function,
   return direct_task_submitter_->SubmitTask(task_spec);
 }
 
-Status CoreWorker::CreateActor(const RayFunction &function,
-                               const std::vector<TaskArg> &args,
-                               const ActorCreationOptions &actor_creation_options,
-                               const std::string &extension_data,
-                               ActorID *return_actor_id,
-                               const std::unordered_map<std::string, std::string>
-                                   &extra_envs) {
+Status CoreWorker::CreateActor(
+    const RayFunction &function, const std::vector<TaskArg> &args,
+    const ActorCreationOptions &actor_creation_options, const std::string &extension_data,
+    const std::unordered_map<std::string, std::string> &extra_envs,
+    ActorID *return_actor_id) {
   const int next_task_index = worker_context_.GetNextTaskIndex();
   const ActorID actor_id =
       ActorID::Of(worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
@@ -844,7 +837,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   BuildCommonTaskSpec(builder, job_id, actor_creation_task_id,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, 1, actor_creation_options.resources,
-                      actor_creation_options.placement_resources, &return_ids);
+                      actor_creation_options.placement_resources, extra_envs,
+                      &return_ids);
   builder.SetActorCreationTaskSpec(actor_id, actor_creation_options.max_reconstructions,
                                    actor_creation_options.dynamic_worker_options,
                                    actor_creation_options.max_concurrency,
@@ -885,10 +879,11 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
       worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
       next_task_index, actor_handle->GetActorID());
   const std::unordered_map<std::string, double> required_resources;
+  const std::unordered_map<std::string, std::string> extra_envs;
   BuildCommonTaskSpec(builder, actor_handle->CreationJobID(), actor_task_id,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, num_returns, task_options.resources,
-                      required_resources, return_ids);
+                      required_resources, extra_envs, return_ids);
 
   const ObjectID new_cursor = return_ids->back();
   actor_handle->SetActorTaskSpec(builder, new_cursor);
@@ -1142,7 +1137,7 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
 
   status = task_execution_callback_(
       task_type, func, task_spec.GetRequiredResources().GetResourceMap(), args,
-      arg_reference_ids, return_ids, return_objects, task_spec.GetExtraEnvs(),
+      arg_reference_ids, task_spec.GetExtraEnvs(), return_ids, return_objects,
       worker_context_.GetWorkerID());
 
   absl::optional<rpc::Address> caller_address(

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -35,12 +35,14 @@ void BuildCommonTaskSpec(
     const std::vector<ray::TaskArg> &args, uint64_t num_returns,
     const std::unordered_map<std::string, double> &required_resources,
     const std::unordered_map<std::string, double> &required_placement_resources,
+    const std::unordered_map<std::string, std::string> &extra_envs,
     std::vector<ObjectID> *return_ids) {
   // Build common task spec.
   builder.SetCommonTaskSpec(task_id, function.GetLanguage(),
                             function.GetFunctionDescriptor(), job_id, current_task_id,
                             task_index, caller_id, address, num_returns,
-                            required_resources, required_placement_resources);
+                            required_resources, extra_envs,
+                            required_placement_resources);
   // Set task arguments.
   for (const auto &arg : args) {
     if (arg.IsPassedByReference()) {
@@ -800,7 +802,10 @@ Status CoreWorker::SetResource(const std::string &resource_name, const double ca
 Status CoreWorker::SubmitTask(const RayFunction &function,
                               const std::vector<TaskArg> &args,
                               const TaskOptions &task_options,
-                              std::vector<ObjectID> *return_ids, int max_retries) {
+                              std::vector<ObjectID> *return_ids,
+                              int max_retries,
+                              const std::unordered_map<std::string, std::string>
+                                 &extra_envs) {
   TaskSpecBuilder builder;
   const int next_task_index = worker_context_.GetNextTaskIndex();
   const auto task_id =
@@ -812,7 +817,9 @@ Status CoreWorker::SubmitTask(const RayFunction &function,
   BuildCommonTaskSpec(builder, worker_context_.GetCurrentJobID(), task_id,
                       worker_context_.GetCurrentTaskID(), next_task_index, GetCallerId(),
                       rpc_address_, function, args, task_options.num_returns,
-                      task_options.resources, required_resources, return_ids);
+                      task_options.resources, required_resources, extra_envs,
+                      return_ids);
+
   TaskSpecification task_spec = builder.Build();
   task_manager_->AddPendingTask(GetCallerId(), rpc_address_, task_spec, CurrentCallSite(),
                                 max_retries);
@@ -823,7 +830,9 @@ Status CoreWorker::CreateActor(const RayFunction &function,
                                const std::vector<TaskArg> &args,
                                const ActorCreationOptions &actor_creation_options,
                                const std::string &extension_data,
-                               ActorID *return_actor_id) {
+                               ActorID *return_actor_id,
+                               const std::unordered_map<std::string, std::string>
+                                   &extra_envs) {
   const int next_task_index = worker_context_.GetNextTaskIndex();
   const ActorID actor_id =
       ActorID::Of(worker_context_.GetCurrentJobID(), worker_context_.GetCurrentTaskID(),
@@ -1133,7 +1142,8 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
 
   status = task_execution_callback_(
       task_type, func, task_spec.GetRequiredResources().GetResourceMap(), args,
-      arg_reference_ids, return_ids, return_objects, worker_context_.GetWorkerID());
+      arg_reference_ids, return_ids, return_objects, task_spec.GetExtraEnvs(),
+      worker_context_.GetWorkerID());
 
   absl::optional<rpc::Address> caller_address(
       worker_context_.GetCurrentTask()->CallerAddress());

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -361,7 +361,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status error if task submission fails, likely due to raylet failure.
   Status SubmitTask(const RayFunction &function, const std::vector<TaskArg> &args,
                     const TaskOptions &task_options, std::vector<ObjectID> *return_ids,
-                    int max_retries);
+                    int max_retries,
+                    const std::unordered_map<std::string, std::string> &extra_envs);
 
   /// Create an actor.
   ///
@@ -376,7 +377,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status error if actor creation fails, likely due to raylet failure.
   Status CreateActor(const RayFunction &function, const std::vector<TaskArg> &args,
                      const ActorCreationOptions &actor_creation_options,
-                     const std::string &extension_data, ActorID *actor_id);
+                     const std::string &extension_data, ActorID *actor_id,
+                     const std::unordered_map<std::string, std::string> &extra_envs);
 
   /// Submit an actor task.
   ///

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -61,6 +61,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       const std::unordered_map<std::string, double> &required_resources,
       const std::vector<std::shared_ptr<RayObject>> &args,
       const std::vector<ObjectID> &arg_reference_ids,
+      const std::unordered_map<std::string, std::string> &extra_envs,
       const std::vector<ObjectID> &return_ids,
       std::vector<std::shared_ptr<RayObject>> *results, const ray::WorkerID &worker_id)>;
 
@@ -377,8 +378,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status error if actor creation fails, likely due to raylet failure.
   Status CreateActor(const RayFunction &function, const std::vector<TaskArg> &args,
                      const ActorCreationOptions &actor_creation_options,
-                     const std::string &extension_data, ActorID *actor_id,
-                     const std::unordered_map<std::string, std::string> &extra_envs);
+                     const std::string &extension_data,
+                     const std::unordered_map<std::string, std::string> &extra_envs,
+                     ActorID *actor_id);
 
   /// Submit an actor task.
   ///

--- a/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_RayNativeRuntime.cc
@@ -51,6 +51,7 @@ JNIEXPORT jlong JNICALL Java_org_ray_runtime_RayNativeRuntime_nativeInitCoreWork
          const std::unordered_map<std::string, double> &required_resources,
          const std::vector<std::shared_ptr<ray::RayObject>> &args,
          const std::vector<ObjectID> &arg_reference_ids,
+         const std::unordered_map<std::string, std::string> &extra_envs,
          const std::vector<ObjectID> &return_ids,
          std::vector<std::shared_ptr<ray::RayObject>> *results,
          const ray::WorkerID &worker_id) {

--- a/src/ray/core_worker/lib/java/org_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/org_ray_runtime_task_NativeTaskSubmitter.cc
@@ -134,10 +134,11 @@ JNIEXPORT jobject JNICALL Java_org_ray_runtime_task_NativeTaskSubmitter_nativeSu
   auto task_options = ToTaskOptions(env, numReturns, callOptions);
 
   std::vector<ObjectID> return_ids;
+  const std::unordered_map<std::string, std::string> exra_envs;
   // TODO (kfstorm): Allow setting `max_retries` via `CallOptions`.
   auto status = GetCoreWorker(nativeCoreWorkerPointer)
                     .SubmitTask(ray_function, task_args, task_options, &return_ids,
-                                /*max_retries=*/0);
+                                /*max_retries=*/0, exra_envs);
 
   THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, nullptr);
 
@@ -152,10 +153,11 @@ Java_org_ray_runtime_task_NativeTaskSubmitter_nativeCreateActor(
   auto task_args = ToTaskArgs(env, args);
   auto actor_creation_options = ToActorCreationOptions(env, actorCreationOptions);
 
+  const std::unordered_map<std::string, std::string> extra_envs;
   ray::ActorID actor_id;
   auto status = GetCoreWorker(nativeCoreWorkerPointer)
                     .CreateActor(ray_function, task_args, actor_creation_options,
-                                 /*extension_data*/ "", &actor_id);
+                                 /*extension_data*/ "", extra_envs, &actor_id);
 
   THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, nullptr);
   return IdToJavaByteArray<ray::ActorID>(env, actor_id);

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -293,7 +293,7 @@ TaskSpecification BuildTaskSpec(const std::unordered_map<std::string, double> &r
   rpc::Address empty_address;
   builder.SetCommonTaskSpec(TaskID::Nil(), Language::PYTHON, function_descriptor,
                             JobID::Nil(), TaskID::Nil(), 0, TaskID::Nil(), empty_address,
-                            1, resources, resources);
+                            1, resources, resources, {});
   return builder.Build();
 }
 

--- a/src/ray/core_worker/test/mock_worker.cc
+++ b/src/ray/core_worker/test/mock_worker.cc
@@ -34,10 +34,11 @@ class MockWorker {
  public:
   MockWorker(const std::string &store_socket, const std::string &raylet_socket,
              int node_manager_port, const gcs::GcsClientOptions &gcs_options)
-      : worker_(WorkerType::WORKER, Language::PYTHON, store_socket, raylet_socket,
-                JobID::FromInt(1), gcs_options, /*log_dir=*/"",
-                /*node_id_address=*/"127.0.0.1", node_manager_port,
-                std::bind(&MockWorker::ExecuteTask, this, _1, _2, _3, _4, _5, _6, _7)) {}
+      : worker_(
+            WorkerType::WORKER, Language::PYTHON, store_socket, raylet_socket,
+            JobID::FromInt(1), gcs_options, /*log_dir=*/"",
+            /*node_id_address=*/"127.0.0.1", node_manager_port,
+            std::bind(&MockWorker::ExecuteTask, this, _1, _2, _3, _4, _5, _6, _7, _8)) {}
 
   void StartExecutingTasks() { worker_.StartExecutingTasks(); }
 
@@ -46,6 +47,7 @@ class MockWorker {
                      const std::unordered_map<std::string, double> &required_resources,
                      const std::vector<std::shared_ptr<RayObject>> &args,
                      const std::vector<ObjectID> &arg_reference_ids,
+                     const std::unordered_map<std::string, std::string> &extra_envs,
                      const std::vector<ObjectID> &return_ids,
                      std::vector<std::shared_ptr<RayObject>> *results) {
     // Note that this doesn't include dummy object id.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -115,6 +115,8 @@ message TaskSpec {
   ActorTaskSpec actor_task_spec = 15;
   // Number of times this task may be retried on worker failure.
   int32 max_retries = 16;
+  // extra envs
+  map<string, string> extra_envs = 17;
 }
 
 // Argument in the task.

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -197,7 +197,7 @@ static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
   builder.SetCommonTaskSpec(RandomTaskId(), Language::PYTHON,
                             ray::FunctionDescriptorBuilder::BuildPython("", "", "", ""),
                             JobID::Nil(), RandomTaskId(), 0, RandomTaskId(), address,
-                            num_returns, {}, {});
+                            num_returns, {}, {}, {});
   for (const auto &arg : arguments) {
     builder.AddByRefArg(arg);
   }

--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -110,7 +110,7 @@ static inline Task ExampleTask(const std::vector<ObjectID> &arguments,
   builder.SetCommonTaskSpec(RandomTaskId(), Language::PYTHON,
                             FunctionDescriptorBuilder::BuildPython("", "", "", ""),
                             JobID::Nil(), RandomTaskId(), 0, RandomTaskId(), address,
-                            num_returns, {}, {});
+                            num_returns, {}, {}, {});
   builder.SetActorCreationTaskSpec(ActorID::Nil(), 1, {}, 1, false, false);
   for (const auto &arg : arguments) {
     builder.AddByRefArg(arg);

--- a/streaming/src/test/mock_actor.cc
+++ b/streaming/src/test/mock_actor.cc
@@ -283,7 +283,7 @@ class StreamingWorker {
     worker_ = std::make_shared<CoreWorker>(
         WorkerType::WORKER, Language::PYTHON, store_socket, raylet_socket,
         JobID::FromInt(1), gcs_options, "", "127.0.0.1", node_manager_port,
-        std::bind(&StreamingWorker::ExecuteTask, this, _1, _2, _3, _4, _5, _6, _7));
+        std::bind(&StreamingWorker::ExecuteTask, this, _1, _2, _3, _4, _5, _6, _7, _8));
 
     RayFunction reader_async_call_func{ray::Language::PYTHON,
                                        ray::FunctionDescriptorBuilder::BuildPython(
@@ -315,6 +315,7 @@ class StreamingWorker {
                      const std::unordered_map<std::string, double> &required_resources,
                      const std::vector<std::shared_ptr<RayObject>> &args,
                      const std::vector<ObjectID> &arg_reference_ids,
+                     const std::unordered_map<std::string, std::string> &extra_envs,
                      const std::vector<ObjectID> &return_ids,
                      std::vector<std::shared_ptr<RayObject>> *results) {
     // Only one arg param used in streaming.

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -277,8 +277,9 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
 
     // Create an actor.
     ActorID actor_id;
-    RAY_CHECK_OK(
-        worker.CreateActor(func, args, actor_options, /*extension_data*/ "", &actor_id));
+    const std::unordered_map<std::string, std::string> extra_envs;
+    RAY_CHECK_OK(worker.CreateActor(func, args, actor_options, /*extension_data*/ "",
+                                    extra_envs, &actor_id));
     return actor_id;
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, we have two ways to set envs:

- Set system level. This is not always true for different purpose remote functions or Actors.

- For each function/actor, we set by `os.envrion`. This's not very convenient.

One common usage for this is set `OMP_NUM_THREADS` for trainer/rolloutworker in rllib. Because the `OMP_NUM_THREADS` can influence the TensorFlow performance a lot when training with CPU. I will add the support for rllib in the following patch.

API changes as following:
```python
@ray.remote(extra_envs={"OMP_NUM_THREADS": "1"})
def func():
    # ...
 
@ray.remote(extra_envs={"OMP_NUM_THREADS": "2"})
class Worker:
    # ....
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
