### PR TITLE
[RLlib] Error: "Unknown trainable [some rllib algo name]"

### DIFF
--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -7,7 +7,6 @@ from ray.experimental.internal_kv import _internal_kv_initialized, \
     _internal_kv_get, _internal_kv_put
 from ray.tune.error import TuneError
 
-
 TRAINABLE_CLASS = "trainable_class"
 ENV_CREATOR = "env_creator"
 RLLIB_MODEL = "rllib_model"
@@ -22,12 +21,10 @@ logger = logging.getLogger(__name__)
 
 
 def has_trainable(trainable_name):
-    #global _global_registry
     return _global_registry.contains(TRAINABLE_CLASS, trainable_name)
 
 
 def get_trainable_cls(trainable_name):
-    #global _global_registry
     validate_trainable(trainable_name)
     return _global_registry.get(TRAINABLE_CLASS, trainable_name)
 
@@ -140,8 +137,5 @@ class _Registry:
         self._to_flush.clear()
 
 
-#try:
-#    _ = _global_registry
-#except NameError:
 _global_registry = _Registry()
 ray.worker._post_init_hooks.append(_global_registry.flush_values)

--- a/rllib/tuned_examples/regression_tests/cartpole-es-tf.yaml
+++ b/rllib/tuned_examples/regression_tests/cartpole-es-tf.yaml
@@ -3,7 +3,7 @@ cartpole-es-tf:
     run: ES
     stop:
         episode_reward_mean: 150
-        timesteps_total: 400000
+        timesteps_total: 500000
     config:
         use_pytorch: false
         num_workers: 2

--- a/rllib/tuned_examples/regression_tests/cartpole-es-torch.yaml
+++ b/rllib/tuned_examples/regression_tests/cartpole-es-torch.yaml
@@ -3,7 +3,7 @@ cartpole-es-torch:
     run: ES
     stop:
         episode_reward_mean: 150
-        timesteps_total: 400000
+        timesteps_total: 500000
     config:
         use_pytorch: true
         num_workers: 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

In case of two consecutive `tune.run`s with `ray.shutdown()` and `ray.init()` between them. the error: Unknown trainer ... is thrown. This PR fixes that bug.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
