### PR TITLE
Modifed dockerfiles for base-deps and autoscaler

### DIFF
--- a/docker/autoscaler/Dockerfile
+++ b/docker/autoscaler/Dockerfile
@@ -2,22 +2,27 @@ FROM rayproject/base-deps
 ARG WHEEL_PATH
 ARG WHEEL_NAME
 
-RUN apt update
-RUN apt install -y curl tmux screen rsync apt-transport-https
-
 # Install kubectl.
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN touch /etc/apt/sources.list.d/kubernetes.list
-RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
-RUN apt update
-RUN apt install -y kubectl
+RUN apt-get update \
+    && apt-get install -y curl \
+                        tmux \
+                        screen \
+                        rsync \
+                        apt-transport-https \
+                        gnupg2 \
+    && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+    && touch /etc/apt/sources.list.d/kubernetes.list \
+    && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update \
+    && apt install -y kubectl \
+    && apt-get clean 
 
 # We have to uninstall wrapt this way for Tensorflow compatibility
 COPY requirements.txt .
-RUN pip install -r requirements.txt
-
 COPY $WHEEL_PATH $WHEEL_NAME
-RUN pip install $WHEEL_NAME[all]
+
+RUN pip --no-cache-dir install -r requirements.txt \
+    && pip --no-cache-dir install $WHEEL_NAME[all]
 
 # For Click
 ENV LC_ALL=C.UTF-8

--- a/docker/autoscaler/Dockerfile
+++ b/docker/autoscaler/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
                         screen \
                         rsync \
                         apt-transport-https \
-                        gnupg2 \
     && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && touch /etc/apt/sources.list.d/kubernetes.list \
     && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && /opt/conda/bin/conda install -y \
         libgcc python=3.6.9 \
     && /opt/conda/bin/conda clean -y --all \
-    && /opt/conda/bin/pip install \
+    && /opt/conda/bin/pip install --no-cache-dir \
         flatbuffers \
         cython==0.29.0 \
         numpy==1.15.4 \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-FROM ubuntu:bionic
+FROM ubuntu:xenial
 RUN apt-get update \
     && apt-get install -y \
         git \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,6 +1,6 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 RUN apt-get update \
     && apt-get install -y \
         git \
@@ -25,11 +25,9 @@ RUN apt-get update \
     && /opt/conda/bin/pip install \
         flatbuffers \
         cython==0.29.0 \
-        numpy==1.15.4
-        
-
-# To avoid the following error on Jenkins:
-# AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-RUN /opt/conda/bin/pip uninstall -y dask
+        numpy==1.15.4 \
+    # To avoid the following error on Jenkins:
+    # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
+    && /opt/conda/bin/pip uninstall -y dask
 
 ENV PATH "/opt/conda/bin:$PATH"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The ray images are larger than they need to be, for example, we include apt cache information which we probably don't need most of the time.

Following changes are made:
1. Chained multiple RUN commands into single one wherever possible to minimise docker layers

2. Removed apt-get cache and pip cache wherever possible

## Related issue number

For issue #7187

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
