### PR TITLE
rsync_down source/target bug.

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -293,7 +293,7 @@ class SSHCommandRunner:
         self.process_runner.check_call([
             "rsync", "--rsh",
             " ".join(["ssh"] + self.get_default_ssh_options(120)), "-avz",
-            "{}@{}:{}".format(self.ssh_user, self.ssh_ip, source), target
+            "{}@{}:{}".format(self.ssh_user, self.ssh_ip, target), source
         ])
 
     def remote_shell_command_str(self):


### PR DESCRIPTION
I supposed that the goal of rsync_down is to copy changes from the cluster back to the source. The current code tries to copy the source folder (not target) from the cluster back to the source folder. It only works if the folder names happen to be the same. This looks like a clear bug to me, but I could be misunderstanding the command.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
