### PR TITLE
Fix heap-use-after-free bug of gcs pub sub testcase

### DIFF
--- a/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
+++ b/src/ray/gcs/pubsub/test/gcs_pub_sub_test.cc
@@ -45,9 +45,13 @@ class GcsPubSubTest : public ::testing::Test {
     pub_sub_.reset();
     client_->Disconnect();
     io_service_.stop();
-    client_.reset();
     thread_io_service_->join();
     thread_io_service_.reset();
+
+    // Note: If we immediately reset client_ after io_service_ stop, because client_ still
+    // has thread executing logic, such as unsubscribe's callback, the problem of heap
+    // used after free will occur.
+    client_.reset();
   }
 
   void Subscribe(const std::string &channel, const std::string &id,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
If we immediately reset client_ after io_service_ stop, because client_ still has thread executing logic, such as unsubscribe's callback, the problem of heap used after free will occur.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
