### PR TITLE
Fix TestTaskLeaseRenewal test failure

### DIFF
--- a/src/ray/raylet/task_dependency_manager_test.cc
+++ b/src/ray/raylet/task_dependency_manager_test.cc
@@ -449,7 +449,12 @@ TEST_F(TaskDependencyManagerTest, TestTaskLeaseRenewal) {
   for (int i = 1; i <= num_expected_calls; i++) {
     sleep_time += i * initial_lease_period_ms_;
   }
-  EXPECT_CALL(*task_accessor_mock_, AsyncAddTaskLease(_, _)).Times(num_expected_calls);
+  // When sleep_time = 10 * initial_lease_period_ms_, test case fails, because the
+  // AsyncAddTaskLease function is expected to be called four times, but only three times.
+  // It's hard to determine the sleep_time value, so let's double it for now.
+  sleep_time = sleep_time * 2;
+  EXPECT_CALL(*task_accessor_mock_, AsyncAddTaskLease(_, _))
+      .Times(testing::AtLeast(num_expected_calls));
   Run(sleep_time);
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When sleep_time = 10 * initial_lease_period_ms_, test case fails, because the AsyncAddTaskLease function is expected to be called four times, but only three times. It's hard to determine the sleep_time value, so let's double it for now.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
