### PR TITLE
[serve] Only access backend_table in master actor

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -293,24 +293,9 @@ def create_backend(func_or_class,
             "Backend must be a function or class, it is {}.".format(
                 type(func_or_class)))
 
-    backend_config_dict = dict(backend_config)
-
-    # save creator which starts replicas
-    global_state.backend_table.register_backend(backend_tag, creator)
-
-    # save information about configurations needed to start the replicas
-    global_state.backend_table.register_info(backend_tag, backend_config_dict)
-
-    # save the initial arguments needed by replicas
-    global_state.backend_table.save_init_args(backend_tag, arg_list)
-
-    # set the backend config inside the router
-    # particularly for max-batch-size
-    router = global_state.get_router()
-    ray.get(router.set_backend_config.remote(backend_tag, backend_config_dict))
     ray.get(
-        global_state.master_actor.scale_replicas.remote(
-            backend_tag, backend_config_dict["num_replicas"]))
+        global_state.master_actor.create_backend.remote(
+            backend_tag, creator, backend_config, arg_list))
 
 
 @_ensure_connected

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -187,15 +187,13 @@ def set_backend_config(backend_tag, backend_config):
 
 @_ensure_connected
 def get_backend_config(backend_tag):
-    """get the backend configuration for a backend tag
+    """Get the backend configuration for a backend tag.
 
     Args:
         backend_tag(str): A registered backend.
     """
-    assert (backend_tag in global_state.backend_table.list_backends()
-            ), "Backend {} is not registered.".format(backend_tag)
-    backend_config_dict = global_state.backend_table.get_info(backend_tag)
-    return BackendConfig(**backend_config_dict)
+    return ray.get(
+        global_state.master_actor.get_backend_config.remote(backend_tag))
 
 
 def _backend_accept_batch(func_or_class):

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -167,10 +167,9 @@ def create_endpoint(endpoint_name, route=None, methods=["GET"]):
         blocking (bool): If true, the function will wait for service to be
             registered before returning
     """
-    methods = [m.upper() for m in methods]
     ray.get(
         global_state.master_actor.create_endpoint.remote(
-            route, endpoint_name, methods))
+            route, endpoint_name, [m.upper() for m in methods]))
 
 
 @_ensure_connected
@@ -181,42 +180,9 @@ def set_backend_config(backend_tag, backend_config):
         backend_tag(str): A registered backend.
         backend_config(BackendConfig) : Desired backend configuration.
     """
-    assert (backend_tag in global_state.backend_table.list_backends()
-            ), "Backend {} is not registered.".format(backend_tag)
-    assert isinstance(backend_config,
-                      BackendConfig), ("backend_config must be"
-                                       " of instance BackendConfig")
-    backend_config_dict = dict(backend_config)
-    old_backend_config_dict = global_state.backend_table.get_info(backend_tag)
-
-    if (not old_backend_config_dict["has_accept_batch_annotation"]
-            and backend_config.max_batch_size is not None):
-        raise batch_annotation_not_found
-
-    global_state.backend_table.register_info(backend_tag, backend_config_dict)
-
-    # inform the router about change in configuration
-    # particularly for setting max_batch_size
-    router = global_state.get_router()
-    ray.get(router.set_backend_config.remote(backend_tag, backend_config_dict))
-
-    # checking if replicas need to be restarted
-    # Replicas are restarted if there is any change in the backend config
-    # related to restart_configs
-    # TODO(alind) : have replica restarting policies selected by the user
-
-    need_to_restart_replicas = any(
-        old_backend_config_dict[k] != backend_config_dict[k]
-        for k in BackendConfig.restart_on_change_fields)
-    if need_to_restart_replicas:
-        # kill all the replicas for restarting with new configurations
-        ray.get(
-            global_state.master_actor.scale_replicas.remote(backend_tag, 0))
-
-    # scale the replicas with new configuration
     ray.get(
-        global_state.master_actor.scale_replicas.remote(
-            backend_tag, backend_config_dict["num_replicas"]))
+        global_state.master_actor.set_backend_config.remote(
+            backend_tag, backend_config))
 
 
 @_ensure_connected

--- a/python/ray/serve/global_state.py
+++ b/python/ray/serve/global_state.py
@@ -229,6 +229,12 @@ class ServeMaster:
         # Scale the replicas with the new configuration.
         self.scale_replicas(backend_tag, backend_config_dict["num_replicas"])
 
+    def get_backend_config(self, backend_tag):
+        assert (backend_tag in self.backend_table.list_backends()
+                ), "Backend {} is not registered.".format(backend_tag)
+        backend_config_dict = self.backend_table.get_info(backend_tag)
+        return BackendConfig(**backend_config_dict)
+
 
 class GlobalState:
     """Encapsulate all global state in the serving system.

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -182,16 +182,16 @@ def test_killing_replicas(serve_instance):
     b_config = BackendConfig(num_replicas=3, num_cpus=2)
     serve.create_backend(Simple, "simple:v1", backend_config=b_config)
     global_state = serve.api._get_global_state()
-    old_replica_tag_list = global_state.backend_table.list_replicas(
-        "simple:v1")
+    old_replica_tag_list = ray.get(
+        global_state.master_actor._list_replicas.remote("simple:v1"))
 
     bnew_config = serve.get_backend_config("simple:v1")
     # change the config
     bnew_config.num_cpus = 1
     # set the config
     serve.set_backend_config("simple:v1", bnew_config)
-    new_replica_tag_list = global_state.backend_table.list_replicas(
-        "simple:v1")
+    new_replica_tag_list = ray.get(
+        global_state.master_actor._list_replicas.remote("simple:v1"))
     new_all_tag_list = list(
         ray.get(global_state.master_actor.get_all_handles.remote()).keys())
 
@@ -216,16 +216,16 @@ def test_not_killing_replicas(serve_instance):
     b_config = BackendConfig(num_replicas=3, max_batch_size=2)
     serve.create_backend(BatchSimple, "bsimple:v1", backend_config=b_config)
     global_state = serve.api._get_global_state()
-    old_replica_tag_list = global_state.backend_table.list_replicas(
-        "bsimple:v1")
+    old_replica_tag_list = ray.get(
+        global_state.master_actor._list_replicas.remote("bsimple:v1"))
 
     bnew_config = serve.get_backend_config("bsimple:v1")
     # change the config
     bnew_config.max_batch_size = 5
     # set the config
     serve.set_backend_config("bsimple:v1", bnew_config)
-    new_replica_tag_list = global_state.backend_table.list_replicas(
-        "bsimple:v1")
+    new_replica_tag_list = ray.get(
+        global_state.master_actor._list_replicas.remote("bsimple:v1"))
     new_all_tag_list = list(
         ray.get(global_state.master_actor.get_all_handles.remote()).keys())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Moves the last remaining table out of global_state and into only the master actor (backend_table).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
