### PR TITLE
Log to terminal if glog is also doing so

### DIFF
--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -349,25 +349,20 @@ class Node:
         raise FileExistsError(errno.EEXIST,
                               "No usable temporary filename found")
 
-    def new_log_files(self, name, redirect_output=True):
+    def new_log_files(self, name):
         """Generate partially randomized filenames for log files.
 
         Args:
             name (str): descriptive string for this log file.
-            redirect_output (bool): True if files should be generated for
-                logging stdout and stderr and false if stdout and stderr
-                should not be redirected.
-                If it is None, it will use the "redirect_output" Ray parameter.
 
         Returns:
-            If redirect_output is true, this will return a tuple of two
-                file handles. The first is for redirecting stdout and the
-                second is for redirecting stderr.
-                If redirect_output is false, this will return a tuple
-                of two None objects.
+            A tuple of two file handles for redirecting (stdout, stderr).
         """
+        redirect_output = self._ray_params.redirect_output
+
         if redirect_output is None:
-            redirect_output = self._ray_params.redirect_output
+            redirect_output = os.getenv("GLOG_logtostderr") != "1"
+
         if not redirect_output:
             return None, None
 
@@ -471,7 +466,7 @@ class Node:
 
     def start_reporter(self):
         """Start the reporter."""
-        stdout_file, stderr_file = self.new_log_files("reporter", True)
+        stdout_file, stderr_file = self.new_log_files("reporter")
         process_info = ray.services.start_reporter(
             self.redis_address,
             stdout_file=stdout_file,
@@ -492,7 +487,7 @@ class Node:
                 fail to start the webui. Otherwise it will print a warning if
                 we fail to start the webui.
         """
-        stdout_file, stderr_file = self.new_log_files("dashboard", True)
+        stdout_file, stderr_file = self.new_log_files("dashboard")
         self._webui_url, process_info = ray.services.start_dashboard(
             require_webui,
             self._ray_params.webui_host,
@@ -580,8 +575,8 @@ class Node:
 
     def new_worker_redirected_log_file(self, worker_id):
         """Create new logging files for workers to redirect its output."""
-        worker_stdout_file, worker_stderr_file = (self.new_log_files(
-            "worker-" + ray.utils.binary_to_hex(worker_id), True))
+        worker_stdout_file, worker_stderr_file = (
+            self.new_log_files("worker-" + ray.utils.binary_to_hex(worker_id)))
         return worker_stdout_file, worker_stderr_file
 
     def start_worker(self):

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -361,6 +361,7 @@ class Node:
         redirect_output = self._ray_params.redirect_output
 
         if redirect_output is None:
+            # Make the default behavior match that of glog.
             redirect_output = os.getenv("GLOG_logtostderr") != "1"
 
         if not redirect_output:

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -939,7 +939,10 @@ def _start_redis_instance(executable,
     if counter == num_retries:
         raise RuntimeError("Couldn't start Redis. "
                            "Check log files: {} {}".format(
-                               stdout_file.name, stderr_file.name))
+                               stdout_file.name
+                               if stdout_file is not None else "<stdout>",
+                               stderr_file.name
+                               if stdout_file is not None else "<stderr>"))
 
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -939,9 +939,8 @@ def _start_redis_instance(executable,
     if counter == num_retries:
         raise RuntimeError("Couldn't start Redis. "
                            "Check log files: {} {}".format(
-                               stdout_file.name
-                               if stdout_file is not None else "<stdout>",
-                               stderr_file.name
+                               stdout_file.name if stdout_file is not None else
+                               "<stdout>", stderr_file.name
                                if stdout_file is not None else "<stderr>"))
 
     # Create a Redis client just for configuring Redis.


### PR DESCRIPTION
## Why are these changes needed?

It's currently painful to log to the terminal, and moreover, the `redirect_output` parameter to `new_log_files` is superfluous (as it is always `True` in every case `new_log_files` is called, either explicitly or by default).

However, the `GLOG_logtostderr` environment variable [already controls whether or not glog logs to a terminal](https://cdn.statically.io/gh/google/glog/0bf00f95aafd4dac31ef423b4d2b99b4988f8465/doc/glog.html).

This PR makes it so that when this variable is set to `1`, subprocesses log to the terminal instead of generating log files, just like glog would. Otherwise, the old behavior is unaffected.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
