### PR TITLE
Issue 8919 checkpoint at end ignored

### DIFF
--- a/rllib/tests/test_checkpoint_restore.py
+++ b/rllib/tests/test_checkpoint_restore.py
@@ -124,6 +124,9 @@ def ckpt_restore_test(alg_name, tfe=False):
                 if abs(a1 - a2) > .1:
                     raise AssertionError("algo={} [a1={} a2={}]".format(
                         alg_name, a1, a2))
+            # Stop both Trainers.
+            alg1.stop()
+            alg2.stop()
 
 
 class TestCheckpointRestore(unittest.TestCase):

--- a/rllib/train.py
+++ b/rllib/train.py
@@ -149,6 +149,7 @@ def run(args, parser):
             args.experiment_name: {  # i.e. log to ~/ray_results/default
                 "run": args.run,
                 "checkpoint_freq": args.checkpoint_freq,
+                "checkpoint_at_end": args.checkpoint_at_end,
                 "keep_checkpoints_num": args.keep_checkpoints_num,
                 "checkpoint_score_attr": args.checkpoint_score_attr,
                 "local_dir": args.local_dir,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

This PR adds support for `--checkpoint-at-end` to `rllib train`, which currently ignores this flag.


<!-- Please give a short summary of the change and the problem this solves. -->

Fixes #8919

<!-- For example: "Closes #1234" -->

Closes #8919 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
