### PR TITLE
[tune]TrialRunner wait on global checkpoint syncdown

### DIFF
--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -225,6 +225,7 @@ class TrialRunner:
             #  which may also contain trial checkpoints. We should selectively
             #  sync the necessary files instead.
             self._syncer.sync_down_if_needed()
+            self._syncer.wait()
 
             if not self.checkpoint_exists(self._local_checkpoint_dir):
                 raise ValueError("Called resume when no checkpoint exists "


### PR DESCRIPTION
Adds waiting for syncer 

## Why are these changes needed?

When resuming a trial, the `TrialRunner` uses `CommandSyncer` to sync checkpoint from S3 to local. `CommandSyncer` yields control back to `TrialRunner` immediately after launching sync in separate process, without wait for sync to finish.
This results in `TrialRunner` not finding the checkpoint locally and raising `ValueError: Called resume when no checkpoint exists in remote or local directory.`

## Related issue number

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
