### PR TITLE
[autoscaler] Fix filesystem permission race conditions

### DIFF
--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -160,9 +160,13 @@ def _configure_key_pair(config):
             logger.info("_configure_key_pair: "
                         "Creating new key pair {}".format(key_name))
             key = ec2.create_key_pair(KeyName=key_name)
-            with open(key_path, "w") as f:
+            with open(
+                    os.open(
+                        key_path,
+                        os.O_WRONLY | os.O_CREAT,
+                        0o600,
+                    ), "w") as f:
                 f.write(key.key_material)
-            os.chmod(key_path, 0o600)
             break
 
     if not key:

--- a/python/ray/autoscaler/aws/config.py
+++ b/python/ray/autoscaler/aws/config.py
@@ -1,4 +1,5 @@
 from distutils.version import StrictVersion
+from functools import partial
 import json
 import os
 import time
@@ -160,12 +161,11 @@ def _configure_key_pair(config):
             logger.info("_configure_key_pair: "
                         "Creating new key pair {}".format(key_name))
             key = ec2.create_key_pair(KeyName=key_name)
-            with open(
-                    os.open(
-                        key_path,
-                        os.O_WRONLY | os.O_CREAT,
-                        0o600,
-                    ), "w") as f:
+
+            # We need to make sure to _create_ the file with the right
+            # permissions. In order to do that we need to change the default
+            # os.open behavior to include the mode we want.
+            with open(key_path, "w", opener=partial(os.open, mode=0o600)) as f:
                 f.write(key.key_material)
             break
 

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -240,7 +240,11 @@ def _configure_key_pair(config):
             # We need to make sure to _create_ the file with the right
             # permissions. In order to do that we need to change the default
             # os.open behavior to include the mode we want.
-            with open(private_key_path, "w", opener=partial(os.open, mode=0o600)) as f:
+            with open(
+                    private_key_path,
+                    "w",
+                    opener=partial(os.open, mode=0o600),
+            ) as f:
                 f.write(private_key)
 
             with open(public_key_path, "w") as f:

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -1,3 +1,4 @@
+from functools import partial
 import os
 import logging
 import time
@@ -236,12 +237,10 @@ def _configure_key_pair(config):
 
             _create_project_ssh_key_pair(project, public_key, ssh_user)
 
-            with open(
-                    os.open(
-                        private_key_path,
-                        os.O_WRONLY | os.O_CREAT,
-                        0o600,
-                    ), "w") as f:
+            # We need to make sure to _create_ the file with the right
+            # permissions. In order to do that we need to change the default
+            # os.open behavior to include the mode we want.
+            with open(private_key_path, "w", opener=partial(os.open, mode=0o600)) as f:
                 f.write(private_key)
 
             with open(public_key_path, "w") as f:

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -236,9 +236,13 @@ def _configure_key_pair(config):
 
             _create_project_ssh_key_pair(project, public_key, ssh_user)
 
-            with open(private_key_path, "w") as f:
+            with open(
+                    os.open(
+                        private_key_path,
+                        os.O_WRONLY | os.O_CREAT,
+                        0o600,
+                    ), "w") as f:
                 f.write(private_key)
-            os.chmod(private_key_path, 0o600)
 
             with open(public_key_path, "w") as f:
                 f.write(public_key)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -223,16 +223,9 @@ class SSHCommandRunner:
         #   the ControlPath directory exists, allowing SSH to maintain
         #   persistent sessions later on.
         try:
-            self.process_runner.check_call(
-                ["mkdir", "-p", self.ssh_control_path])
-        except subprocess.CalledProcessError as e:
+            os.makedirs(self.ssh_control_path, mode=0o700, exist_ok=True)
+        except Exception as e:
             logger.warning(e)
-
-        try:
-            self.process_runner.check_call(
-                ["chmod", "0700", self.ssh_control_path])
-        except subprocess.CalledProcessError as e:
-            logger.warning(self.log_prefix + str(e))
 
     def run(self,
             cmd,

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -224,7 +224,7 @@ class SSHCommandRunner:
         #   persistent sessions later on.
         try:
             os.makedirs(self.ssh_control_path, mode=0o700, exist_ok=True)
-        except Exception as e:
+        except OSError as e:
             logger.warning(e)
 
     def run(self,


### PR DESCRIPTION
## Why are these changes needed?

This fixes a few race conditions where ray's autoscaler creates a file/dir and then sets permissions on it. In order to avoid exposing the contents of these files the way I think is intended, the permissions need to be set at file creation time. Otherwise a well-timed viewer could open a file handle before permissions were set and then read/write after the contents were written to disk.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [n/a] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
