### PR TITLE
[autoscaler] Remove ioctl warning

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -47,7 +47,7 @@ class KubernetesCommandRunner:
     def run(self,
             cmd=None,
             timeout=120,
-            allocate_tty=False,
+            allocate_tty=True,
             exit_on_fail=False,
             port_forward=None,
             with_output=False):
@@ -230,7 +230,7 @@ class SSHCommandRunner:
     def run(self,
             cmd,
             timeout=120,
-            allocate_tty=False,
+            allocate_tty=True,
             exit_on_fail=False,
             port_forward=None,
             with_output=False):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If bash is run interactively (the `-i` flag) over SSH, SSH needs to have a 'pseudo-terminal' running (the`-t` flag). If this is not set, then the following error is printed with every SSH session
```
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
```

The SSH `-t` flag is now enabled by default.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #8704 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
