### PR TITLE
[autoscaler] Azure versioning

### DIFF
--- a/python/ray/autoscaler/azure/azure-config-template.json
+++ b/python/ray/autoscaler/azure/azure-config-template.json
@@ -71,11 +71,17 @@
                     {
                         "name": "ray-subnet",
                         "properties": {
-                            "addressPrefix": "[parameters('subnet')]"
+                            "addressPrefix": "[parameters('subnet')]",
+                            "networkSecurityGroup": {
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups','ray-nsg')]"
+                              }
                         }
                     }
                 ]
-            }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'ray-nsg')]"
+            ]
         }
     ]
 }

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -114,7 +114,7 @@ setup_commands:
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:
-    - pip install azure-cli-core azure-core azure-mgmt-authorization azure-mgmt-network azure-mgmt-compute azure-mgmt-msi
+    - pip install azure-cli-core==2.4.0 azure-mgmt-compute==12.0.0 azure-mgmt-msi==1.0.0 azure-mgmt-network==10.1.0
 
 # Custom commands that will be run on worker nodes after common setup.
 worker_setup_commands: []

--- a/python/ray/autoscaler/azure/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/azure/example-gpu-docker.yaml
@@ -84,7 +84,7 @@ setup_commands:
  
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:
-    - pip install azure-cli-core azure-core azure-mgmt-authorization azure-mgmt-compute azure-mgmt-msi azure-mgmt-network
+    - pip install azure-cli-core==2.4.0 azure-mgmt-compute==12.0.0 azure-mgmt-msi==1.0.0 azure-mgmt-network==10.1.0
 
 # Custom commands that will be run on worker nodes after common setup.
 worker_setup_commands: []

--- a/python/ray/autoscaler/azure/example-gpu.yaml
+++ b/python/ray/autoscaler/azure/example-gpu.yaml
@@ -116,7 +116,7 @@ setup_commands:
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands: 
-    - pip install azure-cli-core azure-core azure-mgmt-authorization azure-mgmt-network azure-mgmt-compute azure-mgmt-msi
+    - pip install azure-cli-core==2.4.0 azure-mgmt-compute==12.0.0 azure-mgmt-msi==1.0.0 azure-mgmt-network==10.1.0
 
 # Custom commands that will be run on worker nodes after common setup.
 worker_setup_commands: []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Azure autoscaler broke with latest azure sdk version. This fixes the version of azure sdk used by the head node and corrects a minor detail linking the network security group to the subnet at configuration.

## Related issue number

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
   - [X] Local deployment tests =)