### PR TITLE
[flaky test] Use check_output in test_debug_tools

### DIFF
--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -38,7 +38,7 @@ def test_raylet_gdb(ray_gdb_start):
 
     # Check process name in `ps aux | grep gdb`
     for process_name in ["raylet/raylet", "plasma/plasma_store_server"]:
-        # Will raise an exception if pgrep doesn't find the procss name.
+        # Will raise an exception if pgrep doesn't find the process name.
         subprocess.check_output(
             ["pgrep", "-f", "gdb.*{}".format(process_name)])
 

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -32,17 +32,15 @@ def test_raylet_gdb(ray_gdb_start):
 
     @ray.remote
     def f():
-        return 42
+        return ray.get(ray.put(42))
 
     assert ray.get(f.remote()) == 42
 
     # Check process name in `ps aux | grep gdb`
     for process_name in ["raylet/raylet", "plasma/plasma_store_server"]:
-        pgrep_command = subprocess.Popen(
-            ["pgrep", "-f", "gdb.*{}".format(process_name)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        assert pgrep_command.communicate()[0]
+        # Will raise an exception if pgrep doesn't find the procss name.
+        subprocess.check_output(
+            ["pgrep", "-f", "gdb.*{}".format(process_name)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_debug_tools.py` has been failing frequently in CI. This attempts to fix it by using `check_output` instead of `Process.communicate` and waiting for the plasma store to be ready by calling `ray.get(ray.put())`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
