### PR TITLE
Fix dragonfly install instructions

### DIFF
--- a/python/ray/tune/suggest/dragonfly.py
+++ b/python/ray/tune/suggest/dragonfly.py
@@ -99,7 +99,7 @@ class DragonflySearch(Searcher):
                  **kwargs):
         assert dragonfly is not None, """dragonfly must be installed!
             You can install Dragonfly with the command:
-            `pip install dragonfly`."""
+            `pip install dragonfly-opt`."""
         assert mode in ["min", "max"], "`mode` must be 'min' or 'max'!"
 
         self._initial_points = []


### PR DESCRIPTION
## Why are these changes needed?

If dragonfly is not installed, an error is raised that says to install via `pip install dragonfly`. This is incorrect; it should be `pip install dragonfly-opt`. 

## Related issue number

https://github.com/ray-project/ray/issues/8084, https://github.com/ray-project/ray/pull/8086

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
