### PR TITLE
Slicing the sampled data in rollout worker and inplace  slicing in SampleBatch

### DIFF
--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -533,7 +533,8 @@ class RolloutWorker(ParallelIteratorWorker):
             batch = self.input_reader.next()
             steps_so_far += batch.count
             batches.append(batch)
-        batch = batches[0].concat_samples(batches)
+        batch = batches[0].concat_samples(batches).slice(start=0,
+                                                         end=self.rollout_fragment_length)
 
         self.callbacks.on_sample_end(worker=self, samples=batch)
 

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -163,18 +163,23 @@ class SampleBatch:
         return slices
 
     @PublicAPI
-    def slice(self, start, end):
+    def slice(self, start, end, inplace=False):
         """Returns a slice of the row data of this batch.
 
         Arguments:
             start (int): Starting index.
             end (int): Ending index.
+            inplace (bool): Inplace slicing the current SampleBatch
 
         Returns:
-            SampleBatch which has a slice of this batch's data.
+            SampleBatch which has a slice of this batch's data w/o inplace slicing.
         """
-
-        return SampleBatch({k: v[start:end] for k, v in self.data.items()})
+        if inplace:
+            for k in self.data.keys():
+                self.data[k] = self.data[k][start:end]
+            return self  # return itself
+        else:
+            return SampleBatch({k: v[start:end] for k, v in self.data.items()})
 
     @PublicAPI
     def keys(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When using offline data, the sampled data length may vary and should be exactly equal to `rollout_fragment_length` when using `tf.function` because the varying input shape (batch size) can incur increasing memory and lead to OOM.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Related issue and its comments:  https://github.com/ray-project/ray/issues/8326 and  https://github.com/ray-project/ray/issues/8326#issuecomment-633206912

<!-- For example: "Closes #1234" -->

## Checks

- [] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested (please justify below)
