### PR TITLE
fix test_global_state_api due to the temporary object

### DIFF
--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -126,7 +126,7 @@ def test_global_state_api(shutdown_only):
     assert ray.cluster_resources()["GPU"] == 3
     assert ray.cluster_resources()["CustomResource"] == 1
 
-    # A driver/worker creates a temporary object during startup. Althougth the
+    # A driver/worker creates a temporary object during startup. Although the
     # temporary object is freed immediately, in a rare case, we can still find
     # the object ID in GCS because Raylet removes the object ID from GCS
     # asynchronously.

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -130,13 +130,10 @@ def test_global_state_api(shutdown_only):
     # temporary object is freed immediately, in a rare case, we can still find
     # the object ID in GCS because Raylet removes the object ID from GCS
     # asynchronously.
-    # Here we wait for a while before checking that ray.objects() is empty.
-    start_time = time.time()
-    while time.time() - start_time < 10:
-        if len(ray.objects()) == 0:
-            break
-        time.sleep(0.1)
-    assert ray.objects() == {}
+    # Because we can't control when workers create the temporary objects, so
+    # We can't assert that `ray.objects()` returns an empty dict. Here we just
+    # make sure `ray.objects()` succeeds.
+    assert len(ray.objects()) >= 0
 
     job_id = ray.utils.compute_job_id_from_driver(
         ray.WorkerID(ray.worker.global_worker.worker_id))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

If we test `test_global_state_api` for many times, we may see below failure.

```
python/ray/tests/test_advanced_3.py::test_global_state_api FAILED        [100%]

=================================== FAILURES ===================================
____________________________ test_global_state_api _____________________________

shutdown_only = None

    def test_global_state_api(shutdown_only):

        error_message = ("The ray global state API cannot be used "
                         "before ray.init has been called.")

        with pytest.raises(Exception, match=error_message):
            ray.objects()

        with pytest.raises(Exception, match=error_message):
            ray.actors()

        with pytest.raises(Exception, match=error_message):
            ray.nodes()

        with pytest.raises(Exception, match=error_message):
            ray.jobs()

        ray.init(num_cpus=5, num_gpus=3, resources={"CustomResource": 1})

        assert ray.cluster_resources()["CPU"] == 5
        assert ray.cluster_resources()["GPU"] == 3
        assert ray.cluster_resources()["CustomResource"] == 1

>       assert ray.objects() == {}
E       AssertionError: assert {'589fd08425d...00000000000'}} == {}
E         Left contains 1 more item:
E         {'589fd08425d3c7c2bc268e8b38f5000000000000': {'Locations': ['c0821845da77ee88c50d09ea83772a66cd659d73'],
E                                                       'ObjectID': '589fd08425d3c7c2bc268e8b38f5000000000000'}}
E         Full diff:
E           {
E         +  ,
E         -  '589fd08425d3c7c2bc268e8b38f5000000000000': {'Locations': ['c0821845da77ee88c50d09ea83772a66cd659d73'],...
E
E         ...Full output truncated (3 lines hidden), use '-vv' to show

python/ray/tests/test_advanced_3.py:129: AssertionError
```

Here we create a temporary object and delete it right away. But since Raylet updates GCS asynchronously, it's still possible to see the object in `ray.objects()` for a short time.

https://github.com/ray-project/ray/blob/4a6c4003fdf92b9186410102838aa6b98fe55d39/python/ray/worker.py#L1232-L1235

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
