### PR TITLE
Fix test_actor_method_metadata_cache

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -118,12 +118,6 @@ def test_actor_method_metadata_cache(ray_start_regular):
     assert len(ray.actor.ActorClassMethodMetadata._cache) == 1
     assert [id(x) for x in list(cache.items())[0]] == cached_data_id
 
-    # Check cache hit when @ray.remote
-    A2 = ray.remote(Actor)
-    assert id(A1.__ray_metadata__) != id(A2.__ray_metadata__)
-    assert id(A1.__ray_metadata__.method_meta) == id(
-        A2.__ray_metadata__.method_meta)
-
 
 def test_actor_name_conflict(ray_start_regular):
     @ray.remote


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

After we use uuid4() as function hash of actor creation function descriptor https://github.com/ray-project/ray/pull/8589, create an ActorHandle will generate a unique actor creation function descriptor. So, the ActorClassMethodMetadata cache will miss when creating mulitple ActorHandles of the same actor class.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
