### PR TITLE
Remove transport type remnants

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -60,21 +60,12 @@ constexpr uint8_t kCreatedByTaskBitsOffset = 15;
 /// The bit offset of the flag `ObjectType` in a flags bytes.
 constexpr uint8_t kObjectTypeBitsOffset = 14;
 
-/// The bit offset of the flag `TransportType` in a flags bytes.
-// TODO(edoakes): this isn't used anymore, should update ID layout.
-// constexpr uint8_t kTransportTypeBitsOffset = 11;
-
 /// The mask that is used to mask the flag `CreatedByTask`.
 constexpr ObjectIDFlagsType kCreatedByTaskFlagBitMask = 0x1 << kCreatedByTaskBitsOffset;
 
 /// The mask that is used to mask a bit to indicates the type of this object.
 /// So it can represent for 2 types.
 constexpr ObjectIDFlagsType kObjectTypeFlagBitMask = 0x1 << kObjectTypeBitsOffset;
-
-/// The mask that is used to mask 3 bits to indicate the type of transport.
-// TODO(edoakes): this isn't used anymore, should update ID layout.
-// constexpr ObjectIDFlagsType kTransportTypeFlagBitMask = 0x7 <<
-// kTransportTypeBitsOffset;
 
 /// The implementations of helper functions.
 inline void SetCreatedByTaskFlag(bool created_by_task, ObjectIDFlagsType *flags) {

--- a/src/ray/design_docs/id_specification.md
+++ b/src/ray/design_docs/id_specification.md
@@ -56,10 +56,10 @@ An `ObjectID` contains 3 parts:
 
 **flags bytes format**
 ```
-  1b     1b        3b                          11b
-+-------------------------------------------------------------------------+
-| (1) | (2) |     (3)      |                (4)unused                     |
-+-------------------------------------------------------------------------+
+  1b     1b                     14b
++-------------------------------------------------------+
+| (1) | (2) |                (4)unused                  |
++-------------------------------------------------------+
 ```
 - The (1) `created_by_task` part is one bit to indicate whether this `ObjectID` is generated (put or returned) from a task.
 
@@ -67,6 +67,4 @@ An `ObjectID` contains 3 parts:
     - `PUT_OBJECT` indicates this object is generated through `ray.put` during the task's execution.
     - `RETURN_OBJECT` indicates this object is the return value of a task.
 
-- The (3) `transport_type` part is 3 bits to indicate the type of the transport which is used to transfer this object. So it can support 8 types.
-
-- There are 11 bits unused in `flags bytes`.
+- There are 14 bits unused in `flags bytes`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Transport type flag in object IDs was removed, but the spec wasn't updated and a few comments were lingering.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
