### PR TITLE
Option to retry failed actor tasks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -575,16 +575,6 @@ cc_test(
 )
 
 cc_test(
-    name = "actor_manager_test",
-    srcs = ["src/ray/core_worker/test/actor_manager_test.cc"],
-    copts = COPTS,
-    deps = [
-        ":core_worker_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
     name = "reference_count_test",
     srcs = ["src/ray/core_worker/reference_count_test.cc"],
     copts = COPTS,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -575,6 +575,16 @@ cc_test(
 )
 
 cc_test(
+    name = "actor_manager_test",
+    srcs = ["src/ray/core_worker/test/actor_manager_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":core_worker_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "reference_count_test",
     srcs = ["src/ray/core_worker/reference_count_test.cc"],
     copts = COPTS,

--- a/doc/source/fault-tolerance.rst
+++ b/doc/source/fault-tolerance.rst
@@ -79,9 +79,9 @@ You can experiment with this behavior by running the following code.
     actor = Actor.remote()
 
     # The actor will be reconstructed up to 5 times. After that, methods will
-    # raise exceptions. The actor is reconstructed by rerunning its
-    # constructor. Methods that were executing when the actor died will also
-    # raise exceptions.
+    # always raise a `RayActorError` exception. The actor is reconstructed by
+    # rerunning its constructor. Methods that were sent or executing when the
+    # actor died will also raise a `RayActorError` exception.
     for _ in range(100):
         try:
             counter = ray.get(actor.increment_and_possibly_fail.remote())
@@ -90,23 +90,23 @@ You can experiment with this behavior by running the following code.
             print('FAILURE')
 
 By default, actor tasks execute with at-most-once semantics
-(`max_task_retries=0` in the `@ray.remote` decorator). This means that if an
+(``max_task_retries=0`` in the ``@ray.remote`` decorator). This means that if an
 actor task is submitted to an actor that is unreachable, Ray will report the
-error with `RayActorError`, a Python-level exception that is thrown when
-`ray.get` is called on the future returned by the task. Note that this
+error with ``RayActorError``, a Python-level exception that is thrown when
+``ray.get`` is called on the future returned by the task. Note that this
 exception may be thrown even though the task did indeed execute successfully.
 For example, this can happen if the actor dies immediately after executing the
 task.
 
 Ray also offers at-least-once execution semantics for actor tasks
-(`max_task_retries=-1` or `max_task_retries > 0`). This means that if an actor
-task is submitted to an actor that is unreachable, the system will
+(``max_task_retries=-1`` or ``max_task_retries > 0``). This means that if an
+actor task is submitted to an actor that is unreachable, the system will
 automatically retry the task until it receives a reply from the actor. With
-this option, the system will only throw a `RayActorError` to the application if
-one of the following occurs: The actor’s `max_restarts` limit has been exceeded
-and the actor cannot be restarted anymore.  The `max_task_retries` limit has
-been exceeded for this particular task. This limit can be set to infinity with
-`max_task_retries = -1`.
+this option, the system will only throw a ``RayActorError`` to the application
+if one of the following occurs: (1) the actor’s ``max_restarts`` limit has been
+exceeded and the actor cannot be restarted anymore, or (2) the
+``max_task_retries`` limit has been exceeded for this particular task. The
+limit can be set to infinity with ``max_task_retries = -1``.
 
 You can experiment with this behavior by running the following code.
 
@@ -153,7 +153,7 @@ For at-least-once actors, the system will still guarantee execution ordering
 according to the initial submission order. For example, any tasks submitted
 after a failed actor task will not execute on the actor until the failed actor
 task has been successfully retried. The system also will not attempt to
-re-execute any tasks that were executed before the failure.
+re-execute any tasks that executed successfully before the failure.
 
 At-least-once execution is best suited for read-only actors or actors with
 ephemeral state that does not need to be rebuilt after a failure. For actors

--- a/doc/source/fault-tolerance.rst
+++ b/doc/source/fault-tolerance.rst
@@ -88,3 +88,77 @@ You can experiment with this behavior by running the following code.
             print(counter)
         except ray.exceptions.RayActorError:
             print('FAILURE')
+
+By default, actor tasks execute with at-most-once semantics
+(`max_task_retries=0` in the `@ray.remote` decorator). This means that if an
+actor task is submitted to an actor that is unreachable, Ray will report the
+error with `RayActorError`, a Python-level exception that is thrown when
+`ray.get` is called on the future returned by the task. Note that this
+exception may be thrown even though the task did indeed execute successfully.
+For example, this can happen if the actor dies immediately after executing the
+task.
+
+Ray also offers at-least-once execution semantics for actor tasks
+(`max_task_retries=-1` or `max_task_retries > 0`). This means that if an actor
+task is submitted to an actor that is unreachable, the system will
+automatically retry the task until it receives a reply from the actor. With
+this option, the system will only throw a `RayActorError` to the application if
+one of the following occurs: The actor’s `max_restarts` limit has been exceeded
+and the actor cannot be restarted anymore.  The `max_task_retries` limit has
+been exceeded for this particular task. This limit can be set to infinity with
+`max_task_retries = -1`.
+
+You can experiment with this behavior by running the following code.
+
+.. code-block:: python
+
+    import os
+    import ray
+
+    ray.init(ignore_reinit_error=True)
+
+    @ray.remote(max_restarts=5, max_task_retries=-1)
+    class Actor:
+        def __init__(self):
+            self.counter = 0
+
+        def increment_and_possibly_fail(self):
+            # Exit after every 10 tasks.
+            if self.counter == 10:
+                os._exit(0)
+            self.counter += 1
+            return self.counter
+
+    actor = Actor.remote()
+
+    # The actor will be reconstructed up to 5 times. The actor is
+    # reconstructed by rerunning its constructor. Methods that were
+    # executing when the actor died will be retried and will not
+    # raise a `RayActorError`. Retried methods may execute twice, once
+    # on the failed actor and a second time on the restarted actor.
+    for _ in range(50):
+        counter = ray.get(actor.increment_and_possibly_fail.remote())
+        print(counter)  # Prints the sequence 1-10 5 times.
+
+    # After the actor has been restarted 5 times, all subsequent methods will
+    # raise a `RayActorError`.
+    for _ in range(10):
+        try:
+            counter = ray.get(actor.increment_and_possibly_fail.remote())
+            print(counter)  # Unreachable.
+        except ray.exceptions.RayActorError:
+            print('FAILURE')  # Prints 10 times.
+
+For at-least-once actors, the system will still guarantee execution ordering
+according to the initial submission order. For example, any tasks submitted
+after a failed actor task will not execute on the actor until the failed actor
+task has been successfully retried. The system also will not attempt to
+re-execute any tasks that were executed before the failure.
+
+At-least-once execution is best suited for read-only actors or actors with
+ephemeral state that does not need to be rebuilt after a failure. For actors
+that have critical state, it is best to take periodic checkpoints and either
+manually restart the actor or automatically restart the actor with at-most-once
+semantics. If the actor’s exact state at the time of failure is needed, the
+application is responsible for resubmitting all tasks since the last
+checkpoint.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -903,6 +903,7 @@ cdef class CoreWorker:
                      FunctionDescriptor function_descriptor,
                      args,
                      uint64_t max_reconstructions,
+                     int64_t max_task_retries,
                      resources,
                      placement_resources,
                      int32_t max_concurrency,
@@ -929,7 +930,7 @@ cdef class CoreWorker:
                 check_status(CCoreWorkerProcess.GetCoreWorker().CreateActor(
                     ray_function, args_vector,
                     CActorCreationOptions(
-                        max_reconstructions, max_concurrency,
+                        max_reconstructions, max_task_retries, max_concurrency,
                         c_resources, c_placement_resources,
                         dynamic_worker_options, is_detached, name, is_asyncio),
                     extension_data,

--- a/python/ray/cross_language.py
+++ b/python/ray/cross_language.py
@@ -77,6 +77,7 @@ def java_actor_class(class_name):
         Language.JAVA,
         JavaFunctionDescriptor(class_name, "<init>", ""),
         0,  # max_restarts,
+        0,  # max_task_retries,
         None,  # num_cpus,
         None,  # num_gpus,
         None,  # memory,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -231,6 +231,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
         CActorCreationOptions()
         CActorCreationOptions(
             uint64_t max_reconstructions,
+            int64_t max_task_retries,
             int32_t max_concurrency,
             const unordered_map[c_string, double] &resources,
             const unordered_map[c_string, double] &placement_resources,

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -51,7 +51,7 @@ py_test(
     size = "medium",
     srcs = ["test_actor_failures.py"],
     # TODO(ekl) enable this once we support actor reconstruction again
-    tags = ["exclusive", "manual"],
+    tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -1805,12 +1805,14 @@ def remote(*args, **kwargs):
       unexpectedly. The minimum valid value is 0 (default), which indicates
       that the actor doesn't need to be reconstructed. And the maximum valid
       value is ray.ray_constants.INFINITE_RECONSTRUCTION.
-    * **max_task_retries**: Only for *actors*. This specifies the maximum
-      number of times that the remote function should be rerun when the actor
-      process executing it crashes unexpectedly. Once this limit is reached,
-      the task will no longer be retried and will instead return a
-      `RayActorError` exception that will be thrown if `ray.get` is called. The
-      default value is 0, and -1 means infinite retries.
+    * **max_task_retries**: Only for *actors*. How many times to retry an actor
+      task if the task fails due to a system error, e.g., the actor has died.
+      If set to -1, the system will retry the failed task until the task
+      succeeds, or the actor has reached its max_restarts limit. If set to n >
+      0, the system will retry the failed task up to n times, after which the
+      task will throw a `RayActorError` exception upon `ray.get`. Note that
+      Python exceptions are not considered system errors and will not trigger
+      retries.
     * **max_retries**: Only for *remote functions*. This specifies the maximum
       number of times that the remote function should be rerun when the worker
       process executing it crashes unexpectedly. The minimum valid value is 0,

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -208,6 +208,10 @@ const rpc::Address &TaskSpecification::CallerAddress() const {
   return message_->caller_address();
 }
 
+WorkerID TaskSpecification::CallerWorkerId() const {
+  return WorkerID::FromBinary(message_->caller_address().worker_id());
+}
+
 // === Below are getter methods specific to actor tasks.
 
 ActorID TaskSpecification::ActorId() const {

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -151,6 +151,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   const rpc::Address &CallerAddress() const;
 
+  WorkerID CallerWorkerId() const;
+
   uint64_t ActorCounter() const;
 
   ObjectID ActorCreationDummyObjectId() const;

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -96,10 +96,4 @@ void ActorHandle::SetActorTaskSpec(TaskSpecBuilder &builder, const ObjectID new_
 
 void ActorHandle::Serialize(std::string *output) { inner_.SerializeToString(output); }
 
-void ActorHandle::Reset() {
-  absl::MutexLock guard(&mutex_);
-  task_counter_ = 0;
-  actor_cursor_ = ObjectID::FromBinary(inner_.actor_cursor());
-}
-
 }  // namespace ray

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -23,7 +23,7 @@ ray::rpc::ActorHandle CreateInnerActorHandle(
     const ray::rpc::Address &owner_address, const class JobID &job_id,
     const ObjectID &initial_cursor, const Language actor_language,
     const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data) {
+    const std::string &extension_data, int64_t max_task_retries) {
   ray::rpc::ActorHandle inner;
   inner.set_actor_id(actor_id.Data(), actor_id.Size());
   inner.set_owner_id(owner_id.Binary());
@@ -34,6 +34,7 @@ ray::rpc::ActorHandle CreateInnerActorHandle(
       actor_creation_task_function_descriptor->GetMessage();
   inner.set_actor_cursor(initial_cursor.Binary());
   inner.set_extension_data(extension_data);
+  inner.set_max_task_retries(max_task_retries);
   return inner;
 }
 
@@ -69,10 +70,10 @@ ActorHandle::ActorHandle(
     const rpc::Address &owner_address, const class JobID &job_id,
     const ObjectID &initial_cursor, const Language actor_language,
     const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-    const std::string &extension_data)
+    const std::string &extension_data, int64_t max_task_retries)
     : ActorHandle(CreateInnerActorHandle(
           actor_id, owner_id, owner_address, job_id, initial_cursor, actor_language,
-          actor_creation_task_function_descriptor, extension_data)) {}
+          actor_creation_task_function_descriptor, extension_data, max_task_retries)) {}
 
 ActorHandle::ActorHandle(const std::string &serialized)
     : ActorHandle(CreateInnerActorHandleFromString(serialized)) {}

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -68,14 +68,6 @@ class ActorHandle {
 
   void Serialize(std::string *output);
 
-  /// Reset the handle state next task submitted.
-  ///
-  /// This should be called whenever the actor is restarted, since the new
-  /// instance of the actor does not have the previous sequence number.
-  /// TODO: We should also move the other actor state (status and IP) inside
-  /// ActorHandle and reset them in this method.
-  void Reset();
-
   int64_t MaxTaskRetries() const { return inner_.max_task_retries(); }
 
  private:

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -37,7 +37,7 @@ class ActorHandle {
               const rpc::Address &owner_address, const JobID &job_id,
               const ObjectID &initial_cursor, const Language actor_language,
               const ray::FunctionDescriptor &actor_creation_task_function_descriptor,
-              const std::string &extension_data);
+              const std::string &extension_data, int64_t max_task_retries);
 
   /// Constructs an ActorHandle from a serialized string.
   ActorHandle(const std::string &serialized);
@@ -76,25 +76,11 @@ class ActorHandle {
   /// ActorHandle and reset them in this method.
   void Reset();
 
-  // Mark the actor handle as dead.
-  void MarkDead() {
-    absl::MutexLock lock(&mutex_);
-    state_ = rpc::ActorTableData::DEAD;
-  }
-
-  // Returns whether the actor is known to be dead.
-  bool IsDead() const {
-    absl::MutexLock lock(&mutex_);
-    return state_ == rpc::ActorTableData::DEAD;
-  }
+  int64_t MaxTaskRetries() const { return inner_.max_task_retries(); }
 
  private:
   // Protobuf-defined persistent state of the actor handle.
   const ray::rpc::ActorHandle inner_;
-
-  /// The actor's state (alive or dead). This defaults to ALIVE. Once marked
-  /// DEAD, the actor handle can never go back to being ALIVE.
-  rpc::ActorTableData::ActorState state_ GUARDED_BY(mutex_) = rpc::ActorTableData::ALIVE;
 
   /// The unique id of the dummy object returned by the previous task.
   /// TODO: This can be removed once we schedule actor tasks by task counter

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -111,12 +111,14 @@ struct TaskOptions {
 /// Options for actor creation tasks.
 struct ActorCreationOptions {
   ActorCreationOptions() {}
-  ActorCreationOptions(uint64_t max_reconstructions, int max_concurrency,
+  ActorCreationOptions(uint64_t max_reconstructions, int64_t max_task_retries,
+                       int max_concurrency,
                        const std::unordered_map<std::string, double> &resources,
                        const std::unordered_map<std::string, double> &placement_resources,
                        const std::vector<std::string> &dynamic_worker_options,
                        bool is_detached, std::string &name, bool is_asyncio)
       : max_reconstructions(max_reconstructions),
+        max_task_retries(max_task_retries),
         max_concurrency(max_concurrency),
         resources(resources),
         placement_resources(placement_resources),
@@ -128,6 +130,10 @@ struct ActorCreationOptions {
   /// Maximum number of times that the actor should be reconstructed when it dies
   /// unexpectedly. It must be non-negative. If it's 0, the actor won't be reconstructed.
   const uint64_t max_reconstructions = 0;
+  /// Maximum number of times that individual tasks can be retried at the
+  /// actor, if the actor dies unexpectedly. If -1, then the task may be
+  /// retried infinitely many times.
+  const int64_t max_task_retries = 0;
   /// The max number of concurrent tasks to run on this direct call actor.
   const int max_concurrency = 1;
   /// Resources required by the whole lifetime of this actor.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -604,20 +604,9 @@ const WorkerID &CoreWorker::GetWorkerID() const { return worker_context_.GetWork
 
 void CoreWorker::SetCurrentTaskId(const TaskID &task_id) {
   worker_context_.SetCurrentTaskId(task_id);
-  bool not_actor_task = false;
   {
     absl::MutexLock lock(&mutex_);
     main_thread_task_id_ = task_id;
-    not_actor_task = actor_id_.IsNil();
-  }
-  if (not_actor_task && task_id.IsNil()) {
-    absl::MutexLock lock(&actor_handles_mutex_);
-    // Reset the seqnos so that for the next task it start off at 0.
-    for (const auto &handle : actor_handles_) {
-      handle.second->Reset();
-    }
-    // TODO(ekl) we can't unsubscribe to actor notifications here due to
-    // https://github.com/ray-project/ray/pull/6885
   }
 }
 
@@ -676,7 +665,12 @@ void CoreWorker::InternalHeartbeat(const boost::system::error_code &error) {
 
   absl::MutexLock lock(&mutex_);
   while (!to_resubmit_.empty() && current_time_ms() > to_resubmit_.front().first) {
-    RAY_CHECK_OK(direct_task_submitter_->SubmitTask(to_resubmit_.front().second));
+    auto &spec = to_resubmit_.front().second;
+    if (spec.IsActorTask()) {
+      RAY_CHECK_OK(direct_actor_submitter_->SubmitTask(spec));
+    } else {
+      RAY_CHECK_OK(direct_task_submitter_->SubmitTask(spec));
+    }
     to_resubmit_.pop_front();
   }
   internal_timer_.expires_at(internal_timer_.expiry() +
@@ -1156,7 +1150,8 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   // WaitForActorOutOfScopeRequest.
   std::unique_ptr<ActorHandle> actor_handle(new ActorHandle(
       actor_id, GetCallerId(), rpc_address_, job_id, /*actor_cursor=*/return_ids[0],
-      function.GetLanguage(), function.GetFunctionDescriptor(), extension_data));
+      function.GetLanguage(), function.GetFunctionDescriptor(), extension_data,
+      actor_creation_options.max_task_retries));
   RAY_CHECK(AddActorHandle(std::move(actor_handle),
                            /*is_owner_handle=*/!actor_creation_options.is_detached))
       << "Actor " << actor_id << " already exists";
@@ -1210,14 +1205,8 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
     ExecuteTaskLocalMode(task_spec, actor_id);
   } else {
     task_manager_->AddPendingTask(GetCallerId(), rpc_address_, task_spec,
-                                  CurrentCallSite());
-    if (actor_handle->IsDead()) {
-      auto status = Status::IOError("sent task to dead actor");
-      task_manager_->PendingTaskFailed(task_spec.TaskId(), rpc::ErrorType::ACTOR_DIED,
-                                       &status);
-    } else {
-      status = direct_actor_submitter_->SubmitTask(task_spec);
-    }
+                                  CurrentCallSite(), actor_handle->MaxTaskRetries());
+    status = direct_actor_submitter_->SubmitTask(task_spec);
   }
   return status;
 }
@@ -1295,6 +1284,7 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
   }
 
   reference_counter_->AddLocalReference(actor_creation_return_id, CurrentCallSite());
+  direct_actor_submitter_->AddActorQueue(actor_id);
 
   bool inserted;
   {
@@ -1309,19 +1299,9 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
       if (actor_data.state() == gcs::ActorTableData::PENDING) {
         // The actor is being created and not yet ready, just ignore!
       } else if (actor_data.state() == gcs::ActorTableData::RECONSTRUCTING) {
-        absl::MutexLock lock(&actor_handles_mutex_);
-        auto it = actor_handles_.find(actor_id);
-        RAY_CHECK(it != actor_handles_.end());
-        // We have to reset the actor handle since the next instance of the
-        // actor will not have the last sequence number that we sent.
-        it->second->Reset();
         direct_actor_submitter_->DisconnectActor(actor_id, false);
       } else if (actor_data.state() == gcs::ActorTableData::DEAD) {
         direct_actor_submitter_->DisconnectActor(actor_id, true);
-
-        ActorHandle *actor_handle = nullptr;
-        RAY_CHECK_OK(GetActorHandle(actor_id, &actor_handle));
-        actor_handle->MarkDead();
         // We cannot erase the actor handle here because clients can still
         // submit tasks to dead actors. This also means we defer unsubscription,
         // otherwise we crash when bulk unsubscribing all actor handles.
@@ -1365,8 +1345,8 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
           // language frontend receives another ref to the same actor. In this
           // case, we must remember the last task counter that we sent to the
           // actor.
-          // TODO(swang): Unsubscribe from the actor table once all local refs
-          // to the actor have gone out of scope.
+          // TODO(ekl) we can't unsubscribe to actor notifications here due to
+          // https://github.com/ray-project/ray/pull/6885
           auto callback = actor_out_of_scope_callbacks_.extract(actor_id);
           if (callback) {
             callback.mapped()(actor_id);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1531,16 +1531,11 @@ Status CoreWorker::ExecuteTask(const TaskSpecification &task_spec,
     return_ids.pop_back();
     task_type = TaskType::ACTOR_CREATION_TASK;
     SetActorId(task_spec.ActorCreationId());
-    // For an actor, set the timestamp as the time its creation task starts execution.
-    SetCallerCreationTimestamp();
     RAY_LOG(INFO) << "Creating actor: " << task_spec.ActorCreationId();
   } else if (task_spec.IsActorTask()) {
     RAY_CHECK(return_ids.size() > 0);
     return_ids.pop_back();
     task_type = TaskType::ACTOR_TASK;
-  } else {
-    // For a non-actor task, set the timestamp as the time it starts execution.
-    SetCallerCreationTimestamp();
   }
 
   // Because we support concurrent actor calls, we need to update the
@@ -2054,11 +2049,6 @@ void CoreWorker::SetWebuiDisplay(const std::string &key, const std::string &mess
 void CoreWorker::SetActorTitle(const std::string &title) {
   absl::MutexLock lock(&mutex_);
   actor_title_ = title;
-}
-
-void CoreWorker::SetCallerCreationTimestamp() {
-  absl::MutexLock lock(&mutex_);
-  direct_actor_submitter_->SetCallerCreationTimestamp(current_sys_time_ms());
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1284,7 +1284,7 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
   }
 
   reference_counter_->AddLocalReference(actor_creation_return_id, CurrentCallSite());
-  direct_actor_submitter_->AddActorQueue(actor_id);
+  direct_actor_submitter_->AddActorQueueIfNotExists(actor_id);
 
   bool inserted;
   {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -428,7 +428,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
   }
 
   direct_actor_submitter_ = std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
-      new CoreWorkerDirectActorTaskSubmitter(rpc_address_, client_factory, memory_store_,
+      new CoreWorkerDirectActorTaskSubmitter(client_factory, memory_store_,
                                              task_manager_));
 
   direct_task_submitter_ =

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -110,6 +110,7 @@ inline ray::ActorCreationOptions ToActorCreationOptions(JNIEnv *env,
   std::string name = "";
   ray::ActorCreationOptions actor_creation_options{
       static_cast<uint64_t>(max_reconstructions),
+      static_cast<uint64_t>(0),  // TODO: Allow setting max_task_retries from Java.
       static_cast<int>(max_concurrency),
       resources,
       resources,

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -28,7 +28,8 @@ void TaskManager::AddPendingTask(const TaskID &caller_id,
                                  const rpc::Address &caller_address,
                                  const TaskSpecification &spec,
                                  const std::string &call_site, int max_retries) {
-  RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId();
+  RAY_LOG(DEBUG) << "Adding pending task " << spec.TaskId() << " with " << max_retries
+                 << " retries";
 
   // Add references for the dependencies to the task.
   std::vector<ObjectID> task_deps;
@@ -90,12 +91,18 @@ Status TaskManager::ResubmitTask(const TaskID &task_id,
     if (it == submissible_tasks_.end()) {
       return Status::Invalid("Task spec missing");
     }
+    if (it->second.spec.IsActorTask()) {
+      return Status::Invalid("Cannot reconstruct objects returned by actors");
+    }
 
     if (!it->second.pending) {
       resubmit = true;
       it->second.pending = true;
-      RAY_CHECK(it->second.num_retries_left > 0);
-      it->second.num_retries_left--;
+      if (it->second.num_retries_left > 0) {
+        it->second.num_retries_left--;
+      } else {
+        RAY_CHECK(it->second.num_retries_left == -1);
+      }
       spec = it->second.spec;
     }
   }
@@ -241,8 +248,8 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     // A finished task can be only be re-executed if it has some number of
     // retries left and returned at least one object that is still in use and
     // stored in plasma.
-    bool task_retryable =
-        it->second.num_retries_left > 0 && !it->second.reconstructable_return_ids.empty();
+    bool task_retryable = it->second.num_retries_left != 0 &&
+                          !it->second.reconstructable_return_ids.empty();
     if (task_retryable) {
       // Pin the task spec if it may be retried again.
       release_lineage = false;
@@ -256,7 +263,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
   ShutdownIfNeeded();
 }
 
-void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
+bool TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
                                     Status *status) {
   // Note that this might be the __ray_terminate__ task, so we don't log
   // loudly with ERROR here.
@@ -278,18 +285,23 @@ void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_
       submissible_tasks_.erase(it);
       num_pending_tasks_--;
     } else {
-      RAY_CHECK(it->second.num_retries_left > 0);
-      it->second.num_retries_left--;
+      if (it->second.num_retries_left > 0) {
+        it->second.num_retries_left--;
+      } else {
+        RAY_CHECK(it->second.num_retries_left == -1);
+      }
       release_lineage = false;
     }
   }
 
+  bool will_retry = false;
   // We should not hold the lock during these calls because they may trigger
   // callbacks in this or other classes.
-  if (num_retries_left > 0) {
+  if (num_retries_left != 0) {
     RAY_LOG(ERROR) << num_retries_left << " retries left for task " << spec.TaskId()
                    << ", attempting to resubmit.";
     retry_task_callback_(spec, /*delay=*/true);
+    will_retry = true;
   } else {
     // Throttled logging of task failure errors.
     {
@@ -319,6 +331,8 @@ void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_
   }
 
   ShutdownIfNeeded();
+
+  return will_retry;
 }
 
 void TaskManager::ShutdownIfNeeded() {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -32,7 +32,7 @@ class TaskFinisherInterface {
   virtual void CompletePendingTask(const TaskID &task_id, const rpc::PushTaskReply &reply,
                                    const rpc::Address &actor_addr) = 0;
 
-  virtual void PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
+  virtual bool PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
                                  Status *status = nullptr) = 0;
 
   virtual void OnTaskDependenciesInlined(
@@ -116,7 +116,8 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// \param[in] task_id ID of the pending task.
   /// \param[in] error_type The type of the specific error.
   /// \param[in] status Optional status message.
-  void PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
+  /// \return Whether the task will be retried or not.
+  bool PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
                          Status *status = nullptr) override;
 
   /// A task's dependencies were inlined in the task spec. This will decrement

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -73,8 +73,9 @@ ActorID CreateActorHelper(std::unordered_map<std::string, double> &resources,
   std::string name = "";
   ActorCreationOptions actor_options{
       max_reconstructions,
-      /*max_concurrency*/ 1, resources, resources,           {},
-      /*is_detached=*/false, name,      /*is_asyncio=*/false};
+      /*max_task_retries=*/0,
+      /*max_concurrency*/ 1,  resources, resources,           {},
+      /*is_detached=*/false,  name,      /*is_asyncio=*/false};
 
   // Create an actor.
   ActorID actor_id;
@@ -644,6 +645,7 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
   std::unordered_map<std::string, double> resources;
   std::string name = "";
   ActorCreationOptions actor_options{0,
+                                     0,
                                      1,
                                      resources,
                                      resources,
@@ -654,7 +656,8 @@ TEST_F(ZeroNodeTest, TestTaskSpecPerf) {
   const auto job_id = NextJobId();
   ActorHandle actor_handle(ActorID::Of(job_id, TaskID::ForDriverTask(job_id), 1),
                            TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-                           function.GetLanguage(), function.GetFunctionDescriptor(), "");
+                           function.GetLanguage(), function.GetFunctionDescriptor(), "",
+                           0);
 
   // Manually create `num_tasks` task specs, and for each of them create a
   // `PushTaskRequest`, this is to batch performance of TaskSpec
@@ -763,10 +766,10 @@ TEST_F(ZeroNodeTest, TestWorkerContext) {
 TEST_F(ZeroNodeTest, TestActorHandle) {
   // Test actor handle serialization and deserialization round trip.
   JobID job_id = NextJobId();
-  ActorHandle original(ActorID::Of(job_id, TaskID::ForDriverTask(job_id), 0),
-                       TaskID::Nil(), rpc::Address(), job_id, ObjectID::FromRandom(),
-                       Language::PYTHON,
-                       ray::FunctionDescriptorBuilder::BuildPython("", "", "", ""), "");
+  ActorHandle original(
+      ActorID::Of(job_id, TaskID::ForDriverTask(job_id), 0), TaskID::Nil(),
+      rpc::Address(), job_id, ObjectID::FromRandom(), Language::PYTHON,
+      ray::FunctionDescriptorBuilder::BuildPython("", "", "", ""), "", 0);
   std::string output;
   original.Serialize(&output);
   ActorHandle deserialized(output);

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -24,16 +24,45 @@
 namespace ray {
 
 using ::testing::_;
+using ::testing::ElementsAre;
+using ::testing::Return;
+
+TaskSpecification CreateActorTaskHelper(ActorID actor_id, WorkerID caller_worker_id,
+                                        int64_t counter,
+                                        TaskID caller_id = TaskID::Nil()) {
+  TaskSpecification task;
+  task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
+  task.GetMutableMessage().set_caller_id(caller_id.Binary());
+  task.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task.GetMutableMessage().mutable_caller_address()->set_worker_id(
+      caller_worker_id.Binary());
+  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_id(actor_id.Binary());
+  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_counter(counter);
+  task.GetMutableMessage().set_num_returns(1);
+  return task;
+}
+
+rpc::PushTaskRequest CreatePushTaskRequestHelper(ActorID actor_id, int64_t counter,
+                                                 WorkerID caller_worker_id,
+                                                 TaskID caller_id,
+                                                 int64_t caller_timestamp) {
+  auto task_spec = CreateActorTaskHelper(actor_id, caller_worker_id, counter, caller_id);
+
+  rpc::PushTaskRequest request;
+  request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
+  request.set_sequence_number(request.task_spec().actor_task_spec().actor_counter());
+  request.set_client_processed_up_to(-1);
+  return request;
+}
 
 class MockWorkerClient : public rpc::CoreWorkerClientInterface {
  public:
   const rpc::Address &Addr() const override { return addr; }
 
   ray::Status PushActorTask(
-      std::unique_ptr<rpc::PushTaskRequest> request,
+      std::unique_ptr<rpc::PushTaskRequest> request, bool skip_queue,
       const rpc::ClientCallback<rpc::PushTaskReply> &callback) override {
-    RAY_CHECK(counter == request->task_spec().actor_task_spec().actor_counter());
-    counter++;
+    received_seq_nos.push_back(request->sequence_number());
     callbacks.push_back(callback);
     return Status::OK();
   }
@@ -50,7 +79,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
 
   rpc::Address addr;
   std::list<rpc::ClientCallback<rpc::PushTaskReply>> callbacks;
-  uint64_t counter = 0;
+  std::vector<uint64_t> received_seq_nos;
 };
 
 class MockTaskFinisher : public TaskFinisherInterface {
@@ -60,7 +89,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
   MOCK_METHOD3(CompletePendingTask, void(const TaskID &, const rpc::PushTaskReply &,
                                          const rpc::Address &addr));
   MOCK_METHOD3(PendingTaskFailed,
-               void(const TaskID &task_id, rpc::ErrorType error_type, Status *status));
+               bool(const TaskID &task_id, rpc::ErrorType error_type, Status *status));
 
   MOCK_METHOD2(OnTaskDependenciesInlined,
                void(const std::vector<ObjectID> &, const std::vector<ObjectID> &));
@@ -68,25 +97,15 @@ class MockTaskFinisher : public TaskFinisherInterface {
   MOCK_METHOD1(MarkTaskCanceled, bool(const TaskID &task_id));
 };
 
-TaskSpecification CreateActorTaskHelper(ActorID actor_id, int64_t counter) {
-  TaskSpecification task;
-  task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
-  task.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_id(actor_id.Binary());
-  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_counter(counter);
-  return task;
-}
-
 class DirectActorSubmitterTest : public ::testing::Test {
  public:
   DirectActorSubmitterTest()
       : worker_client_(std::shared_ptr<MockWorkerClient>(new MockWorkerClient())),
         store_(std::shared_ptr<CoreWorkerMemoryStore>(new CoreWorkerMemoryStore())),
         task_finisher_(std::make_shared<MockTaskFinisher>()),
-        submitter_(address_, [&](const rpc::Address &addr) { return worker_client_; },
-                   store_, task_finisher_) {}
+        submitter_([&](const rpc::Address &addr) { return worker_client_; }, store_,
+                   task_finisher_) {}
 
-  rpc::Address address_;
   std::shared_ptr<MockWorkerClient> worker_client_;
   std::shared_ptr<CoreWorkerMemoryStore> store_;
   std::shared_ptr<MockTaskFinisher> task_finisher_;
@@ -95,16 +114,19 @@ class DirectActorSubmitterTest : public ::testing::Test {
 
 TEST_F(DirectActorSubmitterTest, TestSubmitTask) {
   rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
 
-  auto task = CreateActorTaskHelper(actor_id, 0);
+  auto task = CreateActorTaskHelper(actor_id, worker_id, 0);
   ASSERT_TRUE(submitter_.SubmitTask(task).ok());
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 1);
 
-  task = CreateActorTaskHelper(actor_id, 1);
+  task = CreateActorTaskHelper(actor_id, worker_id, 1);
   ASSERT_TRUE(submitter_.SubmitTask(task).ok());
   ASSERT_EQ(worker_client_->callbacks.size(), 2);
 
@@ -114,20 +136,24 @@ TEST_F(DirectActorSubmitterTest, TestSubmitTask) {
   while (!worker_client_->callbacks.empty()) {
     ASSERT_TRUE(worker_client_->ReplyPushTask());
   }
+  ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
 }
 
 TEST_F(DirectActorSubmitterTest, TestDependencies) {
   rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
   // Create two tasks for the actor with different arguments.
   ObjectID obj1 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
   ObjectID obj2 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
-  auto task1 = CreateActorTaskHelper(actor_id, 0);
+  auto task1 = CreateActorTaskHelper(actor_id, worker_id, 0);
   task1.GetMutableMessage().add_args()->add_object_ids(obj1.Binary());
-  auto task2 = CreateActorTaskHelper(actor_id, 1);
+  auto task2 = CreateActorTaskHelper(actor_id, worker_id, 1);
   task2.GetMutableMessage().add_args()->add_object_ids(obj2.Binary());
 
   // Neither task can be submitted yet because they are still waiting on
@@ -142,20 +168,24 @@ TEST_F(DirectActorSubmitterTest, TestDependencies) {
   ASSERT_EQ(worker_client_->callbacks.size(), 1);
   ASSERT_TRUE(store_->Put(*data, obj2));
   ASSERT_EQ(worker_client_->callbacks.size(), 2);
+  ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
 }
 
 TEST_F(DirectActorSubmitterTest, TestOutOfOrderDependencies) {
   rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
   // Create two tasks for the actor with different arguments.
   ObjectID obj1 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
   ObjectID obj2 = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
-  auto task1 = CreateActorTaskHelper(actor_id, 0);
+  auto task1 = CreateActorTaskHelper(actor_id, worker_id, 0);
   task1.GetMutableMessage().add_args()->add_object_ids(obj1.Binary());
-  auto task2 = CreateActorTaskHelper(actor_id, 1);
+  auto task2 = CreateActorTaskHelper(actor_id, worker_id, 1);
   task2.GetMutableMessage().add_args()->add_object_ids(obj2.Binary());
 
   // Neither task can be submitted yet because they are still waiting on
@@ -171,28 +201,131 @@ TEST_F(DirectActorSubmitterTest, TestOutOfOrderDependencies) {
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
   ASSERT_TRUE(store_->Put(*data, obj1));
   ASSERT_EQ(worker_client_->callbacks.size(), 2);
+  ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
 }
 
-TEST_F(DirectActorSubmitterTest, TestActorFailure) {
+TEST_F(DirectActorSubmitterTest, TestActorDead) {
   rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
   gcs::ActorTableData actor_data;
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
-  // Create two tasks for the actor.
-  auto task1 = CreateActorTaskHelper(actor_id, 0);
-  auto task2 = CreateActorTaskHelper(actor_id, 1);
+  // Create two tasks for the actor. One depends on an object that is not yet available.
+  auto task1 = CreateActorTaskHelper(actor_id, worker_id, 0);
+  ObjectID obj = ObjectID::FromRandom().WithTransportType(TaskTransportType::DIRECT);
+  auto task2 = CreateActorTaskHelper(actor_id, worker_id, 1);
+  task2.GetMutableMessage().add_args()->add_object_ids(obj.Binary());
   ASSERT_TRUE(submitter_.SubmitTask(task1).ok());
   ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
-  ASSERT_EQ(worker_client_->callbacks.size(), 2);
+  ASSERT_EQ(worker_client_->callbacks.size(), 1);
 
-  // Simulate the actor dying. All submitted tasks should get failed.
-  EXPECT_CALL(*task_finisher_, PendingTaskFailed(_, _, _)).Times(2);
+  // Simulate the actor dying. All in-flight tasks should get failed.
+  EXPECT_CALL(*task_finisher_, PendingTaskFailed(task1.TaskId(), _, _)).Times(1);
   EXPECT_CALL(*task_finisher_, CompletePendingTask(_, _, _)).Times(0);
   while (!worker_client_->callbacks.empty()) {
     ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
   }
+
+  EXPECT_CALL(*task_finisher_, PendingTaskFailed(_, _, _)).Times(0);
+  submitter_.DisconnectActor(actor_id, /*dead=*/false);
+  // Actor marked as dead. All queued tasks should get failed.
+  EXPECT_CALL(*task_finisher_, PendingTaskFailed(task2.TaskId(), _, _)).Times(1);
+  submitter_.DisconnectActor(actor_id, /*dead=*/true);
+}
+
+TEST_F(DirectActorSubmitterTest, TestActorRestartNoRetry) {
+  rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
+  gcs::ActorTableData actor_data;
+  submitter_.ConnectActor(actor_id, addr);
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Create four tasks for the actor.
+  auto task1 = CreateActorTaskHelper(actor_id, worker_id, 0);
+  auto task2 = CreateActorTaskHelper(actor_id, worker_id, 1);
+  auto task3 = CreateActorTaskHelper(actor_id, worker_id, 2);
+  auto task4 = CreateActorTaskHelper(actor_id, worker_id, 3);
+  // Submit three tasks.
+  ASSERT_TRUE(submitter_.SubmitTask(task1).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task3).ok());
+
+  EXPECT_CALL(*task_finisher_, CompletePendingTask(task1.TaskId(), _, _)).Times(2);
+  EXPECT_CALL(*task_finisher_, PendingTaskFailed(task2.TaskId(), _, _)).Times(2);
+  // First task finishes. Second task fails.
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::OK()));
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
+
+  // Simulate the actor failing.
+  submitter_.DisconnectActor(actor_id, /*dead=*/false);
+  // Third task fails after the actor is disconnected. It should not get
+  // retried.
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
+
+  // Actor gets restarted.
+  submitter_.ConnectActor(actor_id, addr);
+  ASSERT_TRUE(submitter_.SubmitTask(task4).ok());
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::OK()));
+  ASSERT_TRUE(worker_client_->callbacks.empty());
+  // Actor counter restarts at 0 after the actor is restarted.
+  ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1, 2, 0));
+}
+
+TEST_F(DirectActorSubmitterTest, TestActorRestartRetry) {
+  rpc::Address addr;
+  auto worker_id = WorkerID::FromRandom();
+  addr.set_worker_id(worker_id.Binary());
+  ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
+  submitter_.AddActorQueue(actor_id);
+  gcs::ActorTableData actor_data;
+  submitter_.ConnectActor(actor_id, addr);
+  ASSERT_EQ(worker_client_->callbacks.size(), 0);
+
+  // Create four tasks for the actor.
+  auto task1 = CreateActorTaskHelper(actor_id, worker_id, 0);
+  auto task2 = CreateActorTaskHelper(actor_id, worker_id, 1);
+  auto task3 = CreateActorTaskHelper(actor_id, worker_id, 2);
+  auto task4 = CreateActorTaskHelper(actor_id, worker_id, 3);
+  // Submit three tasks.
+  ASSERT_TRUE(submitter_.SubmitTask(task1).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task3).ok());
+
+  // All tasks will eventually finish.
+  EXPECT_CALL(*task_finisher_, CompletePendingTask(task1.TaskId(), _, _)).Times(4);
+  // Tasks 2 and 3 will be retried.
+  EXPECT_CALL(*task_finisher_, PendingTaskFailed(task2.TaskId(), _, _))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+  // First task finishes. Second task fails.
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::OK()));
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
+
+  // Simulate the actor failing.
+  submitter_.DisconnectActor(actor_id, /*dead=*/false);
+  // Third task fails after the actor is disconnected.
+  ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
+
+  // Actor gets restarted.
+  submitter_.ConnectActor(actor_id, addr);
+  // A new task is submitted.
+  ASSERT_TRUE(submitter_.SubmitTask(task4).ok());
+  // Tasks 2 and 3 get retried.
+  ASSERT_TRUE(submitter_.SubmitTask(task2).ok());
+  ASSERT_TRUE(submitter_.SubmitTask(task3).ok());
+  while (!worker_client_->callbacks.empty()) {
+    ASSERT_TRUE(worker_client_->ReplyPushTask(Status::OK()));
+  }
+  // Actor counter restarts at 0 after the actor is restarted. New task cannot
+  // execute until after tasks 2 and 3 are re-executed.
+  ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1, 2, 2, 0, 1));
 }
 
 class MockDependencyWaiterInterface : public DependencyWaiterInterface {
@@ -202,35 +335,6 @@ class MockDependencyWaiterInterface : public DependencyWaiterInterface {
     return Status::OK();
   }
 };
-
-TaskSpecification CreateActorTaskHelper(ActorID actor_id, int64_t counter,
-                                        TaskID caller_id) {
-  TaskSpecification task;
-  task.GetMutableMessage().set_task_id(TaskID::Nil().Binary());
-  task.GetMutableMessage().set_caller_id(caller_id.Binary());
-  task.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
-  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_id(actor_id.Binary());
-  task.GetMutableMessage().mutable_actor_task_spec()->set_actor_counter(counter);
-  task.GetMutableMessage().set_num_returns(1);
-  return task;
-}
-
-rpc::PushTaskRequest CreatePushTaskRequestHelper(ActorID actor_id, int64_t counter,
-                                                 WorkerID caller_worker_id,
-                                                 TaskID caller_id,
-                                                 int64_t caller_timestamp) {
-  auto task_spec = CreateActorTaskHelper(actor_id, counter, caller_id);
-  rpc::Address rpc_address;
-  rpc_address.set_worker_id(caller_worker_id.Binary());
-
-  rpc::PushTaskRequest request;
-  request.mutable_caller_address()->CopyFrom(rpc_address);
-  request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
-  request.set_caller_version(caller_timestamp);
-  request.set_sequence_number(request.task_spec().actor_task_spec().actor_counter());
-  request.set_client_processed_up_to(-1);
-  return request;
-}
 
 class MockWorkerContext : public WorkerContext {
  public:
@@ -278,7 +382,6 @@ class DirectActorReceiverTest : public ::testing::Test {
 };
 
 TEST_F(DirectActorReceiverTest, TestNewTaskFromDifferentWorker) {
-  rpc::Address addr;
   TaskID current_task_id = TaskID::Nil();
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
   WorkerID worker_id = WorkerID::FromRandom();
@@ -319,7 +422,7 @@ TEST_F(DirectActorReceiverTest, TestNewTaskFromDifferentWorker) {
     receiver_->HandlePushTask(request, &reply, reply_callback);
   }
 
-  // Create another request with the same caller id, but a differnt worker id,
+  // Create another request with the same caller id, but a different worker id,
   // and a newer timestamp. This simulates caller reconstruction.
   // Note that here the task request still has counter 0, which should be
   // ignored normally, but here it's from a different worker and with a newer

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -117,7 +117,7 @@ TEST_F(DirectActorSubmitterTest, TestSubmitTask) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
 
   auto task = CreateActorTaskHelper(actor_id, worker_id, 0);
   ASSERT_TRUE(submitter_.SubmitTask(task).ok());
@@ -144,7 +144,7 @@ TEST_F(DirectActorSubmitterTest, TestDependencies) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
@@ -176,7 +176,7 @@ TEST_F(DirectActorSubmitterTest, TestOutOfOrderDependencies) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
 
@@ -209,7 +209,7 @@ TEST_F(DirectActorSubmitterTest, TestActorDead) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
   gcs::ActorTableData actor_data;
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
@@ -242,7 +242,7 @@ TEST_F(DirectActorSubmitterTest, TestActorRestartNoRetry) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
   gcs::ActorTableData actor_data;
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);
@@ -283,7 +283,7 @@ TEST_F(DirectActorSubmitterTest, TestActorRestartRetry) {
   auto worker_id = WorkerID::FromRandom();
   addr.set_worker_id(worker_id.Binary());
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
-  submitter_.AddActorQueue(actor_id);
+  submitter_.AddActorQueueIfNotExists(actor_id);
   gcs::ActorTableData actor_data;
   submitter_.ConnectActor(actor_id, addr);
   ASSERT_EQ(worker_client_->callbacks.size(), 0);

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -72,9 +72,10 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_tasks_complete++;
   }
 
-  void PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
+  bool PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
                          Status *status) override {
     num_tasks_failed++;
+    return true;
   }
 
   void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -233,8 +233,7 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(const ClientQueue &queue,
   rpc::Address addr(queue.rpc_client->Addr());
   RAY_UNUSED(queue.rpc_client->PushActorTask(
       std::move(request), skip_queue,
-      [this, addr, task_id, actor_id, counter](Status status,
-                                               const rpc::PushTaskReply &reply) {
+      [this, addr, task_id, actor_id](Status status, const rpc::PushTaskReply &reply) {
         bool increment_completed_tasks = true;
         if (!status.ok()) {
           bool will_retry = task_finisher_->PendingTaskFailed(

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -22,7 +22,7 @@ using ray::rpc::ActorTableData;
 
 namespace ray {
 
-void CoreWorkerDirectActorTaskSubmitter::AddActorQueue(const ActorID &actor_id) {
+void CoreWorkerDirectActorTaskSubmitter::AddActorQueueIfNotExists(const ActorID &actor_id) {
   absl::MutexLock lock(&mu_);
   // No need to check whether the insert was successful, since it is possible
   // for this worker to have multiple references to the same actor.

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -118,6 +118,9 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
   RAY_CHECK(!queue->second.rpc_client);
   queue->second.rpc_client =
       std::shared_ptr<rpc::CoreWorkerClientInterface>(client_factory_(address));
+  // TODO(swang): This assumes that replies from the previous incarnation of
+  // the actor have been received. Fix this by setting an epoch for each actor
+  // task, so we can ignore completed tasks from old epochs.
   queue->second.caller_starts_at = queue->second.num_completed_tasks;
   SendPendingTasks(actor_id);
 }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -205,7 +205,6 @@ void CoreWorkerDirectActorTaskSubmitter::PushActorTask(const ClientQueue &queue,
   // fails, then the task data will be gone when the TaskManager attempts to
   // access the task.
   request->mutable_task_spec()->CopyFrom(task_spec.GetMessage());
-  // request.set_caller_version(caller_creation_timestamp_ms_);
 
   request->set_intended_worker_id(queue.worker_id);
   RAY_CHECK(task_spec.ActorCounter() >= queue.caller_starts_at)
@@ -246,10 +245,6 @@ bool CoreWorkerDirectActorTaskSubmitter::IsActorAlive(const ActorID &actor_id) c
 
   auto iter = client_queues_.find(actor_id);
   return (iter != client_queues_.end() && iter->second.rpc_client);
-}
-
-void CoreWorkerDirectActorTaskSubmitter::SetCallerCreationTimestamp(int64_t timestamp) {
-  caller_creation_timestamp_ms_ = timestamp;
 }
 
 void CoreWorkerDirectTaskReceiver::Init(

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -131,9 +131,9 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
   // TODO(swang): This assumes that all replies from the previous incarnation
   // of the actor have been received. Fix this by setting an epoch for each
   // actor task, so we can ignore completed tasks from old epochs.
-  RAY_LOG(DEBUG) << "Resetting caller starts at for actor " << actor_id << " from "
-                 << queue->second.caller_starts_at << " to "
-                 << queue->second.num_completed_tasks;
+  RAY_LOG(INFO) << "Resetting caller starts at for actor " << actor_id << " from "
+                << queue->second.caller_starts_at << " to "
+                << queue->second.num_completed_tasks;
   queue->second.caller_starts_at = queue->second.num_completed_tasks;
   SendPendingTasks(actor_id);
 }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -22,7 +22,8 @@ using ray::rpc::ActorTableData;
 
 namespace ray {
 
-void CoreWorkerDirectActorTaskSubmitter::AddActorQueueIfNotExists(const ActorID &actor_id) {
+void CoreWorkerDirectActorTaskSubmitter::AddActorQueueIfNotExists(
+    const ActorID &actor_id) {
   absl::MutexLock lock(&mu_);
   // No need to check whether the insert was successful, since it is possible
   // for this worker to have multiple references to the same actor.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -109,7 +109,7 @@ class CoreWorkerDirectActorTaskSubmitter {
     /// The actor's pending requests, ordered by the task number (see below
     /// diagram) in the request. The bool indicates whether the dependencies
     /// for that task have been resolved yet. A task will be sent after its
-    /// dependencies have been resolved and its task nunmber matches
+    /// dependencies have been resolved and its task number matches
     /// next_send_position.
     std::map<uint64_t, std::pair<TaskSpecification, bool>> requests;
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -172,12 +172,6 @@ class CoreWorkerDirectActorTaskSubmitter {
   /// Used to complete tasks.
   std::shared_ptr<TaskFinisherInterface> task_finisher_;
 
-  /// Timestamp when the caller is created.
-  /// - if this worker is an actor, this is set to the time that the actor creation
-  ///   task starts execution;
-  /// - otherwise, it's set to the time that the current task starts execution.
-  int64_t caller_creation_timestamp_ms_ = 0;
-
   friend class CoreWorkerTest;
 };
 

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -119,6 +119,9 @@ class CoreWorkerDirectActorTaskSubmitter {
     /// instance of the actor knows from which task to start executing. This
     /// increases monotonically.
     uint64_t caller_starts_at = 0;
+    /// The number of tasks sent to this actor by this worker that will never
+    /// be submitted again. This is used to reset caller_starts_at if the actor
+    /// dies and is restarted.
     uint64_t num_completed_tasks = 0;
 
     /// A force-kill request that should be sent to the actor once an RPC

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -124,9 +124,10 @@ class CoreWorkerDirectActorTaskSubmitter {
     /// ^ caller_starts_at
     ///
     /// Suppose the actor crashes and recovers. Then, caller_starts_at is reset
-    /// to the current num_completed_tasks, and this amount is subtracted from
-    /// each task's counter. Therefore, the recovered actor will restart
-    /// execution from task 4.
+    /// to the current num_completed_tasks. caller_starts_at is then subtracted
+    /// from each task's counter, so the recovered actor will receive the
+    /// sequence numbers 0, 1, 2 (and so on) for tasks 4, 5, 6, respectively.
+    /// Therefore, the recovered actor will restart execution from task 4.
     /// 0 1 2 3 4 5 6 7 8 9
     ///             ^ next_send_position
     ///         ^ num_completed_tasks
@@ -150,7 +151,7 @@ class CoreWorkerDirectActorTaskSubmitter {
     /// instance of the actor knows from which task to start executing.
     uint64_t caller_starts_at = 0;
     /// Out of the tasks sent by this worker to the actor, the number of tasks
-    /// that we wil never send to the actor again.  This is used to reset
+    /// that we will never send to the actor again. This is used to reset
     /// caller_starts_at if the actor dies and is restarted. We only include
     /// tasks that will not be sent again, to support automatic task retry on
     /// actor failure.

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -63,7 +63,7 @@ class CoreWorkerDirectActorTaskSubmitter {
   /// not receive another reference to the same actor.
   ///
   /// \param[in] actor_id The actor for whom to add a queue.
-  void AddActorQueue(const ActorID &actor_id);
+  void AddActorQueueIfNotExists(const ActorID &actor_id);
 
   /// Submit a task to an actor for execution.
   ///

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -39,8 +39,8 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
             } else {
               RAY_LOG(ERROR) << "Failed to create actor " << actor_id
                              << " with: " << status.ToString();
-              task_finisher_->PendingTaskFailed(
-                  task_id, rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
+              RAY_UNUSED(task_finisher_->PendingTaskFailed(
+                  task_id, rpc::ErrorType::ACTOR_CREATION_FAILED, &status));
             }
           }));
       return;
@@ -70,8 +70,8 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
       }
     }
     if (!keep_executing) {
-      task_finisher_->PendingTaskFailed(task_spec.TaskId(),
-                                        rpc::ErrorType::TASK_CANCELLED, nullptr);
+      RAY_UNUSED(task_finisher_->PendingTaskFailed(
+          task_spec.TaskId(), rpc::ErrorType::TASK_CANCELLED, nullptr));
     }
   });
   return Status::OK();
@@ -256,7 +256,6 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
   // NOTE(swang): CopyFrom is needed because if we use Swap here and the task
   // fails, then the task data will be gone when the TaskManager attempts to
   // access the task.
-  request->mutable_caller_address()->CopyFrom(rpc_address_);
   request->mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   request->mutable_resource_mapping()->CopyFrom(assigned_resources);
   request->set_intended_worker_id(addr.worker_id.Binary());
@@ -284,10 +283,10 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
           // failure (e.g., by contacting the raylet). If it was a process
           // failure, it may have been an application-level error and it may
           // not make sense to retry the task.
-          task_finisher_->PendingTaskFailed(
+          RAY_UNUSED(task_finisher_->PendingTaskFailed(
               task_id,
               is_actor ? rpc::ErrorType::ACTOR_DIED : rpc::ErrorType::WORKER_DIED,
-              &status);
+              &status));
         } else {
           task_finisher_->CompletePendingTask(task_id, reply, addr.ToProto());
         }
@@ -321,8 +320,8 @@ Status CoreWorkerDirectTaskSubmitter::CancelTask(TaskSpecification task_spec,
             task_queues_.erase(scheduling_key);
             CancelWorkerLeaseIfNeeded(scheduling_key);
           }
-          task_finisher_->PendingTaskFailed(task_spec.TaskId(),
-                                            rpc::ErrorType::TASK_CANCELLED);
+          RAY_UNUSED(task_finisher_->PendingTaskFailed(task_spec.TaskId(),
+                                                       rpc::ErrorType::TASK_CANCELLED));
           return Status::OK();
         }
       }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -51,7 +51,7 @@ message ActorHandle {
   // An extension field that is used for storing app-language-specific data.
   bytes extension_data = 8;
 
-  // How many times tasks may be retried on this actor if the actor fails. 
+  // How many times tasks may be retried on this actor if the actor fails.
   int64 max_task_retries = 9;
 }
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -50,6 +50,9 @@ message ActorHandle {
 
   // An extension field that is used for storing app-language-specific data.
   bytes extension_data = 8;
+
+  // How many times tasks may be retried on this actor if the actor fails. 
+  int64 max_task_retries = 9;
 }
 
 message AssignTaskRequest {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -109,14 +109,6 @@ message PushTaskRequest {
   int64 client_processed_up_to = 5;
   // Resource mapping ids assigned to the worker executing the task.
   repeated ResourceMapEntry resource_mapping = 6;
-  // The version of the caller. This is used to distinguish on-the-fly
-  // requests from a caller before it die, and requests from the reconstructed
-  // caller, which might happen theoretically when network has issues.
-  // - For an actor, this is set to the timestamp when the actor is created,
-  //   so it can be used to differentiate which is the new reconstructed actor.
-  // - For a non-actor task, it's set to the timestamp the task starts
-  // execution.
-  int64 caller_version = 7;
 }
 
 message PushTaskReply {

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -92,23 +92,21 @@ message ReturnObject {
 message PushTaskRequest {
   // The ID of the worker this message is intended for.
   bytes intended_worker_id = 1;
-  // Address of the caller.
-  Address caller_address = 2;
   // The task to be pushed.
-  TaskSpec task_spec = 3;
+  TaskSpec task_spec = 2;
   // The sequence number of the task for this client. This must increase
   // sequentially starting from zero for each actor handle. The server
   // will guarantee tasks execute in this sequence, waiting for any
   // out-of-order request messages to arrive as necessary.
   // If set to -1, ordering is disabled and the task executes immediately.
-  int64 sequence_number = 4;
+  int64 sequence_number = 3;
   // The max sequence number the client has processed responses for. This
   // is a performance optimization that allows the client to tell the server
   // to cancel any PushTaskRequests with seqno <= this value, rather than
   // waiting for the server to time out waiting for missing messages.
-  int64 client_processed_up_to = 5;
+  int64 client_processed_up_to = 4;
   // Resource mapping ids assigned to the worker executing the task.
-  repeated ResourceMapEntry resource_mapping = 6;
+  repeated ResourceMapEntry resource_mapping = 5;
 }
 
 message PushTaskReply {

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -112,9 +112,12 @@ class CoreWorkerClientInterface {
   /// Push an actor task directly from worker to worker.
   ///
   /// \param[in] request The request message.
+  /// \param[in] skip_queue Whether to skip the task queue. This will send the
+  /// task for execution immediately.
   /// \param[in] callback The callback function that handles reply.
   /// \return if the rpc call succeeds
   virtual ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request,
+                                    bool skip_queue,
                                     const ClientCallback<PushTaskReply> &callback) {
     return Status::NotImplemented("");
   }
@@ -244,16 +247,17 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   RPC_CLIENT_METHOD(CoreWorkerService, PlasmaObjectReady, grpc_client_, override)
 
-  ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request,
+  ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
                             const ClientCallback<PushTaskReply> &callback) override {
-    request->set_sequence_number(request->task_spec().actor_task_spec().actor_counter());
+    if (skip_queue) {
+      // Reset to the minimum to avoid taking the lock.
+      request->set_client_processed_up_to(-1);
+      return INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback,
+                             grpc_client_);
+    }
+
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      if (request->task_spec().caller_id() != cur_caller_id_) {
-        // We are running a new task, reset the seq no counter.
-        max_finished_seq_no_ = -1;
-        cur_caller_id_ = request->task_spec().caller_id();
-      }
       send_queue_.push_back(std::make_pair(std::move(request), callback));
     }
     SendRequests();
@@ -292,6 +296,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (seq_no > max_finished_seq_no_) {
+            RAY_LOG(DEBUG) << "Setting max finished seq no " << seq_no;
             max_finished_seq_no_ = seq_no;
           }
           rpc_bytes_in_flight_ -= task_size;
@@ -301,6 +306,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
         callback(status, reply);
       };
 
+      RAY_LOG(DEBUG) << "Push task " << seq_no;
       INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, rpc_callback, grpc_client_);
     }
 
@@ -331,10 +337,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
   /// The max sequence number we have processed responses for.
   int64_t max_finished_seq_no_ GUARDED_BY(mutex_) = -1;
-
-  /// The task id we are currently sending requests for. When this changes,
-  /// the max finished seq no counter is reset.
-  std::string cur_caller_id_;
 };
 
 }  // namespace rpc

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -296,7 +296,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (seq_no > max_finished_seq_no_) {
-            RAY_LOG(DEBUG) << "Setting max finished seq no " << seq_no;
             max_finished_seq_no_ = seq_no;
           }
           rpc_bytes_in_flight_ -= task_size;
@@ -306,7 +305,6 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
         callback(status, reply);
       };
 
-      RAY_LOG(DEBUG) << "Push task " << seq_no;
       INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, rpc_callback, grpc_client_);
     }
 

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -250,7 +250,9 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   ray::Status PushActorTask(std::unique_ptr<PushTaskRequest> request, bool skip_queue,
                             const ClientCallback<PushTaskReply> &callback) override {
     if (skip_queue) {
-      // Reset to the minimum to avoid taking the lock.
+      // Set this value so that the actor does not skip any tasks when
+      // processing this request. We could also set it to max_finished_seq_no_,
+      // but we just set it to the default of -1 to avoid taking the lock.
       request->set_client_processed_up_to(-1);
       return INVOKE_RPC_CALL(CoreWorkerService, PushTask, *request, callback,
                              grpc_client_);

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -275,8 +275,9 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     std::string name = "";
     ActorCreationOptions actor_options{
         max_restarts,
-        /*max_concurrency=*/1, resources, resources,           {},
-        /*is_detached=*/false, name,      /*is_asyncio=*/false};
+        /*max_task_retries=*/0,
+        /*max_concurrency=*/1,  resources, resources,           {},
+        /*is_detached=*/false,  name,      /*is_asyncio=*/false};
     // Create an actor.
     ActorID actor_id;
     RAY_CHECK_OK(CoreWorkerProcess::GetCoreWorker().CreateActor(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Add option for system to transparently allow actor tasks to be retried upon failure. This means that an application does not need to catch `RayActorError`s for actors that can be restarted infinitely many times, if the task retry limit is also set to infinity. See the included changes to the docs for code examples.

The PR works by incrementing the number of completed tasks (tasks that will never be sent again) per actor on the calling worker. If the actor is restarted, the new sequence numbers sent to the actor will be offset by the number of completed tasks at the time that the caller reconnected to the actor. See the diagram in `direct_actor_transport.h` for more details. The PR also refactors the actor transport class to consolidate per-actor state.

This PR does not account for cases where the PushTaskReply from the previous actor incarnation is delayed. This can cause problems because the number of completed tasks may become out of sync. I'll leave this for a future PR.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
