### PR TITLE
Prefer built-in system compilers over Clang download

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -185,13 +185,15 @@ install_node() {
   fi
 }
 
+install_toolchains() {
+  "${ROOT_DIR}"/install-toolchains.sh
+}
+
 install_dependencies() {
 
   install_bazel
   install_base
-  if [ -n "${GITHUB_WORKFLOW-}" ]; then  # Not for Travis (keep built-in compilers there)
-    "${ROOT_DIR}"/install-toolchains.sh
-  fi
+  install_toolchains
   install_nvm
   install_pip
 

--- a/ci/travis/install-toolchains.sh
+++ b/ci/travis/install-toolchains.sh
@@ -2,10 +2,10 @@
 
 set -euxo pipefail
 
-LLVM_VERSION="9.0.0"
+LLVM_VERSION="9.0.0"  # This is not necessarily guaranteed (e.g. we might use the system compiler)
 
-install_toolchains() {
-  local osversion="" url="" urlbase="https://releases.llvm.org" targetdir="/usr/local"
+install_clang() {
+  local cc="clang++" osversion="" url="" urlbase="https://releases.llvm.org" targetdir="/usr/local"
   case "${OSTYPE}" in
     msys)
       osversion=win
@@ -15,6 +15,7 @@ install_toolchains() {
         osversion="${osversion}32"
       fi
       url="${urlbase}/${LLVM_VERSION}/LLVM-${LLVM_VERSION}-${osversion}.exe"
+      cc="clang-cl"
       ;;
     linux-gnu)
       osversion="${OSTYPE}-$(sed -n -e '/^PRETTY_NAME/ { s/^[^=]*="\(.*\)"/\1/g; s/ /-/; s/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/; s/ .*//; p }' /etc/os-release | tr '[:upper:]' '[:lower:]')"
@@ -26,18 +27,27 @@ install_toolchains() {
   if [ -z "${url}" ]; then
     url="${urlbase}/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-${HOSTTYPE}-${osversion}.tar.xz"
   fi
-  curl -f -s -L -R "${url}" | if [ "${OSTYPE}" = "msys" ]; then
-    local target="./${url##*/}"
-    install /dev/stdin "${target}"
-    mkdir -p -- "${targetdir}"
-    7z x -bsp0 -bso0 "${target}" -o"${targetdir}"
-    MSYS2_ARG_CONV_EXCL="*" Reg Add "HKLM\SOFTWARE\LLVM\LLVM" /ve /t REG_SZ /f /reg:32 \
-      /d "$(cygpath -w -- "${targetdir}")" > /dev/null
-    rm -f -- "${target}"
-  else
-    sudo tar -x -J --strip-components=1 -C "${targetdir}"
+  if ! command -v "${cc}"; then
+    case "${osversion}" in
+      linux-gnu-ubuntu*)
+        sudo apt-get install -qq -o=Dpkg::Use-Pty=0 install clang clang-format clang-tidy
+        ;;
+      *)  # Fallback for all platforms is to download from LLVM's site, but avoided until necessary
+        local target="./${url##*/}"
+        curl -f -s -L -R --show-error -o "${target}" "${url}"
+        if [ "${OSTYPE}" = "msys" ]; then
+          mkdir -p -- "${targetdir}"
+          7z x -bsp0 -bso0 "${target}" -o"${targetdir}"
+          MSYS2_ARG_CONV_EXCL="*" Reg Add "HKLM\SOFTWARE\LLVM\LLVM" /ve /t REG_SZ /f /reg:32 \
+            /d "$(cygpath -w -- "${targetdir}")" > /dev/null
+          rm -f -- "${target}"
+        else
+          sudo tar -x -J --strip-components=1 -f "${target}" -C "${targetdir}"
+        fi
+        ;;
+    esac
   fi
-  "${targetdir}"/bin/clang --version 1>&2
+  "${cc}" --version
 }
 
-install_toolchains "$@"
+install_clang "$@"


### PR DESCRIPTION
## Why are these changes needed?

This avoids hitting LLVM servers on platforms where we already have access to Clang.

Now that we prefer the system compilers, we make Travis execute this code path as well.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
