### PR TITLE
[serve] Add basic test for specifying the method in a serve call

### DIFF
--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -40,6 +40,23 @@ def test_e2e(serve_instance):
     assert resp == "POST"
 
 
+def test_call_method(serve_instance):
+    serve.create_endpoint("call-method", "/call-method")
+
+    class CallMethod:
+        def method(self, request):
+            return "hello"
+
+    serve.create_backend(CallMethod, "call-method")
+    serve.set_traffic("call-method", {"call-method": 1.0})
+
+    resp = requests.get(
+        "http://127.0.0.1:8000/call-method",
+        timeout=1,
+        headers={"X-SERVE-CALL-METHOD": "method"})
+    assert resp.text == "hello"
+
+
 def test_no_route(serve_instance):
     serve.create_endpoint("noroute-endpoint")
 

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -50,11 +50,16 @@ def test_call_method(serve_instance):
     serve.create_backend(CallMethod, "call-method")
     serve.set_traffic("call-method", {"call-method": 1.0})
 
+    # Test HTTP path.
     resp = requests.get(
         "http://127.0.0.1:8000/call-method",
         timeout=1,
         headers={"X-SERVE-CALL-METHOD": "method"})
     assert resp.text == "hello"
+
+    # Test serve handle path.
+    handle = serve.get_handle("call-method")
+    assert ray.get(handle.options("method").remote()) == "hello"
 
 
 def test_no_route(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Adds a simple test for specifying the serve caller method.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
