### PR TITLE
[tune] Use perf_counter instead of time in trainable.py

### DIFF
--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -170,9 +170,9 @@ class Trainable:
         self._restored = False
         self._trial_info = trial_info
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         self._setup(copy.deepcopy(self.config))
-        setup_time = time.time() - start_time
+        setup_time = time.perf_counter() - start_time
         if setup_time > SETUP_TIME_THRESHOLD:
             logger.info("_setup took {:.3f} seconds. If your trainable is "
                         "slow to initialize, consider setting "
@@ -256,7 +256,7 @@ class Trainable:
         Returns:
             A dict that describes training progress.
         """
-        start = time.time()
+        start = time.perf_counter()
         result = self._train()
         assert isinstance(result, dict), "_train() needs to return a dict."
 
@@ -272,7 +272,7 @@ class Trainable:
         if result.get(TIME_THIS_ITER_S) is not None:
             time_this_iter = result[TIME_THIS_ITER_S]
         else:
-            time_this_iter = time.time() - start
+            time_this_iter = time.perf_counter() - start
         self._time_total += time_this_iter
         self._time_since_restore += time_this_iter
 


### PR DESCRIPTION
https://docs.python.org/3/library/time.html#time.perf_counter

`time.perf_counter` should be used instead of `time.time`.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

See https://stackoverflow.com/a/85533/7127932. 

## Related issue number

n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/. (n/a)
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
      - This shouldn't cause any breaking changes
