### PR TITLE
Fixed: contrib/MADDPG MADDPGTFPolicy missing self.config assignment

### DIFF
--- a/rllib/contrib/maddpg/maddpg_policy.py
+++ b/rllib/contrib/maddpg/maddpg_policy.py
@@ -48,6 +48,7 @@ class MADDPGTFPolicy(MADDPGPostprocessing, TFPolicy):
     def __init__(self, obs_space, act_space, config):
         # _____ Initial Configuration
         config = dict(ray.rllib.contrib.maddpg.DEFAULT_CONFIG, **config)
+        self.config = config
         self.global_step = tf.train.get_or_create_global_step()
 
         # FIXME: Get done from info is required since agentwise done is not


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixing parameterization of MADDPG. 
Using some non-default parameters in the current MADDPG implementation is problematic because then `self.config` in  `ray/rllib/contrib/maddpg/maddpg_policy.py` is never created or assigned. 

The fix is to simply define the missing variable in the initialize. This is not affecting the rest of the current MADDPG logic in any way. Literally one line of code added in the `maddpg_policy.py`.

## Related issue number

Related to the following issue: https://github.com/ray-project/ray/issues/8185

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
