### PR TITLE
[tune] np.array compat for logger

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -218,7 +218,8 @@ class TBXLogger(Logger):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif (type(value) == list and len(value) > 0) or (type(value) == np.ndarray and value.size > 0):
+            elif (type(value) == list and len(value) > 0) or (
+                    type(value) == np.ndarray and value.size > 0):
                 valid_result[full_attr] = value
                 try:
                     self._file_writer.add_histogram(

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -218,7 +218,7 @@ class TBXLogger(Logger):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif type(value) in [list, np.ndarray] and len(value) > 0:
+            elif (type(value) == list and len(value) > 0) or (type(value) == np.ndarray and value.size > 0):
                 valid_result[full_attr] = value
                 try:
                     self._file_writer.add_histogram(

--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -218,8 +218,9 @@ class TBXLogger(Logger):
                 valid_result[full_attr] = value
                 self._file_writer.add_scalar(
                     full_attr, value, global_step=step)
-            elif (type(value) == list and len(value) > 0) or (
-                    type(value) == np.ndarray and value.size > 0):
+            elif (type(value) == list
+                  and len(value) > 0) or (type(value) == np.ndarray
+                                          and value.size > 0):
                 valid_result[full_attr] = value
                 try:
                     self._file_writer.add_histogram(


### PR DESCRIPTION
Bug fix: If the value is a np.array of size 1 then len(value) raises an error.