### PR TITLE
SetErrorMode for all Ray processes

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -66,12 +66,7 @@ WorkerPool::WorkerPool(boost::asio::io_service &io_service, int num_workers,
       raylet_config_(raylet_config),
       starting_worker_timeout_callback_(starting_worker_timeout_callback) {
   RAY_CHECK(maximum_startup_concurrency > 0);
-#ifdef _WIN32
-  // If worker processes fail to initialize, don't display an error window.
-  SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS);
-  // If worker processes crash, don't display an error window.
-  SetErrorMode(GetErrorMode() | SEM_NOGPFAULTERRORBOX);
-#else
+#ifndef _WIN32
   // Ignore SIGCHLD signals. If we don't do this, then worker processes will
   // become zombies instead of dying gracefully.
   signal(SIGCHLD, SIG_IGN);

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -214,6 +214,12 @@ void RayLog::ShutDownRayLog() {
 }
 
 void RayLog::InstallFailureSignalHandler() {
+#ifdef _WIN32
+  // If process fails to initialize, don't display an error window.
+  SetErrorMode(GetErrorMode() | SEM_FAILCRITICALERRORS);
+  // If process crashes, don't display an error window.
+  SetErrorMode(GetErrorMode() | SEM_NOGPFAULTERRORBOX);
+#endif
 #ifdef RAY_USE_GLOG
   if (is_failure_signal_handler_installed_) {
     return;


### PR DESCRIPTION
## Why are these changes needed?

Disables Windows error popup for all Ray processes, not just workers.

## Related issue number

#631, #7739

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
