### PR TITLE
Fix a cluster corruption after restarting a worker node

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -182,6 +182,8 @@ def get_address_info_from_redis_helper(redis_address,
 
     relevant_client = None
     for client_info in client_table:
+        if not client_info['Alive']:
+            continue
         client_node_ip_address = client_info["NodeManagerAddress"]
         if (client_node_ip_address == node_ip_address
                 or (client_node_ip_address == "127.0.0.1"

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -182,7 +182,7 @@ def get_address_info_from_redis_helper(redis_address,
 
     relevant_client = None
     for client_info in client_table:
-        if not client_info['Alive']:
+        if not client_info["Alive"]:
             continue
         client_node_ip_address = client_info["NodeManagerAddress"]
         if (client_node_ip_address == node_ip_address


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Restarting a worker node makes a cluster of multiple nodes corrupted because the redis server has both records of an inactive worker node and an active worker node at the same time. The error happens when ray.init() is conducted on the worker node.

## Related issue number



## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
