### PR TITLE
[GCS]Optimize gcs client testcases

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -873,7 +873,7 @@ TEST_F(ServiceBasedGcsClientTest, TestDetectGcsAvailability) {
   JobID add_job_id = JobID::FromInt(1);
   auto job_table_data = GenJobTableData(add_job_id);
 
-  RAY_LOG(INFO) << "GCS service init port = " << gcs_server_->GetPort();
+  RAY_LOG(INFO) << "Initializing GCS service, port = " << gcs_server_->GetPort();
   gcs_server_->Stop();
   thread_gcs_server_->join();
 
@@ -884,7 +884,7 @@ TEST_F(ServiceBasedGcsClientTest, TestDetectGcsAvailability) {
   while (gcs_server_->GetPort() == 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
-  RAY_LOG(INFO) << "GCS service restart success, port = " << gcs_server_->GetPort();
+  RAY_LOG(INFO) << "GCS service restarted, port = " << gcs_server_->GetPort();
 
   std::promise<bool> promise;
   RAY_CHECK_OK(gcs_client_->Jobs().AsyncAdd(

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -19,10 +19,6 @@
 
 namespace ray {
 
-static std::string redis_server_executable;
-static std::string redis_client_executable;
-static std::string libray_redis_module_path;
-
 class GcsServerTest : public RedisServiceManagerForTest {
  public:
   void SetUp() override {

--- a/streaming/src/test/mock_actor.cc
+++ b/streaming/src/test/mock_actor.cc
@@ -421,7 +421,6 @@ class StreamingWorker {
     std::shared_ptr<ActorHandle> actor_handle(new ActorHandle(actor_handle_serialized));
     STREAMING_CHECK(actor_handle != nullptr);
     STREAMING_LOG(INFO) << " actor id from handle: " << actor_handle->GetActorID();
-    ;
 
     // STREAMING_LOG(INFO) << "actor_handle_serialized: " << actor_handle_serialized;
     // peer_actor_handle_ =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Optimize gcs client testcases:
1.Sync wait for Subscribe/Unsubscribe to finish. 
2.Add object info/stats/worker info/error info test case.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
