### PR TITLE
[raysgd] Improve raysgd examples

### DIFF
--- a/ci/jenkins_tests/run_tune_tests.sh
+++ b/ci/jenkins_tests/run_tune_tests.sh
@@ -59,7 +59,7 @@ $SUPPRESS_OUTPUT docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} 
     python /ray/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py --smoke-test --num-workers=2
 
 $SUPPRESS_OUTPUT docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} --memory-swap=-1 $DOCKER_SHA \
-    python /ray/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py --smoke-test --tune
+    python /ray/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py --smoke-test
 
 $SUPPRESS_OUTPUT docker run --rm --shm-size=${SHM_SIZE} --memory=${MEMORY_SIZE} --memory-swap=-1 $DOCKER_SHA \
     python /ray/python/ray/util/sgd/torch/examples/dcgan.py --smoke-test --num-workers=2

--- a/doc/source/raysgd/raysgd_pytorch.rst
+++ b/doc/source/raysgd/raysgd_pytorch.rst
@@ -454,6 +454,9 @@ Advanced: Hyperparameter Tuning
 .. literalinclude:: ../../../python/ray/util/sgd/torch/examples/tune_example.py
    :language: python
    :start-after: __torch_tune_example__
+   :end-before: __end_torch_tune_example__
+
+You can see the `Tune example script <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/tune_example.py>`_ for an end-to-end example.
 
 
 Simultaneous Multi-model Training
@@ -584,8 +587,14 @@ to contribute an example, feel free to create a `pull request here <https://gith
 - `Torch training example <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/train_example.py>`__:
    Simple example of using Ray's TorchTrainer.
 
+- `TorchTrainer and RayTune example <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/tune_example.py>`__:
+   Simple example of hyperparameter tuning with Ray's TorchTrainer.
+
 - `CIFAR10 example <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py>`__:
    Training a ResNet18 model on CIFAR10.
+
+- `CIFAR10 RayTune example <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py>`__:
+   Tuning a ResNet18 model on CIFAR10 with Population-based training on RayTune.
 
 - `DCGAN example <https://github.com/ray-project/ray/blob/master/python/ray/util/sgd/torch/examples/dcgan.py>`__:
    Training a Deep Convolutional GAN on MNIST. It constructs two models and two optimizers and uses a custom training operator.

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -97,7 +97,7 @@ class DistributedTorchRunner(TorchRunner):
 
         # This needs to happen after apex
         self.models = [
-            DistributedDataParallel(model, device_ids=[0])
+            DistributedDataParallel(model, device_ids=self.device_ids)
             for model in self.models
         ]
 

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         "--tune", action="store_true", default=False, help="Tune training")
 
     args, _ = parser.parse_known_args()
-
-    ray.init(address=args.address, log_to_driver=True)
+    num_cpus = 4 if args.smoke_test else None
+    ray.init(address=args.address, num_cpus=num_cpus, log_to_driver=True)
 
     trainer1 = TorchTrainer(
         model_creator=ResNet18,

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
         use_tqdm=True)
     pbar = trange(args.num_epochs, unit="epoch")
     for i in pbar:
-        info = {"num_steps": 1} if args.test_mode else {}
+        info = {"num_steps": 1} if args.smoke_test else {}
         info["epoch_idx"] = i
         info["num_epochs"] = args.num_epochs
         # Increase `max_retries` to turn on fault tolerance.

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
@@ -1,7 +1,10 @@
+import numpy as np
 import os
 import torch
 import torch.nn as nn
 import argparse
+from ray import tune
+from ray.tune.schedulers import PopulationBasedTraining
 from torch.utils.data import DataLoader, Subset
 from torchvision.datasets import CIFAR10
 import torchvision.transforms as transforms
@@ -9,6 +12,7 @@ import torchvision.transforms as transforms
 from tqdm import trange
 
 import ray
+from ray.tune import CLIReporter
 from ray.util.sgd.torch import TorchTrainer
 from ray.util.sgd.torch.resnet import ResNet18
 from ray.util.sgd.utils import BATCH_SIZE
@@ -43,7 +47,7 @@ def cifar_creator(config):
     validation_dataset = CIFAR10(
         root="~/data", train=False, download=False, transform=transform_test)
 
-    if config["test_mode"]:
+    if config.get("test_mode"):
         train_dataset = Subset(train_dataset, list(range(64)))
         validation_dataset = Subset(validation_dataset, list(range(64)))
 
@@ -60,11 +64,6 @@ def optimizer_creator(model, config):
         model.parameters(),
         lr=config.get("lr", 0.1),
         momentum=config.get("momentum", 0.9))
-
-
-def scheduler_creator(optimizer, config):
-    return torch.optim.lr_scheduler.MultiStepLR(
-        optimizer, milestones=[150, 250, 350], gamma=0.1)
 
 
 if __name__ == "__main__":
@@ -101,37 +100,51 @@ if __name__ == "__main__":
         "--tune", action="store_true", default=False, help="Tune training")
 
     args, _ = parser.parse_known_args()
-
     ray.init(address=args.address, log_to_driver=True)
 
-    trainer1 = TorchTrainer(
+    TorchTrainable = TorchTrainer.as_trainable(
         model_creator=ResNet18,
         data_creator=cifar_creator,
         optimizer_creator=optimizer_creator,
         loss_creator=nn.CrossEntropyLoss,
-        scheduler_creator=scheduler_creator,
         initialization_hook=initialization_hook,
         num_workers=args.num_workers,
         config={
-            "lr": 0.1,
-            "test_mode": args.smoke_test,  # subset the data
-            # this will be split across workers.
-            BATCH_SIZE: 128 * args.num_workers
+            "test_mode": args.test_mode,  # whether to to subset the data
+            BATCH_SIZE: 128 * args.num_workers,
         },
         use_gpu=args.use_gpu,
-        scheduler_step_freq="epoch",
-        use_fp16=args.fp16,
-        use_tqdm=True)
-    pbar = trange(args.num_epochs, unit="epoch")
-    for i in pbar:
-        info = {"num_steps": 1} if args.test_mode else {}
-        info["epoch_idx"] = i
-        info["num_epochs"] = args.num_epochs
-        # Increase `max_retries` to turn on fault tolerance.
-        trainer1.train(max_retries=1, info=info)
-        val_stats = trainer1.validate()
-        pbar.set_postfix(dict(acc=val_stats["val_accuracy"]))
+        use_fp16=args.use_fp16)
 
-    print(trainer1.validate())
-    trainer1.shutdown()
-    print("success!")
+    pbt_scheduler = PopulationBasedTraining(
+        time_attr="training_iteration",
+        metric="val_loss",
+        mode="min",
+        perturbation_interval=1,
+        hyperparam_mutations={
+            # distribution for resampling
+            "lr": lambda: np.random.uniform(0.001, 1),
+            # allow perturbations within this set of categorical values
+            "momentum": [0.8, 0.9, 0.99],
+        })
+
+    reporter = CLIReporter()
+    reporter.add_metric_column("val_loss", "loss")
+    reporter.add_metric_column("val_accuracy", "acc")
+
+    analysis = tune.run(
+        TorchTrainable,
+        num_samples=4,
+        config={
+            "lr": tune.choice([0.001, 0.01, 0.1]),
+            "momentum": 0.8
+        },
+        stop={"training_iteration": 2 if args.test_mode else 100},
+        max_failures=3,  # used for fault tolerance
+        checkpoint_freq=3,  # used for fault tolerance
+        keep_checkpoints_num=1,  # used for fault tolerance
+        verbose=2,
+        progress_reporter=reporter,
+        scheduler=pbt_scheduler)
+
+    print(analysis.get_best_config(metric="val_loss", mode="min"))

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
             BATCH_SIZE: 128 * args.num_workers,
         },
         use_gpu=args.use_gpu,
-        use_fp16=args.use_fp16)
+        use_fp16=args.fp16)
 
     pbt_scheduler = PopulationBasedTraining(
         time_attr="training_iteration",

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         initialization_hook=initialization_hook,
         num_workers=args.num_workers,
         config={
-            "test_mode": args.test_mode,  # whether to to subset the data
+            "test_mode": args.smoke_test,  # whether to to subset the data
             BATCH_SIZE: 128 * args.num_workers,
         },
         use_gpu=args.use_gpu,
@@ -137,7 +137,7 @@ if __name__ == "__main__":
             "lr": tune.choice([0.001, 0.01, 0.1]),
             "momentum": 0.8
         },
-        stop={"training_iteration": 2 if args.test_mode else 100},
+        stop={"training_iteration": 2 if args.smoke_test else 100},
         max_failures=3,  # used for fault tolerance
         checkpoint_freq=3,  # used for fault tolerance
         keep_checkpoints_num=1,  # used for fault tolerance

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_pbt.py
@@ -9,8 +9,6 @@ from torch.utils.data import DataLoader, Subset
 from torchvision.datasets import CIFAR10
 import torchvision.transforms as transforms
 
-from tqdm import trange
-
 import ray
 from ray.tune import CLIReporter
 from ray.util.sgd.torch import TorchTrainer

--- a/python/ray/util/sgd/torch/examples/dcgan.py
+++ b/python/ray/util/sgd/torch/examples/dcgan.py
@@ -128,9 +128,6 @@ def optimizer_creator(models, config):
 
 class GANOperator(TrainingOperator):
     def setup(self, config):
-        self.device = torch.device("cuda"
-                                   if torch.cuda.is_available() else "cpu")
-
         self.classifier = LeNet()
         self.classifier.load_state_dict(
             torch.load(config["classification_model_path"]))
@@ -183,6 +180,7 @@ class GANOperator(TrainingOperator):
 
         # Compute a discriminator update for real images
         discriminator.zero_grad()
+        # self.device is set automatically
         real_cpu = batch[0].to(self.device)
         batch_size = real_cpu.size(0)
         label = torch.full((batch_size, ), real_label, device=self.device)

--- a/python/ray/util/sgd/torch/examples/tune_example.py
+++ b/python/ray/util/sgd/torch/examples/tune_example.py
@@ -7,31 +7,15 @@ but we put comments right after code blocks to prevent large white spaces
 in the documentation.
 """
 
-# __torch_tune_example__
-import numpy as np
 import torch
 import torch.nn as nn
+from torch.utils.data import DataLoader
 
 import ray
 from ray import tune
 from ray.util.sgd.torch import TorchTrainer
 from ray.util.sgd.utils import BATCH_SIZE
-
-
-class LinearDataset(torch.utils.data.Dataset):
-    """y = a * x + b"""
-
-    def __init__(self, a, b, size=1000):
-        x = np.random.random(size).astype(np.float32) * 10
-        x = np.arange(0, 10, 10 / size, dtype=np.float32)
-        self.x = torch.from_numpy(x)
-        self.y = torch.from_numpy(a * x + b)
-
-    def __getitem__(self, index):
-        return self.x[index, None], self.y[index, None]
-
-    def __len__(self):
-        return len(self.x)
+from ray.util.sgd.torch.examples.train_example import LinearDataset
 
 
 def model_creator(config):
@@ -47,22 +31,18 @@ def data_creator(config):
     """Returns training dataloader, validation dataloader."""
     train_dataset = LinearDataset(2, 5)
     val_dataset = LinearDataset(2, 5, size=400)
-    train_loader = torch.utils.data.DataLoader(
-        train_dataset,
-        batch_size=config[BATCH_SIZE],
-    )
-    validation_loader = torch.utils.data.DataLoader(
-        val_dataset,
-        batch_size=config[BATCH_SIZE])
+    train_loader = DataLoader(train_dataset, batch_size=config[BATCH_SIZE])
+    validation_loader = DataLoader(val_dataset, batch_size=config[BATCH_SIZE])
     return train_loader, validation_loader
 
 
+# __torch_tune_example__
 def tune_example(num_workers=1, use_gpu=False):
     TorchTrainable = TorchTrainer.as_trainable(
         model_creator=model_creator,
         data_creator=data_creator,
         optimizer_creator=optimizer_creator,
-        loss_creator=nn.MSELoss,
+        loss_creator=nn.MSELoss,  # Note that we specify a Loss class.
         num_workers=num_workers,
         use_gpu=use_gpu,
         config={BATCH_SIZE: 128}
@@ -76,6 +56,7 @@ def tune_example(num_workers=1, use_gpu=False):
         verbose=1)
 
     return analysis.get_best_config(metric="validation_loss", mode="min")
+# __end_torch_tune_example__
 
 
 if __name__ == "__main__":

--- a/python/ray/util/sgd/torch/torch_runner.py
+++ b/python/ray/util/sgd/torch/torch_runner.py
@@ -176,6 +176,7 @@ class TorchRunner:
             validation_loader=self.validation_loader,
             world_rank=0,
             schedulers=self.schedulers,
+            use_gpu=self.use_gpu,
             use_fp16=self.use_fp16,
             use_tqdm=self.use_tqdm)
 

--- a/python/ray/util/sgd/torch/torch_runner.py
+++ b/python/ray/util/sgd/torch/torch_runner.py
@@ -23,8 +23,8 @@ except ImportError:
     pass
 
 
-def _remind_gpu_usage(use_gpu, rank):
-    if rank > 0:
+def _remind_gpu_usage(use_gpu, is_chief):
+    if not is_chief:
         return
     if not use_gpu and torch.cuda.is_available():
         logger.info("GPUs detected but not using them. Set `use_gpu` to "

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -34,11 +34,12 @@ class TorchTrainer:
     """Train a PyTorch model using distributed PyTorch.
 
     Launches a set of actors which connect via distributed PyTorch and
-    coordinate gradient updates to train the provided model.
+    coordinate gradient updates to train the provided model. If Ray is not
+    initialized, TorchTrainer will automatically initialize a local Ray
+    cluster for you. Be sure to run `ray.init(address="auto")` to leverage
+    multi-node training.
 
     .. code-block:: python
-
-        ray.init()
 
         def model_creator(config):
             return nn.Linear(1, 1)
@@ -117,7 +118,8 @@ class TorchTrainer:
             automatically use "nccl" if `use_gpu` is True, and "gloo"
             otherwise.
         add_dist_sampler (bool): Whether to automatically add a
-            DistributedSampler to all created dataloaders.
+            DistributedSampler to all created dataloaders. Only applicable
+            if num_workers > 1.
         use_fp16 (bool): Enables mixed precision training via apex if apex
             is installed. This is automatically done after the model and
             optimizers are constructed and will work for multi-model training.

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -116,6 +116,8 @@ class TorchTrainer:
             support "nccl", "gloo", and "auto". If "auto", RaySGD will
             automatically use "nccl" if `use_gpu` is True, and "gloo"
             otherwise.
+        add_dist_sampler (bool): Whether to automatically add a
+            DistributedSampler to all created dataloaders.
         use_fp16 (bool): Enables mixed precision training via apex if apex
             is installed. This is automatically done after the model and
             optimizers are constructed and will work for multi-model training.
@@ -148,11 +150,12 @@ class TorchTrainer:
             initialization_hook=None,
             config=None,
             num_workers=1,
-            use_gpu=False,
+            use_gpu="auto",
             backend="auto",
             use_fp16=False,
             use_tqdm=False,
             apex_args=None,
+            add_dist_sampler=True,
             scheduler_step_freq="batch",
             num_replicas=None,
             batch_size=None,
@@ -202,19 +205,20 @@ class TorchTrainer:
 
         self.initialization_hook = initialization_hook
         self.config = {} if config is None else config
+        if use_gpu == "auto":
+            use_gpu = torch.cuda.is_available()
 
         if backend == "auto":
             backend = "nccl" if use_gpu else "gloo"
 
         logger.debug("Using {} as backend.".format(backend))
         self.backend = backend
-
-        # TODO: Have an auto "use_gpu" option to detect and use GPUs.
         self.use_gpu = use_gpu
         self.max_replicas = num_workers
 
         self.use_fp16 = use_fp16
         self.use_tqdm = use_tqdm
+        self.add_dist_sampler = add_dist_sampler
 
         if apex_args and not isinstance(apex_args, dict):
             raise ValueError("apex_args needs to be a dict object.")
@@ -230,6 +234,11 @@ class TorchTrainer:
         _validate_scheduler_step_freq(scheduler_step_freq)
         self.scheduler_step_freq = scheduler_step_freq
 
+        if not ray.is_initialized() and self.max_replicas > 1:
+            logger.info("Automatically initializing single-node Ray. To use "
+                        "multi-node training, be sure to run `ray.init("
+                        "address='auto')` before instantiating the Trainer.")
+            ray.init()
         self._start_workers(self.max_replicas)
 
     def _configure_and_split_batch(self, num_workers):
@@ -259,39 +268,30 @@ class TorchTrainer:
         if batch_size_per_worker:
             worker_config[BATCH_SIZE] = batch_size_per_worker
 
+        params = dict(
+            model_creator=self.model_creator,
+            data_creator=self.data_creator,
+            optimizer_creator=self.optimizer_creator,
+            loss_creator=self.loss_creator,
+            scheduler_creator=self.scheduler_creator,
+            backend=self.backend,
+            training_operator_cls=self.training_operator_cls,
+            config=worker_config,
+            use_fp16=self.use_fp16,
+            use_gpu=self.use_gpu,
+            use_tqdm=self.use_tqdm,
+            apex_args=self.apex_args,
+            scheduler_step_freq=self.scheduler_step_freq)
+
         if num_workers == 1:
             # Start local worker
-            self.local_worker = TorchRunner(
-                model_creator=self.model_creator,
-                data_creator=self.data_creator,
-                optimizer_creator=self.optimizer_creator,
-                loss_creator=self.loss_creator,
-                scheduler_creator=self.scheduler_creator,
-                training_operator_cls=self.training_operator_cls,
-                config=worker_config,
-                use_fp16=self.use_fp16,
-                use_tqdm=self.use_tqdm,
-                apex_args=self.apex_args,
-                scheduler_step_freq=self.scheduler_step_freq)
-
+            self.local_worker = TorchRunner(**params)
             if self.initialization_hook:
                 self.apply_all_workers(self.initialization_hook)
-
             self.local_worker.setup()
         else:
-            params = dict(
-                model_creator=self.model_creator,
-                data_creator=self.data_creator,
-                optimizer_creator=self.optimizer_creator,
-                loss_creator=self.loss_creator,
-                scheduler_creator=self.scheduler_creator,
-                backend=self.backend,
-                training_operator_cls=self.training_operator_cls,
-                config=worker_config,
-                use_fp16=self.use_fp16,
-                use_tqdm=self.use_tqdm,
-                apex_args=self.apex_args,
-                scheduler_step_freq=self.scheduler_step_freq)
+            params.update(
+                backend=self.backend, add_dist_sampler=self.add_dist_sampler)
 
             # Start local worker
             self.local_worker = LocalDistributedRunner(
@@ -455,7 +455,11 @@ class TorchTrainer:
         local_call = self.local_worker.apply_operator(fn)
         return [local_call] + ray.get(remote_calls)
 
-    def validate(self, num_steps=None, profile=False, info=None):
+    def validate(self,
+                 num_steps=None,
+                 profile=False,
+                 reduce_results=True,
+                 info=None):
         """Evaluates the model on the validation data set.
 
         Args:
@@ -463,6 +467,10 @@ class TorchTrainer:
                 This corresponds also to the number of times
                 ``TrainingOperator.validate_batch`` is called.
             profile (bool): Returns time stats for the evaluation procedure.
+            reduce_results (bool): Whether to average all metrics across
+                all workers into one dict. If a metric is a non-numerical
+                value (or nested dictionaries), one value will be randomly
+                selected among the workers. If False, returns a list of dicts.
             info (dict): Optional dictionary passed to the training
                 operator for `validate` and `validate_batch`.
 
@@ -477,8 +485,12 @@ class TorchTrainer:
             w.validate.remote(**params) for w in self.remote_workers
         ]
         local_worker_stats = self.local_worker.validate(**params)
-        return self._process_stats([local_worker_stats] +
-                                   ray.get(remote_worker_stats))
+        worker_stats = [local_worker_stats] + ray.get(remote_worker_stats)
+
+        if reduce_results:
+            return self._process_stats(worker_stats)
+        else:
+            return worker_stats
 
     def update_scheduler(self, metric):
         """Calls ``scheduler.step(metric)`` on all schedulers.
@@ -496,6 +508,17 @@ class TorchTrainer:
         if len(unwrapped) == 1:
             return unwrapped[0]
         return unwrapped
+
+    def get_local_operator(self):
+        """Returns the local TrainingOperator object.
+
+        Be careful not to perturb its state, or else you can cause the system
+        to enter an inconsistent state.
+
+        Returns:
+            TrainingOperator: The local TrainingOperator object.
+        """
+        return self.local_worker.training_operator
 
     def state_dict(self):
         return self.local_worker.state_dict()

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -276,7 +276,6 @@ class TorchTrainer:
             optimizer_creator=self.optimizer_creator,
             loss_creator=self.loss_creator,
             scheduler_creator=self.scheduler_creator,
-            backend=self.backend,
             training_operator_cls=self.training_operator_cls,
             config=worker_config,
             use_fp16=self.use_fp16,

--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -336,7 +336,7 @@ class TrainingOperator:
 
     @property
     def device(self):
-    	"""The torch device, at your convenience."""
+        """The torch device, at your convenience."""
         return self._device
 
     @property

--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -60,6 +60,7 @@ class TrainingOperator:
                  world_rank,
                  criterion=None,
                  schedulers=None,
+                 use_gpu=False,
                  use_fp16=False,
                  use_tqdm=False):
         # You are not expected to override this method.
@@ -80,6 +81,8 @@ class TrainingOperator:
                     type(schedulers)))
         self._config = config
         self._use_fp16 = use_fp16
+        self._use_gpu = use_gpu and torch.cuda.is_available()
+        self._device = torch.device("cuda" if self._use_gpu else "cpu")
         if tqdm is None and use_tqdm:
             raise ValueError("tqdm must be installed to use tqdm in training.")
         self._use_tqdm = use_tqdm
@@ -324,12 +327,16 @@ class TrainingOperator:
         }
 
     def state_dict(self):
-        """Returns a serializable representation of the operator state."""
+        """Override this to return a representation of the operator state."""
         pass
 
     def load_state_dict(self, state_dict):
-        """Loads a serializable representation of the operator state."""
+        """Override this to load the representation of the operator state."""
         pass
+
+    @property
+    def device(self):
+        return self._device
 
     @property
     def config(self):

--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -336,6 +336,7 @@ class TrainingOperator:
 
     @property
     def device(self):
+    	"""The torch device, at your convenience."""
         return self._device
 
     @property


### PR DESCRIPTION
## Why are these changes needed?

Usability improvements and a better example for Tune + RaySGD. 



Listed here: 
* Adds a separate CIFAR PBT script
* Automatically initializes Ray if user forgets and prints an info string.
* Automatically detects and uses a GPU if parameter is set to "auto".
* Reminds users that a GPU is available if the user is not using it.
* Allows users to turn off the DistributedSampler augmentation.
* Informs torch that we are only using 1 GPU per process (which enables more features like SyncBatchNorm). Previously Torch didn't receive this explicit notification (in distributed_torch_runner). 
* Allows the validation results to not be reduced.
* Initializes the data_creator first. This is so that the model can be defined off of the data specification.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)