### PR TITLE
Fix serve long running test

### DIFF
--- a/ci/long_running_tests/workloads/serve.py
+++ b/ci/long_running_tests/workloads/serve.py
@@ -44,8 +44,8 @@ def echo(_):
 
 
 serve.create_endpoint("echo", "/echo")
-config = serve.BackendConfig(num_replicas=30, max_batch_size=16)
-serve.create_backend(echo, "echo:v1", backend_config=config)
+config = {"num_replicas": 30, "max_batch_size": 16}
+serve.create_backend("echo:v1", echo, config=config)
 serve.set_traffic("echo", {"echo:v1": 1})
 
 print("Warming up")
@@ -54,7 +54,7 @@ for _ in range(5):
     print(resp)
     time.sleep(0.5)
 
-connections = int(config.num_replicas * config.max_batch_size * 0.75)
+connections = int(config["num_replicas"] * config["max_batch_size"] * 0.75)
 
 while True:
     proc = subprocess.Popen(

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -11,6 +11,9 @@ def _callable_accepts_batch(func_or_class):
 class BackendConfig:
     def __init__(self, config_dict, accepts_batches=False):
         assert isinstance(config_dict, dict)
+        # Make a copy so that we don't modify the input dict.
+        config_dict = config_dict.copy()
+
         self.accepts_batches = accepts_batches
         self.num_replicas = config_dict.pop("num_replicas", 1)
         self.max_batch_size = config_dict.pop("max_batch_size", None)

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -9,6 +9,11 @@ def test_backend_config_validation():
     with pytest.raises(ValueError, match="unknown_key"):
         BackendConfig({"unknown_key": -1})
 
+    # Test that the input dict isn't modified.
+    config = {"num_replicas": 2}
+    BackendConfig(config)
+    assert len(config) == 1 and config["num_replicas"] == 2
+
     # Test num_replicas validation.
     BackendConfig({"num_replicas": 1})
     with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

API was updated in serve but not long running test for release testing.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
