### PR TITLE
[rllib] Torch sequence_mask now works for tensors on different devices

### DIFF
--- a/rllib/utils/torch_ops.py
+++ b/rllib/utils/torch_ops.py
@@ -51,8 +51,8 @@ def sequence_mask(lengths, maxlen, dtype=None):
     if maxlen is None:
         maxlen = lengths.max()
 
-    mask = ~(torch.ones((len(lengths), maxlen)).cumsum(dim=1).t() > lengths). \
-        t()
+    mask = ~(torch.ones((len(lengths), maxlen)).to(
+        lengths.device).cumsum(dim=1).t() > lengths).t()
     mask.type(dtype or torch.bool)
 
     return mask


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The [RLlib Torch RNN example](https://github.com/ray-project/ray/blob/master/rllib/examples/custom_torch_rnn_model.py) only uses CPUs. When adding GPUs, the following exception is thrown.

```
import argparse

import ray
from ray.rllib.examples.cartpole_lstm import CartPoleStatelessEnv
from ray.rllib.examples.custom_keras_rnn_model import RepeatInitialEnv, \
    RepeatAfterMeEnv
from ray.rllib.models.preprocessors import get_preprocessor
from ray.rllib.models.torch.recurrent_torch_model import RecurrentTorchModel
from ray.rllib.models.modelv2 import ModelV2
from ray.rllib.utils.annotations import override
from ray.rllib.utils import try_import_torch
from ray.rllib.models import ModelCatalog
import ray.tune as tune

torch, nn = try_import_torch()

parser = argparse.ArgumentParser()
parser.add_argument("--run", type=str, default="PPO")
parser.add_argument("--env", type=str, default="repeat_initial")
parser.add_argument("--stop", type=int, default=90)
parser.add_argument("--num-cpus", type=int, default=0)
parser.add_argument("--fc-size", type=int, default=64)
parser.add_argument("--lstm-cell-size", type=int, default=256)


class RNNModel(RecurrentTorchModel):
    def __init__(self,
                 obs_space,
                 action_space,
                 num_outputs,
                 model_config,
                 name,
                 fc_size=64,
                 lstm_state_size=256):
        super().__init__(obs_space, action_space, num_outputs, model_config,
                         name)

        self.obs_size = get_preprocessor(obs_space)(obs_space).size
        self.fc_size = fc_size
        self.lstm_state_size = lstm_state_size
        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
        
        # Build the Module from fc + LSTM + 2xfc (action + value outs).
        self.fc1 = nn.Linear(self.obs_size, self.fc_size)
        self.lstm = nn.LSTM(
            self.fc_size, self.lstm_state_size, batch_first=True).to(self.device)
        self.action_branch = nn.Linear(self.lstm_state_size, num_outputs).to(self.device)
        self.value_branch = nn.Linear(self.lstm_state_size, 1).to(self.device)
        # Store the value output to save an extra forward pass.
        self._cur_value = None

    @override(ModelV2)
    def get_initial_state(self):
        # make hidden states on same device as model
        h = [
            self.fc1.weight.new(1, self.lstm_state_size).zero_().squeeze(0),
            self.fc1.weight.new(1, self.lstm_state_size).zero_().squeeze(0)
        ]
        return h

    @override(ModelV2)
    def value_function(self):
        assert self._cur_value is not None, "must call forward() first"
        return self._cur_value

    @override(RecurrentTorchModel)
    def forward_rnn(self, inputs, state, seq_lens):
        """Feeds `inputs` (B x T x ..) through the Gru Unit.

        Returns the resulting outputs as a sequence (B x T x ...).
        Values are stored in self._cur_value in simple (B) shape (where B
        contains both the B and T dims!).

        Returns:
            NN Outputs (B x T x ...) as sequence.
            The state batches as a List of two items (c- and h-states).
        """
        x = nn.functional.relu(self.fc1(inputs))
        lstm_out = self.lstm(
            x, [torch.unsqueeze(state[0], 0),
                torch.unsqueeze(state[1], 0)])
        action_out = self.action_branch(lstm_out[0])
        self._cur_value = torch.reshape(self.value_branch(lstm_out[0]), [-1])
        return action_out, [
            torch.squeeze(lstm_out[1][0], 0),
            torch.squeeze(lstm_out[1][1], 0)
        ]


if __name__ == "__main__":
    args = parser.parse_args()

    ray.init(num_cpus=args.num_cpus or None)
    ModelCatalog.register_custom_model("rnn", RNNModel)
    tune.register_env(
        "repeat_initial", lambda _: RepeatInitialEnv(episode_len=100))
    tune.register_env(
        "repeat_after_me", lambda _: RepeatAfterMeEnv({"repeat_delay": 1}))
    tune.register_env("cartpole_stateless", lambda _: CartPoleStatelessEnv())

    config = {
        "env": args.env,
        "use_pytorch": True,
        "num_workers": 4,
        "num_gpus": 1,
        "num_envs_per_worker": 20,
        "gamma": 0.9,
        "entropy_coeff": 0.0001,
        "model": {
            "custom_model": "rnn",
            "max_seq_len": 20,
            "lstm_use_prev_action_reward": "store_true",
            "custom_options": {
                "fc_size": args.fc_size,
                "lstm_state_size": args.lstm_cell_size,
            }
        },
        "lr": 3e-4,
        "num_sgd_iter": 5,
        "vf_loss_coeff": 0.0003,
    }

    tune.run(
        args.run,
        stop={
            "episode_reward_mean": args.stop,
            "timesteps_total": 100000
        },
        config=config,
    )
```

```
Traceback (most recent call last):
  File "[...]/ray/tune/trial_runner.py", line 467, in _process_trial
    result = self.trial_executor.fetch_result(trial)
  File "[...]/ray/tune/ray_trial_executor.py", line 381, in fetch_result
    result = ray.get(trial_future[0], DEFAULT_GET_TIMEOUT)
  File "[...]/ray/worker.py", line 1513, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(RuntimeError): ray::PPO.train() (pid=121560, ip=128.232.69.20)
  File "python/ray/_raylet.pyx", line 452, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 407, in ray._raylet.execute_task.function_executor
  File "[...]/ray/rllib/agents/trainer.py", line 505, in train
    raise e
  File "[...]/ray/rllib/agents/trainer.py", line 491, in train
    result = Trainable.train(self)
  File "[...]/ray/tune/trainable.py", line 261, in train
    result = self._train()
  File "[...]/ray/rllib/agents/trainer_template.py", line 150, in _train
    fetches = self.optimizer.step()
  File "[...]/ray/rllib/optimizers/sync_samples_optimizer.py", line 71, in step
    self.standardize_fields)
  File "[...]/ray/rllib/utils/sgd.py", line 117, in do_minibatch_sgd
    }, minibatch.count)))[policy_id]
  File "[...]/ray/rllib/evaluation/rollout_worker.py", line 632, in learn_on_batch
    info_out[pid] = policy.learn_on_batch(batch)
  File "[...]/ray/rllib/policy/torch_policy.py", line 159, in learn_on_batch
    loss_out = self._loss(self, self.model, self.dist_class, train_batch)
  File "[...]/ray/rllib/agents/ppo/ppo_torch_policy.py", line 122, in ppo_surrogate_loss
    mask = sequence_mask(train_batch["seq_lens"], max_seq_len)
  File "[...]/ray/rllib/utils/torch_ops.py", line 26, in sequence_mask
    mask = ~(torch.ones((len(lengths), maxlen)).cumsum(dim=1).t() > lengths). \
  File "[...]/torch/tensor.py", line 28, in wrapped
    return f(*args, **kwargs)
RuntimeError: expected device cpu but got device cuda:0
```

I am not sure if this is actually an RLLib issue or if this could also have been fixed by adding the `.to()` at the appropriate place in the training script, but this fixed it for me at least.

## Related issue number

#7206 
#7797 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
