### PR TITLE
[RLlib] use Mapping instead of dict in summarize()

### DIFF
--- a/rllib/utils/debug.py
+++ b/rllib/utils/debug.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pprint
+from typing import Mapping
 
 from ray.rllib.policy.sample_batch import SampleBatch, MultiAgentBatch
 
@@ -17,7 +18,7 @@ def summarize(obj):
 
 
 def _summarize(obj):
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {k: _summarize(v) for k, v in obj.items()}
     elif hasattr(obj, "_asdict"):
         return {


### PR DESCRIPTION
Use Mapping instead of dict in summarize() to accommodate non-dict grads/params (e.g. haiku's frozendict)

## Why are these changes needed?

Some containers for weights / grads aren't instances of `dict` (or derivatives thereof). An example is [Haiku](https://dm-haiku.readthedocs.io/)'s `frozendict`, which is a `Mapping`, but not a full-fledged `dict`. In this example, some `dict` functionality is dropped to make the `frozendict` immutable.

By the way, this isn't just a cosmetic change. The large `__repr__` was flooding by remote workers sdtout/stderr, which meant I wasn't able to check my logs.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
This doesn't affect any existing functionality.