### PR TITLE
Avoid fate sharing with owner for detached actors

### DIFF
--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -6,9 +6,6 @@ import pytest
 import ray
 from ray import serve
 
-# TODO(edoakes): the failure tests currently fail with the GCS service enabled.
-os.environ["RAY_GCS_SERVICE_ENABLED"] = "false"
-
 if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False):
     serve.master._CRASH_AFTER_CHECKPOINT_PROBABILITY = 0.5
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2514,9 +2514,9 @@ void NodeManager::AssignTask(const std::shared_ptr<Worker> &worker, const Task &
                                                  : worker->GetTaskResourceIds());
 
     // If the owner has died since this task was queued, cancel the task by
-    // killing the worker.
-    if (failed_workers_cache_.count(owner_worker_id) > 0 ||
-        failed_nodes_cache_.count(owner_node_id) > 0) {
+    // killing the worker (unless this task is for a detached actor).
+    if (!worker->IsDetachedActor() && (failed_workers_cache_.count(owner_worker_id) > 0 ||
+                                       failed_nodes_cache_.count(owner_node_id) > 0)) {
       // TODO(swang): Skip assigning this task to this worker instead of
       // killing the worker?
       KillWorker(worker);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The raylet will "cancel" tasks if their owner has died unexpectedly before they're executed. However, for detached actors we should not fate share with the owner. This change adds a check to avoid killing the worker for detached actor creation tasks.

This was causing the serve failure tests to break when running with the GCS service. The behavior was: when running `test_failure.py`, `test_http_proxy_failure` would loop forever with the HTTP proxy being restarted and immediately `SIGTERM`'d. Confirmed that this change fixes the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
