### PR TITLE
[autoscaler] Improve SSH Command Failure Logging

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -273,7 +273,7 @@ class SSHCommandRunner:
                     "Command failed: \n\n  {}\n".format(quoted_cmd)) from None
             else:
                 raise click.ClickException(
-                    "SSH command Failed. Look above to see the output from the"
+                    "SSH command Failed. See above for the output from the"
                     " failure.") from None
 
     def run_rsync_up(self, source, target):

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -351,11 +351,11 @@ class NodeUpdater:
             if hasattr(e, "cmd"):
                 error_str = "(Exit Status {}) {}".format(
                     e.returncode, " ".join(e.cmd))
-            logger.error(self.log_prefix +
-                         "Error updating {}".format(error_str))
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED})
-            raise e
+            logger.error(self.log_prefix +
+                         "Error executing: {}".format(error_str) + "\n")
+            return
 
         self.provider.set_node_tags(
             self.node_id, {

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -255,7 +255,7 @@ class SSHCommandRunner:
         if cmd:
             logger.info(self.log_prefix +
                         "Running {} on {}...".format(cmd, self.ssh_ip))
-            logger.info("Begin Remote Output from {}".format(self.ssh_ip))
+            logger.info("Begin remote output from {}".format(self.ssh_ip))
             final_cmd += with_interactive(cmd)
         else:
             # We do this because `-o ControlMaster` causes the `-N` flag to
@@ -273,7 +273,7 @@ class SSHCommandRunner:
                     "Command failed: \n\n  {}\n".format(quoted_cmd)) from None
             else:
                 raise Exception(
-                    "SSH Command Failed. Look above to see the output from the"
+                    "SSH command Failed. Look above to see the output from the"
                     " failure.") from None
 
     def run_rsync_up(self, source, target):

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -272,7 +272,7 @@ class SSHCommandRunner:
                 raise click.ClickException(
                     "Command failed: \n\n  {}\n".format(quoted_cmd)) from None
             else:
-                raise Exception(
+                raise click.ClickException(
                     "SSH command Failed. Look above to see the output from the"
                     " failure.") from None
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -355,7 +355,9 @@ class NodeUpdater:
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_UPDATE_FAILED})
             logger.error(self.log_prefix +
                          "Error executing: {}".format(error_str) + "\n")
-            return
+            if isinstance(e, click.ClickException):
+                return
+            raise
 
         self.provider.set_node_tags(
             self.node_id, {

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -255,6 +255,7 @@ class SSHCommandRunner:
         if cmd:
             logger.info(self.log_prefix +
                         "Running {} on {}...".format(cmd, self.ssh_ip))
+            logger.info("Begin Remote Output from {}".format(self.ssh_ip))
             final_cmd += with_interactive(cmd)
         else:
             # We do this because `-o ControlMaster` causes the `-N` flag to

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -273,8 +273,8 @@ class SSHCommandRunner:
                     "Command failed: \n\n  {}\n".format(quoted_cmd)) from None
             else:
                 raise Exception(
-                    "SSH Command Failed. Look above to see the output from the failure."
-                ) from None
+                    "SSH Command Failed. Look above to see the output from the"
+                    " failure.") from None
 
     def run_rsync_up(self, source, target):
         self.set_ssh_ip_if_required()

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -269,9 +269,11 @@ class SSHCommandRunner:
             if exit_on_fail:
                 quoted_cmd = " ".join(final_cmd[:-1] + [quote(final_cmd[-1])])
                 raise click.ClickException(
-                    "Command failed: \n\n  {}\n".format(quoted_cmd))
+                    "Command failed: \n\n  {}\n".format(quoted_cmd)) from None
             else:
-                raise
+                raise Exception(
+                    "SSH Command Failed. Look above to see the output from the failure."
+                ) from None
 
     def run_rsync_up(self, source, target):
         self.set_ssh_ip_if_required()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When SSH fails, it looks like Subprocess fails--this PR changes that to explicitly tell users to look at the *actual* error message that is from the failed command. Furthermore, it changes the number of times that the command is printed from 3 times to one time. Having a repeated command gets confusing (especially in this example when the command is quite long). _It also hides the actual SSH command because the 'SSH part' of the command is quite verbose and detracts from the actual command._

This also adds a log message that explicitly states where remote log output begins. This is necessary when ray commands are included in the remote command because both remote and local logs begin with `YEAR-MONTH-DATE TIME <Log_Level> Filename`.


Before:
<pre>
2020-06-02 13:32:03,563 INFO updater.py:257 -- NodeUpdater: HEAD_NODE: Running docker exec  ray_docker /bin/sh -c 'ulimit -c unlimited && ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml'  on HEAD_NODE...
2020-06-02 20:32:04,484 INFO scripts.py:393 -- Using IP address HEAD_NODE for this node.
2020-06-02 20:32:04,486 INFO resource_spec.py:212 -- Starting Ray with 4.44 GiB memory available for workers and up to 2.22 GiB for objects. You can adjust these settings with ray.init(memory=<bytes>, object_store_memory=<bytes>).
Traceback (most recent call last):
<<< Remote Traceback >>>
RuntimeError: Couldn't start Redis. Check log files: /tmp/ray/session_2020-06-02_20-32-04_485434_3301/logs/redis.out /tmp/ray/session_2020-06-02_20-32-04_485434_3301/logs/redis.err
2020-06-02 13:32:04,711 INFO log_timer.py:17 -- NodeUpdater: HEAD_NODE: Ray start commands completed [LogTimer=4335ms]
2020-06-02 13:32:04,712 INFO log_timer.py:17 -- NodeUpdater: HEAD_NODE: Applied config ad845201a31027a50368bbc8abf7269b7d3bc352 [LogTimer=4956ms]
<b>2020-06-02 13:32:04,712 ERROR updater.py:352 -- NodeUpdater: HEAD_NODE: Error updating (Exit Status 1) ssh -i ~/.ssh/id_rsa -o ConnectTimeout=120s -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPath=/tmp/ray_ssh_d24a99211e/c21f969b5f/%C -o ControlPersist=10s -o IdentitiesOnly=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=5 -o ServerAliveCountMax=3 username@HEAD_NODE bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && docker exec  ray_docker /bin/sh -c '"'"'ulimit -c unlimited && ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml'"'"' '</b>
<i>2020-06-02 13:32:04,713 INFO node_provider.py:81 -- ClusterState: Writing cluster state: ['WORKER1', 'WORKER2', 'HEAD_NODE']</i>
<b>Exception in thread Thread-1:
Traceback (most recent call last):
  File "/Users/user_name/miniconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/Users/user_name/Documents/ray/python/ray/autoscaler/updater.py", line 355, in run
    raise e
  File "/Users/user_name/Documents/ray/python/ray/autoscaler/updater.py", line 345, in run
    self.do_update()
  File "/Users/user_name/Documents/ray/python/ray/autoscaler/updater.py", line 437, in do_update
    self.cmd_runner.run(cmd)
  File "/Users/user_name/Documents/ray/python/ray/autoscaler/updater.py", line 267, in run
    self.process_runner.check_call(final_cmd)
  File "/Users/user_name/miniconda3/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['ssh', '-i', '~/.ssh/id_rsa', '-o', 'ConnectTimeout=120s', '-o', 'StrictHostKeyChecking=no', '-o', 'ControlMaster=auto', '-o', 'ControlPath=/tmp/ray_ssh_d24a99211e/c21f969b5f/%C', '-o', 'ControlPersist=10s', '-o', 'IdentitiesOnly=yes', '-o', 'ExitOnForwardFailure=yes', '-o', 'ServerAliveInterval=5', '-o', 'ServerAliveCountMax=3', 'username@HEAD_NODE', 'bash', '--login', '-c', '-i', '\'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && docker exec  ray_docker /bin/sh -c \'"\'"\'ulimit -c unlimited && ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml\'"\'"\' \'']' returned non-zero exit status 1.</b>

2020-06-02 13:32:04,737 ERROR commands.py:285 -- get_or_create_head_node: Updating HEAD_NODE failed
</pre>


After:
<pre>
020-06-02 13:30:26,170 INFO updater.py:257 -- NodeUpdater: HEAD_NODE: Running docker exec  ray_docker /bin/sh -c 'ulimit -c unlimited && ray start --head --port=6379 --autoscaling-config=~/ray_bootstrap_config.yaml'  on HEAD_NODE...
<b>2020-06-02 13:30:26,170 INFO updater.py:258 -- Begin Remote Output from HEAD_NODE</b>
2020-06-02 20:30:27,091 INFO scripts.py:393 -- Using IP address HEAD_NODE for this node.
2020-06-02 20:30:27,093 INFO resource_spec.py:212 -- Starting Ray with 4.44 GiB memory available for workers and up to 2.22 GiB for objects. You can adjust these settings with ray.init(memory=<bytes>, object_store_memory=<bytes>).
Traceback (most recent call last):
<<< Remote Traceback >>>
RuntimeError: Couldn't start Redis. Check log files: /tmp/ray/session_2020-06-02_20-30-27_092468_3187/logs/redis.out /tmp/ray/session_2020-06-02_20-30-27_092468_3187/logs/redis.err
2020-06-02 13:30:27,324 INFO log_timer.py:17 -- NodeUpdater: HEAD_NODE: Ray start commands completed [LogTimer=4288ms]
2020-06-02 13:30:27,324 INFO log_timer.py:17 -- NodeUpdater: HEAD_NODE: Applied config ad845201a31027a50368bbc8abf7269b7d3bc352 [LogTimer=4910ms]
<b>2020-06-02 13:30:27,325 INFO node_provider.py:81 -- ClusterState: Writing cluster state: ['WORKER1', 'WORKER2', 'HEAD_NODE']</b>
<b>2020-06-02 13:30:27,325 ERROR updater.py:355 -- NodeUpdater: HEAD_NODE: Error updating SSH Command Failed. Look above to see the output from the failure.</b>

2020-06-02 13:30:27,328 ERROR commands.py:285 -- get_or_create_head_node: Updating HEAD_NODE failed
</pre>



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
