### PR TITLE
Fix memory mis-counting in memory monitor for container environment

### DIFF
--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -114,6 +114,13 @@ class MemoryMonitor:
                 with open("/sys/fs/cgroup/memory/memory.usage_in_bytes",
                           "rb") as f:
                     used_gb = int(f.read()) / (1024**3)
+                # Exclude the page cache
+                with open("/sys/fs/cgroup/memory/memory.stat", "r") as f:
+                    for line in f.readlines():
+                        if line.split(" ")[0] == "cache":
+                            used_gb = \
+                                used_gb - int(line.split(" ")[1]) / (1024**3)
+                assert used_gb >= 0
             if used_gb > total_gb * self.error_threshold:
                 raise RayOutOfMemoryError(
                     RayOutOfMemoryError.get_message(used_gb, total_gb,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The memory_monitor in Ray for container environment calculates the used memory from `/sys/fs/cgroup/memory/memory.usage_in_bytes`.  [See here](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt). 

However, this number includes both RSS and Cache (page cache).  If the actors running Ray are I/O intensive, this will trigger the unnecessary OOM since the page cache can be freed at zero cost. To make the used memory count behavior the same as [`psutil.virtual_memory().available`](https://github.com/giampaolo/psutil/blob/master/psutil/_pslinux.py#L384), which is `avail = (free + buffers + cached)`, we should exclude the page cache from used memory.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
