### PR TITLE
[Hotfix] [Serve] Disable Deployment Tutorial Test

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -89,11 +89,13 @@ py_test(
     deps = [":serve_lib"]
 )
 
-py_test(
-    name = "tutorial_deploy",
-    size = "small",
-    srcs = glob(["examples/doc/*.py"]),
-    tags = ["exclusive"],
-    deps = [":serve_lib"]
-)
+# Disable the deployment tutorial test because it requires
+# ray start --head in the background.
+# py_test(
+    #name = "tutorial_deploy",
+    #size = "small",
+    #srcs = glob(["examples/doc/*.py"]),
+    #tags = ["exclusive"],
+    #deps = [":serve_lib"]
+# )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/8524 was merged but the tests were failing because ray serve's tutorial_deploy breaks.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
