### PR TITLE
Fix build breakage due to soft torch import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ matrix:
         - if [ $RAY_CI_LINUX_WHEELS_AFFECTED != "1" ]; then exit; fi
 
         # Explicitly sleep 60 seconds for logs to go through
-        - ./ci/travis/test-wheels.sh || cat /tmp/ray/session_latest/logs/* || sleep 60 || false
+        - ./ci/travis/test-wheels.sh || cat /tmp/ray/session_latest/logs/* || (sleep 60 && false)
       cache: false
 
     # Build MacOS wheels.
@@ -168,7 +168,7 @@ matrix:
         - if [ $RAY_CI_MACOS_WHEELS_AFFECTED != "1" ]; then exit; fi
 
         # Explicitly sleep 60 seconds for logs to go through
-        - ./ci/travis/test-wheels.sh || cat /tmp/ray/session_latest/logs/* || sleep 60 || false
+        - ./ci/travis/test-wheels.sh || cat /tmp/ray/session_latest/logs/* || (sleep 60 && false)
 
     # RLlib: Learning tests (from rllib/tuned_examples/regression_tests/*.yaml).
     - os: linux

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -148,7 +148,12 @@ def get_variable(value, framework="tf", tf_name="unnamed-variable"):
     """
     if framework == "tf":
         import tensorflow as tf
-        return tf.compat.v1.get_variable(tf_name, initializer=value)
+        dtype = getattr(
+            value, "dtype", tf.float32
+            if isinstance(value, float) else tf.int32
+            if isinstance(value, int) else None)
+        return tf.compat.v1.get_variable(
+            tf_name, initializer=value, dtype=dtype)
     # torch or None: Return python primitive.
     return value
 


### PR DESCRIPTION
Soft torch import led to reference to nn.Module being None, crashing tests. This fixes it by stubbing out a fake nn.Module class which raises ImportError on use.

Closes https://github.com/ray-project/ray/issues/7776