### PR TITLE
[RLlib] Make envs specifiable in configs by their class path.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1120,7 +1120,7 @@ py_test(
 py_test(
     name = "tests/test_avail_actions_qmix",
     tags = ["tests_dir", "tests_dir_A"],
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_avail_actions_qmix.py"]
 )
 

--- a/rllib/utils/from_config.py
+++ b/rllib/utils/from_config.py
@@ -73,6 +73,8 @@ def from_config(cls, config=None, **kwargs):
         pass
     if isinstance(config, dict):
         type_ = config.pop("type", None)
+        if type_ is None and isinstance(cls, str):
+            type_ = cls
         ctor_kwargs = config
         # Give kwargs priority over things defined in config dict.
         # This way, one can pass a generic `spec` and then override single

--- a/rllib/utils/tests/test_framework_agnostic_components.py
+++ b/rllib/utils/tests/test_framework_agnostic_components.py
@@ -165,6 +165,14 @@ class TestFrameWorkAgnosticComponents(unittest.TestCase):
                 value = sess.run(value)
             check(value, np.array([-6.6]))  # prop_b == -1.5
 
+    def test_unregistered_envs(self):
+        """Tests, whether an Env can be specified simply by its absolute class.
+        """
+        env_cls = "ray.rllib.examples.env.stateless_cartpole.StatelessCartPole"
+        env = from_config(env_cls, {"config": 42.0})
+        state = env.reset()
+        self.assertTrue(state.shape == (2, ))
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR adds support for specifying custom Envs by their fully qualified class path, e.g.:
```
env: "ray.rllib.examples.env.simple_corridor.SimpleCorridor" 
```

This allows having custom (non gym) Envs specified easily within yaml files.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
