### PR TITLE
[GCS] No need to send actor death signal from gcs client

### DIFF
--- a/src/ray/gcs/redis_accessor.cc
+++ b/src/ray/gcs/redis_accessor.cc
@@ -101,16 +101,6 @@ Status RedisLogBasedActorInfoAccessor::AsyncUpdate(
                  << ", actor id: " << actor_id << ", log_length: " << log_length;
   auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
                                const ActorTableData &data) {
-    // If we successfully appended a record to the GCS table of the actor that
-    // has died, signal this to anyone receiving signals from this actor.
-    if (data.state() == ActorTableData::DEAD ||
-        data.state() == ActorTableData::RECONSTRUCTING) {
-      std::vector<std::string> args = {"XADD", actor_id.Hex(), "*", "signal",
-                                       "ACTOR_DIED_SIGNAL"};
-      auto redis_context = client->primary_context();
-      RAY_CHECK_OK(redis_context->RunArgvAsync(args));
-    }
-
     if (callback != nullptr) {
       callback(Status::OK());
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

GCS Client will send actor died signal to notify python worker that an actor has dead. It seems that python worker does not need this signal now, so GCS Client can remove these signal logic.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#7675

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
