### PR TITLE
[SGD] Variable worker CPU requirements

### DIFF
--- a/python/ray/util/sgd/tests/test_tensorflow.py
+++ b/python/ray/util/sgd/tests/test_tensorflow.py
@@ -47,7 +47,8 @@ def test_tune_train(ray_start_2_cpus, num_replicas):  # noqa: F811
         "data_creator": tune.function(simple_dataset),
         "num_replicas": num_replicas,
         "use_gpu": False,
-        "trainer_config": SIMPLE_CONFIG
+        "trainer_config": SIMPLE_CONFIG,
+        "num_cpus_per_worker": 1
     }
 
     tune.run(

--- a/python/ray/util/sgd/tests/test_torch_runner.py
+++ b/python/ray/util/sgd/tests/test_torch_runner.py
@@ -190,7 +190,8 @@ class TestLocalDistributedRunner(unittest.TestCase):
         mock_runner._set_cuda_device = MagicMock()
         preset_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
 
-        LocalDistributedRunner._try_reserve_and_set_cuda(mock_runner)
+        LocalDistributedRunner._try_reserve_resources_and_set_cuda(
+            mock_runner, 0, 1)
 
         self.assertTrue(mock_runner._set_cuda_device.called)
         local_device = mock_runner._set_cuda_device.call_args[0][0]
@@ -228,7 +229,8 @@ class TestLocalDistributedRunner(unittest.TestCase):
             init_mock.return_value = False
             mock_runner = MagicMock()
             mock_runner._set_cuda_device = MagicMock()
-            LocalDistributedRunner._try_reserve_and_set_cuda(mock_runner)
+            LocalDistributedRunner._try_reserve_resources_and_set_cuda(
+                mock_runner, 0, 1)
             args, _ = mock_runner._set_cuda_device.call_args
             self.assertTrue(("1" in args) or "0" in args)
             self.assertEquals(len(os.environ["CUDA_VISIBLE_DEVICES"]), 1)
@@ -239,7 +241,8 @@ class TestLocalDistributedRunner(unittest.TestCase):
             init_mock.return_value = False
             mock_runner = MagicMock()
             mock_runner._set_cuda_device = MagicMock()
-            LocalDistributedRunner._try_reserve_and_set_cuda(mock_runner)
+            LocalDistributedRunner._try_reserve_resources_and_set_cuda(
+                mock_runner, 0, 1)
             mock_runner._set_cuda_device.assert_called_with("0")
             self.assertEquals(len(os.environ["CUDA_VISIBLE_DEVICES"]), 1)
 

--- a/python/ray/util/sgd/tests/test_torch_runner.py
+++ b/python/ray/util/sgd/tests/test_torch_runner.py
@@ -258,7 +258,7 @@ class TestLocalDistributedRunner(unittest.TestCase):
         mock_runner = MagicMock()
         mock_runner._is_set = False
         LocalDistributedRunner._set_cuda_device(mock_runner, "123")
-        self.assertEqual(mock_runner.local_cuda_device, "123")
+        self.assertEquals(mock_runner.local_cuda_device, "123")
         self.assertTrue(set_mock.called)
         set_mock.assert_called_with(123)
 
@@ -269,7 +269,7 @@ class TestLocalDistributedRunner(unittest.TestCase):
         LocalDistributedRunner._try_reserve_and_set_resources(
             mock_runner, 4, 0)
         remaining = ray.available_resources()["CPU"]
-        self.assertEqual(int(remaining), 6)
+        self.assertEquals(int(remaining), 6)
 
     def testV2ReserveCPUResources(self):
         mock_runner = MagicMock()
@@ -278,4 +278,4 @@ class TestLocalDistributedRunner(unittest.TestCase):
         LocalDistributedRunner._try_reserve_and_set_resources(
             mock_runner, 4, 1)
         remaining = ray.available_resources()["CPU"]
-        self.assertEqual(int(remaining), 6)
+        self.assertEquals(int(remaining), 6)

--- a/python/ray/util/sgd/tests/test_torch_runner.py
+++ b/python/ray/util/sgd/tests/test_torch_runner.py
@@ -245,13 +245,11 @@ class TestLocalDistributedRunner(unittest.TestCase):
         os.environ["CUDA_VISIBLE_DEVICES"] = "0"
         with patch("torch.cuda.is_initialized") as init_mock:
             init_mock.return_value = False
-            init_mock.return_value = False
             self._testReserveCUDAResource(init_mock, 0)
 
     def test1VisibleNotInitializedAndReserveCPUResource(self):
         os.environ["CUDA_VISIBLE_DEVICES"] = "0"
         with patch("torch.cuda.is_initialized") as init_mock:
-            init_mock.return_value = False
             init_mock.return_value = False
             self._testReserveCUDAResource(init_mock, 2)
 

--- a/python/ray/util/sgd/tf/tf_trainer.py
+++ b/python/ray/util/sgd/tf/tf_trainer.py
@@ -18,6 +18,7 @@ class TFTrainer:
                  data_creator,
                  config=None,
                  num_replicas=1,
+                 num_cpus_per_worker=1,
                  use_gpu=False,
                  verbose=False):
         """Sets up the TensorFlow trainer.
@@ -32,6 +33,8 @@ class TFTrainer:
                 'data_creator'. Also contains `fit_config`, which is passed
                 into `model.fit(data, **fit_config)` and
                 `evaluate_config` which is passed into `model.evaluate`.
+            num_cpus_per_worker (int): Sets the cpu requirement for each
+                worker.
             num_replicas (int): Sets number of workers used in distributed
                 training. Workers will be placed arbitrarily across the
                 cluster.
@@ -41,6 +44,7 @@ class TFTrainer:
         self.model_creator = model_creator
         self.data_creator = data_creator
         self.config = {} if config is None else config
+        self.num_cpus_per_worker = num_cpus_per_worker
         self.use_gpu = use_gpu
         self.num_replicas = num_replicas
         self.verbose = verbose
@@ -48,7 +52,8 @@ class TFTrainer:
         # Generate actor class
         # todo: are these resource quotas right?
         # should they be exposed to the client codee?
-        Runner = ray.remote(num_cpus=1, num_gpus=int(use_gpu))(TFRunner)
+        Runner = ray.remote(num_cpus=self.num_cpus_per_worker,
+                            num_gpus=int(use_gpu))(TFRunner)
 
         # todo: should we warn about using
         # distributed training on one device only?
@@ -182,7 +187,8 @@ class TFTrainable(Trainable):
             data_creator=config["data_creator"],
             config=config.get("trainer_config", {}),
             num_replicas=config["num_replicas"],
-            use_gpu=config["use_gpu"])
+            use_gpu=config["use_gpu"],
+            num_cpus_per_worker=config["num_cpus_per_worker"])
 
     def _train(self):
 

--- a/python/ray/util/sgd/tf/tf_trainer.py
+++ b/python/ray/util/sgd/tf/tf_trainer.py
@@ -188,7 +188,7 @@ class TFTrainable(Trainable):
             config=config.get("trainer_config", {}),
             num_replicas=config["num_replicas"],
             use_gpu=config["use_gpu"],
-            num_cpus_per_worker=config["num_cpus_per_worker"])
+            num_cpus_per_worker=config.get("num_cpus_per_worker", 1))
 
     def _train(self):
 

--- a/python/ray/util/sgd/tf/tf_trainer.py
+++ b/python/ray/util/sgd/tf/tf_trainer.py
@@ -52,8 +52,8 @@ class TFTrainer:
         # Generate actor class
         # todo: are these resource quotas right?
         # should they be exposed to the client codee?
-        Runner = ray.remote(num_cpus=self.num_cpus_per_worker,
-                            num_gpus=int(use_gpu))(TFRunner)
+        Runner = ray.remote(
+            num_cpus=self.num_cpus_per_worker, num_gpus=int(use_gpu))(TFRunner)
 
         # todo: should we warn about using
         # distributed training on one device only?

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -346,7 +346,8 @@ class LocalDistributedRunner(DistributedTorchRunner):
         global _dummy_gpu_actor
         if cleanup:
             if _dummy_cpu_actor or _dummy_gpu_actor:
-                assert not self.is_actor(), "Actor shouldn't have a dummy actor."
+                assert not self.is_actor(), ("Actor shouldn't have a "
+                                             "dummy actor.")
             if _dummy_cpu_actor:
                 ray.kill(_dummy_cpu_actor)
             if _dummy_gpu_actor:

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -292,7 +292,6 @@ class LocalDistributedRunner(DistributedTorchRunner):
 
         # Reserve a local GPU or CPU for the local worker
         # TODO: we should make sure this NEVER dies.
-        self.local_cpu_device = None
         self.local_cuda_device = "0"
         self._is_set = False
         if num_gpus:

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -192,8 +192,9 @@ class _DummyActor:
 
     def cpu_devices(self):
         all_resource_ids = ray.get_resource_ids()
-        assigned_ids = [resource_id
-                        for resource_id, _ in all_resource_ids.get("CPU", [])]
+        assigned_ids = [
+            resource_id for resource_id, _ in all_resource_ids.get("CPU", [])
+        ]
         return assigned_ids
 
 

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -232,8 +232,7 @@ def reserve_resources(num_cpus, num_gpus, retries=20):
     for _ in range(retries):
         if _dummy_actor is None:
             _dummy_actor = ray.remote(
-                num_cpus=num_cpus,
-                num_gpus=1,
+                num_cpus=num_cpus, num_gpus=1,
                 resources={"node:" + ip: 0.1})(_DummyActor).remote()
 
         reserved_gpu_device = ray.get(_dummy_actor.cuda_devices.remote())

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -281,11 +281,11 @@ class LocalDistributedRunner(DistributedTorchRunner):
     def _try_reserve_resources_and_set_cuda(self, num_cpus, num_gpus):
         visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         reserved_gpu_device = reserve_resources(num_cpus, 1)
+        if num_gpus == 0:
+            return
         # This needs to be set even if torch.cuda is already
         # initialized because the env var is used later when
         # starting the DDP setup.
-        if num_gpus == 0:
-            return
         os.environ["CUDA_VISIBLE_DEVICES"] = reserved_gpu_device
         if visible_devices:
             # We want to set the index on the visible devices list.

--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -254,8 +254,7 @@ def reserve_resources(num_cpus, num_gpus, retries=20):
     for _ in range(retries):
         if _dummy_cuda_actor is None:
             _dummy_cuda_actor = ray.remote(
-                num_cpus=0,
-                num_gpus=num_gpus,
+                num_cpus=0, num_gpus=num_gpus,
                 resources={"node:" + ip: 0.1})(_DummyActor).remote()
 
         reserved_cuda_device = ray.get(_dummy_cuda_actor.cuda_devices.remote())

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -124,6 +124,7 @@ class TorchTrainer:
         num_workers (int): the number of workers used in distributed
             training. If 1, the worker will not be wrapped with
             DistributedDataParallel.
+        num_cpus_per_worker (int): Sets the cpu requirement for each worker.
         use_gpu (bool): Sets resource allocation for workers to 1 GPU
             if true, and automatically moves both the model and optimizer
             to the available CUDA device.
@@ -175,6 +176,7 @@ class TorchTrainer:
             initialization_hook=None,
             config=None,
             num_workers=1,
+            num_cpus_per_worker=1,
             use_gpu="auto",
             backend="auto",
             wrap_ddp=True,
@@ -240,6 +242,7 @@ class TorchTrainer:
 
         logger.debug("Using {} as backend.".format(backend))
         self.backend = backend
+        self.num_cpus_per_worker = num_cpus_per_worker
         self.use_gpu = use_gpu
         self.max_replicas = num_workers
 
@@ -328,11 +331,13 @@ class TorchTrainer:
 
             # Start local worker
             self.local_worker = LocalDistributedRunner(
-                num_cpus=1, num_gpus=int(self.use_gpu), **params)
+                num_cpus=self.num_cpus_per_worker,
+                num_gpus=int(self.use_gpu), **params)
 
             # Generate actor class
             RemoteRunner = ray.remote(
-                num_cpus=1, num_gpus=int(self.use_gpu))(DistributedTorchRunner)
+                num_cpus=self.num_cpus_per_worker,
+                num_gpus=int(self.use_gpu))(DistributedTorchRunner)
             # Start workers
             self.remote_workers = [
                 RemoteRunner.remote(**params) for i in range(num_workers - 1)
@@ -736,12 +741,14 @@ class TorchTrainer:
             def default_resource_request(cls, config):
                 num_workers = config.get("num_workers",
                                          kwargs.get("num_workers", 1))
+                num_cpus = config.get("num_cpus_per_worker",
+                                      kwargs.get("num_cpus_per_worker", 1))
                 use_gpu = config.get("use_gpu", kwargs.get("use_gpu"))
 
                 remote_worker_count = num_workers - 1
 
                 return Resources(
-                    cpu=1,
+                    cpu=num_cpus,
                     gpu=int(use_gpu),
                     extra_cpu=int(remote_worker_count),
                     extra_gpu=int(int(use_gpu) * remote_worker_count))

--- a/python/ray/util/sgd/torch/torch_trainer.py
+++ b/python/ray/util/sgd/torch/torch_trainer.py
@@ -332,7 +332,8 @@ class TorchTrainer:
             # Start local worker
             self.local_worker = LocalDistributedRunner(
                 num_cpus=self.num_cpus_per_worker,
-                num_gpus=int(self.use_gpu), **params)
+                num_gpus=int(self.use_gpu),
+                **params)
 
             # Generate actor class
             RemoteRunner = ray.remote(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Support set the CPU resource requirements for the training worker. This is useful for CPU only distributed model training to avoid CPU resource competition. And we also need extra processes to do speed up data loading, so the CPU resources should be specified.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
