### PR TITLE
[autoscaler] Enable Rsync with Docker Containers 

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -509,7 +509,7 @@ def rsync(config_file,
             logger.warning(
                 "A docker container was specified in the cluster YAML, but"
                 "the docker flag was not specified. To run this command inside"
-                "the container, add --docker to your ray command.")
+                " the container, add --docker to your ray command.")
 
         for node_id in nodes:
             updater = NodeUpdaterThread(

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -505,6 +505,12 @@ def rsync(config_file,
         if docker and config["docker"]["container_name"] is None:
             raise ValueError("Docker container not specified in config.")
 
+        if not docker and config["docker"]["container_name"] is not None:
+            logger.warning(
+                "A docker container was specified in the cluster YAML, but"
+                "the docker flag was not specified. To run this command inside"
+                "the container, add --docker to your ray command.")
+
         for node_id in nodes:
             updater = NodeUpdaterThread(
                 node_id=node_id,

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -502,7 +502,7 @@ def rsync(config_file,
                 create_if_needed=False)
         ]
 
-        if docker and config["docker"]["container_name"] == None:
+        if docker and config["docker"]["container_name"] is None:
             raise ValueError("Docker container not specified in config.")
 
         for node_id in nodes:
@@ -523,7 +523,8 @@ def rsync(config_file,
             else:
                 rsync = updater.rsync_up
 
-            container_name = config["docker"]["container_name"] if docker else None
+            container_name = config["docker"][
+                "container_name"] if docker else None
 
             if source and target:
                 rsync(source, target, container=container_name)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -377,7 +377,7 @@ class NodeUpdater:
                           "Synced {} to {}".format(local_path, remote_path)):
                 self.cmd_runner.run("mkdir -p {}".format(
                     os.path.dirname(remote_path)))
-                sync_cmd(local_path, remote_path, docker=container)
+                sync_cmd(local_path, remote_path, container=container)
 
     def wait_ready(self, deadline):
         with LogTimer(self.log_prefix + "Got remote shell"):

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -444,9 +444,11 @@ class NodeUpdater:
 
         if container:
             # Copy file into docker
-            docker_cp = "docker cp {} {}:{}".format(target, container, target.strip("~"))
+            docker_cp = "docker cp {} {}:{}".format(target, container,
+                                                    target.strip("~"))
             # Move to desired location
-            docker_relocate = with_docker_exec(["mv {} {}".format(target.strip("~"), target)], container)[0]
+            docker_relocate = with_docker_exec(
+                ["mv {} {}".format(target.strip("~"), target)], container)[0]
             self.cmd_runner.run("{} && {}".format(docker_cp, docker_relocate))
 
     def rsync_down(self, source, target, container=None):
@@ -454,12 +456,16 @@ class NodeUpdater:
                     "Syncing {} from {}...".format(source, target))
         if container:
             # Move file to non-relative path
-            docker_prepare = with_docker_exec(["mv {} {}".format(source, source.strip("~"))], container)[0]
+            docker_prepare = with_docker_exec(
+                ["mv {} {}".format(source, source.strip("~"))], container)[0]
             # Copy file out of container
-            docker_cp = "docker cp {}:{} {}".format(container, source.strip("~"), source)
+            docker_cp = "docker cp {}:{} {}".format(container,
+                                                    source.strip("~"), source)
             # Move file back to original location
-            docker_cleanup = with_docker_exec(["mv {} {}".format(source.strip("~"), source)], container)[0]
-            self.cmd_runner.run("{} && {} && {} ".format(docker_prepare, docker_cp, docker_cleanup))
+            docker_cleanup = with_docker_exec(
+                ["mv {} {}".format(source.strip("~"), source)], container)[0]
+            self.cmd_runner.run("{} && {} && {} ".format(
+                docker_prepare, docker_cp, docker_cleanup))
 
         self.cmd_runner.run_rsync_down(source, target)
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -709,7 +709,13 @@ def attach(cluster_config_file, start, screen, tmux, cluster_name, new,
     help="Runs command in the docker container specified in cluster_config.")
 def rsync_down(cluster_config_file, source, target, cluster_name, docker):
     """Download specific files from a Ray cluster."""
-    rsync(cluster_config_file, source, target, cluster_name, down=True, docker=docker)
+    rsync(
+        cluster_config_file,
+        source,
+        target,
+        cluster_name,
+        down=True,
+        docker=docker)
 
 
 @cli.command()
@@ -733,7 +739,8 @@ def rsync_down(cluster_config_file, source, target, cluster_name, docker):
     is_flag=True,
     default=False,
     help="Runs command in the docker container specified in cluster_config.")
-def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes, docker):
+def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes,
+             docker):
     """Upload specific files to a Ray cluster."""
     rsync(
         cluster_config_file,
@@ -814,7 +821,13 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
                                  True, cluster_name)
 
     target = os.path.join("~", os.path.basename(script))
-    rsync(cluster_config_file, script, target, cluster_name, down=False,docker=docker)
+    rsync(
+        cluster_config_file,
+        script,
+        target,
+        cluster_name,
+        down=False,
+        docker=docker)
     command_parts = ["python", target]
     if script_args:
         command_parts += list(script_args)

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -702,9 +702,14 @@ def attach(cluster_config_file, start, screen, tmux, cluster_name, new,
     required=False,
     type=str,
     help="Override the configured cluster name.")
-def rsync_down(cluster_config_file, source, target, cluster_name):
+@click.option(
+    "--docker",
+    is_flag=True,
+    default=False,
+    help="Runs command in the docker container specified in cluster_config.")
+def rsync_down(cluster_config_file, source, target, cluster_name, docker):
     """Download specific files from a Ray cluster."""
-    rsync(cluster_config_file, source, target, cluster_name, down=True)
+    rsync(cluster_config_file, source, target, cluster_name, down=True, docker=docker)
 
 
 @cli.command()
@@ -723,7 +728,12 @@ def rsync_down(cluster_config_file, source, target, cluster_name):
     is_flag=True,
     required=False,
     help="Upload to all nodes (workers and head).")
-def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes):
+@click.option(
+    "--docker",
+    is_flag=True,
+    default=False,
+    help="Runs command in the docker container specified in cluster_config.")
+def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes, docker):
     """Upload specific files to a Ray cluster."""
     rsync(
         cluster_config_file,
@@ -731,7 +741,8 @@ def rsync_up(cluster_config_file, source, target, cluster_name, all_nodes):
         target,
         cluster_name,
         down=False,
-        all_nodes=all_nodes)
+        all_nodes=all_nodes,
+        docker=docker)
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})
@@ -803,8 +814,7 @@ def submit(cluster_config_file, docker, screen, tmux, stop, start,
                                  True, cluster_name)
 
     target = os.path.join("~", os.path.basename(script))
-    rsync(cluster_config_file, script, target, cluster_name, down=False)
-
+    rsync(cluster_config_file, script, target, cluster_name, down=False,docker=docker)
     command_parts = ["python", target]
     if script_args:
         command_parts += list(script_args)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Ray cannot currently rsync into or out of docker containers. This is a problem also for `ray submit` which uses rsync; 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/4183

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
