### PR TITLE
Fix installing pickle5-backport for Python 3.8.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -135,7 +135,8 @@ if [ "$RAY_BUILD_PYTHON" == "YES" ]; then
   pickle5_available=0
   pickle5_path="$ROOT_DIR/python/ray/pickle5_files"
   # Check if the current Python alrady has pickle5 (either comes with newer Python versions, or has been installed by us before).
-  if PYTHONPATH="$pickle5_path:$PYTHONPATH" "$PYTHON_EXECUTABLE" -s -c "import pickle5" 2>/dev/null; then
+  check_pickle5_command="import sys\nif sys.version_info < (3, 8, 2): import pickle5;"
+  if PYTHONPATH="$pickle5_path:$PYTHONPATH" "$PYTHON_EXECUTABLE" -s -c "exec(\"$check_pickle5_command\")" 2>/dev/null; then
     pickle5_available=1
   fi
   if [ 1 -ne "${pickle5_available}" ]; then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This bug was introduced by #8418. The reason is because in Python 5, `pickle5` is named  just `pickle`. So we only check `import pickle5` for old Python version. 

Tested manually on 3.8.2 and 3.7.2 with and without pickle5-backport installed.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
