### PR TITLE
ray.objects() should only return objects created by local driver

### DIFF
--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -12,7 +12,7 @@ from ray import (
 )
 
 from ray.utils import (decode, binary_to_hex, hex_to_binary,
-                       compute_job_id_from_driver, extrace_job_id_from_object)
+                       compute_job_id_from_driver, extract_job_id_from_object)
 
 from ray._raylet import GlobalStateAccessor
 
@@ -292,8 +292,11 @@ class GlobalState:
                 object_location_info = gcs_utils.ObjectLocationInfo.FromString(
                     object_table[i])
                 object_id = binary_to_hex(object_location_info.object_id)
-                if job_id == extrace_job_id_from_object(object_id).hex():
-                    results[object_id] = self._gen_object_info(object_location_info)
+                object_job_id = extract_job_id_from_object(
+                    object_location_info.object_id)
+                if job_id == object_job_id.hex():
+                    results[object_id] = self._gen_object_info(
+                        object_location_info)
             return results
 
     def _gen_object_info(self, object_location_info):

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -128,6 +128,9 @@ def test_global_state_api(shutdown_only):
 
     assert ray.objects() == {}
 
+    ray.put(1)
+    assert len(ray.objects()) == 1
+
     job_id = ray.utils.compute_job_id_from_driver(
         ray.WorkerID(ray.worker.global_worker.worker_id))
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -266,6 +266,12 @@ def compute_driver_id_from_job(job_id):
     return ray.WorkerID(driver_id_str)
 
 
+def extrace_job_id_from_object(object_id):
+    assert isinstance(object_id, ray.ObjectID)
+    job_id_str = object_id.binary()[12:12 + ray.JobID.size()]
+    return ray.JobID(job_id_str)
+
+
 def get_cuda_visible_devices():
     """Get the device IDs in the CUDA_VISIBLE_DEVICES environment variable.
 

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -266,8 +266,8 @@ def compute_driver_id_from_job(job_id):
     return ray.WorkerID(driver_id_str)
 
 
-def extrace_job_id_from_object(object_id):
-    assert isinstance(object_id, ray.ObjectID)
+def extract_job_id_from_object(object_id_str):
+    object_id = binary_to_object_id(object_id_str)
     job_id_str = object_id.binary()[12:12 + ray.JobID.size()]
     return ray.JobID(job_id_str)
 


### PR DESCRIPTION
## Why are these changes needed?

Return only the objects created by local driver since ray.objects() are not meant to communicate with plasma store.

## Related issue number

Closes: #7904 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Already exist unit tests 
