### PR TITLE
[Java] fix serializer test location

### DIFF
--- a/java/runtime/src/test/java/io/ray/runtime/serializer/SerializerTest.java
+++ b/java/runtime/src/test/java/io/ray/runtime/serializer/SerializerTest.java
@@ -1,4 +1,4 @@
-package io.ray.api.test;
+package io.ray.runtime.serializer;
 
 import io.ray.runtime.serializer.Serializer;
 import java.util.ArrayList;

--- a/java/test/src/main/java/io/ray/api/test/SerializerTest.java
+++ b/java/test/src/main/java/io/ray/api/test/SerializerTest.java
@@ -1,4 +1,4 @@
-package io.ray.runtime.util;
+package io.ray.api.test;
 
 import io.ray.runtime.serializer.Serializer;
 import java.util.ArrayList;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Move `SerializerTest` to package `test` module
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
