### PR TITLE
[Async] Remove Monitor + Cleanup Code

### DIFF
--- a/python/ray/async_compat.py
+++ b/python/ray/async_compat.py
@@ -6,12 +6,16 @@ import asyncio
 from collections import namedtuple, Counter
 import time
 import threading
+import inspect
 
 import ray
 
 
 def sync_to_async(func):
     """Convert a blocking function to async function"""
+
+    if inspect.iscoroutinefunction(func):
+        return func
 
     async def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -95,44 +99,3 @@ def get_async(object_id):
     user_future.object_id = object_id
 
     return user_future
-
-
-class AsyncMonitorState:
-    def __init__(self, loop):
-        self.names = dict()
-        self.names_lock = threading.Lock()
-
-        self.sleep_time = 1.0
-        self.monitor_loop_future = asyncio.ensure_future(
-            self.monitor(), loop=loop)
-
-    async def monitor(self):
-        while True:
-            await asyncio.sleep(self.sleep_time)
-            all_tasks = self.get_all_task_names()
-            ray.show_in_webui(
-                str(len(all_tasks)), key="Number of concurrent task runing")
-            ray.show_in_webui(
-                str(dict(Counter(all_tasks))), key="Concurrent tasks")
-
-    def register_coroutine(self, coro, name):
-        with self.names_lock:
-            self.names[coro] = name
-
-    def unregister_coroutine(self, coro):
-        with self.names_lock:
-            self.names.pop(coro)
-
-    def get_all_task_names(self):
-        names = []
-        with self.names_lock:
-            names = list(self.names.values())
-        return names
-
-    def kill(self):
-        """Kill the monitor's loop
-
-        This should be called in order to clean an event loop
-        that this monitor is running.
-        """
-        self.monitor_loop_future.cancel()

--- a/python/ray/async_compat.py
+++ b/python/ray/async_compat.py
@@ -3,9 +3,8 @@ This file should only be imported from Python 3.
 It will raise SyntaxError when importing from Python 2.
 """
 import asyncio
-from collections import namedtuple, Counter
+from collections import namedtuple
 import time
-import threading
 import inspect
 
 import ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR
- removes the AsyncMonitor object in async actor. The async monitor was originally used to display current coroutines in webui. The current approach has high overhead and is not used a lot.
- unify the code path between serialization and execution.

The first improves performance and the second helps reduce code duplication

```
base
1:1 async-actor calls sync per second 1366.31 +- 446.92
1:1 async-actor calls async per second 4262.56 +- 245.26
1:1 async-actor calls with args async per second 3065.18 +- 108.67
1:n async-actor calls async per second 8682.61 +- 491.3
n:n async-actor calls async per second 10922.85 +- 1005.09


removed async monitor
1:1 async-actor calls sync per second 1657.8 +- 543.5
1:1 async-actor calls async per second 4989.9 +- 26.25
1:1 async-actor calls with args async per second 3258.19 +- 20.96
1:n async-actor calls async per second 9442.7 +- 148.75
n:n async-actor calls async per second 16876.93 +- 275.8

unify run_async_func_in_event_loop code path
1:1 async-actor calls sync per second 1615.72 +- 561.08
1:1 async-actor calls async per second 5014.63 +- 25.4
1:1 async-actor calls with args async per second 3345.41 +- 45.26
1:n async-actor calls async per second 9568.68 +- 292.37
n:n async-actor calls async per second 16260.74 +- 571.8
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
