### PR TITLE
[projects] Fix repo URL in create command

### DIFF
--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -103,7 +103,7 @@ def create(project_name, cluster_yaml, requirements):
         try:
             repo = subprocess.check_output(
                 "git remote get-url origin".split(" ")).strip()
-            logger.info("Setting repo URL to %s", repo)
+            logger.info("Setting repo URL to %s", repo.decode('UTF-8'))
         except subprocess.CalledProcessError:
             pass
 

--- a/python/ray/projects/scripts.py
+++ b/python/ray/projects/scripts.py
@@ -121,7 +121,7 @@ def create(project_name, cluster_yaml, requirements):
                 r"{{repo_string}}", "# repo: {}".format("..."))
         else:
             project_template = project_template.replace(
-                r"{{repo_string}}", "repo: {}".format(repo))
+                r"{{repo_string}}", "repo: {}".format(repo.decode('utf-8')))
     with open(PROJECT_YAML, "w") as f:
         f.write(project_template)
 


### PR DESCRIPTION
## Why are these changes needed?

The current output of `ray project create myproj` looks like:
```
2020-06-10 10:52:48,403	WARNING scripts.py:85 -- Using default autoscaler yaml
2020-06-10 10:52:48,406	WARNING scripts.py:95 -- Using default requirements.txt
2020-06-10 10:52:48,449	INFO scripts.py:106 -- Setting repo URL to b'git@github.com:user/repo.git'
```
Note that the output indicates that the repo is a byte-string. 

From [the docs](https://docs.python.org/3/library/subprocess.html#subprocess.check_output):
> By default, this function will return the data as encoded bytes. The actual encoding of the output data may depend on the command being invoked, so the decoding to text will often need to be handled at the application level.

## Related issue number
n/a

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
