### PR TITLE
Change tf_utils.py get_weights to evaluate all tensors at once rather than calling tensor.eval per-tensor

### DIFF
--- a/python/ray/experimental/tf_utils.py
+++ b/python/ray/experimental/tf_utils.py
@@ -161,10 +161,7 @@ class TensorFlowVariables:
             Dictionary mapping variable names to their weights.
         """
         self._check_sess()
-        return {
-            k: v.eval(session=self.sess)
-            for k, v in self.variables.items()
-        }
+        return self.sess.run(self.variables)
 
     def set_weights(self, new_weights):
         """Sets the weights to new_weights.


### PR DESCRIPTION
## Why are these changes needed?

>Somewhere down the call stack Ray calls this function for each policy, for each element of that policy. The tf graph is the same size for each agent, and grows linearly. Thus, you get a linearly increasing amount of eval calls to a linearly increasingly large graph = exponential growth. [source](https://github.com/ray-project/ray/issues/5982#issuecomment-629217172)

Calling this function is currently very slow. Tensorflow supports batched tensor evaluation, which is much faster, and functionally equivalent.

The plots below detail memory use vs time when using [2,3,4,5] agents sequentially. Memory use is highest for each of the 4 subplots when training, time before that is initialization time.

Before this change:
![num_agents](https://user-images.githubusercontent.com/5096835/82066727-181ae080-96d0-11ea-8c28-17179c37423c.png)
Initialization time in seconds:
2: 100
3: 212
4: 378
5: 610

After this change:
![plots_sess_run](https://user-images.githubusercontent.com/5096835/82259411-d00fee00-995b-11ea-91bd-4916a48f3a73.png)
Initialization time in seconds:
2: 65
3: 111
4: 179
5: 284

## Related issue number

Fixes #5982.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] This PR is not tested (please justify below)
Couldn't get the tests to run locally when following developer installation docs, which fail on missing imports. However, tested with my own repo.