### PR TITLE
Async actor microbenchmark Script

### DIFF
--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -244,11 +244,11 @@ def main():
     a = [AsyncActor.remote() for _ in range(n_cpu)]
 
     @ray.remote
-    def work(actors):
+    def async_actor_work(actors):
         ray.get([actors[i % n_cpu].small_value.remote() for i in range(n)])
 
     def async_actor_multi():
-        ray.get([work.remote(a) for _ in range(m)])
+        ray.get([async_actor_work.remote(a) for _ in range(m)])
 
     timeit("n:n async-actor calls async", async_actor_multi, m * n)
 

--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -1,5 +1,6 @@
 """This is the script for `ray microbenchmark`."""
 
+import asyncio
 import os
 import time
 import numpy as np
@@ -20,6 +21,22 @@ class Actor:
 
     def small_value_batch(self, n):
         ray.get([small_value.remote() for _ in range(n)])
+
+
+@ray.remote
+class AsyncActor:
+    async def private_coroutine(self):
+        await asyncio.sleep(0)
+        return b"ok"
+
+    async def small_value(self):
+        return await self.private_coroutine()
+
+    async def small_value_with_arg(self, x):
+        return await self.private_coroutine()
+
+    async def small_value_batch(self, n):
+        await asyncio.wait([small_value.remote() for _ in range(n)])
 
 
 @ray.remote(num_cpus=0)
@@ -189,6 +206,51 @@ def main():
 
     timeit("n:n actor calls with arg async", actor_multi2_direct_arg,
            n * len(clients))
+
+    a = AsyncActor.remote()
+
+    def actor_sync():
+        ray.get(a.small_value.remote())
+
+    timeit("1:1 async-actor calls sync", actor_sync)
+
+    a = AsyncActor.remote()
+
+    def async_actor():
+        ray.get([a.small_value.remote() for _ in range(1000)])
+
+    timeit("1:1 async-actor calls async", async_actor, 1000)
+
+    a = AsyncActor.remote()
+
+    def async_actor():
+        ray.get([a.small_value_with_arg.remote(i) for i in range(1000)])
+
+    timeit("1:1 async-actor calls with args async", async_actor, 1000)
+
+    n = 5000
+    n_cpu = multiprocessing.cpu_count() // 2
+    actors = [AsyncActor.remote() for _ in range(n_cpu)]
+    client = Client.remote(actors)
+
+    def async_actor_async():
+        ray.get(client.small_value_batch.remote(n))
+
+    timeit("1:n async-actor calls async", async_actor_async, n * len(actors))
+
+    n = 5000
+    m = 4
+    n_cpu = multiprocessing.cpu_count() // 2
+    a = [AsyncActor.remote() for _ in range(n_cpu)]
+
+    @ray.remote
+    def work(actors):
+        ray.get([actors[i % n_cpu].small_value.remote() for i in range(n)])
+
+    def async_actor_multi():
+        ray.get([work.remote(a) for _ in range(m)])
+
+    timeit("n:n async-actor calls async", async_actor_multi, m * n)
 
 
 if __name__ == "__main__":

--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -25,15 +25,11 @@ class Actor:
 
 @ray.remote
 class AsyncActor:
-    async def private_coroutine(self):
-        await asyncio.sleep(0)
+    async def small_value(self):
         return b"ok"
 
-    async def small_value(self):
-        return await self.private_coroutine()
-
     async def small_value_with_arg(self, x):
-        return await self.private_coroutine()
+        return b"ok"
 
     async def small_value_batch(self, n):
         await asyncio.wait([small_value.remote() for _ in range(n)])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We haven't tracked async actor performance in the release. This script will add async actor benchmark result.

Every benchmarking is done in the same way as sync calls except `1:1 async-actor calls with args async`. We measure this to understand overhead caused by async actor deserialization.

## Related issue number


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
