### PR TITLE
[tune] Safer try-catch for TensorboardX

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -186,7 +186,8 @@ class TBXLogger(Logger):
         {"a": {"b": 1, "c": 2}} -> {"a/b": 1, "a/c": 2}
     """
 
-    VALID_HPARAMS = (str, bool, int, float, list, None)
+    # NoneType is not supported on the last TBX release yet.
+    VALID_HPARAMS = (str, bool, int, float, list)
 
     def _init(self):
         try:
@@ -255,17 +256,19 @@ class TBXLogger(Logger):
         flat_params = flatten_dict(self.trial.evaluated_params)
         scrubbed_params = {
             k: v
-            for k, v in flat_params.items() if isinstance(v, VALID_SUMMARY_TYPES)
+            for k, v in flat_params.items()
+            if isinstance(v, self.VALID_HPARAMS)
         }
 
         removed = {
             k: v
             for k, v in flat_params.items()
-            if not isinstance(v, VALID_SUMMARY_TYPES)
+            if not isinstance(v, self.VALID_HPARAMS)
         }
-        logger.info(
-            "Removed the following hyperparameter values when "
-            "logging to tensorboard: %s", str(removed))
+        if removed:
+            logger.info(
+                "Removed the following hyperparameter values when "
+                "logging to tensorboard: %s", str(removed))
 
         from tensorboardX.summary import hparams
         try:

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -255,9 +255,18 @@ class TBXLogger(Logger):
         flat_params = flatten_dict(self.trial.evaluated_params)
         scrubbed_params = {
             k: v
-            for k, v in flat_params.items()
-            if type(v) in VALID_SUMMARY_TYPES
+            for k, v in flat_params.items() if type(v) in VALID_SUMMARY_TYPES
         }
+
+        removed = {
+            k: v
+            for k, v in flat_params.items()
+            if type(v) not in VALID_SUMMARY_TYPES
+        }
+        logger.info(
+            "Removed the following hyperparameter values when "
+            "logging to tensorboard: %s", str(removed))
+
         from tensorboardX.summary import hparams
         try:
             experiment_tag, session_start_tag, session_end_tag = hparams(

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -186,7 +186,7 @@ class TBXLogger(Logger):
         {"a": {"b": 1, "c": 2}} -> {"a/b": 1, "a/c": 2}
     """
 
-    VALID_HPARAMS = {str, bool, int, float, None}
+    VALID_HPARAMS = (str, bool, int, float, list, None)
 
     def _init(self):
         try:
@@ -255,13 +255,13 @@ class TBXLogger(Logger):
         flat_params = flatten_dict(self.trial.evaluated_params)
         scrubbed_params = {
             k: v
-            for k, v in flat_params.items() if type(v) in VALID_SUMMARY_TYPES
+            for k, v in flat_params.items() if isinstance(v, VALID_SUMMARY_TYPES)
         }
 
         removed = {
             k: v
             for k, v in flat_params.items()
-            if type(v) not in VALID_SUMMARY_TYPES
+            if not isinstance(v, VALID_SUMMARY_TYPES)
         }
         logger.info(
             "Removed the following hyperparameter values when "

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -46,13 +46,32 @@ class LoggerSuite(unittest.TestCase):
         logger.close()
 
     def testTBX(self):
-        config = {"a": 2, "b": 5, "c": {"c": {"D": 123}, "e": None}}
+        config = {"a": 2, "b": [1, 2], "c": {"c": {"D": 123}}}
         t = Trial(evaluated_params=config, trial_id="tbx")
         logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)
         logger.on_result(result(0, 4))
         logger.on_result(result(1, 4))
         logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
         logger.close()
+
+    def testBadTBX(self):
+        config = {"b": (1, 2, 3)}
+        t = Trial(evaluated_params=config, trial_id="tbx")
+        logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)
+        logger.on_result(result(0, 4))
+        logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
+        with self.assertLogs("ray.tune.logger", level="INFO") as cm:
+            logger.close()
+        assert "INFO" in cm.output[0]
+
+        config = {"None": None}
+        t = Trial(evaluated_params=config, trial_id="tbx")
+        logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)
+        logger.on_result(result(0, 4))
+        logger.on_result(result(2, 4, score=[1, 2, 3], hello={"world": 1}))
+        with self.assertLogs("ray.tune.logger", level="INFO") as cm:
+            logger.close()
+        assert "INFO" in cm.output[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
TensorboardX doesn't support many types for its logger.

This prevents the user 'error'.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)