### PR TITLE
Fix reusing the cached hash of nil ID

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -372,7 +372,7 @@ ObjectID ObjectID::GenerateObjectId(const std::string &task_id_binary,
                                     ObjectIDFlagsType flags,
                                     ObjectIDIndexType object_index) {
   RAY_CHECK(task_id_binary.size() == TaskID::Size());
-  ObjectID ret = ObjectID::Nil();
+  ObjectID ret;
   std::memcpy(ret.id_, task_id_binary.c_str(), TaskID::kLength);
   std::memcpy(ret.id_ + TaskID::kLength, &flags, sizeof(flags));
   std::memcpy(ret.id_ + TaskID::kLength + kFlagsBytesLength, &object_index,

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -444,7 +444,7 @@ template <typename T>
 T BaseID<T>::FromBinary(const std::string &binary) {
   RAY_CHECK(binary.size() == T::Size() || binary.size() == 0)
       << "expected size is " << T::Size() << ", but got " << binary.size();
-  T t = T::Nil();
+  T t;
   std::memcpy(t.MutableData(), binary.data(), binary.size());
   return t;
 }

--- a/src/ray/common/id_test.cc
+++ b/src/ray/common/id_test.cc
@@ -113,6 +113,16 @@ TEST(NilTest, TestIsNil) {
   ASSERT_TRUE(ObjectID::Nil().IsNil());
 }
 
+TEST(HashTest, TestNilHash) {
+  // Manually trigger the hash calculation of the static global nil ID.
+  auto nil_hash = ObjectID::Nil().Hash();
+  ObjectID id1 = ObjectID::FromRandom();
+  ASSERT_NE(nil_hash, id1.Hash());
+  ObjectID id2 = ObjectID::FromBinary(ObjectID::FromRandom().Binary());
+  ASSERT_NE(nil_hash, id2.Hash());
+  ASSERT_NE(id1.Hash(), id2.Hash());
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If `SomeID::Nil().Hash()` was called, `SomeID::FromRandom()` and `SomeID::FromBinary()` would reuse the cached hash value, which was calculated in `SomeID::Nil().Hash()`. The root cause is that a copy of [the static nil ID](https://github.com/ray-project/ray/blob/ca6eabc9cb728a829d5305a4dd19216ed925f2e4/src/ray/common/id.h#L454) is used when generating a new ID.

Another way of fixing this is to make `BaseID<T>::Nil()` returns `T` instead of `const T &`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
