### PR TITLE
Update README to say that python 2 is deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,7 @@ Ray is packaged with the following libraries for accelerating machine learning w
 Install Ray with: ``pip install ray``. For nightly wheels, see the
 `Installation page <https://docs.ray.io/en/latest/installation.html>`__.
 
-**NOTE:** `We are deprecating Python 2 support soon.`_
-
-.. _`We are deprecating Python 2 support soon.`: https://github.com/ray-project/ray/issues/6580
+**NOTE:** As of Ray 0.8.1, Python 2 is no longer supported.
 
 Quick Start
 -----------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Has been deprecated since 0.8.1.