### PR TITLE
[Release Test] Node failure fix.

### DIFF
--- a/ci/long_running_tests/workloads/node_failures.py
+++ b/ci/long_running_tests/workloads/node_failures.py
@@ -4,7 +4,7 @@ import time
 
 import ray
 from ray.cluster_utils import Cluster
-from ray.test_utils import get_non_head_nodes
+from ray.test_utils import get_other_nodes
 
 num_redis_shards = 5
 redis_max_memory = 10**8
@@ -51,8 +51,8 @@ while True:
 
     for _ in range(100):
         previous_ids = [f.remote(previous_id) for previous_id in previous_ids]
+    node_to_kill = get_other_nodes(cluster, exclude_head=True)[0]
 
-    node_to_kill = get_non_head_nodes(cluster)[0]
     # Remove the first non-head node.
     cluster.remove_node(node_to_kill)
     cluster.add_node()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`ray.init(cluster.address)` does not guarantee that Ray is initialized in the head node. This means that if the script is connected to one of worker nodes in the cluster, and if that node is removed by `cluster.remove_node`, the local raylet connected to the script fails. Since we don't handle local raylet failure now, this will cause tests to be broken when 
- the script is connected to one of the worker nodes
- and that node is removed by `cluster.remove_node(node_to_kill)`. 

This PR uses a `get_other_nodes(exclude_head=True)`, which excludes head node + "node that is connected to the script" from the list of nodes to be removed. 



## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
