### PR TITLE
Warn only after sufficient retries on redis server

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -11,13 +11,13 @@ import socket
 import subprocess
 import sys
 import time
-import redis
+import ray
+import psutil
 
 import colorama
 # Ray modules
-import ray
 import ray.ray_constants as ray_constants
-import psutil
+import redis
 
 resource = None
 if sys.platform != "win32":
@@ -935,8 +935,9 @@ def _start_redis_instance(executable,
         load_module_args += ["--loadmodule", module]
 
     while counter < num_retries:
-        if counter > 0:
-            logger.warning("Redis failed to start, retrying now.")
+        if counter > num_retries // 2:
+            logger.warning("Redis failed to start after"
+                           "{} retries,  trying again.".format(counter))
 
         # Construct the command to start the Redis server.
         command = [executable]

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -934,8 +934,10 @@ def _start_redis_instance(executable,
     for module in modules:
         load_module_args += ["--loadmodule", module]
 
+    wait_tries = 1
     while counter < num_retries:
-        if counter > num_retries // 2:
+        if counter > wait_tries:
+            wait_tries *= 2
             logger.warning("Redis failed to start after"
                            "{} retries,  trying again.".format(counter))
 


### PR DESCRIPTION

## Why are these changes needed?

Currently the warning on the redis server check is too soon (after 0.1 seconds). Need to wait for sufficient time before raising a warning
## Related issue number

Closes #8777 

## Checks

- [ X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
