### PR TITLE
Example local serving

### DIFF
--- a/rllib/examples/serving/cartpole_serving_local.py
+++ b/rllib/examples/serving/cartpole_serving_local.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Example of running inference on a policy. Copy this file for your use case.
+To try this out run:
+    $ python cartpole_local_serving.py
+"""
+
+import argparse
+import os
+
+import ray
+from ray.rllib.agents.dqn import DQNTrainer
+from ray.rllib.agents.ppo import PPOTrainer
+
+CHECKPOINT_FILE = "last_checkpoint_{}.out"
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--run", type=str, default="DQN")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    ray.init()
+
+    env = "CartPole-v0"
+
+    if args.run == "DQN":
+        # Example of using DQN (supports off-policy actions).
+        trainer = DQNTrainer(env=env)
+    elif args.run == "PPO":
+        # Example of using PPO (does NOT support off-policy actions).
+        trainer = PPOTrainer(env=env)
+    else:
+        raise ValueError("--run must be DQN or PPO")
+
+    checkpoint_path = CHECKPOINT_FILE.format(args.run)
+
+    # Attempt to restore from checkpoint if possible.
+    if os.path.exists(checkpoint_path):
+        checkpoint_path = open(checkpoint_path).read()
+        print("Restoring from checkpoint path", checkpoint_path)
+        trainer.restore(checkpoint_path)
+
+    # Serving and training loop
+    env = trainer.env_creator({})
+    state = trainer.get_policy().get_initial_state()
+    obs = env.reset()
+    while True:
+        action, state, info_trainer = trainer.compute_action(obs, state=state, full_fetch=True)
+        obs, reward, done, info = env.step(action)
+        env.render()
+        if done:
+            obs = env.reset()
+

--- a/rllib/examples/serving/cartpole_serving_local.py
+++ b/rllib/examples/serving/cartpole_serving_local.py
@@ -44,9 +44,9 @@ if __name__ == "__main__":
     state = trainer.get_policy().get_initial_state()
     obs = env.reset()
     while True:
-        action, state, info_trainer = trainer.compute_action(obs, state=state, full_fetch=True)
+        action, state, info_trainer = trainer.compute_action(
+            obs, state=state, full_fetch=True)
         obs, reward, done, info = env.step(action)
         env.render()
         if done:
             obs = env.reset()
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

While there is an example for remote serving, I believe there is no full local serving example. Maybe this is obvious for more experienced users or if one has experience with other RL frameworks, but when I first started, this was quite confusing to me (and there recently was a similar request in Slack).

Other RL framework have an example for such serving easily visible (e.g. [stable-baselines](https://github.com/hill-a/stable-baselines#example)).

This serving example should also be able to deal with recurrent policies.

I am not sure if the `examples/serving.py` folder would be the right place or if this should better be placed directly in `examples`.

## Related issue number

-/-

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
