### PR TITLE
[core] Fix Task Cancelation Bug with Missing Task owner

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1205,17 +1205,21 @@ Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {
       GetActorHandle(object_id.TaskId().ActorId(), &h).ok()) {
     return Status::Invalid("Actor task cancellation is not supported.");
   }
+
+  // Check for locally submitted tasks first to avoid a situation where the
+  // TaskId is known, but the ownership information is missing.
+  auto task_spec = task_manager_->GetTaskSpec(object_id.TaskId());
+  if (task_spec.has_value() && !task_spec.value().IsActorCreationTask()) {
+    return direct_task_submitter_->CancelTask(task_spec.value(), force_kill);
+  }
+
   rpc::Address obj_addr;
   if (!reference_counter_->GetOwner(object_id, nullptr, &obj_addr)) {
     return Status::Invalid("No owner found for object.");
   }
+
   if (obj_addr.SerializeAsString() != rpc_address_.SerializeAsString()) {
     return direct_task_submitter_->CancelRemoteTask(object_id, obj_addr, force_kill);
-  }
-
-  auto task_spec = task_manager_->GetTaskSpec(object_id.TaskId());
-  if (task_spec.has_value() && !task_spec.value().IsActorCreationTask()) {
-    return direct_task_submitter_->CancelTask(task_spec.value(), force_kill);
   }
   return Status::OK();
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1207,7 +1207,9 @@ Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {
   }
 
   // Check for locally submitted tasks first to avoid a situation where the
-  // TaskId is known, but the ownership information is missing.
+  // TaskId is known, but the ownership information is missing. This happens
+  // if the ObjectID information is discarded, but the TaskSpec remains
+  // because the task is still executing.
   auto task_spec = task_manager_->GetTaskSpec(object_id.TaskId());
   if (task_spec.has_value() && !task_spec.value().IsActorCreationTask()) {
     return direct_task_submitter_->CancelTask(task_spec.value(), force_kill);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
There are cases where cancelation fails because an object's owner cannot be found. This should not prevent cancelation of objects that were locally submitted. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Partially closes #8565

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
