### PR TITLE
[GCS]Add gcs table storage interface

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -789,8 +789,8 @@ cc_library(
 )
 
 cc_test(
-    name = "gcs_table_storage_test",
-    srcs = ["src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc"],
+    name = "redis_gcs_table_storage_test",
+    srcs = ["src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc"],
     args = ["$(location redis-server) $(location redis-cli) $(location libray_redis_module.so)"],
     copts = COPTS,
     data = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -804,9 +804,9 @@ cc_test(
         "//:redis-server",
     ],
     deps = [
+        ":gcs_server_lib",
         ":gcs_table_storage_lib",
         ":store_client_test_lib",
-        ":gcs_server_lib",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -714,7 +714,10 @@ cc_test(
 
 cc_test(
     name = "gcs_server_rpc_test",
-    srcs = ["src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc"],
+    srcs = [
+        "src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc",
+        "src/ray/gcs/test/gcs_test_util.h",
+    ],
     args = ["$(location redis-server) $(location redis-cli) $(location libray_redis_module.so)"],
     copts = COPTS,
     data = [
@@ -732,7 +735,7 @@ cc_test(
     name = "gcs_node_manager_test",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc",
-        "src/ray/gcs/gcs_server/test/gcs_test_util.h",
+        "src/ray/gcs/test/gcs_test_util.h",
     ],
     copts = COPTS,
     deps = [
@@ -745,7 +748,7 @@ cc_test(
     name = "gcs_actor_scheduler_test",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc",
-        "src/ray/gcs/gcs_server/test/gcs_test_util.h",
+        "src/ray/gcs/test/gcs_test_util.h",
     ],
     copts = COPTS,
     deps = [
@@ -758,7 +761,7 @@ cc_test(
     name = "gcs_actor_manager_test",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc",
-        "src/ray/gcs/gcs_server/test/gcs_test_util.h",
+        "src/ray/gcs/test/gcs_test_util.h",
     ],
     copts = COPTS,
     deps = [
@@ -784,13 +787,15 @@ cc_library(
         ":ray_common",
         ":gcs",
         ":redis_store_client",
-#        ":gcs_cc_proto",
     ],
 )
 
 cc_test(
     name = "redis_gcs_table_storage_test",
-    srcs = ["src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc"],
+    srcs = [
+        "src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc",
+        "src/ray/gcs/test/gcs_test_util.h",
+    ],
     args = ["$(location redis-server) $(location redis-cli) $(location libray_redis_module.so)"],
     copts = COPTS,
     data = [
@@ -801,6 +806,7 @@ cc_test(
     deps = [
         ":gcs_table_storage_lib",
         ":store_client_test_lib",
+        ":gcs_server_lib",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -827,7 +833,10 @@ cc_library(
 
 cc_test(
     name = "gcs_server_test",
-    srcs = ["src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc"],
+    srcs = [
+        "src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc",
+        "src/ray/gcs/test/gcs_test_util.h",
+    ],
     args = ["$(location redis-server) $(location redis-cli) $(location libray_redis_module.so)"],
     copts = COPTS,
     data = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -768,6 +768,44 @@ cc_test(
 )
 
 cc_library(
+    name = "gcs_table_storage_lib",
+    srcs = glob(
+        [
+            "src/ray/gcs/gcs_server/gcs_table_storage.cc",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "src/ray/gcs/gcs_server/gcs_table_storage.h",
+        ],
+    ),
+    copts = COPTS,
+    deps = [
+        ":ray_common",
+        ":gcs",
+        ":redis_store_client",
+#        ":gcs_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "gcs_table_storage_test",
+    srcs = ["src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc"],
+    args = ["$(location redis-server) $(location redis-cli) $(location libray_redis_module.so)"],
+    copts = COPTS,
+    data = [
+        "//:libray_redis_module.so",
+        "//:redis-cli",
+        "//:redis-server",
+    ],
+    deps = [
+        ":gcs_table_storage_lib",
+        ":store_client_test_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "service_based_gcs_client_lib",
     srcs = glob(
         [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -821,6 +821,7 @@ cc_library(
     deps = [
         ":gcs",
         ":gcs_service_rpc",
+        ":redis_store_client",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -784,8 +784,8 @@ cc_library(
     ),
     copts = COPTS,
     deps = [
-        ":ray_common",
         ":gcs",
+        ":ray_common",
         ":redis_store_client",
     ],
 )

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -17,6 +17,7 @@
 #include "ray/common/test_util.h"
 #include "ray/gcs/gcs_client/service_based_accessor.h"
 #include "ray/gcs/gcs_server/gcs_server.h"
+#include "ray/gcs/test/gcs_test_util.h"
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 
 namespace ray {
@@ -452,74 +453,6 @@ class ServiceBasedGcsClientTest : public RedisServiceManagerForTest {
     EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
   }
 
-  std::shared_ptr<rpc::JobTableData> GenJobTableData(JobID job_id) {
-    auto job_table_data = std::make_shared<rpc::JobTableData>();
-    job_table_data->set_job_id(job_id.Binary());
-    job_table_data->set_is_dead(false);
-    job_table_data->set_timestamp(std::time(nullptr));
-    job_table_data->set_node_manager_address("127.0.0.1");
-    job_table_data->set_driver_pid(5667L);
-    return job_table_data;
-  }
-
-  std::shared_ptr<rpc::ActorTableData> GenActorTableData(const JobID &job_id) {
-    auto actor_table_data = std::make_shared<rpc::ActorTableData>();
-    ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
-    actor_table_data->set_actor_id(actor_id.Binary());
-    actor_table_data->set_job_id(job_id.Binary());
-    actor_table_data->set_state(
-        rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
-    actor_table_data->set_max_reconstructions(1);
-    actor_table_data->set_remaining_reconstructions(1);
-    return actor_table_data;
-  }
-
-  rpc::GcsNodeInfo GenGcsNodeInfo(const std::string &node_id) {
-    rpc::GcsNodeInfo gcs_node_info;
-    gcs_node_info.set_node_id(node_id);
-    gcs_node_info.set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
-    gcs_node_info.set_node_manager_address("127.0.0.1");
-    return gcs_node_info;
-  }
-
-  std::shared_ptr<rpc::TaskTableData> GenTaskTableData(const std::string &job_id,
-                                                       const std::string &task_id) {
-    auto task_table_data = std::make_shared<rpc::TaskTableData>();
-    rpc::Task task;
-    rpc::TaskSpec task_spec;
-    task_spec.set_job_id(job_id);
-    task_spec.set_task_id(task_id);
-    task.mutable_task_spec()->CopyFrom(task_spec);
-    task_table_data->mutable_task()->CopyFrom(task);
-    return task_table_data;
-  }
-
-  std::shared_ptr<rpc::TaskLeaseData> GenTaskLeaseData(const std::string &task_id,
-                                                       const std::string &node_id) {
-    auto task_lease_data = std::make_shared<rpc::TaskLeaseData>();
-    task_lease_data->set_task_id(task_id);
-    task_lease_data->set_node_manager_id(node_id);
-    return task_lease_data;
-  }
-
-  std::shared_ptr<rpc::ProfileTableData> GenProfileTableData(const ClientID &node_id) {
-    auto profile_table_data = std::make_shared<rpc::ProfileTableData>();
-    profile_table_data->set_component_id(node_id.Binary());
-    return profile_table_data;
-  }
-
-  std::shared_ptr<rpc::ErrorTableData> GenErrorTableData(const JobID &job_id) {
-    auto error_table_data = std::make_shared<rpc::ErrorTableData>();
-    error_table_data->set_job_id(job_id.Binary());
-    return error_table_data;
-  }
-
-  std::shared_ptr<rpc::WorkerFailureData> GenWorkerFailureData() {
-    auto worker_failure_data = std::make_shared<rpc::WorkerFailureData>();
-    worker_failure_data->set_timestamp(std::time(nullptr));
-    return worker_failure_data;
-  }
-
   // GCS server.
   gcs::GcsServerConfig config;
   std::unique_ptr<gcs::GcsServer> gcs_server_;
@@ -537,7 +470,7 @@ class ServiceBasedGcsClientTest : public RedisServiceManagerForTest {
 TEST_F(ServiceBasedGcsClientTest, TestJobInfo) {
   // Create job table data.
   JobID add_job_id = JobID::FromInt(1);
-  auto job_table_data = GenJobTableData(add_job_id);
+  auto job_table_data = Mocker::GenJobTableData(add_job_id);
 
   // Subscribe to finished jobs.
   std::atomic<int> finished_job_count(0);
@@ -555,7 +488,7 @@ TEST_F(ServiceBasedGcsClientTest, TestJobInfo) {
 TEST_F(ServiceBasedGcsClientTest, TestActorInfo) {
   // Create actor table data.
   JobID job_id = JobID::FromInt(1);
-  auto actor_table_data = GenActorTableData(job_id);
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
   ActorID actor_id = ActorID::FromBinary(actor_table_data->actor_id());
 
   // Subscribe to any update operations of an actor.
@@ -586,7 +519,7 @@ TEST_F(ServiceBasedGcsClientTest, TestActorInfo) {
 TEST_F(ServiceBasedGcsClientTest, TestActorCheckpoint) {
   // Create actor checkpoint data.
   JobID job_id = JobID::FromInt(1);
-  auto actor_table_data = GenActorTableData(job_id);
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
   ActorID actor_id = ActorID::FromBinary(actor_table_data->actor_id());
 
   ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
@@ -611,8 +544,8 @@ TEST_F(ServiceBasedGcsClientTest, TestActorCheckpoint) {
 TEST_F(ServiceBasedGcsClientTest, TestActorSubscribeAll) {
   // Create actor table data.
   JobID job_id = JobID::FromInt(1);
-  auto actor_table_data1 = GenActorTableData(job_id);
-  auto actor_table_data2 = GenActorTableData(job_id);
+  auto actor_table_data1 = Mocker::GenActorTableData(job_id);
+  auto actor_table_data2 = Mocker::GenActorTableData(job_id);
 
   // Subscribe to any register or update operations of actors.
   std::atomic<int> actor_update_count(0);
@@ -630,8 +563,8 @@ TEST_F(ServiceBasedGcsClientTest, TestActorSubscribeAll) {
 
 TEST_F(ServiceBasedGcsClientTest, TestNodeInfo) {
   // Create gcs node info.
-  ClientID node1_id = ClientID::FromRandom();
-  auto gcs_node1_info = GenGcsNodeInfo(node1_id.Binary());
+  auto gcs_node1_info = Mocker::GenNodeInfo();
+  ClientID node1_id = ClientID::FromBinary(gcs_node1_info->node_id());
 
   // Subscribe to node addition and removal events from GCS.
   std::atomic<int> register_count(0);
@@ -647,16 +580,16 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeInfo) {
   ASSERT_TRUE(SubscribeToNodeChange(on_subscribe));
 
   // Register local node to GCS.
-  ASSERT_TRUE(RegisterSelf(gcs_node1_info));
+  ASSERT_TRUE(RegisterSelf(*gcs_node1_info));
   sleep(1);
   EXPECT_EQ(gcs_client_->Nodes().GetSelfId(), node1_id);
-  EXPECT_EQ(gcs_client_->Nodes().GetSelfInfo().node_id(), gcs_node1_info.node_id());
-  EXPECT_EQ(gcs_client_->Nodes().GetSelfInfo().state(), gcs_node1_info.state());
+  EXPECT_EQ(gcs_client_->Nodes().GetSelfInfo().node_id(), gcs_node1_info->node_id());
+  EXPECT_EQ(gcs_client_->Nodes().GetSelfInfo().state(), gcs_node1_info->state());
 
   // Register a node to GCS.
-  ClientID node2_id = ClientID::FromRandom();
-  auto gcs_node2_info = GenGcsNodeInfo(node2_id.Binary());
-  ASSERT_TRUE(RegisterNode(gcs_node2_info));
+  auto gcs_node2_info = Mocker::GenNodeInfo();
+  ClientID node2_id = ClientID::FromBinary(gcs_node2_info->node_id());
+  ASSERT_TRUE(RegisterNode(*gcs_node2_info));
   WaitPendingDone(register_count, 2);
 
   // Get information of all nodes from GCS.
@@ -734,7 +667,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeHeartbeat) {
 TEST_F(ServiceBasedGcsClientTest, TestTaskInfo) {
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::ForDriverTask(job_id);
-  auto task_table_data = GenTaskTableData(job_id.Binary(), task_id.Binary());
+  auto task_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
 
   // Subscribe to the event that the given task is added in GCS.
   std::atomic<int> task_count(0);
@@ -773,7 +706,7 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskInfo) {
 
   // Add a task lease to GCS.
   ClientID node_id = ClientID::FromRandom();
-  auto task_lease = GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  auto task_lease = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
   ASSERT_TRUE(AddTaskLease(task_lease));
   WaitPendingDone(task_lease_count, 2);
 
@@ -842,7 +775,7 @@ TEST_F(ServiceBasedGcsClientTest, TestObjectInfo) {
 TEST_F(ServiceBasedGcsClientTest, TestStats) {
   // Add profile data to GCS.
   ClientID node_id = ClientID::FromRandom();
-  auto profile_table_data = GenProfileTableData(node_id);
+  auto profile_table_data = Mocker::GenProfileTableData(node_id);
   ASSERT_TRUE(AddProfileData(profile_table_data));
 }
 
@@ -856,7 +789,7 @@ TEST_F(ServiceBasedGcsClientTest, TestWorkerInfo) {
   ASSERT_TRUE(SubscribeToWorkerFailures(on_subscribe));
 
   // Report a worker failure to GCS.
-  auto worker_failure_data = GenWorkerFailureData();
+  auto worker_failure_data = Mocker::GenWorkerFailureData();
   ASSERT_TRUE(ReportWorkerFailure(worker_failure_data));
   WaitPendingDone(worker_failure_count, 1);
 }
@@ -864,14 +797,14 @@ TEST_F(ServiceBasedGcsClientTest, TestWorkerInfo) {
 TEST_F(ServiceBasedGcsClientTest, TestErrorInfo) {
   // Report a job error to GCS.
   JobID job_id = JobID::FromInt(1);
-  auto error_table_data = GenErrorTableData(job_id);
+  auto error_table_data = Mocker::GenErrorTableData(job_id);
   ASSERT_TRUE(ReportJobError(error_table_data));
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestDetectGcsAvailability) {
   // Create job table data.
   JobID add_job_id = JobID::FromInt(1);
-  auto job_table_data = GenJobTableData(add_job_id);
+  auto job_table_data = Mocker::GenJobTableData(add_job_id);
 
   RAY_LOG(INFO) << "Initializing GCS service, port = " << gcs_server_->GetPort();
   gcs_server_->Stop();

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -21,6 +21,12 @@ namespace ray {
 namespace gcs {
 
 template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Put(const Key &key, const Data &value,
+                                const StatusCallback &callback) {
+  return store_client_->AsyncPut(table_name_, key, value, callback);
+}
+
+template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Put(const JobID &job_id, const Key &key, const Data &value,
                                 const StatusCallback &callback) {
   return store_client_->AsyncPutWithIndex(table_name_, key, job_id, value, callback);
@@ -47,6 +53,7 @@ Status GcsTable<Key, Data>::Delete(const JobID &job_id, const Key &key,
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Delete(const JobID &job_id, const std::vector<Key> &keys,
                                    const StatusCallback &callback) {
+  // TODO(ffbin): We will use redis store client batch delete interface directly later.
   auto finished_count = std::make_shared<int>(0);
   int size = keys.size();
   for (Key key : keys) {

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -13,14 +13,9 @@
 // limitations under the License.
 
 #include "gcs_table_storage.h"
-#include "ray/common/common_protocol.h"
-#include "ray/common/constants.h"
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/gcs/callback.h"
-#include "ray/gcs/store_client/redis_store_client.h"
-#include "ray/protobuf/gcs.pb.h"
-#include "ray/util/logging.h"
 
 namespace ray {
 namespace gcs {
@@ -68,11 +63,7 @@ Status GcsTable<Key, Data>::Delete(const JobID &job_id, const std::vector<Key> &
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Delete(const JobID &job_id, const StatusCallback &callback) {
-  RAY_LOG(INFO) << "Deleting table " << table_name_ << " item, job id = " << job_id;
-  auto status = store_client_->AsyncDeleteByIndex(table_name_, job_id, callback);
-  RAY_LOG(INFO) << "Finished deleting table " << table_name_
-                << " item, job id = " << job_id;
-  return status;
+  return store_client_->AsyncDeleteByIndex(table_name_, job_id, callback);
 }
 
 template class GcsTable<JobID, JobTableData>;

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -44,7 +44,7 @@ Status GcsTable<Key, Data>::Delete(const Key &key, const StatusCallback &callbac
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithIndex<Key, Data>::PutWithJobId(const JobID &job_id, const Key &key,
+Status GcsTableWithJobId<Key, Data>::PutWithJobId(const JobID &job_id, const Key &key,
                                                   const Data &value,
                                                   const StatusCallback &callback) {
   return this->store_client_->AsyncPutWithIndex(this->table_name_, key, job_id, value,
@@ -52,7 +52,7 @@ Status GcsTableWithIndex<Key, Data>::PutWithJobId(const JobID &job_id, const Key
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithIndex<Key, Data>::GetByJobId(
+Status GcsTableWithJobId<Key, Data>::GetByJobId(
     const JobID &job_id, const SegmentedCallback<std::pair<Key, Data>> &callback) {
   // TODO(ffbin): We will add this function after redis store client support
   // AsyncGetByIndex interface.
@@ -60,7 +60,7 @@ Status GcsTableWithIndex<Key, Data>::GetByJobId(
 }
 
 template <typename Key, typename Data>
-Status GcsTableWithIndex<Key, Data>::DeleteByJobId(const JobID &job_id,
+Status GcsTableWithJobId<Key, Data>::DeleteByJobId(const JobID &job_id,
                                                    const StatusCallback &callback) {
   return this->store_client_->AsyncDeleteByIndex(this->table_name_, job_id, callback);
 }
@@ -97,13 +97,13 @@ template class GcsTable<TaskID, TaskTableData>;
 template class GcsTable<TaskID, TaskLeaseData>;
 template class GcsTable<TaskID, TaskReconstructionData>;
 template class GcsTable<ObjectID, ObjectTableDataList>;
-template class GcsTableWithIndex<ActorID, ActorTableData>;
-template class GcsTableWithIndex<ActorCheckpointID, ActorCheckpointData>;
-template class GcsTableWithIndex<ActorID, ActorCheckpointIdData>;
-template class GcsTableWithIndex<TaskID, TaskTableData>;
-template class GcsTableWithIndex<TaskID, TaskLeaseData>;
-template class GcsTableWithIndex<TaskID, TaskReconstructionData>;
-template class GcsTableWithIndex<ObjectID, ObjectTableDataList>;
+template class GcsTableWithJobId<ActorID, ActorTableData>;
+template class GcsTableWithJobId<ActorCheckpointID, ActorCheckpointData>;
+template class GcsTableWithJobId<ActorID, ActorCheckpointIdData>;
+template class GcsTableWithJobId<TaskID, TaskTableData>;
+template class GcsTableWithJobId<TaskID, TaskLeaseData>;
+template class GcsTableWithJobId<TaskID, TaskReconstructionData>;
+template class GcsTableWithJobId<ObjectID, ObjectTableDataList>;
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -1,0 +1,118 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gcs_table_storage.h"
+#include "ray/common/common_protocol.h"
+#include "ray/common/constants.h"
+#include "ray/common/id.h"
+#include "ray/common/status.h"
+#include "ray/gcs/callback.h"
+#include "ray/gcs/store_client/redis_store_client.h"
+#include "ray/protobuf/gcs.pb.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace gcs {
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Put(const JobID &job_id, const Key &key,
+                                 const Data &value,
+                                 const StatusCallback &callback) {
+  RAY_LOG(INFO) << "Putting " << key << " into " << table_name_;
+  auto status = store_client_->AsyncPutWithIndex(table_name_, key, job_id, value, callback);
+  RAY_LOG(INFO) << "Finished putting " << key << " into " << table_name_;
+  return status;
+}
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Get(const JobID &job_id, const Key &key,
+                                 const OptionalItemCallback<Data> &callback) {
+  RAY_LOG(INFO) << "Getting " << key << " from " << table_name_;
+  auto status = store_client_->AsyncGet(table_name_, key, callback);
+  RAY_LOG(INFO) << "Finished getting " << key << " from " << table_name_;
+  return status;
+}
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::GetAll(const JobID &job_id,
+                                    const SegmentedCallback<std::pair<Key, Data>> &callback) {
+  RAY_LOG(INFO) << "Getting all " << job_id << " from " << table_name_;
+  auto status = store_client_->AsyncGetAll(table_name_, callback);
+  RAY_LOG(INFO) << "Finished getting all " << job_id << " from " << table_name_;
+  return status;
+}
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Delete(const JobID &job_id, const Key &key,
+                                    const StatusCallback &callback) {
+  RAY_LOG(INFO) << "Deleting table " << table_name_ << " item, key = " << key
+                << ", job id = " << job_id;
+  auto status = store_client_->AsyncDelete(table_name_, key, callback);
+  RAY_LOG(INFO) << "Finished deleting table " << table_name_ << " item, key = " << key
+                << ", job id = " << job_id;
+  return status;
+}
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Delete(const JobID &job_id, const std::vector<Key> &keys,
+                                    const StatusCallback &callback) {
+//  RAY_LOG(INFO) << "Deleting table " << table_name_ << " items, job id = " << job_id
+//                << ", key size = " << keys.size();
+//  int finished_count = 0;
+//  int size = keys.size();
+//  for (Key key : keys) {
+//    std::string str_key = key.Binary();
+//    // TODO(ffbin)
+//    auto done = [&finished_count, size, callback](Status status) {
+//      ++finished_count;
+//      if (finished_count == size) {
+//        RAY_LOG(INFO) << "9999999999999 666666666666666";
+//        //        callback(Status::OK());
+//      }
+//    };
+//    RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, str_key, done));
+//  }
+//  callback(Status::OK());
+//  RAY_LOG(INFO) << "Finished deleting table " << table_name_
+//                << " items, job id = " << job_id << ", key size = " << keys.size();
+  return Status::OK();
+}
+
+template <typename Key, typename Data>
+Status GcsTable<Key, Data>::Delete(const JobID &job_id, const StatusCallback &callback) {
+  RAY_LOG(INFO) << "Deleting table " << table_name_ << " item, job id = " << job_id;
+  auto status = store_client_->AsyncDeleteByIndex(table_name_, job_id, callback);
+  RAY_LOG(INFO) << "Finished deleting table " << table_name_
+                << " item, job id = " << job_id;
+  return status;
+}
+
+template class GcsTable<JobID, JobTableData>;
+template class GcsTable<ActorID, ActorTableData>;
+template class GcsTable<ActorCheckpointID, ActorCheckpointData>;
+template class GcsTable<ActorID, ActorCheckpointIdData>;
+template class GcsTable<TaskID, TaskTableData>;
+template class GcsTable<TaskID, TaskLeaseData>;
+template class GcsTable<TaskID, TaskReconstructionData>;
+template class GcsTable<ObjectID, ObjectTableDataList>;
+template class GcsTable<ClientID, GcsNodeInfo>;
+template class GcsTable<ClientID, ResourceMap>;
+template class GcsTable<ClientID, HeartbeatTableData>;
+template class GcsTable<ClientID, HeartbeatBatchTableData>;
+template class GcsTable<JobID, ErrorTableData>;
+template class GcsTable<UniqueID, ProfileTableData>;
+template class GcsTable<WorkerID, WorkerFailureData>;
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -26,66 +26,43 @@ namespace ray {
 namespace gcs {
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::Put(const JobID &job_id, const Key &key,
-                                 const Data &value,
-                                 const StatusCallback &callback) {
-  RAY_LOG(INFO) << "Putting " << key << " into " << table_name_;
-  auto status = store_client_->AsyncPutWithIndex(table_name_, key, job_id, value, callback);
-  RAY_LOG(INFO) << "Finished putting " << key << " into " << table_name_;
-  return status;
+Status GcsTable<Key, Data>::Put(const JobID &job_id, const Key &key, const Data &value,
+                                const StatusCallback &callback) {
+  return store_client_->AsyncPutWithIndex(table_name_, key, job_id, value, callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Get(const JobID &job_id, const Key &key,
-                                 const OptionalItemCallback<Data> &callback) {
-  RAY_LOG(INFO) << "Getting " << key << " from " << table_name_;
-  auto status = store_client_->AsyncGet(table_name_, key, callback);
-  RAY_LOG(INFO) << "Finished getting " << key << " from " << table_name_;
-  return status;
+                                const OptionalItemCallback<Data> &callback) {
+  return store_client_->AsyncGet(table_name_, key, callback);
 }
 
 template <typename Key, typename Data>
-Status GcsTable<Key, Data>::GetAll(const JobID &job_id,
-                                    const SegmentedCallback<std::pair<Key, Data>> &callback) {
-  RAY_LOG(INFO) << "Getting all " << job_id << " from " << table_name_;
-  auto status = store_client_->AsyncGetAll(table_name_, callback);
-  RAY_LOG(INFO) << "Finished getting all " << job_id << " from " << table_name_;
-  return status;
+Status GcsTable<Key, Data>::GetAll(
+    const JobID &job_id, const SegmentedCallback<std::pair<Key, Data>> &callback) {
+  return store_client_->AsyncGetAll(table_name_, callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Delete(const JobID &job_id, const Key &key,
-                                    const StatusCallback &callback) {
-  RAY_LOG(INFO) << "Deleting table " << table_name_ << " item, key = " << key
-                << ", job id = " << job_id;
-  auto status = store_client_->AsyncDelete(table_name_, key, callback);
-  RAY_LOG(INFO) << "Finished deleting table " << table_name_ << " item, key = " << key
-                << ", job id = " << job_id;
-  return status;
+                                   const StatusCallback &callback) {
+  return store_client_->AsyncDelete(table_name_, key, callback);
 }
 
 template <typename Key, typename Data>
 Status GcsTable<Key, Data>::Delete(const JobID &job_id, const std::vector<Key> &keys,
-                                    const StatusCallback &callback) {
-//  RAY_LOG(INFO) << "Deleting table " << table_name_ << " items, job id = " << job_id
-//                << ", key size = " << keys.size();
-//  int finished_count = 0;
-//  int size = keys.size();
-//  for (Key key : keys) {
-//    std::string str_key = key.Binary();
-//    // TODO(ffbin)
-//    auto done = [&finished_count, size, callback](Status status) {
-//      ++finished_count;
-//      if (finished_count == size) {
-//        RAY_LOG(INFO) << "9999999999999 666666666666666";
-//        //        callback(Status::OK());
-//      }
-//    };
-//    RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, str_key, done));
-//  }
-//  callback(Status::OK());
-//  RAY_LOG(INFO) << "Finished deleting table " << table_name_
-//                << " items, job id = " << job_id << ", key size = " << keys.size();
+                                   const StatusCallback &callback) {
+  auto finished_count = std::make_shared<int>(0);
+  int size = keys.size();
+  for (Key key : keys) {
+    auto done = [finished_count, size, callback](Status status) {
+      ++(*finished_count);
+      if (*finished_count == size) {
+        callback(Status::OK());
+      }
+    };
+    RAY_CHECK_OK(store_client_->AsyncDelete(table_name_, key, done));
+  }
   return Status::OK();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -41,22 +41,6 @@ using rpc::TaskReconstructionData;
 using rpc::TaskTableData;
 using rpc::WorkerFailureData;
 
-#define JOB_TABLE_NAME "JOB";
-#define ACTOR_TABLE_NAME "ACTOR";
-#define ACTOR_CHECKPOINT_TABLE_NAME "ACTOR_CHECKPOINT";
-#define ACTOR_CHECKPOINT_ID_TABLE_NAME "ACTOR_CHECKPOINT_ID";
-#define TASK_TABLE_NAME "TASK";
-#define TASK_LEASE_TABLE_NAME "TASK_LEASE";
-#define TASK_RECONSTRUCTION_TABLE_NAME "TASK_RECONSTRUCTION";
-#define OBJECT_TABLE_NAME "OBJECT";
-#define NODE_TABLE_NAME "NODE";
-#define NODE_RESOURCE_TABLE_NAME "NODE_RESOURCE";
-#define HEARTBEAT_TABLE_NAME "HEARTBEAT";
-#define HEARTBEAT_BATCH_TABLE_NAME "HEARTBEAT_BATCH";
-#define ERROR_INFO_TABLE_NAME "ERROR_INFO";
-#define PROFILE_TABLE_NAME "PROFILE";
-#define WORKER_FAILURE_TABLE_NAME "WORKER_FAILURE";
-
 /// \class GcsTable
 ///
 /// GcsTable supports putting, getting and deleting of GCS table data.
@@ -70,6 +54,9 @@ class GcsTable {
       : store_client_(store_client) {}
 
   virtual ~GcsTable() { store_client_.reset(); }
+
+  Status Put(const Key &key, const Data &value,
+             const StatusCallback &callback);
 
   Status Put(const JobID &job_id, const Key &key, const Data &value,
              const StatusCallback &callback);
@@ -99,7 +86,7 @@ class GcsJobTable : public GcsTable<JobID, JobTableData> {
   explicit GcsJobTable(
       std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = JOB_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::JOB);
   }
 };
 
@@ -108,7 +95,7 @@ class GcsActorTable : public GcsTable<ActorID, ActorTableData> {
   explicit GcsActorTable(
       std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = ACTOR_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::ACTOR);
   }
 };
 
@@ -118,7 +105,7 @@ class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpoi
       std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>
           store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = ACTOR_CHECKPOINT_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT);
   }
 };
 
@@ -127,7 +114,7 @@ class GcsActorCheckpointIdTable : public GcsTable<ActorID, ActorCheckpointIdData
   explicit GcsActorCheckpointIdTable(
       std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = ACTOR_CHECKPOINT_ID_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT_ID);
   }
 };
 
@@ -136,7 +123,7 @@ class GcsTaskTable : public GcsTable<TaskID, TaskTableData> {
   explicit GcsTaskTable(
       std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = TASK_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::TASK);
   }
 };
 
@@ -145,7 +132,7 @@ class GcsTaskLeaseTable : public GcsTable<TaskID, TaskLeaseData> {
   explicit GcsTaskLeaseTable(
       std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = TASK_LEASE_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::TASK_LEASE);
   }
 };
 
@@ -154,7 +141,7 @@ class GcsTaskReconstructionTable : public GcsTable<TaskID, TaskReconstructionDat
   explicit GcsTaskReconstructionTable(
       std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = TASK_RECONSTRUCTION_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::TASK_RECONSTRUCTION);
   }
 };
 
@@ -163,7 +150,7 @@ class GcsObjectTable : public GcsTable<ObjectID, ObjectTableDataList> {
   explicit GcsObjectTable(
       std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = OBJECT_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::OBJECT);
   }
 };
 
@@ -172,7 +159,7 @@ class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
   explicit GcsNodeTable(
       std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = NODE_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::CLIENT);
   }
 };
 
@@ -181,7 +168,7 @@ class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
   explicit GcsNodeResourceTable(
       std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = NODE_RESOURCE_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::NODE_RESOURCE);
   }
 };
 
@@ -190,7 +177,7 @@ class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
   explicit GcsHeartbeatTable(
       std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = HEARTBEAT_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT);
   }
 };
 
@@ -199,7 +186,7 @@ class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData
   explicit GcsHeartbeatBatchTable(
       std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = HEARTBEAT_BATCH_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT_BATCH);
   }
 };
 
@@ -208,7 +195,7 @@ class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
   explicit GcsErrorInfoTable(
       std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = ERROR_INFO_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::ERROR_INFO);
   }
 };
 
@@ -217,7 +204,7 @@ class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
   explicit GcsProfileTable(
       std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = PROFILE_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::PROFILE);
   }
 };
 
@@ -226,54 +213,16 @@ class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
   explicit GcsWorkerFailureTable(
       std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client)
       : GcsTable(std::move(store_client)) {
-    table_name_ = WORKER_FAILURE_TABLE_NAME;
+    table_name_ = TablePrefix_Name(TablePrefix::WORKER_FAILURE);
   }
 };
 
+/// \class GcsTableStorage
+///
+/// This class is not meant to be used directly. All gcs table storage classes should
+/// derive from this class and override class member variables.
 class GcsTableStorage {
  public:
-  explicit GcsTableStorage(std::shared_ptr<RedisClient> redis_client) {
-    job_table_.reset(new GcsJobTable(
-        std::make_shared<RedisStoreClient<JobID, JobTableData, JobID>>(redis_client)));
-    actor_table_.reset(new GcsActorTable(
-        std::make_shared<RedisStoreClient<ActorID, ActorTableData, JobID>>(
-            redis_client)));
-    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(
-        std::make_shared<RedisStoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>(
-            redis_client)));
-    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(
-        std::make_shared<RedisStoreClient<ActorID, ActorCheckpointIdData, JobID>>(
-            redis_client)));
-    task_table_.reset(new GcsTaskTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskTableData, JobID>>(redis_client)));
-    task_lease_table_.reset(new GcsTaskLeaseTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskLeaseData, JobID>>(redis_client)));
-    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskReconstructionData, JobID>>(
-            redis_client)));
-    object_table_.reset(new GcsObjectTable(
-        std::make_shared<RedisStoreClient<ObjectID, ObjectTableDataList, JobID>>(
-            redis_client)));
-    node_table_.reset(new GcsNodeTable(
-        std::make_shared<RedisStoreClient<ClientID, GcsNodeInfo, JobID>>(redis_client)));
-    node_resource_table_.reset(new GcsNodeResourceTable(
-        std::make_shared<RedisStoreClient<ClientID, ResourceMap, JobID>>(redis_client)));
-    heartbeat_table_.reset(new GcsHeartbeatTable(
-        std::make_shared<RedisStoreClient<ClientID, HeartbeatTableData, JobID>>(
-            redis_client)));
-    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(
-        std::make_shared<RedisStoreClient<ClientID, HeartbeatBatchTableData, JobID>>(
-            redis_client)));
-    error_info_table_.reset(new GcsErrorInfoTable(
-        std::make_shared<RedisStoreClient<JobID, ErrorTableData, JobID>>(redis_client)));
-    profile_table_.reset(new GcsProfileTable(
-        std::make_shared<RedisStoreClient<UniqueID, ProfileTableData, JobID>>(
-            redis_client)));
-    worker_failure_table_.reset(new GcsWorkerFailureTable(
-        std::make_shared<RedisStoreClient<WorkerID, WorkerFailureData, JobID>>(
-            redis_client)));
-  }
-
   GcsJobTable &JobTable() {
     RAY_CHECK(job_table_ != nullptr);
     return *job_table_;
@@ -349,7 +298,7 @@ class GcsTableStorage {
     return *worker_failure_table_;
   }
 
- private:
+ protected:
   std::unique_ptr<GcsJobTable> job_table_;
   std::unique_ptr<GcsActorTable> actor_table_;
   std::unique_ptr<GcsActorCheckpointTable> actor_checkpoint_table_;
@@ -365,6 +314,54 @@ class GcsTableStorage {
   std::unique_ptr<GcsErrorInfoTable> error_info_table_;
   std::unique_ptr<GcsProfileTable> profile_table_;
   std::unique_ptr<GcsWorkerFailureTable> worker_failure_table_;
+};
+
+/// \class RedisGcsTableStorage
+/// RedisGcsTableStorage is an implementation of `GcsTableStorage`
+/// that uses redis as storage.
+class RedisGcsTableStorage : public GcsTableStorage {
+ public:
+  explicit RedisGcsTableStorage(std::shared_ptr<RedisClient> redis_client) {
+    job_table_.reset(new GcsJobTable(
+        std::make_shared<RedisStoreClient<JobID, JobTableData, JobID>>(redis_client)));
+    actor_table_.reset(new GcsActorTable(
+        std::make_shared<RedisStoreClient<ActorID, ActorTableData, JobID>>(
+            redis_client)));
+    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(
+        std::make_shared<RedisStoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>(
+            redis_client)));
+    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(
+        std::make_shared<RedisStoreClient<ActorID, ActorCheckpointIdData, JobID>>(
+            redis_client)));
+    task_table_.reset(new GcsTaskTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskTableData, JobID>>(redis_client)));
+    task_lease_table_.reset(new GcsTaskLeaseTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskLeaseData, JobID>>(redis_client)));
+    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskReconstructionData, JobID>>(
+            redis_client)));
+    object_table_.reset(new GcsObjectTable(
+        std::make_shared<RedisStoreClient<ObjectID, ObjectTableDataList, JobID>>(
+            redis_client)));
+    node_table_.reset(new GcsNodeTable(
+        std::make_shared<RedisStoreClient<ClientID, GcsNodeInfo, JobID>>(redis_client)));
+    node_resource_table_.reset(new GcsNodeResourceTable(
+        std::make_shared<RedisStoreClient<ClientID, ResourceMap, JobID>>(redis_client)));
+    heartbeat_table_.reset(new GcsHeartbeatTable(
+        std::make_shared<RedisStoreClient<ClientID, HeartbeatTableData, JobID>>(
+            redis_client)));
+    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(
+        std::make_shared<RedisStoreClient<ClientID, HeartbeatBatchTableData, JobID>>(
+            redis_client)));
+    error_info_table_.reset(new GcsErrorInfoTable(
+        std::make_shared<RedisStoreClient<JobID, ErrorTableData, JobID>>(redis_client)));
+    profile_table_.reset(new GcsProfileTable(
+        std::make_shared<RedisStoreClient<UniqueID, ProfileTableData, JobID>>(
+            redis_client)));
+    worker_failure_table_.reset(new GcsWorkerFailureTable(
+        std::make_shared<RedisStoreClient<WorkerID, WorkerFailureData, JobID>>(
+            redis_client)));
+  }
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -1,0 +1,327 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RAY_GCS_GCS_TABLE_STORAGE_H_
+#define RAY_GCS_GCS_TABLE_STORAGE_H_
+
+#include "ray/common/id.h"
+#include "ray/gcs/accessor.h"
+#include "ray/gcs/callback.h"
+#include "ray/gcs/pb_util.h"
+#include "ray/gcs/redis_client.h"
+#include "ray/gcs/redis_gcs_client.h"
+#include "ray/gcs/store_client/redis_store_client.h"
+#include "ray/gcs/store_client/store_client.h"
+#include "ray/protobuf/gcs.pb.h"
+
+namespace ray {
+namespace gcs {
+
+using rpc::ActorCheckpointData;
+using rpc::ActorCheckpointIdData;
+using rpc::ActorTableData;
+using rpc::ErrorTableData;
+using rpc::GcsNodeInfo;
+using rpc::HeartbeatBatchTableData;
+using rpc::HeartbeatTableData;
+using rpc::JobTableData;
+using rpc::ObjectTableData;
+using rpc::ObjectTableDataList;
+using rpc::ProfileTableData;
+using rpc::ResourceMap;
+using rpc::ResourceTableData;
+using rpc::TaskLeaseData;
+using rpc::TaskReconstructionData;
+using rpc::TaskTableData;
+using rpc::WorkerFailureData;
+
+static const std::string kJobTable = "JOB";
+static const std::string kActorTable = "ACTOR";
+static const std::string kActorCheckpointTable = "ACTOR_CHECKPOINT";
+static const std::string kActorCheckpointIdTable = "ACTOR_CHECKPOINT_ID";
+static const std::string kTaskTable = "TASK";
+static const std::string kTaskLeaseTable = "TASK_LEASE";
+static const std::string kTaskReconstructionTable = "TASK_RECONSTRUCTION";
+static const std::string kObjectTable = "OBJECT";
+static const std::string kNodeTable = "NODE";
+static const std::string kHeartbeatTable = "HEARTBEAT";
+static const std::string kHeartbeatBatchTable = "HEARTBEAT_BATCH";
+static const std::string kNodeResourceTable = "NODE_RESOURCE";
+static const std::string kErrorInfoTable = "ERROR_INFO";
+static const std::string kProfileTable = "PROFILE";
+static const std::string kWorkerFailureTable = "WORKER_FAILURE";
+
+template <typename Key, typename Data>
+class GcsTable {
+ public:
+  GcsTable(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
+      : store_client_(store_client) {}
+
+  virtual ~GcsTable() {
+    store_client_.reset();
+  }
+
+  Status Put(const JobID &job_id, const Key &key, const Data &value,
+             const StatusCallback &callback);
+
+  Status Get(const JobID &job_id, const Key &key,
+             const OptionalItemCallback<Data> &callback);
+
+  Status GetAll(const JobID &job_id, const SegmentedCallback<std::pair<Key, Data>> &callback);
+
+  Status Delete(const JobID &job_id, const Key &key, const StatusCallback &callback);
+
+  Status Delete(const JobID &job_id, const std::vector<Key> &keys,
+                const StatusCallback &callback);
+
+  Status Delete(const JobID &job_id, const StatusCallback &callback);
+
+ protected:
+  std::string table_name_;
+
+ private:
+  std::shared_ptr<StoreClient<Key, Data, JobID>> store_client_;
+};
+
+class GcsJobTable : public GcsTable<JobID, JobTableData> {
+ public:
+  explicit GcsJobTable(std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kJobTable;
+  }
+};
+
+class GcsActorTable : public GcsTable<ActorID, ActorTableData> {
+ public:
+  explicit GcsActorTable(std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kActorTable;
+  }
+};
+
+class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpointData> {
+ public:
+  explicit GcsActorCheckpointTable(std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kActorCheckpointTable;
+  }
+};
+
+class GcsActorCheckpointIdTable : public GcsTable<ActorID, ActorCheckpointIdData> {
+ public:
+  explicit GcsActorCheckpointIdTable(std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kActorCheckpointIdTable;
+  }
+};
+
+class GcsTaskTable : public GcsTable<TaskID, TaskTableData> {
+ public:
+  explicit GcsTaskTable(std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kTaskTable;
+  }
+};
+
+class GcsTaskLeaseTable : public GcsTable<TaskID, TaskLeaseData> {
+ public:
+  explicit GcsTaskLeaseTable(std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kTaskLeaseTable;
+  }
+};
+
+class GcsTaskReconstructionTable : public GcsTable<TaskID, TaskReconstructionData> {
+ public:
+  explicit GcsTaskReconstructionTable(std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
+      : GcsTable(store_client) {
+    table_name_ = kTaskReconstructionTable;
+  }
+};
+
+class GcsObjectTable : public GcsTable<ObjectID, ObjectTableDataList> {
+ public:
+  explicit GcsObjectTable(std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kObjectTable;
+  }
+};
+
+class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
+ public:
+  explicit GcsNodeTable(std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kNodeTable;
+  }
+};
+
+class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
+ public:
+  explicit GcsNodeResourceTable(std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kNodeResourceTable;
+  }
+};
+
+class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
+ public:
+  explicit GcsHeartbeatTable(std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kHeartbeatTable;
+  }
+};
+
+class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData> {
+ public:
+  explicit GcsHeartbeatBatchTable(std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kHeartbeatBatchTable;
+  }
+};
+
+class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
+ public:
+  explicit GcsErrorInfoTable(std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kErrorInfoTable;
+  }
+};
+
+class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
+ public:
+  explicit GcsProfileTable(std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kProfileTable;
+  }
+};
+
+class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
+ public:
+  explicit GcsWorkerFailureTable(std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client) : GcsTable(store_client) {
+    table_name_ = kWorkerFailureTable;
+  }
+};
+
+class GcsTableStorage {
+ public:
+  explicit GcsTableStorage(std::shared_ptr<RedisClient> redis_client) {
+    std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> job_table_store_client;
+//        std::make_shared<StoreClient<JobID, JobTableData, JobID>>(redis_client);
+    job_table_.reset(new GcsJobTable(job_table_store_client));
+
+//    actor_table_.reset(new GcsActorTable(store_client));
+//    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(store_client));
+//    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(store_client));
+//    task_table_.reset(new GcsTaskTable(store_client));
+//    task_lease_table_.reset(new GcsTaskLeaseTable(store_client));
+//    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(store_client));
+//    object_table_.reset(new GcsObjectTable(store_client));
+//    node_table_.reset(new GcsNodeTable(store_client));
+//    node_resource_table_.reset(new GcsNodeResourceTable(store_client));
+//    heartbeat_table_.reset(new GcsHeartbeatTable(store_client));
+//    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(store_client));
+//    error_info_table_.reset(new GcsErrorInfoTable(store_client));
+//    profile_table_.reset(new GcsProfileTable(store_client));
+//    worker_failure_table_.reset(new GcsWorkerFailureTable(store_client));
+  }
+
+  GcsJobTable &JobTable() {
+    RAY_CHECK(job_table_ != nullptr);
+    return *job_table_;
+  }
+
+  GcsActorTable &ActorTable() {
+    RAY_CHECK(actor_table_ != nullptr);
+    return *actor_table_;
+  }
+
+  GcsActorCheckpointTable &ActorCheckpointTable() {
+    RAY_CHECK(actor_checkpoint_table_ != nullptr);
+    return *actor_checkpoint_table_;
+  }
+
+  GcsActorCheckpointIdTable &ActorCheckpointIdTable() {
+    RAY_CHECK(actor_checkpoint_id_table_ != nullptr);
+    return *actor_checkpoint_id_table_;
+  }
+
+  GcsTaskTable &TaskTable() {
+    RAY_CHECK(task_table_ != nullptr);
+    return *task_table_;
+  }
+
+  GcsTaskLeaseTable &TaskLeaseTable() {
+    RAY_CHECK(task_lease_table_ != nullptr);
+    return *task_lease_table_;
+  }
+
+  GcsTaskReconstructionTable &TaskReconstructionTable() {
+    RAY_CHECK(task_reconstruction_table_ != nullptr);
+    return *task_reconstruction_table_;
+  }
+
+  GcsObjectTable &ObjectTable() {
+    RAY_CHECK(object_table_ != nullptr);
+    return *object_table_;
+  }
+
+  GcsNodeTable &NodeTable() {
+    RAY_CHECK(node_table_ != nullptr);
+    return *node_table_;
+  }
+
+  GcsNodeResourceTable &NodeResourceTable() {
+    RAY_CHECK(node_resource_table_ != nullptr);
+    return *node_resource_table_;
+  }
+
+  GcsHeartbeatTable &HeartbeatTable() {
+    RAY_CHECK(heartbeat_table_ != nullptr);
+    return *heartbeat_table_;
+  }
+
+  GcsHeartbeatBatchTable &HeartbeatBatchTable() {
+    RAY_CHECK(heartbeat_batch_table_ != nullptr);
+    return *heartbeat_batch_table_;
+  }
+
+  GcsErrorInfoTable &ErrorInfoTable() {
+    RAY_CHECK(error_info_table_ != nullptr);
+    return *error_info_table_;
+  }
+
+  GcsProfileTable &ProfileTable() {
+    RAY_CHECK(profile_table_ != nullptr);
+    return *profile_table_;
+  }
+
+  GcsWorkerFailureTable &WorkerFailureTable() {
+    RAY_CHECK(worker_failure_table_ != nullptr);
+    return *worker_failure_table_;
+  }
+
+ private:
+  std::unique_ptr<GcsJobTable> job_table_;
+  std::unique_ptr<GcsActorTable> actor_table_;
+  std::unique_ptr<GcsActorCheckpointTable> actor_checkpoint_table_;
+  std::unique_ptr<GcsActorCheckpointIdTable> actor_checkpoint_id_table_;
+  std::unique_ptr<GcsTaskTable> task_table_;
+  std::unique_ptr<GcsTaskLeaseTable> task_lease_table_;
+  std::unique_ptr<GcsTaskReconstructionTable> task_reconstruction_table_;
+  std::unique_ptr<GcsObjectTable> object_table_;
+  std::unique_ptr<GcsNodeTable> node_table_;
+  std::unique_ptr<GcsNodeResourceTable> node_resource_table_;
+  std::unique_ptr<GcsHeartbeatTable> heartbeat_table_;
+  std::unique_ptr<GcsHeartbeatBatchTable> heartbeat_batch_table_;
+  std::unique_ptr<GcsErrorInfoTable> error_info_table_;
+  std::unique_ptr<GcsProfileTable> profile_table_;
+  std::unique_ptr<GcsWorkerFailureTable> worker_failure_table_;
+};
+
+}  // namespace gcs
+}  // namespace ray
+
+#endif  // RAY_GCS_GCS_TABLE_STORAGE_H_

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -15,14 +15,9 @@
 #ifndef RAY_GCS_GCS_TABLE_STORAGE_H_
 #define RAY_GCS_GCS_TABLE_STORAGE_H_
 
-#include "ray/common/id.h"
-#include "ray/gcs/accessor.h"
-#include "ray/gcs/callback.h"
-#include "ray/gcs/pb_util.h"
-#include "ray/gcs/redis_client.h"
-#include "ray/gcs/redis_gcs_client.h"
+#include <utility>
+
 #include "ray/gcs/store_client/redis_store_client.h"
-#include "ray/gcs/store_client/store_client.h"
 #include "ray/protobuf/gcs.pb.h"
 
 namespace ray {
@@ -46,22 +41,28 @@ using rpc::TaskReconstructionData;
 using rpc::TaskTableData;
 using rpc::WorkerFailureData;
 
-static const std::string kJobTable = "JOB";
-static const std::string kActorTable = "ACTOR";
-static const std::string kActorCheckpointTable = "ACTOR_CHECKPOINT";
-static const std::string kActorCheckpointIdTable = "ACTOR_CHECKPOINT_ID";
-static const std::string kTaskTable = "TASK";
-static const std::string kTaskLeaseTable = "TASK_LEASE";
-static const std::string kTaskReconstructionTable = "TASK_RECONSTRUCTION";
-static const std::string kObjectTable = "OBJECT";
-static const std::string kNodeTable = "NODE";
-static const std::string kHeartbeatTable = "HEARTBEAT";
-static const std::string kHeartbeatBatchTable = "HEARTBEAT_BATCH";
-static const std::string kNodeResourceTable = "NODE_RESOURCE";
-static const std::string kErrorInfoTable = "ERROR_INFO";
-static const std::string kProfileTable = "PROFILE";
-static const std::string kWorkerFailureTable = "WORKER_FAILURE";
+#define JOB_TABLE_NAME "JOB";
+#define ACTOR_TABLE_NAME "ACTOR";
+#define ACTOR_CHECKPOINT_TABLE_NAME "ACTOR_CHECKPOINT";
+#define ACTOR_CHECKPOINT_ID_TABLE_NAME "ACTOR_CHECKPOINT_ID";
+#define TASK_TABLE_NAME "TASK";
+#define TASK_LEASE_TABLE_NAME "TASK_LEASE";
+#define TASK_RECONSTRUCTION_TABLE_NAME "TASK_RECONSTRUCTION";
+#define OBJECT_TABLE_NAME "OBJECT";
+#define NODE_TABLE_NAME "NODE";
+#define NODE_RESOURCE_TABLE_NAME "NODE_RESOURCE";
+#define HEARTBEAT_TABLE_NAME "HEARTBEAT";
+#define HEARTBEAT_BATCH_TABLE_NAME "HEARTBEAT_BATCH";
+#define ERROR_INFO_TABLE_NAME "ERROR_INFO";
+#define PROFILE_TABLE_NAME "PROFILE";
+#define WORKER_FAILURE_TABLE_NAME "WORKER_FAILURE";
 
+/// \class GcsTable
+///
+/// GcsTable supports putting, getting and deleting of GCS table data.
+/// This class is not meant to be used directly. All gcs table classes should
+/// derive from this class and override the table_name_ member with a unique value
+/// for that table.
 template <typename Key, typename Data>
 class GcsTable {
  public:
@@ -97,8 +98,8 @@ class GcsJobTable : public GcsTable<JobID, JobTableData> {
  public:
   explicit GcsJobTable(
       std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kJobTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = JOB_TABLE_NAME;
   }
 };
 
@@ -106,8 +107,8 @@ class GcsActorTable : public GcsTable<ActorID, ActorTableData> {
  public:
   explicit GcsActorTable(
       std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kActorTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = ACTOR_TABLE_NAME;
   }
 };
 
@@ -116,8 +117,8 @@ class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpoi
   explicit GcsActorCheckpointTable(
       std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>
           store_client)
-      : GcsTable(store_client) {
-    table_name_ = kActorCheckpointTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = ACTOR_CHECKPOINT_TABLE_NAME;
   }
 };
 
@@ -125,8 +126,8 @@ class GcsActorCheckpointIdTable : public GcsTable<ActorID, ActorCheckpointIdData
  public:
   explicit GcsActorCheckpointIdTable(
       std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kActorCheckpointIdTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = ACTOR_CHECKPOINT_ID_TABLE_NAME;
   }
 };
 
@@ -134,8 +135,8 @@ class GcsTaskTable : public GcsTable<TaskID, TaskTableData> {
  public:
   explicit GcsTaskTable(
       std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kTaskTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = TASK_TABLE_NAME;
   }
 };
 
@@ -143,8 +144,8 @@ class GcsTaskLeaseTable : public GcsTable<TaskID, TaskLeaseData> {
  public:
   explicit GcsTaskLeaseTable(
       std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kTaskLeaseTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = TASK_LEASE_TABLE_NAME;
   }
 };
 
@@ -152,8 +153,8 @@ class GcsTaskReconstructionTable : public GcsTable<TaskID, TaskReconstructionDat
  public:
   explicit GcsTaskReconstructionTable(
       std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kTaskReconstructionTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = TASK_RECONSTRUCTION_TABLE_NAME;
   }
 };
 
@@ -161,8 +162,8 @@ class GcsObjectTable : public GcsTable<ObjectID, ObjectTableDataList> {
  public:
   explicit GcsObjectTable(
       std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kObjectTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = OBJECT_TABLE_NAME;
   }
 };
 
@@ -170,8 +171,8 @@ class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
  public:
   explicit GcsNodeTable(
       std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kNodeTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = NODE_TABLE_NAME;
   }
 };
 
@@ -179,8 +180,8 @@ class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
  public:
   explicit GcsNodeResourceTable(
       std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kNodeResourceTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = NODE_RESOURCE_TABLE_NAME;
   }
 };
 
@@ -188,8 +189,8 @@ class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
  public:
   explicit GcsHeartbeatTable(
       std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kHeartbeatTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = HEARTBEAT_TABLE_NAME;
   }
 };
 
@@ -197,8 +198,8 @@ class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData
  public:
   explicit GcsHeartbeatBatchTable(
       std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kHeartbeatBatchTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = HEARTBEAT_BATCH_TABLE_NAME;
   }
 };
 
@@ -206,8 +207,8 @@ class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
  public:
   explicit GcsErrorInfoTable(
       std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kErrorInfoTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = ERROR_INFO_TABLE_NAME;
   }
 };
 
@@ -215,8 +216,8 @@ class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
  public:
   explicit GcsProfileTable(
       std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kProfileTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = PROFILE_TABLE_NAME;
   }
 };
 
@@ -224,8 +225,8 @@ class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
  public:
   explicit GcsWorkerFailureTable(
       std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client)
-      : GcsTable(store_client) {
-    table_name_ = kWorkerFailureTable;
+      : GcsTable(std::move(store_client)) {
+    table_name_ = WORKER_FAILURE_TABLE_NAME;
   }
 };
 

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -55,14 +55,40 @@ class GcsTable {
 
   virtual ~GcsTable() = default;
 
+  /// Write data to the table asynchronously.
+  ///
+  /// \param key The key that will be written to the table.
+  /// \param value The value of the key that will be written to the table.
+  /// \param callback Callback that will be called after write finishes.
+  /// \return Status
   virtual Status Put(const Key &key, const Data &value, const StatusCallback &callback);
 
+  /// Get data from the table asynchronously.
+  ///
+  /// \param key The key to lookup from the table.
+  /// \param callback Callback that will be called after read finishes.
+  /// \return Status
   Status Get(const Key &key, const OptionalItemCallback<Data> &callback);
 
+  /// Get all data from the table asynchronously.
+  ///
+  /// \param callback Callback that will be called after data has been received.
+  /// If the callback return `has_more == true` mean there's more data to be received.
+  /// \return Status
   Status GetAll(const SegmentedCallback<std::pair<Key, Data>> &callback);
 
+  /// Delete data from the table asynchronously.
+  ///
+  /// \param key The key that will be deleted from the table.
+  /// \param callback Callback that will be called after delete finishes.
+  /// \return Status
   Status Delete(const Key &key, const StatusCallback &callback);
 
+  /// Delete a batch of data from the table asynchronously.
+  ///
+  /// \param keys The batch key that will be deleted from the table.
+  /// \param callback Callback that will be called after delete finishes.
+  /// \return Status
   Status BatchDelete(const std::vector<Key> &keys, const StatusCallback &callback);
 
  protected:
@@ -82,11 +108,27 @@ class GcsTableWithJobId : public GcsTable<Key, Data> {
   explicit GcsTableWithJobId(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
       : GcsTable<Key, Data>(store_client) {}
 
+  /// Write data to the table asynchronously.
+  ///
+  /// \param key The key that will be written to the table. The job id can be obtained
+  /// from the key. \param value The value of the key that will be written to the table.
+  /// \param callback Callback that will be called after write finishes.
+  /// \return Status
   Status Put(const Key &key, const Data &value, const StatusCallback &callback) override;
 
+  /// Get all the data of the specified job id from the table asynchronously.
+  ///
+  /// \param job_id The key to lookup from the table.
+  /// \param callback Callback that will be called after read finishes.
+  /// \return Status
   Status GetByJobId(const JobID &job_id,
                     const SegmentedCallback<std::pair<Key, Data>> &callback);
 
+  /// Delete all the data of the specified job id from the table asynchronously.
+  ///
+  /// \param job_id The key that will be deleted from the table.
+  /// \param callback Callback that will be called after delete finishes.
+  /// \return Status
   Status DeleteByJobId(const JobID &job_id, const StatusCallback &callback);
 
  protected:

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -65,12 +65,10 @@ static const std::string kWorkerFailureTable = "WORKER_FAILURE";
 template <typename Key, typename Data>
 class GcsTable {
  public:
-  GcsTable(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
+  explicit GcsTable(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
       : store_client_(store_client) {}
 
-  virtual ~GcsTable() {
-    store_client_.reset();
-  }
+  virtual ~GcsTable() { store_client_.reset(); }
 
   Status Put(const JobID &job_id, const Key &key, const Data &value,
              const StatusCallback &callback);
@@ -78,7 +76,8 @@ class GcsTable {
   Status Get(const JobID &job_id, const Key &key,
              const OptionalItemCallback<Data> &callback);
 
-  Status GetAll(const JobID &job_id, const SegmentedCallback<std::pair<Key, Data>> &callback);
+  Status GetAll(const JobID &job_id,
+                const SegmentedCallback<std::pair<Key, Data>> &callback);
 
   Status Delete(const JobID &job_id, const Key &key, const StatusCallback &callback);
 
@@ -96,7 +95,8 @@ class GcsTable {
 
 class GcsJobTable : public GcsTable<JobID, JobTableData> {
  public:
-  explicit GcsJobTable(std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
+  explicit GcsJobTable(
+      std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
       : GcsTable(store_client) {
     table_name_ = kJobTable;
   }
@@ -104,7 +104,8 @@ class GcsJobTable : public GcsTable<JobID, JobTableData> {
 
 class GcsActorTable : public GcsTable<ActorID, ActorTableData> {
  public:
-  explicit GcsActorTable(std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
+  explicit GcsActorTable(
+      std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
       : GcsTable(store_client) {
     table_name_ = kActorTable;
   }
@@ -112,7 +113,9 @@ class GcsActorTable : public GcsTable<ActorID, ActorTableData> {
 
 class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpointData> {
  public:
-  explicit GcsActorCheckpointTable(std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>> store_client)
+  explicit GcsActorCheckpointTable(
+      std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>
+          store_client)
       : GcsTable(store_client) {
     table_name_ = kActorCheckpointTable;
   }
@@ -120,7 +123,8 @@ class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpoi
 
 class GcsActorCheckpointIdTable : public GcsTable<ActorID, ActorCheckpointIdData> {
  public:
-  explicit GcsActorCheckpointIdTable(std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
+  explicit GcsActorCheckpointIdTable(
+      std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
       : GcsTable(store_client) {
     table_name_ = kActorCheckpointIdTable;
   }
@@ -128,14 +132,17 @@ class GcsActorCheckpointIdTable : public GcsTable<ActorID, ActorCheckpointIdData
 
 class GcsTaskTable : public GcsTable<TaskID, TaskTableData> {
  public:
-  explicit GcsTaskTable(std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsTaskTable(
+      std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kTaskTable;
   }
 };
 
 class GcsTaskLeaseTable : public GcsTable<TaskID, TaskLeaseData> {
  public:
-  explicit GcsTaskLeaseTable(std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
+  explicit GcsTaskLeaseTable(
+      std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
       : GcsTable(store_client) {
     table_name_ = kTaskLeaseTable;
   }
@@ -143,7 +150,8 @@ class GcsTaskLeaseTable : public GcsTable<TaskID, TaskLeaseData> {
 
 class GcsTaskReconstructionTable : public GcsTable<TaskID, TaskReconstructionData> {
  public:
-  explicit GcsTaskReconstructionTable(std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
+  explicit GcsTaskReconstructionTable(
+      std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
       : GcsTable(store_client) {
     table_name_ = kTaskReconstructionTable;
   }
@@ -151,56 +159,72 @@ class GcsTaskReconstructionTable : public GcsTable<TaskID, TaskReconstructionDat
 
 class GcsObjectTable : public GcsTable<ObjectID, ObjectTableDataList> {
  public:
-  explicit GcsObjectTable(std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsObjectTable(
+      std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kObjectTable;
   }
 };
 
 class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
  public:
-  explicit GcsNodeTable(std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsNodeTable(
+      std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kNodeTable;
   }
 };
 
 class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
  public:
-  explicit GcsNodeResourceTable(std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsNodeResourceTable(
+      std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kNodeResourceTable;
   }
 };
 
 class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
  public:
-  explicit GcsHeartbeatTable(std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsHeartbeatTable(
+      std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kHeartbeatTable;
   }
 };
 
 class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData> {
  public:
-  explicit GcsHeartbeatBatchTable(std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsHeartbeatBatchTable(
+      std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kHeartbeatBatchTable;
   }
 };
 
 class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
  public:
-  explicit GcsErrorInfoTable(std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsErrorInfoTable(
+      std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kErrorInfoTable;
   }
 };
 
 class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
  public:
-  explicit GcsProfileTable(std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsProfileTable(
+      std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kProfileTable;
   }
 };
 
 class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
  public:
-  explicit GcsWorkerFailureTable(std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client) : GcsTable(store_client) {
+  explicit GcsWorkerFailureTable(
+      std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client)
+      : GcsTable(store_client) {
     table_name_ = kWorkerFailureTable;
   }
 };
@@ -208,24 +232,45 @@ class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
 class GcsTableStorage {
  public:
   explicit GcsTableStorage(std::shared_ptr<RedisClient> redis_client) {
-    std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> job_table_store_client;
-//        std::make_shared<StoreClient<JobID, JobTableData, JobID>>(redis_client);
-    job_table_.reset(new GcsJobTable(job_table_store_client));
-
-//    actor_table_.reset(new GcsActorTable(store_client));
-//    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(store_client));
-//    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(store_client));
-//    task_table_.reset(new GcsTaskTable(store_client));
-//    task_lease_table_.reset(new GcsTaskLeaseTable(store_client));
-//    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(store_client));
-//    object_table_.reset(new GcsObjectTable(store_client));
-//    node_table_.reset(new GcsNodeTable(store_client));
-//    node_resource_table_.reset(new GcsNodeResourceTable(store_client));
-//    heartbeat_table_.reset(new GcsHeartbeatTable(store_client));
-//    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(store_client));
-//    error_info_table_.reset(new GcsErrorInfoTable(store_client));
-//    profile_table_.reset(new GcsProfileTable(store_client));
-//    worker_failure_table_.reset(new GcsWorkerFailureTable(store_client));
+    job_table_.reset(new GcsJobTable(
+        std::make_shared<RedisStoreClient<JobID, JobTableData, JobID>>(redis_client)));
+    actor_table_.reset(new GcsActorTable(
+        std::make_shared<RedisStoreClient<ActorID, ActorTableData, JobID>>(
+            redis_client)));
+    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(
+        std::make_shared<RedisStoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>(
+            redis_client)));
+    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(
+        std::make_shared<RedisStoreClient<ActorID, ActorCheckpointIdData, JobID>>(
+            redis_client)));
+    task_table_.reset(new GcsTaskTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskTableData, JobID>>(redis_client)));
+    task_lease_table_.reset(new GcsTaskLeaseTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskLeaseData, JobID>>(redis_client)));
+    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(
+        std::make_shared<RedisStoreClient<TaskID, TaskReconstructionData, JobID>>(
+            redis_client)));
+    object_table_.reset(new GcsObjectTable(
+        std::make_shared<RedisStoreClient<ObjectID, ObjectTableDataList, JobID>>(
+            redis_client)));
+    node_table_.reset(new GcsNodeTable(
+        std::make_shared<RedisStoreClient<ClientID, GcsNodeInfo, JobID>>(redis_client)));
+    node_resource_table_.reset(new GcsNodeResourceTable(
+        std::make_shared<RedisStoreClient<ClientID, ResourceMap, JobID>>(redis_client)));
+    heartbeat_table_.reset(new GcsHeartbeatTable(
+        std::make_shared<RedisStoreClient<ClientID, HeartbeatTableData, JobID>>(
+            redis_client)));
+    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(
+        std::make_shared<RedisStoreClient<ClientID, HeartbeatBatchTableData, JobID>>(
+            redis_client)));
+    error_info_table_.reset(new GcsErrorInfoTable(
+        std::make_shared<RedisStoreClient<JobID, ErrorTableData, JobID>>(redis_client)));
+    profile_table_.reset(new GcsProfileTable(
+        std::make_shared<RedisStoreClient<UniqueID, ProfileTableData, JobID>>(
+            redis_client)));
+    worker_failure_table_.reset(new GcsWorkerFailureTable(
+        std::make_shared<RedisStoreClient<WorkerID, WorkerFailureData, JobID>>(
+            redis_client)));
   }
 
   GcsJobTable &JobTable() {

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -67,16 +67,16 @@ class GcsTable {
   std::shared_ptr<StoreClient<Key, Data, JobID>> store_client_;
 };
 
-/// \class GcsTableWithIndex
+/// \class GcsTableWithJobId
 ///
-/// GcsTableWithIndex supports putting, getting and deleting of GCS table data.
+/// GcsTableWithJobId supports putting, getting and deleting of GCS table data.
 /// This class is not meant to be used directly. All gcs table classes with job id should
 /// derive from this class and override the table_name_ member with a unique value
 /// for that table.
 template <typename Key, typename Data>
-class GcsTableWithIndex : public GcsTable<Key, Data> {
+class GcsTableWithJobId : public GcsTable<Key, Data> {
  public:
-  explicit GcsTableWithIndex(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
+  explicit GcsTableWithJobId(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
       : GcsTable<Key, Data>(store_client) {}
 
   Status PutWithJobId(const JobID &job_id, const Key &key, const Data &value,
@@ -97,71 +97,71 @@ class GcsJobTable : public GcsTable<JobID, JobTableData> {
   }
 };
 
-class GcsActorTable : public GcsTableWithIndex<ActorID, ActorTableData> {
+class GcsActorTable : public GcsTableWithJobId<ActorID, ActorTableData> {
  public:
   explicit GcsActorTable(
       std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR);
   }
 };
 
 class GcsActorCheckpointTable
-    : public GcsTableWithIndex<ActorCheckpointID, ActorCheckpointData> {
+    : public GcsTableWithJobId<ActorCheckpointID, ActorCheckpointData> {
  public:
   explicit GcsActorCheckpointTable(
       std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>
           store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT);
   }
 };
 
 class GcsActorCheckpointIdTable
-    : public GcsTableWithIndex<ActorID, ActorCheckpointIdData> {
+    : public GcsTableWithJobId<ActorID, ActorCheckpointIdData> {
  public:
   explicit GcsActorCheckpointIdTable(
       std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT_ID);
   }
 };
 
-class GcsTaskTable : public GcsTableWithIndex<TaskID, TaskTableData> {
+class GcsTaskTable : public GcsTableWithJobId<TaskID, TaskTableData> {
  public:
   explicit GcsTaskTable(
       std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK);
   }
 
   Status BatchDelete(const std::vector<TaskID> &keys, const StatusCallback &callback);
 };
 
-class GcsTaskLeaseTable : public GcsTableWithIndex<TaskID, TaskLeaseData> {
+class GcsTaskLeaseTable : public GcsTableWithJobId<TaskID, TaskLeaseData> {
  public:
   explicit GcsTaskLeaseTable(
       std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_LEASE);
   }
 };
 
 class GcsTaskReconstructionTable
-    : public GcsTableWithIndex<TaskID, TaskReconstructionData> {
+    : public GcsTableWithJobId<TaskID, TaskReconstructionData> {
  public:
   explicit GcsTaskReconstructionTable(
       std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_RECONSTRUCTION);
   }
 };
 
-class GcsObjectTable : public GcsTableWithIndex<ObjectID, ObjectTableDataList> {
+class GcsObjectTable : public GcsTableWithJobId<ObjectID, ObjectTableDataList> {
  public:
   explicit GcsObjectTable(
       std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client)
-      : GcsTableWithIndex(std::move(store_client)) {
+      : GcsTableWithJobId(std::move(store_client)) {
     table_name_ = TablePrefix_Name(TablePrefix::OBJECT);
   }
 };

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <ray/gcs/gcs_server/test/gcs_test_util.h>
+#include <ray/gcs/test/gcs_test_util.h>
 
 #include <memory>
 #include "gtest/gtest.h"

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <ray/gcs/gcs_server/test/gcs_test_util.h>
+#include <ray/gcs/test/gcs_test_util.h>
 
 #include <memory>
 #include "gmock/gmock.h"

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <ray/gcs/gcs_server/test/gcs_test_util.h>
+#include <ray/gcs/test/gcs_test_util.h>
 
 #include <memory>
 #include "gtest/gtest.h"

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 #include "ray/common/test_util.h"
 #include "ray/gcs/gcs_server/gcs_server.h"
+#include "ray/gcs/test/gcs_test_util.h"
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 
 namespace ray {
@@ -382,56 +383,6 @@ class GcsServerTest : public RedisServiceManagerForTest {
     return status == std::future_status::ready;
   }
 
-  rpc::JobTableData GenJobTableData(JobID job_id) {
-    rpc::JobTableData job_table_data;
-    job_table_data.set_job_id(job_id.Binary());
-    job_table_data.set_is_dead(false);
-    job_table_data.set_timestamp(std::time(nullptr));
-    job_table_data.set_node_manager_address("127.0.0.1");
-    job_table_data.set_driver_pid(5667L);
-    return job_table_data;
-  }
-
-  rpc::ActorTableData GenActorTableData(const ActorID &actor_id) {
-    rpc::ActorTableData actor_table_data;
-    actor_table_data.set_actor_id(actor_id.Binary());
-    actor_table_data.set_job_id(actor_id.JobId().Binary());
-    actor_table_data.set_state(
-        rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
-    actor_table_data.set_max_reconstructions(1);
-    actor_table_data.set_remaining_reconstructions(1);
-    return actor_table_data;
-  }
-
-  rpc::GcsNodeInfo GenGcsNodeInfo(const std::string &node_id) {
-    rpc::GcsNodeInfo gcs_node_info;
-    gcs_node_info.set_node_id(node_id);
-    gcs_node_info.set_node_manager_address("127.0.0.1");
-    gcs_node_info.set_node_manager_port(6000);
-    gcs_node_info.set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
-    return gcs_node_info;
-  }
-
-  rpc::TaskTableData GenTaskTableData(const std::string &job_id,
-                                      const std::string &task_id) {
-    rpc::TaskTableData task_table_data;
-    rpc::Task task;
-    rpc::TaskSpec task_spec;
-    task_spec.set_job_id(job_id);
-    task_spec.set_task_id(task_id);
-    task.mutable_task_spec()->CopyFrom(task_spec);
-    task_table_data.mutable_task()->CopyFrom(task);
-    return task_table_data;
-  }
-
-  rpc::TaskLeaseData GenTaskLeaseData(const std::string &task_id,
-                                      const std::string &node_id) {
-    rpc::TaskLeaseData task_lease_data;
-    task_lease_data.set_task_id(task_id);
-    task_lease_data.set_node_manager_id(node_id);
-    return task_lease_data;
-  }
-
  protected:
   // Gcs server
   std::unique_ptr<gcs::GcsServer> gcs_server_;
@@ -450,32 +401,31 @@ class GcsServerTest : public RedisServiceManagerForTest {
 TEST_F(GcsServerTest, TestActorInfo) {
   // Create actor_table_data
   JobID job_id = JobID::FromInt(1);
-  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
-  rpc::ActorTableData actor_table_data = GenActorTableData(actor_id);
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
 
   // Register actor
   rpc::RegisterActorInfoRequest register_actor_info_request;
-  register_actor_info_request.mutable_actor_table_data()->CopyFrom(actor_table_data);
+  register_actor_info_request.mutable_actor_table_data()->CopyFrom(*actor_table_data);
   ASSERT_TRUE(RegisterActorInfo(register_actor_info_request));
-  rpc::ActorTableData result = GetActorInfo(actor_table_data.actor_id());
+  rpc::ActorTableData result = GetActorInfo(actor_table_data->actor_id());
   ASSERT_TRUE(result.state() ==
               rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
 
   // Update actor state
   rpc::UpdateActorInfoRequest update_actor_info_request;
-  actor_table_data.set_state(
+  actor_table_data->set_state(
       rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
-  update_actor_info_request.set_actor_id(actor_table_data.actor_id());
-  update_actor_info_request.mutable_actor_table_data()->CopyFrom(actor_table_data);
+  update_actor_info_request.set_actor_id(actor_table_data->actor_id());
+  update_actor_info_request.mutable_actor_table_data()->CopyFrom(*actor_table_data);
   ASSERT_TRUE(UpdateActorInfo(update_actor_info_request));
-  result = GetActorInfo(actor_table_data.actor_id());
+  result = GetActorInfo(actor_table_data->actor_id());
   ASSERT_TRUE(result.state() ==
               rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
 
   // Add actor checkpoint
   ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
   rpc::ActorCheckpointData checkpoint;
-  checkpoint.set_actor_id(actor_table_data.actor_id());
+  checkpoint.set_actor_id(actor_table_data->actor_id());
   checkpoint.set_checkpoint_id(checkpoint_id.Binary());
   checkpoint.set_execution_dependency(checkpoint_id.Binary());
 
@@ -483,39 +433,38 @@ TEST_F(GcsServerTest, TestActorInfo) {
   add_actor_checkpoint_request.mutable_checkpoint_data()->CopyFrom(checkpoint);
   ASSERT_TRUE(AddActorCheckpoint(add_actor_checkpoint_request));
   rpc::ActorCheckpointData checkpoint_result =
-      GetActorCheckpoint(actor_id.Binary(), checkpoint_id.Binary());
-  ASSERT_TRUE(checkpoint_result.actor_id() == actor_table_data.actor_id());
+      GetActorCheckpoint(actor_table_data->actor_id(), checkpoint_id.Binary());
+  ASSERT_TRUE(checkpoint_result.actor_id() == actor_table_data->actor_id());
   ASSERT_TRUE(checkpoint_result.checkpoint_id() == checkpoint_id.Binary());
   rpc::ActorCheckpointIdData checkpoint_id_result =
-      GetActorCheckpointID(actor_table_data.actor_id());
-  ASSERT_TRUE(checkpoint_id_result.actor_id() == actor_table_data.actor_id());
+      GetActorCheckpointID(actor_table_data->actor_id());
+  ASSERT_TRUE(checkpoint_id_result.actor_id() == actor_table_data->actor_id());
   ASSERT_TRUE(checkpoint_id_result.checkpoint_ids_size() == 1);
 }
 
 TEST_F(GcsServerTest, TestJobInfo) {
   // Create job_table_data
   JobID job_id = JobID::FromInt(1);
-  rpc::JobTableData job_table_data = GenJobTableData(job_id);
+  auto job_table_data = Mocker::GenJobTableData(job_id);
 
   // Add job
   rpc::AddJobRequest add_job_request;
-  add_job_request.mutable_data()->CopyFrom(job_table_data);
+  add_job_request.mutable_data()->CopyFrom(*job_table_data);
   ASSERT_TRUE(AddJob(add_job_request));
 
   // Mark job finished
   rpc::MarkJobFinishedRequest mark_job_finished_request;
-  mark_job_finished_request.set_job_id(job_table_data.job_id());
+  mark_job_finished_request.set_job_id(job_table_data->job_id());
   ASSERT_TRUE(MarkJobFinished(mark_job_finished_request));
 }
 
 TEST_F(GcsServerTest, TestNodeInfo) {
   // Create gcs node info
-  ClientID node_id = ClientID::FromRandom();
-  rpc::GcsNodeInfo gcs_node_info = GenGcsNodeInfo(node_id.Binary());
+  auto gcs_node_info = Mocker::GenNodeInfo();
 
   // Register node info
   rpc::RegisterNodeRequest register_node_info_request;
-  register_node_info_request.mutable_node_info()->CopyFrom(gcs_node_info);
+  register_node_info_request.mutable_node_info()->CopyFrom(*gcs_node_info);
   ASSERT_TRUE(RegisterNode(register_node_info_request));
   std::vector<rpc::GcsNodeInfo> node_info_list = GetAllNodeInfo();
   ASSERT_TRUE(node_info_list.size() == 1);
@@ -524,12 +473,12 @@ TEST_F(GcsServerTest, TestNodeInfo) {
 
   // Report heartbeat
   rpc::ReportHeartbeatRequest report_heartbeat_request;
-  report_heartbeat_request.mutable_heartbeat()->set_client_id(node_id.Binary());
+  report_heartbeat_request.mutable_heartbeat()->set_client_id(gcs_node_info->node_id());
   ASSERT_TRUE(ReportHeartbeat(report_heartbeat_request));
 
   // Unregister node info
   rpc::UnregisterNodeRequest unregister_node_info_request;
-  unregister_node_info_request.set_node_id(node_id.Binary());
+  unregister_node_info_request.set_node_id(gcs_node_info->node_id());
   ASSERT_TRUE(UnregisterNode(unregister_node_info_request));
   node_info_list = GetAllNodeInfo();
   ASSERT_TRUE(node_info_list.size() == 1);
@@ -538,21 +487,21 @@ TEST_F(GcsServerTest, TestNodeInfo) {
 
   // Update node resources
   rpc::UpdateResourcesRequest update_resources_request;
-  update_resources_request.set_node_id(node_id.Binary());
+  update_resources_request.set_node_id(gcs_node_info->node_id());
   rpc::ResourceTableData resource_table_data;
   resource_table_data.set_resource_capacity(1.0);
   std::string resource_name = "CPU";
   (*update_resources_request.mutable_resources())[resource_name] = resource_table_data;
   ASSERT_TRUE(UpdateResources(update_resources_request));
-  auto resources = GetResources(node_id.Binary());
+  auto resources = GetResources(gcs_node_info->node_id());
   ASSERT_TRUE(resources.size() == 1);
 
   // Delete node resources
   rpc::DeleteResourcesRequest delete_resources_request;
-  delete_resources_request.set_node_id(node_id.Binary());
+  delete_resources_request.set_node_id(gcs_node_info->node_id());
   delete_resources_request.add_resource_name_list(resource_name);
   ASSERT_TRUE(DeleteResources(delete_resources_request));
-  resources = GetResources(node_id.Binary());
+  resources = GetResources(gcs_node_info->node_id());
   ASSERT_TRUE(resources.empty());
 }
 
@@ -591,11 +540,11 @@ TEST_F(GcsServerTest, TestTaskInfo) {
   // Create task_table_data
   JobID job_id = JobID::FromInt(1);
   TaskID task_id = TaskID::ForDriverTask(job_id);
-  rpc::TaskTableData job_table_data = GenTaskTableData(job_id.Binary(), task_id.Binary());
+  auto job_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
 
   // Add task
   rpc::AddTaskRequest add_task_request;
-  add_task_request.mutable_task_data()->CopyFrom(job_table_data);
+  add_task_request.mutable_task_data()->CopyFrom(*job_table_data);
   ASSERT_TRUE(AddTask(add_task_request));
   rpc::TaskTableData result = GetTask(task_id.Binary());
   ASSERT_TRUE(result.task().task_spec().job_id() == job_id.Binary());
@@ -609,10 +558,9 @@ TEST_F(GcsServerTest, TestTaskInfo) {
 
   // Add task lease
   ClientID node_id = ClientID::FromRandom();
-  rpc::TaskLeaseData task_lease_data =
-      GenTaskLeaseData(task_id.Binary(), node_id.Binary());
+  auto task_lease_data = Mocker::GenTaskLeaseData(task_id.Binary(), node_id.Binary());
   rpc::AddTaskLeaseRequest add_task_lease_request;
-  add_task_lease_request.mutable_task_lease_data()->CopyFrom(task_lease_data);
+  add_task_lease_request.mutable_task_lease_data()->CopyFrom(*task_lease_data);
   ASSERT_TRUE(AddTaskLease(add_task_lease_request));
 
   // Attempt task reconstruction

--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc
@@ -1,0 +1,523 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_server/gcs_table_storage.h"
+#include "gtest/gtest.h"
+#include "ray/gcs/store_client/redis_store_client.h"
+#include "ray/gcs/store_client/test/store_client_test_base.h"
+#include "ray/util/test_util.h"
+
+namespace ray {
+
+class GcsTableStorageTest : public gcs::StoreClientTestBase {
+ public:
+  GcsTableStorageTest() {}
+
+  virtual ~GcsTableStorageTest() {}
+
+  virtual void SetUp() override {
+    io_service_pool_ = std::make_shared<IOServicePool>(io_service_num_);
+    io_service_pool_->Run();
+
+    gcs::StoreClientOptions options("127.0.0.1", REDIS_SERVER_PORT, "", true);
+    store_client_ = std::make_shared<gcs::RedisStoreClient>(options);
+    Status status = store_client_->Connect(io_service_pool_);
+    RAY_CHECK_OK(status);
+  }
+
+  virtual void TearDown() override {
+    store_client_->Disconnect();
+    io_service_pool_->Stop();
+
+    store_client_.reset();
+    io_service_pool_.reset();
+  }
+
+  void InitStoreClient() override {}
+
+ protected:
+  std::shared_ptr<rpc::JobTableData> GenJobTableData(JobID job_id) {
+    auto data = std::make_shared<rpc::JobTableData>();
+    data->set_job_id(job_id.Binary());
+    data->set_is_dead(false);
+    data->set_timestamp(std::time(nullptr));
+    data->set_node_manager_address("127.0.0.1");
+    data->set_driver_pid(5667L);
+    return data;
+  }
+
+  std::shared_ptr<rpc::ActorTableData> GenActorTableData(JobID job_id, ActorID actor_id) {
+    auto data = std::make_shared<rpc::ActorTableData>();
+    data->set_actor_id(actor_id.Binary());
+    data->set_job_id(job_id.Binary());
+    data->set_state(rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
+    data->set_max_reconstructions(1);
+    data->set_remaining_reconstructions(1);
+    return data;
+  }
+
+  std::shared_ptr<rpc::ActorCheckpointData> GenActorCheckpointData(
+      ActorID actor_id, ActorCheckpointID checkpoint_id) {
+    auto data = std::make_shared<rpc::ActorCheckpointData>();
+    data->set_actor_id(actor_id.Binary());
+    data->set_checkpoint_id(checkpoint_id.Binary());
+    data->set_execution_dependency(checkpoint_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::ActorCheckpointIdData> GenActorCheckpointIdData(
+      ActorID actor_id, ActorCheckpointID checkpoint_id) {
+    auto data = std::make_shared<rpc::ActorCheckpointIdData>();
+    data->set_actor_id(actor_id.Binary());
+    data->add_checkpoint_ids(checkpoint_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::TaskTableData> GenTaskTableData(const JobID &job_id,
+                                                       const TaskID &task_id) {
+    auto data = std::make_shared<rpc::TaskTableData>();
+    rpc::Task task;
+    rpc::TaskSpec task_spec;
+    task_spec.set_job_id(job_id.Binary());
+    task_spec.set_task_id(task_id.Binary());
+    task.mutable_task_spec()->CopyFrom(task_spec);
+    data->mutable_task()->CopyFrom(task);
+    return data;
+  }
+
+  std::shared_ptr<rpc::TaskLeaseData> GenTaskLeaseData(const TaskID &task_id,
+                                                       const ClientID &node_id) {
+    auto data = std::make_shared<rpc::TaskLeaseData>();
+    data->set_task_id(task_id.Binary());
+    data->set_node_manager_id(node_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::TaskReconstructionData> GenTaskReconstructionData(
+      const TaskID &task_id, const ClientID &node_id) {
+    auto data = std::make_shared<rpc::TaskReconstructionData>();
+    data->set_task_id(task_id.Binary());
+    data->set_num_reconstructions(1);
+    data->set_node_manager_id(node_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::ObjectTableDataList> GenObjectTableDataList(
+      const ClientID &node_id) {
+    auto data = std::make_shared<rpc::ObjectTableDataList>();
+    rpc::ObjectTableData object_table_data;
+    object_table_data.set_manager(node_id.Binary());
+    object_table_data.set_object_size(1);
+    data->add_items()->CopyFrom(object_table_data);
+    return data;
+  }
+
+  std::shared_ptr<rpc::GcsNodeInfo> GenGcsNodeInfo(const ClientID &node_id) {
+    auto data = std::make_shared<rpc::GcsNodeInfo>();
+    data->set_node_id(node_id.Binary());
+    data->set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
+    return data;
+  }
+
+  std::shared_ptr<rpc::ResourceMap> GenResourceMap(const ClientID &node_id) {
+    rpc::ResourceTableData resource_table_data;
+    resource_table_data.set_resource_capacity(1.0);
+    auto data = std::make_shared<rpc::ResourceMap>();
+    (*data->mutable_items())["attr1"] = resource_table_data;
+    return data;
+  }
+
+  std::shared_ptr<rpc::HeartbeatTableData> GenHeartbeatTableData(
+      const ClientID &node_id) {
+    auto data = std::make_shared<rpc::HeartbeatTableData>();
+    data->set_client_id(node_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::HeartbeatBatchTableData> GenHeartbeatBatchTableData(
+      const ClientID &node_id) {
+    auto data = std::make_shared<rpc::HeartbeatBatchTableData>();
+    rpc::HeartbeatTableData heartbeat_table_data;
+    heartbeat_table_data.set_client_id(node_id.Binary());
+    data->add_batch()->CopyFrom(heartbeat_table_data);
+    return data;
+  }
+
+  std::shared_ptr<rpc::ErrorTableData> GenErrorInfoTable(const JobID &job_id) {
+    auto data = std::make_shared<rpc::ErrorTableData>();
+    data->set_job_id(job_id.Binary());
+    return data;
+  }
+
+  std::shared_ptr<rpc::ProfileTableData> GenProfileTableData() {
+    auto data = std::make_shared<rpc::ProfileTableData>();
+    data->set_component_type("object_manager");
+    return data;
+  }
+
+  std::shared_ptr<rpc::WorkerFailureData> GenWorkerFailureData() {
+    auto data = std::make_shared<rpc::WorkerFailureData>();
+    data->set_timestamp(std::time(nullptr));
+    return data;
+  }
+
+  template <typename TABLE, typename KEY, typename VALUE>
+  void Put(TABLE &table, const JobID &job_id, const KEY &key,
+           const std::shared_ptr<VALUE> &value) {
+    auto on_done = [this](Status status) { --pending_count_; };
+    ++pending_count_;
+    RAY_CHECK_OK(table.Put(job_id, key, value, on_done));
+    WaitPendingDone();
+  }
+
+  template <typename TABLE, typename KEY, typename VALUE>
+  int Get(TABLE &table, const JobID &job_id, const KEY &key, std::vector<VALUE> &values) {
+    auto on_done = [this, &values](Status status, const boost::optional<VALUE> &result) {
+      RAY_CHECK_OK(status);
+      --pending_count_;
+      values.clear();
+      if (result) {
+        values.push_back(*result);
+      }
+    };
+    ++pending_count_;
+    RAY_CHECK_OK(table.Get(job_id, key, on_done));
+    WaitPendingDone();
+    return values.size();
+  }
+
+  template <typename TABLE, typename VALUE>
+  int GetAll(TABLE &table, const JobID &job_id, std::vector<VALUE> &values) {
+    auto on_done = [this, &values](Status status, const std::vector<VALUE> &result) {
+      RAY_CHECK_OK(status);
+      values.assign(result.begin(), result.end());
+      --pending_count_;
+    };
+    ++pending_count_;
+    RAY_CHECK_OK(table.GetAll(job_id, on_done));
+    WaitPendingDone();
+    return values.size();
+  }
+
+  template <typename TABLE, typename KEY>
+  void Delete(TABLE &table, const JobID &job_id, const KEY &key) {
+    auto on_done = [this](Status status) {
+      RAY_CHECK_OK(status);
+      --pending_count_;
+    };
+    ++pending_count_;
+    RAY_CHECK_OK(table.Delete(job_id, key, on_done));
+    WaitPendingDone();
+  }
+
+  template <typename TABLE>
+  void Delete(TABLE &table, const JobID &job_id) {
+    auto on_done = [this](Status status) {
+      RAY_CHECK_OK(status);
+      --pending_count_;
+    };
+    ++pending_count_;
+    RAY_CHECK_OK(table.Delete(job_id, on_done));
+    WaitPendingDone();
+  }
+};
+
+TEST_F(GcsTableStorageTest, TestJobTableApi) {
+  gcs::GcsJobTable table(store_client_);
+  JobID job1_id = JobID::FromInt(1);
+  JobID job2_id = JobID::FromInt(2);
+
+  // Put.
+  Put(table, job1_id, job1_id, GenJobTableData(job1_id));
+  Put(table, job2_id, job2_id, GenJobTableData(job1_id));
+
+  // Get.
+  std::vector<rpc::JobTableData> values;
+  ASSERT_EQ(Get(table, job2_id, job2_id, values), 1);
+  ASSERT_EQ(Get(table, job2_id, job2_id, values), 1);
+  ASSERT_EQ(GetAll(table, job1_id, values), 2);
+
+  // Delete.
+  Delete(table, job1_id, job1_id);
+  ASSERT_EQ(Get(table, job1_id, job1_id, values), 0);
+  Delete(table, job2_id);
+  ASSERT_EQ(GetAll(table, job2_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestActorTableApi) {
+  gcs::GcsActorTable table(store_client_);
+  JobID job_id = JobID::FromInt(3);
+  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+
+  // Put.
+  Put(table, job_id, actor_id, GenActorTableData(job_id, actor_id));
+
+  // Get.
+  std::vector<rpc::ActorTableData> values;
+  ASSERT_EQ(Get(table, job_id, actor_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, actor_id);
+  ASSERT_EQ(Get(table, job_id, actor_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestActorCheckpointTableApi) {
+  gcs::GcsActorCheckpointTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
+
+  // Put.
+  Put(table, job_id, checkpoint_id, GenActorCheckpointData(actor_id, checkpoint_id));
+
+  // Get.
+  std::vector<rpc::ActorCheckpointData> values;
+  ASSERT_EQ(Get(table, job_id, checkpoint_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, checkpoint_id);
+  ASSERT_EQ(Get(table, job_id, checkpoint_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestActorCheckpointIdTableApi) {
+  gcs::GcsActorCheckpointIdTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
+
+  // Put.
+  Put(table, job_id, actor_id, GenActorCheckpointIdData(actor_id, checkpoint_id));
+
+  // Get.
+  std::vector<rpc::ActorCheckpointIdData> values;
+  ASSERT_EQ(Get(table, job_id, actor_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, actor_id);
+  ASSERT_EQ(Get(table, job_id, actor_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestTaskTableApi) {
+  gcs::GcsTaskTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+
+  // Put.
+  Put(table, job_id, task_id, GenTaskTableData(job_id, task_id));
+
+  // Get.
+  std::vector<rpc::TaskTableData> values;
+  ASSERT_EQ(Get(table, job_id, task_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, task_id);
+  ASSERT_EQ(Get(table, job_id, task_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestTaskLeaseTableApi) {
+  gcs::GcsTaskLeaseTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, task_id, GenTaskLeaseData(task_id, node_id));
+
+  // Get.
+  std::vector<rpc::TaskLeaseData> values;
+  ASSERT_EQ(Get(table, job_id, task_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, task_id);
+  ASSERT_EQ(Get(table, job_id, task_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestTaskReconstructionTableApi) {
+  gcs::GcsTaskReconstructionTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::ForDriverTask(job_id);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, task_id, GenTaskReconstructionData(task_id, node_id));
+
+  // Get.
+  std::vector<rpc::TaskReconstructionData> values;
+  ASSERT_EQ(Get(table, job_id, task_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, task_id);
+  ASSERT_EQ(Get(table, job_id, task_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestObjectTableApi) {
+  gcs::GcsObjectTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ClientID node_id = ClientID::FromRandom();
+  ObjectID object_id = ObjectID::FromRandom();
+
+  // Put.
+  Put(table, job_id, object_id, GenObjectTableDataList(node_id));
+
+  // Get.
+  std::vector<rpc::ObjectTableDataList> values;
+  ASSERT_EQ(Get(table, job_id, object_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, object_id);
+  ASSERT_EQ(Get(table, job_id, object_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestNodeTableApi) {
+  gcs::GcsNodeTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, node_id, GenGcsNodeInfo(node_id));
+
+  // Get.
+  std::vector<rpc::GcsNodeInfo> values;
+  ASSERT_EQ(Get(table, job_id, node_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, node_id);
+  ASSERT_EQ(Get(table, job_id, node_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestNodeResourceTableApi) {
+  gcs::GcsNodeResourceTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, node_id, GenResourceMap(node_id));
+
+  // Get.
+  std::vector<rpc::ResourceMap> values;
+  ASSERT_EQ(Get(table, job_id, node_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, node_id);
+  ASSERT_EQ(Get(table, job_id, node_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestHeartbeatTableApi) {
+  gcs::GcsHeartbeatTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, node_id, GenHeartbeatTableData(node_id));
+
+  // Get.
+  std::vector<rpc::HeartbeatTableData> values;
+  ASSERT_EQ(Get(table, job_id, node_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, node_id);
+  ASSERT_EQ(Get(table, job_id, node_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestHeartbeatBatchTableApi) {
+  gcs::GcsHeartbeatBatchTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  ClientID node_id = ClientID::FromRandom();
+
+  // Put.
+  Put(table, job_id, node_id, GenHeartbeatBatchTableData(node_id));
+
+  // Get.
+  std::vector<rpc::HeartbeatBatchTableData> values;
+  ASSERT_EQ(Get(table, job_id, node_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, node_id);
+  ASSERT_EQ(Get(table, job_id, node_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestErrorInfoTableApi) {
+  gcs::GcsErrorInfoTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+
+  // Put.
+  Put(table, job_id, job_id, GenErrorInfoTable(job_id));
+
+  // Get.
+  std::vector<rpc::ErrorTableData> values;
+  ASSERT_EQ(Get(table, job_id, job_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, job_id);
+  ASSERT_EQ(Get(table, job_id, job_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestProfileTableApi) {
+  gcs::GcsProfileTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  UniqueID unique_id = UniqueID::FromRandom();
+
+  // Put.
+  Put(table, job_id, unique_id, GenProfileTableData());
+
+  // Get.
+  std::vector<rpc::ProfileTableData> values;
+  ASSERT_EQ(Get(table, job_id, unique_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, unique_id);
+  ASSERT_EQ(Get(table, job_id, unique_id, values), 0);
+}
+
+TEST_F(GcsTableStorageTest, TestWorkerFailureTableApi) {
+  gcs::GcsWorkerFailureTable table(store_client_);
+  JobID job_id = JobID::FromInt(1);
+  WorkerID worker_id = WorkerID::FromRandom();
+
+  // Put.
+  Put(table, job_id, worker_id, GenWorkerFailureData());
+
+  // Get.
+  std::vector<rpc::WorkerFailureData> values;
+  ASSERT_EQ(Get(table, job_id, worker_id, values), 1);
+  ASSERT_EQ(GetAll(table, job_id, values), 1);
+
+  // Delete.
+  Delete(table, job_id, worker_id);
+  ASSERT_EQ(Get(table, job_id, worker_id, values), 0);
+}
+
+}  // namespace ray
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  RAY_CHECK(argc == 4);
+  ray::REDIS_SERVER_EXEC_PATH = argv[1];
+  ray::REDIS_CLIENT_EXEC_PATH = argv[2];
+  ray::REDIS_MODULE_LIBRARY_PATH = argv[3];
+  return RUN_ALL_TESTS();
+}

--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test.cc
@@ -31,7 +31,7 @@ class GcsTableStorageTest : public gcs::StoreClientTestBase {
     redis_client_ = std::make_shared<gcs::RedisClient>(options);
     RAY_CHECK_OK(redis_client_->Connect(io_service_pool_->GetAll()));
 
-    gcs_table_storage_ = std::make_shared<gcs::GcsTableStorage>(redis_client_);
+    gcs_table_storage_ = std::make_shared<gcs::RedisGcsTableStorage>(redis_client_);
   }
 
   void DisconnectStoreClient() override { redis_client_->Disconnect(); }

--- a/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
+++ b/src/ray/gcs/gcs_server/test/redis_gcs_table_storage_test.cc
@@ -17,6 +17,7 @@
 #include "ray/gcs/gcs_server/gcs_table_storage.h"
 #include "ray/gcs/store_client/redis_store_client.h"
 #include "ray/gcs/store_client/test/store_client_test_base.h"
+#include "ray/gcs/test/gcs_test_util.h"
 
 namespace ray {
 
@@ -37,126 +38,6 @@ class GcsTableStorageTest : public gcs::StoreClientTestBase {
   void DisconnectStoreClient() override { redis_client_->Disconnect(); }
 
  protected:
-  rpc::JobTableData GenJobTableData(JobID job_id) {
-    rpc::JobTableData data;
-    data.set_job_id(job_id.Binary());
-    data.set_is_dead(false);
-    data.set_timestamp(std::time(nullptr));
-    data.set_node_manager_address("127.0.0.1");
-    data.set_driver_pid(5667L);
-    return data;
-  }
-
-  rpc::ActorTableData GenActorTableData(JobID job_id, ActorID actor_id) {
-    rpc::ActorTableData data;
-    data.set_actor_id(actor_id.Binary());
-    data.set_job_id(job_id.Binary());
-    data.set_state(rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
-    data.set_max_reconstructions(1);
-    data.set_remaining_reconstructions(1);
-    return data;
-  }
-
-  rpc::ActorCheckpointData GenActorCheckpointData(ActorID actor_id,
-                                                  ActorCheckpointID checkpoint_id) {
-    rpc::ActorCheckpointData data;
-    data.set_actor_id(actor_id.Binary());
-    data.set_checkpoint_id(checkpoint_id.Binary());
-    data.set_execution_dependency(checkpoint_id.Binary());
-    return data;
-  }
-
-  rpc::ActorCheckpointIdData GenActorCheckpointIdData(ActorID actor_id,
-                                                      ActorCheckpointID checkpoint_id) {
-    rpc::ActorCheckpointIdData data;
-    data.set_actor_id(actor_id.Binary());
-    data.add_checkpoint_ids(checkpoint_id.Binary());
-    return data;
-  }
-
-  rpc::TaskTableData GenTaskTableData(const JobID &job_id, const TaskID &task_id) {
-    rpc::TaskTableData data;
-    rpc::Task task;
-    rpc::TaskSpec task_spec;
-    task_spec.set_job_id(job_id.Binary());
-    task_spec.set_task_id(task_id.Binary());
-    task.mutable_task_spec()->CopyFrom(task_spec);
-    data.mutable_task()->CopyFrom(task);
-    return data;
-  }
-
-  rpc::TaskLeaseData GenTaskLeaseData(const TaskID &task_id, const ClientID &node_id) {
-    rpc::TaskLeaseData data;
-    data.set_task_id(task_id.Binary());
-    data.set_node_manager_id(node_id.Binary());
-    return data;
-  }
-
-  rpc::TaskReconstructionData GenTaskReconstructionData(const TaskID &task_id,
-                                                        const ClientID &node_id) {
-    rpc::TaskReconstructionData data;
-    data.set_task_id(task_id.Binary());
-    data.set_num_reconstructions(1);
-    data.set_node_manager_id(node_id.Binary());
-    return data;
-  }
-
-  rpc::ObjectTableDataList GenObjectTableDataList(const ClientID &node_id) {
-    rpc::ObjectTableDataList data;
-    rpc::ObjectTableData object_table_data;
-    object_table_data.set_manager(node_id.Binary());
-    object_table_data.set_object_size(1);
-    data.add_items()->CopyFrom(object_table_data);
-    return data;
-  }
-
-  rpc::GcsNodeInfo GenGcsNodeInfo(const ClientID &node_id) {
-    rpc::GcsNodeInfo data;
-    data.set_node_id(node_id.Binary());
-    data.set_state(rpc::GcsNodeInfo_GcsNodeState_ALIVE);
-    return data;
-  }
-
-  rpc::ResourceMap GenResourceMap(const ClientID &node_id) {
-    rpc::ResourceTableData resource_table_data;
-    resource_table_data.set_resource_capacity(1.0);
-    rpc::ResourceMap data;
-    (*data.mutable_items())["attr1"] = resource_table_data;
-    return data;
-  }
-
-  rpc::HeartbeatTableData GenHeartbeatTableData(const ClientID &node_id) {
-    rpc::HeartbeatTableData data;
-    data.set_client_id(node_id.Binary());
-    return data;
-  }
-
-  rpc::HeartbeatBatchTableData GenHeartbeatBatchTableData(const ClientID &node_id) {
-    rpc::HeartbeatBatchTableData data;
-    rpc::HeartbeatTableData heartbeat_table_data;
-    heartbeat_table_data.set_client_id(node_id.Binary());
-    data.add_batch()->CopyFrom(heartbeat_table_data);
-    return data;
-  }
-
-  rpc::ErrorTableData GenErrorInfoTable(const JobID &job_id) {
-    rpc::ErrorTableData data;
-    data.set_job_id(job_id.Binary());
-    return data;
-  }
-
-  rpc::ProfileTableData GenProfileTableData() {
-    rpc::ProfileTableData data;
-    data.set_component_type("object_manager");
-    return data;
-  }
-
-  rpc::WorkerFailureData GenWorkerFailureData() {
-    rpc::WorkerFailureData data;
-    data.set_timestamp(std::time(nullptr));
-    return data;
-  }
-
   template <typename TABLE, typename KEY, typename VALUE>
   void Put(TABLE &table, const KEY &key, const VALUE &value) {
     auto on_done = [this](Status status) { --pending_count_; };
@@ -181,21 +62,6 @@ class GcsTableStorageTest : public gcs::StoreClientTestBase {
     return values.size();
   }
 
-  template <typename TABLE, typename KEY, typename VALUE>
-  int GetAll(TABLE &table, std::vector<std::pair<KEY, VALUE>> &values) {
-    auto on_done = [this, &values](Status status, bool has_more,
-                                   const std::vector<std::pair<KEY, VALUE>> &result) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-      values.clear();
-      values.push_back(result);
-    };
-    ++pending_count_;
-    RAY_CHECK_OK(table.GetAll(on_done));
-    WaitPendingDone();
-    return values.size();
-  }
-
   template <typename TABLE, typename KEY>
   void Delete(TABLE &table, const KEY &key) {
     auto on_done = [this](Status status) {
@@ -207,44 +73,20 @@ class GcsTableStorageTest : public gcs::StoreClientTestBase {
     WaitPendingDone();
   }
 
-  template <typename TABLE, typename KEY, typename VALUE>
-  int GetByJobId(TABLE &table, const JobID &job_id,
-                 std::vector<std::pair<KEY, VALUE>> &values) {
-    auto on_done = [this, &values](Status status, bool has_more,
-                                   const std::vector<std::pair<KEY, VALUE>> &result) {
-      RAY_CHECK_OK(status);
-      values.assign(result.begin(), result.end());
-      --pending_count_;
-    };
-    ++pending_count_;
-    RAY_CHECK_OK(table.GetByJobId(job_id, on_done));
-    WaitPendingDone();
-    return values.size();
-  }
-
-  template <typename TABLE>
-  void DeleteByJobId(TABLE &table, const JobID &job_id) {
-    auto on_done = [this](Status status) {
-      RAY_CHECK_OK(status);
-      --pending_count_;
-    };
-    ++pending_count_;
-    RAY_CHECK_OK(table.DeleteByJobId(job_id, on_done));
-    WaitPendingDone();
-  }
-
   std::shared_ptr<gcs::RedisClient> redis_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
 };
 
-TEST_F(GcsTableStorageTest, TestJobTableApi) {
+TEST_F(GcsTableStorageTest, TestGcsTableApi) {
   auto table = gcs_table_storage_->JobTable();
   JobID job1_id = JobID::FromInt(1);
   JobID job2_id = JobID::FromInt(2);
+  auto job1_table_data = Mocker::GenJobTableData(job1_id);
+  auto job2_table_data = Mocker::GenJobTableData(job2_id);
 
   // Put.
-  Put(table, job1_id, GenJobTableData(job1_id));
-  Put(table, job2_id, GenJobTableData(job2_id));
+  Put(table, job1_id, *job1_table_data);
+  Put(table, job2_id, *job2_table_data);
 
   // Get.
   std::vector<rpc::JobTableData> values;
@@ -257,13 +99,14 @@ TEST_F(GcsTableStorageTest, TestJobTableApi) {
   ASSERT_EQ(Get(table, job2_id, values), 1);
 }
 
-TEST_F(GcsTableStorageTest, TestActorTableApi) {
+TEST_F(GcsTableStorageTest, TestGcsTableWithJobIdApi) {
   auto table = gcs_table_storage_->ActorTable();
   JobID job_id = JobID::FromInt(3);
-  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+  auto actor_table_data = Mocker::GenActorTableData(job_id);
+  ActorID actor_id = ActorID::FromBinary(actor_table_data->actor_id());
 
   // Put.
-  Put(table, actor_id, GenActorTableData(job_id, actor_id));
+  Put(table, actor_id, *actor_table_data);
 
   // Get.
   std::vector<rpc::ActorTableData> values;
@@ -272,226 +115,6 @@ TEST_F(GcsTableStorageTest, TestActorTableApi) {
   // Delete.
   Delete(table, actor_id);
   ASSERT_EQ(Get(table, actor_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestActorCheckpointTableApi) {
-  auto table = gcs_table_storage_->ActorCheckpointTable();
-  JobID job_id = JobID::FromInt(1);
-  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
-  ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
-
-  // Put.
-  Put(table, checkpoint_id, GenActorCheckpointData(actor_id, checkpoint_id));
-
-  // Get.
-  std::vector<rpc::ActorCheckpointData> values;
-  ASSERT_EQ(Get(table, checkpoint_id, values), 1);
-
-  // Delete.
-  Delete(table, checkpoint_id);
-  ASSERT_EQ(Get(table, checkpoint_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestActorCheckpointIdTableApi) {
-  auto table = gcs_table_storage_->ActorCheckpointIdTable();
-  JobID job_id = JobID::FromInt(1);
-  ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
-  ActorCheckpointID checkpoint_id = ActorCheckpointID::FromRandom();
-
-  // Put.
-  Put(table, actor_id, GenActorCheckpointIdData(actor_id, checkpoint_id));
-
-  // Get.
-  std::vector<rpc::ActorCheckpointIdData> values;
-  ASSERT_EQ(Get(table, actor_id, values), 1);
-
-  // Delete.
-  Delete(table, actor_id);
-  ASSERT_EQ(Get(table, actor_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestTaskTableApi) {
-  auto table = gcs_table_storage_->TaskTable();
-  JobID job_id = JobID::FromInt(1);
-  TaskID task_id = TaskID::ForDriverTask(job_id);
-
-  // Put.
-  Put(table, task_id, GenTaskTableData(job_id, task_id));
-
-  // Get.
-  std::vector<rpc::TaskTableData> values;
-  ASSERT_EQ(Get(table, task_id, values), 1);
-
-  // Delete.
-  Delete(table, task_id);
-  ASSERT_EQ(Get(table, task_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestTaskLeaseTableApi) {
-  auto table = gcs_table_storage_->TaskLeaseTable();
-  JobID job_id = JobID::FromInt(1);
-  TaskID task_id = TaskID::ForDriverTask(job_id);
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, task_id, GenTaskLeaseData(task_id, node_id));
-
-  // Get.
-  std::vector<rpc::TaskLeaseData> values;
-  ASSERT_EQ(Get(table, task_id, values), 1);
-
-  // Delete.
-  Delete(table, task_id);
-  ASSERT_EQ(Get(table, task_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestTaskReconstructionTableApi) {
-  auto table = gcs_table_storage_->TaskReconstructionTable();
-  JobID job_id = JobID::FromInt(1);
-  TaskID task_id = TaskID::ForDriverTask(job_id);
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, task_id, GenTaskReconstructionData(task_id, node_id));
-
-  // Get.
-  std::vector<rpc::TaskReconstructionData> values;
-  ASSERT_EQ(Get(table, task_id, values), 1);
-
-  // Delete.
-  Delete(table, task_id);
-  ASSERT_EQ(Get(table, task_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestObjectTableApi) {
-  auto table = gcs_table_storage_->ObjectTable();
-  JobID job_id = JobID::FromInt(1);
-  ActorID actor_id = ActorID::NilFromJob(job_id);
-  ClientID node_id = ClientID::FromRandom();
-  ObjectID object_id = ObjectID::ForActorHandle(actor_id);
-
-  // Put.
-  Put(table, object_id, GenObjectTableDataList(node_id));
-
-  // Get.
-  std::vector<rpc::ObjectTableDataList> values;
-  ASSERT_EQ(Get(table, object_id, values), 1);
-
-  // Delete.
-  Delete(table, object_id);
-  ASSERT_EQ(Get(table, object_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestNodeTableApi) {
-  auto table = gcs_table_storage_->NodeTable();
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, node_id, GenGcsNodeInfo(node_id));
-
-  // Get.
-  std::vector<rpc::GcsNodeInfo> values;
-  ASSERT_EQ(Get(table, node_id, values), 1);
-
-  // Delete.
-  Delete(table, node_id);
-  ASSERT_EQ(Get(table, node_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestNodeResourceTableApi) {
-  auto table = gcs_table_storage_->NodeResourceTable();
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, node_id, GenResourceMap(node_id));
-
-  // Get.
-  std::vector<rpc::ResourceMap> values;
-  ASSERT_EQ(Get(table, node_id, values), 1);
-
-  // Delete.
-  Delete(table, node_id);
-  ASSERT_EQ(Get(table, node_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestHeartbeatTableApi) {
-  auto table = gcs_table_storage_->HeartbeatTable();
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, node_id, GenHeartbeatTableData(node_id));
-
-  // Get.
-  std::vector<rpc::HeartbeatTableData> values;
-  ASSERT_EQ(Get(table, node_id, values), 1);
-
-  // Delete.
-  Delete(table, node_id);
-  ASSERT_EQ(Get(table, node_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestHeartbeatBatchTableApi) {
-  auto table = gcs_table_storage_->HeartbeatBatchTable();
-  ClientID node_id = ClientID::FromRandom();
-
-  // Put.
-  Put(table, node_id, GenHeartbeatBatchTableData(node_id));
-
-  // Get.
-  std::vector<rpc::HeartbeatBatchTableData> values;
-  ASSERT_EQ(Get(table, node_id, values), 1);
-
-  // Delete.
-  Delete(table, node_id);
-  ASSERT_EQ(Get(table, node_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestErrorInfoTableApi) {
-  auto table = gcs_table_storage_->ErrorInfoTable();
-  JobID job_id = JobID::FromInt(1);
-
-  // Put.
-  Put(table, job_id, GenErrorInfoTable(job_id));
-
-  // Get.
-  std::vector<rpc::ErrorTableData> values;
-  ASSERT_EQ(Get(table, job_id, values), 1);
-
-  // Delete.
-  Delete(table, job_id);
-  ASSERT_EQ(Get(table, job_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestProfileTableApi) {
-  auto table = gcs_table_storage_->ProfileTable();
-  UniqueID unique_id = UniqueID::FromRandom();
-
-  // Put.
-  Put(table, unique_id, GenProfileTableData());
-
-  // Get.
-  std::vector<rpc::ProfileTableData> values;
-  ASSERT_EQ(Get(table, unique_id, values), 1);
-
-  // Delete.
-  Delete(table, unique_id);
-  ASSERT_EQ(Get(table, unique_id, values), 0);
-}
-
-TEST_F(GcsTableStorageTest, TestWorkerFailureTableApi) {
-  auto table = gcs_table_storage_->WorkerFailureTable();
-  WorkerID worker_id = WorkerID::FromRandom();
-
-  // Put.
-  Put(table, worker_id, GenWorkerFailureData());
-
-  // Get.
-  std::vector<rpc::WorkerFailureData> values;
-  ASSERT_EQ(Get(table, worker_id, values), 1);
-
-  // Delete.
-  Delete(table, worker_id);
-  ASSERT_EQ(Get(table, worker_id, values), 0);
 }
 
 }  // namespace ray

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -145,6 +145,20 @@ Status RedisStoreClient<Key, Data, IndexKey>::AsyncDeleteByIndex(
 }
 
 template class RedisStoreClient<ActorID, rpc::ActorTableData, JobID>;
+template class RedisStoreClient<JobID, rpc::JobTableData, JobID>;
+template class RedisStoreClient<ActorCheckpointID, rpc::ActorCheckpointData, JobID>;
+template class RedisStoreClient<ActorID, rpc::ActorCheckpointIdData, JobID>;
+template class RedisStoreClient<TaskID, rpc::TaskTableData, JobID>;
+template class RedisStoreClient<TaskID, rpc::TaskLeaseData, JobID>;
+template class RedisStoreClient<TaskID, rpc::TaskReconstructionData, JobID>;
+template class RedisStoreClient<ObjectID, rpc::ObjectTableDataList, JobID>;
+template class RedisStoreClient<ClientID, rpc::GcsNodeInfo, JobID>;
+template class RedisStoreClient<ClientID, rpc::ResourceMap, JobID>;
+template class RedisStoreClient<ClientID, rpc::HeartbeatTableData, JobID>;
+template class RedisStoreClient<ClientID, rpc::HeartbeatBatchTableData, JobID>;
+template class RedisStoreClient<JobID, rpc::ErrorTableData, JobID>;
+template class RedisStoreClient<UniqueID, rpc::ProfileTableData, JobID>;
+template class RedisStoreClient<WorkerID, rpc::WorkerFailureData, JobID>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -15,13 +15,13 @@
 #ifndef RAY_GCS_TEST_UTIL_H
 #define RAY_GCS_TEST_UTIL_H
 
-#include <ray/common/task/task.h>
-#include <ray/common/task/task_util.h>
-#include <ray/common/test_util.h>
-#include <ray/gcs/gcs_server/gcs_actor_manager.h>
-#include <ray/gcs/gcs_server/gcs_actor_scheduler.h>
-#include <ray/gcs/gcs_server/gcs_node_manager.h>
-#include <ray/util/asio_util.h>
+#include "src/ray/common/task/task.h"
+#include "src/ray/common/task/task_util.h"
+#include "src/ray/common/test_util.h"
+#include "src/ray/gcs/gcs_server/gcs_actor_manager.h"
+#include "src/ray/gcs/gcs_server/gcs_actor_scheduler.h"
+#include "src/ray/gcs/gcs_server/gcs_node_manager.h"
+#include "src/ray/util/asio_util.h"
 
 #include <memory>
 #include <utility>
@@ -57,6 +57,67 @@ struct Mocker {
     node->set_node_manager_port(port);
     node->set_node_manager_address("127.0.0.1");
     return node;
+  }
+
+  static std::shared_ptr<rpc::JobTableData> GenJobTableData(JobID job_id) {
+    auto job_table_data = std::make_shared<rpc::JobTableData>();
+    job_table_data->set_job_id(job_id.Binary());
+    job_table_data->set_is_dead(false);
+    job_table_data->set_timestamp(std::time(nullptr));
+    job_table_data->set_node_manager_address("127.0.0.1");
+    job_table_data->set_driver_pid(5667L);
+    return job_table_data;
+  }
+
+  static std::shared_ptr<rpc::ActorTableData> GenActorTableData(const JobID &job_id) {
+    auto actor_table_data = std::make_shared<rpc::ActorTableData>();
+    ActorID actor_id = ActorID::Of(job_id, RandomTaskId(), 0);
+    actor_table_data->set_actor_id(actor_id.Binary());
+    actor_table_data->set_job_id(job_id.Binary());
+    actor_table_data->set_state(
+        rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
+    actor_table_data->set_max_reconstructions(1);
+    actor_table_data->set_remaining_reconstructions(1);
+    return actor_table_data;
+  }
+
+  static std::shared_ptr<rpc::TaskTableData> GenTaskTableData(
+      const std::string &job_id, const std::string &task_id) {
+    auto task_table_data = std::make_shared<rpc::TaskTableData>();
+    rpc::Task task;
+    rpc::TaskSpec task_spec;
+    task_spec.set_job_id(job_id);
+    task_spec.set_task_id(task_id);
+    task.mutable_task_spec()->CopyFrom(task_spec);
+    task_table_data->mutable_task()->CopyFrom(task);
+    return task_table_data;
+  }
+
+  static std::shared_ptr<rpc::TaskLeaseData> GenTaskLeaseData(
+      const std::string &task_id, const std::string &node_id) {
+    auto task_lease_data = std::make_shared<rpc::TaskLeaseData>();
+    task_lease_data->set_task_id(task_id);
+    task_lease_data->set_node_manager_id(node_id);
+    return task_lease_data;
+  }
+
+  static std::shared_ptr<rpc::ProfileTableData> GenProfileTableData(
+      const ClientID &node_id) {
+    auto profile_table_data = std::make_shared<rpc::ProfileTableData>();
+    profile_table_data->set_component_id(node_id.Binary());
+    return profile_table_data;
+  }
+
+  static std::shared_ptr<rpc::ErrorTableData> GenErrorTableData(const JobID &job_id) {
+    auto error_table_data = std::make_shared<rpc::ErrorTableData>();
+    error_table_data->set_job_id(job_id.Binary());
+    return error_table_data;
+  }
+
+  static std::shared_ptr<rpc::WorkerFailureData> GenWorkerFailureData() {
+    auto worker_failure_data = std::make_shared<rpc::WorkerFailureData>();
+    worker_failure_data->set_timestamp(std::time(nullptr));
+    return worker_failure_data;
   }
 
   class MockWorkerClient : public rpc::CoreWorkerClientInterface {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -303,6 +303,13 @@ message WorkerFailureData {
   bool intentional_disconnect = 4;
 }
 
+message ResourceMap {
+  map<string, ResourceTableData> items = 1;
+}
+
+message ObjectTableDataList {
+  repeated ObjectTableData items = 1;
+}
 // This enum type is used as object's metadata to indicate the object's creating
 // task has failed because of a certain error.
 // TODO(hchen): We may want to make these errors more specific. E.g., we may want


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Now we use the redis to store gcs table data. In the future, we will plugin access to other storage, so we abstract a layer of table storage interface.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
