### PR TITLE
Fix '//:redis_client' build on RHEL 7.6 ppc64le

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,13 +38,6 @@ else
   exit 1
 fi
 
-CXXOPT=
-# Determine machine hardware to decide whether to use c++0x or gnu++0x standard
-machine="$(uname -m)"
-if [[ "$unamestr" == "Linux" && "$machine" == "ppc64le" ]]; then
-  CXXOPT=--cxxopt=-std=gnu++0x
-fi
-
 RAY_BUILD_PYTHON="YES"
 RAY_BUILD_JAVA="NO"
 PYTHON_EXECUTABLE=""
@@ -167,7 +160,7 @@ if [ "$RAY_BUILD_PYTHON" == "YES" ]; then
 
   export PYTHON3_BIN_PATH="$PYTHON_EXECUTABLE"
 
-  "$BAZEL_EXECUTABLE" build //:ray_pkg $CXXOPT
+  "$BAZEL_EXECUTABLE" build //:ray_pkg
 fi
 
 popd

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,13 @@ else
   exit 1
 fi
 
+CXXOPT=
+# Determine machine hardware to decide whether to use c++0x or gnu++0x standard
+machine="$(uname -m)"
+if [[ "$unamestr" == "Linux" && "$machine" == "ppc64le" ]]; then
+  CXXOPT=--cxxopt=-std=gnu++0x
+fi
+
 RAY_BUILD_PYTHON="YES"
 RAY_BUILD_JAVA="NO"
 PYTHON_EXECUTABLE=""
@@ -160,7 +167,7 @@ if [ "$RAY_BUILD_PYTHON" == "YES" ]; then
 
   export PYTHON3_BIN_PATH="$PYTHON_EXECUTABLE"
 
-  "$BAZEL_EXECUTABLE" build //:ray_pkg
+  "$BAZEL_EXECUTABLE" build //:ray_pkg $CXXOPT
 fi
 
 popd

--- a/thirdparty/patches/msgpack-windows-iovec.patch
+++ b/thirdparty/patches/msgpack-windows-iovec.patch
@@ -1,11 +1,8 @@
 diff --git include/msgpack/v1/vrefbuffer.hpp include/msgpack/v1/vrefbuffer.hpp
 --- include/msgpack/v1/vrefbuffer.hpp
 +++ include/msgpack/v1/vrefbuffer.hpp
-@@ -28,4 +28,12 @@
--struct iovec {
--    void  *iov_base;
--    size_t iov_len;
--};
+@@ -28,4 +28,19 @@
++#ifdef _WIN32
 +#ifndef _WS2DEF_
 +#include <Winsock2.h>
 +#endif
@@ -17,6 +14,12 @@ diff --git include/msgpack/v1/vrefbuffer.hpp include/msgpack/v1/vrefbuffer.hpp
 +#endif
 +#ifndef iov_len
 +#define iov_len len
++#endif
++#else
+ struct iovec {
+     void  *iov_base;
+     size_t iov_len;
+ };
 +#endif
 @@ -171,1 +179,1 @@
 -                const_cast<const void *>((m_tail - 1)->iov_base)


### PR DESCRIPTION
## Why are these changes needed?

Default '-std=c++0x' flag for cpp compilation results in
errors in building msgpack which is a dependency for
redis_client. The error seen:
  external/msgpack/include/msgpack/v1/vrefbuffer.hpp:29:22:
     fatal error: Winsock2.h: No such file or directory
     #include <Winsock2.h>
This causes build failure for 'redis_client'.

Similar build issues were seen for '@plasma//:plasma_client'
with older commits of ray back in March 2020. Relevant PR:
https://github.com/ray-project/ray/pull/7828

Adding '-std=gnu++0x' to build flags fixes the build.

## Related issue number

Closes https://github.com/ray-project/ray/issues/9034

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
