### PR TITLE
[WIP] postponed call to OnWorkerIdle in CoreWorkerDirectTaskSubmitter::Push…

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -758,6 +758,7 @@ Status CoreWorker::Put(const RayObject &object,
 Status CoreWorker::Put(const RayObject &object,
                        const std::vector<ObjectID> &contained_object_ids,
                        const ObjectID &object_id, bool pin_object) {
+  RAY_LOG(INFO) << "is this the one?";
   bool object_exists;
   if (options_.is_local_mode) {
     RAY_CHECK(memory_store_->Put(object, object_id));

--- a/src/ray/core_worker/transport/dependency_resolver.cc
+++ b/src/ray/core_worker/transport/dependency_resolver.cc
@@ -94,8 +94,10 @@ void LocalDependencyResolver::ResolveDependencies(TaskSpecification &task,
 
   for (const auto &it : state->local_dependencies) {
     const ObjectID &obj_id = it.first;
+    RAY_LOG(INFO) << "called GetAsync!";
     in_memory_store_->GetAsync(obj_id, [this, state, obj_id,
                                         on_complete](std::shared_ptr<RayObject> obj) {
+      RAY_LOG(INFO) << "returned from getAsync";
       RAY_CHECK(obj != nullptr);
       bool complete = false;
       std::vector<ObjectID> inlined_dependency_ids;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The code in this PR fixes a small bug in direct_task_transport.cc that was causing some minor inefficiencies. 

<!-- Please give a short summary of the change and the problem this solves. -->

With this change, Ray will be able to reuse workers for tasks whose dependency was resolved by the previously executed task. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ x ] This PR is not tested (please justify below)
