### PR TITLE
[Serve] Raise exception when _scale_replicas is infeasible

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -107,6 +107,7 @@ class ReplicaConfig:
         else:
             self.ray_actor_options = ray_actor_options
 
+        self.resource_dict = {}
         self._validate()
 
     def _validate(self):
@@ -138,6 +139,7 @@ class ReplicaConfig:
                     "num_cpus in ray_actor_options must be an int or a float.")
             elif num_cpus < 0:
                 raise ValueError("num_cpus in ray_actor_options must be >= 0.")
+            self.resource_dict["CPU"] = num_cpus
 
             num_gpus = self.ray_actor_options.get("num_gpus", 0)
             if not isinstance(num_gpus, (int, float)):
@@ -145,6 +147,7 @@ class ReplicaConfig:
                     "num_gpus in ray_actor_options must be an int or a float.")
             elif num_gpus < 0:
                 raise ValueError("num_gpus in ray_actor_options must be >= 0.")
+            self.resource_dict["GPU"] = num_gpus
 
             memory = self.ray_actor_options.get("memory", 0)
             if not isinstance(memory, (int, float)):
@@ -152,6 +155,7 @@ class ReplicaConfig:
                     "memory in ray_actor_options must be an int or a float.")
             elif memory < 0:
                 raise ValueError("num_gpus in ray_actor_options must be >= 0.")
+            self.resource_dict["memory"] = memory
 
             object_store_memory = self.ray_actor_options.get(
                 "object_store_memory", 0)
@@ -162,8 +166,10 @@ class ReplicaConfig:
             elif object_store_memory < 0:
                 raise ValueError(
                     "object_store_memory in ray_actor_options must be >= 0.")
+            self.resource_dict["object_store_memory"] = object_store_memory
 
-            if not isinstance(
-                    self.ray_actor_options.get("resources", {}), dict):
+            custom_resources = self.ray_actor_options.get("resources", {})
+            if not isinstance(custom_resources, dict):
                 raise TypeError(
                     "resources in ray_actor_options must be a dictionary.")
+            self.resource_dict.update(custom_resources)

--- a/python/ray/serve/master.py
+++ b/python/ray/serve/master.py
@@ -444,7 +444,6 @@ class ServeMaster:
                                  num_possible,
                                  current_num_replicas + num_possible))
 
-        if delta_num_replicas > 0:
             logger.debug("Adding {} replicas to backend {}".format(
                 delta_num_replicas, backend_tag))
             for _ in range(delta_num_replicas):

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -4,7 +4,8 @@ import json
 import numpy as np
 import pytest
 
-from ray.serve.utils import ServeEncoder, chain_future, unpack_future
+from ray.serve.utils import (ServeEncoder, chain_future, unpack_future,
+                             MockScheduler)
 
 
 def test_bytes_encoder():
@@ -64,6 +65,28 @@ async def test_future_chaining():
     for future in single_futures:
         with pytest.raises(ValueError):
             await future
+
+
+def test_mock_scheduler():
+    ray_nodes = [{
+        "NodeID": "AAA",
+        "Alive": True,
+        "Resources": {
+            "CPU": 2.0,
+            "GPU": 2.0
+        }
+    }, {
+        "NodeID": "BBB",
+        "Alive": True,
+        "Resources": {
+            "CPU": 4.0,
+        }
+    }]
+    sched = MockScheduler(ray_nodes=ray_nodes)
+    assert sched.try_schedule({"CPU": 4})
+    assert sched.try_schedule({"CPU": 2, "GPU": 2})
+    assert not sched.try_schedule({"CPU": 100})
+    assert not sched.try_schedule({"CPU": 2})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR raises an exception if user tries to scale the number of replicas to what's possible beyond the machine and provide helpful message to help user adjust, for example:

```
Cannot scale backend f:1 to 56 replicas. Ray Serve tried to add 56 replicas but the 
resources only allows 36 to be added. To fix this, consider scaling to replica to 36.
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
