### PR TITLE
[RLlib] Retry pip installs (after waiting n seconds) in install-dependencies.sh

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -228,7 +228,7 @@ install_dependencies() {
       status=$errmsg && echo "'pip install ...' failed, will retry after n seconds!" && sleep 30;
     done
     if [ "$status" != "0" ]; then
-      echo "${status}" && exit 1
+      echo "${status}" && return 1
     fi
   fi
 

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -216,7 +216,16 @@ install_dependencies() {
       # These packages aren't Windows-compatible
       pip_packages+=(blist)  # https://github.com/DanielStutzbach/blist/issues/81#issue-391460716
     fi
-    CC=gcc pip install "${pip_packages[@]}"
+
+    # Try n times; we often encounter OpenSSL.SSL.WantReadError (or others)
+    # that break the entire CI job: Simply retry installation in this case
+    # after n seconds.
+    while [ 1 ]
+    do
+      CC=gcc pip install "${pip_packages[@]}" && break;
+      echo "'pip install ...' failed, will retry after n seconds!";
+      sleep 10;
+    done
   fi
 
   if [ "${LINT-}" = 1 ]; then

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -220,12 +220,16 @@ install_dependencies() {
     # Try n times; we often encounter OpenSSL.SSL.WantReadError (or others)
     # that break the entire CI job: Simply retry installation in this case
     # after n seconds.
-    while [ 1 ]
+    local status="0";
+    local errmsg="";
+    for i in {1..3};
     do
-      CC=gcc pip install "${pip_packages[@]}" && break;
-      echo "'pip install ...' failed, will retry after n seconds!";
-      sleep 10;
+      errmsg=$(CC=gcc pip install "${pip_packages[@]}" 2>&1) && break;
+      status=$errmsg && echo "'pip install ...' failed, will retry after n seconds!" && sleep 30;
     done
+    if [ "$status" != "0" ]; then
+      echo "${status}" && exit 1
+    fi
   fi
 
   if [ "${LINT-}" = 1 ]; then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

The PR adds re-trying `pip install`s in install-dependencies.sh to defend against SSH errors (or others).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
