### PR TITLE
Patch redis-py bug for Windows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1505,7 +1505,6 @@ genrule(
     name = "redis",
     srcs = [
     ] + select({
-        # Windows is not supported yet, so make stubs for it
         "@bazel_tools//src/conditions:windows": [
             "@com_github_tporadowski_redis_bin//file",
         ],
@@ -1519,7 +1518,6 @@ genrule(
         "redis-cli",
     ],
     cmd = select({
-        # Windows is not supported yet, so make stubs for it
         "@bazel_tools//src/conditions:windows": """
             unzip -q -o -- $(location @com_github_tporadowski_redis_bin//file) redis-server.exe redis-cli.exe &&
             mv -f -- redis-server.exe $(location redis-server) &&

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -30,6 +30,9 @@ thirdparty_files = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "thirdparty_files")
 sys.path.insert(0, thirdparty_files)
 
+import ray.compat  # noqa: E402
+ray.compat.apply_patches()
+
 # Expose ray ABI symbols which may be dependent by other shared
 # libraries such as _streaming.so. See BUILD.bazel:_raylet
 python_shared_lib_suffix = ".so" if sys.platform != "win32" else ".pyd"

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -30,8 +30,9 @@ thirdparty_files = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "thirdparty_files")
 sys.path.insert(0, thirdparty_files)
 
-import ray.compat  # noqa: E402
-ray.compat.patch_redis_empty_recv()
+if sys.platform == "win32":
+    import ray.compat  # noqa: E402
+    ray.compat.patch_redis_empty_recv()
 
 # Expose ray ABI symbols which may be dependent by other shared
 # libraries such as _streaming.so. See BUILD.bazel:_raylet

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -31,7 +31,7 @@ thirdparty_files = os.path.join(
 sys.path.insert(0, thirdparty_files)
 
 import ray.compat  # noqa: E402
-ray.compat.apply_patches()
+ray.compat.patch_redis_empty_recv()
 
 # Expose ray ABI symbols which may be dependent by other shared
 # libraries such as _streaming.so. See BUILD.bazel:_raylet

--- a/python/ray/compat.py
+++ b/python/ray/compat.py
@@ -8,16 +8,16 @@ def patch_redis_empty_recv():
     redis-py does not handle these errors correctly.
     This patch translates connection resets to empty reads as in POSIX.
     """
-    if sys.platform == "win32":
-        import redis
+    assert sys.platform == "win32"
+    import redis
 
-        def redis_recv(sock, *args, **kwargs):
-            result = b""
-            try:
-                result = redis._compat.recv(sock, *args, **kwargs)
-            except socket.error as ex:
-                if ex.errno not in [errno.ECONNRESET, errno.ECONNREFUSED]:
-                    raise
-            return result
+    def redis_recv(sock, *args, **kwargs):
+        result = b""
+        try:
+            result = redis._compat.recv(sock, *args, **kwargs)
+        except socket.error as ex:
+            if ex.errno not in [errno.ECONNRESET, errno.ECONNREFUSED]:
+                raise
+        return result
 
-        redis.connection.recv = redis_recv
+    redis.connection.recv = redis_recv

--- a/python/ray/compat.py
+++ b/python/ray/compat.py
@@ -3,7 +3,11 @@ import socket
 import sys
 
 
-def patch_redis():
+def patch_redis_empty_recv():
+    """On Windows, socket disconnect result in errors rather than empty reads.
+    redis-py does not handle these errors correctly.
+    This patch translates connection resets to empty reads as in POSIX.
+    """
     if sys.platform == "win32":
         import redis
 
@@ -17,7 +21,3 @@ def patch_redis():
             return result
 
         redis.connection.recv = redis_recv
-
-
-def apply_patches():
-    patch_redis()

--- a/python/ray/compat.py
+++ b/python/ray/compat.py
@@ -1,0 +1,23 @@
+import errno
+import socket
+import sys
+
+
+def patch_redis():
+    if sys.platform == "win32":
+        import redis
+
+        def redis_recv(sock, *args, **kwargs):
+            result = b""
+            try:
+                result = redis._compat.recv(sock, *args, **kwargs)
+            except socket.error as ex:
+                if ex.errno not in [errno.ECONNRESET, errno.ECONNREFUSED]:
+                    raise
+            return result
+
+        redis.connection.recv = redis_recv
+
+
+def apply_patches():
+    patch_redis()


### PR DESCRIPTION
## Why are these changes needed?

Socket disconnection result in errors on Windows rather than empty reads, which redis-py does not handle. This patch handles translates connection resets to empty reads.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
