### PR TITLE
[Test] Cluster util fix 

### DIFF
--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -135,9 +135,8 @@ class Cluster:
                 raise ValueError(
                     "Removing a node that is connected to this Ray client "
                     "is not allowed because it will break the driver."
-                    "Please make sure to use a function "
-                    "get_other_node to avoid removing a node that the Ray"
-                    " client is connected.")
+                    "You can use the get_other_node utility to avoid removing"
+                    "a node that the Ray client is connected.")
 
         if self.head_node == node:
             self.head_node.kill_all_processes(

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -130,7 +130,7 @@ class Cluster:
         """
         global_node = ray.worker._global_node
         if global_node is not None:
-            if node._raylet_socket_name != global_node._raylet_socket_name: 
+            if node._raylet_socket_name != global_node._raylet_socket_name:
                 ray.shutdown()
                 raise ValueError(
                     "Removing a node that is connected to this Ray client "

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -130,7 +130,7 @@ class Cluster:
         """
         global_node = ray.worker._global_node
         if global_node is not None:
-            if node._raylet_socket_name != global_node._raylet_socket_name:
+            if node._raylet_socket_name == global_node._raylet_socket_name:
                 ray.shutdown()
                 raise ValueError(
                     "Removing a node that is connected to this Ray client "

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -128,6 +128,17 @@ class Cluster:
             node (Node): Worker node of which all associated processes
                 will be removed.
         """
+        global_node = ray.worker._global_node
+        if global_node is not None:
+            if node._raylet_socket_name != global_node._raylet_socket_name: 
+                ray.shutdown()
+                raise ValueError(
+                    "Removing a node that is connected to this Ray client "
+                    "is not allowed because it will break the driver."
+                    "Please make sure to use a function "
+                    "get_other_node to avoid removing a node that the Ray"
+                    " client is connected.")
+
         if self.head_node == node:
             self.head_node.kill_all_processes(
                 check_alive=False, allow_graceful=allow_graceful)

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -17,7 +17,6 @@ from ray.test_utils import (
     wait_for_errors,
     wait_for_pid_to_exit,
     generate_internal_config_map,
-    get_non_head_nodes,
     get_other_nodes,
 )
 

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -288,10 +288,12 @@ def test_actor_restart_on_node_failure(ray_start_cluster):
     cluster = ray_start_cluster
     # Head node with no resources.
     cluster.add_node(num_cpus=0, _internal_config=config)
-    # Node to place the actor.
-    cluster.add_node(num_cpus=1, _internal_config=config)
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
+
+    # Node to place the actor.
+    actor_node = cluster.add_node(num_cpus=1, _internal_config=config)
+    cluster.wait_for_nodes()
 
     @ray.remote(num_cpus=1, max_restarts=1, max_task_retries=-1)
     class RestartableActor:
@@ -311,7 +313,7 @@ def test_actor_restart_on_node_failure(ray_start_cluster):
     ray.get(actor.ready.remote())
     results = [actor.increase.remote() for _ in range(100)]
     # Kill actor node, while the above task is still being executed.
-    cluster.remove_node(get_non_head_nodes(cluster)[-1])
+    cluster.remove_node(actor_node)
     cluster.add_node(num_cpus=1, _internal_config=config)
     cluster.wait_for_nodes()
     # Check that none of the tasks failed and the actor is restarted.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When using `cluster_utils.Cluster`, we should not allow to remove a node that is connected to the driver because it will break the driver. This PR will have a basic check to avoid any test that has this mistake. (But it does not solve the fundamental problem). 

To solve the fundamental problem, we should either
1. Always connect client to the head node in `cluster_utils.Cluster`
2. Provide an API for a driver to pick a node.

## Related issue number

Partially close https://github.com/ray-project/ray/issues/8888

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
Manually tested
