### PR TITLE
[tune] Stop-gap fix for PBT checkpointing

### DIFF
--- a/python/ray/tune/durable_trainable.py
+++ b/python/ray/tune/durable_trainable.py
@@ -86,7 +86,7 @@ class DurableTrainable(Trainable):
         """
         try:
             local_dirpath = TrainableUtil.find_checkpoint_dir(checkpoint_path)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             logger.warning("Trial %s: checkpoint path not found during "
                            "garbage collection. See issue #6697.")
         else:

--- a/python/ray/tune/durable_trainable.py
+++ b/python/ray/tune/durable_trainable.py
@@ -60,7 +60,6 @@ class DurableTrainable(Trainable):
             if checkpoint_dir.starts_with(os.path.abspath(self.logdir)):
                 raise ValueError("`checkpoint_dir` must be `self.logdir`, or "
                                  "a sub-directory.")
-
         checkpoint_path = super(DurableTrainable, self).save(checkpoint_dir)
         self.storage_client.sync_up(self.logdir, self.remote_checkpoint_dir)
         self.storage_client.wait()
@@ -87,8 +86,9 @@ class DurableTrainable(Trainable):
         try:
             local_dirpath = TrainableUtil.find_checkpoint_dir(checkpoint_path)
         except FileNotFoundError:
-            logger.warning("Trial %s: checkpoint path not found during "
-                           "garbage collection. See issue #6697.")
+            logger.warning(
+                "Trial %s: checkpoint path not found during "
+                "garbage collection. See issue #6697.", self.trial_id)
         else:
             self.storage_client.delete(self._storage_path(local_dirpath))
         super(DurableTrainable, self).delete_checkpoint(checkpoint_path)

--- a/python/ray/tune/examples/pbt_example.py
+++ b/python/ray/tune/examples/pbt_example.py
@@ -108,6 +108,7 @@ if __name__ == "__main__":
         name="pbt_test",
         scheduler=pbt,
         reuse_actors=True,
+        checkpoint_freq=20,
         verbose=False,
         stop={
             "training_iteration": 2000,

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -745,9 +745,6 @@ class PopulationBasedTestingSuite(unittest.TestCase):
         pbt.reset_stats()
         return pbt, runner
 
-    def testPerturbationCheckpointConflict(self):
-        pbt, runner = self.basicSetup()
-
     def testCheckpointsMostPromisingTrials(self):
         pbt, runner = self.basicSetup()
         trials = runner.get_trials()

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -186,7 +186,7 @@ class EarlyStoppingSuite(unittest.TestCase):
 
 
 class _MockTrialExecutor(TrialExecutor):
-    def start_trial(self, trial, checkpoint_obj=None):
+    def start_trial(self, trial, checkpoint_obj=None, train=True):
         trial.logger_running = True
         trial.restored_checkpoint = checkpoint_obj.value
         trial.status = Trial.RUNNING
@@ -196,7 +196,7 @@ class _MockTrialExecutor(TrialExecutor):
         if stop_logger:
             trial.logger_running = False
 
-    def restore(self, trial, checkpoint=None):
+    def restore(self, trial, checkpoint=None, block=False):
         pass
 
     def save(self, trial, type=Checkpoint.PERSISTENT, result=None):
@@ -744,6 +744,9 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                     TrialScheduler.CONTINUE)
         pbt.reset_stats()
         return pbt, runner
+
+    def testPerturbationCheckpointConflict(self):
+        pbt, runner = self.basicSetup()
 
     def testCheckpointsMostPromisingTrials(self):
         pbt, runner = self.basicSetup()

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -555,6 +555,16 @@ class Trainable:
         """
         return self._iteration
 
+    @property
+    def training_iteration(self):
+        """Current training iteration (same as `self.iteration`).
+
+        This value is automatically incremented every time `train()` is called
+        and is automatically inserted into the training result dict.
+
+        """
+        return self._iteration
+
     def get_config(self):
         """Returns configuration passed in by Tune."""
         return self.config

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -186,7 +186,7 @@ class Trainable:
     def default_resource_request(cls, config):
         """Provides a static resource requirement for the given configuration.
 
-        This can be overriden by sub-classes to set the correct trial resource
+        This can be overridden by sub-classes to set the correct trial resource
         allocation, so the user does not need to.
 
         .. code-block:: python

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -108,7 +108,7 @@ class TrialInfo:
     """Serializable struct for holding information for a Trial.
 
     Attributes:
-        trial_name (str): String name of the currernt trial.
+        trial_name (str): String name of the current trial.
         trial_id (str): trial_id of the trial
     """
 
@@ -191,8 +191,7 @@ class Trial:
         self.evaluated_params = evaluated_params or {}
         self.experiment_tag = experiment_tag
         trainable_cls = self.get_trainable_cls()
-        if trainable_cls and hasattr(trainable_cls,
-                                     "default_resource_request"):
+        if trainable_cls:
             default_resources = trainable_cls.default_resource_request(
                 self.config)
             if default_resources:

--- a/python/ray/tune/trial_executor.py
+++ b/python/ray/tune/trial_executor.py
@@ -72,13 +72,14 @@ class TrialExecutor:
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "has_resources() method")
 
-    def start_trial(self, trial, checkpoint=None):
+    def start_trial(self, trial, checkpoint=None, train=True):
         """Starts the trial restoring from checkpoint if checkpoint is provided.
 
         Args:
             trial (Trial): Trial to be started.
             checkpoint (Checkpoint): A Python object or path storing the state
             of trial.
+            train (bool): Whether or not to start training.
         """
         raise NotImplementedError("Subclasses of TrialExecutor must provide "
                                   "start_trial() method")
@@ -211,7 +212,7 @@ class TrialExecutor:
         """Returns a string describing the total resources available."""
         raise NotImplementedError
 
-    def restore(self, trial, checkpoint=None):
+    def restore(self, trial, checkpoint=None, block=False):
         """Restores training state from a checkpoint.
 
         If checkpoint is None, try to restore from trial.checkpoint.
@@ -220,6 +221,7 @@ class TrialExecutor:
         Args:
             trial (Trial): Trial to be restored.
             checkpoint (Checkpoint): Checkpoint to restore from.
+            block (bool): Whether or not to block on restore before returning.
 
         Returns:
             False if error occurred, otherwise return True.


### PR DESCRIPTION
- Stop-gap fix for in-phase checkpointing and perturbation #7258. A more comprehensive fix requires redesigning the scheduler API.
- Stop-gap fix for GC bug in `DurableTrainable`. Checkpoint often is not found due to #6697

Closes #8102.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
