### PR TITLE
[testing] Adding useful error messages for long_running_tests

### DIFF
--- a/ci/long_running_tests/workloads/actor_deaths.py
+++ b/ci/long_running_tests/workloads/actor_deaths.py
@@ -15,7 +15,7 @@ num_nodes = 2
 message = ("Make sure there is enough memory on this machine to run this "
            "workload. We divide the system memory by 2 to provide a buffer.")
 assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
-        ray.utils.get_system_memory() / 2)
+        ray.utils.get_system_memory() / 2), message
 
 # Simulate a cluster on one machine.
 

--- a/ci/long_running_tests/workloads/many_drivers.py
+++ b/ci/long_running_tests/workloads/many_drivers.py
@@ -14,7 +14,7 @@ num_nodes = 4
 message = ("Make sure there is enough memory on this machine to run this "
            "workload. We divide the system memory by 2 to provide a buffer.")
 assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
-        ray.utils.get_system_memory() / 2)
+        ray.utils.get_system_memory() / 2), message
 
 # Simulate a cluster on one machine.
 

--- a/ci/long_running_tests/workloads/many_tasks.py
+++ b/ci/long_running_tests/workloads/many_tasks.py
@@ -15,7 +15,7 @@ num_nodes = 10
 message = ("Make sure there is enough memory on this machine to run this "
            "workload. We divide the system memory by 2 to provide a buffer.")
 assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
-        ray.utils.get_system_memory() / 2)
+        ray.utils.get_system_memory() / 2), message
 
 # Simulate a cluster on one machine.
 

--- a/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/ci/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -18,7 +18,7 @@ num_nodes = 10
 message = ("Make sure there is enough memory on this machine to run this "
            "workload. We divide the system memory by 2 to provide a buffer.")
 assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
-        ray.utils.get_system_memory() / 2)
+        ray.utils.get_system_memory() / 2), message
 
 # Simulate a cluster on one machine.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When assert fails, the 'message' should be printed--it currently does nothing.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
