### PR TITLE
[RLlib] Make PyTorch Model forward pass faster in vf-case.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1528,7 +1528,7 @@ py_test(
     name = "examples/cartpole_lstm_impala_tf",
     main = "examples/cartpole_lstm.py",
     tags = ["examples", "examples_C"],
-    size = "small",
+    size = "medium",
     srcs = ["examples/cartpole_lstm.py"],
     args = ["--as-test", "--run=IMPALA", "--stop-reward=40", "--num-cpus=4"]
 )

--- a/rllib/examples/models/autoregressive_action_model.py
+++ b/rllib/examples/models/autoregressive_action_model.py
@@ -148,10 +148,11 @@ class TorchAutoregressiveActionModel(TorchModelV2, nn.Module):
         #     [ctx_input, a1_input])
         self.action_module = _ActionModel()
 
+        self._context = None
+
     def forward(self, input_dict, state, seq_lens):
-        context = self.context_layer(input_dict["obs"])
-        self._value_out = self.value_branch(context)
-        return context, state
+        self._context = self.context_layer(input_dict["obs"])
+        return self._context, state
 
     def value_function(self):
-        return torch.reshape(self._value_out, [-1])
+        return torch.reshape(self.value_branch(self._context), [-1])

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -174,17 +174,18 @@ class TorchBatchNormModel(TorchModelV2, nn.Module):
             activation_fn=None)
 
         self._hidden_layers = nn.Sequential(*layers)
+        self._hidden_out = None
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
         # Set the correct train-mode for our hidden module (only important
         # b/c we have some batch-norm layers).
         self._hidden_layers.train(mode=input_dict["is_training"])
-        hidden_out = self._hidden_layers(input_dict["obs"])
-        logits = self._logits(hidden_out)
-        self._value_out = self._value_branch(hidden_out)
+        self._hidden_out = self._hidden_layers(input_dict["obs"])
+        logits = self._logits(self._hidden_out)
         return logits, []
 
     @override(ModelV2)
     def value_function(self):
-        return torch.reshape(self._value_out, [-1])
+        assert self._hidden_out, "must call forward first!"
+        return torch.reshape(self._value_branch(self._hidden_out), [-1])

--- a/rllib/examples/models/batch_norm_model.py
+++ b/rllib/examples/models/batch_norm_model.py
@@ -187,5 +187,5 @@ class TorchBatchNormModel(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def value_function(self):
-        assert self._hidden_out, "must call forward first!"
+        assert self._hidden_out is not None, "must call forward first!"
         return torch.reshape(self._value_branch(self._hidden_out), [-1])

--- a/rllib/examples/models/centralized_critic_models.py
+++ b/rllib/examples/models/centralized_critic_models.py
@@ -161,14 +161,17 @@ class YetAnotherTorchCentralizedCriticModel(TorchModelV2, nn.Module):
 
         self.value_model = TorchFC(obs_space, action_space, 1, model_config,
                                    name + "_vf")
+        self._model_in = None
 
     def forward(self, input_dict, state, seq_lens):
-        self._value_out, _ = self.value_model({
-            "obs": input_dict["obs_flat"]
-        }, state, seq_lens)
+        # Store model-input for possible `value_function()` call.
+        self._model_in = [input_dict["obs_flat"], state, seq_lens]
         return self.action_model({
             "obs": input_dict["obs"]["own_obs"]
         }, state, seq_lens)
 
     def value_function(self):
-        return torch.reshape(self._value_out, [-1])
+        value_out, _ = self.value_model({
+            "obs": self._model_in[0]
+        }, self._model_in[1], self._model_in[2])
+        return torch.reshape(value_out, [-1])

--- a/rllib/examples/models/fast_model.py
+++ b/rllib/examples/models/fast_model.py
@@ -73,5 +73,5 @@ class TorchFastModel(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def value_function(self):
-        assert self._output, "must call forward first!"
+        assert self._output is not None, "must call forward first!"
         return torch.reshape(torch.mean(self._output, -1), [-1])

--- a/rllib/examples/models/fast_model.py
+++ b/rllib/examples/models/fast_model.py
@@ -63,14 +63,15 @@ class TorchFastModel(TorchModelV2, nn.Module):
         # Only needed to give some params to the optimizer (even though,
         # they are never used anywhere).
         self.dummy_layer = SlimFC(1, 1)
+        self._output = None
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
-        output = self.bias + \
+        self._output = self.bias + \
             torch.zeros(size=(input_dict["obs"].shape[0], self.num_outputs))
-        self._value_out = torch.mean(output, -1)  # fake value
-        return output, []
+        return self._output, []
 
     @override(ModelV2)
     def value_function(self):
-        return torch.reshape(self._value_out, [-1])
+        assert self._output, "must call forward first!"
+        return torch.reshape(torch.mean(self._output, -1), [-1])

--- a/rllib/examples/models/shared_weights_model.py
+++ b/rllib/examples/models/shared_weights_model.py
@@ -121,5 +121,5 @@ class TorchSharedWeightsModel(TorchModelV2, nn.Module):
 
     @override(ModelV2)
     def value_function(self):
-        assert self._output, "must call forward first!"
+        assert self._output is not None, "must call forward first!"
         return torch.reshape(self.vf(self._output), [-1])

--- a/rllib/examples/models/shared_weights_model.py
+++ b/rllib/examples/models/shared_weights_model.py
@@ -110,15 +110,16 @@ class TorchSharedWeightsModel(TorchModelV2, nn.Module):
         # Non-shared final layer.
         self.last_layer = SlimFC(32, self.num_outputs, activation_fn=nn.ReLU)
         self.vf = SlimFC(32, 1, activation_fn=None)
+        self._output = None
 
     @override(ModelV2)
     def forward(self, input_dict, state, seq_lens):
         out = self.first_layer(input_dict["obs"])
-        out = TORCH_GLOBAL_SHARED_LAYER(out)
-        model_out = self.last_layer(out)
-        self._value_out = self.vf(out)
+        self._output = TORCH_GLOBAL_SHARED_LAYER(out)
+        model_out = self.last_layer(self._output)
         return model_out, []
 
     @override(ModelV2)
     def value_function(self):
-        return torch.reshape(self._value_out, [-1])
+        assert self._output, "must call forward first!"
+        return torch.reshape(self.vf(self._output), [-1])

--- a/rllib/models/tf/modelv1_compat.py
+++ b/rllib/models/tf/modelv1_compat.py
@@ -110,7 +110,7 @@ def make_v1_wrapper(legacy_model_cls):
 
         @override(ModelV2)
         def value_function(self):
-            assert self.cur_instance, "must call forward first"
+            assert self.cur_instance is not None, "must call forward first"
 
             with tf.variable_scope(self.variable_scope):
                 with tf.variable_scope("value_function", reuse=tf.AUTO_REUSE):

--- a/rllib/models/torch/fcnet.py
+++ b/rllib/models/torch/fcnet.py
@@ -96,20 +96,21 @@ class FullyConnectedNetwork(TorchModelV2, nn.Module):
             out_size=1,
             initializer=normc_initializer(1.0),
             activation_fn=None)
-        # Holds the current value output.
-        self._cur_value = None
+        # Holds the current "base" output (before logits layer).
+        self._features = None
+        #self._cur_value = None
 
     @override(TorchModelV2)
     def forward(self, input_dict, state, seq_lens):
         obs = input_dict["obs_flat"].float()
-        features = self._hidden_layers(obs.reshape(obs.shape[0], -1))
-        logits = self._logits(features) if self._logits else features
+        self._features = self._hidden_layers(obs.reshape(obs.shape[0], -1))
+        logits = self._logits(self._features) if self._logits else \
+            self._features
         if self.free_log_std:
             logits = self._append_free_log_std(logits)
-        self._cur_value = self._value_branch(features).squeeze(1)
         return logits, state
 
     @override(TorchModelV2)
     def value_function(self):
-        assert self._cur_value is not None, "must call forward() first"
-        return self._cur_value
+        assert self._features is not None, "must call forward() first"
+        return self._value_branch(self._features).squeeze(1)

--- a/rllib/models/torch/fcnet.py
+++ b/rllib/models/torch/fcnet.py
@@ -98,7 +98,6 @@ class FullyConnectedNetwork(TorchModelV2, nn.Module):
             activation_fn=None)
         # Holds the current "base" output (before logits layer).
         self._features = None
-        #self._cur_value = None
 
     @override(TorchModelV2)
     def forward(self, input_dict, state, seq_lens):

--- a/rllib/models/torch/visionnet.py
+++ b/rllib/models/torch/visionnet.py
@@ -58,19 +58,20 @@ class VisionNetwork(TorchModelV2, nn.Module):
             out_channels, num_outputs, initializer=nn.init.xavier_uniform_)
         self._value_branch = SlimFC(
             out_channels, 1, initializer=normc_initializer())
-        self._cur_value = None
+        # Holds the current "base" output (before logits layer).
+        self._features = None
+        #self._cur_value = None
 
     @override(TorchModelV2)
     def forward(self, input_dict, state, seq_lens):
-        features = self._hidden_layers(input_dict["obs"].float())
-        logits = self._logits(features)
-        self._cur_value = self._value_branch(features).squeeze(1)
+        self._features = self._hidden_layers(input_dict["obs"].float())
+        logits = self._logits(self._features)
         return logits, state
 
     @override(TorchModelV2)
     def value_function(self):
-        assert self._cur_value is not None, "must call forward() first"
-        return self._cur_value
+        assert self._features is not None, "must call forward() first"
+        return self._value_branch(self._features).squeeze(1)
 
     def _hidden_layers(self, obs):
         res = self._convs(obs.permute(0, 3, 1, 2))  # switch to channel-major

--- a/rllib/models/torch/visionnet.py
+++ b/rllib/models/torch/visionnet.py
@@ -60,7 +60,6 @@ class VisionNetwork(TorchModelV2, nn.Module):
             out_channels, 1, initializer=normc_initializer())
         # Holds the current "base" output (before logits layer).
         self._features = None
-        #self._cur_value = None
 
     @override(TorchModelV2)
     def forward(self, input_dict, state, seq_lens):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR speeds up the forward pass in a PyTorch Model with vf branch by only calling the vf-branch, when really needed (usually, for action inference, vf should not need to be called).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
