### PR TITLE
[autoscaler] Run ray stop on cluster before tearing it down

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -80,8 +80,8 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name,
     confirm("This will destroy your cluster", yes)
 
     if not workers_only:
-        exec_cluster(config_file, "ray stop", False, False, False, False, False,
-                     override_cluster_name, None, False)
+        exec_cluster(config_file, "ray stop", False, False, False, False,
+                     False, override_cluster_name, None, False)
 
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -78,6 +78,8 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name,
     validate_config(config)
 
     confirm("This will destroy your cluster", yes)
+    exec_cluster(config_file, "ray stop", False, False, False, False, False,
+                override_cluster_name, None, False)
 
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -78,8 +78,10 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name,
     validate_config(config)
 
     confirm("This will destroy your cluster", yes)
-    exec_cluster(config_file, "ray stop", False, False, False, False, False,
-                override_cluster_name, None, False)
+
+    if not workers_only:
+        exec_cluster(config_file, "ray stop", False, False, False, False, False,
+                     override_cluster_name, None, False)
 
     provider = get_node_provider(config["provider"], config["cluster_name"])
     try:


### PR DESCRIPTION
## Why are these changes needed?
This PR resolves a race condition when tearing down a cluster. While the cluster is stopping, Ray could still be running on the head node. It sees that the worker nodes are being shut down and create a new set of worker nodes, which will be leaked.

<!-- Please give a short summary of the change and the problem this solves. -->
This PR runs `ray stop` on the cluster before the teardown so that ray will not be running when head node is stopping. 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
