### PR TITLE
[rllib] Fix dict/tuple hybrid action space for tensorflow eager execution

### DIFF
--- a/rllib/models/tf/tf_action_dist.py
+++ b/rllib/models/tf/tf_action_dist.py
@@ -230,7 +230,7 @@ class DiagGaussian(TFActionDistribution):
     @override(ActionDistribution)
     def logp(self, x):
         return -0.5 * tf.reduce_sum(
-            tf.square((x - self.mean) / self.std), axis=1) - \
+            tf.square((tf.to_float(x) - self.mean) / self.std), axis=1) - \
             0.5 * np.log(2.0 * np.pi) * tf.to_float(tf.shape(x)[1]) - \
             tf.reduce_sum(self.log_std, axis=1)
 

--- a/rllib/tests/test_supported_spaces.py
+++ b/rllib/tests/test_supported_spaces.py
@@ -48,7 +48,7 @@ OBSERVATION_SPACES_TO_TEST = {
 }
 
 
-def check_support(alg, config, check_bounds=False):
+def check_support(alg, config, check_bounds=False, tfe=False):
     config["log_level"] = "ERROR"
 
     def _do_check(alg, config, a_name, o_name):
@@ -95,7 +95,10 @@ def check_support(alg, config, check_bounds=False):
                     pass
         print(stat)
 
-    for _ in framework_iterator(config, frameworks=("tf", "torch")):
+    frameworks = ("tf", "torch")
+    if tfe:
+        frameworks += ("tfe", )
+    for _ in framework_iterator(config, frameworks=frameworks):
         # Check all action spaces.
         for a_name, action_space in ACTION_SPACES_TO_TEST.items():
             _do_check(alg, config, a_name, "discrete")
@@ -141,7 +144,7 @@ class ModelSupportedSpaces(unittest.TestCase):
 
     def test_dqn(self):
         config = {"timesteps_per_iteration": 1}
-        check_support("DQN", config)
+        check_support("DQN", config, tfe=True)
 
     def test_es(self):
         check_support(
@@ -163,11 +166,11 @@ class ModelSupportedSpaces(unittest.TestCase):
             "rollout_fragment_length": 10,
             "sgd_minibatch_size": 1,
         }
-        check_support("PPO", config, check_bounds=True)
+        check_support("PPO", config, check_bounds=True, tfe=True)
 
     def test_pg(self):
         config = {"num_workers": 1, "optimizer": {}}
-        check_support("PG", config, check_bounds=True)
+        check_support("PG", config, check_bounds=True, tfe=True)
 
     def test_sac(self):
         check_support("SAC", {}, check_bounds=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Tensorflow eager execution was not supported using the `Dict` and `Tuple` action space. 
This PR attempts to fix it.

I modified the `test_supported_spaces.py` to include test with `tfe` for `DQN`, `PPO` and `PG` algorithms. Others algorithms seem not to support eager mode.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #8739

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
    - [x] Unit tests
    - [ ] Release tests
    - [ ] This PR is not tested (please justify below)

