### PR TITLE
[serve] Temporarily disable test_master_crashes

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -21,15 +21,16 @@ py_test(
 )
 
 # Runs test_api and test_failure with injected failures in the master actor.
-py_test(
-    name = "test_master_crashes",
-    size = "medium",
-    srcs = glob(["tests/test_master_crashes.py",
-                 "tests/test_api.py",
-                 "tests/test_failure.py"],
-                exclude=["tests/test_nonblocking.py",
-                         "tests/test_serve.py"]),
-)
+# TODO(edoakes): reenable this once we're using GCS actor fault tolerance.
+# py_test(
+    # name = "test_master_crashes",
+    # size = "medium",
+    # srcs = glob(["tests/test_master_crashes.py",
+                 # "tests/test_api.py",
+                 # "tests/test_failure.py"],
+                # exclude=["tests/test_nonblocking.py",
+                         # "tests/test_serve.py"]),
+# )
 
 py_test(
     name = "echo_full",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Test is failing nondeterministically in CI. This could be a bug in serve or could be a Ray issue with actor reconstruction, so let's punt debugging it until the GCS service is enabled for serve and iimplements named detached actors.