### PR TITLE
Deserialize Args in Event Loop Thread

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -297,22 +297,6 @@ cdef void prepare_args(
                     CTaskArg.PassByReference((CObjectID.FromBinary(
                         core_worker.put_serialized_object(serialized_arg)))))
 
-cdef deserialize_args(
-        const c_vector[shared_ptr[CRayObject]] &c_args,
-        const c_vector[CObjectID] &arg_reference_ids):
-    if c_args.empty():
-        return [], {}
-
-    args = ray.worker.global_worker.deserialize_objects(
-             RayObjectsToDataMetadataPairs(c_args),
-             VectorToObjectIDs(arg_reference_ids))
-
-    for arg in args:
-        if isinstance(arg, RayError):
-            raise arg
-
-    return ray.signature.recover_args(args)
-
 
 cdef execute_task(
         CTaskType task_type,
@@ -331,7 +315,7 @@ cdef execute_task(
         CoreWorker core_worker = worker.core_worker
         JobID job_id = core_worker.get_current_job_id()
         CTaskID task_id = core_worker.core_worker.get().GetCurrentTaskId()
-        CFiberEvent fiber_event
+        CFiberEvent task_done_event
 
     # Automatically restrict the GPUs available to this task.
     ray.utils.set_cuda_visible_devices(ray.get_gpu_ids())
@@ -410,13 +394,13 @@ cdef execute_task(
                 future = asyncio.run_coroutine_threadsafe(coroutine, loop)
 
                 def callback(future):
-                    fiber_event.Notify()
+                    task_done_event.Notify()
                     monitor_state.unregister_coroutine(coroutine)
 
                 future.add_done_callback(callback)
                 with nogil:
                     (core_worker.core_worker.get()
-                        .YieldCurrentFiber(fiber_event))
+                        .YieldCurrentFiber(task_done_event))
 
                 return future.result()
 
@@ -431,7 +415,28 @@ cdef execute_task(
                 worker.memory_monitor.raise_if_low_memory()
 
             with core_worker.profile_event(b"task:deserialize_arguments"):
-                args, kwargs = deserialize_args(c_args, c_arg_reference_ids)
+                if c_args.empty():
+                    args, kwargs = [], {}
+                metadata_pairs = RayObjectsToDataMetadataPairs(c_args)
+                object_ids = VectorToObjectIDs(c_arg_reference_ids)
+
+                if core_worker.current_actor_is_asyncio():
+                    # We deserialize objects in event loop thread to prevent
+                    # segfaults. See #7799
+                    def deserialize_args():
+                        return ray.worker.global_worker.deserialize_objects(
+                            metadata_pairs, object_ids)
+                    args = core_worker.run_function_in_event_loop(
+                        deserialize_args)
+                else:
+                    args = ray.worker.global_worker.deserialize_objects(
+                        metadata_pairs, object_ids)
+
+                for arg in args:
+                    if isinstance(arg, RayError):
+                        raise arg
+                args, kwargs = ray.signature.recover_args(args)
+
             if (<int>task_type == <int>TASK_TYPE_ACTOR_CREATION_TASK):
                 actor = worker.actors[core_worker.get_actor_id()]
                 class_name = actor.__class__.__name__
@@ -446,7 +451,6 @@ cdef execute_task(
                     task_exception = False
                     if c_return_ids.size() == 1:
                         outputs = (outputs,)
-
             # Store the outputs in the object store.
             with core_worker.profile_event(b"task:store_outputs"):
                 core_worker.store_task_outputs(
@@ -1106,6 +1110,18 @@ cdef class CoreWorker:
             self.async_thread.start()
 
         return self.async_event_loop
+
+    def run_function_in_event_loop(self, func):
+        cdef:
+            CFiberEvent event
+        loop = self.create_or_get_event_loop()
+        coroutine = sync_to_async(func)()
+        future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+        future.add_done_callback(lambda _: event.Notify())
+        with nogil:
+            (self.core_worker.get()
+                .YieldCurrentFiber(event))
+        return future.result()
 
     def destory_event_loop_if_exists(self):
         if self.async_event_loop is not None:

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3410,9 +3410,13 @@ std::string FormatMemoryInfo(std::vector<rpc::GetNodeStatsReply> node_stats) {
     for (const auto &worker_stats : reply.workers_stats()) {
       bool pid_printed = false;
       for (const auto &object_ref : worker_stats.core_worker_stats().object_refs()) {
+        auto obj_id = ObjectID::FromBinary(object_ref.object_id());
         if (!object_ref.pinned_in_memory() && object_ref.local_ref_count() == 0 &&
             object_ref.submitted_task_ref_count() == 0 &&
             object_ref.contained_in_owned_size() == 0) {
+          continue;
+        }
+        if (obj_id.IsNil()) {
           continue;
         }
         if (!pid_printed) {
@@ -3423,7 +3427,6 @@ std::string FormatMemoryInfo(std::vector<rpc::GetNodeStatsReply> node_stats) {
           }
           pid_printed = true;
         }
-        auto obj_id = ObjectID::FromBinary(object_ref.object_id());
         builder << obj_id.Hex() << "  ";
         // TODO(ekl) we could convey more information about the reference status.
         if (object_ref.pinned_in_memory()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
We are facing unknown segfault passing torch tensors in asyncio mode. I spent few hours tracking it down, it turns out the issue exists in deserializing objects. In the current asyncio mode, deserializer doesn't operate in a normal python stack, it operates on a fiber stack through the fiber thread; this somehow fails torch deserialization. Probably due to cloudpickle stack unwinding? 

Anyway, this PR runs deserializing procedure in event loop if necessary. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fixes #7799

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
