### PR TITLE
--redis-address -> --address

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -394,7 +394,7 @@ def start(node_ip_address, redis_address, address, redis_port,
             raise Exception("If --head is not passed in, --redis-shard-ports "
                             "is not allowed.")
         if redis_address is None:
-            raise Exception("If --head is not passed in, --redis-address must "
+            raise Exception("If --head is not passed in, --address must "
                             "be provided.")
         if num_redis_shards is not None:
             raise Exception("If --head is not passed in, --num-redis-shards "


### PR DESCRIPTION
Exception tells user to use --redis-address, but it is deprecated, and its use will itself produce an exception. This tells the user to use the now-current --address.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Exception tells user to use --redis-address, but it is deprecated, and its use will itself produce an exception. This tells the user to use the now-current --address.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X ] This PR is not tested (please justify below)
I am deleting one word in a help message, unlikely to wreck anything.
