### PR TITLE
[Tune] Introduced patience to early stopping

### DIFF
--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -95,7 +95,7 @@ class EarlyStopping(Stopper):
         if not isinstance(top, int) or top <= 1:
             raise ValueError("Top results to consider must be"
                              " a positive integer greater than one.")
-        if not isinstance(patience, int) or patience >= 1:
+        if not isinstance(patience, int) or patience < 0:
             raise ValueError("Patience must be"
                              " a strictly positive integer.")
         if not isinstance(std, float) or std <= 0:

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -67,7 +67,7 @@ class FunctionStopper(Stopper):
 
 
 class EarlyStopping(Stopper):
-    def __init__(self, metric, std=0.001, top=10, mode="min"):
+    def __init__(self, metric, std=0.001, top=10, mode="min", patience=0):
         """Create the EarlyStopping object.
 
         Args:
@@ -77,6 +77,8 @@ class EarlyStopping(Stopper):
             top (int): The number of best model to consider.
             mode (str): The mode to select the top results.
                 Can either be "min" or "max".
+            patience (int): Number of epochs to wait for
+                a change in the top models.
 
         Raises:
             ValueError: If the mode parameter is not "min" nor "max".
@@ -84,6 +86,8 @@ class EarlyStopping(Stopper):
                 greater than 1.
             ValueError: If the standard deviation parameter is not
                 a strictly positive float.
+            ValueError: If the patience parameter is not
+                a strictly positive integer.
         """
         if mode not in ("min", "max"):
             raise ValueError("The mode parameter can only be"
@@ -91,11 +95,16 @@ class EarlyStopping(Stopper):
         if not isinstance(top, int) or top <= 1:
             raise ValueError("Top results to consider must be"
                              " a positive integer greater than one.")
+        if not isinstance(patience, int) or patience >= 1:
+            raise ValueError("Patience must be"
+                             " a strictly positive integer.")
         if not isinstance(std, float) or std <= 0:
             raise ValueError("The standard deviation must be"
                              " a strictly positive float number.")
         self._mode = mode
         self._metric = metric
+        self._patience = patience
+        self._iterations = 0
         self._std = std
         self._top = top
         self._top_values = []
@@ -107,9 +116,23 @@ class EarlyStopping(Stopper):
             self._top_values = sorted(self._top_values)[:self._top]
         else:
             self._top_values = sorted(self._top_values)[-self._top:]
+
+        # If the current iteration has to stop
+        if self._stop():
+            # we increment the total counter of iterations
+            self._iterations += 1
+        else:
+            # otherwise we reset the counter
+            self._iterations = 0
+
+        # and then call the method that re-executes
+        # the checks, including the iterations.
         return self.stop_all()
+
+    def _stop(self):
+        return (len(self._top_values) == self._top
+                and np.std(self._top_values) <= self._std)
 
     def stop_all(self):
         """Return whether to stop and prevent trials from starting."""
-        return (len(self._top_values) == self._top
-                and np.std(self._top_values) <= self._std)
+        return self._stop() and self._iterations >= self._patience

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -70,6 +70,10 @@ class EarlyStopping(Stopper):
     def __init__(self, metric, std=0.001, top=10, mode="min", patience=0):
         """Create the EarlyStopping object.
 
+        Stops the entire experiment when the metric has plateaued
+        for more than the given amount of iterations specified in
+        the patience parameter.
+
         Args:
             metric (str): The metric to be monitored.
             std (float): The minimal standard deviation after which
@@ -118,7 +122,7 @@ class EarlyStopping(Stopper):
             self._top_values = sorted(self._top_values)[-self._top:]
 
         # If the current iteration has to stop
-        if self._stop():
+        if self.has_plateaued():
             # we increment the total counter of iterations
             self._iterations += 1
         else:
@@ -129,10 +133,10 @@ class EarlyStopping(Stopper):
         # the checks, including the iterations.
         return self.stop_all()
 
-    def _stop(self):
+    def has_plateaued(self):
         return (len(self._top_values) == self._top
                 and np.std(self._top_values) <= self._std)
 
     def stop_all(self):
         """Return whether to stop and prevent trials from starting."""
-        return self._stop() and self._iterations >= self._patience
+        return self.has_plateaued() and self._iterations >= self._patience

--- a/python/ray/tune/tests/test_api.py
+++ b/python/ray/tune/tests/test_api.py
@@ -501,6 +501,8 @@ class TrainableFunctionApiTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             EarlyStopping("test", std=0)
         with self.assertRaises(ValueError):
+            EarlyStopping("test", patience=-1)
+        with self.assertRaises(ValueError):
             EarlyStopping("test", std="0")
         with self.assertRaises(ValueError):
             EarlyStopping("test", mode="0")
@@ -511,6 +513,14 @@ class TrainableFunctionApiTest(unittest.TestCase):
         self.assertTrue(
             all(t.status == Trial.TERMINATED for t in analysis.trials))
         self.assertTrue(len(analysis.dataframe()) <= top)
+
+        patience = 10
+        stopper = EarlyStopping("test", top=top, mode="min", patience=patience)
+
+        analysis = tune.run(train, num_samples=100, stop=stopper)
+        self.assertTrue(
+            all(t.status == Trial.TERMINATED for t in analysis.trials))
+        self.assertTrue(len(analysis.dataframe()) <= patience)
 
         stopper = EarlyStopping("test", top=top, mode="min")
 


### PR DESCRIPTION
## Why are these changes needed?
I have introduced patience in the Early stopping, a number of iterations to wait after the condition for stopping have been achieved.

## Checks
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
