### PR TITLE
[serve] Remove serve.route decorator

### DIFF
--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -1,11 +1,11 @@
 from ray.serve.backend_config import BackendConfig
 from ray.serve.policy import RoutePolicy
-from ray.serve.api import (
-    init, create_backend, create_endpoint, link, split, get_handle, stat,
-    set_backend_config, get_backend_config, accept_batch, route)  # noqa: E402
+from ray.serve.api import (init, create_backend, create_endpoint, link, split,
+                           get_handle, stat, set_backend_config,
+                           get_backend_config, accept_batch)  # noqa: E402
 
 __all__ = [
     "init", "create_backend", "create_endpoint", "link", "split", "get_handle",
     "stat", "set_backend_config", "get_backend_config", "BackendConfig",
-    "RoutePolicy", "accept_batch", "route"
+    "RoutePolicy", "accept_batch"
 ]

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -327,33 +327,3 @@ def stat(percentiles=[50, 90, 95],
     """
     [monitor] = ray.get(master_actor.get_metric_monitor.remote())
     return ray.get(monitor.collect.remote(percentiles, agg_windows_seconds))
-
-
-class route:
-    """Convient method to create a backend and link to service.
-
-    When called, the following will happen:
-    - An endpoint is created with the same of the function
-    - A backend is created and instantiate the function
-    - The endpoint and backend are linked together
-    - The handle is returned
-
-    .. code-block:: python
-
-        @serve.route("/path")
-        def my_handler(flask_request):
-            ...
-    """
-
-    def __init__(self, url_route):
-        self.route = url_route
-
-    def __call__(self, func_or_class):
-        name = func_or_class.__name__
-        backend_tag = "{}:v0".format(name)
-
-        create_backend(func_or_class, backend_tag)
-        create_endpoint(name, self.route)
-        link(name, backend_tag)
-
-        return get_handle(name)

--- a/python/ray/serve/examples/benchmark.py
+++ b/python/ray/serve/examples/benchmark.py
@@ -8,10 +8,13 @@ from tqdm import tqdm
 serve.init(blocking=True)
 
 
-@serve.route("/noop")
 def noop(_):
     return ""
 
+
+serve.create_endpoint("noop", "/noop")
+serve.create_backend(noop, "noop")
+serve.split("noop", {"noop": 1.0})
 
 url = "{}/noop".format(DEFAULT_HTTP_ADDRESS)
 while requests.get(url).status_code == 404:

--- a/python/ray/serve/examples/doc/quickstart_class.py
+++ b/python/ray/serve/examples/doc/quickstart_class.py
@@ -4,7 +4,6 @@ import requests
 serve.init()
 
 
-@serve.route("/counter")
 class Counter:
     def __init__(self):
         self.count = 0
@@ -12,6 +11,10 @@ class Counter:
     def __call__(self, flask_request):
         return {"current_counter": self.count}
 
+
+serve.create_endpoint("counter", "/counter")
+serve.create_backend(Counter, "counter")
+serve.split("counter", {"counter": 1.0})
 
 requests.get("http://127.0.0.1:8000/counter").json()
 # > {"current_counter": self.count}

--- a/python/ray/serve/examples/doc/quickstart_function.py
+++ b/python/ray/serve/examples/doc/quickstart_function.py
@@ -4,10 +4,13 @@ import requests
 serve.init()
 
 
-@serve.route("/hello")
 def echo(flask_request):
     return "hello " + flask_request.args.get("name", "serve!")
 
+
+serve.create_endpoint("hello", "/hello")
+serve.create_backend(echo, "hello")
+serve.split("hello", {"hello": 1.0})
 
 requests.get("http://127.0.0.1:8000/hello").text
 # > "hello serve!"

--- a/python/ray/serve/examples/echo_pipeline.py
+++ b/python/ray/serve/examples/echo_pipeline.py
@@ -12,26 +12,40 @@ serve.init(blocking=True)
 
 # a backend can be a function or class.
 # it can be made to be invoked from web as well as python.
-@serve.route("/echo_v1")
 def echo_v1(_, response="hello from python!"):
     return f"echo_v1({response})"
 
 
-@serve.route("/echo_v2")
+serve.create_endpoint("echo_v1", "/echo_v1")
+serve.create_backend(echo_v1, "echo_v1")
+serve.split("echo_v1", {"echo_v1": 1.0})
+
+
 def echo_v2(_, relay=""):
     return f"echo_v2({relay})"
 
 
-@serve.route("/echo_v3")
+serve.create_endpoint("echo_v2", "/echo_v2")
+serve.create_backend(echo_v2, "echo_v2")
+serve.split("echo_v2", {"echo_v2": 1.0})
+
+
 def echo_v3(_, relay=""):
     return f"echo_v3({relay})"
 
 
-@serve.route("/echo_v4")
+serve.create_endpoint("echo_v3", "/echo_v3")
+serve.create_backend(echo_v3, "echo_v3")
+serve.split("echo_v3", {"echo_v3": 1.0})
+
+
 def echo_v4(_, relay1="", relay2=""):
     return f"echo_v4({relay1} , {relay2})"
 
 
+serve.create_endpoint("echo_v4", "/echo_v4")
+serve.create_backend(echo_v4, "echo_v4")
+serve.split("echo_v4", {"echo_v4": 1.0})
 """
 The pipeline created is as follows -
             "my_endpoint1"

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -5,8 +5,6 @@ import requests
 from ray import serve
 from ray.serve import BackendConfig
 import ray
-from ray.serve.exceptions import RayServeException
-from ray.serve.handle import RayServeHandle
 
 
 def test_e2e(serve_instance):
@@ -40,21 +38,6 @@ def test_e2e(serve_instance):
 
     resp = requests.post("http://127.0.0.1:8000/api").json()["method"]
     assert resp == "POST"
-
-
-def test_route_decorator(serve_instance):
-    @serve.route("/hello_world")
-    def hello_world(_):
-        return ""
-
-    assert isinstance(hello_world, RayServeHandle)
-
-    hello_world.scale(2)
-    assert serve.get_backend_config("hello_world:v0").num_replicas == 2
-
-    with pytest.raises(
-            RayServeException, match="method does not accept batching"):
-        hello_world.set_max_batch_size(2)
 
 
 def test_no_route(serve_instance):

--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -14,9 +14,12 @@ ray.init(address="{}")
 from ray import serve
 serve.init()
 
-@serve.route("/driver")
 def driver(flask_request):
     return "OK!"
+
+serve.create_endpoint("driver", "/driver")
+serve.create_backend(driver, "driver")
+serve.split("driver", {{"driver": 1.0}})
 """.format(ray.worker._global_node._redis_address)
 
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This doesn't work properly when imported and we want to keep the API minimal for now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
