### PR TITLE
[Doc] Fix Docstring for Task Cancellation

### DIFF
--- a/doc/source/package-ref.rst
+++ b/doc/source/package-ref.rst
@@ -15,6 +15,8 @@ Ray Package Reference
 
 .. autofunction:: ray.kill
 
+.. autofunction:: ray.cancel
+
 .. autofunction:: ray.get_gpu_ids
 
 .. autofunction:: ray.get_resource_ids

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1682,7 +1682,7 @@ def kill(actor):
 
 
 def cancel(object_id, force=False):
-    """Cancels a locally-submitted task according to the following pseudocode.
+    """Cancels a locally-submitted task according to the following conditions.
 
     If the specified task is pending execution, it will not be executed. If
     the task is currently executing, the behavior depends on the `force` flag.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1699,9 +1699,9 @@ def cancel(object_id, force=False):
 
     Args:
         task_object_id (ObjectID): ObjectID returned by the task
-                                    that should be canceled.
+                                   that should be canceled.
         force (boolean): Whether to force-kill a running task by killing
-                        the worker that is running the task.
+                         the worker that is running the task.
     Raises:
         ValueError: This is also raised for actor tasks, already completed
                     tasks, and non-locally submitted tasks.

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1692,15 +1692,19 @@ def cancel(object_id, force=False):
         force=True
             The worker executing the task will immediately exit.
     Task is FINISHED executing:
-        Nothing happens. 
+        Nothing happens.
 
-    Only non-actor tasks can be canceled. Canceled tasks will not be retried (max_retries will not be respected). 
+    Only non-actor tasks can be canceled. Canceled tasks will not be
+    retried (max_retries will not be respected).
 
     Args:
-            task_object_id (ObjectID): ObjectID returned by the task that should be canceled. 
-            force (boolean): Whether to force-kill a running task by killing the worker that is running the task. 
-    Raises: 
-            ValueError: This is also raised for actor tasks, already completed tasks, and non-locally submitted tasks.
+            task_object_id (ObjectID): ObjectID returned by the task
+                                        that should be canceled.
+            force (boolean): Whether to force-kill a running task by
+                            killing the worker that is running the task.
+    Raises:
+            ValueError: This is also raised for actor tasks, already
+                        completed tasks, and non-locally submitted tasks.
     """
     worker = ray.worker.global_worker
     worker.check_connected()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1685,7 +1685,7 @@ def cancel(object_id, force=False):
     """Cancels a locally-submitted task according to the following pseudocode.
 
     Task is PENDING execution:
-        Pending task is canceled.
+        Task is not executed.
     Task is CURRENTLY executing:
         force=False:
             KeyboardInterrupt will be raised in Python.
@@ -1697,14 +1697,16 @@ def cancel(object_id, force=False):
     Only non-actor tasks can be canceled. Canceled tasks will not be
     retried (max_retries will not be respected).
 
+    Calling ray.get on a canceled task will raise a RayCancellationError.
+
     Args:
-        task_object_id (ObjectID): ObjectID returned by the task
-                                   that should be canceled.
+        object_id (ObjectID): ObjectID returned by the task
+            that should be canceled.
         force (boolean): Whether to force-kill a running task by killing
-                         the worker that is running the task.
+            the worker that is running the task.
     Raises:
         ValueError: This is also raised for actor tasks, already completed
-                    tasks, and non-locally submitted tasks.
+            tasks, and non-locally submitted tasks.
     """
     worker = ray.worker.global_worker
     worker.check_connected()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1685,10 +1685,10 @@ def cancel(object_id, force=False):
     """Cancels a locally-submitted task according to the following conditions.
 
     If the specified task is pending execution, it will not be executed. If
-    the task is currently executing, the behavior depends on the ``force`` flag.
-    When ``force=False``, a KeyboardInterrupt will be raised in Python and when
-    ``force=True``, the executing the task will immediately exit. If the task is
-    already finished, nothing will happen.
+    the task is currently executing, the behavior depends on the ``force``
+    flag. When ``force=False``, a KeyboardInterrupt will be raised in Python
+    and when ``force=True``, the executing the task will immediately exit. If
+    the task is already finished, nothing will happen.
 
     Only non-actor tasks can be canceled. Canceled tasks will not be
     retried (max_retries will not be respected).

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1698,13 +1698,13 @@ def cancel(object_id, force=False):
     retried (max_retries will not be respected).
 
     Args:
-            task_object_id (ObjectID): ObjectID returned by the task
-                                        that should be canceled.
-            force (boolean): Whether to force-kill a running task by
-                            killing the worker that is running the task.
+        task_object_id (ObjectID): ObjectID returned by the task
+                                    that should be canceled.
+        force (boolean): Whether to force-kill a running task by killing
+                        the worker that is running the task.
     Raises:
-            ValueError: This is also raised for actor tasks, already
-                        completed tasks, and non-locally submitted tasks.
+        ValueError: This is also raised for actor tasks, already completed
+                    tasks, and non-locally submitted tasks.
     """
     worker = ray.worker.global_worker
     worker.check_connected()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1685,9 +1685,9 @@ def cancel(object_id, force=False):
     """Cancels a locally-submitted task according to the following conditions.
 
     If the specified task is pending execution, it will not be executed. If
-    the task is currently executing, the behavior depends on the `force` flag.
-    When `force=False`, a KeyboardInterrupt will be raised in Python and when
-    `force=True`, the executing the task will immediately exit. If the task is
+    the task is currently executing, the behavior depends on the ``force`` flag.
+    When ``force=False``, a KeyboardInterrupt will be raised in Python and when
+    ``force=True``, the executing the task will immediately exit. If the task is
     already finished, nothing will happen.
 
     Only non-actor tasks can be canceled. Canceled tasks will not be

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1682,16 +1682,25 @@ def kill(actor):
 
 
 def cancel(object_id, force=False):
-    """Kill a task forcefully.
+    """Cancels a locally-submitted task according to the following pseudocode.
 
-    This will interrupt any running tasks on the actor, causing them to fail
-    immediately. Any atexit handlers installed in the actor will still be run.
+    Task is PENDING execution:
+        Pending task is canceled.
+    Task is CURRENTLY executing:
+        force=False:
+            KeyboardInterrupt will be raised in Python.
+        force=True
+            The worker executing the task will immediately exit.
+    Task is FINISHED executing:
+        Nothing happens. 
 
-    If this actor is reconstructable, it will be attempted to be reconstructed.
+    Only non-actor tasks can be canceled. Canceled tasks will not be retried (max_retries will not be respected). 
 
     Args:
-        id (ActorHandle or ObjectID): Handle for the actor to kill or ObjectID
-            of the task to kill.
+            task_object_id (ObjectID): ObjectID returned by the task that should be canceled. 
+            force (boolean): Whether to force-kill a running task by killing the worker that is running the task. 
+    Raises: 
+            ValueError: This is also raised for actor tasks, already completed tasks, and non-locally submitted tasks.
     """
     worker = ray.worker.global_worker
     worker.check_connected()

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1684,15 +1684,11 @@ def kill(actor):
 def cancel(object_id, force=False):
     """Cancels a locally-submitted task according to the following pseudocode.
 
-    Task is PENDING execution:
-        Task is not executed.
-    Task is CURRENTLY executing:
-        force=False:
-            KeyboardInterrupt will be raised in Python.
-        force=True
-            The worker executing the task will immediately exit.
-    Task is FINISHED executing:
-        Nothing happens.
+    If the specified task is pending execution, it will not be executed. If
+    the task is currently executing, the behavior depends on the `force` flag.
+    When `force=False`, a KeyboardInterrupt will be raised in Python and when
+    `force=True`, the executing the task will immediately exit. If the task is
+    already finished, nothing will happen.
 
     Only non-actor tasks can be canceled. Canceled tasks will not be
     retried (max_retries will not be respected).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fixing Documentation for `ray.cancel`. This PR adds the most up-to-date documentation for the feature. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
