### PR TITLE
[RLlib] Remove all instances of tf.contrib.layers. ... from RLlib code (deprecated).

### DIFF
--- a/rllib/agents/ddpg/ddpg_policy.py
+++ b/rllib/agents/ddpg/ddpg_policy.py
@@ -54,6 +54,7 @@ class DDPGPostprocessing:
                 feed_dict={
                     self.cur_observations: states,
                     self._is_exploring: False,
+                    self._timestep: self.global_timestep,
                 })
             distance_in_action_space = np.sqrt(
                 np.mean(np.square(clean_actions - noisy_actions)))

--- a/rllib/agents/ddpg/ddpg_policy.py
+++ b/rllib/agents/ddpg/ddpg_policy.py
@@ -415,17 +415,14 @@ class DDPGTFPolicy(DDPGPostprocessing, TFPolicy):
         activation = getattr(tf.nn, self.config["actor_hidden_activation"])
         for hidden in self.config["actor_hiddens"]:
             if self.config["parameter_noise"]:
-                import tensorflow.contrib.layers as layers
-                action_out = layers.fully_connected(
-                    action_out,
-                    num_outputs=hidden,
-                    activation_fn=activation,
-                    normalizer_fn=layers.layer_norm)
+                action_out = tf.keras.layers.Dense(
+                    units=hidden, activation=activation)(action_out)
+                action_out = tf.keras.layers.LayerNormalization()(action_out)
             else:
-                action_out = tf.layers.dense(
-                    action_out, units=hidden, activation=activation)
-        action_out = tf.layers.dense(
-            action_out, units=action_space.shape[0], activation=None)
+                action_out = tf.keras.layers.Dense(
+                    units=hidden, activation=activation)(action_out)
+        action_out = tf.keras.layers.Dense(
+            units=action_space.shape[0], activation=None)(action_out)
 
         # Use sigmoid to scale to [0,1], but also double magnitude of input to
         # emulate behaviour of tanh activation used in DDPG and TD3 papers.

--- a/rllib/agents/ddpg/ddpg_policy.py
+++ b/rllib/agents/ddpg/ddpg_policy.py
@@ -414,15 +414,12 @@ class DDPGTFPolicy(DDPGPostprocessing, TFPolicy):
 
         activation = getattr(tf.nn, self.config["actor_hidden_activation"])
         for hidden in self.config["actor_hiddens"]:
+            action_out = tf.layers.dense(
+                action_out, units=hidden, activation=activation)
             if self.config["parameter_noise"]:
-                action_out = tf.keras.layers.Dense(
-                    units=hidden, activation=activation)(action_out)
                 action_out = tf.keras.layers.LayerNormalization()(action_out)
-            else:
-                action_out = tf.keras.layers.Dense(
-                    units=hidden, activation=activation)(action_out)
-        action_out = tf.keras.layers.Dense(
-            units=action_space.shape[0], activation=None)(action_out)
+        action_out = tf.layers.dense(
+            action_out, units=action_space.shape[0], activation=None)
 
         # Use sigmoid to scale to [0,1], but also double magnitude of input to
         # emulate behaviour of tanh activation used in DDPG and TD3 papers.

--- a/rllib/agents/dqn/distributional_q_model.py
+++ b/rllib/agents/dqn/distributional_q_model.py
@@ -125,14 +125,12 @@ class DistributionalQModel(TFModelV2):
                     state_out = self._noisy_layer("dueling_hidden_%d" % i,
                                                   state_out, q_hiddens[i],
                                                   sigma0)
-                elif parameter_noise:
-                    state_out = tf.keras.layers.Dense(
-                        units=q_hiddens[i],
-                        activation_fn=tf.nn.relu,
-                        normalizer_fn=tf.contrib.layers.layer_norm)(state_out)
                 else:
                     state_out = tf.keras.layers.Dense(
                         units=q_hiddens[i], activation=tf.nn.relu)(state_out)
+                    if parameter_noise:
+                        state_out = tf.keras.layers.LayerNormalization()(
+                            state_out)
             if use_noisy:
                 state_score = self._noisy_layer(
                     "dueling_output",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

DQN and DDPG (if param noise is used) are still using the deprecated `tf.contrib.layers.dense` ...
classes. This PR replaces these by `tf.keras.layers.Dense`.

<!-- Please give a short summary of the change and the problem this solves. -->

Issue #7850 

<!-- For example: "Closes #1234" -->

Closes #7850 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
