### PR TITLE
[azure] default workers spot instances + billing profile

### DIFF
--- a/python/ray/autoscaler/azure/azure-vm-template.json
+++ b/python/ray/autoscaler/azure/azure-vm-template.json
@@ -68,6 +68,20 @@
             "metadata": {
                 "description": "If true creates a public ip"
             }
+        },
+        "priority": {
+            "type": "string",
+            "defaultValue": "Regular",
+            "metadata": {
+                "description": "Specifies the priority for the virtual machine."
+            }
+        },
+        "maxPrice": {
+            "type": "int",
+            "defaultValue": -1,
+            "metadata": {
+                "description": "Specifies the maximum price to pay for Azure Spot VM."
+            }
         }
     },
     "variables": {
@@ -212,6 +226,10 @@
                             ]
                         }
                     }
+                },
+                "priority": "[parameters('priority')]",
+                "billingProfile": {
+                    "maxPrice": "[parameters('maxPrice')]"
                 }
             },
             "identity": {

--- a/python/ray/autoscaler/azure/azure-vm-template.json
+++ b/python/ray/autoscaler/azure/azure-vm-template.json
@@ -76,9 +76,9 @@
                 "description": "Specifies the priority for the virtual machine."
             }
         },
-        "maxPrice": {
-            "type": "int",
-            "defaultValue": -1,
+        "billingProfile": {
+            "type": "object",
+            "defaultValue": {},
             "metadata": {
                 "description": "Specifies the maximum price to pay for Azure Spot VM."
             }
@@ -228,9 +228,7 @@
                     }
                 },
                 "priority": "[parameters('priority')]",
-                "billingProfile": {
-                    "maxPrice": "[parameters('maxPrice')]"
-                }
+                "billingProfile": "[parameters('billingProfile')]"
             },
             "identity": {
                 "type": "UserAssigned",

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -92,7 +92,8 @@ worker_nodes:
         # optionally set priority to use Spot instances 
         priority: Spot
         # set a maximum price for spot instances if desired
-        # maxPrice: -1
+        # billingProfile:
+        #     maxPrice: -1
 
 # Files or directories to copy to the head and worker nodes. The format is a
 # dictionary from REMOTE_PATH: LOCAL_PATH, e.g.

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -65,6 +65,11 @@ auth:
     ssh_private_key: ~/.ssh/id_rsa
     ssh_public_key: ~/.ssh/id_rsa.pub
 
+# More specific customization to node configurations can be made using the ARM template azure-vm-template.json file
+# See documentation here: https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-03-01/virtualmachines
+# Changes to the local file will be used during deployment of the head node, however worker nodes deployment occurs 
+# on the head node, so changes to the template must be included in the wheel file used in setup_commands section below
+
 # Provider-specific config for the head node, e.g. instance type.
 head_node:
     azure_arm_parameters:
@@ -84,6 +89,10 @@ worker_nodes:
         imageOffer: ubuntu-1804
         imageSku: 1804-gen2
         imageVersion: 20.02.01
+        # optionally set priority to use Spot instances 
+        priority: Spot
+        # set a maximum price for spot instances if desired
+        # maxPrice: -1
 
 # Files or directories to copy to the head and worker nodes. The format is a
 # dictionary from REMOTE_PATH: LOCAL_PATH, e.g.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Current default azure autoscaler does not allow for specifying spot instances, despite what is in the documentation. These changes make the default workers spot instances and add documentation in the example-full.yaml on how to adjust billingProfile parameters for spot instances.

<!-- Please give a short summary of the change and the problem this solves. -->

Closes #8394

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] Local tests (deploying new clusters to Azure)
   - [ ] This PR is not tested (please justify below)
