### PR TITLE
Customize service account name.

### DIFF
--- a/deploy/ray-operator/Makefile
+++ b/deploy/ray-operator/Makefile
@@ -64,7 +64,7 @@ controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
 	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d)" ;\
+	CONTROLLER_GEN_TMP_DIR="$$(mktemp -d)" ;\
 	cd "$$CONTROLLER_GEN_TMP_DIR" ;\
 	go mod init tmp ;\
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.2 ;\

--- a/deploy/ray-operator/api/v1alpha1/raycluster_types.go
+++ b/deploy/ray-operator/api/v1alpha1/raycluster_types.go
@@ -98,6 +98,9 @@ type Extension struct {
 	// but do not directly imply semantics to the core system. Labels can be used to organize and to select subsets of objects.
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// The service acccount name.
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
 	// NodeSelector specifies a map of key-value pairs. For the pod to be eligible
 	// to run on a node, the node must have each of the indicated key-value pairs as
 	// labels. Optional.

--- a/deploy/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/deploy/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -836,6 +836,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  serviceAccountName:
+                    description: The service acccount name.
+                    type: string
                   tolerations:
                     description: The pod this Toleration is attached to tolerates
                       any taint that matches the triple <key,value,effect> using the

--- a/deploy/ray-operator/controllers/common/pod.go
+++ b/deploy/ray-operator/controllers/common/pod.go
@@ -1,10 +1,15 @@
 package common
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rayiov1alpha1 "ray-operator/api/v1alpha1"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultServiceAccountName = "default"
 )
 
 type PodConfig struct {
@@ -28,12 +33,16 @@ func BuildPod(conf *PodConfig) *corev1.Pod {
 	// Build the containers for the pod (there is currently only one).
 	containers := []corev1.Container{buildContainer(conf)}
 
+	serviceAccountName := defaultServiceAccountName
+	if len(conf.Extension.ServiceAccountName) > 0 {
+		serviceAccountName = conf.Extension.ServiceAccountName
+	}
 	spec := corev1.PodSpec{
 		Volumes:            conf.Extension.Volumes,
 		Containers:         containers,
 		Affinity:           conf.Extension.Affinity,
 		Tolerations:        conf.Extension.Tolerations,
-		ServiceAccountName: conf.RayCluster.Namespace,
+		ServiceAccountName: serviceAccountName,
 	}
 
 	pod := &corev1.Pod{


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Adds a service account field to the pod config instead of using namespace as the service account. There is a default service account in each namespace, which is enough as default.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
It's updating the ray operator, so 
