### PR TITLE
Fix bug in java/test.sh

### DIFF
--- a/java/test.sh
+++ b/java/test.sh
@@ -8,7 +8,8 @@ set -x
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 run_testng() {
-    $@ || exit_code=$?
+    $@
+    local exit_code=$?
     # exit_code == 2 means there are skipped tests.
     if [ $exit_code -ne 2 ] && [ $exit_code -ne 0 ] ; then
         exit $exit_code


### PR DESCRIPTION
## Why are these changes needed?

Fixes a scripting bug.

```
+'[' -ne 2 ']'
./java/test.sh: line 13: [: -ne: unary operator expected
```

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
