### PR TITLE
Add warning for bad MacOS hostname

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from os.path import dirname
+from socket import gethostname
 import sys
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,10 @@ if "OMP_NUM_THREADS" not in os.environ:
                  "degradation with many workers (issue #6998). You can "
                  "override this by explicitly setting OMP_NUM_THREADS.")
     os.environ["OMP_NUM_THREADS"] = "1"
+
+if sys.platform == "darwin" and not gethostname().endswith(".local"):
+    logger.warning("The GCS Service may not correctly resolve your hostname."
+                   "To fix this please look at issue #7837")
 
 # Add the directory containing pickle5 to the Python path so that we find the
 # pickle5 version packaged with ray and not a pre-existing pickle5.

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -21,8 +21,9 @@ if "OMP_NUM_THREADS" not in os.environ:
     os.environ["OMP_NUM_THREADS"] = "1"
 
 if sys.platform == "darwin" and not gethostname().endswith(".local"):
-    logger.warning("The GCS Service may not correctly resolve your hostname."
-                   "To fix this please look at issue #7837")
+    logger.warning(
+        "The Ray Control Service may not correctly resolve your hostname."
+        "To fix, look at https://github.com/ray-project/ray/issues/7837")
 
 # Add the directory containing pickle5 to the Python path so that we find the
 # pickle5 version packaged with ray and not a pre-existing pickle5.

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -22,7 +22,7 @@ if "OMP_NUM_THREADS" not in os.environ:
 
 if sys.platform == "darwin" and not gethostname().endswith(".local"):
     logger.warning(
-        "The Ray Control Service may not correctly resolve your hostname."
+        "The Ray Control Service may not correctly resolve your hostname. "
         "To fix, look at https://github.com/ray-project/ray/issues/7837")
 
 # Add the directory containing pickle5 to the Python path so that we find the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Checks that the hostname ends with `.local` on MacOS.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Addresses problems in #7837 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
