### PR TITLE
[Serve] Serve failure test hotfix.

### DIFF
--- a/ci/long_running_tests/workloads/serve_failure.py
+++ b/ci/long_running_tests/workloads/serve_failure.py
@@ -70,8 +70,11 @@ class RandomTest:
     def create_endpoint(self):
         if len(self.endpoints) == self.max_endpoints:
             endpoint_to_delete = self.endpoints.pop()
-            serve.delete_endpoint(endpoint_to_delete)
-            serve.delete_backend(endpoint_to_delete)
+            try:
+                serve.delete_endpoint(endpoint_to_delete)
+                serve.delete_backend(endpoint_to_delete)
+            except ray.exceptions.RayActorError as e:
+                print(e)
 
         new_endpoint = "".join(
             [random.choice(string.ascii_letters) for _ in range(10)])
@@ -79,9 +82,12 @@ class RandomTest:
         def handler(self, *args):
             return new_endpoint
 
-        serve.create_backend(new_endpoint, handler)
-        serve.create_endpoint(
-            new_endpoint, backend=new_endpoint, route="/" + new_endpoint)
+        try:
+            serve.create_backend(new_endpoint, handler)
+            serve.create_endpoint(
+                new_endpoint, backend=new_endpoint, route="/" + new_endpoint)
+        except ray.exceptions.RayActorError as e:
+            print(e)
 
         self.endpoints.append(new_endpoint)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When `ray.get(master_actor.create_backend.remote(backend_tag, backend_config, replica_config))` is called by `serve.create_backend`, this raises an `RayActorError` exception because master_actor just literally killed. At the release test, we don't catch this exception, so it crashes the driver (because there's uncaught exception). This kills Raylet & GCS server, which introduces a weird errors in there.

I don't know what's the right behavior in this case, but it seems like wrapping `serve.create_backend`, `serve.create_endpoint`, `serve.delete_endpoint`, `serve.delete_endpoint`  by 
```
try: 
except ray.exceptions.RayActorError:
``` 
resolves the issue.

Conclusion: the problem is that we don't catch RayActorError anymore, and that crashes the driver. In the past, we manually caught RayActorError to retry actor task, but not anymore after we rely on Ray's actor retries mechanism. related PR: https://github.com/ray-project/ray/commit/4155d5830f55dffab8200ca97c679ad69dde9358)

##NOTE
This is a hotfix, and I am not sure if it is the right behavior you want. Feel free to reject the PR if we need other solutions.

## Related issue number

Closes https://github.com/ray-project/ray/issues/8915

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
