### PR TITLE
Fix actor creation function descriptor conflict

### DIFF
--- a/python/ray/includes/function_descriptor.pxi
+++ b/python/ray/includes/function_descriptor.pxi
@@ -11,6 +11,7 @@ from ray.includes.function_descriptor cimport (
 import hashlib
 import cython
 import inspect
+import uuid
 
 
 ctypedef object (*FunctionDescriptor_from_cpp)(const CFunctionDescriptor &)
@@ -206,8 +207,8 @@ cdef class PythonFunctionDescriptor(FunctionDescriptor):
         """
         module_name = target_class.__module__
         class_name = target_class.__name__
-        # Use id(targe_class) as function hash to solve actor name conflict.
-        return cls(module_name, "__init__", class_name, str(id(target_class)))
+        # Use a random uuid as function hash to solve actor name conflict.
+        return cls(module_name, "__init__", class_name, str(uuid.uuid4()))
 
     @property
     def module_name(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The id of actor class is not safe for generating actor creation function descriptor.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
