### PR TITLE
fix encoding issue

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -120,7 +120,7 @@ class FunctionActorManager:
             function_or_class.__name__ + ":" + string_file.getvalue())
 
         # Return a hash of the identifier in case it is too large.
-        return hashlib.sha1(collision_identifier.encode("ascii")).digest()
+        return hashlib.sha1(collision_identifier.encode()).digest()
 
     def export(self, remote_function):
         """Pickle a remote function and export it to redis.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
There is no need to ensure 'ascii' encode here. it will cause encoding error in python3 if user using a non ascii character in remote function.

In **python2**, user need to add `# -*- coding: UTF-8 -*-` to get non-ascii code run, and the dis.dis in python2 will return the ascii-ensured disassemble result, for example
```
# -*- coding: UTF-8 -*-

import dis

def a():
  return 'あ'

print(dis.dis(a))
```
will give
```
  6           0 LOAD_CONST               1 ('\xe3\x81\x82')
              3 RETURN_VALUE        
```

But **python3** is different, following code
```
import dis

def a():
  return 'あ'

print(dis.dis(a))
```
will give
```
  4           0 LOAD_CONST               1 ('あ')
              2 RETURN_VALUE
```
and if you still using 'ascii' to encode the disassemble result, encoding error will occurs.

It it seems that ray already drop out the support for python2, so I think there is no reason to use 'ascii' here.

## Related issue number
#7755 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
