### PR TITLE
Fix resubscribe miss callback index bug

### DIFF
--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -45,8 +45,15 @@ Status GcsPubSub::SubscribeAll(const std::string &channel, const Callback &subsc
 }
 
 Status GcsPubSub::Unsubscribe(const std::string &channel, const std::string &id) {
-  return redis_client_->GetPrimaryContext()->PUnsubscribeAsync(
-      GenChannelPattern(channel, boost::optional<std::string>(id)));
+  std::string pattern = GenChannelPattern(channel, id);
+  {
+    absl::MutexLock lock(&mutex_);
+    auto it = subscribe_callback_index_.find(pattern);
+    RAY_CHECK(it != subscribe_callback_index_.end());
+    unsubscribe_callback_index_[pattern] = it->second;
+    subscribe_callback_index_.erase(it);
+  }
+  return redis_client_->GetPrimaryContext()->PUnsubscribeAsync(pattern);
 }
 
 Status GcsPubSub::SubscribeInternal(const std::string &channel, const Callback &subscribe,
@@ -58,8 +65,8 @@ Status GcsPubSub::SubscribeInternal(const std::string &channel, const Callback &
       if (reply->IsUnsubscribeCallback()) {
         absl::MutexLock lock(&mutex_);
         ray::gcs::RedisCallbackManager::instance().remove(
-            subscribe_callback_index_[pattern]);
-        subscribe_callback_index_.erase(pattern);
+            unsubscribe_callback_index_[pattern]);
+        unsubscribe_callback_index_.erase(pattern);
       } else if (reply->IsSubscribeCallback()) {
         if (done) {
           done(Status::OK());
@@ -80,6 +87,8 @@ Status GcsPubSub::SubscribeInternal(const std::string &channel, const Callback &
                                                                     &out_callback_index);
   if (id) {
     absl::MutexLock lock(&mutex_);
+    // If the same pattern has been subscribed more than once, the last subscription takes
+    // effect.
     subscribe_callback_index_[pattern] = out_callback_index;
   }
   return status;

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -101,6 +101,7 @@ class GcsPubSub {
   absl::Mutex mutex_;
 
   std::unordered_map<std::string, int64_t> subscribe_callback_index_ GUARDED_BY(mutex_);
+  std::unordered_map<std::string, int64_t> unsubscribe_callback_index_ GUARDED_BY(mutex_);
 };
 
 }  // namespace gcs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Test scenario:
Subscribe to pattern A, then unsubscribe and subscribe to pattern A again. 
Because the unsubscribe callback is asynchronous, it may get the callback index of the second pattern A and delete it, resulting in no callback index found when the data of the second pattern A arrives.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
