### PR TITLE
Fix Serve Flaky test_api::test_batching

### DIFF
--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -158,7 +158,12 @@ def test_batching(serve_instance):
 
     # set the max batch size
     serve.create_backend(
-        "counter:v11", BatchingExample, config={"max_batch_size": 5})
+        "counter:v11",
+        BatchingExample,
+        config={
+            "max_batch_size": 5,
+            "batch_wait_timeout": 1
+        })
     serve.create_endpoint(
         "counter1", backend="counter:v11", route="/increment2")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Serve's test batching is flaky in travis: 
https://travis-ci.com/github/ray-project/ray/jobs/346769123

```
    
        counter_result = ray.get(future_list)
        # since count is only updated per batch of queries
        # If there atleast one __call__ fn call with batch size greater than 1
        # counter result will always be less than 20
>       assert max(counter_result) < 20
E       assert 20 < 20
E        +  where 20 = max([1, 2, 3, 4, 5, 6, ...])
```

I think the error come from that we expect router will send all queries to the worker, but due to the slow environment, workers finishes the query faster than the router can sends them, so there aren't any batching effect. I can't reproduce this locally so I expect it's part of travis environment issue. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
