### PR TITLE
Shorten test_joblib

### DIFF
--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -46,8 +46,7 @@ def test_svm_single_node(shutdown_only):
     }
 
     model = SVC(kernel="rbf")
-    search = RandomizedSearchCV(
-        model, param_space, cv=3, n_iter=50, verbose=10)
+    search = RandomizedSearchCV(model, param_space, cv=3, n_iter=2, verbose=10)
     register_ray()
     with joblib.parallel_backend("ray"):
         search.fit(digits.data, digits.target)
@@ -64,8 +63,7 @@ def test_svm_multiple_nodes(ray_start_cluster_2_nodes):
     }
 
     model = SVC(kernel="rbf")
-    search = RandomizedSearchCV(
-        model, param_space, cv=5, n_iter=100, verbose=10)
+    search = RandomizedSearchCV(model, param_space, cv=5, n_iter=2, verbose=10)
     register_ray()
     with joblib.parallel_backend("ray"):
         search.fit(digits.data, digits.target)
@@ -123,7 +121,7 @@ def test_sklearn_benchmarks(ray_start_cluster_2_nodes):
 
     # Create train-test split.
     print("Creating train-test split...")
-    n_train = 6000
+    n_train = 100
     X_train = X[:n_train]
     y_train = y[:n_train]
     register_ray()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_joblib.py` times out frequently in CI. Given that these are just testing that the ray backend is functioning, we can test with fewer iterations/less data.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
