### PR TITLE
[CI] Don't uninstall ruby in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ git:
   quiet: true
 
 before_install:
-  - rvm reset && rvm implode --force && gem uninstall rvm || true  # uninstall Ruby RVM
-  - unset -f cd  # Travis defines this on Mac for RVM, but it floods the trace log and isn't relevant for us
   - |
     git clone -q -n "https://github.com/${TRAVIS_REPO_SLUG}.git" "${TRAVIS_REPO_SLUG}"
     cd -- "${TRAVIS_REPO_SLUG}"


### PR DESCRIPTION
Linux and Mac wheels have been failing to upload in Travis with the following error.

```
$ ruby -S gem uninstall -aIx dpl
0.87s$ ruby -S gem install dpl --pre
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.3.0 directory.
The command "ruby -S gem install dpl --pre" failed and exited with 1 during .
```