### PR TITLE
[core] Reduces Wait Time on Failed Connection

### DIFF
--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -65,7 +65,7 @@ class AsyncClient {
 
       do {
         io_service_.run_one();
-      } while (!(*is_timeout) && !is_connected);
+      } while (!(*is_timeout) && !is_connected && !error_code_.failed());
 
       timer_.cancel();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If Ping is called on a closed RPC port, the call will take as long as `timeout_ms`, even if the connection fails. It doesn't make sense to keep waiting for success.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
