### PR TITLE
Change get_action_shape to avoid unexpected behavior

### DIFF
--- a/rllib/models/catalog.py
+++ b/rllib/models/catalog.py
@@ -216,7 +216,7 @@ class ModelCatalog:
         """
 
         if isinstance(action_space, gym.spaces.Discrete):
-            return (tf.int64, (None, ))
+            return (action_space.dtype, (None, ))
         elif isinstance(action_space, (gym.spaces.Box, Simplex)):
             return (tf.float32, (None, ) + action_space.shape)
         elif isinstance(action_space, gym.spaces.MultiDiscrete):


### PR DESCRIPTION
## What does this change do?

Change get_action_shape so that it uses the dtype of the Discrete object, rather than overwriting it with tf.int64.

## Why are these changes needed?

This avoids unexpected behavior when subclassing Discrete to change the default dtype.
For existing use of Discrete, nothing should change, as the dtype of Discrete is tf.int64 [by default](https://github.com/openai/gym/blob/master/gym/spaces/discrete.py#L16), and can only be changed by subclassing it and overriding `__init__`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] This PR is not tested (please justify below)
Couldn't get the tests to run locally when following [developer installation docs](https://docs.ray.io/en/master/development.html#developing-ray-python-only), which fail on missing imports.
