### PR TITLE
Fixes bug in [raysgd] training operator

### DIFF
--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -230,7 +230,7 @@ class TrainingOperator:
         """
         features, target = batch
         # Create non_blocking tensors for distributed training
-        if torch.cuda.is_available():
+        if self._use_gpu:
             features = features.cuda(non_blocking=True)
             target = target.cuda(non_blocking=True)
 
@@ -309,7 +309,7 @@ class TrainingOperator:
                 calculate averages.
         """
         features, target = batch
-        if torch.cuda.is_available():
+        if self._use_gpu:
             features = features.cuda(non_blocking=True)
             target = target.cuda(non_blocking=True)
 

--- a/python/ray/util/sgd/torch/training_operator.py
+++ b/python/ray/util/sgd/torch/training_operator.py
@@ -230,7 +230,7 @@ class TrainingOperator:
         """
         features, target = batch
         # Create non_blocking tensors for distributed training
-        if self._use_gpu:
+        if self.use_gpu:
             features = features.cuda(non_blocking=True)
             target = target.cuda(non_blocking=True)
 
@@ -309,7 +309,7 @@ class TrainingOperator:
                 calculate averages.
         """
         features, target = batch
-        if self._use_gpu:
+        if self.use_gpu:
             features = features.cuda(non_blocking=True)
             target = target.cuda(non_blocking=True)
 
@@ -403,6 +403,11 @@ class TrainingOperator:
     def schedulers(self):
         """List of schedulers created by the ``scheduler_creator``."""
         return self._schedulers
+
+    @property
+    def use_gpu(self):
+        """Returns True if cuda is available and use_gpu is True."""
+        return self._use_gpu
 
     @property
     def use_fp16(self):


### PR DESCRIPTION
The Torch default training operator has a bug when use_gpu is specified as False, but cuda is still available on the machine.

## Why are these changes needed?

Solves the above issue - Fixes the default example script for RaySGD.

## Checks

- [ x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x ] This PR is not tested (please justify below)

This PR fixes a minor bug in the current code.
