### PR TITLE
[Serve] Improve error message when result is not a list

### DIFF
--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -1,5 +1,6 @@
 import traceback
 import inspect
+from collections.abc import Iterable
 
 import ray
 from ray import serve
@@ -195,8 +196,18 @@ class RayServeWorker:
             self.request_counter.add(batch_size)
             result_list = await call_method(*arg_list, **kwargs_list)
 
-            if (not isinstance(result_list,
-                               list)) or (len(result_list) != batch_size):
+            if not isinstance(result_list, Iterable) or isinstance(
+                    result_list, (dict, set)):
+                error_message = ("Worker returned a {}. RayServe expect "
+                                 "an ordered iterable object.".format(
+                                     type(result_list)))
+                raise RayServeException(error_message)
+
+            # Normalize the result into a list type. This operation is fast
+            # in Python because it doesn't copy anything.
+            result_list = [val for val in result_list]
+
+            if (len(result_list) != batch_size):
                 error_message = ("Worker doesn't preserve batch size. The "
                                  "input has length {} but the returned list "
                                  "has length {}. Please return a list of "

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -198,14 +198,14 @@ class RayServeWorker:
 
             if not isinstance(result_list, Iterable) or isinstance(
                     result_list, (dict, set)):
-                error_message = ("Worker returned a {}. RayServe expect "
-                                 "an ordered iterable object.".format(
+                error_message = ("RayServe expects an ordered iterable object "
+                                 "but the worker returned a {}".format(
                                      type(result_list)))
                 raise RayServeException(error_message)
 
             # Normalize the result into a list type. This operation is fast
             # in Python because it doesn't copy anything.
-            result_list = [val for val in result_list]
+            result_list = list(result_list)
 
             if (len(result_list) != batch_size):
                 error_message = ("Worker doesn't preserve batch size. The "

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -1,5 +1,7 @@
 import json
 
+import numpy as np
+
 from ray.serve.utils import ServeEncoder
 
 
@@ -7,3 +9,14 @@ def test_bytes_encoder():
     data_before = {"inp": {"nest": b"bytes"}}
     data_after = {"inp": {"nest": "bytes"}}
     assert json.loads(json.dumps(data_before, cls=ServeEncoder)) == data_after
+
+
+def test_numpy_encoding():
+    data = [1, 2]
+    floats = np.array(data).astype(np.float32)
+    ints = floats.astype(np.int32)
+    uints = floats.astype(np.uint32)
+
+    assert json.loads(json.dumps(floats, cls=ServeEncoder)) == data
+    assert json.loads(json.dumps(ints, cls=ServeEncoder)) == data
+    assert json.loads(json.dumps(uints, cls=ServeEncoder)) == data

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -69,6 +69,10 @@ class ServeEncoder(json.JSONEncoder):
         if isinstance(o, Exception):
             return str(o)
         if isinstance(o, np.ndarray):
+            if o.dtype.kind == "f":  # floats
+                o = o.astype(float)
+            if o.dtype.kind in {"i", "u"}:  # signed and unsigned integers.
+                o = o.astype(int)
             return o.tolist()
         return super().default(o)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
- Add more validation for batch result data types.
- Support numpy types
- Support arbitrary iterables

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
