### PR TITLE
[rllib] observation function api for multi-agent

### DIFF
--- a/doc/source/rllib-env.rst
+++ b/doc/source/rllib-env.rst
@@ -253,9 +253,9 @@ The most general way of implementing a centralized critic involves modifying the
 
 To update the critic, you'll also have to modify the loss of the policy. For an end-to-end runnable example, see `examples/centralized_critic.py <https://github.com/ray-project/ray/blob/master/rllib/examples/centralized_critic.py>`__.
 
-**Strategy 2: Sharing observations through the environment**:
+**Strategy 2: Sharing observations through an observation function**:
 
-Alternatively, the env itself can be modified to share observations between agents. In this strategy, each observation includes all global state, and policies use a custom model to ignore state they aren't supposed to "see" when computing actions. The advantage of this approach is that it's very simple and you don't have to change the algorithm at all -- just use an env wrapper and custom model. However, it is a bit less principled in that you have to change the agent observation spaces and the environment. You can find a runnable example of this strategy at `examples/centralized_critic_2.py <https://github.com/ray-project/ray/blob/master/rllib/examples/centralized_critic_2.py>`__.
+Alternatively, you can use an observation function to share observations between agents. In this strategy, each observation includes all global state, and policies use a custom model to ignore state they aren't supposed to "see" when computing actions. The advantage of this approach is that it's very simple and you don't have to change the algorithm at all -- just use the observation func (i.e., like an env wrapper) and custom model. However, it is a bit less principled in that you have to change the agent observation spaces to include training-time only information. You can find a runnable example of this strategy at `examples/centralized_critic_2.py <https://github.com/ray-project/ray/blob/master/rllib/examples/centralized_critic_2.py>`__.
 
 Grouping Agents
 ~~~~~~~~~~~~~~~

--- a/rllib/agents/callbacks.py
+++ b/rllib/agents/callbacks.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from ray.rllib.env import BaseEnv
-from ray.rllib.policy import Policy
+from ray.rllib.policy import Policy, PolicyID, AgentID
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.evaluation import MultiAgentEpisode, RolloutWorker
 from ray.rllib.utils.annotations import PublicAPI
@@ -27,7 +27,7 @@ class DefaultCallbacks:
         self.legacy_callbacks = legacy_callbacks_dict or {}
 
     def on_episode_start(self, worker: RolloutWorker, base_env: BaseEnv,
-                         policies: Dict[str, Policy],
+                         policies: Dict[PolicyID, Policy],
                          episode: MultiAgentEpisode, **kwargs):
         """Callback run on the rollout worker before each episode starts.
 
@@ -73,8 +73,8 @@ class DefaultCallbacks:
             })
 
     def on_episode_end(self, worker: RolloutWorker, base_env: BaseEnv,
-                       policies: Dict[str, Policy], episode: MultiAgentEpisode,
-                       **kwargs):
+                       policies: Dict[PolicyID, Policy],
+                       episode: MultiAgentEpisode, **kwargs):
         """Runs when an episode is done.
 
         Args:
@@ -99,9 +99,9 @@ class DefaultCallbacks:
 
     def on_postprocess_trajectory(
             self, worker: RolloutWorker, episode: MultiAgentEpisode,
-            agent_id: str, policy_id: str, policies: Dict[str, Policy],
-            postprocessed_batch: SampleBatch,
-            original_batches: Dict[str, SampleBatch], **kwargs):
+            agent_id: AgentID, policy_id: PolicyID,
+            policies: Dict[PolicyID, Policy], postprocessed_batch: SampleBatch,
+            original_batches: Dict[AgentID, SampleBatch], **kwargs):
         """Called immediately after a policy's postprocess_fn is called.
 
         You can use this callback to do additional postprocessing for a policy,

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -345,6 +345,10 @@ COMMON_CONFIG = {
         "policy_mapping_fn": None,
         # Optional whitelist of policies to train, or None for all policies.
         "policies_to_train": None,
+        # Optional function that can be used to enhance the local agent
+        # observations to include more state.
+        # See rllib/evaluation/observation_function.py for more info.
+        "observation_fn": None,
     },
 }
 # __sphinx_doc_end__

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -380,7 +380,7 @@ class _MultiAgentEnvToBaseEnv(BaseEnv):
             assert isinstance(rewards, dict), "Not a multi-agent reward"
             assert isinstance(dones, dict), "Not a multi-agent return"
             assert isinstance(infos, dict), "Not a multi-agent info"
-            if set(obs.keys()) != set(rewards.keys()):
+            if set(obs.keys()) - {"__all__"} != set(rewards.keys()):
                 raise ValueError(
                     "Key set for obs and rewards must be the same: "
                     "{} vs {}".format(obs.keys(), rewards.keys()))

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -380,7 +380,7 @@ class _MultiAgentEnvToBaseEnv(BaseEnv):
             assert isinstance(rewards, dict), "Not a multi-agent reward"
             assert isinstance(dones, dict), "Not a multi-agent return"
             assert isinstance(infos, dict), "Not a multi-agent info"
-            if set(obs.keys()) - {"__all__"} != set(rewards.keys()):
+            if set(obs.keys()) != set(rewards.keys()):
                 raise ValueError(
                     "Key set for obs and rewards must be the same: "
                     "{} vs {}".format(obs.keys(), rewards.keys()))

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from ray.rllib.env import BaseEnv
 from ray.rllib.policy import Policy, AgentID, PolicyID
-from ray.rllib.evaluation import MultiAgentEpisode
+from ray.rllib.evaluation import MultiAgentEpisode, RolloutWorker
 from ray.rllib.utils.framework import TensorType
 
 
@@ -19,7 +19,7 @@ class ObservationFunction:
     """
 
     def observe(self, agent_obs: Dict[AgentID, TensorType],
-                worker: "RolloutWorker", base_env: BaseEnv,
+                worker: RolloutWorker, base_env: BaseEnv,
                 policies: Dict[PolicyID, Policy], episode: MultiAgentEpisode,
                 **kw) -> Dict[AgentID, TensorType]:
         """Callback run on each environment step to observe the environment.

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -15,7 +15,7 @@ class ObservationFunction:
     Observations functions can be specified in the multi-agent config by
     specifying {"observation_function": YourObsFuncSubclass}.
 
-    This API is *experimental*.
+    This API is **experimental**.
     """
 
     def observe(self, agent_obs: Dict[AgentID, TensorType],

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -13,7 +13,8 @@ class ObservationFunction:
     in multi-agent scenarios.
 
     Observations functions can be specified in the multi-agent config by
-    specifying {"observation_function": YourObsFunc}.
+    specifying ``{"observation_function": YourObsFunc}``. Note that
+    ``YourObsFunc`` can be a plain Python function.
 
     This API is **experimental**.
     """

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -18,14 +18,10 @@ class ObservationFunction:
     This API is *experimental*.
     """
 
-    def observe(
-            self,
-            agent_obs: Dict[AgentID, TensorType],
-            worker: "RolloutWorker",
-            base_env: BaseEnv,
-            policies: Dict[PolicyID, Policy],
-            episode: MultiAgentEpisode,
-            **kw) -> Dict[AgentID, TensorType]:
+    def observe(self, agent_obs: Dict[AgentID, TensorType],
+                worker: "RolloutWorker", base_env: BaseEnv,
+                policies: Dict[PolicyID, Policy], episode: MultiAgentEpisode,
+                **kw) -> Dict[AgentID, TensorType]:
         """Callback run on each environment step to observe the environment.
 
         This method takes in the original agent observation dict returned by
@@ -58,12 +54,12 @@ class ObservationFunction:
         Examples:
             >>> # Observer that merges global state into individual obs. It is
             ... # rewriting the discrete obs into a tuple with global state.
-            >>> ex1.observe({"a": 1, "b": 2, "global_state": 101})
+            >>> ex1.observe({"a": 1, "b": 2, "global_state": 101}, ...)
             {"a": [1, 101], "b": [2, 101]}
 
             >>> # Observer for e.g., custom centralized critic model. It is
             ... # rewriting the discrete obs into a dict with more data.
-            >>> ex2.observe({"a": 1, "b": 2})
+            >>> ex2.observe({"a": 1, "b": 2}, ...)
             {"a": {"self": 1, "other": 2}, "b": {"self": 2, "other": 1}}
         """
 

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -1,0 +1,70 @@
+from typing import Dict
+
+from ray.rllib.env import BaseEnv
+from ray.rllib.policy import Policy, AgentID, PolicyID
+from ray.rllib.evaluation import MultiAgentEpisode
+from ray.rllib.utils.framework import TensorType
+
+
+class ObservationFunction:
+    """Interceptor function for rewriting observations from the environment.
+
+    These callbacks can be used for preprocessing of observations, especially
+    in multi-agent scenarios.
+
+    Observations functions can be specified in the multi-agent config by
+    specifying {"observation_function": YourObsFuncSubclass}.
+
+    This API is *experimental*.
+    """
+
+    def observe(
+            self,
+            agent_obs: Dict[AgentID, TensorType],
+            worker: "RolloutWorker",
+            base_env: BaseEnv,
+            policies: Dict[PolicyID, Policy],
+            episode: MultiAgentEpisode,
+            **kw) -> Dict[AgentID, TensorType]:
+        """Callback run on each environment step to observe the environment.
+
+        This method takes in the original agent observation dict returned by
+        a MultiAgentEnv, and returns a possibly modified one. It can be
+        thought of as a "wrapper" around the environment.
+
+        TODO(ekl): allow end-to-end differentiation through the observation
+            function and policy losses.
+
+        TODO(ekl): enable batch processing.
+
+        Args:
+            agent_obs (dict): Dictionary of default observations from the
+                environment. The default implementation of observe() simply
+                returns this dict.
+            worker (RolloutWorker): Reference to the current rollout worker.
+            base_env (BaseEnv): BaseEnv running the episode. The underlying
+                env object can be gotten by calling base_env.get_unwrapped().
+            policies (dict): Mapping of policy id to policy objects. In single
+                agent mode there will only be a single "default" policy.
+            episode (MultiAgentEpisode): Episode state object.
+            kwargs: Forward compatibility placeholder.
+
+        Returns:
+            new_agent_obs (dict): copy of agent obs with updates. You can
+                rewrite or drop data from the dict if needed (e.g., the env
+                can have a dummy "global" observation, and the observer can
+                merge the global state into individual observations.
+
+        Examples:
+            >>> # Observer that merges global state into individual obs. It is
+            ... # rewriting the discrete obs into a tuple with global state.
+            >>> ex1.observe({"a": 1, "b": 2, "global_state": 101})
+            {"a": [1, 101], "b": [2, 101]}
+
+            >>> # Observer for e.g., custom centralized critic model. It is
+            ... # rewriting the discrete obs into a dict with more data.
+            >>> ex2.observe({"a": 1, "b": 2})
+            {"a": {"self": 1, "other": 2}, "b": {"self": 2, "other": 1}}
+        """
+
+        return agent_obs

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -13,15 +13,15 @@ class ObservationFunction:
     in multi-agent scenarios.
 
     Observations functions can be specified in the multi-agent config by
-    specifying {"observation_function": YourObsFuncSubclass}.
+    specifying {"observation_function": YourObsFunc}.
 
     This API is **experimental**.
     """
 
-    def observe(self, agent_obs: Dict[AgentID, TensorType],
-                worker: RolloutWorker, base_env: BaseEnv,
-                policies: Dict[PolicyID, Policy], episode: MultiAgentEpisode,
-                **kw) -> Dict[AgentID, TensorType]:
+    def __call__(self, agent_obs: Dict[AgentID, TensorType],
+                 worker: RolloutWorker, base_env: BaseEnv,
+                 policies: Dict[PolicyID, Policy], episode: MultiAgentEpisode,
+                 **kw) -> Dict[AgentID, TensorType]:
         """Callback run on each environment step to observe the environment.
 
         This method takes in the original agent observation dict returned by
@@ -54,12 +54,12 @@ class ObservationFunction:
         Examples:
             >>> # Observer that merges global state into individual obs. It is
             ... # rewriting the discrete obs into a tuple with global state.
-            >>> ex1.observe({"a": 1, "b": 2, "global_state": 101}, ...)
+            >>> observe_fn({"a": 1, "b": 2, "global_state": 101}, ...)
             {"a": [1, 101], "b": [2, 101]}
 
             >>> # Observer for e.g., custom centralized critic model. It is
             ... # rewriting the discrete obs into a dict with more data.
-            >>> ex2.observe({"a": 1, "b": 2}, ...)
+            >>> observe_fn({"a": 1, "b": 2}, ...)
             {"a": {"self": 1, "other": 2}, "b": {"self": 2, "other": 1}}
         """
 

--- a/rllib/evaluation/observation_function.py
+++ b/rllib/evaluation/observation_function.py
@@ -13,8 +13,8 @@ class ObservationFunction:
     in multi-agent scenarios.
 
     Observations functions can be specified in the multi-agent config by
-    specifying ``{"observation_function": YourObsFunc}``. Note that
-    ``YourObsFunc`` can be a plain Python function.
+    specifying ``{"observation_function": your_obs_func}``. Note that
+    ``your_obs_func`` can be a plain Python function.
 
     This API is **experimental**.
     """
@@ -55,12 +55,12 @@ class ObservationFunction:
         Examples:
             >>> # Observer that merges global state into individual obs. It is
             ... # rewriting the discrete obs into a tuple with global state.
-            >>> observe_fn({"a": 1, "b": 2, "global_state": 101}, ...)
+            >>> example_obs_fn1({"a": 1, "b": 2, "global_state": 101}, ...)
             {"a": [1, 101], "b": [2, 101]}
 
             >>> # Observer for e.g., custom centralized critic model. It is
             ... # rewriting the discrete obs into a dict with more data.
-            >>> observe_fn({"a": 1, "b": 2}, ...)
+            >>> example_obs_fn2({"a": 1, "b": 2}, ...)
             {"a": {"self": 1, "other": 2}, "b": {"self": 2, "other": 1}}
         """
 

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -467,7 +467,7 @@ class RolloutWorker(EvaluatorInterface, ParallelIteratorWorker):
                 blackhole_outputs="simulation" in input_evaluation,
                 soft_horizon=soft_horizon,
                 no_done_at_end=no_done_at_end,
-                observation_func=observation_func)
+                observation_fn=observation_fn)
             self.sampler.start()
         else:
             self.sampler = SyncSampler(
@@ -486,7 +486,7 @@ class RolloutWorker(EvaluatorInterface, ParallelIteratorWorker):
                 clip_actions=clip_actions,
                 soft_horizon=soft_horizon,
                 no_done_at_end=no_done_at_end,
-                observation_func=observation_func)
+                observation_fn=observation_fn)
 
         self.input_reader = input_creator(self.io_context)
         assert isinstance(self.input_reader, InputReader), self.input_reader

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -449,11 +449,6 @@ class RolloutWorker(EvaluatorInterface, ParallelIteratorWorker):
                 raise ValueError(
                     "Unknown evaluation method: {}".format(method))
 
-        if observation_fn:
-            observer = observation_fn()
-        else:
-            observer = None
-
         if sample_async:
             self.sampler = AsyncSampler(
                 self,
@@ -472,7 +467,7 @@ class RolloutWorker(EvaluatorInterface, ParallelIteratorWorker):
                 blackhole_outputs="simulation" in input_evaluation,
                 soft_horizon=soft_horizon,
                 no_done_at_end=no_done_at_end,
-                observer=observer)
+                observation_func=observation_func)
             self.sampler.start()
         else:
             self.sampler = SyncSampler(
@@ -491,7 +486,7 @@ class RolloutWorker(EvaluatorInterface, ParallelIteratorWorker):
                 clip_actions=clip_actions,
                 soft_horizon=soft_horizon,
                 no_done_at_end=no_done_at_end,
-                observer=observer)
+                observation_func=observation_func)
 
         self.input_reader = input_creator(self.io_context)
         assert isinstance(self.input_reader, InputReader), self.input_reader

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -78,7 +78,7 @@ class SyncSampler(SamplerInput):
                  clip_actions=True,
                  soft_horizon=False,
                  no_done_at_end=False,
-                 observer=None):
+                 observation_func=None):
         self.base_env = BaseEnv.to_base_env(env)
         self.rollout_fragment_length = rollout_fragment_length
         self.horizon = horizon
@@ -93,7 +93,7 @@ class SyncSampler(SamplerInput):
             self.policy_mapping_fn, self.rollout_fragment_length, self.horizon,
             self.preprocessors, self.obs_filters, clip_rewards, clip_actions,
             pack, callbacks, tf_sess, self.perf_stats, soft_horizon,
-            no_done_at_end, observer)
+            no_done_at_end, observation_func)
         self.metrics_queue = queue.Queue()
 
     def get_data(self):
@@ -142,7 +142,7 @@ class AsyncSampler(threading.Thread, SamplerInput):
                  blackhole_outputs=False,
                  soft_horizon=False,
                  no_done_at_end=False,
-                 observer=None):
+                 observation_func=None):
         for _, f in obs_filters.items():
             assert getattr(f, "is_concurrent", False), \
                 "Observation Filter must support concurrent updates."
@@ -169,7 +169,7 @@ class AsyncSampler(threading.Thread, SamplerInput):
         self.no_done_at_end = no_done_at_end
         self.perf_stats = PerfStats()
         self.shutdown = False
-        self.observer = observer
+        self.observation_func = observation_func
 
     def run(self):
         try:
@@ -192,7 +192,7 @@ class AsyncSampler(threading.Thread, SamplerInput):
             self.preprocessors, self.obs_filters, self.clip_rewards,
             self.clip_actions, self.pack, self.callbacks, self.tf_sess,
             self.perf_stats, self.soft_horizon, self.no_done_at_end,
-            self.observer)
+            self.observation_func)
         while not self.shutdown:
             # The timeout variable exists because apparently, if one worker
             # dies, the other workers won't die with it, unless the timeout is
@@ -238,7 +238,7 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
                 policy_mapping_fn, rollout_fragment_length, horizon,
                 preprocessors, obs_filters, clip_rewards, clip_actions, pack,
                 callbacks, tf_sess, perf_stats, soft_horizon, no_done_at_end,
-                observer):
+                observation_func):
     """This implements the common experience collection logic.
 
     Args:
@@ -270,7 +270,8 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
             environment when the horizon is hit.
         no_done_at_end (bool): Ignore the done=True at the end of the episode
             and instead record done=False.
-        observer (ObservationFunction): Optional multi-agent observation func.
+        observation_func (ObservationFunction): Optional multi-agent
+            observation func to use for preprocessing observations.
 
     Yields:
         rollout (SampleBatch): Object containing state, action, reward,
@@ -355,7 +356,7 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
             worker, base_env, policies, batch_builder_pool, active_episodes,
             unfiltered_obs, rewards, dones, infos, off_policy_actions, horizon,
             preprocessors, obs_filters, rollout_fragment_length, pack,
-            callbacks, soft_horizon, no_done_at_end, observer)
+            callbacks, soft_horizon, no_done_at_end, observation_func)
         perf_stats.processing_time += time.time() - t1
         for o in outputs:
             yield o
@@ -380,11 +381,11 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
         perf_stats.env_wait_time += time.time() - t4
 
 
-def _process_observations(worker, base_env, policies, batch_builder_pool,
-                          active_episodes, unfiltered_obs, rewards, dones,
-                          infos, off_policy_actions, horizon, preprocessors,
-                          obs_filters, rollout_fragment_length, pack,
-                          callbacks, soft_horizon, no_done_at_end, observer):
+def _process_observations(
+        worker, base_env, policies, batch_builder_pool, active_episodes,
+        unfiltered_obs, rewards, dones, infos, off_policy_actions, horizon,
+        preprocessors, obs_filters, rollout_fragment_length, pack, callbacks,
+        soft_horizon, no_done_at_end, observation_func):
     """Record new data from the environment and prepare for policy evaluation.
 
     Returns:
@@ -447,8 +448,8 @@ def _process_observations(worker, base_env, policies, batch_builder_pool,
             active_envs.add(env_id)
 
         # Custom observation function is applied before preprocessing.
-        if observer:
-            agent_obs = observer.observe(
+        if observation_func:
+            agent_obs = observation_func(
                 agent_obs=agent_obs,
                 worker=worker,
                 base_env=base_env,
@@ -555,8 +556,8 @@ def _process_observations(worker, base_env, policies, batch_builder_pool,
                 # Creates a new episode if this is not async return
                 # If reset is async, we will get its result in some future poll
                 episode = active_episodes[env_id]
-                if observer:
-                    resetted_obs = observer.observe(
+                if observation_func:
+                    resetted_obs = observation_func(
                         agent_obs=resetted_obs,
                         worker=worker,
                         base_env=base_env,

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -255,6 +255,7 @@ class WorkerSet:
             sample_async=config["sample_async"],
             compress_observations=config["compress_observations"],
             num_envs=config["num_envs_per_worker"],
+            observation_fn=config["multiagent"]["observation_fn"],
             observation_filter=config["observation_filter"],
             clip_rewards=config["clip_rewards"],
             clip_actions=config["clip_actions"],

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -15,7 +15,6 @@ import argparse
 
 from ray import tune
 from ray.rllib.agents.callbacks import DefaultCallbacks
-from ray.rllib.env.multi_agent_env import MultiAgentEnv
 from ray.rllib.evaluation.observation_function import ObservationFunction
 from ray.rllib.examples.twostep_game import TwoStepGame
 from ray.rllib.models import ModelCatalog

--- a/rllib/policy/__init__.py
+++ b/rllib/policy/__init__.py
@@ -1,10 +1,12 @@
-from ray.rllib.policy.policy import Policy
+from ray.rllib.policy.policy import Policy, PolicyID, AgentID
 from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.rllib.policy.tf_policy import TFPolicy
 from ray.rllib.policy.torch_policy_template import build_torch_policy
 from ray.rllib.policy.tf_policy_template import build_tf_policy
 
 __all__ = [
+    "AgentID",
+    "PolicyID",
     "Policy",
     "TFPolicy",
     "TorchPolicy",

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 import gym
 import numpy as np
+from typing import Any
 
 from ray.rllib.utils import try_import_tree
 from ray.rllib.utils.annotations import DeveloperAPI
@@ -13,6 +14,12 @@ tree = try_import_tree()
 # By convention, metrics from optimizing the loss can be reported in the
 # `grad_info` dict returned by learn_on_batch() / compute_grads() via this key.
 LEARNER_STATS_KEY = "learner_stats"
+
+# Represents a generic identifier for an agent (e.g., "agent1").
+AgentID = Any
+
+# Represents a generic identifier for a policy (e.g., "pol1").
+PolicyID = str
 
 
 @DeveloperAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This adds an observation function that sits between multi agent envs and policies. It can handle communication / data sharing between local observations, or merging global observations into local observations.

MultiAgentEnv -> policies
MultiAgentEnv -> obs_func -> policies

In the future, the obs func can also be made differentiable to enable shared computation with multi-agent.

Lightly documented; will add more documentation as we iterate on the API.