### PR TITLE
[autoscaler] AWS Autoscaler support for EC2 security group rule configuration

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -53,7 +53,7 @@ if [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "linux" ]]; then
     opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy pytest pytest-timeout networkx tabulate aiohttp \
     uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio \
-    blist scikit-learn numba
+    blist scikit-learn numba boto3
 elif [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "macosx" ]]; then
   # Install miniconda.
   wget -q https://repo.continuum.io/miniconda/Miniconda3-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
@@ -64,7 +64,7 @@ elif [[ "$PYTHON" == "3.6" ]] && [[ "$platform" == "macosx" ]]; then
     opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy pytest pytest-timeout networkx tabulate aiohttp \
     uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio \
-    blist scikit-learn numba
+    blist scikit-learn numba boto3
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y build-essential curl unzip

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -518,11 +518,12 @@ def _get_required_channel_rules(sg, channel_rules, sgids):
             "security_group_ids": set(sgids)
         }
     }
-    ssh_rules_exist = _target_exists(channel_rules.get(SSH_CHANNEL, {})) or \
-        any(_ for _ in sg.ip_permissions if _match_ipp_channel(SSH_CHANNEL, _))
-    if not ssh_rules_exist:
-        default_ssh_targets = {"cidr_ips": ["0.0.0.0/0"]}
-        required_channel_rules[SSH_CHANNEL] = default_ssh_targets
+    for channel in DEFAULT_INBOUND_CHANNELS:
+        rules_exist = _target_exists(channel_rules.get(channel, {})) or \
+            any(_ for _ in sg.ip_permissions if _match_ipp_channel(channel, _))
+        if not rules_exist:
+            default_targets = {"cidr_ips": ["0.0.0.0/0"]}
+            required_channel_rules[channel] = default_targets
     return required_channel_rules
 
 

--- a/python/ray/autoscaler/aws/example-security-groups.yaml
+++ b/python/ray/autoscaler/aws/example-security-groups.yaml
@@ -16,11 +16,10 @@ provider:
     availability_zone: us-west-2a
 
     # AWS EC2 instance inbound rules to use with the head node security group.
-    # These rules can be used to either authorize new inbound connection
-    # sources to the head node, or revoke existing unauthorized inbound
-    # connection sources. However, default rules authorizing
-    # cross-communication between head and worker node security groups cannot
-    # be revoked.
+    # Specifying one or more rules below represents a directive to both add
+    # them to the security group if they don't already exist, and to revoke any
+    # unspecified rules. However, default rules authorizing cross-communication
+    # between head and worker node security groups cannot be revoked.
     head_inbound_rules:
           # The network channel that this rule applies to, specified as a port
           # range and protocol. Any redundant rules specified for the same
@@ -61,35 +60,25 @@ provider:
                   - 192.168.1.0/24
                   - 10.1.0.0/16
 
-          # A rule with a channel but no targets revokes all communication on
-          # that channel. Thus, the below config effectively ensures that any
-          # rule permitting unrestricted inbound traffic across all ports and
-          # protocols is revoked. However, note that this rule still does not
-          # revoke any rules required for proper functionality of your Ray
-          # cluster, such as those permitting arbitrary traffic to pass between
-          # head/worker node security groups.
-        - channel:
-              # Set port and protocol to -1 for the "All Traffic" channel
-              from_port: -1
-              to_port: -1
-              ip_protocol: "-1"
-
     # AWS EC2 instance inbound rules for the worker node security group.
     worker_inbound_rules:
           # This rule overrides the default inbound SSH sources specified in
-          # "default_inbound_sources" below.
+          # "default_inbound_sources" below. A rule with a channel but no
+          # targets revokes all communication on that channel, so the below
+          # rule ensures that all inbound SSH connection sources are revoked
+          # from the worker security group.
         - channel:
               from_port: 22
               to_port: 22
               ip_protocol: "tcp"
-          targets:
-              cidr_ips:
-                  - 192.168.1.0/24
-                  - 10.1.0.0/16
-              cidr_ipv6s:
-                  - 2002::1234:abcd:ffff:c0a8:101/128
 
+          # Note that specifying the below rule has no effect, since all rules
+          # on any unspecified channel would be revoked anyways, and any
+          # requests to revoke rules required for proper functionality of
+          # your Ray cluster, like those permitting all traffic to pass between
+          # head/worker nodes, will be discarded.
         - channel:
+              # Set port and protocol to -1 for the "All Traffic" channel
               from_port: -1
               to_port: -1
               ip_protocol: "-1"

--- a/python/ray/autoscaler/aws/example-security-groups.yaml
+++ b/python/ray/autoscaler/aws/example-security-groups.yaml
@@ -35,8 +35,8 @@ provider:
           # as value lists for each distinct target type. Valid target types
           # include "cidr_ips", "cidr_ipv6s", "prefix_list_ids", and
           # "security_group_ids". Any sources present in this list but not in
-          # your worker node security group rules will be authorized. Any
-          # sources not in this list but present in your worker node security
+          # your head node security group rules will be authorized. Any
+          # sources not in this list but present in your head node security
           # group rules will be revoked.
           targets:
               cidr_ips:

--- a/python/ray/autoscaler/aws/example-security-groups.yaml
+++ b/python/ray/autoscaler/aws/example-security-groups.yaml
@@ -1,0 +1,139 @@
+cluster_name: security-groups
+
+# If true, caches successfully applied cluster configs on disk and never
+# reapplies a cached config. If false, always idempotently applies cluster
+# config. It is recommended to disable the config cache if your use case
+# requires that cluster security group rules always be brought into compliance
+# with the rules specified in your config file during cluster create/update
+# operations.
+config_cache_enabled: false
+
+max_workers: 1
+
+provider:
+    type: aws
+    region: us-west-2
+    availability_zone: us-west-2a
+
+    # AWS EC2 instance inbound rules to use with the head node security group.
+    # These rules can be used to either authorize new inbound connection
+    # sources to the head node, or revoke existing unauthorized inbound
+    # connection sources. However, default rules authorizing
+    # cross-communication between head and worker node security groups cannot
+    # be revoked.
+    head_inbound_rules:
+          # The network channel that this rule applies to, specified as a port
+          # range and protocol. Any redundant rules specified for the same
+          # channel will be grouped by channel and have duplicate targets
+          # automatically removed.
+        - channel:
+            from_port: 80 # port range start (inclusive)
+            to_port: 80 # port range end (inclusive)
+            ip_protocol: "tcp" # protocol, case-insensitive (tcp, udp, or icmp)
+
+          # The inbound connection sources that this rule applies to, specified
+          # as value lists for each distinct target type. Valid target types
+          # include "cidr_ips", "cidr_ipv6s", "prefix_list_ids", and
+          # "security_group_ids". Any sources present in this list but not in
+          # your worker node security group rules will be authorized. Any
+          # sources not in this list but present in your worker node security
+          # group rules will be revoked.
+          targets:
+              cidr_ips:
+                  - 192.168.1.0/24
+              cidr_ipv6s:
+                  - 2002::1234:abcd:ffff:c0a8:101/128
+              # prefix_list_ids:
+              #    - pl-de4dbe3f
+              # security_group_ids:
+              #    - sg-d3afb3ef
+
+          # This redundant rule on TCP port 80 will have its targets
+          # automatically grouped together with the above rule. The
+          # 192.168.1.0/24 target will be deduped and the 10.1.0.0/16 target
+          # will be appended.
+        - channel:
+              from_port: 80
+              to_port: 80
+              ip_protocol: "tcp"
+          targets:
+              cidr_ips:
+                  - 192.168.1.0/24
+                  - 10.1.0.0/16
+
+          # A rule with a channel but no targets revokes all communication on
+          # that channel. Thus, the below config effectively ensures that any
+          # rule permitting unrestricted inbound traffic across all ports and
+          # protocols is revoked. However, note that this rule still does not
+          # revoke any rules required for proper functionality of your Ray
+          # cluster, such as those permitting arbitrary traffic to pass between
+          # head/worker node security groups.
+        - channel:
+              # Set port and protocol to -1 for the "All Traffic" channel
+              from_port: -1
+              to_port: -1
+              ip_protocol: "-1"
+
+    # AWS EC2 instance inbound rules for the worker node security group.
+    worker_inbound_rules:
+          # This rule overrides the default inbound SSH sources specified in
+          # "default_inbound_sources" below.
+        - channel:
+              from_port: 22
+              to_port: 22
+              ip_protocol: "tcp"
+          targets:
+              cidr_ips:
+                  - 192.168.1.0/24
+                  - 10.1.0.0/16
+              cidr_ipv6s:
+                  - 2002::1234:abcd:ffff:c0a8:101/128
+
+        - channel:
+              from_port: -1
+              to_port: -1
+              ip_protocol: "-1"
+
+    # AWS EC2 instance inbound sources to use across all default/required head
+    # and worker node security group channels, except those authorizing
+    # head/worker node cross-communication. These rules will currently be
+    # applied to inbound SSH sources, and are thus equivalent to specifying the
+    # same targets on the SSH channel (to/from TCP port 22) under both
+    # worker_inbound_rules and head_inbound_rules. Also note that any head or
+    # worker SSH inbound rules specified above will override the sources given
+    # here.
+    default_inbound_sources:
+        cidr_ips:
+            - 0.0.0.0/0
+
+auth:
+    ssh_user: ubuntu
+
+#head_node:
+    # Any security group specified below will override the head_inbound_rules
+    # config specified above and will remain unchanged during cluster create
+    # or update operations.
+    # SecurityGroupIds:
+    #     - sg-f13e7f007ed
+
+    # If required, head and worker nodes can exist on different subnets and
+    # communicate via VPC peering.
+    # VPC peering overview: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-peering.html.
+    # Setup VPC peering: https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html.
+    # Configure VPC peering route tables: https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html.
+    # To enable external SSH connectivity, you should also ensure that your VPC
+    # is configured to assign public IPv4 addresses to every EC2 instance
+    # assigned to it.
+    # SubnetIds:
+    #     - subnet-fa7c47
+
+#worker_nodes:
+    # Any security group specified below will override the worker_inbound_rules
+    # config specified above, and will remain unchanged during cluster create
+    # or update operations.
+    # SecurityGroupIds:
+    #     - sg-b47ca7
+
+    # Optionally place worker nodes on a different subnet from the head node.
+    # SubnetIds:
+    #     - subnet-c47fe37

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -46,12 +46,20 @@ def create_or_update_cluster(config_file, override_min_workers,
 def _bootstrap_config(config):
     config = fillout_defaults(config)
 
-    hasher = hashlib.sha1()
-    hasher.update(json.dumps([config], sort_keys=True).encode("utf-8"))
-    cache_key = os.path.join(tempfile.gettempdir(),
-                             "ray-config-{}".format(hasher.hexdigest()))
-    if os.path.exists(cache_key):
-        return json.loads(open(cache_key).read())
+    config_cache_enabled = config.pop("config_cache_enabled", True)
+    if config_cache_enabled:
+        hasher = hashlib.sha1()
+        hasher.update(json.dumps([config], sort_keys=True).encode("utf-8"))
+        cache_key = os.path.join(tempfile.gettempdir(),
+                                 "ray-config-{}".format(hasher.hexdigest()))
+
+        if os.path.exists(cache_key):
+            logger.info(
+                "_bootstrap_config: "
+                "Skipping cluster config due to existing config cache at {}".
+                format(cache_key))
+            return json.loads(open(cache_key).read())
+
     validate_config(config)
 
     importer = NODE_PROVIDERS.get(config["provider"]["type"])
@@ -61,8 +69,9 @@ def _bootstrap_config(config):
 
     bootstrap_config, _ = importer()
     resolved_config = bootstrap_config(config)
-    with open(cache_key, "w") as f:
-        f.write(json.dumps(resolved_config))
+    if config_cache_enabled:
+        with open(cache_key, "w") as f:
+            f.write(json.dumps(resolved_config))
     return resolved_config
 
 

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -11,6 +11,70 @@
                 "type": "string",
                 "description": "shell command"
             }
+        },
+        "aws_ec2_security_group_rule_targets": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "AWS EC2 instance security group targets",
+            "properties": {
+                "cidr_ips": {
+                  "type": "array",
+                  "description": "CIDR IP blocks"
+                },
+                "cidr_ipv6s": {
+                  "type": "array",
+                  "description": "CIDR IPv6 blocks"
+                },
+                "security_group_ids": {
+                  "type": "array",
+                  "description": "Security group IDs"
+                },
+                "prefix_list_ids": {
+                  "type": "array",
+                  "description": "Prefix list IDs"
+                }
+            }
+        },
+        "aws_ec2_security_group_rule_channel": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "AWS EC2 instance security group rule network channel",
+            "required": [ "from_port", "to_port", "ip_protocol" ],
+            "properties": {
+                "from_port": {
+                  "type": "integer",
+                  "description": "Port range start (inclusive)"
+                },
+                "to_port": {
+                  "type": "integer",
+                  "description": "Port range end (inclusive)"
+                },
+                "ip_protocol": {
+                  "type": "string",
+                  "description": "Protocol"
+                }
+            }
+        },
+        "aws_ec2_security_group_rule": {
+            "type": "object",
+            "description": "AWS EC2 instance security group rule",
+            "additionalProperties": false,
+            "required": [ "channel" ],
+            "properties": {
+                "channel": {
+                    "$ref": "#/definitions/aws_ec2_security_group_rule_channel"
+                },
+                "targets": {
+                    "$ref": "#/definitions/aws_ec2_security_group_rule_targets"
+                }
+            }
+        },
+        "aws_ec2_security_group_rules": {
+            "type": "array",
+            "description": "AWS EC2 instance security group rules",
+            "items": {
+                "$ref": "#/definitions/aws_ec2_security_group_rule"
+            }
         }
     },
     "required": [
@@ -83,6 +147,16 @@
                 "use_internal_ips": {
                     "type": "boolean",
                     "description": "don't require public ips"
+                },
+                "default_inbound_sources": {
+                    "$ref": "#/definitions/aws_ec2_security_group_rule_targets",
+                    "description": "AWS EC2 instance inbound sources to use for all default/required head and worker node security group rules, except those authorizing cross head/worker communication."
+                },
+                "head_inbound_rules": {
+                    "$ref": "#/definitions/aws_ec2_security_group_rules"
+                },
+                "worker_inbound_rules": {
+                  "$ref": "#/definitions/aws_ec2_security_group_rules"
                 },
                 "namespace": {
                     "type": "string",
@@ -237,6 +311,11 @@
         },
         "no_restart": {
             "description": "Whether to avoid restarting the cluster during updates. This field is controlled by the ray --no-restart flag and cannot be set by the user."
+        },
+        "config_cache_enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "If true, caches successfully applied cluster configs on disk and never reapplies a cached config. If false, always idempotently applies cluster config."
         }
     }
 }

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -166,6 +166,14 @@ py_test(
     deps = ["//:ray_lib"],
 )
 
+
+py_test(
+    name = "test_autoscaler_aws",
+    size = "small",
+    srcs = ["test_autoscaler_aws.py"],
+    deps = ["//:ray_lib"],
+)
+
 py_test(
     name = "test_autoscaler_yaml",
     size = "small",

--- a/python/ray/tests/test_autoscaler_aws.py
+++ b/python/ray/tests/test_autoscaler_aws.py
@@ -433,7 +433,7 @@ def test_create_sg_different_vpc_same_rules(iam_client_stub, ec2_client_stub):
     config = ray.autoscaler.aws.config.bootstrap_aws(config)
 
     # expect config to show different head and worker security groups residing
-    # on the same subnet
+    # on different subnets
     assert config["head_node"]["SecurityGroupIds"] == [DEFAULT_SG["GroupId"]]
     assert config["head_node"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
     assert config["worker_nodes"]["SecurityGroupIds"] == [AUX_SG["GroupId"]]

--- a/python/ray/tests/test_autoscaler_aws.py
+++ b/python/ray/tests/test_autoscaler_aws.py
@@ -191,7 +191,7 @@ def _load_aws_security_group_example_config():
 
 
 def _mock_path_exists_key_pair(path):
-    key_name, key_path = key_pair(0, "us-west-2")
+    key_name, key_path = key_pair(0, "us-west-2", DEFAULT_KEY_PAIR["KeyName"])
     # This return ternary ensures that we both:
     # 1) Mock key path existence.
     # 2) Properly respond to config cache file existence checks.

--- a/python/ray/tests/test_autoscaler_aws.py
+++ b/python/ray/tests/test_autoscaler_aws.py
@@ -1,0 +1,449 @@
+from datetime import datetime
+
+import pytest
+import os
+import copy
+
+from unittest import mock
+
+from botocore.stub import ANY
+
+import ray.autoscaler.aws.config
+from ray.autoscaler.aws.config import key_pair
+from ray.autoscaler.commands import create_or_update_cluster
+
+# Override global constants used in AWS autoscaler config artifact names.
+# This helps ensure that any unmocked test doesn't alter non-test artifacts.
+ray.autoscaler.aws.config.RAY = \
+    "ray-autoscaler-aws-test"
+ray.autoscaler.aws.config.DEFAULT_RAY_INSTANCE_PROFILE = \
+    ray.autoscaler.aws.config.RAY + "-v1"
+ray.autoscaler.aws.config.DEFAULT_RAY_IAM_ROLE = \
+    ray.autoscaler.aws.config.RAY + "-v1"
+ray.autoscaler.aws.config.SECURITY_GROUP_TEMPLATE = \
+    ray.autoscaler.aws.config.RAY + "-{}"
+
+# Default IAM instance profile to expose to tests.
+DEFAULT_INSTANCE_PROFILE = {
+    "Arn": "arn:aws:iam::336924118301:instance-profile/ExampleInstanceProfile",
+    "CreateDate": datetime(2013, 6, 12, 23, 52, 2, 2),
+    "InstanceProfileId": "AID2MAB8DPLSRHEXAMPLE",
+    "InstanceProfileName": "ExampleInstanceProfile",
+    "Path": "/",
+    "Roles": [
+        {
+            "Arn": "arn:aws:iam::336924118301:role/Test-Role",
+            "AssumeRolePolicyDocument": "ExampleAssumeRolePolicyDocument",
+            "CreateDate": datetime(2013, 1, 9, 6, 33, 26, 2),
+            "Path": "/",
+            "RoleId": "AIDGPMS9RO4H3FEXAMPLE",
+            "RoleName": "Test-Role",
+        },
+    ]
+}
+
+# Default EC2 key pair to expose to tests.
+DEFAULT_KEY_PAIR = {
+    "KeyFingerprint": "1f:51:ae:28:bf:89:e9:d8:1f:25:5d:37:2d:7d:b8:ca:9f",
+    "KeyName": ray.autoscaler.aws.config.RAY + "_us-west-2",
+}
+
+# Primary EC2 subnet to expose to tests.
+DEFAULT_SUBNET = {
+    "AvailabilityZone": "us-west-2a",
+    "AvailableIpAddressCount": 251,
+    "CidrBlock": "10.0.1.0/24",
+    "DefaultForAz": False,
+    "MapPublicIpOnLaunch": True,
+    "State": "available",
+    "SubnetId": "subnet-fa7c47",
+    "VpcId": "vpc-ba71007",
+}
+
+# Secondary EC2 subnet to expose to tests as required.
+AUX_SUBNET = {
+    "AvailabilityZone": "us-west-2a",
+    "AvailableIpAddressCount": 251,
+    "CidrBlock": "192.168.1.0/24",
+    "DefaultForAz": False,
+    "MapPublicIpOnLaunch": True,
+    "State": "available",
+    "SubnetId": "subnet-c47fe37",
+    "VpcId": "vpc-70017ab",
+}
+
+# Default security group settings immediately after creation
+# (prior to inbound rule configuration).
+DEFAULT_SG = {
+    "Description": "Auto-created security group for Ray workers",
+    "GroupName": ray.autoscaler.aws.config.RAY + "-security-groups",
+    "OwnerId": "test-owner",
+    "GroupId": "sg-1234abcd",
+    "VpcId": DEFAULT_SUBNET["VpcId"],
+    "IpPermissions": [],
+    "IpPermissionsEgress": [{
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1",
+        "IpRanges": [{
+            "CidrIp": "0.0.0.0/0"
+        }]
+    }],
+    "Tags": []
+}
+
+# Secondary security group settings after creation
+# (prior to inbound rule configuration).
+AUX_SG = copy.deepcopy(DEFAULT_SG)
+AUX_SG["GroupName"] += "-aux"
+AUX_SG["GroupId"] = "sg-dcba4321"
+
+# Default security group settings immediately after creation on aux subnet
+# (prior to inbound rule configuration).
+DEFAULT_SG_AUX_SUBNET = copy.deepcopy(DEFAULT_SG)
+DEFAULT_SG_AUX_SUBNET["VpcId"] = AUX_SUBNET["VpcId"]
+DEFAULT_SG_AUX_SUBNET["GroupId"] = AUX_SG["GroupId"]
+
+# Default security group settings once default inbound rules are applied
+# (if used by both head and worker nodes)
+DEFAULT_SG_WITH_RULES = copy.deepcopy(DEFAULT_SG)
+DEFAULT_SG_WITH_RULES["IpPermissions"] = [{
+    "FromPort": -1,
+    "ToPort": -1,
+    "IpProtocol": "-1",
+    "UserIdGroupPairs": [{
+        "GroupId": DEFAULT_SG["GroupId"]
+    }]
+}]
+DEFAULT_SG_WITH_RULES["IpPermissions"].extend([{
+    "FromPort": channel[ray.autoscaler.aws.config.FROM_PORT],
+    "ToPort": channel[ray.autoscaler.aws.config.TO_PORT],
+    "IpProtocol": channel[ray.autoscaler.aws.config.IP_PROTOCOL],
+    "IpRanges": [{
+        "CidrIp": "0.0.0.0/0"
+    }]
+} for channel in ray.autoscaler.aws.config.DEFAULT_INBOUND_CHANNELS])
+
+# Default security group once default inbound rules are applied
+# (if using separate security groups for head and worker nodes).
+DEFAULT_SG_DUAL_GROUP_RULES = copy.deepcopy(DEFAULT_SG_WITH_RULES)
+DEFAULT_SG_DUAL_GROUP_RULES["IpPermissions"][0]["UserIdGroupPairs"].append({
+    "GroupId": AUX_SG["GroupId"]
+})
+
+# Default security group on aux subnet once default inbound rules are applied.
+DEFAULT_SG_WITH_RULES_AUX_SUBNET = copy.deepcopy(DEFAULT_SG_DUAL_GROUP_RULES)
+DEFAULT_SG_WITH_RULES_AUX_SUBNET["VpcId"] = AUX_SUBNET["VpcId"]
+DEFAULT_SG_WITH_RULES_AUX_SUBNET["GroupId"] = AUX_SG["GroupId"]
+
+# Secondary security group settings after default inbound rules are applied
+# (if used by both head and worker nodes)
+AUX_SG_WITH_RULES = copy.deepcopy(DEFAULT_SG_WITH_RULES)
+AUX_SG_WITH_RULES["GroupName"] = AUX_SG["GroupName"]
+AUX_SG_WITH_RULES["GroupId"] = AUX_SG["GroupId"]
+AUX_SG_WITH_RULES["IpPermissions"][0]["UserIdGroupPairs"] = [{
+    "GroupId": AUX_SG["GroupId"]
+}]
+
+# Worker security group after inbound rules are applied from
+# ray/autoscaler/aws/example-security-groups.yaml
+EXAMPLE_WORKERS_SECURITY_GROUP = copy.deepcopy(AUX_SG_WITH_RULES)
+EXAMPLE_WORKERS_SECURITY_GROUP["IpPermissions"][0]["UserIdGroupPairs"].insert(
+    0, {"GroupId": DEFAULT_SG["GroupId"]})
+EXAMPLE_WORKERS_SECURITY_GROUP["IpPermissions"][1]["IpRanges"] = [{
+    "CidrIp": "10.1.0.0/16"
+}, {
+    "CidrIp": "192.168.1.0/24"
+}]
+EXAMPLE_WORKERS_SECURITY_GROUP["IpPermissions"][1].setdefault(
+    "Ipv6Ranges", [{
+        "CidrIpv6": "2002::1234:abcd:ffff:c0a8:101/128"
+    }])
+
+# Head security group after inbound rules are applied from
+# ray/autoscaler/aws/example-security-groups.yaml
+EXAMPLE_HEAD_SECURITY_GROUP = copy.deepcopy(DEFAULT_SG_WITH_RULES)
+EXAMPLE_HEAD_SECURITY_GROUP["IpPermissions"][0]["UserIdGroupPairs"].append({
+    "GroupId": EXAMPLE_WORKERS_SECURITY_GROUP["GroupId"]
+})
+EXAMPLE_HEAD_SECURITY_GROUP["IpPermissions"][1]["IpRanges"] = [{
+    "CidrIp": "0.0.0.0/0"
+}]
+EXAMPLE_HEAD_SECURITY_GROUP["IpPermissions"].append({
+    "FromPort": 80,
+    "ToPort": 80,
+    "IpProtocol": "tcp",
+    "IpRanges": [{
+        "CidrIp": "10.1.0.0/16"
+    }, {
+        "CidrIp": "192.168.1.0/24"
+    }],
+    "Ipv6Ranges": [{
+        "CidrIpv6": "2002::1234:abcd:ffff:c0a8:101/128"
+    }]
+})
+
+
+def _load_aws_security_group_example_config():
+    import ray.autoscaler.aws as ray_aws
+    return os.path.join(
+        os.path.dirname(ray_aws.__file__), "example-security-groups.yaml")
+
+
+def _mock_path_exists_key_pair(path):
+    key_name, key_path = key_pair(0, "us-west-2")
+    # This return ternary ensures that we both:
+    # 1) Mock key path existence.
+    # 2) Properly respond to config cache file existence checks.
+    return True if path == key_path else os.path.isfile(path)
+
+
+def _get_or_create_head_node_patch(patch_function):
+    patcher = mock.patch("ray.autoscaler.commands.get_or_create_head_node")
+    get_or_create_head_node_mock = patcher.start()
+    get_or_create_head_node_mock.side_effect = patch_function
+
+
+def _configure_iam_role_default_stubs(iam_client_stub):
+    iam_client_stub.add_response(
+        "get_instance_profile",
+        expected_params={
+            "InstanceProfileName": ray.autoscaler.aws.config.
+            DEFAULT_RAY_INSTANCE_PROFILE
+        },
+        service_response={"InstanceProfile": DEFAULT_INSTANCE_PROFILE})
+
+
+def _configure_key_pair_default_stubs(ec2_client_stub):
+    patcher = mock.patch("os.path.exists")
+    os_path_exists_mock = patcher.start()
+    os_path_exists_mock.side_effect = _mock_path_exists_key_pair
+
+    ec2_client_stub.add_response(
+        "describe_key_pairs",
+        expected_params={
+            "Filters": [{
+                "Name": "key-name",
+                "Values": [DEFAULT_KEY_PAIR["KeyName"]]
+            }]
+        },
+        service_response={"KeyPairs": [DEFAULT_KEY_PAIR]})
+
+
+def _configure_subnet_default_stubs(ec2_client_stub):
+    ec2_client_stub.add_response(
+        "describe_subnets",
+        expected_params={},
+        service_response={"Subnets": [DEFAULT_SUBNET]})
+
+
+def _skip_to_configure_sg_stubs(ec2_client_stub, iam_client_stub):
+    _configure_iam_role_default_stubs(iam_client_stub)
+    _configure_key_pair_default_stubs(ec2_client_stub)
+    _configure_subnet_default_stubs(ec2_client_stub)
+
+
+def _describe_subnets_echo_stub(ec2_client_stub, subnet):
+    ec2_client_stub.add_response(
+        "describe_subnets",
+        expected_params={
+            "Filters": [{
+                "Name": "subnet-id",
+                "Values": [subnet["SubnetId"]]
+            }]
+        },
+        service_response={"Subnets": [subnet]})
+
+
+def _describe_no_security_groups_stub(ec2_client_stub):
+    ec2_client_stub.add_response(
+        "describe_security_groups",
+        expected_params={"Filters": ANY},
+        service_response={})
+
+
+def _create_sg_echo_stub(ec2_client_stub, security_group):
+    ec2_client_stub.add_response(
+        "create_security_group",
+        expected_params={
+            "Description": security_group["Description"],
+            "GroupName": security_group["GroupName"],
+            "VpcId": security_group["VpcId"]
+        },
+        service_response={"GroupId": security_group["GroupId"]})
+
+
+def _describe_sgs_on_vpc_stub(ec2_client_stub, vpc_ids, security_groups):
+    ec2_client_stub.add_response(
+        "describe_security_groups",
+        expected_params={"Filters": [{
+            "Name": "vpc-id",
+            "Values": vpc_ids
+        }]},
+        service_response={"SecurityGroups": security_groups})
+
+
+def _authorize_sg_ingress_stub(ec2_client_stub, security_group):
+    ec2_client_stub.add_response(
+        "authorize_security_group_ingress",
+        expected_params={
+            "GroupId": security_group["GroupId"],
+            "IpPermissions": security_group["IpPermissions"]
+        },
+        service_response={})
+
+
+def _describe_sg_echo_stub(ec2_client_stub, security_group):
+    ec2_client_stub.add_response(
+        "describe_security_groups",
+        expected_params={"GroupIds": [security_group["GroupId"]]},
+        service_response={"SecurityGroups": [security_group]})
+
+
+def test_create_sg_different_rules_same_vpc(iam_client_stub, ec2_client_stub):
+    # use default stubs to skip ahead to security group configuration
+    _skip_to_configure_sg_stubs(ec2_client_stub, iam_client_stub)
+
+    # head and worker nodes have no custom subnets defined,
+    # so return only the default subnet for both security groups
+    _describe_subnets_echo_stub(ec2_client_stub, DEFAULT_SUBNET)
+    # given no existing security groups within the VPC...
+    _describe_no_security_groups_stub(ec2_client_stub)
+    # expect new default security group creation on the head/worker node VPC
+    _create_sg_echo_stub(ec2_client_stub, DEFAULT_SG)
+    # expect new default security group details to be retrieved after creation
+    _describe_sgs_on_vpc_stub(ec2_client_stub, [DEFAULT_SUBNET["VpcId"]],
+                              [DEFAULT_SG])
+
+    # given different head/worker inbound rule configs...
+    # expect an attempt to retrieve the aux group on the shared VPC
+    _describe_sgs_on_vpc_stub(ec2_client_stub, [DEFAULT_SUBNET["VpcId"]],
+                              [DEFAULT_SG])
+    # given only the default security group on the shared VPC...
+    # expect the aux security group to be created
+    _create_sg_echo_stub(ec2_client_stub, AUX_SG)
+    # expect new aux security group details to be retrieved following creation
+    _describe_sgs_on_vpc_stub(ec2_client_stub, [DEFAULT_SUBNET["VpcId"]],
+                              [DEFAULT_SG, AUX_SG])
+
+    # given no existing default security group inbound rules...
+    # expect to authorize all configured head inbound rules
+    _authorize_sg_ingress_stub(ec2_client_stub, EXAMPLE_HEAD_SECURITY_GROUP)
+    # given this modification to the default security group...
+    # expect the next read of ip_permissions to reload them
+    _describe_sg_echo_stub(ec2_client_stub, EXAMPLE_HEAD_SECURITY_GROUP)
+
+    # given no existing aux security group inbound rules...
+    # expect to authorize all configured worker inbound rules
+    _authorize_sg_ingress_stub(ec2_client_stub, EXAMPLE_WORKERS_SECURITY_GROUP)
+    # given this modification to the aux security group...
+    # expect the next read of ip_permissions to reload them
+    _describe_sg_echo_stub(ec2_client_stub, EXAMPLE_WORKERS_SECURITY_GROUP)
+
+    # expect the finalized config to have different head and worker node
+    # security groups on the same subnet
+    def _mock_get_or_create_head(config, *args):
+        assert config["head_node"]["SecurityGroupIds"] == \
+            [DEFAULT_SG["GroupId"]]
+        assert config["head_node"]["SubnetIds"] == \
+            [DEFAULT_SUBNET["SubnetId"]]
+        assert config["worker_nodes"]["SecurityGroupIds"] == \
+            [AUX_SG["GroupId"]]
+        assert config["worker_nodes"]["SubnetIds"] == \
+            [DEFAULT_SUBNET["SubnetId"]]
+
+    _get_or_create_head_node_patch(_mock_get_or_create_head)
+
+    config_file = _load_aws_security_group_example_config()
+    create_or_update_cluster(config_file, None, None, True, False, True, None)
+
+    # expect no pending responses left in IAM or EC2 client stub queues
+    iam_client_stub.assert_no_pending_responses()
+    ec2_client_stub.assert_no_pending_responses()
+
+
+def test_idempotent_sg_configuration(iam_client_stub, ec2_client_stub):
+    # given a cluster config with a directive to disable the config cache...
+    test_create_sg_different_rules_same_vpc(iam_client_stub, ec2_client_stub)
+    # expect no config cache hit and idempotent reapplication of config
+    # (on config cache hit, this test fails due to pending stub responses)
+    test_create_sg_different_rules_same_vpc(iam_client_stub, ec2_client_stub)
+
+
+CONFIG_DEFAULT_RULES_DIFFERENT_VPC = {
+    "cluster_name": "security-groups",
+    "min_workers": 1,
+    "max_workers": 1,
+    "provider": {
+        "type": "aws",
+        "region": "us-west-2",
+        "availability_zone": "us-west-2a",
+    },
+    "auth": {
+        "ssh_user": "ubuntu",
+    },
+    "head_node": {
+        "SubnetIds": [DEFAULT_SUBNET["SubnetId"]]
+    },
+    "worker_nodes": {
+        "SubnetIds": [AUX_SUBNET["SubnetId"]]
+    }
+}
+
+
+def test_create_sg_different_vpc_same_rules(iam_client_stub, ec2_client_stub):
+    config = copy.deepcopy(CONFIG_DEFAULT_RULES_DIFFERENT_VPC)
+
+    # use default stubs to skip ahead to security group configuration
+    _skip_to_configure_sg_stubs(ec2_client_stub, iam_client_stub)
+
+    # given head and worker nodes with custom subnets defined...
+    # expect to first describe the worker subnet ID
+    _describe_subnets_echo_stub(ec2_client_stub, AUX_SUBNET)
+    # expect to second describe the head subnet ID
+    _describe_subnets_echo_stub(ec2_client_stub, DEFAULT_SUBNET)
+    # given no existing security groups within the VPC...
+    _describe_no_security_groups_stub(ec2_client_stub)
+    # expect to first create a security group on the worker node VPC
+    _create_sg_echo_stub(ec2_client_stub, DEFAULT_SG_AUX_SUBNET)
+    # expect new worker security group details to be retrieved after creation
+    _describe_sgs_on_vpc_stub(ec2_client_stub, [AUX_SUBNET["VpcId"]],
+                              [DEFAULT_SG_AUX_SUBNET])
+    # expect to second create a security group on the head node VPC
+    _create_sg_echo_stub(ec2_client_stub, DEFAULT_SG)
+    # expect new head security group details to be retrieved after creation
+    _describe_sgs_on_vpc_stub(ec2_client_stub, [DEFAULT_SUBNET["VpcId"]],
+                              [DEFAULT_SG])
+
+    # given no existing default head security group inbound rules...
+    # expect to authorize all default head inbound rules
+    _authorize_sg_ingress_stub(ec2_client_stub, DEFAULT_SG_DUAL_GROUP_RULES)
+    # given no existing default worker security group inbound rules...
+    # expect to authorize all default worker inbound rules
+    _authorize_sg_ingress_stub(ec2_client_stub,
+                               DEFAULT_SG_WITH_RULES_AUX_SUBNET)
+
+    # given the prior modification to the head security group...
+    # expect the next read of a head security group property to reload it
+    _describe_sg_echo_stub(ec2_client_stub, DEFAULT_SG_WITH_RULES)
+    # given the prior modification to the worker security group...
+    # expect the next read of a worker security group property to reload it
+    _describe_sg_echo_stub(ec2_client_stub, DEFAULT_SG_WITH_RULES_AUX_SUBNET)
+
+    config = ray.autoscaler.aws.config.bootstrap_aws(config)
+
+    # expect config to show different head and worker security groups residing
+    # on the same subnet
+    assert config["head_node"]["SecurityGroupIds"] == [DEFAULT_SG["GroupId"]]
+    assert config["head_node"]["SubnetIds"] == [DEFAULT_SUBNET["SubnetId"]]
+    assert config["worker_nodes"]["SecurityGroupIds"] == [AUX_SG["GroupId"]]
+    assert config["worker_nodes"]["SubnetIds"] == [AUX_SUBNET["SubnetId"]]
+
+    # expect no pending responses left in IAM or EC2 client stub queues
+    iam_client_stub.assert_no_pending_responses()
+    ec2_client_stub.assert_no_pending_responses()
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/setup.py
+++ b/python/setup.py
@@ -173,6 +173,7 @@ def find_version(*filepath):
 
 requires = [
     "aiohttp",
+    "boto3",
     "click",
     "colorama",
     "filelock",


### PR DESCRIPTION
## Why are these changes needed?
1. These changes support common enterprise network security compliance use cases to ensure that inbound AWS EC2 instance connections are restricted to a known set of internal subnets. Although custom security groups or network ACLs may currently be configured to restrict SSH access to internal subnets, their creation requires:
- Learning the current inbound connection rule set required for a Ray cluster and associated CLI tools to function properly (which may change over time).
- Creating a custom security group and/or network ACL prior to running Ray cluster setup (via either a manual or automated out-of-band process).
- Specifying the custom security group ID and/or subnet ID associated with the network ACL in the Ray autoscaler config file (which are only known after creating a custom security group or Network ACL)
In general, I believe that we should decouple AWS autoscaler users from these responsibilities by allowing them to specify common security group configuration overrides to apply during default security group bootstrapping. To that end, these changes expose new AWS autoscaler configuration settings that allow users to specify custom inbound head/worker node security group rules to apply (via authorization of new rules or revocation of old rules) during config bootstrapping. Please refer to the included "example-security-groups.yaml" file for additional details. Also note that, if no custom security group rule config is specified, then prior default security group bootstrap behavior is maintained, namely:
- Inbound rules permitting external connections to previously bootstrapped security groups are not modified.
- Newly bootstrapped security groups allow all network traffic between head and worker nodes as well as external SSH connections from 0.0.0.0/0.

2. These changes also fix a bug which allowed users to specify separate subnet ID configurations for AWS head and worker nodes, but then ignored the configured head node subnet ID during cluster security group bootstrapping. Previously, we would always bootstrap one security group for both head and worker nodes and always choose the VPC associated with a worker's subnet ID (thus failing to create a separate head node security group whenever its subnet ID configuration resolved to a different VPC). Now, separate security groups will be created for head and worker nodes whenever their respective subnet ID configurations resolve to separate VPCs.

It also may be worth noting that additional tests and documentation updates are expected to follow this pull request, but I wanted to collect early reviewer opinions now instead of opening a more complete (but monolithic) pull request later.

## Related issue number
https://github.com/ray-project/ray/issues/8420

## Checks

- [X ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   - [ ] This PR is not tested (please justify below)

