### PR TITLE
Implement GetByJobId in gcs table storage

### DIFF
--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -103,10 +103,9 @@ Status InMemoryStoreClient::AsyncGetByIndex(
         result[kv_iter->first] = kv_iter->second;
       }
     }
-    main_io_service_.post([result, callback]() { callback(result); });
-  } else {
-    main_io_service_.post([result, callback]() { callback(result); });
   }
+  main_io_service_.post([result, callback]() { callback(result); });
+
   return Status::OK();
 }
 

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -98,9 +98,9 @@ Status InMemoryStoreClient::AsyncGetByIndex(
   std::unordered_map<std::string, std::string> result;
   if (iter != table->index_keys_.end()) {
     for (auto &key : iter->second) {
-      auto key_iter = table->records_.find(key);
-      if (key_iter != table->records_.end()) {
-        result[key_iter->first] = key_iter->second;
+      auto kv_iter = table->records_.find(key);
+      if (kv_iter != table->records_.end()) {
+        result[kv_iter->first] = kv_iter->second;
       }
     }
     main_io_service_.post([result, callback]() { callback(result); });

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -42,6 +42,9 @@ class InMemoryStoreClient : public StoreClient {
   Status AsyncGet(const std::string &table_name, const std::string &key,
                   const OptionalItemCallback<std::string> &callback) override;
 
+  Status AsyncGetByIndex(const std::string &table_name, const std::string &index_key,
+                         const MapCallback<std::string, std::string> &callback) override;
+
   Status AsyncGetAll(const std::string &table_name,
                      const MapCallback<std::string, std::string> &callback) override;
 

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -128,10 +128,11 @@ Status RedisStoreClient::AsyncBatchDelete(const std::string &table_name,
 Status RedisStoreClient::AsyncGetByIndex(
     const std::string &table_name, const std::string &index_key,
     const MapCallback<std::string, std::string> &callback) {
+  RAY_CHECK(callback);
   std::string match_pattern = GenRedisMatchPattern(table_name, index_key);
   auto scanner = std::make_shared<RedisScanner>(redis_client_, table_name, match_pattern);
-  auto on_done = [callback,
-                  scanner](const std::unordered_map<std::string, std::string> &result) {
+  auto on_done = [callback, table_name,
+                  index_key](const std::unordered_map<std::string, std::string> &result) {
     callback(result);
   };
   return scanner->ScanKeysAndValues(on_done);

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -125,6 +125,18 @@ Status RedisStoreClient::AsyncBatchDelete(const std::string &table_name,
   return DeleteByKeys(redis_keys, callback);
 }
 
+Status RedisStoreClient::AsyncGetByIndex(
+    const std::string &table_name, const std::string &index_key,
+    const MapCallback<std::string, std::string> &callback) {
+  std::string match_pattern = GenRedisMatchPattern(table_name, index_key);
+  auto scanner = std::make_shared<RedisScanner>(redis_client_, table_name, match_pattern);
+  auto on_done = [callback,
+                  scanner](const std::unordered_map<std::string, std::string> &result) {
+    callback(result);
+  };
+  return scanner->ScanKeysAndValues(on_done);
+}
+
 Status RedisStoreClient::AsyncDeleteByIndex(const std::string &table_name,
                                             const std::string &index_key,
                                             const StatusCallback &callback) {

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -65,25 +65,25 @@ class RedisStoreClient : public StoreClient {
   class RedisScanner {
    public:
     explicit RedisScanner(std::shared_ptr<RedisClient> redis_client,
-                          std::string table_name, std::string match_pattern);
+                          std::string table_name);
 
-    Status ScanKeysAndValues(const MapCallback<std::string, std::string> &callback);
+    Status ScanKeysAndValues(std::string match_pattern,
+                             const MapCallback<std::string, std::string> &callback);
 
-    Status ScanKeys(const MultiItemCallback<std::string> &callback);
+    Status ScanKeys(std::string match_pattern,
+                    const MultiItemCallback<std::string> &callback);
 
-    void MGetValues(const std::vector<std::string> &keys,
-                    const MapCallback<std::string, std::string> &callback);
+    Status MGetValues(const std::vector<std::string> &keys,
+                      const MapCallback<std::string, std::string> &callback);
 
    private:
-    void Scan(const StatusCallback &callback);
+    void Scan(std::string match_pattern, const StatusCallback &callback);
 
-    void OnScanCallback(size_t shard_index, const std::shared_ptr<CallbackReply> &reply,
+    void OnScanCallback(std::string match_pattern, size_t shard_index,
+                        const std::shared_ptr<CallbackReply> &reply,
                         const StatusCallback &callback);
 
     std::string table_name_;
-
-    /// The scan match pattern.
-    std::string match_pattern_;
 
     /// Mutex to protect the shard_to_cursor_ field and the keys_ field and the
     /// key_value_map_ field.

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -40,6 +40,9 @@ class RedisStoreClient : public StoreClient {
   Status AsyncGet(const std::string &table_name, const std::string &key,
                   const OptionalItemCallback<std::string> &callback) override;
 
+  Status AsyncGetByIndex(const std::string &table_name, const std::string &index_key,
+                         const MapCallback<std::string, std::string> &callback) override;
+
   Status AsyncGetAll(const std::string &table_name,
                      const MapCallback<std::string, std::string> &callback) override;
 

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -73,9 +73,6 @@ class RedisStoreClient : public StoreClient {
     Status ScanKeys(std::string match_pattern,
                     const MultiItemCallback<std::string> &callback);
 
-    Status MGetValues(const std::vector<std::string> &keys,
-                      const MapCallback<std::string, std::string> &callback);
-
    private:
     void Scan(std::string match_pattern, const StatusCallback &callback);
 
@@ -91,9 +88,6 @@ class RedisStoreClient : public StoreClient {
 
     /// All keys that scanned from redis.
     absl::flat_hash_set<std::string> keys_;
-
-    /// Key-Value pairs that scanned from redis.
-    std::unordered_map<std::string, std::string> key_value_map_;
 
     /// The scan cursor for each shard.
     std::unordered_map<size_t, size_t> shard_to_cursor_;
@@ -134,6 +128,10 @@ class RedisStoreClient : public StoreClient {
   static std::string GetKeyFromRedisKey(const std::string &redis_key,
                                         const std::string &table_name,
                                         const std::string &index_key);
+
+  static Status MGetValues(std::shared_ptr<RedisClient> redis_client,
+                           std::string table_name, const std::vector<std::string> &keys,
+                           const MapCallback<std::string, std::string> &callback);
 
   std::shared_ptr<RedisClient> redis_client_;
 };

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -71,14 +71,14 @@ class RedisStoreClient : public StoreClient {
 
     Status ScanKeys(const MultiItemCallback<std::string> &callback);
 
+    void MGetValues(const std::vector<std::string> &keys,
+                    const MapCallback<std::string, std::string> &callback);
+
    private:
     void Scan(const StatusCallback &callback);
 
     void OnScanCallback(size_t shard_index, const std::shared_ptr<CallbackReply> &reply,
                         const StatusCallback &callback);
-
-    void MGetValues(const std::vector<std::string> &keys,
-                    const MapCallback<std::string, std::string> &callback);
 
     std::string table_name_;
 

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -65,6 +65,16 @@ class StoreClient {
   virtual Status AsyncGet(const std::string &table_name, const std::string &key,
                           const OptionalItemCallback<std::string> &callback) = 0;
 
+  /// Get data by index from the given table asynchronously.
+  ///
+  /// \param table_name The name of the table to be read.
+  /// \param index_key The secondary key that will be used to get the indexed data.
+  /// \param callback Callback that will be called after read finishes.
+  /// \return Status
+  virtual Status AsyncGetByIndex(
+      const std::string &table_name, const std::string &index_key,
+      const MapCallback<std::string, std::string> &callback) = 0;
+
   /// Get all data from the given table asynchronously.
   ///
   /// \param table_name The name of the table to be read.

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -135,25 +135,19 @@ class StoreClientTestBase : public ::testing::Test {
   void GetByIndex() {
     auto get_calllback =
         [this](const std::unordered_map<std::string, std::string> &result) {
-          RAY_LOG(INFO) << "wangtao result size " << result.size();
           if (!result.empty()) {
             auto key = ActorID::FromBinary(result.begin()->first);
-            RAY_LOG(INFO) << "wangtao key " << key;
             auto it = key_to_index_.find(key);
             RAY_CHECK(it != key_to_index_.end());
-            RAY_LOG(INFO) << "wangtao index " << it->second;
             RAY_CHECK(index_to_keys_[it->second].size() == result.size());
           }
           pending_count_ -= result.size();
         };
-    for (const auto &elem : index_to_keys_) {
-      pending_count_ += elem.second.size();
-      RAY_LOG(INFO) << "wangtao beigin to check index " << elem.first << " and hex "
-                    << elem.first.Hex() << " in table " << table_name_;
-      RAY_CHECK_OK(
-          store_client_->AsyncGetByIndex(table_name_, elem.first.Hex(), get_calllback));
-      WaitPendingDone();
-    }
+    auto iter = index_to_keys_.begin();
+    pending_count_ += iter->second.size();
+    RAY_CHECK_OK(
+        store_client_->AsyncGetByIndex(table_name_, iter->first.Hex(), get_calllback));
+    WaitPendingDone();
   }
 
   void DeleteByIndex() {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

we wanna remove all related information in table when a job is finished. This could be done by simply invoke methods `deleteByJobId`, but checkpoint table is not related with job id but actor id. So we need implement `getByJobId` interface to get all key/value of actors which is related with job id, then delete all checkpoint data using values got.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
