### PR TITLE
Fix a bad usage of std::move

### DIFF
--- a/src/ray/raylet/mock_gcs_client.cc
+++ b/src/ray/raylet/mock_gcs_client.cc
@@ -124,7 +124,7 @@ ray::Status ClientTable::Remove(const ClientID &client_id, DoneCallback done_cal
 ClientID GcsClient::Register(const std::string &ip, uint16_t port) {
   ClientID client_id = ClientID::FromRandom();
   // TODO: handle client registration failure.
-  ray::Status status = client_table().Add(std::move(client_id), ip, port, []() {});
+  ray::Status status = client_table().Add(client_id, ip, port, []() {});
   return client_id;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This variable is moved and then used again.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
