### PR TITLE
Stop messages being printed to the console on shutdown

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -80,7 +80,7 @@ void ServiceBasedGcsClient::Disconnect() {
   gcs_pub_sub_.reset();
   redis_gcs_client_->Disconnect();
   redis_gcs_client_.reset();
-  RAY_LOG(INFO) << "ServiceBasedGcsClient Disconnected.";
+  RAY_LOG(DEBUG) << "ServiceBasedGcsClient Disconnected.";
 }
 
 void ServiceBasedGcsClient::GetGcsServerAddressFromRedis(

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -164,7 +164,7 @@ void RedisClient::Attach() {
 void RedisClient::Disconnect() {
   RAY_CHECK(is_connected_);
   is_connected_ = false;
-  RAY_LOG(INFO) << "RedisClient disconnected.";
+  RAY_LOG(DEBUG) << "RedisClient disconnected.";
 }
 
 std::shared_ptr<RedisContext> RedisClient::GetShardContext(const std::string &shard_key) {

--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -94,7 +94,7 @@ void RedisGcsClient::Disconnect() {
   RAY_CHECK(is_connected_);
   is_connected_ = false;
   redis_client_->Disconnect();
-  RAY_LOG(INFO) << "RedisGcsClient Disconnected.";
+  RAY_LOG(DEBUG) << "RedisGcsClient Disconnected.";
 }
 
 std::string RedisGcsClient::DebugString() const {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Disconnect messages are being printed every time Ray shuts down.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
