### PR TITLE
Use kubectl delete pod in example

### DIFF
--- a/doc/source/deploy-on-kubernetes.rst
+++ b/doc/source/deploy-on-kubernetes.rst
@@ -116,7 +116,7 @@ and checking that they are restarted by Kubernetes:
 .. code-block:: shell
 
   # Delete a worker pod.
-  $ kubectl -n ray delete ray-worker-5c49b7cc57-c6xs8
+  $ kubectl -n ray delete pod ray-worker-5c49b7cc57-c6xs8
   pod "ray-worker-5c49b7cc57-c6xs8" deleted
 
   # Check that a new worker pod was started (this may take a few seconds).
@@ -128,7 +128,7 @@ and checking that they are restarted by Kubernetes:
   ray-worker-5c49b7cc57-ypq8x   1/1     Running   0          0s
 
   # Delete the head pod.
-  $ kubectl -n ray delete ray-head-5455bb66c9-6bxvz
+  $ kubectl -n ray delete pod ray-head-5455bb66c9-6bxvz
   pod "ray-head-5455bb66c9-6bxvz" deleted
 
   # Check that a new head pod was started and the worker pods were restarted.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The example form the documentation fails, if `kubectl delete pod` is not specified.
<!-- Please give a short summary of the change and the problem this solves. -->

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.

