### PR TITLE
Fix node manager miss object info bug

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -215,6 +215,7 @@ ray::Status NodeManager::RegisterGcs() {
   // If the node resource message is received first and then the node message is received,
   // ForwardTask will throw exception, because it can't get node info.
   auto on_done = [this](Status status) {
+    RAY_CHECK_OK(status);
     // Subscribe to resource changes.
     const auto &resources_changed =
         [this](const ClientID &id,
@@ -235,7 +236,7 @@ ray::Status NodeManager::RegisterGcs() {
             ResourceDeleted(id, resource_names);
           }
         };
-    RAY_RETURN_NOT_OK(gcs_client_->Nodes().AsyncSubscribeToResources(
+    RAY_CHECK_OK(gcs_client_->Nodes().AsyncSubscribeToResources(
         /*subscribe_callback=*/resources_changed,
         /*done_callback=*/nullptr));
   };

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -211,33 +211,37 @@ ray::Status NodeManager::RegisterGcs() {
       NodeRemoved(data);
     }
   };
+
+  // If the node resource message is received first and then the node message is received,
+  // ForwardTask will throw exception, because it can't get node info.
+  auto on_done = [this](Status status) {
+    // Subscribe to resource changes.
+    const auto &resources_changed =
+        [this](const ClientID &id,
+               const gcs::ResourceChangeNotification &resource_notification) {
+          if (resource_notification.IsAdded()) {
+            ResourceSet resource_set;
+            for (auto &entry : resource_notification.GetData()) {
+              resource_set.AddOrUpdateResource(entry.first,
+                                               entry.second->resource_capacity());
+            }
+            ResourceCreateUpdated(id, resource_set);
+          } else {
+            RAY_CHECK(resource_notification.IsRemoved());
+            std::vector<std::string> resource_names;
+            for (auto &entry : resource_notification.GetData()) {
+              resource_names.push_back(entry.first);
+            }
+            ResourceDeleted(id, resource_names);
+          }
+        };
+    RAY_RETURN_NOT_OK(gcs_client_->Nodes().AsyncSubscribeToResources(
+        /*subscribe_callback=*/resources_changed,
+        /*done_callback=*/nullptr));
+  };
   // Register a callback to monitor new nodes and a callback to monitor removed nodes.
   RAY_RETURN_NOT_OK(
-      gcs_client_->Nodes().AsyncSubscribeToNodeChange(on_node_change, nullptr));
-
-  // Subscribe to resource changes.
-  const auto &resources_changed =
-      [this](const ClientID &id,
-             const gcs::ResourceChangeNotification &resource_notification) {
-        if (resource_notification.IsAdded()) {
-          ResourceSet resource_set;
-          for (auto &entry : resource_notification.GetData()) {
-            resource_set.AddOrUpdateResource(entry.first,
-                                             entry.second->resource_capacity());
-          }
-          ResourceCreateUpdated(id, resource_set);
-        } else {
-          RAY_CHECK(resource_notification.IsRemoved());
-          std::vector<std::string> resource_names;
-          for (auto &entry : resource_notification.GetData()) {
-            resource_names.push_back(entry.first);
-          }
-          ResourceDeleted(id, resource_names);
-        }
-      };
-  RAY_RETURN_NOT_OK(gcs_client_->Nodes().AsyncSubscribeToResources(
-      /*subscribe_callback=*/resources_changed,
-      /*done_callback=*/nullptr));
+      gcs_client_->Nodes().AsyncSubscribeToNodeChange(on_node_change, on_done));
 
   // Subscribe to heartbeat batches from the monitor.
   const auto &heartbeat_batch_added =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The node manager subscribe node info and node resource. If the node resource message is received first and then the node message is received, ForwardTask will throw exception, because it can't get node info.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
