### PR TITLE
[Core] Add idle timer loop to plasma store

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -102,6 +102,8 @@ PlasmaStore::PlasmaStore(EventLoop* loop, std::string directory, bool hugepages_
       external_store_(external_store) {
   store_info_.directory = directory;
   store_info_.hugepages_enabled = hugepages_enabled;
+  // Setup an empty timer loop. So the event loop can catch the stop flag in time.
+  IdleTimerLoop();
 #ifdef PLASMA_CUDA
   auto maybe_manager = CudaDeviceManager::Instance();
   DCHECK_OK(maybe_manager.status());
@@ -1120,6 +1122,13 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       ARROW_CHECK(0);
   }
   return Status::OK();
+}
+
+void PlasmaStore::IdleTimerLoop() {
+  (void)loop_->AddTimer(15000, [this](int64_t timer_id) {
+    IdleTimerLoop();
+    return kEventLoopTimerDone;
+  });
 }
 
 }  // namespace plasma

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -213,6 +213,9 @@ class PlasmaStore {
   Status FreeCudaMemory(int device_num, int64_t size, uint8_t* out_pointer);
 #endif
 
+  // An empty timer loop. Used for stopping the event loop in time.
+  void IdleTimerLoop();
+
   /// Event loop of the plasma store.
   EventLoop* loop_;
   /// The plasma store information, including the object tables, that is exposed


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Some recent tests show that raylet fails to exit in some tense CI tests (not able to reproduce in my environment). This could relate to https://github.com/antirez/redis/issues/1680. I fix this by introducing a timer loop, so every time after the timer is triggered, the event loop is able to check its flag and stops running.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
