### PR TITLE
[autoscaler] Support creating services in k8s backend

### DIFF
--- a/python/ray/autoscaler/kubernetes/config.py
+++ b/python/ray/autoscaler/kubernetes/config.py
@@ -21,6 +21,10 @@ def using_existing_msg(resource_type, name):
     return "using existing {} '{}'".format(resource_type, name)
 
 
+def deleting_existing_msg(resource_type, name):
+    return "deleting existing {} '{}'".format(resource_type, name)
+
+
 def not_found_msg(resource_type, name):
     return "{} '{}' not found, attempting to create it".format(
         resource_type, name)
@@ -43,6 +47,7 @@ def bootstrap_kubernetes(config):
     _configure_autoscaler_service_account(namespace, config["provider"])
     _configure_autoscaler_role(namespace, config["provider"])
     _configure_autoscaler_role_binding(namespace, config["provider"])
+    _configure_services(namespace, config["provider"])
     return config
 
 
@@ -151,3 +156,38 @@ def _configure_autoscaler_role_binding(namespace, provider_config):
     logger.info(log_prefix + not_found_msg(binding_field, name))
     auth_api().create_namespaced_role_binding(namespace, binding)
     logger.info(log_prefix + created_msg(binding_field, name))
+
+
+def _configure_services(namespace, provider_config):
+    service_field = "services"
+    if service_field not in provider_config:
+        logger.info(log_prefix + not_provided_msg(service_field))
+        return
+
+    services = provider_config[service_field]
+    for service in services:
+        if "namespace" not in service["metadata"]:
+            service["metadata"]["namespace"] = namespace
+        elif service["metadata"]["namespace"] != namespace:
+            raise InvalidNamespaceError(service_field, namespace)
+
+        name = service["metadata"]["name"]
+        field_selector = "metadata.name={}".format(name)
+        services = core_api().list_namespaced_service(
+            namespace, field_selector=field_selector).items
+        if len(services) > 0:
+            assert len(services) == 1
+            existing_service = services[0]
+            if service == existing_service:
+                logger.info(log_prefix +
+                            using_existing_msg(service_field, name))
+                return
+            else:
+                logger.info(log_prefix +
+                            deleting_existing_msg(service_field, name))
+                core_api().delete_namespaced_service(name, namespace)
+        else:
+            logger.info(log_prefix + not_found_msg(service_field, name))
+
+        core_api().create_namespaced_service(namespace, service)
+        logger.info(log_prefix + created_msg(service_field, name))

--- a/python/ray/autoscaler/kubernetes/config.py
+++ b/python/ray/autoscaler/kubernetes/config.py
@@ -21,8 +21,8 @@ def using_existing_msg(resource_type, name):
     return "using existing {} '{}'".format(resource_type, name)
 
 
-def deleting_existing_msg(resource_type, name):
-    return "deleting existing {} '{}'".format(resource_type, name)
+def updating_existing_msg(resource_type, name):
+    return "updating existing {} '{}'".format(resource_type, name)
 
 
 def not_found_msg(resource_type, name):
@@ -179,15 +179,13 @@ def _configure_services(namespace, provider_config):
             assert len(services) == 1
             existing_service = services[0]
             if service == existing_service:
-                logger.info(log_prefix +
-                            using_existing_msg(service_field, name))
+                logger.info(log_prefix + using_existing_msg("service", name))
                 return
             else:
                 logger.info(log_prefix +
-                            deleting_existing_msg(service_field, name))
-                core_api().delete_namespaced_service(name, namespace)
+                            updating_existing_msg("service", name))
+                core_api().patch_namespaced_service(name, namespace, service)
         else:
-            logger.info(log_prefix + not_found_msg(service_field, name))
-
-        core_api().create_namespaced_service(namespace, service)
-        logger.info(log_prefix + created_msg(service_field, name))
+            logger.info(log_prefix + not_found_msg("service", name))
+            core_api().create_namespaced_service(namespace, service)
+            logger.info(log_prefix + created_msg("service", name))

--- a/python/ray/autoscaler/kubernetes/example-full.yaml
+++ b/python/ray/autoscaler/kubernetes/example-full.yaml
@@ -81,6 +81,41 @@ provider:
             name: autoscaler
             apiGroup: rbac.authorization.k8s.io
 
+    services:
+      # Service that maps to the head node of the Ray cluster.
+      - apiVersion: v1
+        kind: Service
+        metadata:
+            # NOTE: If you're running multiple Ray clusters with services
+            # on one Kubernetes cluster, they must have unique service
+            # names.
+            name: ray-head
+        spec:
+            # This selector must match the head node pod's selector below.
+            selector:
+                component: ray-head
+            ports:
+                - protocol: TCP
+                  port: 8000
+                  targetPort: 8000
+
+      # Service that maps to the worker nodes of the Ray cluster.
+      - apiVersion: v1
+        kind: Service
+        metadata:
+            # NOTE: If you're running multiple Ray clusters with services
+            # on one Kubernetes cluster, they must have unique service
+            # names.
+            name: ray-workers
+        spec:
+            # This selector must match the worker node pods' selector below.
+            selector:
+                component: ray-worker
+            ports:
+                - protocol: TCP
+                  port: 8000
+                  targetPort: 8000
+
 # Kubernetes pod config for the head node pod.
 head_node:
     apiVersion: v1
@@ -88,6 +123,11 @@ head_node:
     metadata:
         # Automatically generates a name for the pod with this prefix.
         generateName: ray-head-
+
+        # Must match the head node service selector above if a head node
+        # service is required.
+        labels:
+            component: ray-head
     spec:
         # Change this if you altered the autoscaler_service_account above
         # or want to provide your own.
@@ -160,6 +200,11 @@ worker_nodes:
     metadata:
         # Automatically generates a name for the pod with this prefix.
         generateName: ray-worker-
+
+        # Must match the worker node service selector above if a worker node
+        # service is required.
+        labels:
+            component: ray-worker
     spec:
         serviceAccountName: default
 

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -62,14 +62,19 @@ class KubernetesNodeProvider(NodeProvider):
         return pod.status.pod_ip
 
     def set_node_tags(self, node_id, tags):
-        body = {"metadata": {"labels": tags}}
-        core_api().patch_namespaced_pod(node_id, self.namespace, body)
+        pod = core_api().read_namespaced_pod_status(node_id, self.namespace)
+        pod.metadata.labels.update(tags)
+        core_api().patch_namespaced_pod(node_id, self.namespace, pod)
 
     def create_node(self, node_config, tags, count):
         pod_spec = node_config.copy()
         tags[TAG_RAY_CLUSTER_NAME] = self.cluster_name
         pod_spec["metadata"]["namespace"] = self.namespace
-        pod_spec["metadata"]["labels"] = tags
+        print(pod_spec)
+        if "labels" in pod_spec["metadata"]:
+            pod_spec["metadata"]["labels"].update(tags)
+        else:
+            pod_spec["metadata"]["labels"] = tags
         logger.info(log_prefix + "calling create_namespaced_pod "
                     "(count={}).".format(count))
         for _ in range(count):

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -70,7 +70,6 @@ class KubernetesNodeProvider(NodeProvider):
         pod_spec = node_config.copy()
         tags[TAG_RAY_CLUSTER_NAME] = self.cluster_name
         pod_spec["metadata"]["namespace"] = self.namespace
-        print(pod_spec)
         if "labels" in pod_spec["metadata"]:
             pod_spec["metadata"]["labels"].update(tags)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Users have requested the ability to create a service for both the head and worker nodes. For example, in order to expose a Ray Serve instance, the user needs to be able to query the head from inside or outside of the cluster.

This change opts for just a generic list of services rather than two specific head & worker service fields for flexibility and because we may not want the first-class concept of a head node in the future.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
