### PR TITLE
[autoscaler] Reverts setup.py changes from 76450c8d4

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -188,8 +188,6 @@ def find_version(*filepath):
 
 requires = [
     "aiohttp",
-    "boto3",
-    "botocore",
     "click >= 7.0",
     "colorama",
     "filelock",


### PR DESCRIPTION
## Why are these changes needed?

We accidentally added boto3 & friends to Ray's core `setup.py` requirements list

## Related issue number

n/a

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
