### PR TITLE
[Core] use raylet signal handling in plasma store

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -78,6 +78,12 @@ ObjectManager::ObjectManager(asio::io_service &main_service, const ClientID &sel
 
 ObjectManager::~ObjectManager() { StopRpcService(); }
 
+void ObjectManager::Stop() {
+  if (plasma::plasma_store_runner != nullptr) {
+    plasma::plasma_store_runner->Stop();
+  }
+}
+
 void ObjectManager::RunRpcService() { rpc_service_.run(); }
 
 void ObjectManager::StartRpcService() {

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -184,6 +184,10 @@ class ObjectManager : public ObjectManagerInterface,
 
   ~ObjectManager();
 
+  /// Stop the Plasma Store eventloop. Currently it is only used to handle
+  /// signals from Raylet.
+  void Stop();
+
   /// Subscribe to notifications of objects added to local store.
   /// Upon subscribing, the callback will be invoked for all objects that
   ///

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -90,6 +90,7 @@ void Raylet::Start() {
 }
 
 void Raylet::Stop() {
+  object_manager_.Stop();
   RAY_CHECK_OK(gcs_client_->Nodes().UnregisterSelf());
   acceptor_.close();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Plasma store uses both Arrow signal handler and native unix signal handler, but they interfere with raylet signal handler. The bug can be reproduced in https://github.com/ray-project/ray/pull/8921.

This PR addresses this issue by inheriting raylet signal handler when running plasma store as a thread.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
