### PR TITLE
Fix command config portion of project schema

### DIFF
--- a/python/ray/projects/schema.json
+++ b/python/ray/projects/schema.json
@@ -150,18 +150,15 @@
             }
           },
           "config": {
+            "description": "Configuration options for the command",
             "type": "object",
-            "items": {
-              "description": "Configuration options for the command",
-              "type": "object",
-              "properties": {
-                "tmux": {
-                  "description": "If true, the command will be run inside of tmux",
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
+            "properties": {
+              "tmux": {
+                "description": "If true, the command will be run inside of tmux",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "required": [
@@ -171,7 +168,12 @@
         "additionalProperties": false
       }
     },
-    "output_files": {}
+    "output_files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
   "required": [
     "name",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR fixes a minor issue in the `config` portion of the `commands` field in the project configuration schema, where it was erroneously using the `items` property for an object. It also makes the type of the `output_files` field more specific, indicating that it should be an array of strings.

## Related issue number

N/A

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.