### PR TITLE
[core] Enabling Remote Task Cancelation

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1683,7 +1683,7 @@ def kill(actor):
 
 
 def cancel(object_id, force=False):
-    """Cancels a locally-submitted task according to the following conditions.
+    """Cancels a task according to the following conditions.
 
     If the specified task is pending execution, it will not be executed. If
     the task is currently executing, the behavior depends on the ``force``
@@ -1702,8 +1702,7 @@ def cancel(object_id, force=False):
         force (boolean): Whether to force-kill a running task by killing
             the worker that is running the task.
     Raises:
-        ValueError: This is also raised for actor tasks, already completed
-            tasks, and non-locally submitted tasks.
+        TypeError: This is also raised for actor tasks.
     """
     worker = ray.worker.global_worker
     worker.check_connected()

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1218,7 +1218,7 @@ Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {
   }
   rpc::Address obj_addr;
   if (!reference_counter_->GetOwner(object_id, nullptr, &obj_addr)) {
-    return Status::Invalid("No owner for object");
+    return Status::Invalid("No owner found for object.");
   }
   if (obj_addr.SerializeAsString() != rpc_address_.SerializeAsString()) {
     return direct_task_submitter_->CancelRemoteTask(object_id, obj_addr, force_kill);
@@ -1770,7 +1770,7 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
   // that we own. In this case, we just go through the normal CancelTask procedure.
   if (!request.remote_object_id().empty()) {
     auto status = CancelTask(ObjectID::FromBinary(request.remote_object_id()),
-                          request.force_kill()));
+                             request.force_kill());
     send_reply_callback(status, nullptr, nullptr);
     return;
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1766,8 +1766,8 @@ void CoreWorker::HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest &re
 void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
                                   rpc::CancelTaskReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) {
-  // If remote_object_id is specified, this is a remote cancellation request for an object that we own. In this case, we just
-  // go through the normal CancelTask procedure.
+  // If remote_object_id is specified, this is a remote cancellation request for an object
+  // that we own. In this case, we just go through the normal CancelTask procedure.
   if (!request.remote_object_id().empty()) {
     auto status = CancelTask(ObjectID::FromBinary(request.remote_object_id()),
                           request.force_kill()));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1766,7 +1766,8 @@ void CoreWorker::HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest &re
 void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
                                   rpc::CancelTaskReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) {
-  // Handle remote cancelation requests.
+  // If remote_object_id is specified, this is a remote cancellation request for an object that we own. In this case, we just
+  // go through the normal CancelTask procedure.
   if (!request.remote_object_id().empty()) {
     RAY_UNUSED(CancelTask(ObjectID::FromBinary(request.remote_object_id()),
                           request.force_kill()));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1218,7 +1218,7 @@ Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {
   }
   rpc::Address obj_addr;
   if (!reference_counter_->GetOwner(object_id, nullptr, &obj_addr)) {
-    RAY_LOG(ERROR) << "No owner for object";
+    return Status::Invalid("No owner for object");
   }
   if (obj_addr.SerializeAsString() != rpc_address_.SerializeAsString()) {
     return direct_task_submitter_->CancelRemoteTask(object_id, obj_addr, force_kill);
@@ -1768,9 +1768,9 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
                                   rpc::SendReplyCallback send_reply_callback) {
   // Handle remote cancelation requests.
   if (!request.remote_object_id().empty()) {
-    RAY_UNUSED(CancelTask(ObjectID::FromBinary(request.remote_object_id()),
+    auto status = CancelTask(ObjectID::FromBinary(request.remote_object_id()),
                           request.force_kill()));
-    send_reply_callback(Status::OK(), nullptr, nullptr);
+    send_reply_callback(status, nullptr, nullptr);
     return;
   }
   absl::MutexLock lock(&mutex_);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1763,17 +1763,17 @@ void CoreWorker::HandleWaitForRefRemoved(const rpc::WaitForRefRemovedRequest &re
                                             owner_address, ref_removed_callback);
 }
 
+void CoreWorker::HandleRemoteCancelTask(const rpc::RemoteCancelTaskRequest &request,
+                                        rpc::RemoteCancelTaskReply *reply,
+                                        rpc::SendReplyCallback send_reply_callback) {
+  auto status =
+      CancelTask(ObjectID::FromBinary(request.remote_object_id()), request.force_kill());
+  send_reply_callback(status, nullptr, nullptr);
+}
+
 void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
                                   rpc::CancelTaskReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) {
-  // If remote_object_id is specified, this is a remote cancellation request for an object
-  // that we own. In this case, we just go through the normal CancelTask procedure.
-  if (!request.remote_object_id().empty()) {
-    auto status = CancelTask(ObjectID::FromBinary(request.remote_object_id()),
-                             request.force_kill());
-    send_reply_callback(status, nullptr, nullptr);
-    return;
-  }
   absl::MutexLock lock(&mutex_);
   TaskID task_id = TaskID::FromBinary(request.intended_task_id());
   bool success = main_thread_task_id_ == task_id;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -708,6 +708,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                         rpc::SendReplyCallback send_reply_callback) override;
 
   /// Implements gRPC server handler.
+  void HandleRemoteCancelTask(const rpc::RemoteCancelTaskRequest &request,
+                              rpc::RemoteCancelTaskReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override;
+
+  /// Implements gRPC server handler.
   void HandlePlasmaObjectReady(const rpc::PlasmaObjectReadyRequest &request,
                                rpc::PlasmaObjectReadyReply *reply,
                                rpc::SendReplyCallback send_reply_callback) override;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -376,10 +376,10 @@ Status CoreWorkerDirectTaskSubmitter::CancelRemoteTask(const ObjectID &object_id
   if (client == client_cache_.end()) {
     return Status::Invalid("No remote worker found");
   }
-  auto request = rpc::CancelTaskRequest();
+  auto request = rpc::RemoteCancelTaskRequest();
   request.set_force_kill(force_kill);
   request.set_remote_object_id(object_id.Binary());
-  return client->second->CancelTask(request, nullptr);
+  return client->second->RemoteCancelTask(request, nullptr);
 }
 
 };  // namespace ray

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -367,4 +367,19 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
       }));
   return Status::OK();
 }
+
+Status CoreWorkerDirectTaskSubmitter::CancelRemoteTask(const ObjectID &object_id,
+                                                       const rpc::Address &worker_addr,
+                                                       bool force_kill) {
+  absl::MutexLock lock(&mu_);
+  auto client = client_cache_.find(rpc::WorkerAddress(worker_addr));
+  if (client == client_cache_.end()) {
+    return Status::Invalid("No remote worker found");
+  }
+  auto request = rpc::CancelTaskRequest();
+  request.set_force_kill(force_kill);
+  request.set_remote_object_id(object_id.Binary());
+  return client->second->CancelTask(request, nullptr);
+}
+
 };  // namespace ray

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -80,6 +80,9 @@ class CoreWorkerDirectTaskSubmitter {
   /// \param[in] force_kill Whether to kill the worker executing the task.
   Status CancelTask(TaskSpecification task_spec, bool force_kill);
 
+  Status CancelRemoteTask(const ObjectID &object_id, const rpc::Address &worker_addr,
+                          bool force_kill);
+
  private:
   /// Schedule more work onto an idle worker or return it back to the raylet if
   /// no more tasks are queued for submission. If an error was encountered

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -190,7 +190,7 @@ message CancelTaskRequest {
   bytes intended_task_id = 1;
   // Whether to kill the worker.
   bool force_kill = 2;
-  // Return Object ID of the remote task that should be killed.
+  // Object ID of the remote task that should be killed.
   bytes remote_object_id = 3;
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -18,7 +18,9 @@ package ray.rpc;
 
 import "src/ray/protobuf/common.proto";
 
-message ActiveObjectIDs { repeated bytes object_ids = 1; }
+message ActiveObjectIDs {
+  repeated bytes object_ids = 1;
+}
 
 // Persistent state of an ActorHandle.
 message ActorHandle {
@@ -65,7 +67,8 @@ message AssignTaskRequest {
   bytes resource_ids = 3;
 }
 
-message AssignTaskReply {}
+message AssignTaskReply {
+}
 
 message ReturnObject {
   // Object ID.
@@ -143,7 +146,8 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {}
+message DirectActorCallArgWaitCompleteReply {
+}
 
 message GetObjectStatusRequest {
   // The owner of the object. Note that we do not need to include
@@ -166,7 +170,8 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {}
+message WaitForObjectEvictionReply {
+}
 
 message KillActorRequest {
   // ID of the actor that is intended to be killed.
@@ -177,7 +182,8 @@ message KillActorRequest {
   bool no_reconstruction = 3;
 }
 
-message KillActorReply {}
+message KillActorReply {
+}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
@@ -198,7 +204,8 @@ message RemoteCancelTaskRequest {
   bool force_kill = 2;
 }
 
-message RemoteCancelTaskReply {}
+message RemoteCancelTaskReply {
+}
 
 message GetCoreWorkerStatsRequest {
   // The ID of the worker this message is intended for.
@@ -266,9 +273,11 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {}
+message LocalGCRequest {
+}
 
-message LocalGCReply {}
+message LocalGCReply {
+}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
@@ -276,7 +285,8 @@ message PlasmaObjectReadyRequest {
   int64 metadata_size = 3;
 }
 
-message PlasmaObjectReadyReply {}
+message PlasmaObjectReadyReply {
+}
 
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
@@ -299,14 +309,11 @@ service CoreWorkerService {
   // Request for a worker to issue a cancelation.
   rpc RemoteCancelTask(RemoteCancelTaskRequest) returns (RemoteCancelTaskReply);
   // Get metrics from core workers.
-  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest)
-      returns (GetCoreWorkerStatsReply);
+  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
   // Wait for a borrower to finish using an object. Sent by the object's owner.
-  rpc WaitForRefRemoved(WaitForRefRemovedRequest)
-      returns (WaitForRefRemovedReply);
+  rpc WaitForRefRemoved(WaitForRefRemovedRequest) returns (WaitForRefRemovedReply);
   // Trigger local GC on the worker.
   rpc LocalGC(LocalGCRequest) returns (LocalGCReply);
   // Notification from raylet that an object ID is available in local plasma.
-  rpc PlasmaObjectReady(PlasmaObjectReadyRequest)
-      returns (PlasmaObjectReadyReply);
+  rpc PlasmaObjectReady(PlasmaObjectReadyRequest) returns (PlasmaObjectReadyReply);
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -18,7 +18,9 @@ package ray.rpc;
 
 import "src/ray/protobuf/common.proto";
 
-message ActiveObjectIDs { repeated bytes object_ids = 1; }
+message ActiveObjectIDs {
+  repeated bytes object_ids = 1;
+}
 
 // Persistent state of an ActorHandle.
 message ActorHandle {
@@ -65,7 +67,8 @@ message AssignTaskRequest {
   bytes resource_ids = 3;
 }
 
-message AssignTaskReply {}
+message AssignTaskReply {
+}
 
 message ReturnObject {
   // Object ID.
@@ -143,7 +146,8 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {}
+message DirectActorCallArgWaitCompleteReply {
+}
 
 message GetObjectStatusRequest {
   // The owner of the object. Note that we do not need to include
@@ -166,7 +170,8 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {}
+message WaitForObjectEvictionReply {
+}
 
 message KillActorRequest {
   // ID of the actor that is intended to be killed.
@@ -177,7 +182,8 @@ message KillActorRequest {
   bool no_reconstruction = 3;
 }
 
-message KillActorReply {}
+message KillActorReply {
+}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
@@ -259,9 +265,11 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {}
+message LocalGCRequest {
+}
 
-message LocalGCReply {}
+message LocalGCReply {
+}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
@@ -269,7 +277,8 @@ message PlasmaObjectReadyRequest {
   int64 metadata_size = 3;
 }
 
-message PlasmaObjectReadyReply {}
+message PlasmaObjectReadyReply {
+}
 
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
@@ -290,14 +299,11 @@ service CoreWorkerService {
   // Request that a worker cancels a task.
   rpc CancelTask(CancelTaskRequest) returns (CancelTaskReply);
   // Get metrics from core workers.
-  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest)
-      returns (GetCoreWorkerStatsReply);
+  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
   // Wait for a borrower to finish using an object. Sent by the object's owner.
-  rpc WaitForRefRemoved(WaitForRefRemovedRequest)
-      returns (WaitForRefRemovedReply);
+  rpc WaitForRefRemoved(WaitForRefRemovedRequest) returns (WaitForRefRemovedReply);
   // Trigger local GC on the worker.
   rpc LocalGC(LocalGCRequest) returns (LocalGCReply);
   // Notification from raylet that an object ID is available in local plasma.
-  rpc PlasmaObjectReady(PlasmaObjectReadyRequest)
-      returns (PlasmaObjectReadyReply);
+  rpc PlasmaObjectReady(PlasmaObjectReadyRequest) returns (PlasmaObjectReadyReply);
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -18,9 +18,7 @@ package ray.rpc;
 
 import "src/ray/protobuf/common.proto";
 
-message ActiveObjectIDs {
-  repeated bytes object_ids = 1;
-}
+message ActiveObjectIDs { repeated bytes object_ids = 1; }
 
 // Persistent state of an ActorHandle.
 message ActorHandle {
@@ -67,8 +65,7 @@ message AssignTaskRequest {
   bytes resource_ids = 3;
 }
 
-message AssignTaskReply {
-}
+message AssignTaskReply {}
 
 message ReturnObject {
   // Object ID.
@@ -146,8 +143,7 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {
-}
+message DirectActorCallArgWaitCompleteReply {}
 
 message GetObjectStatusRequest {
   // The owner of the object. Note that we do not need to include
@@ -170,8 +166,7 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {
-}
+message WaitForObjectEvictionReply {}
 
 message KillActorRequest {
   // ID of the actor that is intended to be killed.
@@ -182,22 +177,28 @@ message KillActorRequest {
   bool no_reconstruction = 3;
 }
 
-message KillActorReply {
-}
+message KillActorReply {}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
   bytes intended_task_id = 1;
   // Whether to kill the worker.
   bool force_kill = 2;
-  // Object ID of the remote task that should be killed.
-  bytes remote_object_id = 3;
 }
 
 message CancelTaskReply {
   // Whether the requested task is the currently running task.
   bool attempt_succeeded = 1;
 }
+
+message RemoteCancelTaskRequest {
+  // Object ID of the remote task that should be killed.
+  bytes remote_object_id = 1;
+  // Whether to kill the worker.
+  bool force_kill = 2;
+}
+
+message RemoteCancelTaskReply {}
 
 message GetCoreWorkerStatsRequest {
   // The ID of the worker this message is intended for.
@@ -265,11 +266,9 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {
-}
+message LocalGCRequest {}
 
-message LocalGCReply {
-}
+message LocalGCReply {}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
@@ -277,8 +276,7 @@ message PlasmaObjectReadyRequest {
   int64 metadata_size = 3;
 }
 
-message PlasmaObjectReadyReply {
-}
+message PlasmaObjectReadyReply {}
 
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
@@ -298,12 +296,17 @@ service CoreWorkerService {
   rpc KillActor(KillActorRequest) returns (KillActorReply);
   // Request that a worker cancels a task.
   rpc CancelTask(CancelTaskRequest) returns (CancelTaskReply);
+  // Request for a worker to issue a cancelation.
+  rpc RemoteCancelTask(RemoteCancelTaskRequest) returns (RemoteCancelTaskReply);
   // Get metrics from core workers.
-  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
+  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest)
+      returns (GetCoreWorkerStatsReply);
   // Wait for a borrower to finish using an object. Sent by the object's owner.
-  rpc WaitForRefRemoved(WaitForRefRemovedRequest) returns (WaitForRefRemovedReply);
+  rpc WaitForRefRemoved(WaitForRefRemovedRequest)
+      returns (WaitForRefRemovedReply);
   // Trigger local GC on the worker.
   rpc LocalGC(LocalGCRequest) returns (LocalGCReply);
   // Notification from raylet that an object ID is available in local plasma.
-  rpc PlasmaObjectReady(PlasmaObjectReadyRequest) returns (PlasmaObjectReadyReply);
+  rpc PlasmaObjectReady(PlasmaObjectReadyRequest)
+      returns (PlasmaObjectReadyReply);
 }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -18,9 +18,7 @@ package ray.rpc;
 
 import "src/ray/protobuf/common.proto";
 
-message ActiveObjectIDs {
-  repeated bytes object_ids = 1;
-}
+message ActiveObjectIDs { repeated bytes object_ids = 1; }
 
 // Persistent state of an ActorHandle.
 message ActorHandle {
@@ -67,8 +65,7 @@ message AssignTaskRequest {
   bytes resource_ids = 3;
 }
 
-message AssignTaskReply {
-}
+message AssignTaskReply {}
 
 message ReturnObject {
   // Object ID.
@@ -146,8 +143,7 @@ message DirectActorCallArgWaitCompleteRequest {
   int64 tag = 2;
 }
 
-message DirectActorCallArgWaitCompleteReply {
-}
+message DirectActorCallArgWaitCompleteReply {}
 
 message GetObjectStatusRequest {
   // The owner of the object. Note that we do not need to include
@@ -170,8 +166,7 @@ message WaitForObjectEvictionRequest {
   bytes object_id = 2;
 }
 
-message WaitForObjectEvictionReply {
-}
+message WaitForObjectEvictionReply {}
 
 message KillActorRequest {
   // ID of the actor that is intended to be killed.
@@ -182,14 +177,15 @@ message KillActorRequest {
   bool no_reconstruction = 3;
 }
 
-message KillActorReply {
-}
+message KillActorReply {}
 
 message CancelTaskRequest {
   // ID of task that should be killed.
   bytes intended_task_id = 1;
   // Whether to kill the worker.
   bool force_kill = 2;
+  // Return Object ID of the remote task that should be killed.
+  bytes remote_object_id = 3;
 }
 
 message CancelTaskReply {
@@ -263,11 +259,9 @@ message WaitForRefRemovedReply {
   repeated ObjectReferenceCount borrowed_refs = 1;
 }
 
-message LocalGCRequest {
-}
+message LocalGCRequest {}
 
-message LocalGCReply {
-}
+message LocalGCReply {}
 
 message PlasmaObjectReadyRequest {
   bytes object_id = 1;
@@ -275,8 +269,7 @@ message PlasmaObjectReadyRequest {
   int64 metadata_size = 3;
 }
 
-message PlasmaObjectReadyReply {
-}
+message PlasmaObjectReadyReply {}
 
 service CoreWorkerService {
   // Push a task to a worker from the raylet.
@@ -297,11 +290,14 @@ service CoreWorkerService {
   // Request that a worker cancels a task.
   rpc CancelTask(CancelTaskRequest) returns (CancelTaskReply);
   // Get metrics from core workers.
-  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest) returns (GetCoreWorkerStatsReply);
+  rpc GetCoreWorkerStats(GetCoreWorkerStatsRequest)
+      returns (GetCoreWorkerStatsReply);
   // Wait for a borrower to finish using an object. Sent by the object's owner.
-  rpc WaitForRefRemoved(WaitForRefRemovedRequest) returns (WaitForRefRemovedReply);
+  rpc WaitForRefRemoved(WaitForRefRemovedRequest)
+      returns (WaitForRefRemovedReply);
   // Trigger local GC on the worker.
   rpc LocalGC(LocalGCRequest) returns (LocalGCReply);
   // Notification from raylet that an object ID is available in local plasma.
-  rpc PlasmaObjectReady(PlasmaObjectReadyRequest) returns (PlasmaObjectReadyReply);
+  rpc PlasmaObjectReady(PlasmaObjectReadyRequest)
+      returns (PlasmaObjectReadyReply);
 }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -162,6 +162,12 @@ class CoreWorkerClientInterface {
     return Status::NotImplemented("");
   }
 
+  virtual ray::Status RemoteCancelTask(
+      const RemoteCancelTaskRequest &request,
+      const ClientCallback<RemoteCancelTaskReply> &callback) {
+    return Status::NotImplemented("");
+  }
+
   virtual ray::Status GetCoreWorkerStats(
       const GetCoreWorkerStatsRequest &request,
       const ClientCallback<GetCoreWorkerStatsReply> &callback) {
@@ -216,6 +222,8 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   RPC_CLIENT_METHOD(CoreWorkerService, KillActor, grpc_client_, override)
 
   RPC_CLIENT_METHOD(CoreWorkerService, CancelTask, grpc_client_, override)
+
+  RPC_CLIENT_METHOD(CoreWorkerService, RemoteCancelTask, grpc_client_, override)
 
   RPC_CLIENT_METHOD(CoreWorkerService, WaitForObjectEviction, grpc_client_, override)
 

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -36,6 +36,7 @@ namespace rpc {
   RPC_SERVICE_HANDLER(CoreWorkerService, WaitForRefRemoved)              \
   RPC_SERVICE_HANDLER(CoreWorkerService, KillActor)                      \
   RPC_SERVICE_HANDLER(CoreWorkerService, CancelTask)                     \
+  RPC_SERVICE_HANDLER(CoreWorkerService, RemoteCancelTask)               \
   RPC_SERVICE_HANDLER(CoreWorkerService, GetCoreWorkerStats)             \
   RPC_SERVICE_HANDLER(CoreWorkerService, LocalGC)                        \
   RPC_SERVICE_HANDLER(CoreWorkerService, PlasmaObjectReady)
@@ -49,6 +50,7 @@ namespace rpc {
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(WaitForRefRemoved)              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(KillActor)                      \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(CancelTask)                     \
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(RemoteCancelTask)               \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(GetCoreWorkerStats)             \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(LocalGC)                        \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PlasmaObjectReady)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This enables task cancelation to kill remotely submitted tasks. This ultimately makes the API more simple as users no longer need to worry about where the task was created.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #854

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
