### PR TITLE
Annotate Head Node with {"head": 1.0}

### DIFF
--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -133,7 +133,8 @@ class ResourceSpec(
         # Automatically create a node id resource on each node. This is
         # queryable with ray.state.node_ids() and ray.state.current_node_id().
         resources[NODE_ID_PREFIX + ray.services.get_node_ip_address()] = 1.0
-        resources["head"] = 1.0
+        if is_head:
+            resources["head"] = 1.0
 
         num_cpus = self.num_cpus
         if num_cpus is None:

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -133,6 +133,7 @@ class ResourceSpec(
         # Automatically create a node id resource on each node. This is
         # queryable with ray.state.node_ids() and ray.state.current_node_id().
         resources[NODE_ID_PREFIX + ray.services.get_node_ip_address()] = 1.0
+        resources["head"] = 1.0
 
         num_cpus = self.num_cpus
         if num_cpus is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR adds a static resource for head node, annotating with {"head":1}. This simplify many cases when we need to pin certain task or actor to the head node.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
