### PR TITLE
[WIP] add redis-password to the memory cli command

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1022,12 +1022,18 @@ def stat(address):
     required=False,
     type=str,
     help="Override the address to connect to.")
-def memory(address):
+@click.option(
+    "--redis-password",
+    required=False,
+    type=str,
+    default=ray_constants.REDIS_DEFAULT_PASSWORD,
+    help="If provided, secure Redis ports with this password")
+def memory(address, redis_password):
     """Print object references held in a Ray cluster."""
     if not address:
         address = services.find_redis_address_or_die()
     logger.info("Connecting to Ray instance at {}.".format(address))
-    ray.init(address=address)
+    ray.init(address=address, redis_password=redis_password)
     print(ray.internal.internal_api.memory_summary())
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Not all of the cli commands work with ad-hoc clusters. This is the one that I noticed first.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- - it crashed with "flake8: error: unrecognized arguments: --inline-quotes --no-avoid-escape python/ray/scripts/scripts.py"
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- - appears to be automatic
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- - beats me, that's why it's a draft PR
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
