### PR TITLE
Fixing Wheel Build Command

### DIFF
--- a/python/README-building-wheels.md
+++ b/python/README-building-wheels.md
@@ -1,6 +1,6 @@
 # Building manylinux1 wheels
 
-To cause everything to be rebuilt, this script will delete ALL changes to the
+**WARNING:** To cause everything to be rebuilt, this script will delete ALL changes to the
 repository, including both changes to tracked files, and ANY untracked files.
 
 It will also cause all files inside the repository to be owned by root, and
@@ -9,7 +9,7 @@ produce .whl files owned by root.
 Inside the root directory (i.e., one level above this python directory), run
 
 ```
-docker run --rm -w /ray -v `pwd`:/ray -ti rayproject/arrow_linux_x86_64_base:latest /ray/python/build-wheel-manylinux1.sh
+docker run -e TRAVIS_COMMIT=<commit_number_to_use> --rm -w /ray -v `pwd`:/ray -ti rayproject/arrow_linux_x86_64_base:python-3.8.0 /ray/python/build-wheel-manylinux1.sh
 ```
 
 The wheel files will be placed in the .whl directory.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The existing command listed here is broken and is out of sync with the actual [command](https://github.com/ray-project/ray/blob/c1a97c8c0420dc9b77fda536120741f39d2a8fd1/ci/travis/ci.sh#L217) used to build wheels in CI. 

Also made the warning more prominent because running that in the same place where someone is would be **very sad**. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
