### PR TITLE
[core] Don't warn if we're waiting for workers to start

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -425,6 +425,12 @@ void NodeManager::DoLocalGC() {
 // debug_dump_period_ milliseconds.
 // See https://github.com/ray-project/ray/issues/5790 for details.
 void NodeManager::WarnResourceDeadlock() {
+  if (local_queues_.GetTasks(TaskState::RUNNING).empty()) {
+    // No tasks running at all, don't warn. Probably we are just waiting for
+    // workers to start and join the pool.
+    resource_deadlock_warned_ = false;
+    return;
+  }
   // Check if any progress is being made on this raylet.
   for (const auto &task : local_queues_.GetTasks(TaskState::RUNNING)) {
     // Ignore blocked tasks.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/8326