### PR TITLE
[tune] BayesOpt - finish early when optimizer converges

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -37,6 +37,14 @@ py_test(
 )
 
 py_test(
+    name = "test_convergence_gaussian_process",
+    size = "small",
+    srcs = ["tests/test_convergence_gaussian_process.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive"],
+)
+
+py_test(
     name = "test_dependency",
     size = "small",
     srcs = ["tests/test_dependency.py"],

--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -189,8 +189,11 @@ class BayesOptSearch(Searcher):
         self._config_counter[config_hash] += 1
         top_repeats = max(self._config_counter.values())
 
+        # If patience is set and we've repeated a trial numerous times,
+        # we terminate the experiment.
         if self._patience is not None and top_repeats > self._patience:
             return Searcher.FINISHED
+        # If we have seen a value before, we'll skip it.
         if already_seen and self._skip_duplicate:
             logger.info("Skipping duplicated config: {}.".format(config))
             return None

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -121,7 +121,11 @@ class Searcher:
             trial_id (str): Trial ID used for subsequent notifications.
 
         Returns:
-            dict|None: Configuration for a trial, if possible.
+            dict | FINISHED | None: Configuration for a trial, if possible.
+                If FINISHED is returned, Tune will be notified that
+                no more suggestions/configurations will be provided.
+                If None is returned, Tune will skip the querying of the
+                searcher for this step.
 
         """
         raise NotImplementedError
@@ -174,7 +178,7 @@ class ConcurrencyLimiter(Searcher):
         if len(self.live_trials) >= self.max_concurrent:
             return
         suggestion = self.searcher.suggest(trial_id)
-        if suggestion:
+        if suggestion not in (None, Searcher.FINISHED):
             self.live_trials.add(trial_id)
         return suggestion
 

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -57,6 +57,7 @@ class Searcher:
 
 
     """
+    FINISHED = "FINISHED"
 
     def __init__(self,
                  metric="episode_reward_mean",
@@ -251,6 +252,11 @@ class SearchGenerator(SearchAlgorithm):
         logger.debug("creating trial")
         trial_id = Trial.generate_id()
         suggested_config = self.searcher.suggest(trial_id)
+        if suggested_config == Searcher.FINISHED:
+            self._finished = True
+            logger.debug("Searcher has finished.")
+            return
+
         if suggested_config is None:
             return
         spec = copy.deepcopy(experiment_spec)

--- a/python/ray/tune/suggest/suggestion.py
+++ b/python/ray/tune/suggest/suggestion.py
@@ -173,8 +173,10 @@ class ConcurrencyLimiter(Searcher):
     def suggest(self, trial_id):
         if len(self.live_trials) >= self.max_concurrent:
             return
-        self.live_trials.add(trial_id)
-        return self.searcher.suggest(trial_id)
+        suggestion = self.searcher.suggest(trial_id)
+        if suggestion:
+            self.live_trials.add(trial_id)
+        return suggestion
 
     def on_trial_complete(self, trial_id, result=None, error=False):
         if trial_id not in self.live_trials:

--- a/python/ray/tune/tests/test_convergence_gaussian_process.py
+++ b/python/ray/tune/tests/test_convergence_gaussian_process.py
@@ -2,7 +2,6 @@ import ray
 from ray import tune
 from ray.tune.suggest.bayesopt import BayesOptSearch
 from ray.tune.stopper import EarlyStopping
-from ray.tune.schedulers import AsyncHyperBandScheduler
 import unittest
 
 
@@ -13,6 +12,7 @@ def loss(config, reporter):
 
 class ConvergenceTest(unittest.TestCase):
     """Test convergence in gaussian process."""
+
     def test_convergence_gaussian_process(self):
         ray.init()
 
@@ -20,29 +20,21 @@ class ConvergenceTest(unittest.TestCase):
             "x": (0, 20)  # This is the space of parameters to explore
         }
 
-        resources_per_trial = {
-            "cpu": 1,
-            "gpu": 0
-        }
+        resources_per_trial = {"cpu": 1, "gpu": 0}
 
         # Following bayesian optimization
         gp = BayesOptSearch(
-            space,
-            metric="loss",
-            mode="min",
-            random_search_steps=10
-        )
+            space, metric="loss", mode="min", random_search_steps=10)
 
         # Execution of the BO.
-        tune.run(
+        analysis = tune.run(
             loss,
-            stop=EarlyStopping("loss", mode="min", patience=5),
+            # stop=EarlyStopping("loss", mode="min", patience=5),
             search_alg=gp,
             config={},
             num_samples=100,  # Number of iterations
             resources_per_trial=resources_per_trial,
             raise_on_failed_trial=False,
-            verbose=0
-        )
+            verbose=1)
 
         ray.shutdown()

--- a/python/ray/tune/tests/test_convergence_gaussian_process.py
+++ b/python/ray/tune/tests/test_convergence_gaussian_process.py
@@ -1,7 +1,9 @@
+import numpy as np
+
 import ray
 from ray import tune
 from ray.tune.suggest.bayesopt import BayesOptSearch
-from ray.tune.stopper import EarlyStopping
+from ray.tune.suggest import ConcurrencyLimiter
 import unittest
 
 
@@ -14,7 +16,10 @@ class ConvergenceTest(unittest.TestCase):
     """Test convergence in gaussian process."""
 
     def test_convergence_gaussian_process(self):
-        ray.init()
+        np.random.seed(0)
+        ray.init(
+            local_mode=True, num_cpus=1,
+            num_gpus=1)
 
         space = {
             "x": (0, 20)  # This is the space of parameters to explore
@@ -25,6 +30,8 @@ class ConvergenceTest(unittest.TestCase):
         # Following bayesian optimization
         gp = BayesOptSearch(
             space, metric="loss", mode="min", random_search_steps=10)
+        gp.repeat_float_precision = 5
+        gp = ConcurrencyLimiter(gp, 1)
 
         # Execution of the BO.
         analysis = tune.run(
@@ -35,6 +42,8 @@ class ConvergenceTest(unittest.TestCase):
             num_samples=100,  # Number of iterations
             resources_per_trial=resources_per_trial,
             raise_on_failed_trial=False,
+            fail_fast=True,
             verbose=1)
+        assert len(analysis.trials) == 41
 
         ray.shutdown()

--- a/python/ray/tune/tests/test_convergence_gaussian_process.py
+++ b/python/ray/tune/tests/test_convergence_gaussian_process.py
@@ -17,9 +17,7 @@ class ConvergenceTest(unittest.TestCase):
 
     def test_convergence_gaussian_process(self):
         np.random.seed(0)
-        ray.init(
-            local_mode=True, num_cpus=1,
-            num_gpus=1)
+        ray.init(local_mode=True, num_cpus=1, num_gpus=1)
 
         space = {
             "x": (0, 20)  # This is the space of parameters to explore

--- a/python/ray/tune/tests/test_convergence_gaussian_process.py
+++ b/python/ray/tune/tests/test_convergence_gaussian_process.py
@@ -1,0 +1,48 @@
+import ray
+from ray import tune
+from ray.tune.suggest.bayesopt import BayesOptSearch
+from ray.tune.stopper import EarlyStopping
+from ray.tune.schedulers import AsyncHyperBandScheduler
+import unittest
+
+
+def loss(config, reporter):
+    x = config.get("x")
+    reporter(loss=x**2)  # A simple function to optimize
+
+
+class ConvergenceTest(unittest.TestCase):
+    """Test convergence in gaussian process."""
+    def test_convergence_gaussian_process(self):
+        ray.init()
+
+        space = {
+            "x": (0, 20)  # This is the space of parameters to explore
+        }
+
+        resources_per_trial = {
+            "cpu": 1,
+            "gpu": 0
+        }
+
+        # Following bayesian optimization
+        gp = BayesOptSearch(
+            space,
+            metric="loss",
+            mode="min",
+            random_search_steps=10
+        )
+
+        # Execution of the BO.
+        tune.run(
+            loss,
+            stop=EarlyStopping("loss", mode="min", patience=5),
+            search_alg=gp,
+            config={},
+            num_samples=100,  # Number of iterations
+            resources_per_trial=resources_per_trial,
+            raise_on_failed_trial=False,
+            verbose=0
+        )
+
+        ray.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This pull request will introduce a cache to avoid exploring multiple times the same point.

In the future, we should refactor the SearchAlgorithms to allow this to work across different algorithms. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)