### PR TITLE
[rllib] Copy plasma memory before adding data to replay buffer

### DIFF
--- a/rllib/optimizers/async_replay_optimizer.py
+++ b/rllib/optimizers/async_replay_optimizer.py
@@ -323,6 +323,8 @@ class LocalReplayBuffer(ParallelIteratorWorker):
         return os.uname()[1]
 
     def add_batch(self, batch):
+        # Make a copy so the replay buffer doesn't pin plasma memory.
+        batch = batch.copy()
         # Handle everything as if multiagent
         if isinstance(batch, SampleBatch):
             batch = MultiAgentBatch({DEFAULT_POLICY_ID: batch}, batch.count)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Make a copy of the sample batch passed to replay actors, so it doesn't consume plasma memory indefinitely.

Before this fix, `ray memory` will show a lot of PINNED_IN_MEMORY objects for the replay actors.

## Related issue number

Closes https://github.com/ray-project/ray/issues/8227