### PR TITLE
resolved NameError in ray.tune() call

### DIFF
--- a/rllib/contrib/bandits/examples/tune_LinUCB_train_recommendation.py
+++ b/rllib/contrib/bandits/examples/tune_LinUCB_train_recommendation.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
     start_time = time.time()
     analysis = tune.run(
-        LinUCBTrainer,
+        "contrib/LinUCB",
         config=UCB_CONFIG,
         stop={"training_iteration": training_iterations},
         num_samples=5,


### PR DESCRIPTION
## Why are these changes needed?

The bandit example for LinearUCB throws the following exception with Ray 0.8.5:
    
```
    2020-05-18 14:34:33,111 ERROR trial_runner.py:519 -- Trial LinUCB_ParametricItemRecoEnv_00004: Error processing event.
    Traceback (most recent call last):
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/tune/trial_runner.py", line 467, in _process_trial
        result = self.trial_executor.fetch_result(trial)
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/tune/ray_trial_executor.py", line 431, in fetch_result
        result = ray.get(trial_future[0], DEFAULT_GET_TIMEOUT)
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/worker.py", line 1515, in get
        raise value.as_instanceof_cause()
    ray.exceptions.RayTaskError(NameError): ray::_SeeContrib.train() (pid=96686, ip=192.168.1.65)
      File "python/ray/_raylet.pyx", line 424, in ray._raylet.execute_task
      File "python/ray/_raylet.pyx", line 459, in ray._raylet.execute_task
      File "python/ray/_raylet.pyx", line 462, in ray._raylet.execute_task
      File "python/ray/_raylet.pyx", line 463, in ray._raylet.execute_task
      File "python/ray/_raylet.pyx", line 417, in ray._raylet.execute_task.function_executor
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/rllib/agents/trainer.py", line 448, in __init__
        super().__init__(config, logger_creator)
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/tune/trainable.py", line 174, in __init__
        self._setup(copy.deepcopy(self.config))
      File "/opt/anaconda3/lib/python3.7/site-packages/ray/rllib/__init__.py", line 48, in _setup
        "Please run `contrib/{}` instead.".format(name))
    NameError: Please run `contrib/LinUCB` instead.
```
 
What works is to replace the `tune.run()` argument `LinUCBTrainer` with the string literal `"contrib/LinUCB"`


## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.

There appears to be some issue with CLI options for `flake8`:

```
$ scripts/format.sh
WARNING: clang-format is not installed!
From https://github.com/ray-project/ray
 * branch                master     -> FETCH_HEAD
 * [new branch]          master     -> upstream/master
Usage: flake8 [options] file file ...

flake8: error: no such option: --inline-quotes
```

- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)