### PR TITLE
[tune] Close loggers after updating trial (#8307)

### DIFF
--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -256,9 +256,6 @@ class RayTrialExecutor(TrialExecutor):
             error_msg (str): Optional error message.
             stop_logger (bool): Whether to shut down the trial logger.
         """
-        if stop_logger:
-            trial.close_logger()
-
         self.set_status(trial, Trial.ERROR if error else Trial.TERMINATED)
         trial.set_location(Location())
 
@@ -278,6 +275,8 @@ class RayTrialExecutor(TrialExecutor):
             self.set_status(trial, Trial.ERROR)
         finally:
             trial.set_runner(None)
+            if stop_logger:
+                trial.close_logger()
 
     def start_trial(self, trial, checkpoint=None, train=True):
         """Starts the trial.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closing loggers before updating the value of the `trial.status` and `trial.error_msg` attributes prevents from setting the correct label for experiments when using tracking platforms such as [Neptune](https://neptune.ai/), [Weights&Biases](https://www.wandb.com/), or any other system with an "experiment status" feature.

This PR changes the order of the commands executed in the `RayTrialExecutor._close` so that the trial being closed gets updated with its termination information before the closing the loggers.  

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #8307 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

This PR doesn't introduce any new code that could be tested with unit tests.
