### PR TITLE
[tune] added average scope to experiment analysis

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -273,7 +273,7 @@ class ExperimentAnalysis(Analysis):
         Args:
             metric (str): Key for trial info to order on.
             mode (str): One of [min, max].
-            scope (str): One of [all, last]. If `scope=last`, only look at
+            scope (str): One of [all, last, avg]. If `scope=last`, only look at
                 each trial's final step for `metric`, and compare across
                 trials based on `mode=[min,max]`. If `scope=avg`, consider the
                 simple average over all steps for `metric` and compare across
@@ -292,7 +292,7 @@ class ExperimentAnalysis(Analysis):
         Args:
             metric (str): Key for trial info to order on.
             mode (str): One of [min, max].
-            scope (str): One of [all, last]. If `scope=last`, only look at
+            scope (str): One of [all, last, avg]. If `scope=last`, only look at
                 each trial's final step for `metric`, and compare across
                 trials based on `mode=[min,max]`. If `scope=avg`, consider the
                 simple average over all steps for `metric` and compare across

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -220,8 +220,10 @@ class ExperimentAnalysis(Analysis):
         Args:
             metric (str): Key for trial info to order on.
             mode (str): One of [min, max].
-            scope (str): One of [all, last]. If `scope=last`, only look at
+            scope (str): One of [all, last, avg]. If `scope=last`, only look at
                 each trial's final step for `metric`, and compare across
+                trials based on `mode=[min,max]`. If `scope=avg`, consider the
+                simple average over all steps for `metric` and compare across
                 trials based on `mode=[min,max]`. If `scope=all`, find each
                 trial's min/max score for `metric` based on `mode`, and
                 compare trials based on `mode=[min,max]`.
@@ -231,11 +233,11 @@ class ExperimentAnalysis(Analysis):
                 "ExperimentAnalysis: attempting to get best trial for "
                 "metric {} for mode {} not in [\"max\", \"min\"]".format(
                     metric, mode))
-        if scope not in ["all", "last"]:
+        if scope not in ["all", "last", "avg"]:
             raise ValueError(
                 "ExperimentAnalysis: attempting to get best trial for "
-                "metric {} for scope {} not in [\"all\", \"last\"]".format(
-                    metric, scope))
+                "metric {} for scope {} not in [\"all\", \"last\", \"avg\"]".
+                format(metric, scope))
         best_trial = None
         best_metric_score = None
         for trial in self.trials:
@@ -244,6 +246,8 @@ class ExperimentAnalysis(Analysis):
 
             if scope == "last":
                 metric_score = trial.metric_analysis[metric]["last"]
+            elif scope == "avg":
+                metric_score = trial.metric_analysis[metric]["avg"]
             else:
                 metric_score = trial.metric_analysis[metric][mode]
 
@@ -271,6 +275,8 @@ class ExperimentAnalysis(Analysis):
             mode (str): One of [min, max].
             scope (str): One of [all, last]. If `scope=last`, only look at
                 each trial's final step for `metric`, and compare across
+                trials based on `mode=[min,max]`. If `scope=avg`, consider the
+                simple average over all steps for `metric` and compare across
                 trials based on `mode=[min,max]`. If `scope=all`, find each
                 trial's min/max score for `metric` based on `mode`, and
                 compare trials based on `mode=[min,max]`.
@@ -288,6 +294,8 @@ class ExperimentAnalysis(Analysis):
             mode (str): One of [min, max].
             scope (str): One of [all, last]. If `scope=last`, only look at
                 each trial's final step for `metric`, and compare across
+                trials based on `mode=[min,max]`. If `scope=avg`, consider the
+                simple average over all steps for `metric` and compare across
                 trials based on `mode=[min,max]`. If `scope=all`, find each
                 trial's min/max score for `metric` based on `mode`, and
                 compare trials based on `mode=[min,max]`.

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -214,7 +214,7 @@ class Trial:
         self.last_result = {}
         self.last_update_time = -float("inf")
 
-        # stores in memory max/min/last result for each metric by trial
+        # stores in memory max/min/avg/last result for each metric by trial
         self.metric_analysis = {}
 
         self.export_formats = export_formats
@@ -476,13 +476,18 @@ class Trial:
                     self.metric_analysis[metric] = {
                         "max": value,
                         "min": value,
+                        "avg": value,
                         "last": value
                     }
                 else:
+                    step = result["training_iteration"] or 1
                     self.metric_analysis[metric]["max"] = max(
                         value, self.metric_analysis[metric]["max"])
                     self.metric_analysis[metric]["min"] = min(
                         value, self.metric_analysis[metric]["min"])
+                    self.metric_analysis[metric]["avg"] = 1 / step * (
+                        value +
+                        (step - 1) * self.metric_analysis[metric]["avg"])
                     self.metric_analysis[metric]["last"] = value
 
     def get_trainable_cls(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR introduces a new `avg` scope to `tune.ExperimentAnalysis.get_best_trial` and related functions, as suggested in #8147. The cumulative moving average is updated on each step in `tune.trial.Trial`.

Contrary to the suggestion in the issue, no last n-steps average was introduced, as this would require to pass a new parameter `n` to the trial class so that analytics can be updated. I can't find a way to do this without altering the API too much. If this use case is still required, we could discuss on how to add this later on.

## Related issue number

Closes #8147.

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
