### PR TITLE
[streaming] Use enum to define resource type.

### DIFF
--- a/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/config/master/ResourceConfig.java
+++ b/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/config/master/ResourceConfig.java
@@ -8,16 +8,6 @@ import org.ray.streaming.runtime.config.Config;
 public interface ResourceConfig extends Config {
 
   /**
-   * CPU definition key of resource management.
-   */
-  String RESOURCE_KEY_CPU = "CPU";
-
-  /**
-   * Memory definition key of resource management.
-   */
-  String RESOURCE_KEY_MEM = "MEM";
-
-  /**
    * Number of actors per container.
    */
   String MAX_ACTOR_NUM_PER_CONTAINER = "streaming.container.per.max.actor";

--- a/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/graph/executiongraph/ExecutionVertex.java
+++ b/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/graph/executiongraph/ExecutionVertex.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.ray.api.RayActor;
 import org.ray.api.id.ActorId;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
+import org.ray.streaming.runtime.core.resource.ResourceKey;
 import org.ray.streaming.runtime.core.resource.Slot;
 import org.ray.streaming.runtime.master.JobRuntimeContext;
 import org.ray.streaming.runtime.worker.JobWorker;
@@ -138,10 +139,10 @@ public class ExecutionVertex implements Serializable {
     Map<String, Double> resourceMap = new HashMap<>();
     ResourceConfig resourceConfig = runtimeContext.getConf().masterConfig.resourceConfig;
     if (resourceConfig.isTaskCpuResourceLimit()) {
-      resourceMap.put(ResourceConfig.RESOURCE_KEY_CPU, resourceConfig.taskCpuResource());
+      resourceMap.put(ResourceKey.CPU.name(), resourceConfig.taskCpuResource());
     }
     if (resourceConfig.isTaskMemResourceLimit()) {
-      resourceMap.put(ResourceConfig.RESOURCE_KEY_MEM, resourceConfig.taskMemResource());
+      resourceMap.put(ResourceKey.MEM.name(), resourceConfig.taskMemResource());
     }
     return resourceMap;
   }

--- a/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/graph/executiongraph/ExecutionVertex.java
+++ b/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/graph/executiongraph/ExecutionVertex.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import org.ray.api.RayActor;
 import org.ray.api.id.ActorId;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
-import org.ray.streaming.runtime.core.resource.ResourceKey;
+import org.ray.streaming.runtime.core.resource.ResourceType;
 import org.ray.streaming.runtime.core.resource.Slot;
 import org.ray.streaming.runtime.master.JobRuntimeContext;
 import org.ray.streaming.runtime.worker.JobWorker;
@@ -139,10 +139,10 @@ public class ExecutionVertex implements Serializable {
     Map<String, Double> resourceMap = new HashMap<>();
     ResourceConfig resourceConfig = runtimeContext.getConf().masterConfig.resourceConfig;
     if (resourceConfig.isTaskCpuResourceLimit()) {
-      resourceMap.put(ResourceKey.CPU.name(), resourceConfig.taskCpuResource());
+      resourceMap.put(ResourceType.CPU.name(), resourceConfig.taskCpuResource());
     }
     if (resourceConfig.isTaskMemResourceLimit()) {
-      resourceMap.put(ResourceKey.MEM.name(), resourceConfig.taskMemResource());
+      resourceMap.put(ResourceType.MEM.name(), resourceConfig.taskMemResource());
     }
     return resourceMap;
   }

--- a/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/resource/ResourceKey.java
+++ b/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/resource/ResourceKey.java
@@ -1,0 +1,33 @@
+package org.ray.streaming.runtime.core.resource;
+
+/**
+ * Key for different type of resources.
+ */
+public enum ResourceKey {
+
+  /**
+   *Cpu resource key.
+   */
+  CPU("CPU"),
+
+  /**
+   *Gpu resource key.
+   */
+  GPU("GPU"),
+
+  /**
+   * Memory resource key.
+   */
+  MEM("MEM");
+
+  private String value;
+
+  ResourceKey(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/resource/ResourceType.java
+++ b/streaming/java/streaming-runtime/src/main/java/org/ray/streaming/runtime/core/resource/ResourceType.java
@@ -3,7 +3,7 @@ package org.ray.streaming.runtime.core.resource;
 /**
  * Key for different type of resources.
  */
-public enum ResourceKey {
+public enum ResourceType {
 
   /**
    *Cpu resource key.
@@ -22,7 +22,7 @@ public enum ResourceKey {
 
   private String value;
 
-  ResourceKey(String value) {
+  ResourceType(String value) {
     this.value = value;
   }
 

--- a/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/resourcemanager/ResourceManagerTest.java
+++ b/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/resourcemanager/ResourceManagerTest.java
@@ -13,7 +13,7 @@ import org.ray.streaming.runtime.config.StreamingConfig;
 import org.ray.streaming.runtime.config.global.CommonConfig;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
 import org.ray.streaming.runtime.core.graph.executiongraph.ExecutionGraph;
-import org.ray.streaming.runtime.core.resource.ResourceKey;
+import org.ray.streaming.runtime.core.resource.ResourceType;
 import org.ray.streaming.runtime.master.resourcemanager.ResourceManager;
 import org.ray.streaming.runtime.master.resourcemanager.ResourceManagerImpl;
 import org.ray.streaming.runtime.master.scheduler.strategy.SlotAssignStrategy;
@@ -62,8 +62,8 @@ public class ResourceManagerTest extends BaseUnitTest {
     Assert.assertTrue(slotAssignStrategy instanceof PipelineFirstStrategy);
 
     Map<String, Double> containerResource = new HashMap<>();
-    containerResource.put(ResourceKey.CPU.name(), 16.0);
-    containerResource.put(ResourceKey.MEM.name(), 128.0);
+    containerResource.put(ResourceType.CPU.name(), 16.0);
+    containerResource.put(ResourceType.MEM.name(), 128.0);
     Container container1 = new Container(null, "testAddress1", "testHostName1");
     container1.setAvailableResource(containerResource);
     Container container2 = new Container(null, "testAddress2", "testHostName2");
@@ -92,9 +92,9 @@ public class ResourceManagerTest extends BaseUnitTest {
       Map<String, Double> resource = resourceManager.allocateResource(container, vertex.getResources());
       Assert.assertNotNull(resource);
     });
-    Assert.assertEquals(container1.getAvailableResource().get(ResourceKey.CPU.name()), 14.0);
-    Assert.assertEquals(container2.getAvailableResource().get(ResourceKey.CPU.name()), 14.0);
-    Assert.assertEquals(container1.getAvailableResource().get(ResourceKey.MEM.name()), 118.0);
-    Assert.assertEquals(container2.getAvailableResource().get(ResourceKey.MEM.name()), 118.0);
+    Assert.assertEquals(container1.getAvailableResource().get(ResourceType.CPU.name()), 14.0);
+    Assert.assertEquals(container2.getAvailableResource().get(ResourceType.CPU.name()), 14.0);
+    Assert.assertEquals(container1.getAvailableResource().get(ResourceType.MEM.name()), 118.0);
+    Assert.assertEquals(container2.getAvailableResource().get(ResourceType.MEM.name()), 118.0);
   }
 }

--- a/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/resourcemanager/ResourceManagerTest.java
+++ b/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/resourcemanager/ResourceManagerTest.java
@@ -13,6 +13,7 @@ import org.ray.streaming.runtime.config.StreamingConfig;
 import org.ray.streaming.runtime.config.global.CommonConfig;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
 import org.ray.streaming.runtime.core.graph.executiongraph.ExecutionGraph;
+import org.ray.streaming.runtime.core.resource.ResourceKey;
 import org.ray.streaming.runtime.master.resourcemanager.ResourceManager;
 import org.ray.streaming.runtime.master.resourcemanager.ResourceManagerImpl;
 import org.ray.streaming.runtime.master.scheduler.strategy.SlotAssignStrategy;
@@ -61,8 +62,8 @@ public class ResourceManagerTest extends BaseUnitTest {
     Assert.assertTrue(slotAssignStrategy instanceof PipelineFirstStrategy);
 
     Map<String, Double> containerResource = new HashMap<>();
-    containerResource.put(ResourceConfig.RESOURCE_KEY_CPU, 16.0);
-    containerResource.put(ResourceConfig.RESOURCE_KEY_MEM, 128.0);
+    containerResource.put(ResourceKey.CPU.name(), 16.0);
+    containerResource.put(ResourceKey.MEM.name(), 128.0);
     Container container1 = new Container(null, "testAddress1", "testHostName1");
     container1.setAvailableResource(containerResource);
     Container container2 = new Container(null, "testAddress2", "testHostName2");
@@ -91,9 +92,9 @@ public class ResourceManagerTest extends BaseUnitTest {
       Map<String, Double> resource = resourceManager.allocateResource(container, vertex.getResources());
       Assert.assertNotNull(resource);
     });
-    Assert.assertEquals(container1.getAvailableResource().get(ResourceConfig.RESOURCE_KEY_CPU), 14.0);
-    Assert.assertEquals(container2.getAvailableResource().get(ResourceConfig.RESOURCE_KEY_CPU), 14.0);
-    Assert.assertEquals(container1.getAvailableResource().get(ResourceConfig.RESOURCE_KEY_MEM), 118.0);
-    Assert.assertEquals(container2.getAvailableResource().get(ResourceConfig.RESOURCE_KEY_MEM), 118.0);
+    Assert.assertEquals(container1.getAvailableResource().get(ResourceKey.CPU.name()), 14.0);
+    Assert.assertEquals(container2.getAvailableResource().get(ResourceKey.CPU.name()), 14.0);
+    Assert.assertEquals(container1.getAvailableResource().get(ResourceKey.MEM.name()), 118.0);
+    Assert.assertEquals(container2.getAvailableResource().get(ResourceKey.MEM.name()), 118.0);
   }
 }

--- a/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/schedule/strategy/PipelineFirstStrategyTest.java
+++ b/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/schedule/strategy/PipelineFirstStrategyTest.java
@@ -14,6 +14,7 @@ import org.ray.streaming.runtime.BaseUnitTest;
 import org.ray.streaming.runtime.config.StreamingConfig;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
 import org.ray.streaming.runtime.core.graph.executiongraph.ExecutionGraph;
+import org.ray.streaming.runtime.core.resource.ResourceKey;
 import org.ray.streaming.runtime.master.scheduler.strategy.SlotAssignStrategy;
 import org.ray.streaming.runtime.master.scheduler.strategy.impl.PipelineFirstStrategy;
 import org.ray.streaming.runtime.core.resource.Container;
@@ -48,8 +49,8 @@ public class PipelineFirstStrategyTest extends BaseUnitTest {
     Resources resources = new Resources(resourceConfig);
 
     Map<String, Double> containerResource = new HashMap<>();
-    containerResource.put(ResourceConfig.RESOURCE_KEY_CPU, 16.0);
-    containerResource.put(ResourceConfig.RESOURCE_KEY_MEM, 128.0);
+    containerResource.put(ResourceKey.CPU.name(), 16.0);
+    containerResource.put(ResourceKey.MEM.name(), 128.0);
     for (int i = 0; i < 2; ++i) {
       UniqueId uniqueId = UniqueId.randomId();
       Container container = new Container(uniqueId, "1.1.1." + i,  "localhost" + i);

--- a/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/schedule/strategy/PipelineFirstStrategyTest.java
+++ b/streaming/java/streaming-runtime/src/test/java/org/ray/streaming/runtime/schedule/strategy/PipelineFirstStrategyTest.java
@@ -14,7 +14,7 @@ import org.ray.streaming.runtime.BaseUnitTest;
 import org.ray.streaming.runtime.config.StreamingConfig;
 import org.ray.streaming.runtime.config.master.ResourceConfig;
 import org.ray.streaming.runtime.core.graph.executiongraph.ExecutionGraph;
-import org.ray.streaming.runtime.core.resource.ResourceKey;
+import org.ray.streaming.runtime.core.resource.ResourceType;
 import org.ray.streaming.runtime.master.scheduler.strategy.SlotAssignStrategy;
 import org.ray.streaming.runtime.master.scheduler.strategy.impl.PipelineFirstStrategy;
 import org.ray.streaming.runtime.core.resource.Container;
@@ -49,8 +49,8 @@ public class PipelineFirstStrategyTest extends BaseUnitTest {
     Resources resources = new Resources(resourceConfig);
 
     Map<String, Double> containerResource = new HashMap<>();
-    containerResource.put(ResourceKey.CPU.name(), 16.0);
-    containerResource.put(ResourceKey.MEM.name(), 128.0);
+    containerResource.put(ResourceType.CPU.name(), 16.0);
+    containerResource.put(ResourceType.MEM.name(), 128.0);
     for (int i = 0; i < 2; ++i) {
       UniqueId uniqueId = UniqueId.randomId();
       Container container = new Container(uniqueId, "1.1.1." + i,  "localhost" + i);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Use enum instead of final string in config to define resource type.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
