### PR TITLE
[docs] Tune Search:  Wrong parameter name

### DIFF
--- a/python/ray/tune/suggest/bayesopt.py
+++ b/python/ray/tune/suggest/bayesopt.py
@@ -70,7 +70,7 @@ class BayesOptSearch(Searcher):
             'height': (-100, 100),
         }
         algo = BayesOptSearch(space, metric="mean_loss", mode="min")
-        tune.run(my_func, algo=algo)
+        tune.run(my_func, search_alg=algo)
     """
     # bayes_opt.BayesianOptimization: Optimization object
     optimizer = None

--- a/python/ray/tune/suggest/dragonfly.py
+++ b/python/ray/tune/suggest/dragonfly.py
@@ -68,7 +68,7 @@ class DragonflySearch(Searcher):
 
         algo = DragonflySearch(optimizer, metric="objective", mode="max")
 
-        tune.run(my_func, algo=algo)
+        tune.run(my_func, search_alg=algo)
 
     Parameters:
         optimizer (dragonfly.opt.BlackboxOptimiser): Optimizer provided


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Both on docs and class docstrings, `search_alg=algo` parameter is wrongly used as `algo=algo` on [BayesOpt search](https://docs.ray.io/en/latest/tune-searchalg.html#bayesopt-search) and [DragonFly search](https://docs.ray.io/en/latest/tune-searchalg.html#dragonfly-search).

Could not find the corresponding doc files, only docstring of those classes, so this PR only solves the later one.

To find it on docs, search for "algo=algo" in:
https://docs.ray.io/en/latest/tune-searchalg.html#bayesopt-search
and
https://docs.ray.io/en/latest/tune-searchalg.html#dragonfly-search

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
