### PR TITLE
[GCS]Remove class template parameters from store client

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -50,7 +50,7 @@ using rpc::WorkerFailureData;
 template <typename Key, typename Data>
 class GcsTable {
  public:
-  explicit GcsTable(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
+  explicit GcsTable(std::shared_ptr<StoreClient> &store_client)
       : store_client_(store_client) {}
 
   virtual ~GcsTable() = default;
@@ -93,7 +93,7 @@ class GcsTable {
 
  protected:
   std::string table_name_;
-  std::shared_ptr<StoreClient<Key, Data, JobID>> store_client_;
+  std::shared_ptr<StoreClient> store_client_;
 };
 
 /// \class GcsTableWithJobId
@@ -105,7 +105,7 @@ class GcsTable {
 template <typename Key, typename Data>
 class GcsTableWithJobId : public GcsTable<Key, Data> {
  public:
-  explicit GcsTableWithJobId(std::shared_ptr<StoreClient<Key, Data, JobID>> store_client)
+  explicit GcsTableWithJobId(std::shared_ptr<StoreClient> &store_client)
       : GcsTable<Key, Data>(store_client) {}
 
   /// Write data to the table asynchronously.
@@ -137,31 +137,27 @@ class GcsTableWithJobId : public GcsTable<Key, Data> {
 
 class GcsJobTable : public GcsTable<JobID, JobTableData> {
  public:
-  explicit GcsJobTable(
-      std::shared_ptr<StoreClient<JobID, JobTableData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsJobTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::JOB);
   }
 };
 
 class GcsActorTable : public GcsTableWithJobId<ActorID, ActorTableData> {
  public:
-  explicit GcsActorTable(
-      std::shared_ptr<StoreClient<ActorID, ActorTableData, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsActorTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR);
   }
 
  private:
-  JobID GetJobIdFromKey(const ActorID &key) { return key.JobId(); }
+  JobID GetJobIdFromKey(const ActorID &key) override { return key.JobId(); }
 };
 
 class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpointData> {
  public:
-  explicit GcsActorCheckpointTable(
-      std::shared_ptr<StoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>
-          store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsActorCheckpointTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT);
   }
 };
@@ -169,124 +165,112 @@ class GcsActorCheckpointTable : public GcsTable<ActorCheckpointID, ActorCheckpoi
 class GcsActorCheckpointIdTable
     : public GcsTableWithJobId<ActorID, ActorCheckpointIdData> {
  public:
-  explicit GcsActorCheckpointIdTable(
-      std::shared_ptr<StoreClient<ActorID, ActorCheckpointIdData, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsActorCheckpointIdTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ACTOR_CHECKPOINT_ID);
   }
 
  private:
-  JobID GetJobIdFromKey(const ActorID &key) { return key.JobId(); }
+  JobID GetJobIdFromKey(const ActorID &key) override { return key.JobId(); }
 };
 
 class GcsTaskTable : public GcsTableWithJobId<TaskID, TaskTableData> {
  public:
-  explicit GcsTaskTable(
-      std::shared_ptr<StoreClient<TaskID, TaskTableData, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsTaskTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
 };
 
 class GcsTaskLeaseTable : public GcsTableWithJobId<TaskID, TaskLeaseData> {
  public:
-  explicit GcsTaskLeaseTable(
-      std::shared_ptr<StoreClient<TaskID, TaskLeaseData, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsTaskLeaseTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_LEASE);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
 };
 
 class GcsTaskReconstructionTable
     : public GcsTableWithJobId<TaskID, TaskReconstructionData> {
  public:
-  explicit GcsTaskReconstructionTable(
-      std::shared_ptr<StoreClient<TaskID, TaskReconstructionData, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsTaskReconstructionTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::TASK_RECONSTRUCTION);
   }
 
  private:
-  JobID GetJobIdFromKey(const TaskID &key) { return key.ActorId().JobId(); }
+  JobID GetJobIdFromKey(const TaskID &key) override { return key.ActorId().JobId(); }
 };
 
 class GcsObjectTable : public GcsTableWithJobId<ObjectID, ObjectTableDataList> {
  public:
-  explicit GcsObjectTable(
-      std::shared_ptr<StoreClient<ObjectID, ObjectTableDataList, JobID>> store_client)
-      : GcsTableWithJobId(std::move(store_client)) {
+  explicit GcsObjectTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTableWithJobId(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::OBJECT);
   }
 
  private:
-  JobID GetJobIdFromKey(const ObjectID &key) { return key.TaskId().JobId(); }
+  JobID GetJobIdFromKey(const ObjectID &key) override { return key.TaskId().JobId(); }
 };
 
 class GcsNodeTable : public GcsTable<ClientID, GcsNodeInfo> {
  public:
-  explicit GcsNodeTable(
-      std::shared_ptr<StoreClient<ClientID, GcsNodeInfo, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsNodeTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::CLIENT);
   }
 };
 
 class GcsNodeResourceTable : public GcsTable<ClientID, ResourceMap> {
  public:
-  explicit GcsNodeResourceTable(
-      std::shared_ptr<StoreClient<ClientID, ResourceMap, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsNodeResourceTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::NODE_RESOURCE);
   }
 };
 
 class GcsHeartbeatTable : public GcsTable<ClientID, HeartbeatTableData> {
  public:
-  explicit GcsHeartbeatTable(
-      std::shared_ptr<StoreClient<ClientID, HeartbeatTableData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsHeartbeatTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT);
   }
 };
 
 class GcsHeartbeatBatchTable : public GcsTable<ClientID, HeartbeatBatchTableData> {
  public:
-  explicit GcsHeartbeatBatchTable(
-      std::shared_ptr<StoreClient<ClientID, HeartbeatBatchTableData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsHeartbeatBatchTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::HEARTBEAT_BATCH);
   }
 };
 
 class GcsErrorInfoTable : public GcsTable<JobID, ErrorTableData> {
  public:
-  explicit GcsErrorInfoTable(
-      std::shared_ptr<StoreClient<JobID, ErrorTableData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsErrorInfoTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::ERROR_INFO);
   }
 };
 
 class GcsProfileTable : public GcsTable<UniqueID, ProfileTableData> {
  public:
-  explicit GcsProfileTable(
-      std::shared_ptr<StoreClient<UniqueID, ProfileTableData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsProfileTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::PROFILE);
   }
 };
 
 class GcsWorkerFailureTable : public GcsTable<WorkerID, WorkerFailureData> {
  public:
-  explicit GcsWorkerFailureTable(
-      std::shared_ptr<StoreClient<WorkerID, WorkerFailureData, JobID>> store_client)
-      : GcsTable(std::move(store_client)) {
+  explicit GcsWorkerFailureTable(std::shared_ptr<StoreClient> &store_client)
+      : GcsTable(store_client) {
     table_name_ = TablePrefix_Name(TablePrefix::WORKER_FAILURE);
   }
 };
@@ -373,6 +357,7 @@ class GcsTableStorage {
   }
 
  protected:
+  std::shared_ptr<StoreClient> store_client_;
   std::unique_ptr<GcsJobTable> job_table_;
   std::unique_ptr<GcsActorTable> actor_table_;
   std::unique_ptr<GcsActorCheckpointTable> actor_checkpoint_table_;
@@ -396,45 +381,22 @@ class GcsTableStorage {
 class RedisGcsTableStorage : public GcsTableStorage {
  public:
   explicit RedisGcsTableStorage(std::shared_ptr<RedisClient> redis_client) {
-    job_table_.reset(new GcsJobTable(
-        std::make_shared<RedisStoreClient<JobID, JobTableData, JobID>>(redis_client)));
-    actor_table_.reset(new GcsActorTable(
-        std::make_shared<RedisStoreClient<ActorID, ActorTableData, JobID>>(
-            redis_client)));
-    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(
-        std::make_shared<RedisStoreClient<ActorCheckpointID, ActorCheckpointData, JobID>>(
-            redis_client)));
-    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(
-        std::make_shared<RedisStoreClient<ActorID, ActorCheckpointIdData, JobID>>(
-            redis_client)));
-    task_table_.reset(new GcsTaskTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskTableData, JobID>>(redis_client)));
-    task_lease_table_.reset(new GcsTaskLeaseTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskLeaseData, JobID>>(redis_client)));
-    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(
-        std::make_shared<RedisStoreClient<TaskID, TaskReconstructionData, JobID>>(
-            redis_client)));
-    object_table_.reset(new GcsObjectTable(
-        std::make_shared<RedisStoreClient<ObjectID, ObjectTableDataList, JobID>>(
-            redis_client)));
-    node_table_.reset(new GcsNodeTable(
-        std::make_shared<RedisStoreClient<ClientID, GcsNodeInfo, JobID>>(redis_client)));
-    node_resource_table_.reset(new GcsNodeResourceTable(
-        std::make_shared<RedisStoreClient<ClientID, ResourceMap, JobID>>(redis_client)));
-    heartbeat_table_.reset(new GcsHeartbeatTable(
-        std::make_shared<RedisStoreClient<ClientID, HeartbeatTableData, JobID>>(
-            redis_client)));
-    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(
-        std::make_shared<RedisStoreClient<ClientID, HeartbeatBatchTableData, JobID>>(
-            redis_client)));
-    error_info_table_.reset(new GcsErrorInfoTable(
-        std::make_shared<RedisStoreClient<JobID, ErrorTableData, JobID>>(redis_client)));
-    profile_table_.reset(new GcsProfileTable(
-        std::make_shared<RedisStoreClient<UniqueID, ProfileTableData, JobID>>(
-            redis_client)));
-    worker_failure_table_.reset(new GcsWorkerFailureTable(
-        std::make_shared<RedisStoreClient<WorkerID, WorkerFailureData, JobID>>(
-            redis_client)));
+    store_client_ = std::make_shared<RedisStoreClient>(redis_client);
+    job_table_.reset(new GcsJobTable(store_client_));
+    actor_table_.reset(new GcsActorTable(store_client_));
+    actor_checkpoint_table_.reset(new GcsActorCheckpointTable(store_client_));
+    actor_checkpoint_id_table_.reset(new GcsActorCheckpointIdTable(store_client_));
+    task_table_.reset(new GcsTaskTable(store_client_));
+    task_lease_table_.reset(new GcsTaskLeaseTable(store_client_));
+    task_reconstruction_table_.reset(new GcsTaskReconstructionTable(store_client_));
+    object_table_.reset(new GcsObjectTable(store_client_));
+    node_table_.reset(new GcsNodeTable(store_client_));
+    node_resource_table_.reset(new GcsNodeResourceTable(store_client_));
+    heartbeat_table_.reset(new GcsHeartbeatTable(store_client_));
+    heartbeat_batch_table_.reset(new GcsHeartbeatBatchTable(store_client_));
+    error_info_table_.reset(new GcsErrorInfoTable(store_client_));
+    profile_table_.reset(new GcsProfileTable(store_client_));
+    worker_failure_table_.reset(new GcsWorkerFailureTable(store_client_));
   }
 };
 

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -26,31 +26,29 @@ namespace ray {
 
 namespace gcs {
 
-template <typename Key, typename Data, typename IndexKey>
-class RedisStoreClient : public StoreClient<Key, Data, IndexKey> {
+class RedisStoreClient : public StoreClient {
  public:
   RedisStoreClient(std::shared_ptr<RedisClient> redis_client)
       : redis_client_(std::move(redis_client)) {}
 
-  virtual ~RedisStoreClient() {}
+  Status AsyncPut(const std::string &table_name, const std::string &key,
+                  const std::string &data, const StatusCallback &callback) override;
 
-  Status AsyncPut(const std::string &table_name, const Key &key, const Data &data,
-                  const StatusCallback &callback) override;
-
-  Status AsyncPutWithIndex(const std::string &table_name, const Key &key,
-                           const IndexKey &index_key, const Data &data,
+  Status AsyncPutWithIndex(const std::string &table_name, const std::string &key,
+                           const std::string &index_key, const std::string &data,
                            const StatusCallback &callback) override;
 
-  Status AsyncGet(const std::string &table_name, const Key &key,
-                  const OptionalItemCallback<Data> &callback) override;
+  Status AsyncGet(const std::string &table_name, const std::string &key,
+                  const OptionalItemCallback<std::string> &callback) override;
 
-  Status AsyncGetAll(const std::string &table_name,
-                     const SegmentedCallback<std::pair<Key, Data>> &callback) override;
+  Status AsyncGetAll(
+      const std::string &table_name,
+      const SegmentedCallback<std::pair<std::string, std::string>> &callback) override;
 
-  Status AsyncDelete(const std::string &table_name, const Key &key,
+  Status AsyncDelete(const std::string &table_name, const std::string &key,
                      const StatusCallback &callback) override;
 
-  Status AsyncDeleteByIndex(const std::string &table_name, const IndexKey &index_key,
+  Status AsyncDeleteByIndex(const std::string &table_name, const std::string &index_key,
                             const StatusCallback &callback) override;
 
  private:
@@ -59,8 +57,6 @@ class RedisStoreClient : public StoreClient<Key, Data, IndexKey> {
 
   std::shared_ptr<RedisClient> redis_client_;
 };
-
-typedef RedisStoreClient<ActorID, rpc::ActorTableData, JobID> RedisActorStoreTable;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -30,10 +30,9 @@ namespace gcs {
 
 /// \class StoreClient
 /// Abstract interface of the storage client.
-template <typename Key, typename Data, typename IndexKey>
 class StoreClient {
  public:
-  virtual ~StoreClient() {}
+  virtual ~StoreClient() = default;
 
   /// Write data to the given table asynchronously.
   ///
@@ -42,8 +41,8 @@ class StoreClient {
   /// \param data The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  virtual Status AsyncPut(const std::string &table_name, const Key &key, const Data &data,
-                          const StatusCallback &callback) = 0;
+  virtual Status AsyncPut(const std::string &table_name, const std::string &key,
+                          const std::string &data, const StatusCallback &callback) = 0;
 
   /// Write data to the given table asynchronously.
   ///
@@ -53,8 +52,8 @@ class StoreClient {
   /// \param data The value of the key that will be written to the table.
   /// \param callback Callback that will be called after write finishes.
   /// \return Status
-  virtual Status AsyncPutWithIndex(const std::string &table_name, const Key &key,
-                                   const IndexKey &index_key, const Data &data,
+  virtual Status AsyncPutWithIndex(const std::string &table_name, const std::string &key,
+                                   const std::string &index_key, const std::string &data,
                                    const StatusCallback &callback) = 0;
 
   /// Get data from the given table asynchronously.
@@ -63,8 +62,8 @@ class StoreClient {
   /// \param key The key to lookup from the table.
   /// \param callback Callback that will be called after read finishes.
   /// \return Status
-  virtual Status AsyncGet(const std::string &table_name, const Key &key,
-                          const OptionalItemCallback<Data> &callback) = 0;
+  virtual Status AsyncGet(const std::string &table_name, const std::string &key,
+                          const OptionalItemCallback<std::string> &callback) = 0;
 
   /// Get all data from the given table asynchronously.
   ///
@@ -72,8 +71,9 @@ class StoreClient {
   /// \param callback Callback that will be called after data has been received.
   /// If the callback return `has_more == true` mean there's more data to be received.
   /// \return Status
-  virtual Status AsyncGetAll(const std::string &table_name,
-                             const SegmentedCallback<std::pair<Key, Data>> &callback) = 0;
+  virtual Status AsyncGetAll(
+      const std::string &table_name,
+      const SegmentedCallback<std::pair<std::string, std::string>> &callback) = 0;
 
   /// Delete data from the given table asynchronously.
   ///
@@ -81,7 +81,7 @@ class StoreClient {
   /// \param key The key that will be deleted from the table.
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
-  virtual Status AsyncDelete(const std::string &table_name, const Key &key,
+  virtual Status AsyncDelete(const std::string &table_name, const std::string &key,
                              const StatusCallback &callback) = 0;
 
   /// Delete by index from the given table asynchronously.
@@ -92,14 +92,12 @@ class StoreClient {
   /// \param callback Callback that will be called after delete finishes.
   /// \return Status
   virtual Status AsyncDeleteByIndex(const std::string &table_name,
-                                    const IndexKey &index_key,
+                                    const std::string &index_key,
                                     const StatusCallback &callback) = 0;
 
  protected:
   StoreClient() = default;
 };
-
-typedef StoreClient<ActorID, rpc::ActorTableData, JobID> ActorStoreTable;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -94,7 +94,7 @@ class StoreClientTestBase : public RedisServiceManagerForTest {
   size_t io_service_num_{2};
   std::shared_ptr<IOServicePool> io_service_pool_;
 
-  std::shared_ptr<StoreClient<ActorID, rpc::ActorTableData, JobID>> store_client_;
+  std::shared_ptr<StoreClient> store_client_;
 
   std::string table_name_{"test_table"};
   size_t key_count_{5000};


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Now store client has class template parameters, one store client can only be used by one gcs table. Different store client needs to implement key / value serialization and deserialization code.
So we remove class template parameters from store client and implement key / value serialization and deserialization code in gcs table storage.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
