### PR TITLE
Hide aliased autoscaler commands

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1008,6 +1008,7 @@ def add_command_alias(command, name, hidden):
     new_command.hidden = hidden
     cli.add_command(new_command, name=name)
 
+
 cli.add_command(dashboard)
 cli.add_command(start)
 cli.add_command(stop)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1,4 +1,5 @@
 import click
+import copy
 from datetime import datetime
 import json
 import logging
@@ -523,7 +524,7 @@ def stop(force, verbose):
         subprocess.call([command], shell=True)
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.argument("cluster_config_file", required=True, type=str)
 @click.option(
     "--no-restart",
@@ -569,7 +570,7 @@ def create_or_update(cluster_config_file, min_workers, max_workers, no_restart,
                              no_restart, restart_only, yes, cluster_name)
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.argument("cluster_config_file", required=True, type=str)
 @click.option(
     "--workers-only",
@@ -812,7 +813,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
         port_forward=port_forward)
 
 
-@cli.command()
+@cli.command(hidden=True)
 @click.argument("cluster_config_file", required=True, type=str)
 @click.argument("cmd", required=True, type=str)
 @click.option(
@@ -1002,19 +1003,24 @@ def globalgc(address):
     print("Triggered gc.collect() on all workers.")
 
 
+def add_command_alias(command, name, hidden):
+    new_command = copy.deepcopy(command)
+    new_command.hidden = hidden
+    cli.add_command(new_command, name=name)
+
 cli.add_command(dashboard)
 cli.add_command(start)
 cli.add_command(stop)
-cli.add_command(create_or_update, name="up")
+add_command_alias(create_or_update, name="up", hidden=False)
 cli.add_command(attach)
-cli.add_command(exec_cmd, name="exec")
-cli.add_command(rsync_down, name="rsync_down")
-cli.add_command(rsync_up, name="rsync_up")
+add_command_alias(exec_cmd, name="exec", hidden=False)
+add_command_alias(rsync_down, name="rsync_down", hidden=True)
+add_command_alias(rsync_up, name="rsync_up", hidden=True)
 cli.add_command(submit)
 cli.add_command(teardown)
-cli.add_command(teardown, name="down")
+add_command_alias(teardown, name="down", hidden=False)
 cli.add_command(kill_random_node)
-cli.add_command(get_head_ip, name="get_head_ip")
+add_command_alias(get_head_ip, name="get_head_ip", hidden=True)
 cli.add_command(get_worker_ips)
 cli.add_command(microbenchmark)
 cli.add_command(stack)

--- a/python/setup.py
+++ b/python/setup.py
@@ -188,7 +188,7 @@ def find_version(*filepath):
 
 requires = [
     "aiohttp",
-    "click",
+    "click >= 7.0",
     "colorama",
     "filelock",
     "google",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This hides some deprecated/aliased commands of the autoscaler from the help screen:

```
Usage: ray [OPTIONS] COMMAND [ARGS]...

Options:
  --logging-level TEXT   The logging level threshold, choices=['debug',
                         'info', 'warning', 'error', 'critical'],
                         default='info'
  --logging-format TEXT  The logging format. default='%(asctime)s
                         %(levelname)s %(filename)s:%(lineno)s -- %(message)s'
  --help                 Show this message and exit.

Commands:
  attach            Create or attach to a SSH session to a Ray cluster.
  dashboard         Port-forward a Ray cluster's dashboard to the local...
  down              Tear down a Ray cluster.
  exec              Execute a command via SSH on a Ray cluster.
  get-head-ip       Return the head node IP of a Ray cluster.
  get-worker-ips    Return the list of worker IPs of a Ray cluster.
  globalgc          Trigger Python garbage collection on all cluster...
  kill-random-node  Kills a random Ray node.
  memory            Print object references held in a Ray cluster.
  microbenchmark    Run a local Ray microbenchmark on the current machine.
  monitor           Tails the autoscaler logs of a Ray cluster.
  project           [Experimental] Commands working with ray project
  rsync-down        Download specific files from a Ray cluster.
  rsync-up          Upload specific files to a Ray cluster.
  session           [Experimental] Commands working with sessions, which
                    are...
  stack             Take a stack dump of all Python workers on the local...
  start             Start Ray processes manually on the local machine.
  stat              Get the current metrics protobuf from a Ray cluster...
  stop              Stop Ray processes manually on the local machine.
  submit            Uploads and runs a script on the specified cluster.
  timeline          Take a Chrome tracing timeline for a Ray cluster.
  up                Create or update a Ray cluster.
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below): Looked at the help screen
