### PR TITLE
[Streaming ]print streaming error when tests fail

### DIFF
--- a/streaming/java/test.sh
+++ b/streaming/java/test.sh
@@ -49,8 +49,10 @@ if [ $exit_code -ne 2 ] && [ $exit_code -ne 0 ] ; then
       done
     fi
     for f in /home/travis/build/ray-project/ray/hs_err*log; do
-      echo "Cat file $f"
-      cat "$f"
+      if [ -f "$f" ]; then
+        echo "Cat file $f"
+        cat "$f"
+      fi
     done
     exit $exit_code
 fi

--- a/streaming/java/test.sh
+++ b/streaming/java/test.sh
@@ -37,6 +37,21 @@ fi
 
 # exit_code == 2 means there are skipped tests.
 if [ $exit_code -ne 2 ] && [ $exit_code -ne 0 ] ; then
+    if [ -d "/tmp/ray_streaming_java_test_output/" ] ; then
+      echo "all test output"
+      for f in /tmp/ray_streaming_java_test_output/*; do
+        if [ -f "$f" ]; then
+          echo "Cat file $f"
+          cat "$f"
+        elif [[ -d $f ]]; then
+          echo "$f is a directory"
+        fi
+      done
+    fi
+    for f in /home/travis/build/ray-project/ray/hs_err*log; do
+      echo "Cat file $f"
+      cat "$f"
+    done
     exit $exit_code
 fi
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Some errors in streaming tests are not printed to terminal out, it would be convenient to print these error information so that we can locate errors more conveniently
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
