### PR TITLE
[serve] Add list_backends and list_endpoints

### DIFF
--- a/doc/source/serve/key-concepts.rst
+++ b/doc/source/serve/key-concepts.rst
@@ -23,7 +23,14 @@ model that you'll be serving. To create one, we'll simply specify the name, rout
 
 .. code-block:: python
 
-  serve.create_endpoint("simple_endpoint", "/simple")
+  serve.create_endpoint("simple_endpoint", "/simple", methods=["GET"])
+
+To view all of the existing endpoints that have created, use `serve.list_endpoints`.
+
+.. code-block:: python
+
+  >>> serve.list_endpoints()
+  {'simple_endpoint': {'route': '/simple', 'methods': ['GET'], 'traffic': {}}}
 
 You can also delete an endpoint using `serve.delete_endpoint`.
 Note that this will not delete any associated backends, which can be reused for other endpoints.
@@ -62,6 +69,20 @@ It's important to note that Ray Serve places these backends in individual worker
 
   serve.create_backend("simple_backend", handle_request)
   serve.create_backend("simple_backend_class", RequestHandler)
+
+Similar to endpoints, we can also list all available backends and delete them to reclaim resources.
+
+.. code-block:: python
+  >> serve.list_backends()
+  {
+      'simple_backend': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
+      'simple_backend_class': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
+  }
+  >> serve.delete_backend("simple_backend")
+  >> serve.list_backends()
+  {
+      'simple_backend_class': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},
+  }
 
 Setting Traffic
 ===============

--- a/doc/source/serve/key-concepts.rst
+++ b/doc/source/serve/key-concepts.rst
@@ -70,9 +70,10 @@ It's important to note that Ray Serve places these backends in individual worker
   serve.create_backend("simple_backend", handle_request)
   serve.create_backend("simple_backend_class", RequestHandler)
 
-Similar to endpoints, we can also list all available backends and delete them to reclaim resources.
+We can also list all available backends and delete them to reclaim resources.
 
 .. code-block:: python
+
   >> serve.list_backends()
   {
       'simple_backend': {'accepts_batches': False, 'num_replicas': 1, 'max_batch_size': None},

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -1,10 +1,20 @@
-from ray.serve.api import (init, create_backend, delete_backend,
-                           create_endpoint, delete_endpoint, set_traffic,
-                           get_handle, stat, update_backend_config,
-                           get_backend_config, accept_batch)  # noqa: E402
+from ray.serve.api import (
+    init, create_backend, delete_backend, create_endpoint, delete_endpoint,
+    set_traffic, get_handle, stat, update_backend_config, get_backend_config,
+    accept_batch, list_backends, list_endpoints)  # noqa: E402
 
 __all__ = [
-    "init", "create_backend", "delete_backend", "create_endpoint",
-    "delete_endpoint", "set_traffic", "get_handle", "stat",
-    "update_backend_config", "get_backend_config", "accept_batch"
+    "init",
+    "create_backend",
+    "delete_backend",
+    "create_endpoint",
+    "delete_endpoint",
+    "set_traffic",
+    "get_handle",
+    "stat",
+    "update_backend_config",
+    "get_backend_config",
+    "accept_batch",
+    "list_backends",
+    "list_endpoints",
 ]

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -153,6 +153,16 @@ def delete_endpoint(endpoint):
 
 
 @_ensure_connected
+def list_endpoints():
+    """Returns a dictionary of all registered endpoints.
+
+    The dictionary keys are endpoint names and values are dictionaries
+    of the form: {"methods": List[str], "traffic": Dict[str, float]}.
+    """
+    return retry_actor_failures(master_actor.get_all_endpoints)
+
+
+@_ensure_connected
 def update_backend_config(backend_tag, config_options):
     """Update a backend configuration for a backend tag.
 
@@ -209,6 +219,15 @@ def create_backend(backend_tag,
 
     retry_actor_failures(master_actor.create_backend, backend_tag,
                          backend_config, replica_config)
+
+
+@_ensure_connected
+def list_backends():
+    """Returns a dictionary of all registered backends.
+
+    Dictionary maps backend tags to backend configs.
+    """
+    return retry_actor_failures(master_actor.get_all_backends)
 
 
 @_ensure_connected

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -446,12 +446,22 @@ class ServeMaster:
         return self.workers
 
     def get_all_backends(self):
-        """Used for validation by the API client."""
-        return list(self.backends.keys())
+        """Returns a dictionary of backend tag to backend config dict."""
+        backends = {}
+        for backend_tag, (_, config, _) in self.backends.items():
+            backends[backend_tag] = config.__dict__
+        return backends
 
     def get_all_endpoints(self):
-        """Used for validation by the API client."""
-        return [endpoint for endpoint, methods in self.routes.values()]
+        """Returns a dictionary of endpoint to endpoint config."""
+        endpoints = {}
+        for route, (endpoint, methods) in self.routes.items():
+            endpoints[endpoint] = {
+                "route": route if route.startswith("/") else None,
+                "methods": methods,
+                "traffic": self.traffic_policies.get(endpoint, {})
+            }
+        return endpoints
 
     async def set_traffic(self, endpoint_name, traffic_policy_dictionary):
         """Sets the traffic policy for the specified endpoint."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Users have requested the ability to list existing backends and endpoints.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
