### PR TITLE
[tune] Use scientific notation in tune dashboard

### DIFF
--- a/python/ray/dashboard/client/src/common/formatUtils.ts
+++ b/python/ray/dashboard/client/src/common/formatUtils.ts
@@ -34,8 +34,12 @@ export const formatDuration = (durationInSeconds: number) => {
 export const formatValue = (rawFloat: number) => {
   try {
     const decimals = rawFloat.toString().split(".")[1].length || 0;
-    if (decimals <= 3) return rawFloat.toString(); // Few decimals
-    if (Math.abs(rawFloat.valueOf()) >= 1.0) return rawFloat.toPrecision(5); // Values >= 1
+    if (decimals <= 3) {
+      return rawFloat.toString();
+    } // Few decimals
+    if (Math.abs(rawFloat.valueOf()) >= 1.0) {
+      return rawFloat.toPrecision(5);
+    } // Values >= 1
     return rawFloat.toExponential(); // Values in (-1; 1)
   } catch (e) {
     return rawFloat.toString();

--- a/python/ray/dashboard/client/src/common/formatUtils.ts
+++ b/python/ray/dashboard/client/src/common/formatUtils.ts
@@ -30,3 +30,14 @@ export const formatDuration = (durationInSeconds: number) => {
     `${pad(durationSeconds)}s`,
   ].join(" ");
 };
+
+export const formatParameter = (rawFloat: number) => {
+  try {
+    const decimals = rawFloat.toString().split(".")[1].length || 0;
+    if (decimals <= 3) return rawFloat.toString(); // Few decimals
+    if (Math.abs(rawFloat.valueOf()) >= 1.0) return rawFloat.toPrecision(5); // Values >= 1
+    return rawFloat.toExponential(); // Values in (-1; 1)
+  } catch (e) {
+    return rawFloat.toString();
+  }
+};

--- a/python/ray/dashboard/client/src/common/formatUtils.ts
+++ b/python/ray/dashboard/client/src/common/formatUtils.ts
@@ -31,7 +31,7 @@ export const formatDuration = (durationInSeconds: number) => {
   ].join(" ");
 };
 
-export const formatParameter = (rawFloat: number) => {
+export const formatValue = (rawFloat: number) => {
   try {
     const decimals = rawFloat.toString().split(".")[1].length || 0;
     if (decimals <= 3) return rawFloat.toString(); // Few decimals

--- a/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
@@ -22,7 +22,7 @@ import { connect } from "react-redux";
 import { TuneTrial } from "../../../api";
 import DialogWithTitle from "../../../common/DialogWithTitle";
 import NumberedLines from "../../../common/NumberedLines";
-import { formatParameter } from "../../../common/formatUtils";
+import { formatValue } from "../../../common/formatUtils";
 import { StoreState } from "../../../store";
 import { dashboardActions } from "../state";
 
@@ -389,7 +389,7 @@ class TuneTable extends React.Component<
                       {viewableParams.map((value, index) => (
                         <TableCell className={classes.cell} key={index}>
                           {typeof trial["params"][value] === "number"
-                            ? formatParameter(Number(trial["params"][value]))
+                            ? formatValue(Number(trial["params"][value]))
                             : trial["params"][value]}
                         </TableCell>
                       ))}
@@ -399,7 +399,9 @@ class TuneTable extends React.Component<
                       {trial["metrics"] &&
                         viewableMetrics.map((value, index) => (
                           <TableCell className={classes.cell} key={index}>
-                            {trial["metrics"][value]}
+                          {typeof trial["metrics"][value] === "number"
+                            ? formatValue(Number(trial["metrics"][value]))
+                            : trial["metrics"][value]}
                           </TableCell>
                         ))}
                       <TableCell className={classes.cell}>

--- a/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
@@ -22,6 +22,7 @@ import { connect } from "react-redux";
 import { TuneTrial } from "../../../api";
 import DialogWithTitle from "../../../common/DialogWithTitle";
 import NumberedLines from "../../../common/NumberedLines";
+import { formatParameter } from "../../../common/formatUtils";
 import { StoreState } from "../../../store";
 import { dashboardActions } from "../state";
 
@@ -387,7 +388,9 @@ class TuneTable extends React.Component<
                       </TableCell>
                       {viewableParams.map((value, index) => (
                         <TableCell className={classes.cell} key={index}>
-                          {trial["params"][value]}
+                          {typeof trial["params"][value] === "number"
+                            ? formatParameter(Number(trial["params"][value]))
+                            : trial["params"][value]}
                         </TableCell>
                       ))}
                       <TableCell className={classes.cell}>

--- a/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/tune/TuneTable.tsx
@@ -21,8 +21,8 @@ import React from "react";
 import { connect } from "react-redux";
 import { TuneTrial } from "../../../api";
 import DialogWithTitle from "../../../common/DialogWithTitle";
-import NumberedLines from "../../../common/NumberedLines";
 import { formatValue } from "../../../common/formatUtils";
+import NumberedLines from "../../../common/NumberedLines";
 import { StoreState } from "../../../store";
 import { dashboardActions } from "../state";
 
@@ -399,9 +399,9 @@ class TuneTable extends React.Component<
                       {trial["metrics"] &&
                         viewableMetrics.map((value, index) => (
                           <TableCell className={classes.cell} key={index}>
-                          {typeof trial["metrics"][value] === "number"
-                            ? formatValue(Number(trial["metrics"][value]))
-                            : trial["metrics"][value]}
+                            {typeof trial["metrics"][value] === "number"
+                              ? formatValue(Number(trial["metrics"][value]))
+                              : trial["metrics"][value]}
                           </TableCell>
                         ))}
                       <TableCell className={classes.cell}>

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -875,7 +875,7 @@ class TuneCollector(threading.Thread):
 
             # round all floats
             for key in float_keys:
-                details[key] = round(details[key], 3)
+                details[key] = round(details[key], 12)
 
             # group together config attributes
             for key in config_keys:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Parameter values were rounded incorrectly in the dashboard. Small values were rounded to three digits, and too small values were rounded to `0`. 

The reason for this was two fold. First, the `dashboard.py` API server rounded all floats to three decimal places, so precise values never arrived at the frontend. This rounding has been changed from `3` digits to `12`.

Second, a `formatValue` utility has been added to the frontend, taking care of displaying parameters and metrics. Numbers with fewer than three decimal places are always displayed natively. Numbers between -1 and 1 (exclusive) with more than three decimal places are displayed in scientific notation. Lastly, numbers greater than 1 or smaller than -1 are rounded to five decimal places.

## Related issue number

Should close #8689

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
