### PR TITLE
Change GitHub Actions path to one with spaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
             python-version: 3.6
     env:
       PYTHON: ${{ matrix.python-version }}
-      TRAVIS_BUILD_DIR: ${{ github.workspace }}
       TRAVIS_COMMIT: ${{ github.sha }}
       #TRAVIS_PULL_REQUEST is defined in the scripts to account for "false"
     steps:
@@ -37,6 +36,8 @@ jobs:
       shell: bash -e -o pipefail -l {0}
       run: |
         # Note: only configure settings here that are required _before_ the repository is cloned (such as Git settings).
+        # Put a path with spaces (and use common words like 'src') to verify correct builds
+        export GITHUB_WORKSPACE="${GITHUB_WORKSPACE%/*} src/${GITHUB_WORKSPACE##*/}"
         if [ ! -f ~/.profile ] && [ ! -f ~/.bash_profile ]; then  # missing on some machines, but needed for ~/.bashrc
           echo 'if [ -n "${BASH_VERSION}" ] && [ -f ~/.bashrc ]; then . ~/.bashrc; fi' >> ~/.profile
         fi

--- a/ci/travis/test-wheels.sh
+++ b/ci/travis/test-wheels.sh
@@ -16,9 +16,13 @@ case "${OSTYPE}" in
   *) echo "Unrecognized platform."; exit 1;;
 esac
 
-TEST_DIR="$TRAVIS_BUILD_DIR/python/ray/tests"
+BUILD_DIR="${TRAVIS_BUILD_DIR-}"
+if [ -z "${BUILD_DIR}" ]; then
+  BUILD_DIR="${GITHUB_WORKSPACE}"
+fi
+TEST_DIR="${BUILD_DIR}/python/ray/tests"
 TEST_SCRIPTS=("$TEST_DIR/test_microbenchmarks.py" "$TEST_DIR/test_basic.py")
-UI_TEST_SCRIPT="$TRAVIS_BUILD_DIR/python/ray/tests/test_webui.py"
+UI_TEST_SCRIPT="${BUILD_DIR}/python/ray/tests/test_webui.py"
 
 function retry {
   local n=1


### PR DESCRIPTION
## Why are these changes needed?

Helps make sure Ray runs correctly when paths contain spaces by putting spaces in the CI build path.

## Related issue number

#631

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
