### PR TITLE
[docker] Fix Bug in bazel cache

### DIFF
--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -6,8 +6,8 @@ ADD ray.tar /ray
 ADD git-rev /ray/git-rev
 RUN cd /ray && git init && ./ci/travis/install-bazel.sh
 ENV PATH=$PATH:/root/bin
-RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bashrc 
-RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bashrc 
+RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bazelrc 
+RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bazelrc 
 WORKDIR /ray/
 # The result of bazel build is reused in pip install. It if run first to allow
 # for failover to serial build if parallel build requires too much resources.

--- a/docker/tune_test/build_from_source.Dockerfile
+++ b/docker/tune_test/build_from_source.Dockerfile
@@ -17,8 +17,8 @@ ADD ray.tar /ray
 ADD git-rev /ray/git-rev
 
 RUN bash /ray/ci/travis/install-bazel.sh
-RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bashrc
-RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bashrc
+RUN echo 'build --remote_cache="https://storage.googleapis.com/ray-bazel-cache"' >> $HOME/.bazelrc
+RUN echo 'build --remote_upload_local_results=false' >> $HOME/.bazelrc
 RUN cd /ray/python; pip install -e . --verbose
 
 WORKDIR /ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
These Dockerfiles pipe bazel build info into `bashrc` *not* `bazelrc`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #8974

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
