### PR TITLE
[Core] Fix Un-Used Flag  in Test Cancel

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -205,7 +205,7 @@ def test_fast(shutdown_only, use_force):
     ids = list()
     for _ in range(100):
         x = fast.remote("a")
-        ray.cancel(x)
+        ray.cancel(x, use_force)
         ids.append(x)
 
     @ray.remote
@@ -219,7 +219,7 @@ def test_fast(shutdown_only, use_force):
 
     for idx in range(100, 5100):
         if random.random() > 0.95:
-            ray.cancel(ids[idx])
+            ray.cancel(ids[idx], use_force)
     signaler.send.remote()
     for obj_id in ids:
         try:
@@ -248,7 +248,7 @@ def test_remote_cancel(ray_start_regular, use_force):
     with pytest.raises(RayTimeoutError):
         ray.get(inner, 1)
 
-    ray.cancel(inner)
+    ray.cancel(inner, use_force)
 
     with pytest.raises(valid_exceptions(use_force)):
         ray.get(inner, 10)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

There are two test cases where the `force` flag is not actually being passed into `ray.cancel`. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
