### PR TITLE
[docs] Comments on potential srun orders during Slurm Deployment

### DIFF
--- a/doc/source/deploying-on-slurm.rst
+++ b/doc/source/deploying-on-slurm.rst
@@ -32,11 +32,15 @@ Clusters managed by Slurm may require that Ray is initialized as a part of the s
 
   srun --nodes=1 --ntasks=1 -w $node1 ray start --block --head --redis-port=6379 --redis-password=$redis_password & # Starting the head
   sleep 5
+  # Make sure the head successfully starts before any worker does, otherwise
+  # the worker will not be able to connect to redis. In case of longer delay, 
+  # adjust the sleeptime above to ensure proper order.
 
   for ((  i=1; i<=$worker_num; i++ ))
   do
     node2=${nodes_array[$i]}
     srun --nodes=1 --ntasks=1 -w $node2 ray start --block --address=$ip_head --redis-password=$redis_password & # Starting the workers
+    # Flag --block will keep ray process alive on each compute node.
     sleep 5
   done
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

I have been testing Ray deployment with Slurm on NERSC Cori. I realized that when some requested nodes are busy, or random delay happens between `srun` jobs, the head and worker might start out of order. If a worker starts sooner than the head, it will throw RuntimeError.

I think it's also helpful to mention the purpose of --block.

## Related issue number
Follow up for #8181 @rkooo567 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (only comments change in the documentation)
