### PR TITLE
Upgrade Bazel and add required patches

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -199,6 +199,7 @@ def ray_deps_setup():
         url = "https://github.com/jupp0r/prometheus-cpp/archive/60eaa4ea47b16751a8e8740b05fe70914c68a480.tar.gz",
         sha256 = "ec825b802487ac18b0d98e2e8b7961487b12562f8f82e424521d0a891d9e1373",
         patches = [
+            "//thirdparty/patches:prometheus-windows-headers.patch",
             # https://github.com/jupp0r/prometheus-cpp/pull/225
             "//thirdparty/patches:prometheus-windows-zlib.patch",
             "//thirdparty/patches:prometheus-windows-pollfd.patch",

--- a/ci/travis/install-bazel.sh
+++ b/ci/travis/install-bazel.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
-version="1.1.0"
+version="3.2.0"
 achitecture="${HOSTTYPE}"
 platform="unknown"
 case "${OSTYPE}" in

--- a/thirdparty/patches/prometheus-windows-headers.patch
+++ b/thirdparty/patches/prometheus-windows-headers.patch
@@ -1,0 +1,7 @@
+diff --git core/src/histogram.cc core/src/histogram.cc
+--- core/src/histogram.cc
++++ core/src/histogram.cc
+@@ -6,1 +6,2 @@
+ #include <numeric>
++#include <stdexcept>
+-- 


### PR DESCRIPTION
## Why are these changes needed?

Our Bazel is out-of-date and also lacks late fixes for some bugs that trigger on Windows.

The patch is to compensate for implicit inclusions that are no longer occurring in the compiler toolchain that the newer Bazel uses.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
