### PR TITLE
[Serve] Start Replicas in Parallel

### DIFF
--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -323,7 +323,7 @@ class ServeMaster:
         await worker_handle.ready.remote()
         return worker_handle
 
-    async def _start_a_pending_replica(self, backend_tag, replica_tag):
+    async def _start_replica(self, backend_tag, replica_tag):
         # NOTE(edoakes): the replicas may already be created if we
         # failed after creating them but before writing a
         # checkpoint.
@@ -349,14 +349,14 @@ class ServeMaster:
 
         Clears self.replicas_to_start.
         """
-        create_futures = []
+        replica_started_futures = []
         for backend_tag, replicas_to_create in self.replicas_to_start.items():
             for replica_tag in replicas_to_create:
-                create_futures.append(
-                    self._start_a_pending_replica(backend_tag, replica_tag))
+                replica_started_futures.append(
+                    self._start_replica(backend_tag, replica_tag))
 
         # Wait on all creation task futures together.
-        await asyncio.gather(*create_futures)
+        await asyncio.gather(*replica_started_futures)
 
         self.replicas_to_start.clear()
 

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -332,32 +332,32 @@ class ServeMaster:
 
         Clears self.replicas_to_start.
         """
+
+        async def create_one_replica(backend_tag, replica_tag):
+            # NOTE(edoakes): the replicas may already be created if we
+            # failed after creating them but before writing a
+            # checkpoint.
+            try:
+                worker_handle = ray.util.get_actor(replica_tag)
+            except ValueError:
+                worker_handle = await self._start_backend_worker(
+                    backend_tag, replica_tag)
+
+            self.replicas[backend_tag].append(replica_tag)
+            self.workers[backend_tag][replica_tag] = worker_handle
+
+            # Register the worker with the router.
+            await self.router.add_new_worker.remote(backend_tag, replica_tag,
+                                                    worker_handle)
+
         # We collect all creation coroutines in this list and await on them
         # at the same time. We do this because actor instantiation can take
         # a long time.
         create_actions = []
         for backend_tag, replicas_to_create in self.replicas_to_start.items():
             for replica_tag in replicas_to_create:
-
-                async def create_one_replica():
-                    # NOTE(edoakes): the replicas may already be created if we
-                    # failed after creating them but before writing a
-                    # checkpoint.
-                    try:
-                        worker_handle = ray.util.get_actor(replica_tag)
-                    except ValueError:
-                        worker_handle = await self._start_backend_worker(
-                            backend_tag, replica_tag)
-
-                    self.replicas[backend_tag].append(replica_tag)
-                    self.workers[backend_tag][replica_tag] = worker_handle
-
-                    # Register the worker with the router.
-                    await self.router.add_new_worker.remote(
-                        backend_tag, replica_tag, worker_handle)
-
-                create_actions.append(create_one_replica())
-
+                create_actions.append(
+                    create_one_replica(backend_tag, replica_tag))
         await asyncio.gather(*create_actions)
 
         self.replicas_to_start.clear()

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -323,6 +323,23 @@ class ServeMaster:
         await worker_handle.ready.remote()
         return worker_handle
 
+    async def _start_a_pending_replica(self, backend_tag, replica_tag):
+        # NOTE(edoakes): the replicas may already be created if we
+        # failed after creating them but before writing a
+        # checkpoint.
+        try:
+            worker_handle = ray.util.get_actor(replica_tag)
+        except ValueError:
+            worker_handle = await self._start_backend_worker(
+                backend_tag, replica_tag)
+
+        self.replicas[backend_tag].append(replica_tag)
+        self.workers[backend_tag][replica_tag] = worker_handle
+
+        # Register the worker with the router.
+        await self.router.add_new_worker.remote(backend_tag, replica_tag,
+                                                worker_handle)
+
     async def _start_pending_replicas(self):
         """Starts the pending backend replicas in self.replicas_to_start.
 
@@ -332,33 +349,14 @@ class ServeMaster:
 
         Clears self.replicas_to_start.
         """
-
-        async def create_one_replica(backend_tag, replica_tag):
-            # NOTE(edoakes): the replicas may already be created if we
-            # failed after creating them but before writing a
-            # checkpoint.
-            try:
-                worker_handle = ray.util.get_actor(replica_tag)
-            except ValueError:
-                worker_handle = await self._start_backend_worker(
-                    backend_tag, replica_tag)
-
-            self.replicas[backend_tag].append(replica_tag)
-            self.workers[backend_tag][replica_tag] = worker_handle
-
-            # Register the worker with the router.
-            await self.router.add_new_worker.remote(backend_tag, replica_tag,
-                                                    worker_handle)
-
-        # We collect all creation coroutines in this list and await on them
-        # at the same time. We do this because actor instantiation can take
-        # a long time.
-        create_actions = []
+        create_futures = []
         for backend_tag, replicas_to_create in self.replicas_to_start.items():
             for replica_tag in replicas_to_create:
-                create_actions.append(
-                    create_one_replica(backend_tag, replica_tag))
-        await asyncio.gather(*create_actions)
+                create_futures.append(
+                    self._start_a_pending_replica(backend_tag, replica_tag))
+
+        # Wait on all creation task futures together.
+        await asyncio.gather(*create_futures)
 
         self.replicas_to_start.clear()
 

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -391,6 +391,11 @@ def test_cluster_name():
 
 
 def test_parallel_start(serve_instance):
+    # Test the ability to start multiple replicas in parallel.
+    # In the past, when Serve scale up a backend, it does so one by one and
+    # wait for each replica to initialize. This test avoid this by preventing
+    # the first replica to finish initialization unless the second replica is
+    # also started.
     @ray.remote
     class Barrier:
         def __init__(self, release_on):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR starts all the worker replicas in parallel to prevent master actor waiting on worker instantiation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [TODO] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
