### PR TITLE
[serve] Remove ray_init_kwargs from serve.init

### DIFF
--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+import ray
 from ray import serve
 from ray.serve.utils import retry_actor_failures
 
@@ -11,7 +12,8 @@ if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False):
 
 @pytest.fixture(scope="session")
 def _shared_serve_instance():
-    serve.init(ray_init_kwargs={"num_cpus": 36})
+    ray.init(num_cpus=36)
+    serve.init()
     yield
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This was breaking using the `RAY_ADDRESS` env to connect to a cluster and we should just have users call `ray.init` if they need arguments.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
