### PR TITLE
[Streaming] Fix streaming CI failure.

### DIFF
--- a/streaming/python/runtime/transfer.py
+++ b/streaming/python/runtime/transfer.py
@@ -6,7 +6,8 @@ from typing import List
 import ray
 import ray.streaming._streaming as _streaming
 import ray.streaming.generated.streaming_pb2 as streaming_pb
-from ray.actor import ActorHandle, ActorID
+from ray import ActorID
+from ray.actor import ActorHandle
 from ray.streaming.config import Config
 
 CHANNEL_ID_LEN = 20


### PR DESCRIPTION
ActorID shouldn't be found in ray.actor module.