### PR TITLE
Fix missing Java dependency

### DIFF
--- a/streaming/java/BUILD.bazel
+++ b/streaming/java/BUILD.bazel
@@ -149,6 +149,7 @@ java_binary(
         "@ray_streaming_maven//:com_beust_jcommander",
         "@ray_streaming_maven//:org_mockito_mockito_all",
         "@ray_streaming_maven//:org_powermock_powermock_api_mockito",
+        "@ray_streaming_maven//:org_powermock_powermock_core",
         "@ray_streaming_maven//:org_powermock_powermock_module_testng",
         "@ray_streaming_maven//:org_projectlombok_lombok",
         "@ray_streaming_maven//:org_testng_testng",


### PR DESCRIPTION
## Why are these changes needed?

There's a missing Java dependency in Bazel.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
