### PR TITLE
Lower test_utils.wait_for_condition default timeout to 30s

### DIFF
--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -137,9 +137,7 @@ def wait_for_errors(error_type, num_errors, timeout=20):
         num_errors, error_type))
 
 
-def wait_for_condition(condition_predictor,
-                       timeout=30,
-                       retry_interval_ms=100):
+def wait_for_condition(condition_predictor, timeout=30, retry_interval_ms=100):
     """A helper function that waits until a condition is met.
 
     Args:

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -138,7 +138,7 @@ def wait_for_errors(error_type, num_errors, timeout=20):
 
 
 def wait_for_condition(condition_predictor,
-                       timeout=1000,
+                       timeout=30,
                        retry_interval_ms=100):
     """A helper function that waits until a condition is met.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This timeout was mistakenly set to 1000 seconds by default. This is causing some flaky tests to take up way too much time in CI.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
