### PR TITLE
[docker] Make docker/deploy run smoothly

### DIFF
--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -4,8 +4,10 @@
 FROM ray-project/base-deps
 ADD ray.tar /ray
 ADD git-rev /ray/git-rev
-RUN /ray/ci/travis/install-bazel.sh
+RUN git init && /ray/ci/travis/install-bazel.sh
 ENV PATH=$PATH:/root/bin
-WORKDIR /ray/python
+WORKDIR /ray/
+RUN bazel build //:ray_pkg || bazel build --jobs 1 //:ray_pkg
+WORKDIR /ray/python/
 RUN pip install -e .
 WORKDIR /ray

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -4,9 +4,13 @@
 FROM ray-project/base-deps
 ADD ray.tar /ray
 ADD git-rev /ray/git-rev
-RUN git init && /ray/ci/travis/install-bazel.sh
+RUN cd /ray && git init && ./ci/travis/install-bazel.sh
 ENV PATH=$PATH:/root/bin
+RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bashrc 
+RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bashrc 
 WORKDIR /ray/
+# The result of bazel build is reused in pip install. It if run first to allow
+# for failover to serial build if parallel build requires too much resources.
 RUN bazel build //:ray_pkg || bazel build --jobs 1 //:ray_pkg
 WORKDIR /ray/python/
 RUN pip install -e .


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This fixes one issue and one annoyance with running `build-docker.sh`. 

- The issue is that on not-so-powerful machines Bazel will crash in a way that  looks quite complicated (it is listed below). The solution is to run it with only one concurrent job which should keep resource utilization low. 
```
bazel server terminated abruptly (error code 14 error message 'socket closed')
```

-The annoyance is that 'fatal: not a git repository (or any of the parent directories): .git` is printed during the installation of Bazel. This has no impact on the actual installation, but does look a bit scary to users. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #8547
## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
I tested it locally as it is not included in CI