### PR TITLE
Optimize gcs server resubscribe

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1159,8 +1159,6 @@ cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    # TODO(swang): Enable again once pubsub client supports GCS server restart.
-    tags = ["manual"],
     deps = [
         ":gcs_server_lib",
         ":gcs_test_util_lib",

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -153,10 +153,11 @@ class ActorInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ActorInfoAccessor() = default;
@@ -204,10 +205,11 @@ class JobInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   JobInfoAccessor() = default;
@@ -313,10 +315,11 @@ class TaskInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   TaskInfoAccessor() = default;
@@ -383,10 +386,11 @@ class ObjectInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ObjectInfoAccessor() = default;
@@ -560,10 +564,11 @@ class NodeInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   NodeInfoAccessor() = default;
@@ -663,10 +668,11 @@ class WorkerInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to re
+  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  /// \return Status
-  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   WorkerInfoAccessor() = default;

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -153,11 +153,12 @@ class ActorInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ActorInfoAccessor() = default;
@@ -205,11 +206,12 @@ class JobInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   JobInfoAccessor() = default;
@@ -315,11 +317,12 @@ class TaskInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   TaskInfoAccessor() = default;
@@ -386,11 +389,12 @@ class ObjectInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ObjectInfoAccessor() = default;
@@ -564,11 +568,12 @@ class NodeInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   NodeInfoAccessor() = default;
@@ -668,11 +673,12 @@ class WorkerInfoAccessor {
 
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
-  /// PubSub server restart will cause GCS server restart. In this case, we need to re
-  /// subscribe from PubSub server, otherwise we only need to fetch data from GCS server.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
   ///
   /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
-  virtual void AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
+  virtual void AsyncResubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   WorkerInfoAccessor() = default;

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -154,8 +154,9 @@ class ActorInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ActorInfoAccessor() = default;
@@ -204,8 +205,9 @@ class JobInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   JobInfoAccessor() = default;
@@ -312,8 +314,9 @@ class TaskInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   TaskInfoAccessor() = default;
@@ -381,8 +384,9 @@ class ObjectInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   ObjectInfoAccessor() = default;
@@ -557,8 +561,9 @@ class NodeInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   NodeInfoAccessor() = default;
@@ -659,8 +664,9 @@ class WorkerInfoAccessor {
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   ///
+  /// \param is_pubsub_server_restarted Whether pubsub server is restarted.
   /// \return Status
-  virtual Status AsyncReSubscribe() = 0;
+  virtual Status AsyncReSubscribe(bool is_pubsub_server_restarted) = 0;
 
  protected:
   WorkerInfoAccessor() = default;

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -514,10 +514,9 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToNodeChange(
   RAY_CHECK(node_change_callback_ == nullptr);
   node_change_callback_ = subscribe;
 
-  fetch_node_data_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto callback = [this, subscribe, done](
-                        const Status &status,
-                        const std::vector<GcsNodeInfo> &node_info_list) {
+  fetch_node_data_operation_ = [this](const StatusCallback &done) {
+    auto callback = [this, done](const Status &status,
+                                 const std::vector<GcsNodeInfo> &node_info_list) {
       for (auto &node_info : node_info_list) {
         HandleNotification(node_info);
       }
@@ -528,7 +527,7 @@ Status ServiceBasedNodeInfoAccessor::AsyncSubscribeToNodeChange(
     RAY_CHECK_OK(AsyncGetAll(callback));
   };
 
-  subscribe_node_operation_ = [this, subscribe](const StatusCallback &done) {
+  subscribe_node_operation_ = [this](const StatusCallback &done) {
     auto on_subscribe = [this](const std::string &id, const std::string &data) {
       GcsNodeInfo node_info;
       node_info.ParseFromString(data);

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -274,7 +274,7 @@ class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
-  /// Save the subscribe operation in this function, so we can call it again when PubSub
+  /// Save the subscribe operations, so we can call them again when PubSub
   /// server restarts from a failure.
   std::unordered_map<TaskID, SubscribeOperation> subscribe_task_operations_;
   std::unordered_map<TaskID, SubscribeOperation> subscribe_task_lease_operations_;
@@ -318,7 +318,7 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
   void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
-  /// Save the subscribe operation in this function, so we can call it again when PubSub
+  /// Save the subscribe operations, so we can call them again when PubSub
   /// server restarts from a failure.
   std::unordered_map<ObjectID, SubscribeOperation> subscribe_object_operations_;
 

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -49,7 +49,7 @@ class ServiceBasedJobInfoAccessor : public JobInfoAccessor {
 
   Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -110,7 +110,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
       const ActorID &actor_id,
       const OptionalItemCallback<rpc::ActorCheckpointIdData> &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -195,7 +195,7 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
       const ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
       const StatusCallback &done) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -271,7 +271,7 @@ class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
       const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
       const StatusCallback &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -315,7 +315,7 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
 
   Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -386,7 +386,7 @@ class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
       const std::unordered_map<std::string, std::string> &worker_info,
       const StatusCallback &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override;
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -23,7 +23,8 @@
 namespace ray {
 namespace gcs {
 
-using SubscribeOperation = std::function<Status(const StatusCallback &done)>;
+using SubscribeOperation =
+    std::function<Status(const StatusCallback &done, bool is_pubsub_server_restarted)>;
 
 class ServiceBasedGcsClient;
 
@@ -47,7 +48,7 @@ class ServiceBasedJobInfoAccessor : public JobInfoAccessor {
 
   Status AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &callback) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS
@@ -108,7 +109,7 @@ class ServiceBasedActorInfoAccessor : public ActorInfoAccessor {
       const ActorID &actor_id,
       const OptionalItemCallback<rpc::ActorCheckpointIdData> &callback) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS
@@ -185,7 +186,7 @@ class ServiceBasedNodeInfoAccessor : public NodeInfoAccessor {
       const ItemCallback<rpc::HeartbeatBatchTableData> &subscribe,
       const StatusCallback &done) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS
@@ -257,7 +258,7 @@ class ServiceBasedTaskInfoAccessor : public TaskInfoAccessor {
       const std::shared_ptr<rpc::TaskReconstructionData> &data_ptr,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS
@@ -296,7 +297,7 @@ class ServiceBasedObjectInfoAccessor : public ObjectInfoAccessor {
 
   Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS
@@ -363,7 +364,7 @@ class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
       const std::unordered_map<std::string, std::string> &worker_info,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe() override;
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override;
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when GCS

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -47,13 +47,13 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   };
   std::pair<std::string, int> address = get_server_address();
 
-  auto re_subscribe = [this]() {
-    RAY_CHECK_OK(job_accessor_->AsyncReSubscribe());
-    RAY_CHECK_OK(actor_accessor_->AsyncReSubscribe());
-    RAY_CHECK_OK(node_accessor_->AsyncReSubscribe());
-    RAY_CHECK_OK(task_accessor_->AsyncReSubscribe());
-    RAY_CHECK_OK(object_accessor_->AsyncReSubscribe());
-    RAY_CHECK_OK(worker_accessor_->AsyncReSubscribe());
+  auto re_subscribe = [this](bool is_pubsub_server_restarted) {
+    RAY_CHECK_OK(job_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    RAY_CHECK_OK(actor_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    RAY_CHECK_OK(node_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    RAY_CHECK_OK(task_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    RAY_CHECK_OK(object_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    RAY_CHECK_OK(worker_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
   };
 
   // Connect to gcs service.

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -48,12 +48,12 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   std::pair<std::string, int> address = get_server_address();
 
   auto re_subscribe = [this](bool is_pubsub_server_restarted) {
-    RAY_CHECK_OK(job_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
-    RAY_CHECK_OK(actor_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
-    RAY_CHECK_OK(node_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
-    RAY_CHECK_OK(task_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
-    RAY_CHECK_OK(object_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
-    RAY_CHECK_OK(worker_accessor_->AsyncReSubscribe(is_pubsub_server_restarted));
+    job_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    actor_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    node_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    task_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    object_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    worker_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
   };
 
   // Connect to gcs service.

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -48,12 +48,12 @@ Status ServiceBasedGcsClient::Connect(boost::asio::io_service &io_service) {
   std::pair<std::string, int> address = get_server_address();
 
   auto re_subscribe = [this](bool is_pubsub_server_restarted) {
-    job_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
-    actor_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
-    node_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
-    task_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
-    object_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
-    worker_accessor_->AsyncReSubscribe(is_pubsub_server_restarted);
+    job_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    actor_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    node_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    task_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    object_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
+    worker_accessor_->AsyncResubscribe(is_pubsub_server_restarted);
   };
 
   // Connect to gcs service.

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -488,12 +488,6 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
     ASSERT_TRUE(actor.state() == expected_state);
   }
 
-  void CheckActorData(const gcs::ActorTableData &actor, const ActorID &expected_id,
-                      rpc::ActorTableData_ActorState expected_state) {
-    ASSERT_TRUE(actor.actor_id() == expected_id.Binary() &&
-                actor.state() == expected_state);
-  }
-
   // GCS server.
   gcs::GcsServerConfig config_;
   std::unique_ptr<gcs::GcsServer> gcs_server_;
@@ -908,7 +902,8 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // Restart GCS server.
   RestartGcsServer();
 
-  // RPC calls once, triggering GCS client reconnect GCS server and resubscribe.
+  // We need to send a RPC to detect GCS server restart. Then GCS client will
+  // reconnect to GCS server and resubscribe.
   ASSERT_TRUE(GetActor(actor_id).state() ==
               rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
 

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -846,7 +846,7 @@ TEST_F(ServiceBasedGcsClientTest, TestErrorInfo) {
   ASSERT_TRUE(ReportJobError(error_table_data));
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestJobTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestJobTableResubscribe) {
   // Test that subscription of the job table can still work when GCS server restarts.
   JobID job_id = JobID::FromInt(1);
   auto job_table_data = Mocker::GenJobTableData(job_id);
@@ -865,7 +865,7 @@ TEST_F(ServiceBasedGcsClientTest, TestJobTableReSubscribe) {
   WaitPendingDone(job_update_count, 1);
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestActorTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // Test that subscription of the actor table can still work when GCS server restarts.
   JobID job_id = JobID::FromInt(1);
   auto actor_table_data = Mocker::GenActorTableData(job_id);
@@ -932,7 +932,7 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableReSubscribe) {
                  rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestObjectTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {
   ObjectID object1_id = ObjectID::FromRandom();
   ObjectID object2_id = ObjectID::FromRandom();
   ClientID node_id = ClientID::FromRandom();
@@ -974,7 +974,7 @@ TEST_F(ServiceBasedGcsClientTest, TestObjectTableReSubscribe) {
   WaitPendingDone(object2_change_count, 2);
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestNodeTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {
   // Test that subscription of the node table can still work when GCS server restarts.
   // Subscribe to node addition and removal events from GCS and cache those information.
   std::atomic<int> node_change_count(0);
@@ -1024,7 +1024,7 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableReSubscribe) {
   WaitPendingDone(batch_heartbeat_count, 2);
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestTaskTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestTaskTableResubscribe) {
   JobID job_id = JobID::FromInt(6);
   TaskID task_id = TaskID::ForDriverTask(job_id);
   auto task_table_data = Mocker::GenTaskTableData(job_id.Binary(), task_id.Binary());
@@ -1063,7 +1063,7 @@ TEST_F(ServiceBasedGcsClientTest, TestTaskTableReSubscribe) {
   WaitPendingDone(task_count, 1);
 }
 
-TEST_F(ServiceBasedGcsClientTest, TestWorkerTableReSubscribe) {
+TEST_F(ServiceBasedGcsClientTest, TestWorkerTableResubscribe) {
   // Subscribe to all unexpected failure of workers from GCS.
   std::atomic<int> worker_failure_count(0);
   auto on_subscribe = [&worker_failure_count](const WorkerID &worker_id,

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -908,6 +908,10 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   // Restart GCS server.
   RestartGcsServer();
 
+  // RPC calls once, triggering GCS client reconnect GCS server and resubscribe.
+  ASSERT_TRUE(GetActor(actor_id).state() ==
+              rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
+
   // When GCS client detects that GCS server has restarted, but the pub-sub server
   // didn't restart, it will fetch data again from the GCS server. So we'll receive
   // another notification of ALIVE state.
@@ -927,9 +931,9 @@ TEST_F(ServiceBasedGcsClientTest, TestActorTableResubscribe) {
   WaitPendingDone(num_subscribe_all_notifications, 3);
   WaitPendingDone(num_subscribe_one_notifications, 3);
   CheckActorData(subscribe_all_notifications[2],
-                 rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
+                 rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
   CheckActorData(subscribe_one_notifications[2],
-                 rpc::ActorTableData_ActorState::ActorTableData_ActorState_ALIVE);
+                 rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -968,8 +968,6 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableReSubscribe) {
       };
   ASSERT_TRUE(SubscribeBatchHeartbeat(batch_heartbeat_subscribe));
 
-  RestartGcsServer();
-
   auto node_info = Mocker::GenNodeInfo(1);
   ASSERT_TRUE(RegisterNode(*node_info));
   ClientID node_id = ClientID::FromBinary(node_info->node_id());
@@ -978,10 +976,20 @@ TEST_F(ServiceBasedGcsClientTest, TestNodeTableReSubscribe) {
   auto heartbeat = std::make_shared<rpc::HeartbeatTableData>();
   heartbeat->set_client_id(node_info->node_id());
   ASSERT_TRUE(ReportHeartbeat(heartbeat));
-
-  WaitPendingDone(node_change_count, 1);
-  WaitPendingDone(resource_change_count, 1);
   WaitPendingDone(batch_heartbeat_count, 1);
+
+  RestartGcsServer();
+
+  node_info = Mocker::GenNodeInfo(1);
+  ASSERT_TRUE(RegisterNode(*node_info));
+  node_id = ClientID::FromBinary(node_info->node_id());
+  ASSERT_TRUE(UpdateResources(node_id, key));
+  heartbeat->set_client_id(node_info->node_id());
+  ASSERT_TRUE(ReportHeartbeat(heartbeat));
+
+  WaitPendingDone(node_change_count, 2);
+  WaitPendingDone(resource_change_count, 2);
+  WaitPendingDone(batch_heartbeat_count, 2);
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestTaskTableReSubscribe) {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -290,7 +290,7 @@ struct GcsServerMocker {
       return Status::NotImplemented("");
     }
 
-    void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+    void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
   };
 
   class MockedErrorInfoAccessor : public gcs::ErrorInfoAccessor {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -290,9 +290,7 @@ struct GcsServerMocker {
       return Status::NotImplemented("");
     }
 
-    Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-      return Status::NotImplemented("");
-    }
+    void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
   };
 
   class MockedErrorInfoAccessor : public gcs::ErrorInfoAccessor {

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -290,7 +290,9 @@ struct GcsServerMocker {
       return Status::NotImplemented("");
     }
 
-    Status AsyncReSubscribe() override { return Status::NotImplemented(""); }
+    Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
+      return Status::NotImplemented("");
+    }
   };
 
   class MockedErrorInfoAccessor : public gcs::ErrorInfoAccessor {

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -83,7 +83,9 @@ class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
       const ActorID &actor_id,
       const OptionalItemCallback<ActorCheckpointIdData> &callback) override;
 
-  Status AsyncReSubscribe() override { return Status::NotImplemented(""); }
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
+    return Status::NotImplemented("");
+  }
 
  protected:
   virtual std::vector<ActorID> GetAllActorID() const;
@@ -183,7 +185,7 @@ class RedisJobInfoAccessor : public JobInfoAccessor {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
-  Status AsyncReSubscribe() override {
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
     return Status::NotImplemented("AsyncReSubscribe not implemented");
   }
 
@@ -243,7 +245,7 @@ class RedisTaskInfoAccessor : public TaskInfoAccessor {
       const std::shared_ptr<TaskReconstructionData> &data_ptr,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe() override {
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
     return Status::NotImplemented("AsyncReSubscribe not implemented");
   }
 
@@ -296,7 +298,9 @@ class RedisObjectInfoAccessor : public ObjectInfoAccessor {
 
   Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
 
-  Status AsyncReSubscribe() override { return Status::NotImplemented(""); }
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
+    return Status::NotImplemented("");
+  }
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -377,7 +381,7 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
       const ItemCallback<HeartbeatBatchTableData> &subscribe,
       const StatusCallback &done) override;
 
-  Status AsyncReSubscribe() override {
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
     return Status::NotImplemented("AsyncReSubscribe not implemented");
   }
 
@@ -454,7 +458,9 @@ class RedisWorkerInfoAccessor : public WorkerInfoAccessor {
       const std::unordered_map<std::string, std::string> &worker_info,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe() override { return Status::NotImplemented(""); }
+  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
+    return Status::NotImplemented("");
+  }
 
  private:
   RedisGcsClient *client_impl_{nullptr};

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -83,9 +83,7 @@ class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
       const ActorID &actor_id,
       const OptionalItemCallback<ActorCheckpointIdData> &callback) override;
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  protected:
   virtual std::vector<ActorID> GetAllActorID() const;
@@ -185,9 +183,7 @@ class RedisJobInfoAccessor : public JobInfoAccessor {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("AsyncReSubscribe not implemented");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   /// Append job information to GCS asynchronously.
@@ -245,9 +241,7 @@ class RedisTaskInfoAccessor : public TaskInfoAccessor {
       const std::shared_ptr<TaskReconstructionData> &data_ptr,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("AsyncReSubscribe not implemented");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -298,9 +292,7 @@ class RedisObjectInfoAccessor : public ObjectInfoAccessor {
 
   Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -381,9 +373,7 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
       const ItemCallback<HeartbeatBatchTableData> &subscribe,
       const StatusCallback &done) override;
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("AsyncReSubscribe not implemented");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -458,9 +448,7 @@ class RedisWorkerInfoAccessor : public WorkerInfoAccessor {
       const std::unordered_map<std::string, std::string> &worker_info,
       const StatusCallback &callback) override;
 
-  Status AsyncReSubscribe(bool is_pubsub_server_restarted) override {
-    return Status::NotImplemented("");
-  }
+  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -83,7 +83,7 @@ class RedisLogBasedActorInfoAccessor : public ActorInfoAccessor {
       const ActorID &actor_id,
       const OptionalItemCallback<ActorCheckpointIdData> &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  protected:
   virtual std::vector<ActorID> GetAllActorID() const;
@@ -183,7 +183,7 @@ class RedisJobInfoAccessor : public JobInfoAccessor {
     return Status::NotImplemented("AsyncGetAll not implemented");
   }
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   /// Append job information to GCS asynchronously.
@@ -241,7 +241,7 @@ class RedisTaskInfoAccessor : public TaskInfoAccessor {
       const std::shared_ptr<TaskReconstructionData> &data_ptr,
       const StatusCallback &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -292,7 +292,7 @@ class RedisObjectInfoAccessor : public ObjectInfoAccessor {
 
   Status AsyncUnsubscribeToLocations(const ObjectID &object_id) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -373,7 +373,7 @@ class RedisNodeInfoAccessor : public NodeInfoAccessor {
       const ItemCallback<HeartbeatBatchTableData> &subscribe,
       const StatusCallback &done) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};
@@ -448,7 +448,7 @@ class RedisWorkerInfoAccessor : public WorkerInfoAccessor {
       const std::unordered_map<std::string, std::string> &worker_info,
       const StatusCallback &callback) override;
 
-  void AsyncReSubscribe(bool is_pubsub_server_restarted) override {}
+  void AsyncResubscribe(bool is_pubsub_server_restarted) override {}
 
  private:
   RedisGcsClient *client_impl_{nullptr};

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -88,7 +88,7 @@ class GcsRpcClient {
   GcsRpcClient(const std::string &address, const int port,
                ClientCallManager &client_call_manager,
                std::function<std::pair<std::string, int>()> get_server_address = nullptr,
-               std::function<void()> reconnected_callback = nullptr)
+               std::function<void(bool)> reconnected_callback = nullptr)
       : client_call_manager_(client_call_manager),
         get_server_address_(std::move(get_server_address)),
         reconnected_callback_(std::move(reconnected_callback)) {
@@ -256,7 +256,10 @@ class GcsRpcClient {
       if (index < RayConfig::instance().ping_gcs_rpc_server_max_retries()) {
         Init(address.first, address.second, client_call_manager_);
         if (reconnected_callback_) {
-          reconnected_callback_();
+          // TODO(ffbin): Once we separate the pubsub server and storage addresses, we can
+          // judge whether pubsub server is restarted. Currently, we only support the
+          // scenario where pubsub server does not restart.
+          reconnected_callback_(false);
         }
       } else {
         RAY_LOG(FATAL) << "Couldn't reconnect to GCS server. The last attempted GCS "
@@ -276,7 +279,7 @@ class GcsRpcClient {
   /// Note, we use ping to detect whether the reconnection is successful. If the ping
   /// succeeds but the RPC connection fails, this function might be called called again.
   /// So it needs to be idempotent.
-  std::function<void()> reconnected_callback_;
+  std::function<void(bool)> reconnected_callback_;
 
   /// The gRPC-generated stub.
   std::unique_ptr<GrpcClient<JobInfoGcsService>> job_info_grpc_client_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Currently, GCS client sends RPC request to GCS server. If it fails, it will try to obtain GCS server address from redis and reconnect it. At the same time, it will resubscribe, because GCS server maybe successfully writes storage but fails to publish when it restarts. Currently GCS Client will resubscribe from pubsub server(redis) and get the latest information of some tables from GCS server. But if pubsub server doesn't restart, we don't need to resubscribe from pubsub server and only need get the latest information of some tables from GCS server. If pubsub server restarts, we need create a new gcs pub-sub client because it needs a new redis client, we will implement it in the next pr.
In this pr, we optimize the implementation of gcs server resubscribe, if pubsub server doesn't restart, we only get the latest information of some tables from GCS server.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
