### PR TITLE
redefined SchedulingClass to avoid including the FunctionDescriptor

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -47,7 +47,7 @@ void TaskSpecification::ComputeResources() {
     // the actor tasks need not be scheduled.
 
     // Map the scheduling class descriptor to an integer for performance.
-    auto sched_cls = std::make_pair(GetRequiredResources(), FunctionDescriptor());
+    auto sched_cls = GetRequiredResources();
     absl::MutexLock lock(&mutex_);
     auto it = sched_cls_to_id_.find(sched_cls);
     if (it == sched_cls_to_id_.end()) {

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -17,7 +17,7 @@ extern "C" {
 }
 
 namespace ray {
-typedef std::pair<ResourceSet, ray::FunctionDescriptor> SchedulingClassDescriptor;
+typedef ResourceSet SchedulingClassDescriptor;
 typedef int SchedulingClass;
 
 /// Wrapper class of protobuf `TaskSpec`, see `common.proto` for details.
@@ -195,15 +195,3 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 };
 
 }  // namespace ray
-
-/// We must define the hash since it's not auto-defined for vectors.
-namespace std {
-template <>
-struct hash<ray::SchedulingClassDescriptor> {
-  size_t operator()(ray::SchedulingClassDescriptor const &k) const {
-    size_t seed = std::hash<ray::ResourceSet>()(k.first);
-    seed ^= k.second->Hash();
-    return seed;
-  }
-};
-}  // namespace std

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -836,11 +836,11 @@ TEST(DirectTaskTransportTest, TestSchedulingKeys) {
                     BuildTaskSpec(resources1, descriptor1),
                     BuildTaskSpec(resources2, descriptor1));
 
-  // Tasks with different function descriptors should request different worker leases.
+  // Tasks with different function descriptors do not request different worker leases.
   RAY_LOG(INFO) << "Test different descriptors";
   TestSchedulingKey(store, BuildTaskSpec(resources1, descriptor1),
-                    BuildTaskSpec(resources1, descriptor1),
-                    BuildTaskSpec(resources1, descriptor2));
+                    BuildTaskSpec(resources1, descriptor2),
+                    BuildTaskSpec(resources2, descriptor1));
 
   ObjectID direct1 = ObjectID::FromRandom();
   ObjectID direct2 = ObjectID::FromRandom();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -942,7 +942,7 @@ void NodeManager::DispatchTasks(
   // Approximate fair round robin between classes.
   for (const auto &it : fair_order) {
     const auto &task_resources =
-        TaskSpecification::GetSchedulingClassDescriptor(it->first).first;
+        TaskSpecification::GetSchedulingClassDescriptor(it->first);
     // FIFO order within each class.
     for (const auto &task_id : it->second) {
       const auto &task = local_queues_.GetTaskOfState(task_id, TaskState::READY);

--- a/src/ray/raylet/scheduling_queue.cc
+++ b/src/ray/raylet/scheduling_queue.cc
@@ -461,8 +461,7 @@ std::string SchedulingQueue::DebugString() const {
   for (const auto &pair : num_running_tasks_) {
     result << "\n- ";
     auto desc = TaskSpecification::GetSchedulingClassDescriptor(pair.first);
-    result << desc.second->ToString();
-    result << desc.first.ToString();
+    result << desc.ToString();
     result << ": " << pair.second;
     total += pair.second;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These changes are needed so that functions with different names but with the same resource requirements can be assigned the same SchedulingClass (and SchedulingKey) when being scheduled for execution by a Raylet.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ x ] This PR is not tested (please justify below)
