### PR TITLE
[serve] Replace actor error retry logic with max_task_retries

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -5,8 +5,7 @@ from ray.serve.constants import (DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT,
                                  SERVE_MASTER_NAME, HTTP_PROXY_TIMEOUT)
 from ray.serve.master import ServeMaster
 from ray.serve.handle import RayServeHandle
-from ray.serve.utils import (block_until_http_ready, format_actor_name,
-                             retry_actor_failures)
+from ray.serve.utils import (block_until_http_ready, format_actor_name)
 from ray.serve.exceptions import RayServeException
 from ray.serve.config import BackendConfig, ReplicaConfig
 from ray.serve.router import Query
@@ -111,6 +110,7 @@ def init(name=None,
     master_actor = ServeMaster.options(
         name=master_actor_name,
         max_restarts=-1,
+        max_task_retries=-1,
     ).remote(name, http_node_id, http_host, http_port, metric_exporter)
 
     block_until_http_ready(
@@ -128,8 +128,9 @@ def create_endpoint(endpoint_name, route=None, methods=["GET"]):
         route (str): A string begin with "/". HTTP server will use
             the string to match the path.
     """
-    retry_actor_failures(master_actor.create_endpoint, route, endpoint_name,
-                         [m.upper() for m in methods])
+    ray.get(
+        master_actor.create_endpoint.remote(route, endpoint_name,
+                                            [m.upper() for m in methods]))
 
 
 @_ensure_connected
@@ -138,7 +139,7 @@ def delete_endpoint(endpoint):
 
     Does not delete any associated backends.
     """
-    retry_actor_failures(master_actor.delete_endpoint, endpoint)
+    ray.get(master_actor.delete_endpoint.remote(endpoint))
 
 
 @_ensure_connected
@@ -148,7 +149,7 @@ def list_endpoints():
     The dictionary keys are endpoint names and values are dictionaries
     of the form: {"methods": List[str], "traffic": Dict[str, float]}.
     """
-    return retry_actor_failures(master_actor.get_all_endpoints)
+    return ray.get(master_actor.get_all_endpoints.remote())
 
 
 @_ensure_connected
@@ -163,8 +164,8 @@ def update_backend_config(backend_tag, config_options):
     """
     if not isinstance(config_options, dict):
         raise ValueError("config_options must be a dictionary.")
-    retry_actor_failures(master_actor.update_backend_config, backend_tag,
-                         config_options)
+    ray.get(
+        master_actor.update_backend_config.remote(backend_tag, config_options))
 
 
 @_ensure_connected
@@ -174,7 +175,7 @@ def get_backend_config(backend_tag):
     Args:
         backend_tag(str): A registered backend.
     """
-    return retry_actor_failures(master_actor.get_backend_config, backend_tag)
+    return ray.get(master_actor.get_backend_config.remote(backend_tag))
 
 
 @_ensure_connected
@@ -206,8 +207,9 @@ def create_backend(backend_tag,
         func_or_class, *actor_init_args, ray_actor_options=ray_actor_options)
     backend_config = BackendConfig(config, replica_config.accepts_batches)
 
-    retry_actor_failures(master_actor.create_backend, backend_tag,
-                         backend_config, replica_config)
+    ray.get(
+        master_actor.create_backend.remote(backend_tag, backend_config,
+                                           replica_config))
 
 
 @_ensure_connected
@@ -216,7 +218,7 @@ def list_backends():
 
     Dictionary maps backend tags to backend configs.
     """
-    return retry_actor_failures(master_actor.get_all_backends)
+    return ray.get(master_actor.get_all_backends.remote())
 
 
 @_ensure_connected
@@ -225,7 +227,7 @@ def delete_backend(backend_tag):
 
     The backend must not currently be used by any endpoints.
     """
-    retry_actor_failures(master_actor.delete_backend, backend_tag)
+    ray.get(master_actor.delete_backend.remote(backend_tag))
 
 
 @_ensure_connected
@@ -244,8 +246,9 @@ def set_traffic(endpoint_name, traffic_policy_dictionary):
         traffic_policy_dictionary (dict): a dictionary maps backend names
             to their traffic weights. The weights must sum to 1.
     """
-    retry_actor_failures(master_actor.set_traffic, endpoint_name,
-                         traffic_policy_dictionary)
+    ray.get(
+        master_actor.set_traffic.remote(endpoint_name,
+                                        traffic_policy_dictionary))
 
 
 @_ensure_connected
@@ -268,11 +271,11 @@ def get_handle(endpoint_name,
         RayServeHandle
     """
     if not missing_ok:
-        assert endpoint_name in retry_actor_failures(
-            master_actor.get_all_endpoints)
+        assert endpoint_name in ray.get(
+            master_actor.get_all_endpoints.remote())
 
     return RayServeHandle(
-        retry_actor_failures(master_actor.get_router)[0],
+        ray.get(master_actor.get_router.remote())[0],
         endpoint_name,
         relative_slo_ms,
         absolute_slo_ms,

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -7,8 +7,7 @@ from ray import serve
 from ray.serve import context as serve_context
 from ray.serve.context import FakeFlaskRequest
 from collections import defaultdict
-from ray.serve.utils import (parse_request_item, _get_logger,
-                             retry_actor_failures)
+from ray.serve.utils import (parse_request_item, _get_logger)
 from ray.serve.exceptions import RayServeException
 from ray.serve.metric import MetricClient
 from ray.async_compat import sync_to_async
@@ -39,8 +38,7 @@ def create_backend_worker(func_or_class):
                 _callable = func_or_class(*init_args)
 
             master = serve.api._get_master_actor()
-            [metric_exporter] = retry_actor_failures(
-                master.get_metric_exporter)
+            [metric_exporter] = ray.get(master.get_metric_exporter.remote())
             metric_client = MetricClient(
                 metric_exporter, default_labels={"backend": backend_tag})
             self.backend = RayServeWorker(backend_tag, replica_tag, _callable,

--- a/python/ray/serve/metric/client.py
+++ b/python/ray/serve/metric/client.py
@@ -6,7 +6,7 @@ from ray.serve.metric.types import (
     convert_event_type_to_class,
     MetricMetadata,
 )
-from ray.serve.utils import retry_actor_failures_async, _get_logger
+from ray.serve.utils import _get_logger
 from ray.serve.constants import METRIC_PUSH_INTERVAL_S
 
 logger = _get_logger()
@@ -129,8 +129,7 @@ class MetricClient:
 
         old_batch, self.metric_records = self.metric_records, []
         logger.debug("Pushing metric batch {}".format(old_batch))
-        await retry_actor_failures_async(self.exporter.ingest,
-                                         self.registered_metrics, old_batch)
+        await self.exporter.ingest.remote(self.registered_metrics, old_batch)
 
     async def push_to_exporter_forever(self, interval_s):
         while True:

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 import ray
 from ray import serve
-from ray.serve.utils import retry_actor_failures
 
 if os.environ.get("RAY_SERVE_INTENTIONALLY_CRASH", False):
     serve.master._CRASH_AFTER_CHECKPOINT_PROBABILITY = 0.5
@@ -23,7 +22,7 @@ def serve_instance(_shared_serve_instance):
     yield
     master = serve.api._get_master_actor()
     # Clear all state between tests to avoid naming collisions.
-    for endpoint in retry_actor_failures(master.get_all_endpoints):
+    for endpoint in ray.get(master.get_all_endpoints.remote()):
         serve.delete_endpoint(endpoint)
-    for backend in retry_actor_failures(master.get_all_backends):
+    for backend in ray.get(master.get_all_backends.remote()):
         serve.delete_backend(backend)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

max_task_retries on actors didn't used to be supported, so we implemented in the application level
.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
