### PR TITLE
Restore unset -f cd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ git:
   quiet: true
 
 before_install:
+  - unset -f cd  # Travis defines this on Mac for RVM, but it breaks the Mac build
   - |
     git clone -q -n "https://github.com/${TRAVIS_REPO_SLUG}.git" "${TRAVIS_REPO_SLUG}"
     cd -- "${TRAVIS_REPO_SLUG}"


### PR DESCRIPTION
## Why are these changes needed?

The macOS builds [seem to break](https://travis-ci.com/github/ray-project/ray/jobs/335468594) with the Ruby `cd` for some reason.

## Related issue number

#8463 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
