### PR TITLE
[Asyncio] Remove async init legacy code

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1142,8 +1142,8 @@ cdef class CoreWorker:
             asyncio.set_event_loop(self.async_event_loop)
             # Initialize the async plasma connection.
             # Delayed import due to async_api depends on _raylet.
-            from ray.experimental.async_api import _async_init
-            self.async_event_loop.run_until_complete(_async_init())
+            from ray.experimental.async_api import init as plasma_async_init
+            plasma_async_init()
 
             # Create and attach the monitor object
             monitor_state = AsyncMonitorState(self.async_event_loop)

--- a/python/ray/experimental/async_api.py
+++ b/python/ray/experimental/async_api.py
@@ -1,7 +1,4 @@
-# Note: asyncio is only compatible with Python 3
-
 import asyncio
-import threading
 
 import ray
 from ray.experimental.async_plasma import PlasmaEventHandler
@@ -10,7 +7,10 @@ from ray.services import logger
 handler = None
 
 
-async def _async_init():
+def init():
+    """Initialize plasma event handlers for asyncio support."""
+    assert ray.is_initialized(), "Please call ray.init before async_api.init"
+
     global handler
     if handler is None:
         worker = ray.worker.global_worker
@@ -18,31 +18,6 @@ async def _async_init():
         handler = PlasmaEventHandler(loop, worker)
         worker.core_worker.set_plasma_added_callback(handler)
         logger.debug("AsyncPlasma Connection Created!")
-
-
-def init():
-    """
-    Initialize synchronously.
-    """
-    assert ray.is_initialized(), "Please call ray.init before async_api.init"
-
-    # Noop when handler is set.
-    if handler is not None:
-        return
-
-    loop = asyncio.get_event_loop()
-    if loop.is_running():
-        if loop._thread_id != threading.get_ident():
-            # If the loop is runing outside current thread, we actually need
-            # to do this to make sure the context is initialized.
-            asyncio.run_coroutine_threadsafe(_async_init(), loop=loop)
-        else:
-            async_init_done = asyncio.get_event_loop().create_task(
-                _async_init())
-            # Block until the async init finishes.
-            async_init_done.done()
-    else:
-        asyncio.get_event_loop().run_until_complete(_async_init())
 
 
 def as_future(object_id):

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -113,8 +113,8 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
     loop.set_debug(True)
 
     # This is needed for async plasma
-    from ray.experimental.async_api import _async_init
-    await _async_init()
+    from ray.experimental.async_api import init
+    init()
 
     # Test Async Plasma
     @ray.remote


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The asyncio init code was no longer necessary since we do majority of the processing in core worker now. So the init method will just need to register with core worker. There is no need to run it in async context.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #8176

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
