### PR TITLE
Fix TestGetUncommittedLineage NPE bug

### DIFF
--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -99,7 +99,7 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
   HeartbeatBatchTable &heartbeat_batch_table();
   DynamicResourceTable &resource_table();
   /// Implements the Tasks() interface.
-  raylet::TaskTable &raylet_task_table();
+  virtual raylet::TaskTable &raylet_task_table();
   TaskLeaseTable &task_lease_table();
   TaskReconstructionLog &task_reconstruction_log();
   /// Implements the Errors() interface.

--- a/src/ray/raylet/lineage_cache_test.cc
+++ b/src/ray/raylet/lineage_cache_test.cc
@@ -157,7 +157,7 @@ class MockGcsClient : public gcs::RedisGcsClient {
     node_accessor_.reset(new MockNodeInfoAccessor(this, node_id));
   }
 
-  gcs::raylet::TaskTable &raylet_task_table() { return *task_table_fake_; }
+  gcs::raylet::TaskTable &raylet_task_table() override { return *task_table_fake_; }
 
   MockTaskInfoAccessor &MockTasks() {
     return *dynamic_cast<MockTaskInfoAccessor *>(task_accessor_.get());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
lineage_cache_test.cc try to override raylet_task_table function, but it is not virtual.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
