### PR TITLE
Fix config key in docs for using PyTorch

### DIFF
--- a/doc/source/rllib.rst
+++ b/doc/source/rllib.rst
@@ -37,7 +37,7 @@ Then, you can try out training in the following equivalent ways:
   from ray.rllib.agents.ppo import PPOTrainer
   tune.run(PPOTrainer, config={"env": "CartPole-v0"})  # "log_level": "INFO" for verbose,
                                                        # "eager": True for eager execution,
-                                                       # "torch": True for PyTorch
+                                                       # "use_pytorch": True for PyTorch
 
 Next, we'll cover three key concepts in RLlib: Policies, Samples, and Trainers.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Docs improperly suggest using "torch" when the actual flag is called "use_pytorch"

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

It's a simple doc change.