### PR TITLE
Update RaySGD test to use ray.kill instead of __ray_kill__

### DIFF
--- a/python/ray/util/sgd/tests/test_torch.py
+++ b/python/ray/util/sgd/tests/test_torch.py
@@ -698,7 +698,7 @@ def test_fail_twice(ray_start_2_cpus):  # noqa: F811
 
         if self._num_failures < 2:
             time.sleep(1)  # Make the batch will fail correctly.
-            self.remote_workers[0].__ray_kill__()
+            ray.kill(self.remote_workers[0])
 
         try:
             local_worker_stats = self.local_worker.train_epoch(**params)

--- a/python/ray/util/sgd/tests/test_torch.py
+++ b/python/ray/util/sgd/tests/test_torch.py
@@ -649,7 +649,7 @@ def test_resize(ray_start_2_cpus):  # noqa: F811
 
         if self._num_failures < 1:
             time.sleep(1)  # Make the batch will fail correctly.
-            self.remote_workers[0].__ray_kill__()
+            ray.kill(self.remote_workers[0])
 
         try:
             local_worker_stats = self.local_worker.train_epoch(**params)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`__ray_kill__` was removed but didn't update this SGD test.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
