### PR TITLE
[rllib] Avoid storing torch tensors in SGD info when using grad clipping

### DIFF
--- a/rllib/agents/a3c/a3c_torch_policy.py
+++ b/rllib/agents/a3c/a3c_torch_policy.py
@@ -64,8 +64,11 @@ def apply_grad_clipping(policy, optimizer, loss):
             params = list(
                 filter(lambda p: p.grad is not None, param_group["params"]))
             if params:
-                info["grad_gnorm"] = nn.utils.clip_grad_norm_(
+                grad_gnorm = nn.utils.clip_grad_norm_(
                     params, policy.config["grad_clip"])
+                if isinstance(grad_gnorm, torch.Tensor):
+                    grad_gnorm = grad_gnorm.cpu().numpy()
+                info["grad_gnorm"] = grad_gnorm
     return info
 
 


### PR DESCRIPTION
## Why are these changes needed?

Training crash when using `grad_clip` parameter with PyTorch. This is because the norm that is stored in sgd info is passed to `averaged`, which is further passed to `np.mean`. This results with a following error, as NumPy thinks that object with `dtype` property is probably a numpy-like object:

```
ray.exceptions.RayTaskError(AttributeError): ray::PPO.train() (pid=25941, ip=192.168.1.15)
  File "python/ray/_raylet.pyx", line 463, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 417, in ray._raylet.execute_task.function_executor
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/agents/trainer.py", line 498, in train
    raise e
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/agents/trainer.py", line 484, in train
    result = Trainable.train(self)
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/tune/trainable.py", line 261, in train
    result = self._train()
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/agents/trainer_template.py", line 151, in _train
    fetches = self.optimizer.step()
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/optimizers/sync_samples_optimizer.py", line 71, in step
    self.standardize_fields)
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/utils/sgd.py", line 121, in do_minibatch_sgd
    logger.debug("{} {}".format(i, averaged(iter_extra_fetches)))
  File "/home/twrona/project/venv/lib/python3.7/site-packages/ray/rllib/utils/sgd.py", line 31, in averaged
    out[k] = np.mean(v)
  File "<__array_function__ internals>", line 6, in mean
  File "/home/twrona/project/venv/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 3335, in mean
    out=out, **kwargs)
  File "/home/twrona/project/venv/lib/python3.7/site-packages/numpy/core/_methods.py", line 161, in _mean
    ret = ret.dtype.type(ret / rcount)
AttributeError: 'torch.dtype' object has no attribute 'type'
```

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
