### PR TITLE
Improve the perf of constructing actor task specs.

### DIFF
--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -67,7 +67,6 @@ class FractionalResourceQuantity {
 /// GPUs, and custom labels.
 class ResourceSet {
  public:
-
   static std::shared_ptr<ResourceSet> Nil() {
     static auto nil = std::make_shared<ResourceSet>();
     return nil;

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -67,6 +67,12 @@ class FractionalResourceQuantity {
 /// GPUs, and custom labels.
 class ResourceSet {
  public:
+
+  static std::shared_ptr<ResourceSet> Nil() {
+    static auto nil = std::make_shared<ResourceSet>();
+    return nil;
+  }
+
   /// \brief empty ResourceSet constructor.
   ResourceSet();
 

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -65,7 +65,6 @@ void TaskSpecification::ComputeResources() {
       sched_cls_id_ = it->second;
     }
   }
-
 }
 
 // Task specification getter methods.

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -27,28 +27,45 @@ void TaskSpecification::ComputeResources() {
   if (required_placement_resources.empty()) {
     required_placement_resources = required_resources;
   }
-  required_resources_.reset(new ResourceSet(required_resources));
-  required_placement_resources_.reset(new ResourceSet(required_placement_resources));
 
-  // Map the scheduling class descriptor to an integer for performance.
-  auto sched_cls = std::make_pair(GetRequiredResources(), FunctionDescriptor());
-  absl::MutexLock lock(&mutex_);
-  auto it = sched_cls_to_id_.find(sched_cls);
-  if (it == sched_cls_to_id_.end()) {
-    sched_cls_id_ = ++next_sched_id_;
-    // TODO(ekl) we might want to try cleaning up task types in these cases
-    if (sched_cls_id_ > 100) {
-      RAY_LOG(WARNING) << "More than " << sched_cls_id_
-                       << " types of tasks seen, this may reduce performance.";
-    } else if (sched_cls_id_ > 1000) {
-      RAY_LOG(ERROR) << "More than " << sched_cls_id_
-                     << " types of tasks seen, this may reduce performance.";
-    }
-    sched_cls_to_id_[sched_cls] = sched_cls_id_;
-    sched_id_to_cls_[sched_cls_id_] = sched_cls;
+  if (required_resources.empty()) {
+    // A static nil object is used here to avoid allocating the empty object every time.
+    required_resources_ = ResourceSet::Nil();
   } else {
-    sched_cls_id_ = it->second;
+    required_resources_.reset(new ResourceSet(required_resources));
   }
+
+  if (required_placement_resources.empty()) {
+    required_placement_resources_ = ResourceSet::Nil();
+  } else {
+    required_placement_resources_.reset(new ResourceSet(required_placement_resources));
+  }
+
+  if (!IsActorTask()) {
+    // There is no need to compute `SchedulingClass` for actor tasks since
+    // the actor tasks need not be scheduled.
+
+    // Map the scheduling class descriptor to an integer for performance.
+    auto sched_cls = std::make_pair(GetRequiredResources(), FunctionDescriptor());
+    absl::MutexLock lock(&mutex_);
+    auto it = sched_cls_to_id_.find(sched_cls);
+    if (it == sched_cls_to_id_.end()) {
+      sched_cls_id_ = ++next_sched_id_;
+      // TODO(ekl) we might want to try cleaning up task types in these cases
+      if (sched_cls_id_ > 100) {
+        RAY_LOG(WARNING) << "More than " << sched_cls_id_
+                         << " types of tasks seen, this may reduce performance.";
+      } else if (sched_cls_id_ > 1000) {
+        RAY_LOG(ERROR) << "More than " << sched_cls_id_
+                       << " types of tasks seen, this may reduce performance.";
+      }
+      sched_cls_to_id_[sched_cls] = sched_cls_id_;
+      sched_id_to_cls_[sched_cls_id_] = sched_cls;
+    } else {
+      sched_cls_id_ = it->second;
+    }
+  }
+
 }
 
 // Task specification getter methods.

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -177,11 +177,11 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
  private:
   void ComputeResources();
 
-  /// Field storing required resources. Initalized in constructor.
+  /// Field storing required resources. Initialized in constructor.
   /// TODO(ekl) consider optimizing the representation of ResourceSet for fast copies
-  /// instead of keeping shared ptrs here.
+  /// instead of keeping shared pointers here.
   std::shared_ptr<ResourceSet> required_resources_;
-  /// Field storing required placement resources. Initalized in constructor.
+  /// Field storing required placement resources. Initialized in constructor.
   std::shared_ptr<ResourceSet> required_placement_resources_;
   /// Cached scheduling class of this task.
   SchedulingClass sched_cls_id_;


### PR DESCRIPTION
This PR aims to improve the perf when constructing task specs.

The changes of this PR:
1. Since the required resources of actor tasks are empty, it's necessary to add a static nil object to avoid allocating empty `ResourceSet` every time. 
2. DO NOT compute `SchedulingClass` for actor tasks(It's too heavy because of the static lock).


The escaped time of the `TestTaskSpecPerf` is 2319 ms while it was 3469 ms before this PR.
It improves the perf by **30%+** for actor tasks.