### PR TITLE
Fix DDPG and SAC for eager execution

### DIFF
--- a/rllib/agents/ddpg/ddpg_tf_policy.py
+++ b/rllib/agents/ddpg/ddpg_tf_policy.py
@@ -330,11 +330,11 @@ def gradients_fn(policy, optimizer, loss):
             var_list=policy.model.q_variables(),
             clip_val=policy.config["grad_norm_clipping"])
     else:
-        actor_grads_and_vars = policy._actor_optimizer.compute_gradients(
-            policy.actor_loss, var_list=policy.model.policy_variables())
-        critic_grads_and_vars = policy._critic_optimizer.compute_gradients(
-            policy.critic_loss, var_list=policy.model.q_variables())
-    # Save these for later use in build_apply_op.
+        actor_grads_and_vars = optimizer.compute_gradients(
+                policy.actor_loss, var_list=policy.model.policy_variables())
+        critic_grads_and_vars = optimizer.compute_gradients(
+                policy.critic_loss, var_list=policy.model.q_variables())
+    
     policy._actor_grads_and_vars = [(g, v) for (g, v) in actor_grads_and_vars
                                     if g is not None]
     policy._critic_grads_and_vars = [(g, v) for (g, v) in critic_grads_and_vars

--- a/rllib/agents/ddpg/ddpg_tf_policy.py
+++ b/rllib/agents/ddpg/ddpg_tf_policy.py
@@ -227,7 +227,7 @@ def ddpg_actor_critic_loss(policy, model, _, train_batch):
         else:
             errors = 0.5 * tf.square(td_error)
 
-    critic_loss = tf.reduce_mean(train_batch[PRIO_WEIGHTS] * errors)
+    critic_loss = tf.reduce_mean(tf.cast(train_batch[PRIO_WEIGHTS], dtype=tf.float32) * errors)
     actor_loss = -tf.reduce_mean(q_t_det_policy)
 
     # Add l2-regularization if required.

--- a/rllib/agents/ddpg/ddpg_tf_policy.py
+++ b/rllib/agents/ddpg/ddpg_tf_policy.py
@@ -227,7 +227,8 @@ def ddpg_actor_critic_loss(policy, model, _, train_batch):
         else:
             errors = 0.5 * tf.square(td_error)
 
-    critic_loss = tf.reduce_mean(tf.cast(train_batch[PRIO_WEIGHTS], dtype=tf.float32) * errors)
+    critic_loss = tf.reduce_mean(
+        tf.cast(train_batch[PRIO_WEIGHTS], dtype=tf.float32) * errors)
     actor_loss = -tf.reduce_mean(q_t_det_policy)
 
     # Add l2-regularization if required.
@@ -331,10 +332,10 @@ def gradients_fn(policy, optimizer, loss):
             clip_val=policy.config["grad_norm_clipping"])
     else:
         actor_grads_and_vars = optimizer.compute_gradients(
-                policy.actor_loss, var_list=policy.model.policy_variables())
+            policy.actor_loss, var_list=policy.model.policy_variables())
         critic_grads_and_vars = optimizer.compute_gradients(
-                policy.critic_loss, var_list=policy.model.q_variables())
-    
+            policy.critic_loss, var_list=policy.model.q_variables())
+
     policy._actor_grads_and_vars = [(g, v) for (g, v) in actor_grads_and_vars
                                     if g is not None]
     policy._critic_grads_and_vars = [(g, v) for (g, v) in critic_grads_and_vars

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -335,9 +335,8 @@ def gradients(policy, optimizer, loss):
             ) + optimizer.compute_gradients(
                 policy.critic_loss[1], var_list=q_variables[half_cutoff:])
         else:
-            critic_grads_and_vars = optimizer[
-                0].compute_gradients(
-                    policy.critic_loss[0], var_list=policy.model.q_variables())
+            critic_grads_and_vars = optimizer[0].compute_gradients(
+                policy.critic_loss[0], var_list=policy.model.q_variables())
         alpha_grads_and_vars = optimizer.compute_gradients(
             policy.alpha_loss, var_list=[policy.model.log_alpha])
 

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -325,21 +325,20 @@ def gradients(policy, optimizer, loss):
             var_list=[policy.model.log_alpha],
             clip_val=policy.config["grad_clip"])
     else:
-        actor_grads_and_vars = policy._actor_optimizer.compute_gradients(
+        actor_grads_and_vars = optimizer.compute_gradients(
             policy.actor_loss, var_list=policy.model.policy_variables())
         if policy.config["twin_q"]:
             q_variables = policy.model.q_variables()
             half_cutoff = len(q_variables) // 2
-            base_q_optimizer, twin_q_optimizer = policy._critic_optimizer
-            critic_grads_and_vars = base_q_optimizer.compute_gradients(
+            critic_grads_and_vars = optimizer.compute_gradients(
                 policy.critic_loss[0], var_list=q_variables[:half_cutoff]
-            ) + twin_q_optimizer.compute_gradients(
+            ) + optimizer.compute_gradients(
                 policy.critic_loss[1], var_list=q_variables[half_cutoff:])
         else:
-            critic_grads_and_vars = policy._critic_optimizer[
+            critic_grads_and_vars = optimizer[
                 0].compute_gradients(
                     policy.critic_loss[0], var_list=policy.model.q_variables())
-        alpha_grads_and_vars = policy._alpha_optimizer.compute_gradients(
+        alpha_grads_and_vars = optimizer.compute_gradients(
             policy.alpha_loss, var_list=[policy.model.log_alpha])
 
     # save these for later use in build_apply_op

--- a/rllib/agents/sac/sac_tf_policy.py
+++ b/rllib/agents/sac/sac_tf_policy.py
@@ -335,7 +335,7 @@ def gradients(policy, optimizer, loss):
             ) + optimizer.compute_gradients(
                 policy.critic_loss[1], var_list=q_variables[half_cutoff:])
         else:
-            critic_grads_and_vars = optimizer[0].compute_gradients(
+            critic_grads_and_vars = optimizer.compute_gradients(
                 policy.critic_loss[0], var_list=policy.model.q_variables())
         alpha_grads_and_vars = optimizer.compute_gradients(
             policy.alpha_loss, var_list=[policy.model.log_alpha])


### PR DESCRIPTION
Trying to run DDPG/TD3/SAC would result in errors under Eager execution because
the OptimizerWrapper was not being used to compute the gradients. This PR updates
the code to run through this compatibility layer. Computing the gradients directly with
the optimizer in tf.compat.v1.AdamOptimizer should produce the same values. 

The prior broken and now fixed behavior can be confirmed with:
```
    rllib train --run SAC --env MountainCarContinuous-v0 --eager
    rllib train --run DDPG --env MountainCarContinuous-v0 --eager
    rllib train --run TD3 --env MountainCarContinuous-v0 --eager
```

DDPG also required adding an explicit cast to tf.float32 on the errors. Since there are
other casts hardcoded with this dtype, I don't believe this causes any loss of generality.
Finally the default SAC configuration is also updated to remove a deprecated field and
suppress the warning message.
