### PR TITLE
Convert include guard to pragma once

### DIFF
--- a/src/ray/common/buffer.h
+++ b/src/ray/common/buffer.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_BUFFER_H
-#define RAY_COMMON_BUFFER_H
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -140,5 +139,3 @@ class PlasmaBuffer : public Buffer {
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_BUFFER_H

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_CLIENT_CONNECTION_H
-#define RAY_COMMON_CLIENT_CONNECTION_H
+#pragma once
 
 #include <deque>
 #include <memory>
@@ -217,5 +216,3 @@ class ClientConnection : public ServerConnection {
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_CLIENT_CONNECTION_H

--- a/src/ray/common/common_protocol.h
+++ b/src/ray/common/common_protocol.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMMON_PROTOCOL_H
-#define COMMON_PROTOCOL_H
+#pragma once
 
 #include <flatbuffers/flatbuffers.h>
 #include <unordered_set>
@@ -201,5 +200,3 @@ to_flatbuf(flatbuffers::FlatBufferBuilder &fbb, const std::unordered_set<ID> &id
   }
   return fbb.CreateVector(results);
 }
-
-#endif

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CONSTANTS_H_
-#define RAY_CONSTANTS_H_
+#pragma once
 
 #include <limits.h>
 #include <stdint.h>
@@ -43,5 +42,3 @@ constexpr char kWorkerRayletConfigPlaceholder[] = "RAY_WORKER_RAYLET_CONFIG_PLAC
 /// Public DNS address which is is used to connect and get local IP.
 constexpr char kPublicDNSServerIp[] = "8.8.8.8";
 constexpr int kPublicDNSServerPort = 53;
-
-#endif  // RAY_CONSTANTS_H_

--- a/src/ray/common/function_descriptor.h
+++ b/src/ray/common/function_descriptor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_FUNCTION_DESCRIPTOR_H
-#define RAY_CORE_WORKER_FUNCTION_DESCRIPTOR_H
+#pragma once
 
 #include <string>
 
@@ -252,5 +251,3 @@ class FunctionDescriptorBuilder {
   static FunctionDescriptor Deserialize(const std::string &serialized_binary);
 };
 }  // namespace ray
-
-#endif

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_GRPC_UTIL_H
-#define RAY_COMMON_GRPC_UTIL_H
+#pragma once
 
 #include <google/protobuf/map.h>
 #include <google/protobuf/repeated_field.h>
@@ -121,5 +120,3 @@ inline std::unordered_map<K, V> MapFromProtobuf(::google::protobuf::Map<K, V> pb
 }
 
 }  // namespace ray
-
-#endif

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_ID_H_
-#define RAY_ID_H_
+#pragma once
 
 #include <inttypes.h>
 #include <limits.h>
@@ -494,4 +493,3 @@ DEFINE_UNIQUE_ID(ObjectID);
 
 #undef DEFINE_UNIQUE_ID
 }  // namespace std
-#endif  // RAY_ID_H_

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_NETWORK_UTIL_H
-#define RAY_COMMON_NETWORK_UTIL_H
+#pragma once
 
 #include <boost/asio.hpp>
 #include <boost/asio/deadline_timer.hpp>
@@ -125,4 +124,3 @@ std::string GetValidLocalIp(int port, int64_t timeout_ms);
 bool Ping(const std::string &ip, int port, int64_t timeout_ms);
 
 bool CheckFree(int port);
-#endif  // RAY_COMMON_NETWORK_UTIL_H

--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CONFIG_H
-#define RAY_CONFIG_H
+#pragma once
 
 #include <sstream>
 #include <unordered_map>
@@ -68,5 +67,3 @@ class RayConfig {
 #undef RAY_CONFIG
 };
 // clang-format on
-
-#endif  // RAY_CONFIG_H

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_RAY_OBJECT_H
-#define RAY_COMMON_RAY_OBJECT_H
+#pragma once
 
 #include "absl/types/optional.h"
 #include "ray/common/buffer.h"
@@ -102,5 +101,3 @@ class RayObject {
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_RAY_OBJECT_H

--- a/src/ray/common/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/common/scheduling/cluster_resource_scheduler.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_SCHEDULING_SCHEDULING_H
-#define RAY_COMMON_SCHEDULING_SCHEDULING_H
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -536,5 +535,3 @@ class ClusterResourceScheduler {
   /// Return human-readable string for this scheduler state.
   std::string DebugString() const;
 };
-
-#endif  // RAY_COMMON_SCHEDULING_SCHEDULING_H

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
-#define RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "ray/util/logging.h"
@@ -66,5 +65,3 @@ class StringIdMap {
   /// Get number of identifiers.
   int64_t Count();
 };
-
-#endif  // RAY_COMMON_SCHEDULING_SCHEDULING_IDS_H

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -26,8 +26,7 @@
 
 // Adapted from Apache Arrow, Apache Kudu, TensorFlow
 
-#ifndef RAY_STATUS_H_
-#define RAY_STATUS_H_
+#pragma once
 
 #include <cstring>
 #include <iosfwd>
@@ -258,5 +257,3 @@ inline void Status::operator=(const Status &s) {
 Status boost_to_ray_status(const boost::system::error_code &error);
 
 }  // namespace ray
-
-#endif  // RAY_STATUS_H_

--- a/src/ray/common/task/scheduling_resources.h
+++ b/src/ray/common/task/scheduling_resources.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_SCHEDULING_RESOURCES_H
-#define RAY_COMMON_TASK_SCHEDULING_RESOURCES_H
+#pragma once
 
 #include <string>
 #include <unordered_map>
@@ -546,5 +545,3 @@ struct hash<ray::ResourceSet> {
   }
 };
 }  // namespace std
-
-#endif  // RAY_COMMON_TASK_SCHEDULING_RESOURCES_H

--- a/src/ray/common/task/task.h
+++ b/src/ray/common/task/task.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_TASK_H
-#define RAY_COMMON_TASK_TASK_H
+#pragma once
 
 #include <inttypes.h>
 
@@ -125,5 +124,3 @@ class Task {
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_TASK_TASK_H

--- a/src/ray/common/task/task_common.h
+++ b/src/ray/common/task/task_common.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_TASK_COMMON_H
-#define RAY_COMMON_TASK_TASK_COMMON_H
+#pragma once
 
 #include "ray/protobuf/common.pb.h"
 
@@ -16,5 +15,3 @@ using Language = rpc::Language;
 using TaskType = rpc::TaskType;
 
 }  // namespace ray
-
-#endif

--- a/src/ray/common/task/task_execution_spec.h
+++ b/src/ray/common/task/task_execution_spec.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_TASK_EXECUTION_SPEC_H
-#define RAY_COMMON_TASK_TASK_EXECUTION_SPEC_H
+#pragma once
 
 #include <vector>
 
@@ -41,5 +40,3 @@ class TaskExecutionSpecification : public MessageWrapper<rpc::TaskExecutionSpec>
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_TASK_TASK_EXECUTION_SPEC_H

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_TASK_SPEC_H
-#define RAY_COMMON_TASK_TASK_SPEC_H
+#pragma once
 
 #include <cstddef>
 #include <string>
@@ -208,5 +207,3 @@ struct hash<ray::SchedulingClassDescriptor> {
   }
 };
 }  // namespace std
-
-#endif  // RAY_COMMON_TASK_TASK_SPEC_H

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -1,5 +1,4 @@
-#ifndef RAY_COMMON_TASK_TASK_UTIL_H
-#define RAY_COMMON_TASK_TASK_UTIL_H
+#pragma once
 
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
@@ -144,5 +143,3 @@ class TaskSpecBuilder {
 };
 
 }  // namespace ray
-
-#endif  // RAY_COMMON_TASK_TASK_UTIL_H

--- a/src/ray/common/test_util.h
+++ b/src/ray/common/test_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_TEST_UTIL_H
-#define RAY_COMMON_TEST_UTIL_H
+#pragma once
 
 #include <unistd.h>
 
@@ -117,5 +116,3 @@ class TestSetupUtil {
 };
 
 }  // namespace ray
-
-#endif  // RAY_UTIL_TEST_UTIL_H

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_ACTOR_HANDLE_H
-#define RAY_CORE_WORKER_ACTOR_HANDLE_H
+#pragma once
 
 #include <gtest/gtest_prod.h>
 
@@ -89,5 +88,3 @@ class ActorHandle {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_ACTOR_HANDLE_H

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_ACTOR_MANAGER_H
-#define RAY_CORE_WORKER_ACTOR_MANAGER_H
+#pragma once
 
 #include "ray/core_worker/actor_handle.h"
 #include "ray/gcs/redis_gcs_client.h"
@@ -46,5 +45,3 @@ class ActorManager : public ActorManagerInterface {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_ACTOR_MANAGER_H

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_COMMON_H
-#define RAY_CORE_WORKER_COMMON_H
+#pragma once
 
 #include <string>
 
@@ -156,5 +155,3 @@ struct ActorCreationOptions {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_COMMON_H

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_CONTEXT_H
-#define RAY_CORE_WORKER_CONTEXT_H
+#pragma once
 
 #include <boost/thread.hpp>
 
@@ -96,5 +95,3 @@ class WorkerContext {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_CONTEXT_H

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_CORE_WORKER_H
-#define RAY_CORE_WORKER_CORE_WORKER_H
+#pragma once
 
 #include "absl/base/optimization.h"
 #include "absl/container/flat_hash_map.h"
@@ -1081,5 +1080,3 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_CORE_WORKER_H

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_FIBER_H
-#define RAY_CORE_WORKER_FIBER_H
+#pragma once
 
 #include <ray/util/logging.h>
 #include <boost/fiber/all.hpp>
@@ -142,5 +141,3 @@ class FiberState {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_FIBER_H

--- a/src/ray/core_worker/future_resolver.h
+++ b/src/ray/core_worker/future_resolver.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_FUTURE_RESOLVER_H
-#define RAY_CORE_WORKER_FUTURE_RESOLVER_H
+#pragma once
 
 #include <memory>
 
@@ -60,5 +59,3 @@ class FutureResolver {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_FUTURE_RESOLVER_H

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_COMMON_JAVA_JNI_UTILS_H
-#define RAY_COMMON_JAVA_JNI_UTILS_H
+#pragma once
 
 #include <jni.h>
 
@@ -422,5 +421,3 @@ inline jobject NativeRayFunctionDescriptorToJavaStringList(
   RAY_LOG(FATAL) << "Unknown function descriptor type: " << function_descriptor->Type();
   return NativeStringVectorToJavaStringList(env, std::vector<std::string>());
 }
-
-#endif  // RAY_COMMON_JAVA_JNI_UTILS_H

--- a/src/ray/core_worker/object_recovery_manager.h
+++ b/src/ray/core_worker/object_recovery_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_OBJECT_RECOVERY_MANAGER_H
-#define RAY_CORE_WORKER_OBJECT_RECOVERY_MANAGER_H
+#pragma once
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
@@ -147,5 +146,3 @@ class ObjectRecoveryManager {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_OBJECT_RECOVERY_MANAGER_H

--- a/src/ray/core_worker/profiling.h
+++ b/src/ray/core_worker/profiling.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_PROFILING_H
-#define RAY_CORE_WORKER_PROFILING_H
+#pragma once
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
@@ -81,5 +80,3 @@ class ProfileEvent {
 }  // namespace worker
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_PROFILING_H

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_REF_COUNT_H
-#define RAY_CORE_WORKER_REF_COUNT_H
+#pragma once
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -628,5 +627,3 @@ class ReferenceCounter {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_REF_COUNT_H

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -1,5 +1,4 @@
-#ifndef RAY_CORE_WORKER_MEMORY_STORE_H
-#define RAY_CORE_WORKER_MEMORY_STORE_H
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -177,5 +176,3 @@ class CoreWorkerMemoryStore {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_MEMORY_STORE_H

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_PLASMA_STORE_PROVIDER_H
-#define RAY_CORE_WORKER_PLASMA_STORE_PROVIDER_H
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -164,5 +163,3 @@ class CoreWorkerPlasmaStoreProvider {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_PLASMA_STORE_PROVIDER_H

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_TASK_MANAGER_H
-#define RAY_CORE_WORKER_TASK_MANAGER_H
+#pragma once
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -279,5 +278,3 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_TASK_MANAGER_H

--- a/src/ray/core_worker/transport/dependency_resolver.h
+++ b/src/ray/core_worker/transport/dependency_resolver.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H
-#define RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H
+#pragma once
 
 #include <memory>
 
@@ -60,5 +59,3 @@ class LocalDependencyResolver {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_DEPENDENCY_RESOLVER_H

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_DIRECT_ACTOR_TRANSPORT_H
-#define RAY_CORE_WORKER_DIRECT_ACTOR_TRANSPORT_H
+#pragma once
 
 #include <boost/asio/thread_pool.hpp>
 #include <boost/thread.hpp>
@@ -504,5 +503,3 @@ class CoreWorkerDirectTaskReceiver {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_DIRECT_ACTOR_TRANSPORT_H

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_DIRECT_TASK_H
-#define RAY_CORE_WORKER_DIRECT_TASK_H
+#pragma once
 
 #include <google/protobuf/repeated_field.h>
 
@@ -203,5 +202,3 @@ class CoreWorkerDirectTaskSubmitter {
 };
 
 };  // namespace ray
-
-#endif  // RAY_CORE_WORKER_DIRECT_TASK_H

--- a/src/ray/core_worker/transport/raylet_transport.h
+++ b/src/ray/core_worker/transport/raylet_transport.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CORE_WORKER_RAYLET_TRANSPORT_H
-#define RAY_CORE_WORKER_RAYLET_TRANSPORT_H
+#pragma once
 
 #include <list>
 
@@ -60,5 +59,3 @@ class CoreWorkerRayletTaskReceiver {
 };
 
 }  // namespace ray
-
-#endif  // RAY_CORE_WORKER_RAYLET_TRANSPORT_H

--- a/src/ray/gcs/accessor.h
+++ b/src/ray/gcs/accessor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ACCESSOR_H
-#define RAY_GCS_ACCESSOR_H
+#pragma once
 
 #include "ray/common/id.h"
 #include "ray/common/task/task_spec.h"
@@ -669,5 +668,3 @@ class WorkerInfoAccessor {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_ACCESSOR_H

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -32,8 +32,7 @@
 // Adapted from https://github.com/ryangraham/hiredis-boostasio-adapter
 // (Copyright 2018 Ryan Graham)
 
-#ifndef RAY_GCS_ASIO_H
-#define RAY_GCS_ASIO_H
+#pragma once
 
 #include <stdio.h>
 #include <iostream>
@@ -92,5 +91,3 @@ extern "C" void call_C_delRead(void *private_data);
 extern "C" void call_C_addWrite(void *private_data);
 extern "C" void call_C_delWrite(void *private_data);
 extern "C" void call_C_cleanup(void *private_data);
-
-#endif  // RAY_GCS_ASIO_H

--- a/src/ray/gcs/callback.h
+++ b/src/ray/gcs/callback.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_CALLBACK_H
-#define RAY_GCS_CALLBACK_H
+#pragma once
 
 #include <boost/optional/optional.hpp>
 #include <unordered_map>
@@ -66,5 +65,3 @@ using MapCallback = std::function<void(const std::unordered_map<Key, Value> &res
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_CALLBACK_H

--- a/src/ray/gcs/entry_change_notification.h
+++ b/src/ray/gcs/entry_change_notification.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ENTRY_CHANGE_NOTIFICATION_H
-#define RAY_GCS_ENTRY_CHANGE_NOTIFICATION_H
+#pragma once
 
 #include <ray/protobuf/gcs.pb.h>
 #include <vector>
@@ -76,5 +75,3 @@ typedef MapNotification<std::string, rpc::ResourceTableData> ResourceChangeNotif
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_ENTRY_CHANGE_NOTIFICATION_H

--- a/src/ray/gcs/gcs_client.h
+++ b/src/ray/gcs/gcs_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_GCS_CLIENT_H
-#define RAY_GCS_GCS_CLIENT_H
+#pragma once
 
 #include <boost/asio.hpp>
 #include <memory>
@@ -159,5 +158,3 @@ class GcsClient : public std::enable_shared_from_this<GcsClient> {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_GCS_CLIENT_H

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_GLOBAL_STATE_ACCESSOR_H
-#define RAY_GCS_GLOBAL_STATE_ACCESSOR_H
+#pragma once
 
 #include "ray/rpc/server_call.h"
 #include "service_based_gcs_client.h"
@@ -151,5 +150,3 @@ class GlobalStateAccessor {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_GLOBAL_STATE_ACCESSOR_H

--- a/src/ray/gcs/gcs_client/service_based_accessor.h
+++ b/src/ray/gcs/gcs_client/service_based_accessor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_SERVICE_BASED_ACCESSOR_H
-#define RAY_GCS_SERVICE_BASED_ACCESSOR_H
+#pragma once
 
 #include <ray/common/task/task_spec.h>
 #include "ray/gcs/accessor.h"
@@ -375,5 +374,3 @@ class ServiceBasedWorkerInfoAccessor : public WorkerInfoAccessor {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_SERVICE_BASED_ACCESSOR_H

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.h
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_SERVICE_BASED_GCS_CLIENT_H
-#define RAY_GCS_SERVICE_BASED_GCS_CLIENT_H
+#pragma once
 
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
 #include "ray/gcs/redis_gcs_client.h"
@@ -56,5 +55,3 @@ class RAY_EXPORT ServiceBasedGcsClient : public GcsClient {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_SERVICE_BASED_GCS_CLIENT_H

--- a/src/ray/gcs/gcs_server/error_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/error_info_handler_impl.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ERROR_INFO_HANDLER_IMPL_H
-#define RAY_GCS_ERROR_INFO_HANDLER_IMPL_H
+#pragma once
 
 #include "ray/gcs/redis_gcs_client.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
@@ -37,5 +36,3 @@ class DefaultErrorInfoHandler : public rpc::ErrorInfoHandler {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_GCS_ERROR_INFO_HANDLER_IMPL_H

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ACTOR_MANAGER_H
-#define RAY_GCS_ACTOR_MANAGER_H
+#pragma once
 
 #include <ray/common/id.h>
 #include <ray/common/task/task_execution_spec.h>
@@ -289,5 +288,3 @@ class GcsActorManager : public rpc::ActorInfoHandler {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_ACTOR_MANAGER_H

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ACTOR_SCHEDULER_H
-#define RAY_GCS_ACTOR_SCHEDULER_H
+#pragma once
 
 #include <ray/common/id.h>
 #include <ray/common/task/task_execution_spec.h>
@@ -264,5 +263,3 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_ACTOR_SCHEDULER_H

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_NODE_MANAGER_H
-#define RAY_GCS_NODE_MANAGER_H
+#pragma once
 
 #include <ray/common/id.h>
 #include <ray/gcs/accessor.h>
@@ -219,5 +218,3 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_NODE_MANAGER_H

--- a/src/ray/gcs/gcs_server/gcs_object_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_object_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_OBJECT_MANAGER_H
-#define RAY_GCS_OBJECT_MANAGER_H
+#pragma once
 
 #include "gcs_node_manager.h"
 #include "gcs_table_storage.h"
@@ -140,5 +139,3 @@ class GcsObjectManager : public rpc::ObjectInfoHandler {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_OBJECT_MANAGER_H

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_FAILURE_DETECTOR_H
-#define RAY_GCS_REDIS_FAILURE_DETECTOR_H
+#pragma once
 
 #include <boost/asio.hpp>
 #include "ray/gcs/redis_context.h"
@@ -67,5 +66,3 @@ class GcsRedisFailureDetector {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_FAILURE_DETECTOR_H

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_GCS_SERVER_H
-#define RAY_GCS_GCS_SERVER_H
+#pragma once
 
 #include <ray/gcs/pubsub/gcs_pub_sub.h>
 #include <ray/gcs/redis_gcs_client.h>
@@ -156,5 +155,3 @@ class GcsServer {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_GCS_TABLE_STORAGE_H_
-#define RAY_GCS_GCS_TABLE_STORAGE_H_
+#pragma once
 
 #include <utility>
 
@@ -426,5 +425,3 @@ class InMemoryGcsTableStorage : public GcsTableStorage {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_GCS_TABLE_STORAGE_H_

--- a/src/ray/gcs/gcs_server/job_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/job_info_handler_impl.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_JOB_INFO_HANDLER_IMPL_H
-#define RAY_GCS_JOB_INFO_HANDLER_IMPL_H
+#pragma once
 
 #include "gcs_table_storage.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
@@ -48,5 +47,3 @@ class DefaultJobInfoHandler : public rpc::JobInfoHandler {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_GCS_JOB_INFO_HANDLER_IMPL_H

--- a/src/ray/gcs/gcs_server/stats_handler_impl.h
+++ b/src/ray/gcs/gcs_server/stats_handler_impl.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_STATS_HANDLER_IMPL_H
-#define RAY_GCS_STATS_HANDLER_IMPL_H
+#pragma once
 
 #include "gcs_table_storage.h"
 #include "ray/gcs/redis_gcs_client.h"
@@ -42,5 +41,3 @@ class DefaultStatsHandler : public rpc::StatsHandler {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_GCS_STATS_HANDLER_IMPL_H

--- a/src/ray/gcs/gcs_server/task_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/task_info_handler_impl.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_TASK_INFO_HANDLER_IMPL_H
-#define RAY_GCS_TASK_INFO_HANDLER_IMPL_H
+#pragma once
 
 #include "gcs_table_storage.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
@@ -56,5 +55,3 @@ class DefaultTaskInfoHandler : public rpc::TaskInfoHandler {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_GCS_TASK_INFO_HANDLER_IMPL_H

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_SERVER_TEST_UTIL_H
-#define RAY_GCS_SERVER_TEST_UTIL_H
+#pragma once
 
 #include <memory>
 #include <utility>
@@ -317,5 +316,3 @@ struct GcsServerMocker {
 };
 
 }  // namespace ray
-
-#endif  // RAY_GCS_SERVER_TEST_UTIL_H

--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include "gtest/gtest.h"
 #include "ray/common/id.h"
 #include "ray/common/test_util.h"

--- a/src/ray/gcs/gcs_server/worker_info_handler_impl.h
+++ b/src/ray/gcs/gcs_server/worker_info_handler_impl.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_WORKER_INFO_HANDLER_IMPL_H
-#define RAY_GCS_WORKER_INFO_HANDLER_IMPL_H
+#pragma once
 
 #include "gcs_table_storage.h"
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
@@ -50,5 +49,3 @@ class DefaultWorkerInfoHandler : public rpc::WorkerInfoHandler {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_GCS_WORKER_INFO_HANDLER_IMPL_H

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_PB_UTIL_H
-#define RAY_GCS_PB_UTIL_H
+#pragma once
 
 #include <memory>
 
@@ -115,5 +114,3 @@ inline std::shared_ptr<ray::rpc::ObjectLocationChange> CreateObjectLocationChang
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_PB_UTIL_H

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_GCS_PUB_SUB_H_
-#define RAY_GCS_GCS_PUB_SUB_H_
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
@@ -158,5 +157,3 @@ class GcsPubSub {
 
 }  // namespace gcs
 }  // namespace ray
-
-#endif  // RAY_GCS_GCS_PUB_SUB_H_

--- a/src/ray/gcs/redis_accessor.h
+++ b/src/ray/gcs/redis_accessor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_ACCESSOR_H
-#define RAY_GCS_REDIS_ACCESSOR_H
+#pragma once
 
 #include <ray/common/task/task_spec.h>
 #include "ray/common/id.h"
@@ -467,5 +466,3 @@ class RedisWorkerInfoAccessor : public WorkerInfoAccessor {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_ACCESSOR_H

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_ASYNC_CONTEXT_H
-#define RAY_GCS_REDIS_ASYNC_CONTEXT_H
+#pragma once
 
 #include <stdarg.h>
 #include <mutex>
@@ -83,5 +82,3 @@ class RedisAsyncContext {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_ASYNC_CONTEXT_H

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_CLIENT_H
-#define RAY_GCS_REDIS_CLIENT_H
+#pragma once
 
 #include <map>
 #include <string>
@@ -107,5 +106,3 @@ class RedisClient {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_CLIENT_H

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_CONTEXT_H
-#define RAY_GCS_REDIS_CONTEXT_H
+#pragma once
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
@@ -366,5 +365,3 @@ std::shared_ptr<CallbackReply> RedisContext::RunSync(
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_CONTEXT_H

--- a/src/ray/gcs/redis_gcs_client.h
+++ b/src/ray/gcs/redis_gcs_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_REDIS_GCS_CLIENT_H
-#define RAY_GCS_REDIS_GCS_CLIENT_H
+#pragma once
 
 #include <map>
 #include <string>
@@ -138,5 +137,3 @@ class RAY_EXPORT RedisGcsClient : public GcsClient {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_REDIS_GCS_CLIENT_H

--- a/src/ray/gcs/redis_module/chain_module.h
+++ b/src/ray/gcs/redis_module/chain_module.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_CHAIN_MODULE_H_
-#define RAY_CHAIN_MODULE_H_
+#pragma once
 
 #include <functional>
 
@@ -72,5 +71,3 @@ class RedisChainModule {
   int ChainReplicate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                      NodeFunc node_func, TailFunc tail_func);
 };
-
-#endif  // RAY_CHAIN_MODULE_H_

--- a/src/ray/gcs/redis_module/redis_string.h
+++ b/src/ray/gcs/redis_module/redis_string.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_REDIS_STRING_H_
-#define RAY_REDIS_STRING_H_
+#pragma once
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -89,5 +88,3 @@ std::string RedisString_ToString(RedisModuleString *string) {
   const char *data = RedisModule_StringPtrLen(string, &size);
   return std::string(data, size);
 }
-
-#endif  // RAY_REDIS_STRING_H_

--- a/src/ray/gcs/redis_module/redismodule.h
+++ b/src/ray/gcs/redis_module/redismodule.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef REDISMODULE_H
-#define REDISMODULE_H
+#pragma once
 
 #include <stdint.h>
 #include <stdio.h>
@@ -415,4 +414,3 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
 #define RedisModuleString robj
 
 #endif /* REDISMODULE_CORE */
-#endif /* REDISMOUDLE_H */

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_STORE_CLIENT_IN_MEMORY_STORE_CLIENT_H
-#define RAY_GCS_STORE_CLIENT_IN_MEMORY_STORE_CLIENT_H
+#pragma once
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
@@ -85,5 +84,3 @@ class InMemoryStoreClient : public StoreClient {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_STORE_CLIENT_IN_MEMORY_STORE_CLIENT_H

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_STORE_CLIENT_REDIS_STORE_CLIENT_H
-#define RAY_GCS_STORE_CLIENT_REDIS_STORE_CLIENT_H
+#pragma once
 
 #include "absl/container/flat_hash_set.h"
 #include "ray/gcs/redis_client.h"
@@ -139,5 +138,3 @@ class RedisStoreClient : public StoreClient {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_STORE_CLIENT_REDIS_STORE_CLIENT_H

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_STORE_CLIENT_STORE_CLIENT_H
-#define RAY_GCS_STORE_CLIENT_STORE_CLIENT_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -120,5 +119,3 @@ class StoreClient {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_STORE_CLIENT_STORE_CLIENT_H

--- a/src/ray/gcs/store_client/test/store_client_test_base.h
+++ b/src/ray/gcs/store_client/test/store_client_test_base.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <atomic>
 #include <chrono>
 #include <memory>

--- a/src/ray/gcs/subscription_executor.h
+++ b/src/ray/gcs/subscription_executor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_SUBSCRIPTION_EXECUTOR_H
-#define RAY_GCS_SUBSCRIPTION_EXECUTOR_H
+#pragma once
 
 #include <atomic>
 #include <list>
@@ -106,5 +105,3 @@ class SubscriptionExecutor {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_SUBSCRIPTION_EXECUTOR_H

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_TABLES_H
-#define RAY_GCS_TABLES_H
+#pragma once
 
 #include <map>
 #include <string>
@@ -1024,5 +1023,3 @@ class ClientTable : public Log<ClientID, GcsNodeInfo> {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_TABLES_H

--- a/src/ray/gcs/test/accessor_test_base.h
+++ b/src/ray/gcs/test/accessor_test_base.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_ACCESSOR_TEST_BASE_H
-#define RAY_GCS_ACCESSOR_TEST_BASE_H
+#pragma once
 
 #include <atomic>
 #include <chrono>
@@ -94,5 +93,3 @@ class AccessorTestBase : public ::testing::Test {
 }  // namespace gcs
 
 }  // namespace ray
-
-#endif  // RAY_GCS_ACCESSOR_TEST_BASE_H

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_GCS_TEST_UTIL_H
-#define RAY_GCS_TEST_UTIL_H
+#pragma once
 
 #include <memory>
 #include <utility>
@@ -136,5 +135,3 @@ struct Mocker {
 };
 
 }  // namespace ray
-
-#endif  // RAY_GCS_TEST_UTIL_H

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_OBJECT_MANAGER_OBJECT_BUFFER_POOL_H
-#define RAY_OBJECT_MANAGER_OBJECT_BUFFER_POOL_H
+#pragma once
 
 #include <list>
 #include <memory>
@@ -211,5 +210,3 @@ class ObjectBufferPool {
 };
 
 }  // namespace ray
-
-#endif  // RAY_OBJECT_MANAGER_OBJECT_BUFFER_POOL_H

--- a/src/ray/object_manager/object_directory.h
+++ b/src/ray/object_manager/object_directory.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_OBJECT_MANAGER_OBJECT_DIRECTORY_H
-#define RAY_OBJECT_MANAGER_OBJECT_DIRECTORY_H
+#pragma once
 
 #include <memory>
 #include <mutex>
@@ -197,5 +196,3 @@ class ObjectDirectory : public ObjectDirectoryInterface {
 };
 
 }  // namespace ray
-
-#endif  // RAY_OBJECT_MANAGER_OBJECT_DIRECTORY_H

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_OBJECT_MANAGER_OBJECT_MANAGER_H
-#define RAY_OBJECT_MANAGER_OBJECT_MANAGER_H
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -454,5 +453,3 @@ class ObjectManager : public ObjectManagerInterface,
 };
 
 }  // namespace ray
-
-#endif  // RAY_OBJECT_MANAGER_OBJECT_MANAGER_H

--- a/src/ray/object_manager/object_store_notification_manager.h
+++ b/src/ray/object_manager/object_store_notification_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_OBJECT_MANAGER_OBJECT_STORE_CLIENT_H
-#define RAY_OBJECT_MANAGER_OBJECT_STORE_CLIENT_H
+#pragma once
 
 #include <list>
 #include <memory>
@@ -99,5 +98,3 @@ class ObjectStoreNotificationManager {
 };
 
 }  // namespace ray
-
-#endif  // RAY_OBJECT_MANAGER_OBJECT_STORE_CLIENT_H

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_CLIENT_H
-#define PLASMA_CLIENT_H
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -308,5 +307,3 @@ class ARROW_EXPORT PlasmaClient {
 };
 
 }  // namespace plasma
-
-#endif  // PLASMA_CLIENT_H

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_COMMON_H
-#define PLASMA_COMMON_H
+#pragma once
 
 #include <stddef.h>
 
@@ -123,5 +122,3 @@ typedef std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> ObjectTa
 struct PlasmaStoreInfo;
 extern const PlasmaStoreInfo* plasma_config;
 }  // namespace plasma
-
-#endif  // PLASMA_COMMON_H

--- a/src/ray/object_manager/plasma/compat.h
+++ b/src/ray/object_manager/plasma/compat.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_COMPAT_H
-#define PLASMA_COMPAT_H
+#pragma once
 
 // Workaround for multithreading on XCode 9, see
 // https://issues.apache.org/jira/browse/ARROW-1622 and
@@ -31,5 +30,3 @@ typedef __darwin_mach_port_t mach_port_t;
 mach_port_t pthread_mach_thread_np(pthread_t);
 #endif /* _MACH_PORT_T */
 #endif /* __APPLE__ */
-
-#endif  // PLASMA_COMPAT_H

--- a/src/ray/object_manager/plasma/events.h
+++ b/src/ray/object_manager/plasma/events.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_EVENTS
-#define PLASMA_EVENTS
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -107,5 +106,3 @@ class EventLoop {
 };
 
 }  // namespace plasma
-
-#endif  // PLASMA_EVENTS

--- a/src/ray/object_manager/plasma/eviction_policy.h
+++ b/src/ray/object_manager/plasma/eviction_policy.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_EVICTION_POLICY_H
-#define PLASMA_EVICTION_POLICY_H
+#pragma once
 
 #include <functional>
 #include <list>
@@ -208,5 +207,3 @@ class EvictionPolicy {
 };
 
 }  // namespace plasma
-
-#endif  // PLASMA_EVICTION_POLICY_H

--- a/src/ray/object_manager/plasma/external_store.h
+++ b/src/ray/object_manager/plasma/external_store.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef EXTERNAL_STORE_H
-#define EXTERNAL_STORE_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -119,5 +118,3 @@ class ExternalStores {
   store##Class singleton_##store = store##Class()
 
 }  // namespace plasma
-
-#endif  // EXTERNAL_STORE_H

--- a/src/ray/object_manager/plasma/fling.h
+++ b/src/ray/object_manager/plasma/fling.h
@@ -23,6 +23,8 @@
 //
 // Most of the code is from https://github.com/sharvil/flingfd
 
+#pragma once
+
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/src/ray/object_manager/plasma/hash_table_store.h
+++ b/src/ray/object_manager/plasma/hash_table_store.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef HASH_TABLE_STORE_H
-#define HASH_TABLE_STORE_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -49,5 +48,3 @@ class HashTableStore : public ExternalStore {
 };
 
 }  // namespace plasma
-
-#endif  // HASH_TABLE_STORE_H

--- a/src/ray/object_manager/plasma/io.h
+++ b/src/ray/object_manager/plasma/io.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_IO_H
-#define PLASMA_IO_H
+#pragma once
 
 #include <inttypes.h>
 #include <sys/socket.h>
@@ -65,5 +64,3 @@ int AcceptClient(int socket_fd);
 std::unique_ptr<uint8_t[]> ReadMessageAsync(int sock);
 
 }  // namespace plasma
-
-#endif  // PLASMA_IO_H

--- a/src/ray/object_manager/plasma/malloc.h
+++ b/src/ray/object_manager/plasma/malloc.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_MALLOC_H
-#define PLASMA_MALLOC_H
+#pragma once
 
 #include <inttypes.h>
 #include <stddef.h>
@@ -50,5 +49,3 @@ struct MmapRecord {
 extern std::unordered_map<void*, MmapRecord> mmap_records;
 
 }  // namespace plasma
-
-#endif  // PLASMA_MALLOC_H

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_PLASMA_H
-#define PLASMA_PLASMA_H
+#pragma once
 
 #include <errno.h>
 #include <inttypes.h>
@@ -173,5 +172,3 @@ std::unique_ptr<uint8_t[]> CreatePlasmaNotificationBuffer(
     std::vector<flatbuf::ObjectInfoT>& object_info);
 
 }  // namespace plasma
-
-#endif  // PLASMA_PLASMA_H

--- a/src/ray/object_manager/plasma/plasma_allocator.h
+++ b/src/ray/object_manager/plasma/plasma_allocator.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_ALLOCATOR_H
-#define PLASMA_ALLOCATOR_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -60,5 +59,3 @@ class PlasmaAllocator {
 };
 
 }  // namespace plasma
-
-#endif  // ARROW_PLASMA_ALLOCATOR_H

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_PROTOCOL_H
-#define PLASMA_PROTOCOL_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -247,5 +246,3 @@ Status SendRefreshLRUReply(int sock);
 Status ReadRefreshLRUReply(uint8_t* data, size_t size);
 
 }  // namespace plasma
-
-#endif /* PLASMA_PROTOCOL */

--- a/src/ray/object_manager/plasma/quota_aware_policy.h
+++ b/src/ray/object_manager/plasma/quota_aware_policy.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_QUOTA_AWARE_POLICY_H
-#define PLASMA_QUOTA_AWARE_POLICY_H
+#pragma once
 
 #include <list>
 #include <memory>
@@ -87,5 +86,3 @@ class QuotaAwarePolicy : public EvictionPolicy {
 };
 
 }  // namespace plasma
-
-#endif  // PLASMA_EVICTION_POLICY_H

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_STORE_H
-#define PLASMA_STORE_H
+#pragma once
 
 #include <deque>
 #include <memory>
@@ -246,5 +245,3 @@ class PlasmaStore {
 };
 
 }  // namespace plasma
-
-#endif  // PLASMA_STORE_H

--- a/src/ray/object_manager/plasma/store_runner.h
+++ b/src/ray/object_manager/plasma/store_runner.h
@@ -1,5 +1,4 @@
-#ifndef PLASMA_STORE_RUNNER_H
-#define PLASMA_STORE_RUNNER_H
+#pragma once
 
 #include <memory>
 
@@ -34,5 +33,3 @@ class PlasmaStoreRunner {
 extern std::unique_ptr<PlasmaStoreRunner> plasma_store_runner;
 
 }  // namespace plasma
-
-#endif  // PLASMA_STORE_RUNNER_H

--- a/src/ray/object_manager/plasma/test_util.h
+++ b/src/ray/object_manager/plasma/test_util.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PLASMA_TEST_UTIL_H
-#define PLASMA_TEST_UTIL_H
+#pragma once
 
 #include <algorithm>
 #include <limits>
@@ -45,5 +44,3 @@ ObjectID random_object_id() {
   } while (false);
 
 }  // namespace plasma
-
-#endif  // PLASMA_TEST_UTIL_H

--- a/src/ray/raylet/actor_registration.h
+++ b/src/ray/raylet/actor_registration.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_ACTOR_REGISTRATION_H
-#define RAY_RAYLET_ACTOR_REGISTRATION_H
+#pragma once
 
 #include <unordered_map>
 
@@ -180,5 +179,3 @@ class ActorRegistration {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_ACTOR_REGISTRATION_H

--- a/src/ray/raylet/lineage_cache.h
+++ b/src/ray/raylet/lineage_cache.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_LINEAGE_CACHE_H
-#define RAY_RAYLET_LINEAGE_CACHE_H
+#pragma once
 
 #include <gtest/gtest_prod.h>
 #include <boost/optional.hpp>
@@ -326,5 +325,3 @@ class LineageCache {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_LINEAGE_CACHE_H

--- a/src/ray/raylet/mock_gcs_client.h
+++ b/src/ray/raylet/mock_gcs_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_MOCK_GCS_CLIENT_H
-#define RAY_RAYLET_MOCK_GCS_CLIENT_H
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -101,5 +100,3 @@ class GcsClient {
   std::unique_ptr<ClientTable> client_table_;
 };
 }  // namespace ray
-
-#endif  // RAY_RAYLET_MOCK_GCS_CLIENT_H

--- a/src/ray/raylet/monitor.h
+++ b/src/ray/raylet/monitor.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_MONITOR_H
-#define RAY_RAYLET_MONITOR_H
+#pragma once
 
 #include <memory>
 #include <unordered_set>
@@ -74,5 +73,3 @@ class Monitor {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_MONITOR_H

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_NODE_MANAGER_H
-#define RAY_RAYLET_NODE_MANAGER_H
+#pragma once
 
 #include <boost/asio/steady_timer.hpp>
 
@@ -789,5 +788,3 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
 }  // namespace raylet
 
 }  // end namespace ray
-
-#endif  // RAY_RAYLET_NODE_MANAGER_H

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_RAYLET_H
-#define RAY_RAYLET_RAYLET_H
+#pragma once
 
 #include <list>
 
@@ -103,5 +102,3 @@ class Raylet {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_RAYLET_H

--- a/src/ray/raylet/raylet_client.h
+++ b/src/ray/raylet/raylet_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAYLET_CLIENT_H
-#define RAYLET_CLIENT_H
+#pragma once
 
 #include <ray/protobuf/gcs.pb.h>
 #include <unistd.h>
@@ -340,5 +339,3 @@ class RayletClient : public PinObjectsInterface,
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif

--- a/src/ray/raylet/reconstruction_policy.h
+++ b/src/ray/raylet/reconstruction_policy.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_RECONSTRUCTION_POLICY_H
-#define RAY_RAYLET_RECONSTRUCTION_POLICY_H
+#pragma once
 
 #include <functional>
 #include <unordered_map>
@@ -166,5 +165,3 @@ class ReconstructionPolicy : public ReconstructionPolicyInterface {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_RECONSTRUCTION_POLICY_H

--- a/src/ray/raylet/scheduling_policy.h
+++ b/src/ray/raylet/scheduling_policy.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_SCHEDULING_POLICY_H
-#define RAY_RAYLET_SCHEDULING_POLICY_H
+#pragma once
 
 #include <random>
 #include <unordered_map>
@@ -72,5 +71,3 @@ class SchedulingPolicy {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_SCHEDULING_POLICY_H

--- a/src/ray/raylet/scheduling_queue.h
+++ b/src/ray/raylet/scheduling_queue.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_SCHEDULING_QUEUE_H
-#define RAY_RAYLET_SCHEDULING_QUEUE_H
+#pragma once
 
 #include <array>
 #include <list>
@@ -366,5 +365,3 @@ class SchedulingQueue {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_SCHEDULING_QUEUE_H

--- a/src/ray/raylet/task_dependency_manager.h
+++ b/src/ray/raylet/task_dependency_manager.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_TASK_DEPENDENCY_MANAGER_H
-#define RAY_RAYLET_TASK_DEPENDENCY_MANAGER_H
+#pragma once
 
 // clang-format off
 #include "ray/common/id.h"
@@ -268,5 +267,3 @@ class TaskDependencyManager {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_TASK_DEPENDENCY_MANAGER_H

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_WORKER_H
-#define RAY_RAYLET_WORKER_H
+#pragma once
 
 #include <memory>
 
@@ -202,5 +201,3 @@ class Worker {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_WORKER_H

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RAYLET_WORKER_POOL_H
-#define RAY_RAYLET_WORKER_POOL_H
+#pragma once
 
 #include <inttypes.h>
 
@@ -290,5 +289,3 @@ class WorkerPool {
 }  // namespace raylet
 
 }  // namespace ray
-
-#endif  // RAY_RAYLET_WORKER_POOL_H

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_CLIENT_CALL_H
-#define RAY_RPC_CLIENT_CALL_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 #include <boost/asio.hpp>
@@ -281,5 +280,3 @@ class ClientCallManager {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_GCS_RPC_CLIENT_H
-#define RAY_RPC_GCS_RPC_CLIENT_H
+#pragma once
 
 #include <unistd.h>
 
@@ -291,5 +290,3 @@ class GcsRpcClient {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_GCS_RPC_CLIENT_H

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_GCS_RPC_SERVER_H
-#define RAY_RPC_GCS_RPC_SERVER_H
+#pragma once
 
 #include "ray/protobuf/gcs_service.grpc.pb.h"
 #include "ray/rpc/grpc_server.h"
@@ -468,5 +467,3 @@ using WorkerInfoHandler = WorkerInfoGcsServiceHandler;
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_GCS_RPC_SERVER_H

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_GRPC_CLIENT_H
-#define RAY_RPC_GRPC_CLIENT_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 #include <boost/asio.hpp>
@@ -109,5 +108,3 @@ class GrpcClient {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_GRPC_SERVER_H
-#define RAY_RPC_GRPC_SERVER_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 
@@ -160,5 +159,3 @@ class GrpcService {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_NODE_MANAGER_CLIENT_H
-#define RAY_RPC_NODE_MANAGER_CLIENT_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 
@@ -118,5 +117,3 @@ class NodeManagerWorkerClient
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_NODE_MANAGER_CLIENT_H

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_NODE_MANAGER_SERVER_H
-#define RAY_RPC_NODE_MANAGER_SERVER_H
+#pragma once
 
 #include "ray/protobuf/node_manager.grpc.pb.h"
 #include "ray/protobuf/node_manager.pb.h"
@@ -110,5 +109,3 @@ class NodeManagerGrpcService : public GrpcService {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/object_manager/object_manager_client.h
+++ b/src/ray/rpc/object_manager/object_manager_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_OBJECT_MANAGER_CLIENT_H
-#define RAY_RPC_OBJECT_MANAGER_CLIENT_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/resource_quota.h>
@@ -93,5 +92,3 @@ class ObjectManagerClient {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_OBJECT_MANAGER_CLIENT_H

--- a/src/ray/rpc/object_manager/object_manager_server.h
+++ b/src/ray/rpc/object_manager/object_manager_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_OBJECT_MANAGER_SERVER_H
-#define RAY_RPC_OBJECT_MANAGER_SERVER_H
+#pragma once
 
 #include "ray/protobuf/object_manager.grpc.pb.h"
 #include "ray/protobuf/object_manager.pb.h"
@@ -79,5 +78,3 @@ class ObjectManagerGrpcService : public GrpcService {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_SERVER_CALL_H
-#define RAY_RPC_SERVER_CALL_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 #include <boost/asio.hpp>
@@ -310,5 +309,3 @@ class ServerCallFactoryImpl : public ServerCallFactory {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_CORE_WORKER_CLIENT_H
-#define RAY_RPC_CORE_WORKER_CLIENT_H
+#pragma once
 
 #include <grpcpp/grpcpp.h>
 
@@ -341,5 +340,3 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_CORE_WORKER_CLIENT_H

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_RPC_CORE_WORKER_SERVER_H
-#define RAY_RPC_CORE_WORKER_SERVER_H
+#pragma once
 
 #include "ray/protobuf/core_worker.grpc.pb.h"
 #include "ray/protobuf/core_worker.pb.h"
@@ -103,5 +102,3 @@ class CoreWorkerGrpcService : public GrpcService {
 
 }  // namespace rpc
 }  // namespace ray
-
-#endif  // RAY_RPC_CORE_WORKER_SERVER_H

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_STATS_METRIC_H
-#define RAY_STATS_METRIC_H
+#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -145,5 +144,3 @@ class Sum : public Metric {
 }  // namespace stats
 
 }  // namespace ray
-
-#endif  // RAY_STATS_METRIC_H

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_STATS_METRIC_DEFS_H
-#define RAY_STATS_METRIC_DEFS_H
+#pragma once
 
 /// The definitions of metrics that you can use everywhere.
 ///
@@ -75,5 +74,3 @@ static Gauge ReconstructionPolicyStats(
 static Gauge ConnectionPoolStats("connection_pool_stats",
                                  "Stats the connection pool metrics.", "pcs",
                                  {ValueTypeKey});
-
-#endif  // RAY_STATS_METRIC_DEFS_H

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_STATS_STATS_H
-#define RAY_STATS_STATS_H
+#pragma once
 
 #include <exception>
 #include <string>
@@ -72,5 +71,3 @@ static void Init(const std::string &address, const TagsType &global_tags,
 }  // namespace stats
 
 }  // namespace ray
-
-#endif  // RAY_STATS_STATS_H

--- a/src/ray/stats/tag_defs.h
+++ b/src/ray/stats/tag_defs.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_STATS_TAG_DEFS_H
-#define RAY_STATS_TAG_DEFS_H
+#pragma once
 
 /// The definitions of tag keys that you can use every where.
 /// You can follow these examples to define and register your tag keys.
@@ -38,5 +37,3 @@ static const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
 static const TagKeyType ResourceNameKey = TagKeyType::Register("ResourceName");
 
 static const TagKeyType ValueTypeKey = TagKeyType::Register("ValueType");
-
-#endif  // RAY_STATS_TAG_DEFS_H

--- a/src/ray/util/asio_util.h
+++ b/src/ray/util/asio_util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_ASIO_UTIL_H
-#define RAY_ASIO_UTIL_H
+#pragma once
 
 #include <boost/asio.hpp>
 
@@ -27,5 +26,3 @@ inline void execute_after(boost::asio::io_context &io_context,
     }
   });
 }
-
-#endif  // RAY_ASIO_UTIL_H

--- a/src/ray/util/filesystem.h
+++ b/src/ray/util/filesystem.h
@@ -1,5 +1,4 @@
-#ifndef RAY_UTIL_FILESYSTEM_H
-#define RAY_UTIL_FILESYSTEM_H
+#pragma once
 
 #include <string>
 #include <utility>
@@ -74,5 +73,3 @@ std::string JoinPaths(std::string base, Paths... components) {
   return base;
 }
 }  // namespace ray
-
-#endif  // RAY_UTIL_UTIL_H

--- a/src/ray/util/io_service_pool.h
+++ b/src/ray/util/io_service_pool.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_IO_SERVICE_POOL_H
-#define RAY_UTIL_IO_SERVICE_POOL_H
+#pragma once
 
 #include <atomic>
 #include <boost/asio.hpp>
@@ -79,5 +78,3 @@ inline std::vector<boost::asio::io_service *> IOServicePool::GetAll() {
 }
 
 }  // namespace ray
-
-#endif  // RAY_UTIL_IO_SERVICE_POOL_H

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_LOGGING_H
-#define RAY_UTIL_LOGGING_H
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -171,5 +170,3 @@ class Voidify {
 };
 
 }  // namespace ray
-
-#endif  // RAY_UTIL_LOGGING_H

--- a/src/ray/util/macros.h
+++ b/src/ray/util/macros.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_MACROS_H
-#define RAY_UTIL_MACROS_H
+#pragma once
 
 // From Google gutil
 #ifndef RAY_DISALLOW_COPY_AND_ASSIGN
@@ -54,5 +53,3 @@
 #else
 #define RAY_MUST_USE_RESULT
 #endif
-
-#endif  // RAY_UTIL_MACROS_H

--- a/src/ray/util/memory.h
+++ b/src/ray/util/memory.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_MEMORY_H
-#define RAY_UTIL_MEMORY_H
+#pragma once
 
 #include <stdint.h>
 
@@ -25,5 +24,3 @@ void parallel_memcopy(uint8_t *dst, const uint8_t *src, int64_t nbytes,
                       uintptr_t block_size, int num_threads);
 
 }  // namespace ray
-
-#endif  // RAY_UTIL_MEMORY_H

--- a/src/ray/util/ordered_set.h
+++ b/src/ray/util/ordered_set.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_ORDERED_SET_H
-#define RAY_UTIL_ORDERED_SET_H
+#pragma once
 
 #include <list>
 #include <unordered_map>
@@ -81,5 +80,3 @@ class ordered_set {
   elements_type elements_;
   positions_type positions_;
 };
-
-#endif  // RAY_UTIL_ORDERED_SET_H

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_PROCESS_H
-#define RAY_UTIL_PROCESS_H
+#pragma once
 
 #ifdef __linux__
 #include <fcntl.h>
@@ -102,5 +101,3 @@ struct hash<ray::Process> {
 };
 
 }  // namespace std
-
-#endif

--- a/src/ray/util/sample.h
+++ b/src/ray/util/sample.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_SAMPLE_H
-#define RAY_UTIL_SAMPLE_H
+#pragma once
 
 #include <random>
 
@@ -44,5 +43,3 @@ void random_sample(Iterator begin, Iterator end, size_t num_elements,
   }
   return;
 }
-
-#endif  // RAY_UTIL_SAMPLE_H

--- a/src/ray/util/sequencer.h
+++ b/src/ray/util/sequencer.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_SEQUENCER_H_
-#define RAY_UTIL_SEQUENCER_H_
+#pragma once
 
 #include <deque>
 #include <functional>
@@ -77,5 +76,3 @@ class Sequencer {
 };
 
 }  // namespace ray
-
-#endif  // RAY_UTIL_SEQUENCER_H_

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_UTIL_H
-#define RAY_UTIL_UTIL_H
+#pragma once
 
 #include <chrono>
 #include <iterator>
@@ -166,5 +165,3 @@ void FillRandom(T *data) {
     (*data)[i] = static_cast<uint8_t>(dist(generator));
   }
 }
-
-#endif  // RAY_UTIL_UTIL_H

--- a/src/ray/util/visibility.h
+++ b/src/ray/util/visibility.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RAY_UTIL_VISIBILITY_H
-#define RAY_UTIL_VISIBILITY_H
+#pragma once
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #if defined(_MSC_VER)
@@ -56,5 +55,3 @@
 #else
 #define RAY_TEMPLATE_EXPORT
 #endif
-
-#endif  // RAY_UTIL_VISIBILITY_H

--- a/streaming/src/channel.h
+++ b/streaming/src/channel.h
@@ -1,5 +1,4 @@
-#ifndef RAY_CHANNEL_H
-#define RAY_CHANNEL_H
+#pragma once
 
 #include "config/streaming_config.h"
 #include "queue/queue_handler.h"
@@ -198,5 +197,3 @@ class MockConsumer : public ConsumerChannel {
 
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_CHANNEL_H

--- a/streaming/src/config/streaming_config.h
+++ b/streaming/src/config/streaming_config.h
@@ -1,5 +1,4 @@
-#ifndef RAY_STREAMING_CONFIG_H
-#define RAY_STREAMING_CONFIG_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -67,4 +66,3 @@ class StreamingConfig {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif  // RAY_STREAMING_CONFIG_H

--- a/streaming/src/data_reader.h
+++ b/streaming/src/data_reader.h
@@ -1,5 +1,4 @@
-#ifndef RAY_DATA_READER_H
-#define RAY_DATA_READER_H
+#pragma once
 
 #include <cstdlib>
 #include <functional>
@@ -128,4 +127,3 @@ class DataReader {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif  // RAY_DATA_READER_H

--- a/streaming/src/data_writer.h
+++ b/streaming/src/data_writer.h
@@ -1,5 +1,4 @@
-#ifndef RAY_DATA_WRITER_H
-#define RAY_DATA_WRITER_H
+#pragma once
 
 #include <cstring>
 #include <mutex>
@@ -135,4 +134,3 @@ class DataWriter {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif  // RAY_DATA_WRITER_H

--- a/streaming/src/event_service.h
+++ b/streaming/src/event_service.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_EVENT_SERVER_H
-#define RAY_STREAMING_EVENT_SERVER_H
+#pragma once
+
 #include <condition_variable>
 #include <mutex>
 #include <queue>
@@ -139,4 +139,3 @@ class EventService {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif  // RAY_STREAMING_EVENT_SERVER_H

--- a/streaming/src/flow_control.h
+++ b/streaming/src/flow_control.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_FLOW_CONTROL_H
-#define RAY_STREAMING_FLOW_CONTROL_H
+#pragma once
+
 #include "channel.h"
 
 namespace ray {
@@ -42,4 +42,3 @@ class UnconsumedSeqFlowControl : public FlowControl {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif  // RAY_STREAMING_FLOW_CONTROL_H

--- a/streaming/src/lib/java/streaming_jni_common.h
+++ b/streaming/src/lib/java/streaming_jni_common.h
@@ -1,5 +1,4 @@
-#ifndef RAY_STREAMING_JNI_COMMON_H
-#define RAY_STREAMING_JNI_COMMON_H
+#pragma once
 
 #include <jni.h>
 #include <string>
@@ -104,4 +103,3 @@ std::shared_ptr<ray::RayFunction> FunctionDescriptorToRayFunction(
 void ParseChannelInitParameters(
     JNIEnv *env, jobject param_obj,
     std::vector<ray::streaming::ChannelCreationParameter> &parameter_vec);
-#endif  // RAY_STREAMING_JNI_COMMON_H

--- a/streaming/src/message/message.h
+++ b/streaming/src/message/message.h
@@ -1,5 +1,4 @@
-#ifndef RAY_MESSAGE_H
-#define RAY_MESSAGE_H
+#pragma once
 
 #include <memory>
 
@@ -89,5 +88,3 @@ class StreamingMessage {
 
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_MESSAGE_H

--- a/streaming/src/message/message_bundle.h
+++ b/streaming/src/message/message_bundle.h
@@ -1,5 +1,4 @@
-#ifndef RAY_MESSAGE_BUNDLE_H
-#define RAY_MESSAGE_BUNDLE_H
+#pragma once
 
 #include <ctime>
 #include <list>
@@ -178,5 +177,3 @@ class StreamingMessageBundle : public StreamingMessageBundleMeta {
 };
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_MESSAGE_BUNDLE_H

--- a/streaming/src/message/priority_queue.h
+++ b/streaming/src/message/priority_queue.h
@@ -1,5 +1,4 @@
-#ifndef RAY_PRIORITY_QUEUE_H
-#define RAY_PRIORITY_QUEUE_H
+#pragma once
 
 #include <algorithm>
 #include <memory>
@@ -49,5 +48,3 @@ class PriorityQueue {
 };
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_PRIORITY_QUEUE_H

--- a/streaming/src/queue/message.h
+++ b/streaming/src/queue/message.h
@@ -1,5 +1,4 @@
-#ifndef _STREAMING_QUEUE_MESSAGE_H_
-#define _STREAMING_QUEUE_MESSAGE_H_
+#pragma once
 
 #include "protobuf/streaming_queue.pb.h"
 #include "ray/common/buffer.h"
@@ -232,4 +231,3 @@ class TestCheckStatusRspMsg : public Message {
 
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/queue.h
+++ b/streaming/src/queue/queue.h
@@ -1,5 +1,5 @@
-#ifndef _STREAMING_QUEUE_H_
-#define _STREAMING_QUEUE_H_
+#pragma once
+
 #include <iterator>
 #include <list>
 #include <vector>
@@ -210,4 +210,3 @@ class ReaderQueue : public Queue {
 
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/queue_client.h
+++ b/streaming/src/queue/queue_client.h
@@ -1,5 +1,5 @@
-#ifndef _STREAMING_QUEUE_CLIENT_H_
-#define _STREAMING_QUEUE_CLIENT_H_
+#pragma once
+
 #include "queue_handler.h"
 #include "transport.h"
 
@@ -50,4 +50,3 @@ class WriterClient {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/queue_handler.h
+++ b/streaming/src/queue/queue_handler.h
@@ -1,5 +1,4 @@
-#ifndef _QUEUE_SERVICE_H_
-#define _QUEUE_SERVICE_H_
+#pragma once
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
@@ -177,4 +176,3 @@ class DownstreamQueueMessageHandler : public QueueMessageHandler {
 
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/queue_item.h
+++ b/streaming/src/queue/queue_item.h
@@ -1,5 +1,5 @@
-#ifndef _STREAMING_QUEUE_ITEM_H_
-#define _STREAMING_QUEUE_ITEM_H_
+#pragma once
+
 #include <iterator>
 #include <list>
 #include <thread>
@@ -106,4 +106,3 @@ typedef std::shared_ptr<QueueItem> QueueItemPtr;
 
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/transport.h
+++ b/streaming/src/queue/transport.h
@@ -1,5 +1,4 @@
-#ifndef _STREAMING_QUEUE_TRANSPORT_H_
-#define _STREAMING_QUEUE_TRANSPORT_H_
+#pragma once
 
 #include "ray/common/id.h"
 #include "ray/core_worker/core_worker.h"
@@ -66,4 +65,3 @@ class Transport {
 };
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/queue/utils.h
+++ b/streaming/src/queue/utils.h
@@ -1,5 +1,5 @@
-#ifndef _STREAMING_QUEUE_UTILS_H_
-#define _STREAMING_QUEUE_UTILS_H_
+#pragma once
+
 #include <chrono>
 #include <future>
 #include <thread>
@@ -47,4 +47,3 @@ class PromiseWrapper {
 
 }  // namespace streaming
 }  // namespace ray
-#endif

--- a/streaming/src/ring_buffer.h
+++ b/streaming/src/ring_buffer.h
@@ -1,5 +1,4 @@
-#ifndef RAY_RING_BUFFER_H
-#define RAY_RING_BUFFER_H
+#pragma once
 
 #include <atomic>
 #include <boost/circular_buffer.hpp>
@@ -216,5 +215,3 @@ class StreamingRingBuffer {
 typedef std::shared_ptr<StreamingRingBuffer> StreamingRingBufferPtr;
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_RING_BUFFER_H

--- a/streaming/src/runtime_context.h
+++ b/streaming/src/runtime_context.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_H
-#define RAY_STREAMING_H
+#pragma once
+
 #include <string>
 
 #include "config/streaming_config.h"
@@ -38,5 +38,3 @@ class RuntimeContext {
 
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_STREAMING_H

--- a/streaming/src/status.h
+++ b/streaming/src/status.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_STATUS_H
-#define RAY_STREAMING_STATUS_H
+#pragma once
+
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -43,5 +43,3 @@ static inline std::ostream &operator<<(std::ostream &os, const StreamingStatus &
 
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_STREAMING_STATUS_H

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "ray/common/test_util.h"
 #include "ray/util/filesystem.h"
 

--- a/streaming/src/util/streaming_logging.h
+++ b/streaming/src/util/streaming_logging.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_LOGGING_H
-#define RAY_STREAMING_LOGGING_H
+#pragma once
+
 #include "ray/util/logging.h"
 
 #define STREAMING_LOG RAY_LOG
@@ -7,5 +7,3 @@
 namespace ray {
 namespace streaming {}  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_STREAMING_LOGGING_H

--- a/streaming/src/util/streaming_util.h
+++ b/streaming/src/util/streaming_util.h
@@ -1,5 +1,5 @@
-#ifndef RAY_STREAMING_UTIL_H
-#define RAY_STREAMING_UTIL_H
+#pragma once
+
 #include <boost/any.hpp>
 #include <string>
 #include <unordered_map>
@@ -95,5 +95,3 @@ class Util {
 };
 }  // namespace streaming
 }  // namespace ray
-
-#endif  // RAY_STREAMING_UTIL_H


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Our upstream libraries like Arrow are using `#pragma once` (include plasma store) instead of include guards. I would also like to apply it to Ray, since our include guards are a bit messy (no uniform style/naming protocol)

Supported compiler versions: all major compilers. (https://en.wikipedia.org/wiki/Pragma_once#Portability) especially gcc >= 3.4 (gcc has full C++11 support since 4.8.1)

https://github.com/apache/arrow/pull/6680

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
