### PR TITLE
Fix and merge asio client read/write operations

### DIFF
--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -65,61 +65,48 @@ void RedisAsioClient::operate() {
   if (read_requested_ && !read_in_progress_) {
     read_in_progress_ = true;
     socket_.async_read_some(boost::asio::null_buffers(),
-                            boost::bind(&RedisAsioClient::handle_read, this,
-                                        boost::asio::placeholders::error));
+                            boost::bind(&RedisAsioClient::handle_io, this,
+                                        boost::asio::placeholders::error, false));
   }
 
   if (write_requested_ && !write_in_progress_) {
     write_in_progress_ = true;
     socket_.async_write_some(boost::asio::null_buffers(),
-                             boost::bind(&RedisAsioClient::handle_write, this,
-                                         boost::asio::placeholders::error));
+                             boost::bind(&RedisAsioClient::handle_io, this,
+                                         boost::asio::placeholders::error, true));
   }
 }
 
-void RedisAsioClient::handle_read(boost::system::error_code error_code) {
+void RedisAsioClient::handle_io(boost::system::error_code error_code, bool write) {
   RAY_CHECK(!error_code || error_code == boost::asio::error::would_block ||
-            error_code == boost::asio::error::connection_reset)
-      << "handle_read(error_code = " << error_code << ")";
-  read_in_progress_ = false;
-  redis_async_context_.RedisAsyncHandleRead();
+            error_code == boost::asio::error::connection_reset ||
+            error_code == boost::asio::error::operation_aborted)
+      << "handle_io(error_code = " << error_code << ")";
+  (write ? write_in_progress_ : read_in_progress_) = false;
+  if (error_code != boost::asio::error::operation_aborted) {
+    if (!redis_async_context_.GetRawRedisAsyncContext()) {
+      RAY_LOG(FATAL) << "redis_async_context_ must not be NULL";
+    }
+    write ? redis_async_context_.RedisAsyncHandleWrite()
+          : redis_async_context_.RedisAsyncHandleRead();
+  }
 
   if (error_code == boost::asio::error::would_block) {
     operate();
   }
 }
 
-void RedisAsioClient::handle_write(boost::system::error_code error_code) {
-  RAY_CHECK(!error_code || error_code == boost::asio::error::would_block ||
-            error_code == boost::asio::error::connection_reset)
-      << "handle_write(error_code = " << error_code << ")";
-  write_in_progress_ = false;
-  redis_async_context_.RedisAsyncHandleWrite();
-
-  if (error_code == boost::asio::error::would_block) {
-    operate();
-  }
-}
-
-void RedisAsioClient::add_read() {
+void RedisAsioClient::add_io(bool write) {
   // Because redis commands are non-thread safe, dispatch the operation to backend thread.
-  io_service_.dispatch([this]() {
-    read_requested_ = true;
+  io_service_.dispatch([this, write]() {
+    (write ? write_requested_ : read_requested_) = true;
     operate();
   });
 }
 
-void RedisAsioClient::del_read() { read_requested_ = false; }
-
-void RedisAsioClient::add_write() {
-  // Because redis commands are non-thread safe, dispatch the operation to backend thread.
-  io_service_.dispatch([this]() {
-    write_requested_ = true;
-    operate();
-  });
+void RedisAsioClient::del_io(bool write) {
+  (write ? write_requested_ : read_requested_) = false;
 }
-
-void RedisAsioClient::del_write() { write_requested_ = false; }
 
 void RedisAsioClient::cleanup() {}
 
@@ -129,19 +116,19 @@ static inline RedisAsioClient *cast_to_client(void *private_data) {
 }
 
 extern "C" void call_C_addRead(void *private_data) {
-  cast_to_client(private_data)->add_read();
+  cast_to_client(private_data)->add_io(false);
 }
 
 extern "C" void call_C_delRead(void *private_data) {
-  cast_to_client(private_data)->del_read();
+  cast_to_client(private_data)->del_io(false);
 }
 
 extern "C" void call_C_addWrite(void *private_data) {
-  cast_to_client(private_data)->add_write();
+  cast_to_client(private_data)->add_io(true);
 }
 
 extern "C" void call_C_delWrite(void *private_data) {
-  cast_to_client(private_data)->del_write();
+  cast_to_client(private_data)->del_io(true);
 }
 
 extern "C" void call_C_cleanup(void *private_data) {

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -60,12 +60,9 @@ class RedisAsioClient {
 
   void operate();
 
-  void handle_read(boost::system::error_code ec);
-  void handle_write(boost::system::error_code ec);
-  void add_read();
-  void del_read();
-  void add_write();
-  void del_write();
+  void handle_io(boost::system::error_code ec, bool write);
+  void add_io(bool write);
+  void del_io(bool write);
   void cleanup();
 
  private:


### PR DESCRIPTION
## Why are these changes needed?

On Windows, `RedisAsioClient` appears to receive `boost::asio::error::operation_aborted` due to asynchronous I/O, causing it to crash.

I'm not sure if there is further handling needed in this case, but this PR avoids the crash in that case. (I also deduplicate the read/write code here for ease of maintenance.)

## Related issue number

#631

Closes #8786.

May also handle #8787.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
