### PR TITLE
Add ability to specify SOCKS proxy for SSH connections

### DIFF
--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -220,8 +220,8 @@ class SSHOptions:
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
         return ["-i", self.ssh_key] + [
             x for y in (["-o", "{}={}".format(k, v)]
-                        for k, v in self.arg_dict.items() if v is not None) for x in y
-        ]
+                        for k, v in self.arg_dict.items() if v is not None)
+            for x in y]
 
 
 class SSHCommandRunner(CommandRunnerInterface):
@@ -244,9 +244,9 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.ssh_control_path = ssh_control_path
         self.ssh_ip = None
         self.ssh_proxy_command = auth_config.get("ssh_proxy_command", None)
-        self.base_ssh_options = SSHOptions(self.ssh_private_key,
-                                           self.ssh_control_path,
-                                           ProxyCommand=self.ssh_proxy_command)
+        self.ssh_options = SSHOptions(self.ssh_private_key,
+                                      self.ssh_control_path,
+                                      ProxyCommand=self.ssh_proxy_command)
 
     def _get_node_ip(self):
         if self.use_internal_ip:
@@ -294,7 +294,7 @@ class SSHCommandRunner(CommandRunnerInterface):
             with_output=False,
             ssh_options_override=None,
             **kwargs):
-        ssh_options = ssh_options_override or self.base_ssh_options
+        ssh_options = ssh_options_override or self.ssh_options
 
         assert isinstance(
             ssh_options, SSHOptions
@@ -344,8 +344,8 @@ class SSHCommandRunner(CommandRunnerInterface):
         self._set_ssh_ip_if_required()
         self.process_runner.check_call([
             "rsync", "--rsh",
-            subprocess.list2cmdline(["ssh"] +
-                     self.base_ssh_options.to_ssh_options_list(timeout=120)),
+            subprocess.list2cmdline(
+                ["ssh"] + self.ssh_options.to_ssh_options_list(timeout=120)),
             "-avz", source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
                                               target)
         ])
@@ -354,8 +354,8 @@ class SSHCommandRunner(CommandRunnerInterface):
         self._set_ssh_ip_if_required()
         self.process_runner.check_call([
             "rsync", "--rsh",
-            subprocess.list2cmdline(["ssh"] +
-                     self.base_ssh_options.to_ssh_options_list(timeout=120)),
+            subprocess.list2cmdline(
+                ["ssh"] + self.ssh_options.to_ssh_options_list(timeout=120)),
             "-avz", "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
                                       source), target
         ])

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -219,8 +219,8 @@ class SSHOptions:
     def to_ssh_options_list(self, *, timeout=60):
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
         return ["-i", self.ssh_key] + [
-            x for y in (["-o", "{}={}".format(k, v)]
-                        for k, v in self.arg_dict.items()) for x in y
+            x for y in (["-o", "{}={}".format(k, quote(v))]
+                        for k, v in self.arg_dict.items() if v is not None) for x in y
         ]
 
 
@@ -243,8 +243,10 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.ssh_user = auth_config["ssh_user"]
         self.ssh_control_path = ssh_control_path
         self.ssh_ip = None
+        self.ssh_proxy_command = auth_config.get("ssh_proxy_command", None)
         self.base_ssh_options = SSHOptions(self.ssh_private_key,
-                                           self.ssh_control_path)
+                                           self.ssh_control_path,
+                                           ProxyCommand=self.ssh_proxy_command)
 
     def _get_node_ip(self):
         if self.use_internal_ip:

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -220,8 +220,9 @@ class SSHOptions:
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
         return ["-i", self.ssh_key] + [
             x for y in (["-o", "{}={}".format(k, v)]
-                        for k, v in self.arg_dict.items() if v is not None)
-            for x in y]
+                        for k, v in self.arg_dict.items()
+                        if v is not None) for x in y
+        ]
 
 
 class SSHCommandRunner(CommandRunnerInterface):
@@ -244,9 +245,10 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.ssh_control_path = ssh_control_path
         self.ssh_ip = None
         self.ssh_proxy_command = auth_config.get("ssh_proxy_command", None)
-        self.ssh_options = SSHOptions(self.ssh_private_key,
-                                      self.ssh_control_path,
-                                      ProxyCommand=self.ssh_proxy_command)
+        self.ssh_options = SSHOptions(
+            self.ssh_private_key,
+            self.ssh_control_path,
+            ProxyCommand=self.ssh_proxy_command)
 
     def _get_node_ip(self):
         if self.use_internal_ip:

--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -219,7 +219,7 @@ class SSHOptions:
     def to_ssh_options_list(self, *, timeout=60):
         self.arg_dict["ConnectTimeout"] = "{}s".format(timeout)
         return ["-i", self.ssh_key] + [
-            x for y in (["-o", "{}={}".format(k, quote(v))]
+            x for y in (["-o", "{}={}".format(k, v)]
                         for k, v in self.arg_dict.items() if v is not None) for x in y
         ]
 
@@ -344,7 +344,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         self._set_ssh_ip_if_required()
         self.process_runner.check_call([
             "rsync", "--rsh",
-            " ".join(["ssh"] +
+            subprocess.list2cmdline(["ssh"] +
                      self.base_ssh_options.to_ssh_options_list(timeout=120)),
             "-avz", source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
                                               target)
@@ -354,7 +354,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         self._set_ssh_ip_if_required()
         self.process_runner.check_call([
             "rsync", "--rsh",
-            " ".join(["ssh"] +
+            subprocess.list2cmdline(["ssh"] +
                      self.base_ssh_options.to_ssh_options_list(timeout=120)),
             "-avz", "{}@{}:{}".format(self.ssh_user, self.ssh_ip,
                                       source), target

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -321,6 +321,9 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
 
         # Rewrite the auth config so that the head node can update the workers
         remote_config = copy.deepcopy(config)
+        # drop proxy options if they exist, otherwise
+        # head node won't be able to connect to workers
+        remote_config["auth"].pop("ssh_proxy_command", None)
         if config["provider"]["type"] != "kubernetes":
             remote_key_path = "~/ray_bootstrap_key.pem"
             remote_config["auth"]["ssh_private_key"] = remote_key_path

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -160,6 +160,10 @@
                 },
                 "ssh_private_key": { 
                     "type": "string"
+                },
+                "ssh_proxy_command": {
+                    "description": "A value for ProxyCommand ssh option, for connecting through proxies. Example: nc -x proxy.example.com:1234 %h %p",
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
In some cases like corporate networks external SSH connections must go through a proxy.
This change adds optional field in the autoscaler configuration to specify socks host (and port) for SSH. In current implementation it requires that `nc` is also installed, as it is used internally as `ProxyCommand`.

## Related issue number
Closes https://github.com/modin-project/modin/issues/1539
I know this is an external issue, I can make an issue inside Ray project if needed.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

## Testing strategy justification

There is currently no automated testing for this, but I have added some validation in JSON schema, and we verified this works correctly manually. I'm open at adding tests if pointed at best location for those, as I don't know Ray codebase well enough yet.