### PR TITLE
Remove redundant logger warning

### DIFF
--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -962,6 +962,7 @@ def _start_redis_instance(executable,
                                stdout_file.name if stdout_file is not None else
                                "<stdout>", stderr_file.name
                                if stdout_file is not None else "<stderr>"))
+    
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(
         host="127.0.0.1", port=port, password=password)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -935,9 +935,6 @@ def _start_redis_instance(executable,
         load_module_args += ["--loadmodule", module]
 
     while counter < num_retries:
-        if counter > 0:
-            logger.warning("Redis failed to start, retrying now.")
-
         # Construct the command to start the Redis server.
         command = [executable]
         if password:
@@ -965,7 +962,6 @@ def _start_redis_instance(executable,
                                stdout_file.name if stdout_file is not None else
                                "<stdout>", stderr_file.name
                                if stdout_file is not None else "<stderr>"))
-
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(
         host="127.0.0.1", port=port, password=password)

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -962,7 +962,7 @@ def _start_redis_instance(executable,
                                stdout_file.name if stdout_file is not None else
                                "<stdout>", stderr_file.name
                                if stdout_file is not None else "<stderr>"))
-    
+
     # Create a Redis client just for configuring Redis.
     redis_client = redis.StrictRedis(
         host="127.0.0.1", port=port, password=password)


### PR DESCRIPTION
## Why are these changes needed?

This removes the redundant "Redis failed to start, retrying now" warning which always happens when starting Ray. There is already a "Couldn't start Redis" error throw if the prescribed number of retries is exceeded.

## Related issue number
#8777 

