### PR TITLE
Improve raylet failure msg.

### DIFF
--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -237,8 +237,9 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
           // error.
           RAY_LOG(ERROR)
               << "Core worker failed to get responses from local raylet. This is most "
-                 "likely because the local raylet has been crahsed." RAY_LOG(FATAL)
-              << status.ToString();
+                 "likely because the local raylet has been crahsed. Note that we don't "
+                 "currently handle local raylet failures.";
+          RAY_LOG(FATAL) << status.ToString();
         }
       }));
   RAY_CHECK(pending_lease_requests_

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -235,10 +235,9 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
           // A local request failed. This shouldn't happen if the raylet is still alive
           // and we don't currently handle raylet failures, so treat it as a fatal
           // error.
-          RAY_LOG(ERROR)
-              << "Core worker failed to get responses from local raylet. This is most "
-                 "likely because the local raylet has been crahsed. Note that we don't "
-                 "currently handle local raylet failures.";
+          RAY_LOG(ERROR) << "The worker failed to receive a response from the local "
+                            "raylet. This is most "
+                            "likely because the local raylet has crahsed.";
           RAY_LOG(FATAL) << status.ToString();
         }
       }));

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -235,7 +235,10 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
           // A local request failed. This shouldn't happen if the raylet is still alive
           // and we don't currently handle raylet failures, so treat it as a fatal
           // error.
-          RAY_LOG(FATAL) << status.ToString();
+          RAY_LOG(ERROR)
+              << "Core worker failed to get responses from local raylet. This is most "
+                 "likely because the local raylet has been crahsed." RAY_LOG(FATAL)
+              << status.ToString();
         }
       }));
   RAY_CHECK(pending_lease_requests_


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The error message given when the local raylet fails is not nice. For example, it is giving a log such as "failed to connect to all addresses". This makes sense if you know the context well, but in many cases, it is very confusing. This PR improves the logging message in this case. This logging message should be removed if we properly handle local raylet failures.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
