### PR TITLE
[Core] Remove digests in plasma (4x performance improvement)

### DIFF
--- a/src/ray/object_manager/format/object_manager.fbs
+++ b/src/ray/object_manager/format/object_manager.fbs
@@ -32,9 +32,6 @@ table ObjectInfo {
   create_time: long;
   // How long creation of this object took.
   construct_duration: long;
-  // Hash of the object content. If the object is not sealed yet this is
-  // an empty string.
-  digest: string;
   // Specifies if this object was deleted or added.
   is_deletion: bool;
 }

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -178,21 +178,6 @@ class ARROW_EXPORT PlasmaClient {
   /// \return The return status.
   Status Contains(const ObjectID& object_id, bool* has_object);
 
-  /// List all the objects in the object store.
-  ///
-  /// This API is experimental and might change in the future.
-  ///
-  /// \param[out] objects ObjectTable of objects in the store. For each entry
-  ///             in the map, the following fields are available:
-  ///             - metadata_size: Size of the object metadata in bytes
-  ///             - data_size: Size of the object data in bytes
-  ///             - ref_count: Number of clients referencing the object buffer
-  ///             - create_time: Unix timestamp of the object creation
-  ///             - construct_duration: Object creation time in seconds
-  ///             - state: Is the object still being created or already sealed?
-  /// \return The return status.
-  Status List(ObjectTable* objects);
-
   /// Abort an unsealed object in the object store. If the abort succeeds, then
   /// it will be as if the object was never created at all. The unsealed object
   /// must have only a single reference (the one that would have been removed by

--- a/src/ray/object_manager/plasma/common.fbs
+++ b/src/ray/object_manager/plasma/common.fbs
@@ -31,9 +31,6 @@ table ObjectInfo {
   create_time: long;
   // How long creation of this object took.
   construct_duration: long;
-  // Hash of the object content. If the object is not sealed yet this is
-  // an empty string.
-  digest: string;
   // Specifies if this object was deleted or added.
   is_deletion: bool;
 }

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -45,9 +45,6 @@ enum MessageType:long {
   // See if the store contains an object (will be deprecated).
   PlasmaContainsRequest,
   PlasmaContainsReply,
-  // List all objects in the store.
-  PlasmaListRequest,
-  PlasmaListReply,
   // Get information for a newly connecting client.
   PlasmaConnectRequest,
   PlasmaConnectReply,
@@ -287,13 +284,6 @@ table PlasmaContainsReply {
   object_id: string;
   // 1 if the object is in the store and 0 otherwise.
   has_object: int;
-}
-
-table PlasmaListRequest {
-}
-
-table PlasmaListReply {
-  objects: [ObjectInfo];
 }
 
 // PlasmaConnect is used by a plasma client the first time it connects with the

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -179,8 +179,6 @@ table PlasmaCreateAndSealRequest {
   data: string;
   // The object's metadata.
   metadata: string;
-  // Hash of the object data.
-  digest: string;
 }
 
 table PlasmaCreateAndSealReply {
@@ -194,7 +192,6 @@ table PlasmaCreateAndSealBatchRequest {
     evict_if_full: bool;
     data: [string];
     metadata: [string];
-    digest: [string];
 }
 
 table PlasmaCreateAndSealBatchReply {
@@ -215,8 +212,6 @@ table PlasmaAbortReply {
 table PlasmaSealRequest {
   // ID of the object to be sealed.
   object_id: string;
-  // Hash of the object data.
-  digest: string;
 }
 
 table PlasmaSealReply {

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -90,25 +90,22 @@ Status ReadCreateReply(uint8_t* data, size_t size, ObjectID* object_id,
                        PlasmaObject* object, int* store_fd, int64_t* mmap_size);
 
 Status SendCreateAndSealRequest(int sock, const ObjectID& object_id, bool evict_if_full,
-                                const std::string& data, const std::string& metadata,
-                                unsigned char* digest);
+                                const std::string& data, const std::string& metadata);
 
 Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
                                 bool* evict_if_full, std::string* object_data,
-                                std::string* metadata, std::string* digest);
+                                std::string* metadata);
 
 Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids,
                                      bool evict_if_full,
                                      const std::vector<std::string>& data,
-                                     const std::vector<std::string>& metadata,
-                                     const std::vector<std::string>& digests);
+                                     const std::vector<std::string>& metadata);
 
 Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size,
                                      std::vector<ObjectID>* object_id,
                                      bool* evict_if_full,
                                      std::vector<std::string>* object_data,
-                                     std::vector<std::string>* metadata,
-                                     std::vector<std::string>* digests);
+                                     std::vector<std::string>* metadata);
 
 Status SendCreateAndSealReply(int sock, PlasmaError error);
 
@@ -128,10 +125,9 @@ Status ReadAbortReply(uint8_t* data, size_t size, ObjectID* object_id);
 
 /* Plasma Seal message functions. */
 
-Status SendSealRequest(int sock, ObjectID object_id, const std::string& digest);
+Status SendSealRequest(int sock, ObjectID object_id);
 
-Status ReadSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
-                       std::string* digest);
+Status ReadSealRequest(uint8_t* data, size_t size, ObjectID* object_id);
 
 Status SendSealReply(int sock, ObjectID object_id, PlasmaError error);
 
@@ -186,16 +182,6 @@ Status SendContainsReply(int sock, ObjectID object_id, bool has_object);
 
 Status ReadContainsReply(uint8_t* data, size_t size, ObjectID* object_id,
                          bool* has_object);
-
-/* Plasma List message functions. */
-
-Status SendListRequest(int sock);
-
-Status ReadListRequest(uint8_t* data, size_t size);
-
-Status SendListReply(int sock, const ObjectTable& objects);
-
-Status ReadListReply(uint8_t* data, size_t size, ObjectTable* objects);
 
 /* Plasma Connect message functions. */
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -137,10 +137,7 @@ class PlasmaStore {
   /// get.
   ///
   /// \param object_ids The vector of Object IDs of the objects to be sealed.
-  /// \param digests The vector of digests of the objects. This is used to tell if two
-  /// objects with the same object ID are the same.
-  void SealObjects(const std::vector<ObjectID>& object_ids,
-                   const std::vector<std::string>& digests);
+  void SealObjects(const std::vector<ObjectID>& object_ids);
 
   /// Check if the plasma store contains an object:
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Digests were used in plasma to distinguish objects in case of ObjectID overlapping (although we are not using it). Now our way of generating ObjectID should ensure that different ObjectID points to different objects.

However, computing the digests of large objects is the main overhead and is the main cause of high CPU contention. It also increases the size of IPC calls. This PR removes digests in plasma in change of much better performance. The `List` function call is also removed because it couples with digest and we are not using it.

This PR increases the large object put throughput performance to 4.4x (single client) and 1.55x (multiple clients)

**Performance Comparison:**

```
Before:

single client get calls per second 9293.56 +- 26.26
single client put calls per second 5346.88 +- 129.31
**single client put gigabytes per second 5.01 +- 0.68**
multi client put calls per second 10145.61 +- 226.07
**multi client put gigabytes per second 13.55 +- 5.89**
single client tasks sync per second 1103.01 +- 27.79
single client tasks async per second 14209.19 +- 614.51
multi client tasks async per second 40815.41 +- 2308.02
1:1 actor calls sync per second 1674.11 +- 63.74
1:1 actor calls async per second 6616.05 +- 72.97
1:1 actor calls concurrent per second 5667.39 +- 122.4
1:n actor calls async per second 10050.72 +- 91.84
n:n actor calls async per second 33732.59 +- 421.08
n:n actor calls with arg async per second 10781.66 +- 149.54
1:1 async-actor calls sync per second 1183.84 +- 28.45
1:1 async-actor calls async per second 3862.82 +- 119.24
1:1 async-actor calls with args async per second 2241.18 +- 37.79
1:n async-actor calls async per second 8993.51 +- 100.68
n:n async-actor calls async per second 25275.31 +- 223.06

After this PR:

single client get calls per second 9160.33 +- 176.46
single client put calls per second 5436.99 +- 115.41
**single client put gigabytes per second 22.26 +- 6.62**
multi client put calls per second 9908.4 +- 207.41
**multi client put gigabytes per second 20.99 +- 11.95**
single client tasks sync per second 1206.3 +- 38.53
single client tasks async per second 15651.57 +- 363.69
multi client tasks async per second 43883.96 +- 3129.57
1:1 actor calls sync per second 1648.85 +- 17.1
1:1 actor calls async per second 6880.17 +- 153.93
1:1 actor calls concurrent per second 5906.67 +- 153.06
1:n actor calls async per second 9955.94 +- 131.48
n:n actor calls async per second 34647.68 +- 421.49
n:n actor calls with arg async per second 10194.18 +- 169.31
1:1 async-actor calls sync per second 1193.76 +- 52.08
1:1 async-actor calls async per second 3760.37 +- 69.31
1:1 async-actor calls with args async per second 2264.01 +- 15.16
1:n async-actor calls async per second 8688.2 +- 149.09
n:n async-actor calls async per second 25395.45 +- 117.77
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
