### PR TITLE
[Tune] Added default values for utility kwargs

### DIFF
--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -80,8 +80,6 @@ class BayesOptSearch(Searcher):
             utility_kwargs = dict(
                 acq='ucb',
                 kappa=2.576,
-                kappa_decay=1,
-                kappa_decay_delay=0,
                 xi=0.0,
             )
 

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -32,8 +32,11 @@ class BayesOptSearch(Searcher):
         metric (str): The training result objective value attribute.
         mode (str): One of {min, max}. Determines whether objective is
             minimizing or maximizing the metric attribute.
-        utility_kwargs (dict): Parameters to define the utility function. Must
-            provide values for the keys `kind`, `kappa`, and `xi`.
+        utility_kwargs (dict): Parameters to define the utility function.
+            The default value is a dictionary with three keys:
+            - kind: ucb (Upper Confidence Bound)
+            - kappa: 2.576
+            - xi: 0.0
         random_state (int): Used to initialize BayesOpt.
         verbose (int): Sets verbosity level for BayesOpt packages.
         max_concurrent: Deprecated.

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -66,8 +66,6 @@ class BayesOptSearch(Searcher):
         assert byo is not None, (
             "BayesOpt must be installed!. You can install BayesOpt with"
             " the command: `pip install bayesian-optimization`.")
-        assert utility_kwargs is not None, (
-            "Must define arguments for the utility function!")
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
         self.max_concurrent = max_concurrent
         super(BayesOptSearch, self).__init__(
@@ -75,6 +73,17 @@ class BayesOptSearch(Searcher):
             mode=mode,
             max_concurrent=max_concurrent,
             use_early_stopped_trials=use_early_stopped_trials)
+
+        if utility_kwargs is None:
+            # The defaults arguments are the same
+            # as in the package BayesianOptimization
+            utility_kwargs = dict(
+                acq='ucb',
+                kappa=2.576,
+                kappa_decay=1,
+                kappa_decay_delay=0,
+                xi=0.0,
+            )
 
         if mode == "max":
             self._metric_op = 1.

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -78,7 +78,7 @@ class BayesOptSearch(Searcher):
             # The defaults arguments are the same
             # as in the package BayesianOptimization
             utility_kwargs = dict(
-                acq='ucb',
+                acq="ucb",
                 kappa=2.576,
                 xi=0.0,
             )

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -78,7 +78,7 @@ class BayesOptSearch(Searcher):
             # The defaults arguments are the same
             # as in the package BayesianOptimization
             utility_kwargs = dict(
-                acq="ucb",
+                kind="ucb",
                 kappa=2.576,
                 xi=0.0,
             )

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -212,11 +212,7 @@ class BayesoptWarmStartTest(AbstractWarmStartTest, unittest.TestCase):
             space,
             metric="loss",
             mode="min",
-            utility_kwargs={
-                "kind": "ucb",
-                "kappa": 2.5,
-                "xi": 0.0
-            })
+        )
         return search_alg, cost
 
 


### PR DESCRIPTION
## Why are these changes needed?
Previously, it was not possible to instantiate a `BayesOptSearch` object without leaving the default parameters for the utility function, as it is possible with the [BayesianOptimization package](https://github.com/fmfn/BayesianOptimization/blob/857f0fe05471db35510a6b03463033ad05b7f4f9/bayes_opt/bayesian_optimization.py#L159). I have now added the default parameters when no others are provided.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)