### PR TITLE
[bazel] Remove deprecated and now non-existent flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,9 +32,6 @@ build --host_copt="-Wno-microsoft-unqualified-friend"
 build --per_file_copt="-\\.(asm|S)$,external/com_github_grpc_grpc/.*@-DGRPC_BAZEL_BUILD"
 build --http_timeout_scaling=5.0
 build:iwyu --experimental_action_listener=//:iwyu_cpp
-# This workaround is due to an incompatibility of
-# bazel_common/tools/maven/pom_file.bzl with Bazel 1.0
-build --incompatible_depset_is_not_iterable=false
 
 # Print relative paths when possible
 build:windows --attempt_to_print_relative_paths

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -99,8 +99,8 @@ def ray_deps_setup():
 
     auto_http_archive(
         name = "bazel_common",
-        url = "https://github.com/google/bazel-common/archive/f1115e0f777f08c3cdb115526c4e663005bec69b.tar.gz",
-        sha256 = "50dea89af2e1334e18742f18c91c860446de8d1596947fe87e3cdb0d27b6f8f3",
+        url = "https://github.com/google/bazel-common/archive/084aadd3b854cad5d5e754a7e7d958ac531e6801.tar.gz",
+        sha256 = "a6e372118bc961b182a3a86344c0385b6b509882929c6b12dc03bb5084c775d5",
     )
 
     auto_http_archive(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Remove a deprecated (since bazel 0.5.3) and now unsupported (since bazel 2.0.0) build flag for bazel. (https://github.com/bazelbuild/bazel/commit/9f9f5ec10fed81362c35c50eeb4515bbe5bf8bce)

The original file/function that needed this flag that we are pulling from
https://github.com/ray-project/ray/blob/f86e6230957258b8087e792f63df2030d22c78fd/bazel/ray.bzl#L3 has updated the function to use the proper syntax (i.e. `to_list()`) https://github.com/google/bazel-common/commit/084aadd3b854cad5d5e754a7e7d958ac531e6801
As such it is safe to remove this deprecation flag.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #7884 
After removing this flag from the `.bazelrc` ray builds and installs successfully!

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)

I have also made a commit to update the CI for using the version of `pom_file.bzl` which contains the fix.