### PR TITLE
Use time.perf_counter instead of time.time

### DIFF
--- a/ci/jenkins_tests/miscellaneous/test_wait_hanging.py
+++ b/ci/jenkins_tests/miscellaneous/test_wait_hanging.py
@@ -9,8 +9,8 @@ def f():
 @ray.remote
 def g():
     import time
-    start = time.time()
-    while time.time() < start + 1:
+    start = time.perf_counter()
+    while time.perf_counter() < start + 1:
         ray.get([f.remote() for _ in range(10)])
 
 

--- a/ci/performance_tests/test_performance.py
+++ b/ci/performance_tests/test_performance.py
@@ -155,9 +155,9 @@ def warm_up_cluster(num_nodes, object_store_memory):
 def run_multiple_trials(f, num_trials):
     durations = []
     for _ in range(num_trials):
-        start = time.time()
+        start = time.perf_counter()
         f()
-        durations.append(time.time() - start)
+        durations.append(time.perf_counter() - start)
     return durations
 
 

--- a/ci/regression_test/stress_tests/test_dead_actors.py
+++ b/ci/regression_test/stress_tests/test_dead_actors.py
@@ -76,10 +76,10 @@ parents = [
     Parent.remote(num_children, death_probability) for _ in range(num_parents)
 ]
 
-start = time.time()
+start = time.perf_counter()
 loop_times = []
 for i in range(100):
-    loop_start = time.time()
+    loop_start = time.perf_counter()
     ray.get([parent.ping.remote(10) for parent in parents])
 
     # Kill a parent actor with some probability.
@@ -90,9 +90,9 @@ for i in range(100):
         parents[parent_index] = Parent.remote(num_children, death_probability)
 
     logger.info("Finished trial %s", i)
-    loop_times.append(time.time() - loop_start)
+    loop_times.append(time.perf_counter() - loop_start)
 
-print("Finished in: {}s".format(time.time() - start))
+print("Finished in: {}s".format(time.perf_counter() - start))
 print("Average iteration time: {}s".format(sum(loop_times) / len(loop_times)))
 print("Max iteration time: {}s".format(max(loop_times)))
 print("Min iteration time: {}s".format(min(loop_times)))

--- a/ci/regression_test/stress_tests/test_many_tasks.py
+++ b/ci/regression_test/stress_tests/test_many_tasks.py
@@ -45,60 +45,60 @@ class Actor(object):
 
 # Stage 0: Submit a bunch of small tasks with large returns.
 stage_0_iterations = []
-start_time = time.time()
+start_time = time.perf_counter()
 logger.info("Submitting many tasks with large returns.")
 for i in range(10):
-    iteration_start = time.time()
+    iteration_start = time.perf_counter()
     logger.info("Iteration %s", i)
     ray.get([f.remote(1000000) for _ in range(1000)])
-    stage_0_iterations.append(time.time() - iteration_start)
+    stage_0_iterations.append(time.perf_counter() - iteration_start)
 
-stage_0_time = time.time() - start_time
+stage_0_time = time.perf_counter() - start_time
 logger.info("Finished stage 0 after %s seconds.", stage_0_time)
 
 # Stage 1: Launch a bunch of tasks.
 stage_1_iterations = []
-start_time = time.time()
+start_time = time.perf_counter()
 logger.info("Submitting many tasks.")
 for i in range(10):
-    iteration_start = time.time()
+    iteration_start = time.perf_counter()
     logger.info("Iteration %s", i)
     ray.get([f.remote(0) for _ in range(100000)])
-    stage_1_iterations.append(time.time() - iteration_start)
+    stage_1_iterations.append(time.perf_counter() - iteration_start)
 
-stage_1_time = time.time() - start_time
+stage_1_time = time.perf_counter() - start_time
 logger.info("Finished stage 1 after %s seconds.", stage_1_time)
 
 # Launch a bunch of tasks, each with a bunch of dependencies. TODO(rkn): This
 # test starts to fail if we increase the number of tasks in the inner loop from
 # 500 to 1000. (approximately 615 seconds)
 stage_2_iterations = []
-start_time = time.time()
+start_time = time.perf_counter()
 logger.info("Submitting tasks with many dependencies.")
 x_ids = []
 for _ in range(5):
-    iteration_start = time.time()
+    iteration_start = time.perf_counter()
     for i in range(20):
         logger.info("Iteration %s. Cumulative time %s seconds", i,
-                    time.time() - start_time)
+                    time.perf_counter() - start_time)
         x_ids = [f.remote(0, *x_ids) for _ in range(500)]
     ray.get(x_ids)
-    stage_2_iterations.append(time.time() - iteration_start)
-    logger.info("Finished after %s seconds.", time.time() - start_time)
+    stage_2_iterations.append(time.perf_counter() - iteration_start)
+    logger.info("Finished after %s seconds.", time.perf_counter() - start_time)
 
-stage_2_time = time.time() - start_time
+stage_2_time = time.perf_counter() - start_time
 logger.info("Finished stage 2 after %s seconds.", stage_2_time)
 
 # Create a bunch of actors.
-start_time = time.time()
+start_time = time.perf_counter()
 logger.info("Creating %s actors.", num_remote_cpus)
 actors = [Actor.remote() for _ in range(num_remote_cpus)]
-stage_3_creation_time = time.time() - start_time
+stage_3_creation_time = time.perf_counter() - start_time
 logger.info("Finished stage 3 actor creation in %s seconds.",
             stage_3_creation_time)
 
 # Submit a bunch of small tasks to each actor. (approximately 1070 seconds)
-start_time = time.time()
+start_time = time.perf_counter()
 logger.info("Submitting many small actor tasks.")
 for N in [1000, 100000]:
     x_ids = []
@@ -107,7 +107,7 @@ for N in [1000, 100000]:
         if i % 100 == 0:
             logger.info("Submitted {}".format(i * len(actors)))
     ray.get(x_ids)
-stage_3_time = time.time() - start_time
+stage_3_time = time.perf_counter() - start_time
 logger.info("Finished stage 3 in %s seconds.", stage_3_time)
 
 print("Stage 0 results:")
@@ -134,11 +134,11 @@ print("\tTotal time: {}".format(stage_3_time))
 # TODO(rkn): The test below is commented out because it currently does not
 # pass.
 # # Submit a bunch of actor tasks with all-to-all communication.
-# start_time = time.time()
+# start_time = time.perf_counter()
 # logger.info("Submitting actor tasks with all-to-all communication.")
 # x_ids = []
 # for _ in range(50):
 #     for size_exponent in [0, 1, 2, 3, 4, 5, 6]:
 #         x_ids = [a.method.remote(10**size_exponent, *x_ids) for a in actors]
 # ray.get(x_ids)
-# logger.info("Finished after %s seconds.", time.time() - start_time)
+# logger.info("Finished after %s seconds.", time.perf_counter() - start_time)

--- a/doc/examples/plot_pong_example.py
+++ b/doc/examples/plot_pong_example.py
@@ -277,7 +277,7 @@ for i in range(1, 1 + iterations):
     model_id = ray.put(model)
     gradient_ids = []
     # Launch tasks to compute gradients from multiple rollouts in parallel.
-    start_time = time.time()
+    start_time = time.perf_counter()
     gradient_ids = [
         actor.compute_gradient.remote(model_id) for actor in actors
     ]
@@ -289,7 +289,7 @@ for i in range(1, 1 + iterations):
             grad_buffer[k] += grad[k]
         running_reward = (reward_sum if running_reward is None else
                           running_reward * 0.99 + reward_sum * 0.01)
-    end_time = time.time()
+    end_time = time.perf_counter()
     print("Batch {} computed {} rollouts in {} seconds, "
           "running mean is {}".format(i, batch_size, end_time - start_time,
                                       running_reward))

--- a/doc/source/deploying-on-slurm.rst
+++ b/doc/source/deploying-on-slurm.rst
@@ -33,7 +33,7 @@ Clusters managed by Slurm may require that Ray is initialized as a part of the s
   srun --nodes=1 --ntasks=1 -w $node1 ray start --block --head --redis-port=6379 --redis-password=$redis_password & # Starting the head
   sleep 5
   # Make sure the head successfully starts before any worker does, otherwise
-  # the worker will not be able to connect to redis. In case of longer delay, 
+  # the worker will not be able to connect to redis. In case of longer delay,
   # adjust the sleeptime above to ensure proper order.
 
   for ((  i=1; i<=$worker_num; i++ ))
@@ -70,8 +70,8 @@ Clusters managed by Slurm may require that Ray is initialized as a part of the s
 
   # The following takes one second (assuming that ray was able to access all of the allocated nodes).
   for i in range(60):
-      start = time.time()
+      start = time.perf_counter()
       ip_addresses = ray.get([f.remote() for _ in range(num_cpus)])
       print(Counter(ip_addresses))
-      end = time.time()
+      end = time.perf_counter()
       print(end - start)

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -71,7 +71,7 @@ class StandardAutoscaler:
         self.num_failed_updates = defaultdict(int)
         self.num_successful_updates = defaultdict(int)
         self.num_failures = 0
-        self.last_update_time = 0.0
+        self.last_update_time = time.perf_counter()
         self.update_interval_s = update_interval_s
         self.bringup = True
 
@@ -118,7 +118,7 @@ class StandardAutoscaler:
                 raise e
 
     def _update(self):
-        now = time.time()
+        now = time.perf_counter()
 
         # Throttle autoscaling updates to this interval to avoid exceeding
         # rate limits on API calls.

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -220,10 +220,10 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
                 config["cluster_name"])
             provider.create_node(config["head_node"], head_node_tags, 1)
 
-        start = time.time()
+        start = time.perf_counter()
         head_node = None
         while True:
-            if time.time() - start > 5:
+            if time.perf_counter() - start > 5:
                 raise RuntimeError("Failed to create head node.")
             nodes = provider.non_terminated_nodes(head_node_tags)
             if len(nodes) == 1:

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -153,8 +153,8 @@ class Cluster:
             TimeoutError: An exception is raised if the timeout expires before
                 the node appears in the client table.
         """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while time.perf_counter() - start_time < timeout:
             clients = self.global_state.node_table()
             object_store_socket_names = [
                 client["ObjectStoreSocketName"] for client in clients
@@ -182,8 +182,8 @@ class Cluster:
             TimeoutError: An exception is raised if we time out while waiting
                 for nodes to join.
         """
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while time.perf_counter() - start_time < timeout:
             clients = self.global_state.node_table()
             live_clients = [client for client in clients if client["Alive"]]
 

--- a/python/ray/experimental/queue.py
+++ b/python/ray/experimental/queue.py
@@ -65,11 +65,11 @@ class Queue:
         elif timeout < 0:
             raise ValueError("'timeout' must be a non-negative number")
         else:
-            endtime = time.time() + timeout
+            endtime = time.perf_counter() + timeout
             # Polling
             # Use a condition variable or switch to promise?
             success = False
-            while not success and time.time() < endtime:
+            while not success and time.perf_counter() < endtime:
                 success = ray.get(self.actor.put.remote(item))
             if not success:
                 raise Full
@@ -100,11 +100,11 @@ class Queue:
         elif timeout < 0:
             raise ValueError("'timeout' must be a non-negative number")
         else:
-            endtime = time.time() + timeout
+            endtime = time.perf_counter() + timeout
             # Polling
             # Use a not_full condition variable or return a promise?
             success = False
-            while not success and time.time() < endtime:
+            while not success and time.perf_counter() < endtime:
                 success, item = ray.get(self.actor.get.remote())
             if not success:
                 raise Empty

--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -294,7 +294,7 @@ class FunctionActorManager:
             job_id (str): The ID of the job to push the error message to
                 if this times out.
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
         # Only send the warning once.
         warning_sent = False
         while True:
@@ -306,7 +306,7 @@ class FunctionActorManager:
                 elif not self._worker.actor_id.is_nil() and (
                         self._worker.actor_id in self._worker.actors):
                     break
-            if time.time() - start_time > timeout:
+            if time.perf_counter() - start_time > timeout:
                 warning_message = ("This worker was asked to execute a "
                                    "function that it does not have "
                                    "registered. You may have to restart "
@@ -605,7 +605,7 @@ class FunctionActorManager:
         actor_id = self._worker.actor_id
         checkpoint_info = self._worker.actor_checkpoint_info[actor_id]
         checkpoint_info.num_tasks_since_last_checkpoint += 1
-        now = int(1000 * time.time())
+        now = int(1000 * time.perf_counter())
         checkpoint_context = ray.actor.CheckpointContext(
             actor_id, checkpoint_info.num_tasks_since_last_checkpoint,
             now - checkpoint_info.last_checkpoint_timestamp)
@@ -613,7 +613,7 @@ class FunctionActorManager:
         # and then call `save_checkpoint`.
         if actor.should_checkpoint(checkpoint_context):
             try:
-                now = int(1000 * time.time())
+                now = int(1000 * time.perf_counter())
                 checkpoint_id = (
                     self._worker.core_worker.prepare_actor_checkpoint(actor_id)
                 )

--- a/python/ray/memory_monitor.py
+++ b/python/ray/memory_monitor.py
@@ -102,11 +102,11 @@ class MemoryMonitor:
         self.worker_name = worker_name
 
     def raise_if_low_memory(self):
-        if time.time() - self.last_checked > self.check_interval:
+        if time.perf_counter() - self.last_checked > self.check_interval:
             if "RAY_DEBUG_DISABLE_MEMORY_MONITOR" in os.environ:
                 return  # escape hatch, not intended for user use
 
-            self.last_checked = time.time()
+            self.last_checked = time.perf_counter()
             total_gb = psutil.virtual_memory().total / (1024**3)
             used_gb = total_gb - psutil.virtual_memory().available / (1024**3)
             if self.cgroup_memory_limit_gb < total_gb:

--- a/python/ray/ray_cluster_perf.py
+++ b/python/ray/ray_cluster_perf.py
@@ -27,9 +27,9 @@ def main():
     def f(object_id_list):
         diffs = []
         for object_id in object_id_list:
-            before = time.time()
+            before = time.perf_counter()
             ray.get(object_id)
-            after = time.time()
+            after = time.perf_counter()
             diffs.append(after - before)
             time.sleep(1)
         return np.mean(diffs), np.std(diffs)

--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -72,18 +72,18 @@ def timeit(name, fn, multiplier=1):
     if filter_pattern not in name:
         return
     # warmup
-    start = time.time()
-    while time.time() - start < 1:
+    start = time.perf_counter()
+    while time.perf_counter() - start < 1:
         fn()
     # real run
     stats = []
     for _ in range(4):
-        start = time.time()
+        start = time.perf_counter()
         count = 0
-        while time.time() - start < 2:
+        while time.perf_counter() - start < 2:
             fn()
             count += 1
-        end = time.time()
+        end = time.perf_counter()
         stats.append(multiplier * count / (end - start))
     print(name, "per second", round(np.mean(stats), 2), "+-",
           round(np.std(stats), 2))

--- a/python/ray/serialization.py
+++ b/python/ray/serialization.py
@@ -298,7 +298,7 @@ class SerializationContext:
                             error_timeout=10):
         assert len(data_metadata_pairs) == len(object_ids)
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         results = []
         warning_sent = False
         i = 0
@@ -317,7 +317,7 @@ class SerializationContext:
                 # so that the import thread can acquire it.
                 time.sleep(0.01)
 
-                if time.time() - start_time > error_timeout:
+                if time.perf_counter() - start_time > error_timeout:
                     warning_message = ("This worker or driver is waiting to "
                                        "receive a class definition so that it "
                                        "can deserialize an object from the "

--- a/python/ray/serve/examples/echo_pipeline.py
+++ b/python/ray/serve/examples/echo_pipeline.py
@@ -80,4 +80,5 @@ handle4_oid = handle4.remote(
 print("Firing ended now waiting for the result,"
       "time taken: {} s".format(time.perf_counter() - start))
 result = ray.get(handle4_oid)
-print("Result: {}, time taken: {} s".format(result, time.perf_counter() - start))
+print("Result: {}, time taken: {} s".format(result,
+                                            time.perf_counter() - start))

--- a/python/ray/serve/examples/echo_pipeline.py
+++ b/python/ray/serve/examples/echo_pipeline.py
@@ -71,13 +71,13 @@ handle2 = serve.get_handle("echo_v2")
 handle3 = serve.get_handle("echo_v3")
 handle4 = serve.get_handle("echo_v4")
 
-start = time.time()
-print("Start firing to the pipeline: {} s".format(time.time()))
+start = time.perf_counter()
+print("Start firing to the pipeline: {} s".format(time.perf_counter()))
 handle1_oid = handle1.remote(response="hello")
 handle4_oid = handle4.remote(
     relay1=handle2.remote(relay=handle1_oid),
     relay2=handle3.remote(relay=handle1_oid))
 print("Firing ended now waiting for the result,"
-      "time taken: {} s".format(time.time() - start))
+      "time taken: {} s".format(time.perf_counter() - start))
 result = ray.get(handle4_oid)
-print("Result: {}, time taken: {} s".format(result, time.time() - start))
+print("Result: {}, time taken: {} s".format(result, time.perf_counter() - start))

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -197,7 +197,8 @@ class ServeMaster:
              self.backends_to_remove, self.endpoints_to_remove))
 
         self.kv_store.put(CHECKPOINT_KEY, checkpoint)
-        logger.debug("Wrote checkpoint in {:.2f}".format(time.perf_counter() - start))
+        logger.debug(
+            "Wrote checkpoint in {:.2f}".format(time.perf_counter() - start))
 
         if random.random() < _CRASH_AFTER_CHECKPOINT_PROBABILITY:
             logger.warning("Intentionally crashing after checkpoint")
@@ -270,7 +271,8 @@ class ServeMaster:
         await self._remove_pending_endpoints()
 
         logger.info(
-            "Recovered from checkpoint in {:.3f}s".format(time.perf_counter() - start))
+            "Recovered from checkpoint in {:.3f}s".format(time.perf_counter() -
+                                                          start))
 
         self.write_lock.release()
 

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -190,14 +190,14 @@ class ServeMaster:
     def _checkpoint(self):
         """Checkpoint internal state and write it to the KV store."""
         logger.debug("Writing checkpoint")
-        start = time.time()
+        start = time.perf_counter()
         checkpoint = pickle.dumps(
             (self.routes, self.backends, self.traffic_policies, self.replicas,
              self.replicas_to_start, self.replicas_to_stop,
              self.backends_to_remove, self.endpoints_to_remove))
 
         self.kv_store.put(CHECKPOINT_KEY, checkpoint)
-        logger.debug("Wrote checkpoint in {:.2f}".format(time.time() - start))
+        logger.debug("Wrote checkpoint in {:.2f}".format(time.perf_counter() - start))
 
         if random.random() < _CRASH_AFTER_CHECKPOINT_PROBABILITY:
             logger.warning("Intentionally crashing after checkpoint")
@@ -218,7 +218,7 @@ class ServeMaster:
         """
         assert self.write_lock.locked()
 
-        start = time.time()
+        start = time.perf_counter()
         logger.info("Recovering from checkpoint")
 
         # Load internal state from the checkpoint data.
@@ -270,7 +270,7 @@ class ServeMaster:
         await self._remove_pending_endpoints()
 
         logger.info(
-            "Recovered from checkpoint in {:.3f}s".format(time.time() - start))
+            "Recovered from checkpoint in {:.3f}s".format(time.perf_counter() - start))
 
         self.write_lock.release()
 

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -321,7 +321,8 @@ class Router:
             self.num_error_backend_request.labels(backend=backend).add()
             result = error
         await self.mark_worker_idle(backend, backend_replica_tag)
-        logger.debug("Got result in {:.2f}s".format(time.perf_counter() - start))
+        logger.debug(
+            "Got result in {:.2f}s".format(time.perf_counter() - start))
         return result
 
     def _assign_query_to_worker(self,

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -313,7 +313,7 @@ class Router:
         # If the worker died, this will be a RayActorError. Just return it and
         # let the HTTP proxy handle the retry logic.
         logger.debug("Sending query to replica:" + backend_replica_tag)
-        start = time.time()
+        start = time.perf_counter()
         worker = self.replicas[backend_replica_tag]
         try:
             result = await worker.handle_request.remote(req)
@@ -321,7 +321,7 @@ class Router:
             self.num_error_backend_request.labels(backend=backend).add()
             result = error
         await self.mark_worker_idle(backend, backend_replica_tag)
-        logger.debug("Got result in {:.2f}s".format(time.time() - start))
+        logger.debug("Got result in {:.2f}s".format(time.perf_counter() - start))
         return result
 
     def _assign_query_to_worker(self,

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -8,13 +8,13 @@ from ray import serve
 
 
 def request_with_retries(endpoint, timeout=30):
-    start = time.time()
+    start = time.perf_counter()
     while True:
         try:
             return requests.get(
                 "http://127.0.0.1:8000" + endpoint, timeout=timeout)
         except requests.RequestException:
-            if time.time() - start > timeout:
+            if time.perf_counter() - start > timeout:
                 raise TimeoutError
             time.sleep(0.1)
 
@@ -172,8 +172,8 @@ def test_worker_restart(serve_instance):
     ray.kill(handles[0], no_restart=False)
 
     # Wait until the worker is killed and a one is started.
-    start = time.time()
-    while time.time() - start < 30:
+    start = time.perf_counter()
+    while time.perf_counter() - start < 30:
         response = request_with_retries("/worker_failure", timeout=30)
         if response.text != old_pid:
             break

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -131,7 +131,8 @@ def async_retryable(cls):
             @wraps(f)
             async def retry_method(*args, **kwargs):
                 start = time.perf_counter()
-                while time.perf_counter() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
+                while time.perf_counter(
+                ) - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
                     try:
                         return await f(*args, **kwargs)
                     except ray.exceptions.RayActorError:

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -92,7 +92,7 @@ def block_until_http_ready(http_endpoint,
                            backoff_time_s=1,
                            timeout=HTTP_PROXY_TIMEOUT):
     http_is_ready = False
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     while not http_is_ready:
         try:
@@ -102,7 +102,7 @@ def block_until_http_ready(http_endpoint,
         except Exception:
             pass
 
-        if 0 < timeout < time.time() - start_time:
+        if 0 < timeout < time.perf_counter() - start_time:
             raise TimeoutError(
                 "HTTP proxy not ready after {} seconds.".format(timeout))
 
@@ -130,8 +130,8 @@ def async_retryable(cls):
         def decorate_with_retry(f):
             @wraps(f)
             async def retry_method(*args, **kwargs):
-                start = time.time()
-                while time.time() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
+                start = time.perf_counter()
+                while time.perf_counter() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
                     try:
                         return await f(*args, **kwargs)
                     except ray.exceptions.RayActorError:
@@ -150,8 +150,8 @@ def async_retryable(cls):
 
 
 def retry_actor_failures(f, *args, **kwargs):
-    start = time.time()
-    while time.time() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
+    start = time.perf_counter()
+    while time.perf_counter() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
         try:
             return ray.get(f.remote(*args, **kwargs))
         except ray.exceptions.RayActorError:
@@ -165,8 +165,8 @@ def retry_actor_failures(f, *args, **kwargs):
 
 
 async def retry_actor_failures_async(f, *args, **kwargs):
-    start = time.time()
-    while time.time() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
+    start = time.perf_counter()
+    while time.perf_counter() - start < ACTOR_FAILURE_RETRY_TIMEOUT_S:
         try:
             return await f.remote(*args, **kwargs)
         except ray.exceptions.RayActorError:

--- a/python/ray/state.py
+++ b/python/ray/state.py
@@ -85,12 +85,12 @@ class GlobalState:
         self.global_state_accessor = GlobalStateAccessor(
             redis_address, redis_password, False)
         self.global_state_accessor.connect()
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         num_redis_shards = None
         redis_shard_addresses = []
 
-        while time.time() - start_time < timeout:
+        while time.perf_counter() - start_time < timeout:
             # Attempt to get the number of Redis shards.
             num_redis_shards = self.redis_client.get("NumRedisShards")
             if num_redis_shards is None:
@@ -114,7 +114,7 @@ class GlobalState:
             break
 
         # Check to see if we timed out.
-        if time.time() - start_time >= timeout:
+        if time.perf_counter() - start_time >= timeout:
             raise TimeoutError("Timed out while attempting to initialize the "
                                "global state. num_redis_shards = {}, "
                                "redis_shard_addresses = {}".format(
@@ -637,7 +637,7 @@ class GlobalState:
             overall_largest = max(overall_largest, rev_range[0][1])
 
             num_tasks += self.redis_client.zcount(
-                event_log_set, min=0, max=time.time())
+                event_log_set, min=0, max=time.perf_counter())
         if num_tasks == 0:
             return 0, 0, 0
         return overall_smallest, overall_largest, num_tasks

--- a/python/ray/test_utils.py
+++ b/python/ray/test_utils.py
@@ -52,8 +52,8 @@ def _pid_alive(pid):
 
 
 def wait_for_pid_to_exit(pid, timeout=20):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < timeout:
         if not _pid_alive(pid):
             return
         time.sleep(0.1)
@@ -63,8 +63,8 @@ def wait_for_pid_to_exit(pid, timeout=20):
 
 def wait_for_children_of_pid(pid, num_children=1, timeout=20):
     p = psutil.Process(pid)
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < timeout:
         num_alive = len(p.children(recursive=False))
         if num_alive >= num_children:
             return
@@ -145,8 +145,8 @@ def relevant_errors(error_type):
 
 
 def wait_for_errors(error_type, num_errors, timeout=20):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < timeout:
         if len(relevant_errors(error_type)) >= num_errors:
             return
         time.sleep(0.1)
@@ -165,8 +165,8 @@ def wait_for_condition(condition_predictor, timeout=30, retry_interval_ms=100):
     Return:
         Whether the condition is met within the timeout.
     """
-    start = time.time()
-    while time.time() - start <= timeout:
+    start = time.perf_counter()
+    while time.perf_counter() - start <= timeout:
         if condition_predictor():
             return True
         time.sleep(retry_interval_ms / 1000.0)
@@ -196,13 +196,13 @@ def wait_until_succeeded_without_exception(func,
         return False
 
     time_elapsed = 0
-    start = time.time()
+    start = time.perf_counter()
     while time_elapsed <= timeout_ms:
         try:
             func(*args)
             return True
         except exceptions:
-            time_elapsed = (time.time() - start) * 1000
+            time_elapsed = (time.perf_counter() - start) * 1000
             time.sleep(retry_interval_ms / 1000.0)
     return False
 
@@ -274,14 +274,14 @@ def wait_until_server_available(address,
     ip = ip_port[0]
     port = int(ip_port[1])
     time_elapsed = 0
-    start = time.time()
+    start = time.perf_counter()
     while time_elapsed <= timeout_ms:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(1)
         try:
             s.connect((ip, port))
         except Exception:
-            time_elapsed = (time.time() - start) * 1000
+            time_elapsed = (time.perf_counter() - start) * 1000
             time.sleep(retry_interval_ms / 1000.0)
             s.close()
             continue

--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -479,8 +479,8 @@ def test_actors_and_tasks_with_gpus_version_two(shutdown_only):
     # Make sure that the actor method calls succeeded.
     ray.get(actor_results)
 
-    start_time = time.time()
-    while time.time() - start_time < 30:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < 30:
         seen_gpu_ids, num_calls = ray.get(
             record_gpu_actor.get_gpu_ids_and_calls.remote())
         if num_calls == num_gpus:

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -186,7 +186,7 @@ def test_profiling_api(ray_start_2_cpus):
     # Wait until all of the profiling information appears in the profile
     # table.
     timeout_seconds = 20
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
         profile_data = ray.timeline()
         event_types = {event["cat"] for event in profile_data}
@@ -209,7 +209,7 @@ def test_profiling_api(ray_start_2_cpus):
                for expected_type in expected_types):
             break
 
-        if time.time() - start_time > timeout_seconds:
+        if time.perf_counter() - start_time > timeout_seconds:
             raise RayTestTimeoutException(
                 "Timed out while waiting for information in "
                 "profile table. Missing events: {}.".format(
@@ -232,9 +232,9 @@ def test_wait_cluster(ray_start_cluster):
     # Make sure we have enough workers on the remote nodes to execute some
     # tasks.
     tasks = [f.remote() for _ in range(10)]
-    start = time.time()
+    start = time.perf_counter()
     ray.get(tasks)
-    end = time.time()
+    end = time.perf_counter()
 
     # Submit some more tasks that can only be executed on the remote nodes.
     tasks = [f.remote() for _ in range(10)]

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -41,15 +41,15 @@ def test_resource_constraints(shutdown_only):
     def f(n):
         time.sleep(n)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(10)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 0.5 + time_buffer
     assert duration > 0.5
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(11)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
@@ -57,15 +57,15 @@ def test_resource_constraints(shutdown_only):
     def f(n):
         time.sleep(n)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(3)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 0.5 + time_buffer
     assert duration > 0.5
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(4)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
@@ -73,21 +73,21 @@ def test_resource_constraints(shutdown_only):
     def f(n):
         time.sleep(n)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(2)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 0.5 + time_buffer
     assert duration > 0.5
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(3)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5) for _ in range(4)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
@@ -120,27 +120,27 @@ def test_multi_resource_constraints(shutdown_only):
 
     time_buffer = 2
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5), g.remote(0.5)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 0.5 + time_buffer
     assert duration > 0.5
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5), f.remote(0.5)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([g.remote(0.5), g.remote(0.5)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get([f.remote(0.5), f.remote(0.5), g.remote(0.5), g.remote(0.5)])
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     assert duration < 1 + time_buffer
     assert duration > 1
 
@@ -168,13 +168,13 @@ def test_gpu_ids(shutdown_only):
         time.sleep(0.2)
         return os.getpid()
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
         num_workers_started = len(
             set(ray.get([f.remote() for _ in range(num_gpus)])))
         if num_workers_started == num_gpus:
             break
-        if time.time() > start_time + 10:
+        if time.perf_counter() > start_time + 10:
             raise RayTestTimeoutException(
                 "Timed out while waiting for workers to start "
                 "up.")

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -86,8 +86,8 @@ def test_load_balancing_with_dependencies(ray_start_cluster):
 
 
 def wait_for_num_actors(num_actors, timeout=10):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < timeout:
         if len(ray.actors()) >= num_actors:
             return
         time.sleep(0.1)
@@ -95,8 +95,8 @@ def wait_for_num_actors(num_actors, timeout=10):
 
 
 def wait_for_num_objects(num_objects, timeout=10):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < timeout:
         if len(ray.objects()) >= num_objects:
             return
         time.sleep(0.1)
@@ -403,8 +403,8 @@ def test_ray_stack(ray_start_2_cpus):
     unique_name_3.remote()
 
     success = False
-    start_time = time.time()
-    while time.time() - start_time < 30:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < 30:
         # Attempt to parse the "ray stack" call.
         output = ray.utils.decode(subprocess.check_output(["ray", "stack"]))
         if ("unique_name_1" in output and "unique_name_2" in output

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -163,9 +163,9 @@ def test_many_fractional_resources(shutdown_only):
 
     # Check that the available resources at the end are the same as the
     # beginning.
-    stop_time = time.time() + 10
+    stop_time = time.perf_counter() + 10
     correct_available_resources = False
-    while time.time() < stop_time:
+    while time.perf_counter() < stop_time:
         if (ray.available_resources()["CPU"] == 2.0
                 and ray.available_resources()["GPU"] == 2.0
                 and ray.available_resources()["Custom"] == 2.0):

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -100,7 +100,7 @@ def test_defining_remote_functions(shutdown_only):
 
     @ray.remote
     def j():
-        return time.time()
+        return time.perf_counter()
 
     ray.get(j.remote())
 
@@ -241,9 +241,9 @@ def test_get_with_timeout(ray_start_regular):
     signal = ray.test_utils.SignalActor.remote()
 
     # Check that get() returns early if object is ready.
-    start = time.time()
+    start = time.perf_counter()
     ray.get(signal.wait.remote(should_wait=False), timeout=30)
-    assert time.time() - start < 30
+    assert time.perf_counter() - start < 30
 
     # Check that get() raises a TimeoutError after the timeout if the object
     # is not ready yet.
@@ -253,9 +253,9 @@ def test_get_with_timeout(ray_start_regular):
 
     # Check that a subsequent get() returns early.
     ray.get(signal.send.remote())
-    start = time.time()
+    start = time.perf_counter()
     ray.get(result_id, timeout=30)
-    assert time.time() - start < 30
+    assert time.perf_counter() - start < 30
 
 
 @pytest.mark.parametrize(
@@ -517,9 +517,9 @@ def test_actor_pass_by_ref_order_optimization(shutdown_only):
     runner.remote(slow_value)
     time.sleep(1)
     x2 = runner.remote(fast_value)
-    start = time.time()
+    start = time.perf_counter()
     ray.get(x2)
-    delta = time.time() - start
+    delta = time.perf_counter() - start
     assert delta < 10, "did not skip slow value"
 
 

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -38,7 +38,7 @@ def test_worker_failed(ray_start_workers_separate_multinode):
         time.sleep(0.25)
         return os.getpid()
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     pids = set()
     while len(pids) < num_nodes * num_initial_workers:
         new_pids = ray.get([
@@ -47,7 +47,7 @@ def test_worker_failed(ray_start_workers_separate_multinode):
         ])
         for pid in new_pids:
             pids.add(pid)
-        if time.time() - start_time > 60:
+        if time.perf_counter() - start_time > 60:
             raise RayTestTimeoutException(
                 "Timed out while waiting to get worker PIDs.")
 

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -164,9 +164,9 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
     ray.get(results)
 
     success = False
-    start_time = time.time()
+    start_time = time.perf_counter()
 
-    while time.time() - start_time < TIMEOUT and not success:
+    while time.perf_counter() - start_time < TIMEOUT and not success:
         resources_created = []
         for nid in target_node_ids:
             target_node = next(
@@ -580,9 +580,9 @@ def test_dynamic_res_creation_stress(ray_start_cluster):
     ray.get(results)
 
     success = False
-    start_time = time.time()
+    start_time = time.perf_counter()
 
-    while time.time() - start_time < TIMEOUT and not success:
+    while time.perf_counter() - start_time < TIMEOUT and not success:
         resources = ray.cluster_resources()
         all_resources_created = []
         for i in range(0, NUM_RES_TO_CREATE):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -683,8 +683,8 @@ def test_warning_for_many_duplicate_remote_functions_and_actors(shutdown_only):
 
     ray.get(create_remote_function.remote())
 
-    start_time = time.time()
-    while time.time() < start_time + 10:
+    start_time = time.perf_counter()
+    while time.perf_counter() < start_time + 10:
         log_contents = log_capture_string.getvalue()
         if len(log_contents) > 0:
             break
@@ -719,8 +719,8 @@ def test_warning_for_many_duplicate_remote_functions_and_actors(shutdown_only):
 
     ray.get(create_actor_class.remote())
 
-    start_time = time.time()
-    while time.time() < start_time + 10:
+    start_time = time.perf_counter()
+    while time.perf_counter() < start_time + 10:
         log_contents = log_capture_string.getvalue()
         if len(log_contents) > 0:
             break
@@ -932,10 +932,10 @@ def test_fill_object_store_lru_fallback(shutdown_only):
 
     # Check that objects out of scope are cleaned up quickly.
     ray.get(expensive_task.remote())
-    start = time.time()
+    start = time.perf_counter()
     for _ in range(3):
         ray.get(expensive_task.remote())
-    end = time.time()
+    end = time.perf_counter()
     assert end - start < 3
 
     oids = []

--- a/python/ray/tests/test_iter.py
+++ b/python/ray/tests/test_iter.py
@@ -370,13 +370,13 @@ def test_gather_async_optimized_benchmark(ray_start_regular_shared):
     for i in range(20):
         record = next(local_it)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     #print(start_time)
     count = 0
     for record in local_it:
         count += 1
     assert count == len(items) - 20
-    end_time = time.time() - start_time
+    end_time = time.perf_counter() - start_time
     print(end_time)
 """
 

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -143,9 +143,9 @@ def test_sklearn_benchmarks(ray_start_cluster_2_nodes):
 
             if "n_jobs" in estimator_params:
                 estimator.set_params(n_jobs=num_jobs)
-            time_start = time.time()
+            time_start = time.perf_counter()
             estimator.fit(X_train, y_train)
-            train_time[name] = time.time() - time_start
+            train_time[name] = time.perf_counter() - time_start
             print("training", name, "took", train_time[name], "seconds")
 
 

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -89,9 +89,9 @@ def test_worker_stats(shutdown_only):
     assert target_worker_present
 
     timeout_seconds = 20
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
-        if time.time() - start_time > timeout_seconds:
+        if time.perf_counter() - start_time > timeout_seconds:
             raise RayTestTimeoutException(
                 "Timed out while waiting for worker processes")
 
@@ -144,9 +144,9 @@ def test_worker_stats(shutdown_only):
                 "port": worker.core_worker_stats.port
             })
     timeout_seconds = 20
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
-        if time.time() - start_time > timeout_seconds:
+        if time.perf_counter() - start_time > timeout_seconds:
             raise RayTestTimeoutException("Timed out while killing actors")
         if all(
                 actor_killed(worker.pid) for worker in reply.workers_stats
@@ -192,7 +192,7 @@ def test_raylet_info_endpoint(shutdown_only):
 
     assert (wait_until_server_available(addresses["webui_url"]) is True)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
         time.sleep(1)
         try:
@@ -215,11 +215,11 @@ def test_raylet_info_endpoint(shutdown_only):
                 assert len(children) == 2
                 break
             except AssertionError:
-                if time.time() > start_time + 30:
+                if time.perf_counter() > start_time + 30:
                     raise Exception("Timed out while waiting for actor info \
                         or object store info update.")
         except requests.exceptions.ConnectionError:
-            if time.time() > start_time + 30:
+            if time.perf_counter() > start_time + 30:
                 raise Exception(
                     "Timed out while waiting for dashboard to start.")
 
@@ -240,10 +240,10 @@ def test_raylet_info_endpoint(shutdown_only):
             "pid": actor_pid,
             "duration": 5
         }).json()["result"]
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
         # Sometimes some startup time is required
-        if time.time() - start_time > 30:
+        if time.perf_counter() - start_time > 30:
             raise RayTestTimeoutException(
                 "Timed out while collecting profiling stats.")
         profiling_info = requests.get(

--- a/python/ray/tests/test_microbenchmarks.py
+++ b/python/ray/tests/test_microbenchmarks.py
@@ -17,9 +17,9 @@ def test_timing(ray_start_regular):
     # Measure the time required to submit a remote task to the scheduler.
     elapsed_times = []
     for _ in range(1000):
-        start_time = time.time()
+        start_time = time.perf_counter()
         empty_function.remote()
-        end_time = time.time()
+        end_time = time.perf_counter()
         elapsed_times.append(end_time - start_time)
     elapsed_times = np.sort(elapsed_times)
     average_elapsed_time = sum(elapsed_times) / 1000
@@ -34,9 +34,9 @@ def test_timing(ray_start_regular):
     # (where the remote task returns one value).
     elapsed_times = []
     for _ in range(1000):
-        start_time = time.time()
+        start_time = time.perf_counter()
         trivial_function.remote()
-        end_time = time.time()
+        end_time = time.perf_counter()
         elapsed_times.append(end_time - start_time)
     elapsed_times = np.sort(elapsed_times)
     average_elapsed_time = sum(elapsed_times) / 1000
@@ -51,10 +51,10 @@ def test_timing(ray_start_regular):
     # and get the result.
     elapsed_times = []
     for _ in range(1000):
-        start_time = time.time()
+        start_time = time.perf_counter()
         x = trivial_function.remote()
         ray.get(x)
-        end_time = time.time()
+        end_time = time.perf_counter()
         elapsed_times.append(end_time - start_time)
     elapsed_times = np.sort(elapsed_times)
     average_elapsed_time = sum(elapsed_times) / 1000
@@ -69,9 +69,9 @@ def test_timing(ray_start_regular):
     # Measure the time required to do do a put.
     elapsed_times = []
     for _ in range(1000):
-        start_time = time.time()
+        start_time = time.perf_counter()
         ray.put(1)
-        end_time = time.time()
+        end_time = time.perf_counter()
         elapsed_times.append(end_time - start_time)
     elapsed_times = np.sort(elapsed_times)
     average_elapsed_time = sum(elapsed_times) / 1000
@@ -89,14 +89,14 @@ def test_cache(ray_start_regular):
     v = np.random.rand(1000000)
     A_id = ray.put(A)
     v_id = ray.put(v)
-    a = time.time()
+    a = time.perf_counter()
     for i in range(100):
         A.dot(v)
-    b = time.time() - a
-    c = time.time()
+    b = time.perf_counter() - a
+    c = time.perf_counter()
     for i in range(100):
         ray.get(A_id).dot(ray.get(v_id))
-    d = time.time() - c
+    d = time.perf_counter() - c
 
     if d > 1.5 * b:
         print("WARNING: The caching test was too slow. "

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -180,8 +180,8 @@ import time
 import ray
 ray.init(address="{}")
 object_ids = [ray.put(i) for i in range(1000)]
-start_time = time.time()
-while time.time() - start_time < 30:
+start_time = time.perf_counter()
+while time.perf_counter() - start_time < 30:
     if len(ray.objects()) == 1000:
         break
 else:
@@ -192,8 +192,8 @@ print("success")
     run_string_as_driver(driver_script)
 
     # Make sure the objects are removed from the object table.
-    start_time = time.time()
-    while time.time() - start_time < 30:
+    start_time = time.perf_counter()
+    while time.perf_counter() - start_time < 30:
         if len(ray.objects()) == 0:
             break
     else:
@@ -329,8 +329,8 @@ print("success")
 
     def wait_for_success_output(process_handle, timeout=10):
         # Wait until the process prints "success" and then return.
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while time.perf_counter() - start_time < timeout:
             output_line = ray.utils.decode(
                 process_handle.stdout.readline()).strip()
             print(output_line)

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -38,7 +38,7 @@ def test_worker_failed(ray_start_workers_separate_multinode):
         time.sleep(0.25)
         return os.getpid()
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     pids = set()
     while len(pids) < num_nodes * num_initial_workers:
         new_pids = ray.get([
@@ -47,7 +47,7 @@ def test_worker_failed(ray_start_workers_separate_multinode):
         ])
         for pid in new_pids:
             pids.add(pid)
-        if time.time() - start_time > 60:
+        if time.perf_counter() - start_time > 60:
             raise RayTestTimeoutException(
                 "Timed out while waiting to get worker PIDs.")
 

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -235,9 +235,9 @@ def test_object_transfer_retry(ray_start_cluster):
     # Get the objects locally to cause them to be transferred. This is the
     # first time the objects are getting transferred, so it should happen
     # quickly.
-    start_time = time.time()
+    start_time = time.perf_counter()
     xs = ray.get(x_ids)
-    end_time = time.time()
+    end_time = time.perf_counter()
     if end_time - start_time > repeated_push_delay:
         warnings.warn("The initial transfer took longer than the repeated "
                       "push delay, so this test may not be testing the thing "
@@ -252,14 +252,14 @@ def test_object_transfer_retry(ray_start_cluster):
         ray.worker.global_worker.core_worker.object_exists(x_id)
         for x_id in x_ids)
 
-    end_time = time.time()
+    end_time = time.perf_counter()
     # Make sure that the first time the objects get transferred, it happens
     # quickly.
     assert end_time - start_time < repeated_push_delay
 
     # Get the objects again and make sure they get transferred.
     xs = ray.get(x_ids)
-    end_transfer_time = time.time()
+    end_transfer_time = time.perf_counter()
     # We should have had to wait for the repeated push delay.
     assert end_transfer_time - start_time >= repeated_push_delay
 
@@ -276,9 +276,9 @@ def test_object_transfer_retry(ray_start_cluster):
 
     # Get the objects locally to cause them to be transferred. This should
     # happen quickly.
-    start_time = time.time()
+    start_time = time.perf_counter()
     ray.get(x_ids)
-    end_time = time.time()
+    end_time = time.perf_counter()
     assert end_time - start_time < repeated_push_delay
 
 

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -55,13 +55,13 @@ def _check_refcounts(expected):
 
 
 def check_refcounts(expected, timeout=10):
-    start = time.time()
+    start = time.perf_counter()
     while True:
         try:
             _check_refcounts(expected)
             break
         except AssertionError as e:
-            if time.time() - start > timeout:
+            if time.perf_counter() - start > timeout:
                 raise e
             else:
                 time.sleep(0.1)

--- a/python/ray/tests/test_webui.py
+++ b/python/ray/tests/test_webui.py
@@ -17,14 +17,14 @@ def test_get_webui(shutdown_only):
 
     assert re.match(r"^(localhost|\d+\.\d+\.\d+\.\d+):\d+$", webui_url)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     while True:
         try:
             node_info = requests.get("http://" + webui_url +
                                      "/api/node_info").json()
             break
         except requests.exceptions.ConnectionError:
-            if time.time() > start_time + 30:
+            if time.perf_counter() > start_time + 30:
                 error_log = None
                 out_log = None
                 with open(

--- a/python/ray/tune/automl/search_policy.py
+++ b/python/ray/tune/automl/search_policy.py
@@ -102,7 +102,7 @@ class AutoMLSearcher(SearchAlgorithm):
         self._iteration += 1
         self._unfinished_count = ntrial
         self._total_trial_num += ntrial
-        self._start_ts = time.time()
+        self._start_ts = time.perf_counter()
         logger.info(
             "=========== BEGIN Experiment-Round: %(round)s "
             "[%(new)s NEW | %(total)s TOTAL] ===========", {
@@ -142,7 +142,7 @@ class AutoMLSearcher(SearchAlgorithm):
             if this_trial.status == Trial.RUNNING and not error:
                 succ += 1
 
-            elapsed = time.time() - self._start_ts
+            elapsed = time.perf_counter() - self._start_ts
             logger.info(
                 "=========== END Experiment-Round: %(round)s "
                 "[%(succ)s SUCC | %(fail)s FAIL] this round, "

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -89,7 +89,8 @@ class TuneReporterBase(ProgressReporter):
         self._last_report_time = time.perf_counter()
 
     def should_report(self, trials, done=False):
-        if time.perf_counter() - self._last_report_time > self._max_report_freqency:
+        if time.perf_counter(
+        ) - self._last_report_time > self._max_report_freqency:
             self._last_report_time = time.perf_counter()
             return True
         return done

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -86,11 +86,11 @@ class TuneReporterBase(ProgressReporter):
         self._max_error_rows = max_error_rows
 
         self._max_report_freqency = max_report_frequency
-        self._last_report_time = 0
+        self._last_report_time = time.perf_counter()
 
     def should_report(self, trials, done=False):
-        if time.time() - self._last_report_time > self._max_report_freqency:
-            self._last_report_time = time.time()
+        if time.perf_counter() - self._last_report_time > self._max_report_freqency:
+            self._last_report_time = time.perf_counter()
             return True
         return done
 

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -406,7 +406,8 @@ class RayTrialExecutor(TrialExecutor):
         wait_time = time.perf_counter() - start
         if wait_time > NONTRIVIAL_WAIT_TIME_THRESHOLD_S:
             self._last_nontrivial_wait = time.perf_counter()
-        if time.perf_counter() - self._last_nontrivial_wait > BOTTLENECK_WARN_PERIOD_S:
+        if time.perf_counter(
+        ) - self._last_nontrivial_wait > BOTTLENECK_WARN_PERIOD_S:
             logger.warning(
                 "Over the last {} seconds, the Tune event loop has been "
                 "backlogged processing new results. Consider increasing your "
@@ -521,7 +522,8 @@ class RayTrialExecutor(TrialExecutor):
         has exceeded self._refresh_period. This also assumes that the
         cluster is not resizing very frequently.
         """
-        if time.perf_counter() - self._last_resource_refresh > self._refresh_period:
+        if time.perf_counter(
+        ) - self._last_resource_refresh > self._refresh_period:
             self._update_avail_resources()
 
         currently_available = Resources.subtract(self._avail_resources,

--- a/python/ray/tune/stopper.py
+++ b/python/ray/tune/stopper.py
@@ -16,14 +16,14 @@ class Stopper:
 
         class TimeStopper(Stopper):
             def __init__(self):
-                self._start = time.time()
+                self._start = time.perf_counter()
                 self._deadline = 300
 
             def __call__(self, trial_id, result):
                 return False
 
             def stop_all(self):
-                return time.time() - self._start > self.deadline
+                return time.perf_counter() - self._start > self.deadline
 
         tune.run(Trainable, num_samples=200, stop=TimeStopper())
 

--- a/python/ray/tune/syncer.py
+++ b/python/ray/tune/syncer.py
@@ -84,7 +84,7 @@ class Syncer:
             sync_period (int): Time period between subsequent syncs.
         """
 
-        if time.time() - self.last_sync_up_time > sync_period:
+        if time.perf_counter() - self.last_sync_up_time > sync_period:
             self.sync_up()
 
     def sync_down_if_needed(self, sync_period):
@@ -93,7 +93,7 @@ class Syncer:
         Arguments:
             sync_period (int): Time period between subsequent syncs.
         """
-        if time.time() - self.last_sync_down_time > sync_period:
+        if time.perf_counter() - self.last_sync_down_time > sync_period:
             self.sync_down()
 
     def sync_up(self):
@@ -107,7 +107,7 @@ class Syncer:
             try:
                 result = self.sync_client.sync_up(self._local_dir,
                                                   self._remote_path)
-                self.last_sync_up_time = time.time()
+                self.last_sync_up_time = time.perf_counter()
             except Exception:
                 logger.exception("Sync execution failed.")
         return result
@@ -123,7 +123,7 @@ class Syncer:
             try:
                 result = self.sync_client.sync_down(self._remote_path,
                                                     self._local_dir)
-                self.last_sync_down_time = time.time()
+                self.last_sync_down_time = time.perf_counter()
             except Exception:
                 logger.exception("Sync execution failed.")
         return result

--- a/python/ray/tune/tests/test_commands.py
+++ b/python/ray/tune/tests/test_commands.py
@@ -53,9 +53,9 @@ def test_time(start_ray, tmpdir):
     })
     times = []
     for i in range(5):
-        start = time.time()
+        start = time.perf_counter()
         subprocess.check_call(["tune", "ls", experiment_path])
-        times += [time.time() - start]
+        times += [time.perf_counter() - start]
 
     assert sum(times) / len(times) < 3.0, "CLI is taking too long!"
 

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -170,9 +170,9 @@ class Trainable:
         self._restored = False
         self._trial_info = trial_info
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         self._setup(copy.deepcopy(self.config))
-        setup_time = time.time() - start_time
+        setup_time = time.perf_counter() - start_time
         if setup_time > SETUP_TIME_THRESHOLD:
             logger.info("_setup took {:.3f} seconds. If your trainable is "
                         "slow to initialize, consider setting "
@@ -256,7 +256,7 @@ class Trainable:
         Returns:
             A dict that describes training progress.
         """
-        start = time.time()
+        start = time.perf_counter()
         result = self._train()
         assert isinstance(result, dict), "_train() needs to return a dict."
 
@@ -272,7 +272,7 @@ class Trainable:
         if result.get(TIME_THIS_ITER_S) is not None:
             time_this_iter = result[TIME_THIS_ITER_S]
         else:
-            time_this_iter = time.time() - start
+            time_this_iter = time.perf_counter() - start
         self._time_total += time_this_iter
         self._time_since_restore += time_this_iter
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -467,8 +467,8 @@ class Trial:
         result.update(trial_id=self.trial_id, done=terminate)
         if self.experiment_tag:
             result.update(experiment_tag=self.experiment_tag)
-        if self.verbose and (terminate or time.perf_counter() - self.last_debug >
-                             DEBUG_PRINT_INTERVAL):
+        if self.verbose and (terminate or time.perf_counter() - self.last_debug
+                             > DEBUG_PRINT_INTERVAL):
             print("Result for {}:".format(self))
             print("  {}".format(pretty_print(result).replace("\n", "\n  ")))
             self.last_debug = time.perf_counter()

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -467,14 +467,14 @@ class Trial:
         result.update(trial_id=self.trial_id, done=terminate)
         if self.experiment_tag:
             result.update(experiment_tag=self.experiment_tag)
-        if self.verbose and (terminate or time.time() - self.last_debug >
+        if self.verbose and (terminate or time.perf_counter() - self.last_debug >
                              DEBUG_PRINT_INTERVAL):
             print("Result for {}:".format(self))
             print("  {}".format(pretty_print(result).replace("\n", "\n  ")))
-            self.last_debug = time.time()
+            self.last_debug = time.perf_counter()
         self.set_location(Location(result.get("node_ip"), result.get("pid")))
         self.last_result = result
-        self.last_update_time = time.time()
+        self.last_update_time = time.perf_counter()
         self.result_logger.on_result(self.last_result)
 
         for metric, value in flatten_dict(result).items():

--- a/python/ray/tune/trial_runner.py
+++ b/python/ray/tune/trial_runner.py
@@ -174,7 +174,7 @@ class TrialRunner:
         else:
             logger.debug("Starting a new experiment.")
 
-        self._start_time = time.time()
+        self._start_time = time.perf_counter()
         self._last_checkpoint_time = -float("inf")
         self._checkpoint_period = checkpoint_period
         self._session_str = datetime.fromtimestamp(
@@ -256,7 +256,7 @@ class TrialRunner:
         """
         if not self._local_checkpoint_dir:
             return
-        now = time.time()
+        now = time.perf_counter()
         if now - self._last_checkpoint_time < self._checkpoint_period and (
                 not force):
             return
@@ -680,12 +680,12 @@ class TrialRunner:
         """
         trials = self._search_alg.next_trials()
         if blocking and not trials:
-            start = time.time()
+            start = time.perf_counter()
             # Checking `is_finished` instead of _search_alg.is_finished
             # is fine because blocking only occurs if all trials are
             # finished and search_algorithm is not yet finished
             while (not trials and not self.is_finished()
-                   and time.time() - start < timeout):
+                   and time.perf_counter() - start < timeout):
                 logger.info("Blocking for next trial...")
                 trials = self._search_alg.next_trials()
                 time.sleep(1)

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -18,7 +18,7 @@ except ImportError:
 
 _pinned_objects = []
 PINNED_OBJECT_PREFIX = "ray.tune.PinnedObject:"
-START_OF_TIME = time.time()
+START_OF_TIME = time.perf_counter()
 
 
 class UtilMonitor(Thread):
@@ -124,11 +124,11 @@ class warn_if_slow:
         self.too_slow = False
 
     def __enter__(self):
-        self.start = time.time()
+        self.start = time.perf_counter()
         return self
 
     def __exit__(self, type, value, traceback):
-        now = time.time()
+        now = time.perf_counter()
         if now - self.start > self.threshold and now - START_OF_TIME > 60.0:
             self.too_slow = True
             logger.warning(

--- a/python/ray/util/debug.py
+++ b/python/ray/util/debug.py
@@ -22,11 +22,11 @@ def log_once(key):
         return False
     elif key not in _logged:
         _logged.add(key)
-        _last_logged = time.time()
+        _last_logged = time.perf_counter()
         return True
-    elif _periodic_log and time.time() - _last_logged > 60.0:
+    elif _periodic_log and time.perf_counter() - _last_logged > 60.0:
         _logged.clear()
-        _last_logged = time.time()
+        _last_logged = time.perf_counter()
         return False
     else:
         return False

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -1130,8 +1130,8 @@ class ParallelIteratorWorker(object):
         if batch_ms == 0:
             batch.append(self.par_iter_next())
             return batch
-        t_end = time.time() + (0.001 * batch_ms)
-        while time.time() < t_end:
+        t_end = time.perf_counter() + (0.001 * batch_ms)
+        while time.perf_counter() < t_end:
             try:
                 batch.append(self.par_iter_next())
             except StopIteration:
@@ -1170,8 +1170,8 @@ class ParallelIteratorWorker(object):
         if batch_ms == 0:
             batch.append(self.par_iter_slice(step, start))
             return batch
-        t_end = time.time() + (0.001 * batch_ms)
-        while time.time() < t_end:
+        t_end = time.perf_counter() + (0.001 * batch_ms)
+        while time.perf_counter() < t_end:
             try:
                 batch.append(self.par_iter_slice(step, start))
             except StopIteration:

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -236,12 +236,12 @@ class OrderedIMapIterator(IMapIterator):
             # self._result_thread.next_ready_index() raises a timeout.
             index = -1
             while index != self._next_chunk_index:
-                start = time.time()
+                start = time.perf_counter()
                 index = self._result_thread.next_ready_index(timeout=timeout)
                 self._submit_next_chunk()
                 self._submitted_chunks[index] = True
                 if timeout is not None:
-                    timeout = max(0, timeout - (time.time() - start))
+                    timeout = max(0, timeout - (time.perf_counter() - start))
 
             while self._next_chunk_index < len(
                     self._submitted_chunks

--- a/python/ray/util/sgd/tests/test_torch.py
+++ b/python/ray/util/sgd/tests/test_torch.py
@@ -82,7 +82,7 @@ def test_non_serialized_data(ray_start_2_cpus):  # noqa: F811
 
         return slowed_func
 
-    start = time.time()
+    start = time.perf_counter()
     trainer = TorchTrainer(
         model_creator=model_creator,
         data_creator=slow_data(data_creator),
@@ -90,7 +90,7 @@ def test_non_serialized_data(ray_start_2_cpus):  # noqa: F811
         serialize_data_creation=False,
         loss_creator=lambda config: nn.MSELoss(),
         num_workers=2)
-    elapsed = time.time() - start
+    elapsed = time.perf_counter() - start
     assert elapsed < duration * 2
     trainer.shutdown()
 

--- a/python/ray/util/sgd/tf/examples/cifar_tf_example.py
+++ b/python/ray/util/sgd/tf/examples/cifar_tf_example.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             }
         })
 
-    training_start = time.time()
+    training_start = time.perf_counter()
     num_epochs = 1 if args.smoke_test else 3
     for i in range(num_epochs):
         # Trains num epochs
@@ -210,7 +210,7 @@ if __name__ == "__main__":
         train_stats1.update(trainer.validate())
         print("iter {}:".format(i), train_stats1)
 
-    dt = (time.time() - training_start) / 3
+    dt = (time.perf_counter() - training_start) / 3
     print(f"Training on workers takes: {dt:.3f} seconds/epoch")
 
     model = trainer.get_model()
@@ -218,9 +218,9 @@ if __name__ == "__main__":
     dataset, test_dataset = data_augmentation_creator(
         dict(batch_size=batch_size))
 
-    training_start = time.time()
+    training_start = time.perf_counter()
     model.fit(dataset, steps_per_epoch=num_train_steps, epochs=1)
-    dt = (time.time() - training_start)
+    dt = (time.perf_counter() - training_start)
     print(f"Training on workers takes: {dt:.3f} seconds/epoch")
 
     scores = model.evaluate(test_dataset, steps=num_eval_steps)

--- a/python/ray/util/sgd/torch/examples/segmentation/train_segmentation.py
+++ b/python/ray/util/sgd/torch/examples/segmentation/train_segmentation.py
@@ -173,7 +173,7 @@ def main(args):
     os.makedirs(args.output_dir, exist_ok=True)
 
     print(args)
-    start_time = time.time()
+    start_time = time.perf_counter()
     config = {"args": args, "num_workers": args.num_workers}
     trainer = TorchTrainer(
         model_creator=model_creator,
@@ -195,7 +195,7 @@ def main(args):
         torch.save(state_dict,
                    os.path.join(args.output_dir, "model_{}.pth".format(epoch)))
 
-    total_time = time.time() - start_time
+    total_time = time.perf_counter() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print("Training time {}".format(total_time_str))
 

--- a/python/ray/util/sgd/torch/examples/transformers/transformers_example.py
+++ b/python/ray/util/sgd/torch/examples/transformers/transformers_example.py
@@ -145,7 +145,8 @@ def data_creator(config):
         if args.tokenizer_name else args.model_name_or_path,
         cache_dir=args.cache_dir if args.cache_dir else None,
     )
-    logger.info("tokenizer instantiation time: {}".format(time.perf_counter() - start))
+    logger.info(
+        "tokenizer instantiation time: {}".format(time.perf_counter() - start))
 
     train_dataset = load_and_cache_examples(
         args, args.task_name, tokenizer, evaluate=False)

--- a/python/ray/util/sgd/torch/examples/transformers/transformers_example.py
+++ b/python/ray/util/sgd/torch/examples/transformers/transformers_example.py
@@ -139,13 +139,13 @@ def optimizer_creator(model, cfg):
 
 def data_creator(config):
     args = config["args"]
-    start = time.time()
+    start = time.perf_counter()
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer_name
         if args.tokenizer_name else args.model_name_or_path,
         cache_dir=args.cache_dir if args.cache_dir else None,
     )
-    logger.info("tokenizer instantiation time: {}".format(time.time() - start))
+    logger.info("tokenizer instantiation time: {}".format(time.perf_counter() - start))
 
     train_dataset = load_and_cache_examples(
         args, args.task_name, tokenizer, evaluate=False)

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -700,7 +700,8 @@ class TorchTrainer:
     def _should_resize(self):
         """Returns True if past cooldown and exists resources to scale up."""
         worker_gap = self.max_replicas - 1 - len(self.remote_workers)
-        past_cooldown = (time.perf_counter() - self._last_resize) > RESIZE_COOLDOWN_S
+        past_cooldown = (
+            time.perf_counter() - self._last_resize) > RESIZE_COOLDOWN_S
         if past_cooldown and worker_gap:
             # Assume 1 resource is already reserved for local worker.
             potential_remote_size = self._check_potential_remote_workers_size()

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -686,7 +686,7 @@ class TorchTrainer:
         for i in range(max_retries):
             new_remote_workers = self._check_potential_remote_workers_size()
             if new_remote_workers:
-                self._last_resize = time.time()
+                self._last_resize = time.perf_counter()
                 self._start_workers(int(new_remote_workers) + 1)
                 self.load_state_dict(self.state_dict())
                 return
@@ -700,7 +700,7 @@ class TorchTrainer:
     def _should_resize(self):
         """Returns True if past cooldown and exists resources to scale up."""
         worker_gap = self.max_replicas - 1 - len(self.remote_workers)
-        past_cooldown = (time.time() - self._last_resize) > RESIZE_COOLDOWN_S
+        past_cooldown = (time.perf_counter() - self._last_resize) > RESIZE_COOLDOWN_S
         if past_cooldown and worker_gap:
             # Assume 1 resource is already reserved for local worker.
             potential_remote_size = self._check_potential_remote_workers_size()

--- a/python/ray/util/sgd/utils.py
+++ b/python/ray/util/sgd/utils.py
@@ -41,11 +41,11 @@ class TimerStat:
 
     def __enter__(self):
         assert self._start_time is None, "concurrent updates not supported"
-        self._start_time = time.time()
+        self._start_time = time.perf_counter()
 
     def __exit__(self, type, value, tb):
         assert self._start_time is not None
-        time_delta = time.time() - self._start_time
+        time_delta = time.perf_counter() - self._start_time
         self.push(time_delta)
         self._start_time = None
 

--- a/python/ray/util/timer.py
+++ b/python/ray/util/timer.py
@@ -23,11 +23,11 @@ class _Timer:
 
     def __enter__(self):
         assert self._start_time is None, "concurrent updates not supported"
-        self._start_time = time.time()
+        self._start_time = time.perf_counter()
 
     def __exit__(self, exc_type, exc_value, tb):
         assert self._start_time is not None
-        time_delta = time.time() - self._start_time
+        time_delta = time.perf_counter() - self._start_time
         self.push(time_delta)
         self._start_time = None
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -976,7 +976,7 @@ def print_error_messages_raylet(task_error_queue, threads_stopped):
             continue
         # Delay errors a little bit of time to attempt to suppress redundant
         # messages originating from the worker.
-        while t + UNCAUGHT_ERROR_GRACE_PERIOD > time.time():
+        while t + UNCAUGHT_ERROR_GRACE_PERIOD > time.perf_counter():
             threads_stopped.wait(timeout=1)
             if threads_stopped.is_set():
                 break

--- a/rllib/agents/es/es.py
+++ b/rllib/agents/es/es.py
@@ -119,9 +119,9 @@ class Worker:
         eval_returns, eval_lengths = [], []
 
         # Perform some rollouts with noise.
-        task_tstart = time.time()
+        task_tstart = time.perf_counter()
         while (len(noise_indices) == 0
-               or time.time() - task_tstart < self.min_task_runtime):
+               or time.perf_counter() - task_tstart < self.min_task_runtime):
 
             if np.random.uniform() < self.config["eval_prob"]:
                 # Do an evaluation run with no perturbation.
@@ -207,7 +207,7 @@ class ESTrainer(Trainer):
 
         self.episodes_so_far = 0
         self.reward_list = []
-        self.tstart = time.time()
+        self.tstart = time.perf_counter()
 
     @override(Trainer)
     def get_policy(self, policy=DEFAULT_POLICY_ID):

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -136,7 +136,7 @@ def build_trainer(
                 before_train_step(self)
             prev_steps = self.optimizer.num_steps_sampled
 
-            start = time.time()
+            start = time.perf_counter()
             optimizer_steps_this_iter = 0
             while True:
                 fetches = self.optimizer.step()
@@ -145,7 +145,7 @@ def build_trainer(
                     deprecation_warning("after_optimizer_step",
                                         "execution_plan")
                     after_optimizer_step(self, fetches)
-                if (time.time() - start >= self.config["min_iter_time_s"]
+                if (time.perf_counter() - start >= self.config["min_iter_time_s"]
                         and self.optimizer.num_steps_sampled - prev_steps >=
                         self.config["timesteps_per_iteration"]):
                     break

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -145,7 +145,8 @@ def build_trainer(
                     deprecation_warning("after_optimizer_step",
                                         "execution_plan")
                     after_optimizer_step(self, fetches)
-                if (time.perf_counter() - start >= self.config["min_iter_time_s"]
+                if (time.perf_counter() - start >=
+                        self.config["min_iter_time_s"]
                         and self.optimizer.num_steps_sampled - prev_steps >=
                         self.config["timesteps_per_iteration"]):
                     break

--- a/rllib/contrib/bandits/agents/policy.py
+++ b/rllib/contrib/bandits/agents/policy.py
@@ -47,7 +47,7 @@ class BanditPolicyOverrides:
 
         info = {}
 
-        start = time.time()
+        start = time.perf_counter()
         self.model.partial_fit(unflattened_obs,
                                train_batch[SampleBatch.REWARDS],
                                train_batch[SampleBatch.ACTIONS])
@@ -62,7 +62,7 @@ class BanditPolicyOverrides:
             if log_once("no_regrets"):
                 logger.warning("The env did not report `regret` values in "
                                "its `info` return, ignoring.")
-        info["update_latency"] = time.time() - start
+        info["update_latency"] = time.perf_counter() - start
         return {LEARNER_STATS_KEY: info}
 
 

--- a/rllib/contrib/bandits/examples/tune_LinTS_train_wheel_env.py
+++ b/rllib/contrib/bandits/examples/tune_LinTS_train_wheel_env.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
     print("Running training for %s time steps" % training_iterations)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     analysis = tune.run(
         LinTSTrainer,
         config=TS_CONFIG,
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         num_samples=2,
         checkpoint_at_end=True)
 
-    print("The trials took", time.time() - start_time, "seconds\n")
+    print("The trials took", time.perf_counter() - start_time, "seconds\n")
 
     # Analyze cumulative regrets of the trials
     frame = pd.DataFrame()

--- a/rllib/contrib/bandits/examples/tune_LinUCB_train_recommendation.py
+++ b/rllib/contrib/bandits/examples/tune_LinUCB_train_recommendation.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 
     print("Running training for %s time steps" % training_iterations)
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     analysis = tune.run(
         "contrib/LinUCB",
         config=UCB_CONFIG,
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         num_samples=5,
         checkpoint_at_end=False)
 
-    print("The trials took", time.time() - start_time, "seconds\n")
+    print("The trials took", time.perf_counter() - start_time, "seconds\n")
 
     # Analyze cumulative regrets of the trials
     frame = pd.DataFrame()

--- a/rllib/env/policy_client.py
+++ b/rllib/env/policy_client.py
@@ -223,7 +223,7 @@ class PolicyClient:
 
     def _update_local_policy(self, force=False):
         assert self.inference_thread.is_alive()
-        if (self.update_interval and time.time() - self.last_updated >
+        if (self.update_interval and time.perf_counter() - self.last_updated >
                 self.update_interval) or force:
             logger.info("Querying server for new policy weights.")
             resp = self._send({
@@ -235,7 +235,7 @@ class PolicyClient:
                 "Updating rollout worker weights and global vars {}.".format(
                     global_vars))
             self.rollout_worker.set_weights(weights, global_vars)
-            self.last_updated = time.time()
+            self.last_updated = time.perf_counter()
 
 
 class _LocalInferenceThread(threading.Thread):

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -455,11 +455,11 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
 
     while True:
         perf_stats.iters += 1
-        t0 = time.time()
+        t0 = time.perf_counter()
         # Get observations from all ready agents.
         unfiltered_obs, rewards, dones, infos, off_policy_actions = \
             base_env.poll()
-        perf_stats.env_wait_time += time.time() - t0
+        perf_stats.env_wait_time += time.perf_counter() - t0
 
         if log_once("env_returns"):
             logger.info("Raw obs from env: {}".format(
@@ -467,7 +467,7 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
             logger.info("Info return from env: {}".format(summarize(infos)))
 
         # Process observations and prepare for policy evaluation.
-        t1 = time.time()
+        t1 = time.perf_counter()
         active_envs, to_eval, outputs = _process_observations(
             worker=worker,
             base_env=base_env,
@@ -487,21 +487,21 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
             soft_horizon=soft_horizon,
             no_done_at_end=no_done_at_end,
             observation_fn=observation_fn)
-        perf_stats.processing_time += time.time() - t1
+        perf_stats.processing_time += time.perf_counter() - t1
         for o in outputs:
             yield o
 
         # Do batched policy eval (accross vectorized envs).
-        t2 = time.time()
+        t2 = time.perf_counter()
         eval_results = _do_policy_eval(
             to_eval=to_eval,
             policies=policies,
             active_episodes=active_episodes,
             tf_sess=tf_sess)
-        perf_stats.inference_time += time.time() - t2
+        perf_stats.inference_time += time.perf_counter() - t2
 
         # Process results and update episode state.
-        t3 = time.time()
+        t3 = time.perf_counter()
         actions_to_send = _process_policy_eval_results(
             to_eval=to_eval,
             eval_results=eval_results,
@@ -510,13 +510,13 @@ def _env_runner(worker, base_env, extra_batch_callback, policies,
             off_policy_actions=off_policy_actions,
             policies=policies,
             clip_actions=clip_actions)
-        perf_stats.processing_time += time.time() - t3
+        perf_stats.processing_time += time.perf_counter() - t3
 
         # Return computed actions to ready envs. We also send to envs that have
         # taken off-policy actions; those envs are free to ignore the action.
-        t4 = time.time()
+        t4 = time.perf_counter()
         base_env.send_actions(actions_to_send)
-        perf_stats.env_wait_time += time.time() - t4
+        perf_stats.env_wait_time += time.perf_counter() - t4
 
 
 def _process_observations(

--- a/rllib/execution/metric_ops.py
+++ b/rllib/execution/metric_ops.py
@@ -118,9 +118,9 @@ class OncePerTimeInterval:
 
     Examples:
         >>> throttled_op = train_op.filter(OncePerTimeInterval(5))
-        >>> start = time.time()
+        >>> start = time.perf_counter()
         >>> next(throttled_op)
-        >>> print(time.time() - start)
+        >>> print(time.perf_counter() - start)
         5.00001  # will be greater than 5 seconds
     """
 
@@ -131,7 +131,7 @@ class OncePerTimeInterval:
     def __call__(self, item):
         if self.delay <= 0.0:
             return True
-        now = time.time()
+        now = time.perf_counter()
         if now - self.last_called > self.delay:
             self.last_called = now
             return True

--- a/rllib/offline/json_writer.py
+++ b/rllib/offline/json_writer.py
@@ -60,7 +60,7 @@ class JsonWriter(OutputWriter):
 
     @override(OutputWriter)
     def write(self, sample_batch):
-        start = time.time()
+        start = time.perf_counter()
         data = _to_json(sample_batch, self.compress_columns)
         f = self._get_file()
         f.write(data)
@@ -70,7 +70,7 @@ class JsonWriter(OutputWriter):
         self.bytes_written += len(data)
         logger.debug("Wrote {} bytes to {} in {}s".format(
             len(data), f,
-            time.time() - start))
+            time.perf_counter() - start))
 
     def _get_file(self):
         if not self.cur_file or self.bytes_written >= self.max_file_size:

--- a/rllib/optimizers/aso_tree_aggregator.py
+++ b/rllib/optimizers/aso_tree_aggregator.py
@@ -158,7 +158,7 @@ class AggregationWorker(AggregationWorkerBase):
 
     def get_train_batches(self):
         assert self.initialized, "Must call init() before using this class."
-        start = time.time()
+        start = time.perf_counter()
         result = []
         for batch in self.iter_train_batches(max_yield=5):
             result.append(batch)
@@ -168,7 +168,7 @@ class AggregationWorker(AggregationWorkerBase):
                 result.append(batch)
         logger.debug("Returning {} train batches, {}s".format(
             len(result),
-            time.time() - start))
+            time.perf_counter() - start))
         return result
 
     def get_host(self):

--- a/rllib/optimizers/async_replay_optimizer.py
+++ b/rllib/optimizers/async_replay_optimizer.py
@@ -139,9 +139,9 @@ class AsyncReplayOptimizer(PolicyOptimizer):
     def step(self):
         assert self.learner.is_alive()
         assert len(self.workers.remote_workers()) > 0
-        start = time.time()
+        start = time.perf_counter()
         sample_timesteps, train_timesteps = self._step()
-        time_delta = time.time() - start
+        time_delta = time.perf_counter() - start
         self.timers["sample"].push(time_delta)
         self.timers["sample"].push_units_processed(sample_timesteps)
         if train_timesteps > 0:

--- a/rllib/optimizers/async_samples_optimizer.py
+++ b/rllib/optimizers/async_samples_optimizer.py
@@ -43,7 +43,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
                  _fake_gpus=False):
         PolicyOptimizer.__init__(self, workers)
 
-        self._stats_start_time = time.time()
+        self._stats_start_time = time.perf_counter()
         self._last_stats_time = {}
         self._last_stats_sum = {}
 
@@ -79,7 +79,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
 
         # Stats
         self._optimizer_step_timer = TimerStat()
-        self._stats_start_time = time.time()
+        self._stats_start_time = time.perf_counter()
         self._last_stats_time = {}
 
         if num_aggregation_workers > 0:
@@ -111,7 +111,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
         self._last_stats_sum[key] += val
 
     def get_mean_stats_and_reset(self):
-        now = time.time()
+        now = time.perf_counter()
         mean_stats = {
             key: round(val / (now - self._last_stats_time[key]), 3)
             for key, val in self._last_stats_sum.items()
@@ -119,7 +119,7 @@ class AsyncSamplesOptimizer(PolicyOptimizer):
 
         for key in self._last_stats_sum.keys():
             self._last_stats_sum[key] = 0
-            self._last_stats_time[key] = time.time()
+            self._last_stats_time[key] = time.perf_counter()
 
         return mean_stats
 

--- a/rllib/optimizers/tests/test_optimizers.py
+++ b/rllib/optimizers/tests/test_optimizers.py
@@ -265,8 +265,8 @@ class AsyncSamplesOptimizerTest(unittest.TestCase):
         return local, remotes
 
     def _wait_for(self, optimizer, num_steps_sampled, num_steps_trained):
-        start = time.time()
-        while time.time() - start < 30:
+        start = time.perf_counter()
+        while time.perf_counter() - start < 30:
             optimizer.step()
             if optimizer.num_steps_sampled > num_steps_sampled and \
                     optimizer.num_steps_trained > num_steps_trained:

--- a/rllib/policy/torch_policy.py
+++ b/rllib/policy/torch_policy.py
@@ -250,7 +250,7 @@ class TorchPolicy(Policy):
                         if p.grad is not None:
                             grads.append(p.grad)
 
-                start = time.time()
+                start = time.perf_counter()
                 if torch.cuda.is_available():
                     # Sadly, allreduce_coalesced does not work with CUDA yet.
                     for g in grads:
@@ -265,7 +265,7 @@ class TorchPolicy(Policy):
                         if p.grad is not None:
                             p.grad /= self.distributed_world_size
 
-                grad_info["allreduce_latency"] += time.time() - start
+                grad_info["allreduce_latency"] += time.perf_counter() - start
 
             # Step the optimizer.
             opt.step()

--- a/rllib/tests/test_execution.py
+++ b/rllib/tests/test_execution.py
@@ -109,12 +109,12 @@ def test_metrics(ray_start_regular_shared):
             "collect_metrics_timeout": 10,
         })
 
-    start = time.time()
+    start = time.perf_counter()
     res1 = next(b)
     assert res1["episode_reward_mean"] > 0, res1
     res2 = next(b)
     assert res2["episode_reward_mean"] > 0, res2
-    assert time.time() - start > 2.4
+    assert time.perf_counter() - start > 2.4
     workers.stop()
 
 

--- a/rllib/tests/test_perf.py
+++ b/rllib/tests/test_perf.py
@@ -25,13 +25,13 @@ class TestPerf(unittest.TestCase):
                 env_creator=lambda _: gym.make("CartPole-v0"),
                 policy=MockPolicy,
                 rollout_fragment_length=100)
-            start = time.time()
+            start = time.perf_counter()
             count = 0
-            while time.time() - start < 1:
+            while time.perf_counter() - start < 1:
                 count += ev.sample().count
             print()
             print("Samples per second {}".format(
-                count / (time.time() - start)))
+                count / (time.perf_counter() - start)))
             print()
 
 

--- a/rllib/utils/compression.py
+++ b/rllib/utils/compression.py
@@ -72,8 +72,8 @@ if __name__ == "__main__":
     data = np.ones(size).reshape((32, 80, 80, 4))
 
     count = 0
-    start = time.time()
-    while time.time() - start < 1:
+    start = time.perf_counter()
+    while time.perf_counter() - start < 1:
         pack(data)
         count += 1
     compressed = pack(data)
@@ -81,8 +81,8 @@ if __name__ == "__main__":
     print("Compression ratio: {}".format(round(size * 4 / len(compressed), 2)))
 
     count = 0
-    start = time.time()
-    while time.time() - start < 1:
+    start = time.perf_counter()
+    while time.perf_counter() - start < 1:
         unpack(compressed)
         count += 1
     print("Decompression speed: {} MB/s".format(count * size * 4 / 1e6))

--- a/rllib/utils/tf_run_builder.py
+++ b/rllib/utils/tf_run_builder.py
@@ -65,7 +65,7 @@ def run_timeline(sess, ops, debug_name, feed_dict={}, timeline_dir=None):
 
         run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
         run_metadata = tf.RunMetadata()
-        start = time.time()
+        start = time.perf_counter()
         fetches = sess.run(
             ops,
             options=run_options,
@@ -79,7 +79,7 @@ def run_timeline(sess, ops, debug_name, feed_dict={}, timeline_dir=None):
         _count += 1
         trace_file = open(outf, "w")
         logger.info("Wrote tf timeline ({} s) to {}".format(
-            time.time() - start, os.path.abspath(outf)))
+            time.perf_counter() - start, os.path.abspath(outf)))
         trace_file.write(trace.generate_chrome_trace_format())
     else:
         if log_once("tf_timeline"):

--- a/streaming/python/examples/wordcount.py
+++ b/streaming/python/examples/wordcount.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         .reduce(lambda old_value, new_value:
                 (old_value[0], old_value[1] + new_value[1])) \
         .sink(print)
-    start = time.time()
+    start = time.perf_counter()
     ctx.execute("wordcount")
-    end = time.time()
+    end = time.perf_counter()
     logger.info("Elapsed time: {} secs".format(end - start))


### PR DESCRIPTION
## Why are these changes needed?

`time.perf_counter` should be used for measuring how long a block of code takes, not `time.time`. 

## Related issue number

n/a, see #8686 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
yes, but there were version conflicts so it may not have formatted all files
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
n/a
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
