### PR TITLE
[serve] Pin http proxy to the node that serve.init() is run on

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -124,12 +124,16 @@ def init(blocking=False,
                                    RequestMetadata.ray_serialize,
                                    RequestMetadata.ray_deserialize)
 
+    # TODO(edoakes): for now, always start the HTTP proxy on the node that
+    # serve.init() was run on. We should consider making this configurable
+    # in the future.
+    http_node_id = ray.state.current_node_id()
     master_actor = ServeMaster.options(
         detached=True,
         name=SERVE_MASTER_NAME,
         max_reconstructions=ray.ray_constants.INFINITE_RECONSTRUCTION,
-    ).remote(queueing_policy.value, policy_kwargs, start_server, http_host,
-             http_port, metric_exporter)
+    ).remote(queueing_policy.value, policy_kwargs, start_server, http_node_id,
+             http_host, http_port, metric_exporter)
 
     if start_server and blocking:
         block_until_http_ready("http://{}:{}/-/routes".format(

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -144,7 +144,8 @@ class ServeMaster:
             self.http_proxy = ray.util.get_actor(SERVE_PROXY_NAME)
         except ValueError:
             logger.info(
-                "Starting HTTP proxy with name '{}'".format(SERVE_PROXY_NAME))
+                "Starting HTTP proxy with name '{}' on node '{}'".format(
+                    SERVE_PROXY_NAME, node_id))
             self.http_proxy = async_retryable(HTTPProxyActor).options(
                 detached=True,
                 name=SERVE_PROXY_NAME,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When running on a cluster, users need to know which node to use for HTTP requests. This is not a complete solution but at least gives the user some manual control - whichever node they first run `serve.init()` on will house the HTTP proxy (usually the head node).

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
