### PR TITLE
Increase rayelt client connect timeout to fix test_debug_tools

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -33,9 +33,9 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t actor_max_dummy_objects() const
 
-        int64_t num_connect_attempts() const
+        int64_t raylet_client_num_connect_attempts() const
 
-        int64_t connect_timeout_milliseconds() const
+        int64_t raylet_client_connect_timeout_milliseconds() const
 
         int64_t raylet_fetch_timeout_milliseconds() const
 

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -51,12 +51,12 @@ cdef class Config:
         return RayConfig.instance().actor_max_dummy_objects()
 
     @staticmethod
-    def num_connect_attempts():
-        return RayConfig.instance().num_connect_attempts()
+    def raylet_client_num_connect_attempts():
+        return RayConfig.instance().raylet_client_num_connect_attempts()
 
     @staticmethod
-    def connect_timeout_milliseconds():
-        return RayConfig.instance().connect_timeout_milliseconds()
+    def raylet_client_connect_timeout_milliseconds():
+        return RayConfig.instance().raylet_client_connect_timeout_milliseconds()
 
     @staticmethod
     def raylet_fetch_timeout_milliseconds():

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -149,9 +149,9 @@ RAY_CONFIG(uint64_t, max_lineage_size, 100)
 /// objects to store.
 RAY_CONFIG(int64_t, actor_max_dummy_objects, 1000)
 
-/// Number of times we try connecting to a socket.
-RAY_CONFIG(int64_t, num_connect_attempts, 5)
-RAY_CONFIG(int64_t, connect_timeout_milliseconds, 500)
+/// Number of times raylet client tries connecting to a raylet.
+RAY_CONFIG(int64_t, raylet_client_num_connect_attempts, 10)
+RAY_CONFIG(int64_t, raylet_client_connect_timeout_milliseconds, 1000)
 
 /// The duration that the raylet will wait before reinitiating a
 /// fetch request for a missing task dependency. This time may adapt based on

--- a/src/ray/raylet/raylet_client.cc
+++ b/src/ray/raylet/raylet_client.cc
@@ -54,10 +54,10 @@ raylet::RayletConnection::RayletConnection(boost::asio::io_service &io_service,
     : conn_(io_service) {
   // Pick the default values if the user did not specify.
   if (num_retries < 0) {
-    num_retries = RayConfig::instance().num_connect_attempts();
+    num_retries = RayConfig::instance().raylet_client_num_connect_attempts();
   }
   if (timeout < 0) {
-    timeout = RayConfig::instance().connect_timeout_milliseconds();
+    timeout = RayConfig::instance().raylet_client_connect_timeout_milliseconds();
   }
   RAY_CHECK(!raylet_socket.empty());
   boost::system::error_code ec;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`test_debug_tools` regularly fails in CI. Because when enabling GDB, raylet is slower to start. Then raylet client will time out. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
