### PR TITLE
Fix core dumps in ExitActor

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1806,7 +1806,10 @@ void CoreWorker::HandleCancelTask(const rpc::CancelTaskRequest &request,
     if (options_.log_dir != "") {
       RayLog::ShutDownRayLog();
     }
-    exit(1);
+    // NOTE(hchen): Use `quick_exit` to force-exit this process. If we use `exit` here,
+    // static objects will be destructed in an incorrect order, which will lead to
+    // core dumps.
+    quick_exit(1);
   }
 }
 
@@ -1842,7 +1845,10 @@ void CoreWorker::HandleKillActor(const rpc::KillActorRequest &request,
     if (options_.log_dir != "") {
       RayLog::ShutDownRayLog();
     }
-    exit(1);
+    // NOTE(hchen): Use `quick_exit` to force-exit this process. If we use `exit` here,
+    // static objects will be destructed in an incorrect order, which will lead to
+    // core dumps.
+    quick_exit(1);
   } else {
     Exit(/*intentional=*/true);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`exit` would cause the static objects to destruct. And wrong order of destruction will cause core dumps. 

Reproduce this bug:
```
#  ulimit -c unlimited
import ray

@ray.remote
class MyActor:
    pass

ray.init()

actor = MyActor.remote()

ray.kill(actor)

import time
time.sleep(10)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
