### PR TITLE
Use no_restart=False for ray.kill in Serve failure test

### DIFF
--- a/ci/long_running_tests/workloads/serve_failure.py
+++ b/ci/long_running_tests/workloads/serve_failure.py
@@ -52,7 +52,8 @@ class RandomKiller:
 
     def run(self):
         while True:
-            ray.kill(random.choice(self._get_all_serve_actors()))
+            ray.kill(
+                random.choice(self._get_all_serve_actors()), no_restart=False)
             time.sleep(self.kill_period_s)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`ray.kill` permanently kills an actor. For Serve failure testing, we should be using `ray.kill(actor, no_restart=False)` so that the killed actor will be restarted.

## Related issue number

Closes #8949.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
