### PR TITLE
[core] Remove timeouts in test_cancel

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -53,7 +53,7 @@ def test_cancel_chain(ray_start_regular, use_force):
         ray.get(obj2, timeout=.1)
 
     signaler2.send.remote()
-    ray.get(obj1, timeout=10)
+    ray.get(obj1)
 
 
 @pytest.mark.parametrize("use_force", [True, False])
@@ -89,7 +89,7 @@ def test_cancel_multiple_dependents(ray_start_regular, use_force):
             ray.get(d)
 
     signaler.send.remote()
-    ray.get(head2, timeout=1)
+    ray.get(head2)
 
 
 @pytest.mark.parametrize("use_force", [True, False])
@@ -109,7 +109,7 @@ def test_single_cpu_cancel(shutdown_only, use_force):
     assert len(ray.wait([obj3], timeout=.1)[0]) == 0
     ray.cancel(obj3, use_force)
     with pytest.raises(valid_exceptions(use_force)):
-        ray.get(obj3, 10)
+        ray.get(obj3)
 
     ray.cancel(obj1, use_force)
 
@@ -151,7 +151,7 @@ def test_comprehensive(ray_start_regular, use_force):
     signaler.send.remote()
 
     with pytest.raises(valid_exceptions(use_force)):
-        ray.get(combo, 10)
+        ray.get(combo)
 
 
 @pytest.mark.parametrize("use_force", [True, False])
@@ -179,7 +179,7 @@ def test_stress(shutdown_only, use_force):
 
     for done in cancelled:
         with pytest.raises(valid_exceptions(use_force)):
-            ray.get(done, 10)
+            ray.get(done)
 
     for indx in range(len(tasks)):
         t = tasks[indx]
@@ -188,7 +188,7 @@ def test_stress(shutdown_only, use_force):
             cancelled.add(t)
         if t in cancelled:
             with pytest.raises(valid_exceptions(use_force)):
-                ray.get(t, 10)
+                ray.get(t)
         else:
             ray.get(t)
 
@@ -223,7 +223,7 @@ def test_fast(shutdown_only, use_force):
     signaler.send.remote()
     for obj_id in ids:
         try:
-            ray.get(obj_id, 10)
+            ray.get(obj_id)
         except Exception as e:
             assert isinstance(e, valid_exceptions(use_force))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fixing flakiness in `test_cancel.py` caused by early timeouts

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
