### PR TITLE
Suppress GRPC SO_REUSADDR warning on Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,8 @@ build --host_copt="-Wno-inconsistent-missing-override"
 build --host_copt="-Wno-microsoft-unqualified-friend"
 # This workaround is needed due to https://github.com/bazelbuild/bazel/issues/4341
 build --per_file_copt="-\\.(asm|S)$,external/com_github_grpc_grpc/.*@-DGRPC_BAZEL_BUILD"
+# Don't generate warnings about kernel features we don't need https://github.com/ray-project/ray/issues/6832
+build:linux --per_file_copt="-\\.(asm|S)$,external/com_github_grpc_grpc/.*@-DGPR_MANYLINUX1"
 build --http_timeout_scaling=5.0
 build:iwyu --experimental_action_listener=//:iwyu_cpp
 


### PR DESCRIPTION
## Why are these changes needed?

Compiles GRPC in manylinux mode (which we already do for building wheels) in order to [avoid checks that emit spurious errors in WSL](https://github.com/grpc/grpc/blob/4790ab6d97e634a1ede983be393f3bb3c132b2f7/src/core/lib/iomgr/socket_utils_common_posix.cc#L199).

## Related issue number

#6832

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
