### PR TITLE
[sgd] Properly set cuda devices for different initializations

### DIFF
--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -216,16 +216,14 @@ def reserve_cuda_device(num_gpus, match_devices=False, retries=20):
 
         reserved_device = ray.get(_dummy_actor.cuda_devices.remote())
 
-        if reserved_device == cuda_device:
-            logger.info("Devices match: %s and %s", reserved_device,
-                        cuda_device)
-            success = True
-            break
-        else:
+        if cuda_device and not reserved_device == cuda_device:
             logger.info("Devices don't match: %s and %s", reserved_device,
                         cuda_device)
             _dummy_actor.__ray_terminate__.remote()
             _dummy_actor = None
+        else:
+            success = True
+            break
 
     if not success:
         raise RuntimeError(

--- a/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
+++ b/python/ray/util/sgd/torch/examples/cifar_pytorch_example.py
@@ -18,6 +18,7 @@ def initialization_hook():
     # Need this for avoiding a connection restart issue on AWS.
     os.environ["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
     os.environ["NCCL_LL_THRESHOLD"] = "0"
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
 
     # set the below if needed
     # print("NCCL DEBUG SET")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Right now, it is impossible to use RaySGD with SLURM because of CUDA device setting conflicts. 

This PR should introduce a fix to play properly with pre-set GPU ids.

This PR needs quite a bit of testing, so it is not ready to merge yet.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)