### PR TITLE
[Java] Fix shutdown hook in worker mode

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
+++ b/java/runtime/src/main/java/io/ray/runtime/RayNativeRuntime.java
@@ -102,12 +102,14 @@ public final class RayNativeRuntime extends AbstractRayRuntime {
 
   @Override
   public void shutdown() {
-    nativeShutdown();
-    if (null != manager) {
-      manager.cleanup();
-      manager = null;
+    if (rayConfig.workerMode == WorkerType.DRIVER) {
+      nativeShutdown();
+      if (null != manager) {
+        manager.cleanup();
+        manager = null;
+      }
+      RayConfig.reset();
     }
-    RayConfig.reset();
     LOGGER.info("RayNativeRuntime shutdown");
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When JVM is exiting in a Java worker, the shutdown hook is called and `Ray.shutdown()` is invoked, but `nativeShutdown()` or `CoreWorkerProcess::Shutdown()` is only allowed to be called by a driver. This results in below error log:

```
F0420 18:43:05.049088 35747 core_worker.cc:91]  Check failed: instance_->options_.worker_type == WorkerType::DRIVER The `Shutdown` interface is for driver only.
*** Check failure stack trace: ***
    @     0x7fe2a05063ad  google::LogMessage::Fail()
    @     0x7fe2a050781c  google::LogMessage::SendToLog()
    @     0x7fe2a0506089  google::LogMessage::Flush()
    @     0x7fe2a05062a1  google::LogMessage::~LogMessage()
    @     0x7fe2a04e4459  ray::RayLog::~RayLog()
    @     0x7fe29ffda00a  ray::CoreWorkerProcess::Shutdown()
```

This can be verified by checking the worker log of the test case `testWorkerProcessDying`. However, the test case itself won't fail.

I've verified that after applying the fix, the above logs are not generated anymore.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
