### PR TITLE
[GCS]profile info getting implementation based gcs service

### DIFF
--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -10,4 +10,4 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         c_bool Connect()
         void Disconnect()
         c_vector[c_string] GetAllJobInfo()
-
+        c_vector[c_string] GetAllProfileInfo()

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -22,3 +22,6 @@ cdef class GlobalStateAccessor:
 
     def get_job_table(self):
         return self.inner.get().GetAllJobInfo()
+
+    def get_profile_table(self):
+        return self.inner.get().GetAllProfileInfo()

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -570,6 +570,13 @@ class StatsInfoAccessor {
       const std::shared_ptr<rpc::ProfileTableData> &data_ptr,
       const StatusCallback &callback) = 0;
 
+  /// Get all profile info from GCS asynchronously.
+  ///
+  /// \param callback Callback that will be called after lookup finished.
+  /// \return Status
+  virtual Status AsyncGetAll(
+      const MultiItemCallback<rpc::ProfileTableData> &callback) = 0;
+
  protected:
   StatsInfoAccessor() = default;
 };

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -80,5 +80,22 @@ std::vector<std::string> GlobalStateAccessor::GetAllJobInfo() {
   return job_table_data;
 }
 
+std::vector<std::string> GlobalStateAccessor::GetAllProfileInfo() {
+  std::vector<std::string> profile_table_data;
+  std::promise<bool> promise;
+  auto on_done = [&profile_table_data, &promise](
+                     const Status &status,
+                     const std::vector<rpc::ProfileTableData> &result) {
+    RAY_CHECK_OK(status);
+    for (auto &data : result) {
+      profile_table_data.push_back(data.SerializeAsString());
+    }
+    promise.set_value(true);
+  };
+  RAY_CHECK_OK(gcs_client_->Stats().AsyncGetAll(on_done));
+  promise.get_future().get();
+  return profile_table_data;
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -51,6 +51,13 @@ class GlobalStateAccessor {
   /// protobuf function.
   std::vector<std::string> GetAllJobInfo();
 
+  /// Get information of all profiles from GCS Service.
+  ///
+  /// \return All profile info. To support multi-language, we serialized each
+  /// ProfileTableData and returned the serialized string. Where used, it needs to be
+  /// deserialized with protobuf function.
+  std::vector<std::string> GetAllProfileInfo();
+
  private:
   /// Whether this client is connected to gcs server.
   bool is_connected_{false};

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -1068,6 +1068,21 @@ Status ServiceBasedStatsInfoAccessor::AsyncAddProfileData(
   return Status::OK();
 }
 
+Status ServiceBasedStatsInfoAccessor::AsyncGetAll(
+    const MultiItemCallback<rpc::ProfileTableData> &callback) {
+  RAY_LOG(DEBUG) << "Getting all profile info.";
+  RAY_CHECK(callback);
+  rpc::GetAllProfileInfoRequest request;
+  client_impl_->GetGcsRpcClient().GetAllProfileInfo(
+      request,
+      [callback](const Status &status, const rpc::GetAllProfileInfoReply &reply) {
+        auto result = VectorFromProtobuf(reply.profile_info_list());
+        callback(status, result);
+        RAY_LOG(DEBUG) << "Finished getting all job info.";
+      });
+  return Status::OK();
+}
+
 ServiceBasedErrorInfoAccessor::ServiceBasedErrorInfoAccessor(
     ServiceBasedGcsClient *client_impl)
     : client_impl_(client_impl) {}

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -281,6 +281,8 @@ class ServiceBasedStatsInfoAccessor : public StatsInfoAccessor {
   Status AsyncAddProfileData(const std::shared_ptr<rpc::ProfileTableData> &data_ptr,
                              const StatusCallback &callback) override;
 
+  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData> &callback) override;
+
  private:
   ServiceBasedGcsClient *client_impl_;
 };

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -105,6 +105,20 @@ TEST_F(GlobalStateAccessorTest, TestJobTable) {
   ASSERT_EQ(global_state_->GetAllJobInfo().size(), job_count);
 }
 
+TEST_F(GlobalStateAccessorTest, TestProfileTable) {
+  int profile_count = 100;
+  ASSERT_EQ(global_state_->GetAllProfileInfo().size(), 0);
+  for (int index = 0; index < profile_count; ++index) {
+    auto client_id = ClientID::FromRandom();
+    auto profile_table_data = Mocker::GenProfileTableData(client_id);
+    std::promise<bool> promise;
+    RAY_CHECK_OK(gcs_client_->Stats().AsyncAddProfileData(profile_table_data,
+        [&promise](Status status) { promise.set_value(status.ok()); }));
+    WaitReady(promise.get_future(), timeout_ms_);
+  }
+  ASSERT_EQ(global_state_->GetAllProfileInfo().size(), profile_count);
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -112,7 +112,8 @@ TEST_F(GlobalStateAccessorTest, TestProfileTable) {
     auto client_id = ClientID::FromRandom();
     auto profile_table_data = Mocker::GenProfileTableData(client_id);
     std::promise<bool> promise;
-    RAY_CHECK_OK(gcs_client_->Stats().AsyncAddProfileData(profile_table_data,
+    RAY_CHECK_OK(gcs_client_->Stats().AsyncAddProfileData(
+        profile_table_data,
         [&promise](Status status) { promise.set_value(status.ok()); }));
     WaitReady(promise.get_future(), timeout_ms_);
   }

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -229,7 +229,7 @@ std::unique_ptr<rpc::TaskInfoHandler> GcsServer::InitTaskInfoHandler() {
 
 std::unique_ptr<rpc::StatsHandler> GcsServer::InitStatsHandler() {
   return std::unique_ptr<rpc::DefaultStatsHandler>(
-      new rpc::DefaultStatsHandler(*redis_gcs_client_));
+      new rpc::DefaultStatsHandler(gcs_table_storage_));
 }
 
 std::unique_ptr<rpc::ErrorInfoHandler> GcsServer::InitErrorInfoHandler() {

--- a/src/ray/gcs/gcs_server/stats_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.cc
@@ -46,13 +46,13 @@ void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &requ
 void DefaultStatsHandler::HandleGetAllProfileInfo(
     const rpc::GetAllProfileInfoRequest &request, rpc::GetAllProfileInfoReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(INFO) << "Getting all profile info.";
+  RAY_LOG(DEBUG) << "Getting all profile info.";
   auto on_done = [reply, send_reply_callback](
                      const std::unordered_map<UniqueID, ProfileTableData> &result) {
     for (auto &data : result) {
-      reply->add_profile_info_list()->CopyFrom(data.second);  // wangtao
+      reply->add_profile_info_list()->CopyFrom(data.second);
     }
-    RAY_LOG(INFO) << "Finished getting all profile info.";
+    RAY_LOG(DEBUG) << "Finished getting all profile info.";
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
 

--- a/src/ray/gcs/gcs_server/stats_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.cc
@@ -35,7 +35,6 @@ void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &requ
   };
   Status status = gcs_table_storage_->ProfileTable().Put(UniqueID::FromRandom(),
                                                          *profile_table_data, on_done);
-  ;
   if (!status.ok()) {
     on_done(status);
   }

--- a/src/ray/gcs/gcs_server/stats_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.cc
@@ -33,13 +33,32 @@ void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &requ
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
-
-  Status status = gcs_client_.Stats().AsyncAddProfileData(profile_table_data, on_done);
+  Status status = gcs_table_storage_->ProfileTable().Put(UniqueID::FromRandom(),
+                                                         *profile_table_data, on_done);
+  ;
   if (!status.ok()) {
     on_done(status);
   }
   RAY_LOG(DEBUG) << "Finished adding profile data, component type = "
                  << request.profile_data().component_type() << ", node id = " << node_id;
+}
+
+void DefaultStatsHandler::HandleGetAllProfileInfo(
+    const rpc::GetAllProfileInfoRequest &request, rpc::GetAllProfileInfoReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  RAY_LOG(INFO) << "Getting all profile info.";
+  auto on_done = [reply, send_reply_callback](
+                     const std::unordered_map<UniqueID, ProfileTableData> &result) {
+    for (auto &data : result) {
+      reply->add_profile_info_list()->CopyFrom(data.second);  // wangtao
+    }
+    RAY_LOG(INFO) << "Finished getting all profile info.";
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
+  Status status = gcs_table_storage_->ProfileTable().GetAll(on_done);
+  if (!status.ok()) {
+    on_done(std::unordered_map<UniqueID, ProfileTableData>());
+  }
 }
 
 }  // namespace rpc

--- a/src/ray/gcs/gcs_server/stats_handler_impl.cc
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.cc
@@ -33,6 +33,7 @@ void DefaultStatsHandler::HandleAddProfileData(const AddProfileDataRequest &requ
     }
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
+
   Status status = gcs_table_storage_->ProfileTable().Put(UniqueID::FromRandom(),
                                                          *profile_table_data, on_done);
   if (!status.ok()) {
@@ -54,6 +55,7 @@ void DefaultStatsHandler::HandleGetAllProfileInfo(
     RAY_LOG(INFO) << "Finished getting all profile info.";
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };
+
   Status status = gcs_table_storage_->ProfileTable().GetAll(on_done);
   if (!status.ok()) {
     on_done(std::unordered_map<UniqueID, ProfileTableData>());

--- a/src/ray/gcs/gcs_server/stats_handler_impl.h
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.h
@@ -15,6 +15,7 @@
 #ifndef RAY_GCS_STATS_HANDLER_IMPL_H
 #define RAY_GCS_STATS_HANDLER_IMPL_H
 
+#include "gcs_table_storage.h"
 #include "ray/gcs/redis_gcs_client.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 
@@ -24,15 +25,19 @@ namespace rpc {
 /// This implementation class of `StatsHandler`.
 class DefaultStatsHandler : public rpc::StatsHandler {
  public:
-  explicit DefaultStatsHandler(gcs::RedisGcsClient &gcs_client)
-      : gcs_client_(gcs_client) {}
+  explicit DefaultStatsHandler(std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage)
+      : gcs_table_storage_(std::move(gcs_table_storage)) {}
 
   void HandleAddProfileData(const AddProfileDataRequest &request,
                             AddProfileDataReply *reply,
                             SendReplyCallback send_reply_callback) override;
 
+  void HandleGetAllProfileInfo(const rpc::GetAllProfileInfoRequest &request,
+                               rpc::GetAllProfileInfoReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override;
+
  private:
-  gcs::RedisGcsClient &gcs_client_;
+  std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
 };
 
 }  // namespace rpc

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -404,6 +404,10 @@ class RedisStatsInfoAccessor : public StatsInfoAccessor {
   Status AsyncAddProfileData(const std::shared_ptr<ProfileTableData> &data_ptr,
                              const StatusCallback &callback) override;
 
+  Status AsyncGetAll(const MultiItemCallback<rpc::ProfileTableData> &callback) override {
+    return Status::NotImplemented("AsyncGetAll not implemented");
+  }
+
  private:
   RedisGcsClient *client_impl_{nullptr};
 };

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -368,10 +368,20 @@ message AddProfileDataReply {
   GcsStatus status = 1;
 }
 
+message GetAllProfileInfoRequest {
+}
+
+message GetAllProfileInfoReply {
+  GcsStatus status = 1;
+  repeated ProfileTableData profile_info_list = 2;
+}
+
 // Service for stats access.
 service StatsGcsService {
   // Add profile data to GCS Service.
   rpc AddProfileData(AddProfileDataRequest) returns (AddProfileDataReply);
+  // Get information of all profiles from GCS Service.
+  rpc GetAllProfileInfo(GetAllProfileInfoRequest) returns (GetAllProfileInfoReply);
 }
 
 message ReportJobErrorRequest {

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -191,6 +191,9 @@ class GcsRpcClient {
   /// Add profile data to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(StatsGcsService, AddProfileData, stats_grpc_client_, )
 
+  /// Get information of all profiles from GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(StatsGcsService, GetAllProfileInfo, stats_grpc_client_, )
+
   /// Report a job error to GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(ErrorInfoGcsService, ReportJobError,
                              error_info_grpc_client_, )

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -345,6 +345,10 @@ class StatsGcsServiceHandler {
   virtual void HandleAddProfileData(const AddProfileDataRequest &request,
                                     AddProfileDataReply *reply,
                                     SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetAllProfileInfo(const GetAllProfileInfoRequest &request,
+                                       GetAllProfileInfoReply *reply,
+                                       SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `StatsGcsService`.
@@ -364,6 +368,7 @@ class StatsGrpcService : public GrpcService {
       const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories) override {
     STATS_SERVICE_RPC_HANDLER(AddProfileData);
+    STATS_SERVICE_RPC_HANDLER(GetAllProfileInfo);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

We have made gcs a service. All table info should be obtained from new gcs service instead of direct accessing of redis.

This PR changes the new way of accessing profile info aka. stats.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
