### PR TITLE
[Testcases] Fix torch.nn.functional import error (RLlib) in case torch is not installed.

### DIFF
--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -1,4 +1,8 @@
 # Script used for checking changes for incremental testing cases
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 import re
 import subprocess

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -1,8 +1,4 @@
 # Script used for checking changes for incremental testing cases
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import re
 import subprocess

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -103,7 +103,7 @@ def try_import_tfp(error=False):
 class NNStub:
     def __init__(self, *a, **kw):
         # Fake nn.functional module within torch.nn.
-        self.F = None
+        self.functional = None
 
 
 # Fake class for torch.nn.Module to allow it to be inherited from.

--- a/rllib/utils/framework.py
+++ b/rllib/utils/framework.py
@@ -101,7 +101,9 @@ def try_import_tfp(error=False):
 
 # Fake module for torch.nn.
 class NNStub:
-    pass
+    def __init__(self, *a, **kw):
+        # Fake nn.functional module within torch.nn.
+        self.F = None
 
 
 # Fake class for torch.nn.Module to allow it to be inherited from.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Master build is currently broken due to a hard torch requirement in RLlib (torch.nn.functional). This PR fixes that problem.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
