### PR TITLE
Fix determine_tests_to_run

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -61,7 +61,9 @@ init() {
 
   local variable_definitions
   variable_definitions=($(python "${ROOT_DIR}"/determine_tests_to_run.py))
-  { declare "${variable_definitions[@]}"; } > /dev/null 2> /dev/null
+  if [ 0 -lt "${#variable_definitions[@]}" ]; then
+    declare "${variable_definitions[@]}"
+  fi
 
   if ! (set +x && should_run_job ${job_names//,/ }); then
     exit 0

--- a/ci/travis/determine_tests_to_run.py
+++ b/ci/travis/determine_tests_to_run.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             with open(os.environ["GITHUB_EVENT_PATH"], "rb") as f:
                 event = json.loads(f.read())
             base = event["pull_request"]["base"]["sha"]
-            commit_range = "{}...{}".format(base, event["after"])
+            commit_range = "{}...{}".format(base, event.get("after", ""))
         files = list_changed_files(commit_range)
 
         print(pformat(files), file=sys.stderr)


### PR DESCRIPTION
## Why are these changes needed?

`declare` echoes slightly differently under `set -x`; we didn't intend to suppress everything.

Also GitHub seems to omit `after` in the event info when there's only a single commit; try to address that.

## Related issue number

#7988

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
