### PR TITLE
[Serve] Call serve.init in function handler

### DIFF
--- a/python/ray/serve/task_runner.py
+++ b/python/ray/serve/task_runner.py
@@ -3,6 +3,7 @@ import traceback
 import inspect
 
 import ray
+from ray import serve
 from ray.serve import context as serve_context
 from ray.serve.context import FakeFlaskRequest
 from collections import defaultdict
@@ -19,6 +20,8 @@ class TaskRunner:
     """
 
     def __init__(self, func_to_run):
+        serve.init()
+
         self.func = func_to_run
 
         # This parameter let argument inspection work with inner function.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Complement of #7922, this adds serve init in function based executor.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
