### PR TITLE
[RLlib] Remove all f-strings to keep py3.5 compatibility.

### DIFF
--- a/rllib/contrib/bandits/examples/LinTS_train_wheel_env.py
+++ b/rllib/contrib/bandits/examples/LinTS_train_wheel_env.py
@@ -10,7 +10,7 @@ from ray.rllib.contrib.bandits.envs import WheelBanditEnv
 
 def plot_model_weights(means, covs):
     fmts = ["bo", "ro", "yx", "k+", "gx"]
-    labels = [f"arm{i}" for i in range(5)]
+    labels = ["arm{}".format(i) for i in range(5)]
 
     fig, ax = plt.subplots(figsize=(6, 4))
 

--- a/rllib/contrib/bandits/examples/tune_LinTS_train_wheel_env.py
+++ b/rllib/contrib/bandits/examples/tune_LinTS_train_wheel_env.py
@@ -15,7 +15,7 @@ from ray.rllib.contrib.bandits.envs import WheelBanditEnv
 
 def plot_model_weights(means, covs, ax):
     fmts = ["bo", "ro", "yx", "k+", "gx"]
-    labels = [f"arm{i}" for i in range(5)]
+    labels = ["arm{}".format(i) for i in range(5)]
 
     ax.set_title("Weights distributions of arms")
 

--- a/rllib/contrib/bandits/models/linear_regression.py
+++ b/rllib/contrib/bandits/models/linear_regression.py
@@ -85,9 +85,9 @@ class OnlineLinearRegression(nn.Module):
         assert x.ndim in [2, 3], \
             "Input context tensor must be 2 or 3 dimensional, where the" \
             " first dimension is batch size"
-        assert x.shape[
-            1] == self.d, f"Feature dimensions of weights ({self.d}) and " \
-                          f"context ({x.shape[1]}) do not match!"
+        assert x.shape[1] == self.d, \
+            "Feature dimensions of weights ({}) and context ({}) do not " \
+            "match!".format(self.d, x.shape[1])
         if y:
             assert torch.is_tensor(y) and y.numel() == 1,\
                 "Target should be a tensor;" \
@@ -134,9 +134,9 @@ class DiscreteLinearModel(TorchModelV2, nn.Module):
             return scores
 
     def partial_fit(self, x, y, arm):
-        assert 0 <= arm.item() < len(self.arms),\
-            f"Invalid arm: {arm.item()}." \
-            f"It should be 0 <= arm < {len(self.arms)}"
+        assert 0 <= arm.item() < len(self.arms), \
+            "Invalid arm: {}. It should be 0 <= arm < {}".format(
+                arm.item(), len(self.arms))
         self.arms[arm].partial_fit(x, y)
 
     @override(ModelV2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Python 3.5 is currently not supported due to some f-strings in RLlib (Bandit code).

<!-- Please give a short summary of the change and the problem this solves. -->

#7920 

<!-- For example: "Closes #1234" -->

Closes #7920 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
