### PR TITLE
[serve] Fix outdated docstring for create_endpoint

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -136,8 +136,6 @@ def create_endpoint(endpoint_name, route=None, methods=["GET"]):
             used as key to set traffic policy.
         route (str): A string begin with "/". HTTP server will use
             the string to match the path.
-        blocking (bool): If true, the function will wait for service to be
-            registered before returning
     """
     retry_actor_failures(master_actor.create_endpoint, route, endpoint_name,
                          [m.upper() for m in methods])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
