### PR TITLE
[autoscaler] Improve Logtimer log messages

### DIFF
--- a/python/ray/autoscaler/log_timer.py
+++ b/python/ray/autoscaler/log_timer.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 
 class LogTimer:
-    def __init__(self, message, show_status=True):
+    def __init__(self, message, show_status=False):
         self._message = message
         self._show_status = show_status
 

--- a/python/ray/autoscaler/log_timer.py
+++ b/python/ray/autoscaler/log_timer.py
@@ -15,7 +15,7 @@ class LogTimer:
     def __exit__(self, *error_vals):
         td = datetime.datetime.utcnow() - self._start_time
         if any(error_vals):
-            self._status_string = "FAILED"
+            self._status_string = "failed"
         logger.info(" ".join([
             self._message, self._status_string,
             "[LogTimer={:.0f}ms]".format(td.total_seconds() * 1000)

--- a/python/ray/autoscaler/log_timer.py
+++ b/python/ray/autoscaler/log_timer.py
@@ -5,18 +5,19 @@ logger = logging.getLogger(__name__)
 
 
 class LogTimer:
-    def __init__(self, message, success_string=""):
+    def __init__(self, message, show_status=True):
         self._message = message
-        self._status_string = success_string
+        self._show_status = show_status
 
     def __enter__(self):
         self._start_time = datetime.datetime.utcnow()
 
     def __exit__(self, *error_vals):
         td = datetime.datetime.utcnow() - self._start_time
-        if any(error_vals):
-            self._status_string = "failed"
+        status = ""
+        if self._show_status:
+            status = "failed" if any(error_vals) else "succeeded"
         logger.info(" ".join([
-            self._message, self._status_string,
+            self._message, status,
             "[LogTimer={:.0f}ms]".format(td.total_seconds() * 1000)
         ]))

--- a/python/ray/autoscaler/log_timer.py
+++ b/python/ray/autoscaler/log_timer.py
@@ -5,13 +5,18 @@ logger = logging.getLogger(__name__)
 
 
 class LogTimer:
-    def __init__(self, message):
+    def __init__(self, message, success_string=""):
         self._message = message
+        self._status_string = success_string
 
     def __enter__(self):
         self._start_time = datetime.datetime.utcnow()
 
-    def __exit__(self, *_):
+    def __exit__(self, *error_vals):
         td = datetime.datetime.utcnow() - self._start_time
-        logger.info(self._message +
-                    " [LogTimer={:.0f}ms]".format(td.total_seconds() * 1000))
+        if any(error_vals):
+            self._status_string = "FAILED"
+        logger.info(" ".join([
+            self._message, self._status_string,
+            "[LogTimer={:.0f}ms]".format(td.total_seconds() * 1000)
+        ]))

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -423,15 +423,15 @@ class NodeUpdater:
             # Run init commands
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_SETTING_UP})
-            with LogTimer(self.log_prefix + "Initialization commands"):
+            with LogTimer(self.log_prefix + "Initialization commands", True):
                 for cmd in self.initialization_commands:
                     self.cmd_runner.run(cmd)
 
-            with LogTimer(self.log_prefix + "Setup commands"):
+            with LogTimer(self.log_prefix + "Setup commands", True):
                 for cmd in self.setup_commands:
                     self.cmd_runner.run(cmd)
 
-        with LogTimer(self.log_prefix + "Ray start commands"):
+        with LogTimer(self.log_prefix + "Ray start commands", True):
             for cmd in self.ray_start_commands:
                 self.cmd_runner.run(cmd)
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -423,16 +423,16 @@ class NodeUpdater:
             # Run init commands
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_SETTING_UP})
-            with LogTimer(self.log_prefix +
-                          "Initialization commands completed"):
+            with LogTimer(self.log_prefix + "Initialization commands",
+                          "completed"):
                 for cmd in self.initialization_commands:
                     self.cmd_runner.run(cmd)
 
-            with LogTimer(self.log_prefix + "Setup commands completed"):
+            with LogTimer(self.log_prefix + "Setup commands", "completed"):
                 for cmd in self.setup_commands:
                     self.cmd_runner.run(cmd)
 
-        with LogTimer(self.log_prefix + "Ray start commands completed"):
+        with LogTimer(self.log_prefix + "Ray start commands", "completed"):
             for cmd in self.ray_start_commands:
                 self.cmd_runner.run(cmd)
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -423,15 +423,19 @@ class NodeUpdater:
             # Run init commands
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_SETTING_UP})
-            with LogTimer(self.log_prefix + "Initialization commands", True):
+            with LogTimer(
+                    self.log_prefix + "Initialization commands",
+                    show_status=True):
                 for cmd in self.initialization_commands:
                     self.cmd_runner.run(cmd)
 
-            with LogTimer(self.log_prefix + "Setup commands", True):
+            with LogTimer(
+                    self.log_prefix + "Setup commands", show_status=True):
                 for cmd in self.setup_commands:
                     self.cmd_runner.run(cmd)
 
-        with LogTimer(self.log_prefix + "Ray start commands", True):
+        with LogTimer(
+                self.log_prefix + "Ray start commands", show_status=True):
             for cmd in self.ray_start_commands:
                 self.cmd_runner.run(cmd)
 

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -423,16 +423,15 @@ class NodeUpdater:
             # Run init commands
             self.provider.set_node_tags(
                 self.node_id, {TAG_RAY_NODE_STATUS: STATUS_SETTING_UP})
-            with LogTimer(self.log_prefix + "Initialization commands",
-                          "completed"):
+            with LogTimer(self.log_prefix + "Initialization commands"):
                 for cmd in self.initialization_commands:
                     self.cmd_runner.run(cmd)
 
-            with LogTimer(self.log_prefix + "Setup commands", "completed"):
+            with LogTimer(self.log_prefix + "Setup commands"):
                 for cmd in self.setup_commands:
                     self.cmd_runner.run(cmd)
 
-        with LogTimer(self.log_prefix + "Ray start commands", "completed"):
+        with LogTimer(self.log_prefix + "Ray start commands"):
             for cmd in self.ray_start_commands:
                 self.cmd_runner.run(cmd)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Logtimer currently prints 'conflicting' messages when a task fails.  It prints the default message, regardless of what the outcome is. The new behavior prints a different log if the timed method/code fails. 


Current Behavior (on failure): `Ray start commands completed`
New Behavior (on failure):  `Ray start commands FAILED`



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
