### PR TITLE
[tune] Avoid breakage - soft deprecation warning for search algs

### DIFF
--- a/python/ray/tune/examples/hyperopt_example.py
+++ b/python/ray/tune/examples/hyperopt_example.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--smoke-test", action="store_true", help="Finish quickly for testing")
     args, _ = parser.parse_known_args()
-    ray.init(configure_logging=False)
+    ray.init()
 
     space = {
         "width": hp.uniform("width", 0, 20),

--- a/python/ray/tune/suggest/ax.py
+++ b/python/ray/tune/suggest/ax.py
@@ -70,15 +70,18 @@ class AxSearch(Searcher):
             logger.warning("Detected sequential enforcement. Setting max "
                            "concurrency to 1.")
             max_concurrent = 1
+        self.max_concurrent = max_concurrent
         self._parameters = list(exp.parameters)
         self._live_index_mapping = {}
         super(AxSearch, self).__init__(
             metric=self._objective_name,
             mode=mode,
-            max_concurrent=max_concurrent,
             use_early_stopped_trials=use_early_stopped_trials)
 
     def suggest(self, trial_id):
+        if self.max_concurrent:
+            if len(self._live_trial_mapping) >= self.max_concurrent:
+                return None
         parameters, trial_index = self._ax.get_next_trial()
         self._live_index_mapping[trial_id] = trial_index
         return parameters

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -60,7 +60,7 @@ class BayesOptSearch(Searcher):
         assert utility_kwargs is not None, (
             "Must define arguments for the utility function!")
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
-
+        self.max_concurrent = max_concurrent
         super(BayesOptSearch, self).__init__(
             metric=metric,
             mode=mode,
@@ -79,6 +79,9 @@ class BayesOptSearch(Searcher):
         self.utility = byo.UtilityFunction(**utility_kwargs)
 
     def suggest(self, trial_id):
+        if self.max_concurrent:
+            if len(self._live_trial_mapping) >= self.max_concurrent:
+                return None
         new_trial = self.optimizer.suggest(self.utility)
 
         self._live_trial_mapping[trial_id] = new_trial

--- a/python/ray/tune/suggest/hyperopt.py
+++ b/python/ray/tune/suggest/hyperopt.py
@@ -88,6 +88,7 @@ class HyperOptSearch(Searcher):
             mode=mode,
             max_concurrent=max_concurrent,
             use_early_stopped_trials=use_early_stopped_trials)
+        self.max_concurrent = max_concurrent
         # hyperopt internally minimizes, so "max" => -1
         if mode == "max":
             self.metric_op = -1.
@@ -118,6 +119,9 @@ class HyperOptSearch(Searcher):
             self.rstate = np.random.RandomState(random_state_seed)
 
     def suggest(self, trial_id):
+        if self.max_concurrent:
+            if len(self._live_trial_mapping) >= self.max_concurrent:
+                return None
         if self._points_to_evaluate > 0:
             new_trial = self._hpopt_trials.trials[self._points_to_evaluate - 1]
             self._points_to_evaluate -= 1

--- a/python/ray/tune/suggest/skopt.py
+++ b/python/ray/tune/suggest/skopt.py
@@ -93,6 +93,7 @@ class SkOptSearch(Searcher):
         _validate_warmstart(parameter_names, points_to_evaluate,
                             evaluated_rewards)
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
+        self.max_concurrent = max_concurrent
         super(SkOptSearch, self).__init__(
             metric=metric,
             mode=mode,
@@ -114,6 +115,9 @@ class SkOptSearch(Searcher):
         self._live_trial_mapping = {}
 
     def suggest(self, trial_id):
+        if self.max_concurrent:
+            if len(self._live_trial_mapping) >= self.max_concurrent:
+                return None
         if self._initial_points:
             suggested_config = self._initial_points[0]
             del self._initial_points[0]

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import warnings
 
 from ray.tune.error import TuneError
 from ray.tune.experiment import convert_to_experiment_list
@@ -68,9 +69,11 @@ class Searcher:
                 "Early stopped trials are now always used. If this is a "
                 "problem, file an issue: https://github.com/ray-project/ray.")
         if max_concurrent is not None:
-            raise DeprecationWarning(
+            warnings.warn(
                 "max_concurrent is now deprecated for this search algorithm. "
-                "Please use tune.suggest.ConcurrencyLimiter instead.")
+                "Please wrap tune.suggest.ConcurrencyLimiter instead. "
+                "This warning will raise an error in a future version of Ray.",
+                DeprecationWarning)
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
         self._metric = metric
         self._mode = mode

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import warnings
 
 from ray.tune.error import TuneError
 from ray.tune.experiment import convert_to_experiment_list
@@ -69,11 +68,10 @@ class Searcher:
                 "Early stopped trials are now always used. If this is a "
                 "problem, file an issue: https://github.com/ray-project/ray.")
         if max_concurrent is not None:
-            warnings.warn(
-                "max_concurrent is now deprecated for this search algorithm. "
-                "Please wrap tune.suggest.ConcurrencyLimiter instead. "
-                "This warning will raise an error in a future version of Ray.",
-                DeprecationWarning)
+            logger.warning(
+                "DeprecationWarning: `max_concurrent` is deprecated for this "
+                "search algorithm. Use tune.suggest.ConcurrencyLimiter() "
+                "instead. This will raise an error in future versions of Ray.")
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
         self._metric = metric
         self._mode = mode


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This prevents Tune from breaking workloads.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)