### PR TITLE
Warn if Autoscaling-config flag not set.

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -169,6 +169,21 @@ def monitor_cluster(cluster_config_file, num_lines, override_cluster_name):
                  override_cluster_name, None)
 
 
+def warn_about_bad_start_command(start_commands):
+    ray_start_cmd = list(
+        filter(lambda x: "ray start" in x, ray_start_commands))
+    if len(ray_start_cmd) == 0:
+        logger.warning(
+            "Ray start is not included in the head_start_ray_commands section."
+        )
+    if not any(["autoscaling-config" in x for x in ray_start_cmd]):
+        logger.warning(
+            "Ray start on the head node does not have the flag"
+            "--autoscaling-config set. The head node will not launch"
+            "workers. Add --autoscaling-config=~/ray_bootstrap_config.yaml"
+            "to ray start in the head_start_ray_commands section.")
+
+
 def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
                             override_cluster_name):
     """Create the cluster head node, which in turn creates the workers."""
@@ -257,15 +272,8 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             init_commands = config["head_setup_commands"]
             ray_start_commands = config["head_start_ray_commands"]
 
-        ray_start_cmd = list(
-            filter(lambda x: "ray start" in x, ray_start_commands))
-        if len(ray_start_cmd) and not \
-                any(["autoscaling-config" in x for x in ray_start_cmd]):
-            logger.warning(
-                "Ray start on the head node does not have the flag"
-                "--autoscaling-config set. The head node will not launch"
-                "workers. Add --autoscaling-config=~/ray_bootstrap_config.yaml"
-                "to ray start in the head_start_ray_commands section.")
+        if not no_restart:
+            warn_about_bad_start_command(ray_start_commands)
 
         updater = NodeUpdaterThread(
             node_id=head_node,

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -262,8 +262,10 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
         if len(ray_start_cmd) and not \
                 any(["autoscaling-config" in x for x in ray_start_cmd]):
             logger.warning(
-                "Head node start command does not have the flag --autoscaling"
-                "-config set. The head node will not launch workers.")
+                "Ray start on the head node does not have the flag"
+                "--autoscaling-config set. The head node will not launch"
+                "workers. Add --autoscaling-config=~/ray_bootstrap_config.yaml"
+                "to ray start in the head_start_ray_commands section.")
 
         updater = NodeUpdaterThread(
             node_id=head_node,

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -170,13 +170,12 @@ def monitor_cluster(cluster_config_file, num_lines, override_cluster_name):
 
 
 def warn_about_bad_start_command(start_commands):
-    ray_start_cmd = list(
-        filter(lambda x: "ray start" in x, ray_start_commands))
+    ray_start_cmd = list(filter(lambda x: "ray start" in x, start_commands))
     if len(ray_start_cmd) == 0:
         logger.warning(
             "Ray start is not included in the head_start_ray_commands section."
         )
-    if not any(["autoscaling-config" in x for x in ray_start_cmd]):
+    if not any("autoscaling-config" in x for x in ray_start_cmd):
         logger.warning(
             "Ray start on the head node does not have the flag"
             "--autoscaling-config set. The head node will not launch"

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -257,6 +257,14 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             init_commands = config["head_setup_commands"]
             ray_start_commands = config["head_start_ray_commands"]
 
+        ray_start_cmd = list(
+            filter(lambda x: "ray start" in x, ray_start_commands))
+        if len(ray_start_cmd) and not \
+                any(["autoscaling-config" in x for x in ray_start_cmd]):
+            logger.warning(
+                "Head node start command does not have the flag --autoscaling"
+                "-config set. The head node will not launch workers.")
+
         updater = NodeUpdaterThread(
             node_id=head_node,
             provider_config=config["provider"],

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -260,7 +260,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
         ray_start_cmd = list(
             filter(lambda x: "ray start" in x, ray_start_commands))
         if len(ray_start_cmd) and not \
-                any(["autoscaling-config" in x for x in ray_start_cmd]):
+                any("autoscaling-config" in x for x in ray_start_cmd):
             logger.warning(
                 "Ray start on the head node does not have the flag"
                 "--autoscaling-config set. The head node will not launch"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If `autoscaling-config` is not included in `ray start` on the head node, the head node will not launch workers. This is not immediately apparent, and seems to be causing some users to report that autoscaler is not working.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Addresses #4902 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
