### PR TITLE
[autoscaler] Create Docker Command Runner

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -321,7 +321,8 @@ class StandardAutoscaler:
                 self.config["worker_start_ray_commands"]),
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
-            use_internal_ip=True)
+            use_internal_ip=True,
+            docker_config=self.config["docker"])
         updater.start()
         self.updaters[node_id] = updater
 
@@ -360,7 +361,8 @@ class StandardAutoscaler:
             ray_start_commands=with_head_node_ip(ray_start_commands),
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
-            use_internal_ip=True)
+            use_internal_ip=True,
+            docker_config=self.config["docker"])
         updater.start()
         self.updaters[node_id] = updater
 

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -147,7 +147,8 @@ def kill_node(config_file, yes, hard, override_cluster_name):
                 initialization_commands=[],
                 setup_commands=[],
                 ray_start_commands=[],
-                runtime_hash="")
+                runtime_hash="",
+                docker_config=config["docker"])
 
             _exec(updater, "ray stop", False, False)
 
@@ -286,7 +287,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             setup_commands=init_commands,
             ray_start_commands=ray_start_commands,
             runtime_hash=runtime_hash,
-        )
+            docker_config=config["docker"])
         updater.start()
         updater.join()
 
@@ -407,7 +408,7 @@ def exec_cluster(config_file,
             setup_commands=[],
             ray_start_commands=[],
             runtime_hash="",
-        )
+            docker_config=config["docker"])
 
         def wrap_docker(command):
             container_name = config["docker"]["container_name"]
@@ -530,7 +531,7 @@ def rsync(config_file,
                 setup_commands=[],
                 ray_start_commands=[],
                 runtime_hash="",
-            )
+                docker_config=config["docker"])
             if down:
                 rsync = updater.rsync_down
             else:

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -87,7 +87,13 @@ class KubernetesNodeProvider(NodeProvider):
         for node_id in node_ids:
             self.terminate_node(node_id)
 
-    def get_command_runner(self, log_prefix, node_id, auth_config,
-                           cluster_name, process_runner, use_internal_ip):
+    def get_command_runner(self,
+                           log_prefix,
+                           node_id,
+                           auth_config,
+                           cluster_name,
+                           process_runner,
+                           use_internal_ip,
+                           docker_config=None):
         return KubernetesCommandRunner(log_prefix, self.namespace, node_id,
                                        auth_config, process_runner)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -3,7 +3,7 @@ import logging
 import os
 import yaml
 
-from ray.autoscaler.updater import SSHCommandRunner
+from ray.autoscaler.updater import SSHCommandRunner, DockerCommandRunner
 
 logger = logging.getLogger(__name__)
 
@@ -211,8 +211,14 @@ class NodeProvider:
         """Clean-up when a Provider is no longer required."""
         pass
 
-    def get_command_runner(self, log_prefix, node_id, auth_config,
-                           cluster_name, process_runner, use_internal_ip):
+    def get_command_runner(self,
+                           log_prefix,
+                           node_id,
+                           auth_config,
+                           cluster_name,
+                           process_runner,
+                           use_internal_ip,
+                           docker_config=None):
         """ Returns the CommandRunner class used to perform SSH commands.
 
         Args:
@@ -226,7 +232,14 @@ class NodeProvider:
             in the CommandRunner. E.g., subprocess.
         use_internal_ip(bool): whether the node_id belongs to an internal ip
             or external ip.
+        docker_config(dict): If set, the docker information of the docker
+            container that commands should be run on.
         """
-
-        return SSHCommandRunner(log_prefix, node_id, self, auth_config,
-                                cluster_name, process_runner, use_internal_ip)
+        if docker_config and docker_config["container_name"] != "":
+            return DockerCommandRunner(docker_config, log_prefix, node_id,
+                                       self, auth_config, cluster_name,
+                                       process_runner, use_internal_ip)
+        else:
+            return SSHCommandRunner(log_prefix, node_id, self, auth_config,
+                                    cluster_name, process_runner,
+                                    use_internal_ip)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -235,11 +235,16 @@ class NodeProvider:
         docker_config(dict): If set, the docker information of the docker
             container that commands should be run on.
         """
+        common_args = {
+            "log_prefix": log_prefix,
+            "node_id": node_id,
+            "provider": self,
+            "auth_config": auth_config,
+            "cluster_name": cluster_name,
+            "process_runner": process_runner,
+            "use_internal_ip": use_internal_ip
+        }
         if docker_config and docker_config["container_name"] != "":
-            return DockerCommandRunner(docker_config, log_prefix, node_id,
-                                       self, auth_config, cluster_name,
-                                       process_runner, use_internal_ip)
+            return DockerCommandRunner(docker_config, **common_args)
         else:
-            return SSHCommandRunner(log_prefix, node_id, self, auth_config,
-                                    cluster_name, process_runner,
-                                    use_internal_ip)
+            return SSHCommandRunner(**common_args)

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -328,10 +328,12 @@ class DockerCommandRunner(SSHCommandRunner):
         self.ssh_command_runner.run_rsync_down(source, target)
 
     def remote_shell_command_str(self):
-        return "ssh -tt -o IdentitiesOnly=yes -i {} {}@{} docker exec -it {} "
-        "/bin/bash\n".format(self.ssh_command_runner.ssh_private_key,
-                             self.ssh_command_runner.ssh_user,
-                             self.ssh_command_runner.ssh_ip, self.docker_name)
+        ## TODO(ilr): FIXME
+        return "ssh -tt -o IdentitiesOnly=yes -i {} {}@{} docker \
+            exec -it {} /bin/bash\n".format(
+            self.ssh_command_runner.ssh_private_key,
+            self.ssh_command_runner.ssh_user, self.ssh_command_runner.ssh_ip,
+            self.docker_name)
 
     def clean_squiggly(self, string):
         return string.replace(

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -298,7 +298,7 @@ class SSHCommandRunner:
 
 
 class DockerCommandRunner(SSHCommandRunner):
-    def __init__(self, doker_config, log_prefix, node_id, provider,
+    def __init__(self, docker_config, log_prefix, node_id, provider,
                  auth_config, cluster_name, process_runner, use_internal_ip):
         self.ssh_command_runner = SSHCommandRunner(
             log_prefix, node_id, provider, auth_config, cluster_name,

--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -328,11 +328,9 @@ class DockerCommandRunner(SSHCommandRunner):
         self.ssh_command_runner.run_rsync_down(source, target)
 
     def remote_shell_command_str(self):
-        ## TODO(ilr): FIXME
-        return "ssh -tt -o IdentitiesOnly=yes -i {} {}@{} docker \
-            exec -it {} /bin/bash\n".format(
-            self.ssh_command_runner.ssh_private_key,
-            self.ssh_command_runner.ssh_user, self.ssh_command_runner.ssh_ip,
+        inner_str = self.ssh_command_runner.remote_shell_command_str().replace(
+            "ssh", "ssh -tt", 1).strip("\n")
+        return inner_str + " docker exec -it {} /bin/bash\n".format(
             self.docker_name)
 
     def clean_squiggly(self, string):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR is the first in a few PRs to refactor how the autoscaler interfaces with docker. This PR mainly focuses on how the CommandRunner is instantiated. The DockerCommandRunner mostly passes commands down to an enclosed SSHCommandRunner. The main functionality change
 is that rsync actually sends the file into docker.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #4183
Closes #4403
Replaces #8527
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
