### PR TITLE
[RLlib] Fix gym.Wrapper problem for MA Envs.

### DIFF
--- a/rllib/agents/ppo/__init__.py
+++ b/rllib/agents/ppo/__init__.py
@@ -1,5 +1,10 @@
 from ray.rllib.agents.ppo.ppo import PPOTrainer, DEFAULT_CONFIG
 from ray.rllib.agents.ppo.appo import APPOTrainer
 from ray.rllib.agents.ppo.ddppo import DDPPOTrainer
+from ray.rllib.agents.ppo.ppo_tf_policy import PPOTFPolicy
+from ray.rllib.agents.ppo.ppo_torch_policy import PPOTorchPolicy
 
-__all__ = ["APPOTrainer", "DDPPOTrainer", "PPOTrainer", "DEFAULT_CONFIG"]
+__all__ = [
+    "APPOTrainer", "DDPPOTrainer", "PPOTFPolicy", "PPOTorchPolicy",
+    "PPOTrainer", "DEFAULT_CONFIG"
+]

--- a/rllib/env/base_env.py
+++ b/rllib/env/base_env.py
@@ -1,3 +1,5 @@
+import gym
+
 from ray.rllib.env.external_env import ExternalEnv
 from ray.rllib.env.external_multi_agent_env import ExternalMultiAgentEnv
 from ray.rllib.env.vector_env import VectorEnv
@@ -87,7 +89,9 @@ class BaseEnv:
                 "(i.e. vectorization is enabled).")
 
         if not isinstance(env, BaseEnv):
-            if isinstance(env, MultiAgentEnv):
+            env_to_check = unwrap_gym_env(env)
+            # MultiAgentEnv.
+            if isinstance(env_to_check, MultiAgentEnv):
                 if remote_envs:
                     env = RemoteVectorEnv(
                         make_env,
@@ -99,18 +103,21 @@ class BaseEnv:
                         make_env=make_env,
                         existing_envs=[env],
                         num_envs=num_envs)
-            elif isinstance(env, ExternalMultiAgentEnv):
+            # ExternalMultiAgentEnv.
+            elif isinstance(env_to_check, ExternalMultiAgentEnv):
                 if num_envs != 1:
                     raise ValueError(
                         "ExternalMultiAgentEnv does not currently support "
                         "num_envs > 1.")
                 env = _ExternalEnvToBaseEnv(env, multiagent=True)
-            elif isinstance(env, ExternalEnv):
+            # ExternalEnvEnv.
+            elif isinstance(env_to_check, ExternalEnv):
                 if num_envs != 1:
                     raise ValueError(
                         "ExternalEnv does not currently support num_envs > 1.")
                 env = _ExternalEnvToBaseEnv(env)
-            elif isinstance(env, VectorEnv):
+            # VectorEnv.
+            elif isinstance(env_to_check, VectorEnv):
                 env = _VectorEnvToBaseEnv(env)
             else:
                 if remote_envs:
@@ -359,7 +366,7 @@ class _MultiAgentEnvToBaseEnv(BaseEnv):
         while len(self.envs) < self.num_envs:
             self.envs.append(self.make_env(len(self.envs)))
         for env in self.envs:
-            assert isinstance(env, MultiAgentEnv)
+            assert isinstance(unwrap_gym_env(env), MultiAgentEnv)
         self.env_states = [_MultiAgentEnvState(env) for env in self.envs]
 
     @override(BaseEnv)
@@ -410,7 +417,7 @@ class _MultiAgentEnvToBaseEnv(BaseEnv):
 
 class _MultiAgentEnvState:
     def __init__(self, env):
-        assert isinstance(env, MultiAgentEnv)
+        assert isinstance(unwrap_gym_env(env), MultiAgentEnv)
         self.env = env
         self.initialized = False
 
@@ -445,3 +452,23 @@ class _MultiAgentEnvState:
         self.last_infos = {agent_id: {} for agent_id in self.last_obs.keys()}
         self.last_dones["__all__"] = False
         return self.last_obs
+
+
+def unwrap_gym_env(env):
+    """Unwraps a gym.Wrapper Env and returns the completely unwrapped core Env.
+
+    Works on arbitrarily (often) wrapped Envs, e.g.:
+    env = gym.ActionWrapper(gym.RewardWrapper([my_core_env]))
+    unwrap_gym(env) -> [my_core_env]
+
+    Args:
+        env (gym.Env): The gym environment to unwrap.
+
+    Returns:
+        gym.Env: The innermost Env (that's not a gym.Wrapper).
+    """
+    # Unwrap gym.Wrappers to actually get the wrapped type.
+    core_env = env
+    while isinstance(core_env, gym.Wrapper):
+        core_env = core_env.env
+    return core_env


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

When wrapping a MultiAgentEnv with a gym Wrapper, RLlib incorrectly pre-processes observations and crashes due to a Space mismatch. This PR makes sure that RLlib is always aware of the actual underlying (wrapped) Env.

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes issue #8303 

<!-- For example: "Closes #1234" -->

Closes #8303 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
