### PR TITLE
C++ worker API refactoring

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -13,9 +13,14 @@ namespace ray {
 namespace api {
 
 template <typename T>
-class RayObject;
+class ObjectRef;
 template <typename T>
-class RayActor;
+class ActorHandle;
+template <typename ReturnType>
+class TaskCaller;
+
+template <typename ReturnType>
+class ActorTaskCaller;
 
 class WaitResult;
 
@@ -27,9 +32,9 @@ class Ray {
   /// Store an object in the object store.
   ///
   /// \param[in] obj The object which should be stored.
-  /// \return RayObject A reference to the object in the object store.
+  /// \return ObjectRef A reference to the object in the object store.
   template <typename T>
-  static RayObject<T> Put(const T &obj);
+  static ObjectRef<T> Put(const T &obj);
 
   /// Get a list of objects from the object store.
   /// This method will be blocked until all the objects are ready.
@@ -45,9 +50,9 @@ class Ray {
   /// \param[in] objects The object array which should be got.
   /// \return shared pointer array of the result.
   template <typename T>
-  static std::vector<std::shared_ptr<T>> Get(const std::vector<RayObject<T>> &ids);
+  static std::vector<std::shared_ptr<T>> Get(const std::vector<ObjectRef<T>> &ids);
 
-  /// Wait for a list of RayObjects to be locally available,
+  /// Wait for a list of Objects to be locally available,
   /// until specified number of objects are ready, or specified timeout has passed.
   ///
   /// \param[in] ids The object id array which should be waited.
@@ -61,7 +66,7 @@ class Ray {
 /// Include the `Call` methods for calling remote functions.
 #include "api/generated/call_funcs.generated.h"
 
-/// Include the `CreateActor` methods for creating actors.
+/// Include the `Actor` methods for creating actors.
 #include "api/generated/create_actors.generated.h"
 
  private:
@@ -69,72 +74,75 @@ class Ray {
 
   static std::once_flag is_inited_;
 
-  /// Used by RayObject to implement .Get()
+  /// Used by ObjectRef to implement .Get()
   template <typename T>
-  static std::shared_ptr<T> Get(const RayObject<T> &object);
+  static std::shared_ptr<T> Get(const ObjectRef<T> &object);
 
   template <typename ReturnType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>
-  static RayObject<ReturnType> CallInternal(FuncType &func, ExecFuncType &exec_func,
-                                            ArgTypes &... args);
+  static TaskCaller<ReturnType> TaskInternal(FuncType &func, ExecFuncType &exec_func,
+                                             ArgTypes &... args);
 
   template <typename ReturnType, typename FuncType, typename ExecFuncType,
             typename... ArgTypes>
-  static RayActor<ReturnType> CreateActorInternal(FuncType &func, ExecFuncType &exec_func,
-                                                  ArgTypes &... args);
+  static ActorHandle<ReturnType> CreateActorInternal(FuncType &func,
+                                                     ExecFuncType &exec_func,
+                                                     ArgTypes &... args);
 
   template <typename ReturnType, typename ActorType, typename FuncType,
             typename ExecFuncType, typename... ArgTypes>
-  static RayObject<ReturnType> CallActorInternal(FuncType &actor_func,
-                                                 ExecFuncType &exec_func,
-                                                 RayActor<ActorType> &actor,
-                                                 ArgTypes &... args);
+  static ActorTaskCaller<ReturnType> CallActorInternal(FuncType &actor_func,
+                                                       ExecFuncType &exec_func,
+                                                       ActorHandle<ActorType> &actor,
+                                                       ArgTypes &... args);
 
 /// Include the `Call` methods for calling actor methods.
-/// Used by RayActor to implement .Call()
+/// Used by ActorHandle to implement .Call()
 #include "api/generated/call_actors.generated.h"
 
   template <typename T>
-  friend class RayObject;
+  friend class ObjectRef;
 
   template <typename ActorType>
-  friend class RayActor;
+  friend class ActorHandle;
 };
 
 }  // namespace api
 }  // namespace ray
 
 // --------- inline implementation ------------
+#include <ray/api/actor_handle.h>
+#include <ray/api/actor_task_caller.h>
 #include <ray/api/arguments.h>
-#include <ray/api/ray_actor.h>
-#include <ray/api/ray_object.h>
+#include <ray/api/object_ref.h>
 #include <ray/api/serializer.h>
+#include <ray/api/task_caller.h>
 #include <ray/api/wait_result.h>
 
 namespace ray {
 namespace api {
 
 template <typename T>
-inline static std::vector<ObjectID> RayObjectsToObjectIDs(
-    const std::vector<RayObject<T>> &ray_objects) {
+inline static std::vector<ObjectID> ObjectRefsToObjectIDs(
+    const std::vector<ObjectRef<T>> &object_refs) {
   std::vector<ObjectID> object_ids;
-  for (auto it = ray_objects.begin(); it != ray_objects.end(); it++) {
+  for (auto it = object_refs.begin(); it != object_refs.end(); it++) {
     object_ids.push_back(it->ID());
   }
   return object_ids;
 }
 
 template <typename T>
-inline RayObject<T> Ray::Put(const T &obj) {
+inline ObjectRef<T> Ray::Put(const T &obj) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Serializer::Serialize(packer, obj);
   auto id = runtime_->Put(buffer);
-  return RayObject<T>(id);
+  return ObjectRef<T>(id);
 }
 
 template <typename T>
-inline std::shared_ptr<T> Ray::Get(const RayObject<T> &object) {
+inline std::shared_ptr<T> Ray::Get(const ObjectRef<T> &object) {
   auto packed_object = runtime_->Get(object.ID());
   msgpack::unpacker unpacker;
   unpacker.reserve_buffer(packed_object->size());
@@ -163,8 +171,8 @@ inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectID> &ids
 }
 
 template <typename T>
-inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<RayObject<T>> &ids) {
-  auto object_ids = RayObjectsToObjectIDs<T>(ids);
+inline std::vector<std::shared_ptr<T>> Ray::Get(const std::vector<ObjectRef<T>> &ids) {
+  auto object_ids = ObjectRefsToObjectIDs<T>(ids);
   return Get<T>(object_ids);
 }
 
@@ -175,23 +183,22 @@ inline WaitResult Ray::Wait(const std::vector<ObjectID> &ids, int num_objects,
 
 template <typename ReturnType, typename FuncType, typename ExecFuncType,
           typename... ArgTypes>
-inline RayObject<ReturnType> Ray::CallInternal(FuncType &func, ExecFuncType &exec_func,
-                                               ArgTypes &... args) {
+inline TaskCaller<ReturnType> Ray::TaskInternal(FuncType &func, ExecFuncType &exec_func,
+                                                ArgTypes &... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
   RemoteFunctionPtrHolder ptr;
   ptr.function_pointer = reinterpret_cast<uintptr_t>(func);
   ptr.exec_function_pointer = reinterpret_cast<uintptr_t>(exec_func);
-  auto returned_object_id = runtime_->Call(ptr, buffer);
-  return RayObject<ReturnType>(returned_object_id);
+  return TaskCaller<ReturnType>(runtime_, ptr, buffer);
 }
 
 template <typename ReturnType, typename FuncType, typename ExecFuncType,
           typename... ArgTypes>
-inline RayActor<ReturnType> Ray::CreateActorInternal(FuncType &create_func,
-                                                     ExecFuncType &exec_func,
-                                                     ArgTypes &... args) {
+inline ActorHandle<ReturnType> Ray::CreateActorInternal(FuncType &create_func,
+                                                        ExecFuncType &exec_func,
+                                                        ArgTypes &... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
@@ -199,15 +206,15 @@ inline RayActor<ReturnType> Ray::CreateActorInternal(FuncType &create_func,
   ptr.function_pointer = reinterpret_cast<uintptr_t>(create_func);
   ptr.exec_function_pointer = reinterpret_cast<uintptr_t>(exec_func);
   auto returned_actor_id = runtime_->CreateActor(ptr, buffer);
-  return RayActor<ReturnType>(returned_actor_id);
+  return ActorHandle<ReturnType>(returned_actor_id);
 }
 
 template <typename ReturnType, typename ActorType, typename FuncType,
           typename ExecFuncType, typename... ArgTypes>
-inline RayObject<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
-                                                    ExecFuncType &exec_func,
-                                                    RayActor<ActorType> &actor,
-                                                    ArgTypes &... args) {
+inline ActorTaskCaller<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
+                                                          ExecFuncType &exec_func,
+                                                          ActorHandle<ActorType> &actor,
+                                                          ArgTypes &... args) {
   std::shared_ptr<msgpack::sbuffer> buffer(new msgpack::sbuffer());
   msgpack::packer<msgpack::sbuffer> packer(buffer.get());
   Arguments::WrapArgs(packer, args...);
@@ -215,8 +222,7 @@ inline RayObject<ReturnType> Ray::CallActorInternal(FuncType &actor_func,
   MemberFunctionPtrHolder holder = *(MemberFunctionPtrHolder *)(&actor_func);
   ptr.function_pointer = reinterpret_cast<uintptr_t>(holder.value[0]);
   ptr.exec_function_pointer = reinterpret_cast<uintptr_t>(exec_func);
-  auto returned_object_id = runtime_->CallActor(ptr, actor.ID(), buffer);
-  return RayObject<ReturnType>(returned_object_id);
+  return ActorTaskCaller<ReturnType>(runtime_, actor.ID(), ptr, buffer);
 }
 
 #include <ray/api/generated/exec_funcs.generated.h>

--- a/cpp/include/ray/api/actor_creator.h
+++ b/cpp/include/ray/api/actor_creator.h
@@ -1,0 +1,41 @@
+
+#pragma once
+
+#include "ray/core.h"
+
+namespace ray {
+namespace api {
+
+template <typename ActorType>
+class ActorCreator {
+ public:
+  ActorCreator();
+
+  ActorCreator(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+               std::shared_ptr<msgpack::sbuffer> args);
+
+  ActorHandle<ActorType> Remote();
+
+ private:
+  RayRuntime *runtime_;
+  RemoteFunctionPtrHolder ptr_;
+  std::shared_ptr<msgpack::sbuffer> args_;
+};
+
+// ---------- implementation ----------
+
+template <typename ActorType>
+ActorCreator<ActorType>::ActorCreator() {}
+
+template <typename ActorType>
+ActorCreator<ActorType>::ActorCreator(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+                                      std::shared_ptr<msgpack::sbuffer> args)
+    : runtime_(runtime), ptr_(ptr), args_(args) {}
+
+template <typename ActorType>
+ActorHandle<ActorType> ActorCreator<ActorType>::Remote() {
+  auto returned_actor_id = runtime_->CreateActor(ptr_, args_);
+  return ActorHandle<ActorType>(returned_actor_id);
+}
+}  // namespace api
+}  // namespace ray

--- a/cpp/include/ray/api/actor_handle.h
+++ b/cpp/include/ray/api/actor_handle.h
@@ -13,11 +13,11 @@ namespace api {
 /// \param ActorType The type of the concrete actor class.
 /// Note, the `Call` method is defined in actor_call.generated.h.
 template <typename ActorType>
-class RayActor {
+class ActorHandle {
  public:
-  RayActor();
+  ActorHandle();
 
-  RayActor(const ActorID &id);
+  ActorHandle(const ActorID &id);
 
   /// Get a untyped ID of the actor
   const ActorID &ID() const;
@@ -25,7 +25,7 @@ class RayActor {
   /// Include the `Call` methods for calling remote functions.
 #include <ray/api/generated/actor_call.generated.h>
 
-  /// Make RayActor serializable
+  /// Make ActorHandle serializable
   MSGPACK_DEFINE(id_);
 
  private:
@@ -35,15 +35,15 @@ class RayActor {
 // ---------- implementation ----------
 
 template <typename ActorType>
-RayActor<ActorType>::RayActor() {}
+ActorHandle<ActorType>::ActorHandle() {}
 
 template <typename ActorType>
-RayActor<ActorType>::RayActor(const ActorID &id) {
+ActorHandle<ActorType>::ActorHandle(const ActorID &id) {
   id_ = id;
 }
 
 template <typename ActorType>
-const ActorID &RayActor<ActorType>::ID() const {
+const ActorID &ActorHandle<ActorType>::ID() const {
   return id_;
 }
 

--- a/cpp/include/ray/api/actor_task_caller.h
+++ b/cpp/include/ray/api/actor_task_caller.h
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include "ray/core.h"
+
+namespace ray {
+namespace api {
+
+template <typename ReturnType>
+class ActorTaskCaller {
+ public:
+  ActorTaskCaller();
+
+  ActorTaskCaller(RayRuntime *runtime, ActorID id, RemoteFunctionPtrHolder ptr,
+                  std::shared_ptr<msgpack::sbuffer> args);
+
+  ObjectRef<ReturnType> Remote();
+
+ private:
+  RayRuntime *runtime_;
+  ActorID id_;
+  RemoteFunctionPtrHolder ptr_;
+  std::shared_ptr<msgpack::sbuffer> args_;
+};
+
+// ---------- implementation ----------
+
+template <typename ReturnType>
+ActorTaskCaller<ReturnType>::ActorTaskCaller() {}
+
+template <typename ReturnType>
+ActorTaskCaller<ReturnType>::ActorTaskCaller(RayRuntime *runtime, ActorID id,
+                                             RemoteFunctionPtrHolder ptr,
+                                             std::shared_ptr<msgpack::sbuffer> args)
+    : runtime_(runtime), id_(id), ptr_(ptr), args_(args) {}
+
+template <typename ReturnType>
+ObjectRef<ReturnType> ActorTaskCaller<ReturnType>::Remote() {
+  auto returned_object_id = runtime_->CallActor(ptr_, id_, args_);
+  return ObjectRef<ReturnType>(returned_object_id);
+}
+}  // namespace api
+}  // namespace ray

--- a/cpp/include/ray/api/arguments.h
+++ b/cpp/include/ray/api/arguments.h
@@ -36,10 +36,10 @@ inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer) {}
 template <typename Arg1Type>
 inline void Arguments::WrapArgs(msgpack::packer<msgpack::sbuffer> &packer,
                                 Arg1Type &arg1) {
-  /// Notice RayObjectClassPrefix should be modified by RayObject class name or namespace.
-  static const std::string RayObjectClassPrefix = "N3ray3api9RayObject";
+  /// Notice ObjectRefClassPrefix should be modified by ObjectRef class name or namespace.
+  static const std::string ObjectRefClassPrefix = "N3ray3api9ObjectRef";
   std::string type_name = typeid(arg1).name();
-  if (type_name.rfind(RayObjectClassPrefix, 0) == 0) {
+  if (type_name.rfind(ObjectRefClassPrefix, 0) == 0) {
     /// Pass by reference.
     Serializer::Serialize(packer, true);
   } else {
@@ -61,12 +61,12 @@ inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker) {}
 template <typename Arg1Type>
 inline void Arguments::UnwrapArgs(msgpack::unpacker &unpacker,
                                   std::shared_ptr<Arg1Type> *arg1) {
-  bool is_ray_object;
-  Serializer::Deserialize(unpacker, &is_ray_object);
-  if (is_ray_object) {
-    RayObject<Arg1Type> ray_object;
-    Serializer::Deserialize(unpacker, &ray_object);
-    *arg1 = ray_object.Get();
+  bool is_object_ref;
+  Serializer::Deserialize(unpacker, &is_object_ref);
+  if (is_object_ref) {
+    ObjectRef<Arg1Type> object_ref;
+    Serializer::Deserialize(unpacker, &object_ref);
+    *arg1 = object_ref.Get();
   } else {
     Serializer::Deserialize(unpacker, arg1);
   }

--- a/cpp/include/ray/api/generated/actor_call.generated.h
+++ b/cpp/include/ray/api/generated/actor_call.generated.h
@@ -2,40 +2,40 @@
 /// The following `Call` methods are used to call remote functions of actors.
 /// Their arguments and return types are as following:
 /// \param[in] actor_func The function pointer to be remote execution.
-/// \param[in] arg1...argn The function arguments passed by a value or RayObject.
-/// \return RayObject.
+/// \param[in] arg1...argn The function arguments passed by a value or ObjectRef.
+/// \return ActorTaskCaller.
 
 // TODO(Guyang Song): code generation
 
 // 0 args
 template <typename ReturnType>
-RayObject<ReturnType> Call(ActorFunc0<ActorType, ReturnType> actor_func);
+ActorTaskCaller<ReturnType> Task(ActorFunc0<ActorType, ReturnType> actor_func);
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                           Arg1Type arg1);
+ActorTaskCaller<ReturnType> Task(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
+                                 Arg1Type arg1);
 
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                           RayObject<Arg1Type> &arg1);
+ActorTaskCaller<ReturnType> Task(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
+                                 ObjectRef<Arg1Type> &arg1);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Call(
+ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
     Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Call(
+ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayObject<Arg1Type> &arg1, Arg2Type arg2);
+    ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Call(
+ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
-    RayObject<Arg2Type> &arg2);
+    ObjectRef<Arg2Type> &arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Call(
+ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2);
+    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);

--- a/cpp/include/ray/api/generated/actor_call_impl.generated.h
+++ b/cpp/include/ray/api/generated/actor_call_impl.generated.h
@@ -3,55 +3,55 @@
 // 0 args
 template <typename ActorType>
 template <typename ReturnType>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc0<ActorType, ReturnType> actor_func) {
-  return Ray::Call(actor_func, *this);
+  return Ray::Task(actor_func, *this);
 }
 
 // 1 arg
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, Arg1Type arg1) {
-  return Ray::Call(actor_func, *this, arg1);
+  return Ray::Task(actor_func, *this, arg1);
 }
 
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
-    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, RayObject<Arg1Type> &arg1) {
-  return Ray::Call(actor_func, *this, arg1);
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ObjectRef<Arg1Type> &arg1) {
+  return Ray::Task(actor_func, *this, arg1);
 }
 
 // 2 args
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
     Arg2Type arg2) {
-  return Ray::Call(actor_func, *this, arg1, arg2);
+  return Ray::Task(actor_func, *this, arg1, arg2);
 }
 
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayObject<Arg1Type> &arg1, Arg2Type arg2) {
-  return Ray::Call(actor_func, *this, arg1, arg2);
+    ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+  return Ray::Task(actor_func, *this, arg1, arg2);
 }
 
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func, Arg1Type arg1,
-    RayObject<Arg2Type> &arg2) {
-  return Ray::Call(actor_func, *this, arg1, arg2);
+    ObjectRef<Arg2Type> &arg2) {
+  return Ray::Task(actor_func, *this, arg1, arg2);
 }
 
 template <typename ActorType>
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> RayActor<ActorType>::Call(
+ActorTaskCaller<ReturnType> ActorHandle<ActorType>::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2) {
-  return Ray::Call(actor_func, *this, arg1, arg2);
+    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+  return Ray::Task(actor_func, *this, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/call_actors.generated.h
+++ b/cpp/include/ray/api/generated/call_actors.generated.h
@@ -4,35 +4,37 @@
 
 // 0 args
 template <typename ReturnType, typename ActorType>
-static RayObject<ReturnType> Call(ActorFunc0<ActorType, ReturnType> actor_func,
-                                  RayActor<ActorType> &actor);
+static ActorTaskCaller<ReturnType> Task(ActorFunc0<ActorType, ReturnType> actor_func,
+                                        ActorHandle<ActorType> &actor);
 
 // 1 arg
 template <typename ReturnType, typename ActorType, typename Arg1Type>
-static RayObject<ReturnType> Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                                  RayActor<ActorType> &actor, Arg1Type arg1);
+static ActorTaskCaller<ReturnType> Task(
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    Arg1Type arg1);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type>
-static RayObject<ReturnType> Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                                  RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1);
+static ActorTaskCaller<ReturnType> Task(
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    ObjectRef<Arg1Type> &arg1);
 
 // 2 args
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(
+static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, Arg1Type arg1, Arg2Type arg2);
+    ActorHandle<ActorType> &actor, Arg1Type arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(
+static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1, Arg2Type arg2);
+    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(
+static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, Arg1Type arg1, RayObject<Arg2Type> &arg2);
+    ActorHandle<ActorType> &actor, Arg1Type arg1, ObjectRef<Arg2Type> &arg2);
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(
+static ActorTaskCaller<ReturnType> Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2);
+    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);

--- a/cpp/include/ray/api/generated/call_actors_impl.generated.h
+++ b/cpp/include/ray/api/generated/call_actors_impl.generated.h
@@ -1,59 +1,61 @@
 // TODO(Guyang Song): code generation
 // 0 args
 template <typename ReturnType, typename ActorType>
-RayObject<ReturnType> Ray::Call(ActorFunc0<ActorType, ReturnType> actor_func,
-                                RayActor<ActorType> &actor) {
+ActorTaskCaller<ReturnType> Ray::Task(ActorFunc0<ActorType, ReturnType> actor_func,
+                                      ActorHandle<ActorType> &actor) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType>, actor);
 }
 
 // 1 arg
 template <typename ReturnType, typename ActorType, typename Arg1Type>
-RayObject<ReturnType> Ray::Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                                RayActor<ActorType> &actor, Arg1Type arg1) {
+ActorTaskCaller<ReturnType> Ray::Task(
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    Arg1Type arg1) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type>, actor, arg1);
 }
 
 template <typename ReturnType, typename ActorType, typename Arg1Type>
-RayObject<ReturnType> Ray::Call(ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func,
-                                RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1) {
+ActorTaskCaller<ReturnType> Ray::Task(
+    ActorFunc1<ActorType, ReturnType, Arg1Type> actor_func, ActorHandle<ActorType> &actor,
+    ObjectRef<Arg1Type> &arg1) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type>, actor, arg1);
 }
 
 // 2 args
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(
+ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, Arg1Type arg1, Arg2Type arg2) {
+    ActorHandle<ActorType> &actor, Arg1Type arg1, Arg2Type arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
 }
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(
+ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1, Arg2Type arg2) {
+    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
 }
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(
+ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, Arg1Type arg1, RayObject<Arg2Type> &arg2) {
+    ActorHandle<ActorType> &actor, Arg1Type arg1, ObjectRef<Arg2Type> &arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);
 }
 
 template <typename ReturnType, typename ActorType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(
+ActorTaskCaller<ReturnType> Ray::Task(
     ActorFunc2<ActorType, ReturnType, Arg1Type, Arg2Type> actor_func,
-    RayActor<ActorType> &actor, RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2) {
+    ActorHandle<ActorType> &actor, ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
   return CallActorInternal<ReturnType, ActorType>(
       actor_func, ActorExecFunction<ReturnType, ActorType, Arg1Type, Arg2Type>, actor,
       arg1, arg2);

--- a/cpp/include/ray/api/generated/call_funcs.generated.h
+++ b/cpp/include/ray/api/generated/call_funcs.generated.h
@@ -2,36 +2,36 @@
 /// The following `Call` methods are used to call remote functions.
 /// Their arguments and return types are as following:
 /// \param[in] func The function pointer to be remote execution.
-/// \param[in] arg1...argn The function arguments passed by a value or RayObject.
-/// \return RayObject.
+/// \param[in] arg1...argn The function arguments passed by a value or ObjectRef.
+/// \return TaskCaller.
 
 // TODO(Guyang Song): code generation
 
 // 0 args
 template <typename ReturnType>
-static RayObject<ReturnType> Call(Func0<ReturnType> func);
+static TaskCaller<ReturnType> Task(Func0<ReturnType> func);
 
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-static RayObject<ReturnType> Call(Func1<ReturnType, Arg1Type> func, Arg1Type arg1);
+static TaskCaller<ReturnType> Task(Func1<ReturnType, Arg1Type> func, Arg1Type arg1);
 
 template <typename ReturnType, typename Arg1Type>
-static RayObject<ReturnType> Call(Func1<ReturnType, Arg1Type> func,
-                                  RayObject<Arg1Type> &arg1);
+static TaskCaller<ReturnType> Task(Func1<ReturnType, Arg1Type> func,
+                                   ObjectRef<Arg1Type> &arg1);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                  Arg1Type arg1, Arg2Type arg2);
+static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                   Arg1Type arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                  RayObject<Arg1Type> &arg1, Arg2Type arg2);
+static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                   ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                  Arg1Type arg1, RayObject<Arg2Type> &arg2);
+static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                   Arg1Type arg1, ObjectRef<Arg2Type> &arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayObject<ReturnType> Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                  RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2);
+static TaskCaller<ReturnType> Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                   ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);

--- a/cpp/include/ray/api/generated/call_funcs_impl.generated.h
+++ b/cpp/include/ray/api/generated/call_funcs_impl.generated.h
@@ -2,47 +2,47 @@
 
 // 0 args
 template <typename ReturnType>
-RayObject<ReturnType> Ray::Call(Func0<ReturnType> func) {
-  return CallInternal<ReturnType>(func, NormalExecFunction<ReturnType>);
+TaskCaller<ReturnType> Ray::Task(Func0<ReturnType> func) {
+  return TaskInternal<ReturnType>(func, NormalExecFunction<ReturnType>);
 }
 
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> Ray::Call(Func1<ReturnType, Arg1Type> func, Arg1Type arg1) {
-  return CallInternal<ReturnType>(func, NormalExecFunction<ReturnType, Arg1Type>, arg1);
+TaskCaller<ReturnType> Ray::Task(Func1<ReturnType, Arg1Type> func, Arg1Type arg1) {
+  return TaskInternal<ReturnType>(func, NormalExecFunction<ReturnType, Arg1Type>, arg1);
 }
 
 template <typename ReturnType, typename Arg1Type>
-RayObject<ReturnType> Ray::Call(Func1<ReturnType, Arg1Type> func,
-                                RayObject<Arg1Type> &arg1) {
-  return CallInternal<ReturnType>(func, NormalExecFunction<ReturnType, Arg1Type>, arg1);
+TaskCaller<ReturnType> Ray::Task(Func1<ReturnType, Arg1Type> func,
+                                 ObjectRef<Arg1Type> &arg1) {
+  return TaskInternal<ReturnType>(func, NormalExecFunction<ReturnType, Arg1Type>, arg1);
 }
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(Func2<ReturnType, Arg1Type, Arg2Type> func, Arg1Type arg1,
-                                Arg2Type arg2) {
-  return CallInternal<ReturnType>(
+TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                 Arg1Type arg1, Arg2Type arg2) {
+  return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                RayObject<Arg1Type> &arg1, Arg2Type arg2) {
-  return CallInternal<ReturnType>(
+TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                 ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
+  return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(Func2<ReturnType, Arg1Type, Arg2Type> func, Arg1Type arg1,
-                                RayObject<Arg2Type> &arg2) {
-  return CallInternal<ReturnType>(
+TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                 Arg1Type arg1, ObjectRef<Arg2Type> &arg2) {
+  return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayObject<ReturnType> Ray::Call(Func2<ReturnType, Arg1Type, Arg2Type> func,
-                                RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2) {
-  return CallInternal<ReturnType>(
+TaskCaller<ReturnType> Ray::Task(Func2<ReturnType, Arg1Type, Arg2Type> func,
+                                 ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
+  return TaskInternal<ReturnType>(
       func, NormalExecFunction<ReturnType, Arg1Type, Arg2Type>, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/create_actors.generated.h
+++ b/cpp/include/ray/api/generated/create_actors.generated.h
@@ -3,40 +3,40 @@
 /// Their arguments and return types are as following:
 /// \param[in] create_func The function pointer to be remote execution.
 /// \param[in] arg1...argn The function arguments passed by a value or ObjectRef.
-/// \return ActorHandle.
+/// \return ActorCreator.
 
 // TODO(Guyang Song): code generation
 
 // 0 args
-template <typename ReturnType>
-static ActorHandle<ReturnType> Actor(CreateActorFunc0<ReturnType> create_func);
+template <typename ActorType>
+static ActorCreator<ActorType> Actor(CreateActorFunc0<ActorType> create_func);
 
 // 1 arg
-template <typename ReturnType, typename Arg1Type>
-static ActorHandle<ReturnType> Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+template <typename ActorType, typename Arg1Type>
+static ActorCreator<ActorType> Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
                                      Arg1Type arg1);
 
-template <typename ReturnType, typename Arg1Type>
-static ActorHandle<ReturnType> Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+template <typename ActorType, typename Arg1Type>
+static ActorCreator<ActorType> Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
                                      ObjectRef<Arg1Type> &arg1);
 
 // 2 args
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static ActorHandle<ReturnType> Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+static ActorCreator<ActorType> Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     Arg2Type arg2);
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static ActorHandle<ReturnType> Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+static ActorCreator<ActorType> Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
     ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static ActorHandle<ReturnType> Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+static ActorCreator<ActorType> Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     ObjectRef<Arg2Type> &arg2);
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static ActorHandle<ReturnType> Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+static ActorCreator<ActorType> Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
     ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);

--- a/cpp/include/ray/api/generated/create_actors.generated.h
+++ b/cpp/include/ray/api/generated/create_actors.generated.h
@@ -2,41 +2,41 @@
 /// The following `Call` methods are used to call remote functions and create an actor.
 /// Their arguments and return types are as following:
 /// \param[in] create_func The function pointer to be remote execution.
-/// \param[in] arg1...argn The function arguments passed by a value or RayObject.
-/// \return RayActor.
+/// \param[in] arg1...argn The function arguments passed by a value or ObjectRef.
+/// \return ActorHandle.
 
 // TODO(Guyang Song): code generation
 
 // 0 args
 template <typename ReturnType>
-static RayActor<ReturnType> CreateActor(CreateActorFunc0<ReturnType> create_func);
+static ActorHandle<ReturnType> Actor(CreateActorFunc0<ReturnType> create_func);
 
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-static RayActor<ReturnType> CreateActor(
-    CreateActorFunc1<ReturnType, Arg1Type> create_func, Arg1Type arg1);
+static ActorHandle<ReturnType> Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+                                     Arg1Type arg1);
 
 template <typename ReturnType, typename Arg1Type>
-static RayActor<ReturnType> CreateActor(
-    CreateActorFunc1<ReturnType, Arg1Type> create_func, RayObject<Arg1Type> &arg1);
+static ActorHandle<ReturnType> Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+                                     ObjectRef<Arg1Type> &arg1);
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayActor<ReturnType> CreateActor(
+static ActorHandle<ReturnType> Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayActor<ReturnType> CreateActor(
+static ActorHandle<ReturnType> Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
-    RayObject<Arg1Type> &arg1, Arg2Type arg2);
+    ObjectRef<Arg1Type> &arg1, Arg2Type arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayActor<ReturnType> CreateActor(
+static ActorHandle<ReturnType> Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
-    RayObject<Arg2Type> &arg2);
+    ObjectRef<Arg2Type> &arg2);
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-static RayActor<ReturnType> CreateActor(
+static ActorHandle<ReturnType> Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
-    RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2);
+    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2);

--- a/cpp/include/ray/api/generated/create_actors_impl.generated.h
+++ b/cpp/include/ray/api/generated/create_actors_impl.generated.h
@@ -1,56 +1,56 @@
 // TODO(Guyang Song): code generation
 
 // 0 args
-template <typename ReturnType>
-ActorHandle<ReturnType> Ray::Actor(CreateActorFunc0<ReturnType> create_func) {
-  return CreateActorInternal<ReturnType>(create_func,
-                                         CreateActorExecFunction<ReturnType *>);
+template <typename ActorType>
+ActorCreator<ActorType> Ray::Actor(CreateActorFunc0<ActorType> create_func) {
+  return CreateActorInternal<ActorType>(create_func,
+                                        CreateActorExecFunction<ActorType *>);
 }
 
 // 1 arg
-template <typename ReturnType, typename Arg1Type>
-ActorHandle<ReturnType> Ray::Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+template <typename ActorType, typename Arg1Type>
+ActorCreator<ActorType> Ray::Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
                                    Arg1Type arg1) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type>, arg1);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type>, arg1);
 }
 
-template <typename ReturnType, typename Arg1Type>
-ActorHandle<ReturnType> Ray::Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+template <typename ActorType, typename Arg1Type>
+ActorCreator<ActorType> Ray::Actor(CreateActorFunc1<ActorType, Arg1Type> create_func,
                                    ObjectRef<Arg1Type> &arg1) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type>, arg1);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type>, arg1);
 }
 
 // 2 args
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-ActorHandle<ReturnType> Ray::Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+ActorCreator<ActorType> Ray::Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     Arg2Type arg2) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-ActorHandle<ReturnType> Ray::Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+ActorCreator<ActorType> Ray::Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
     ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-ActorHandle<ReturnType> Ray::Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+ActorCreator<ActorType> Ray::Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     ObjectRef<Arg2Type> &arg2) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
-template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-ActorHandle<ReturnType> Ray::Actor(
-    CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
+template <typename ActorType, typename Arg1Type, typename Arg2Type>
+ActorCreator<ActorType> Ray::Actor(
+    CreateActorFunc2<ActorType, Arg1Type, Arg2Type> create_func,
     ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
-  return CreateActorInternal<ReturnType>(
-      create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
+  return CreateActorInternal<ActorType>(
+      create_func, CreateActorExecFunction<ActorType *, Arg1Type, Arg2Type>, arg1, arg2);
 }

--- a/cpp/include/ray/api/generated/create_actors_impl.generated.h
+++ b/cpp/include/ray/api/generated/create_actors_impl.generated.h
@@ -2,29 +2,29 @@
 
 // 0 args
 template <typename ReturnType>
-RayActor<ReturnType> Ray::CreateActor(CreateActorFunc0<ReturnType> create_func) {
+ActorHandle<ReturnType> Ray::Actor(CreateActorFunc0<ReturnType> create_func) {
   return CreateActorInternal<ReturnType>(create_func,
                                          CreateActorExecFunction<ReturnType *>);
 }
 
 // 1 arg
 template <typename ReturnType, typename Arg1Type>
-RayActor<ReturnType> Ray::CreateActor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
-                                      Arg1Type arg1) {
+ActorHandle<ReturnType> Ray::Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+                                   Arg1Type arg1) {
   return CreateActorInternal<ReturnType>(
       create_func, CreateActorExecFunction<ReturnType *, Arg1Type>, arg1);
 }
 
 template <typename ReturnType, typename Arg1Type>
-RayActor<ReturnType> Ray::CreateActor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
-                                      RayObject<Arg1Type> &arg1) {
+ActorHandle<ReturnType> Ray::Actor(CreateActorFunc1<ReturnType, Arg1Type> create_func,
+                                   ObjectRef<Arg1Type> &arg1) {
   return CreateActorInternal<ReturnType>(
       create_func, CreateActorExecFunction<ReturnType *, Arg1Type>, arg1);
 }
 
 // 2 args
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayActor<ReturnType> Ray::CreateActor(
+ActorHandle<ReturnType> Ray::Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
     Arg2Type arg2) {
   return CreateActorInternal<ReturnType>(
@@ -32,25 +32,25 @@ RayActor<ReturnType> Ray::CreateActor(
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayActor<ReturnType> Ray::CreateActor(
+ActorHandle<ReturnType> Ray::Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
-    RayObject<Arg1Type> &arg1, Arg2Type arg2) {
+    ObjectRef<Arg1Type> &arg1, Arg2Type arg2) {
   return CreateActorInternal<ReturnType>(
       create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayActor<ReturnType> Ray::CreateActor(
+ActorHandle<ReturnType> Ray::Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func, Arg1Type arg1,
-    RayObject<Arg2Type> &arg2) {
+    ObjectRef<Arg2Type> &arg2) {
   return CreateActorInternal<ReturnType>(
       create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
 }
 
 template <typename ReturnType, typename Arg1Type, typename Arg2Type>
-RayActor<ReturnType> Ray::CreateActor(
+ActorHandle<ReturnType> Ray::Actor(
     CreateActorFunc2<ReturnType, Arg1Type, Arg2Type> create_func,
-    RayObject<Arg1Type> &arg1, RayObject<Arg2Type> &arg2) {
+    ObjectRef<Arg1Type> &arg1, ObjectRef<Arg2Type> &arg2) {
   return CreateActorInternal<ReturnType>(
       create_func, CreateActorExecFunction<ReturnType *, Arg1Type, Arg2Type>, arg1, arg2);
 }

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -14,13 +14,13 @@ namespace api {
 /// Represents an object in the object store..
 /// \param T The type of object.
 template <typename T>
-class RayObject {
+class ObjectRef {
  public:
-  RayObject();
+  ObjectRef();
 
-  RayObject(const ObjectID &id);
+  ObjectRef(const ObjectID &id);
 
-  bool operator==(const RayObject<T> &object) const;
+  bool operator==(const ObjectRef<T> &object) const;
 
   /// Get a untyped ID of the object
   const ObjectID &ID() const;
@@ -31,7 +31,7 @@ class RayObject {
   /// \return shared pointer of the result.
   std::shared_ptr<T> Get() const;
 
-  /// Make RayObject serializable
+  /// Make ObjectRef serializable
   MSGPACK_DEFINE(id_);
 
  private:
@@ -42,25 +42,25 @@ class RayObject {
 #include <ray/api.h>
 
 template <typename T>
-RayObject<T>::RayObject() {}
+ObjectRef<T>::ObjectRef() {}
 
 template <typename T>
-RayObject<T>::RayObject(const ObjectID &id) {
+ObjectRef<T>::ObjectRef(const ObjectID &id) {
   id_ = id;
 }
 
 template <typename T>
-inline bool RayObject<T>::operator==(const RayObject<T> &object) const {
+inline bool ObjectRef<T>::operator==(const ObjectRef<T> &object) const {
   return id_ == object.id_;
 }
 
 template <typename T>
-const ObjectID &RayObject<T>::ID() const {
+const ObjectID &ObjectRef<T>::ID() const {
   return id_;
 }
 
 template <typename T>
-inline std::shared_ptr<T> RayObject<T>::Get() const {
+inline std::shared_ptr<T> ObjectRef<T>::Get() const {
   return Ray::Get(*this);
 }
 }  // namespace api

--- a/cpp/include/ray/api/task_caller.h
+++ b/cpp/include/ray/api/task_caller.h
@@ -1,0 +1,41 @@
+
+#pragma once
+
+#include "ray/core.h"
+
+namespace ray {
+namespace api {
+
+template <typename ReturnType>
+class TaskCaller {
+ public:
+  TaskCaller();
+
+  TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+             std::shared_ptr<msgpack::sbuffer> args);
+
+  ObjectRef<ReturnType> Remote();
+
+ private:
+  RayRuntime *runtime_;
+  RemoteFunctionPtrHolder ptr_;
+  std::shared_ptr<msgpack::sbuffer> args_;
+};
+
+// ---------- implementation ----------
+
+template <typename ReturnType>
+TaskCaller<ReturnType>::TaskCaller() {}
+
+template <typename ReturnType>
+TaskCaller<ReturnType>::TaskCaller(RayRuntime *runtime, RemoteFunctionPtrHolder ptr,
+                                   std::shared_ptr<msgpack::sbuffer> args)
+    : runtime_(runtime), ptr_(ptr), args_(args) {}
+
+template <typename ReturnType>
+ObjectRef<ReturnType> TaskCaller<ReturnType>::Remote() {
+  auto returned_object_id = runtime_->Call(ptr_, args_);
+  return ObjectRef<ReturnType>(returned_object_id);
+}
+}  // namespace api
+}  // namespace ray

--- a/cpp/src/example/example.cc
+++ b/cpp/src/example/example.cc
@@ -60,7 +60,7 @@ int main() {
             << result5 << std::endl;
 
   /// create actor and actor function remote call
-  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate);
+  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate).Remote();
   auto r6 = actor.Task(&Counter::Add, 5).Remote();
   auto r7 = actor.Task(&Counter::Add, 1).Remote();
   auto r8 = actor.Task(&Counter::Add, 1).Remote();

--- a/cpp/src/example/example.cc
+++ b/cpp/src/example/example.cc
@@ -36,9 +36,9 @@ int main() {
   auto getRsult = obj.Get();
 
   /// general function remote call（args passed by value）
-  auto r0 = Ray::Call(Return1);
-  auto r1 = Ray::Call(Plus1, 1);
-  auto r2 = Ray::Call(Plus, 1, 2);
+  auto r0 = Ray::Task(Return1).Remote();
+  auto r1 = Ray::Task(Plus1, 1).Remote();
+  auto r2 = Ray::Task(Plus, 1, 2).Remote();
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());
@@ -48,9 +48,9 @@ int main() {
             << result2 << std::endl;
 
   /// general function remote call（args passed by reference）
-  auto r3 = Ray::Call(Return1);
-  auto r4 = Ray::Call(Plus1, r3);
-  auto r5 = Ray::Call(Plus, r4, 1);
+  auto r3 = Ray::Task(Return1).Remote();
+  auto r4 = Ray::Task(Plus1, r3).Remote();
+  auto r5 = Ray::Task(Plus, r4, 1).Remote();
 
   int result3 = *(r3.Get());
   int result4 = *(r4.Get());
@@ -60,11 +60,11 @@ int main() {
             << result5 << std::endl;
 
   /// create actor and actor function remote call
-  RayActor<Counter> actor = Ray::CreateActor(Counter::FactoryCreate);
-  auto r6 = actor.Call(&Counter::Add, 5);
-  auto r7 = actor.Call(&Counter::Add, 1);
-  auto r8 = actor.Call(&Counter::Add, 1);
-  auto r9 = actor.Call(&Counter::Add, r8);
+  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate);
+  auto r6 = actor.Task(&Counter::Add, 5).Remote();
+  auto r7 = actor.Task(&Counter::Add, 1).Remote();
+  auto r8 = actor.Task(&Counter::Add, 1).Remote();
+  auto r9 = actor.Task(&Counter::Add, r8).Remote();
 
   int result6 = *(r6.Get());
   int result7 = *(r7.Get());

--- a/cpp/src/ray/runtime/object/object_store.h
+++ b/cpp/src/ray/runtime/object/object_store.h
@@ -40,7 +40,7 @@ class ObjectStore {
   std::vector<std::shared_ptr<msgpack::sbuffer>> Get(
       const std::vector<ObjectID> &ids, int timeout_ms = default_get_timeout_ms);
 
-  /// Wait for a list of RayObjects to be locally available,
+  /// Wait for a list of ObjectRefs to be locally available,
   /// until specified number of objects are ready, or specified timeout has passed.
   ///
   /// \param[in] ids The object id array which should be waited.

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -44,9 +44,9 @@ TEST(RayApiTest, PutTest) {
 
 TEST(RayApiTest, WaitTest) {
   Ray::Init();
-  auto r0 = Ray::Call(Return1);
-  auto r1 = Ray::Call(Plus1, 3);
-  auto r2 = Ray::Call(Plus, 2, 3);
+  auto r0 = Ray::Task(Return1).Remote();
+  auto r1 = Ray::Task(Plus1, 3).Remote();
+  auto r2 = Ray::Task(Plus, 2, 3).Remote();
   std::vector<ObjectID> objects = {r0.ID(), r1.ID(), r2.ID()};
   WaitResult result = Ray::Wait(objects, 3, 1000);
   EXPECT_EQ(result.ready.size(), 3);
@@ -59,9 +59,9 @@ TEST(RayApiTest, WaitTest) {
 }
 
 TEST(RayApiTest, CallWithValueTest) {
-  auto r0 = Ray::Call(Return1);
-  auto r1 = Ray::Call(Plus1, 3);
-  auto r2 = Ray::Call(Plus, 2, 3);
+  auto r0 = Ray::Task(Return1).Remote();
+  auto r1 = Ray::Task(Plus1, 3).Remote();
+  auto r2 = Ray::Task(Plus, 2, 3).Remote();
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());
@@ -73,11 +73,11 @@ TEST(RayApiTest, CallWithValueTest) {
 }
 
 TEST(RayApiTest, CallWithObjectTest) {
-  auto rt0 = Ray::Call(Return1);
-  auto rt1 = Ray::Call(Plus1, rt0);
-  auto rt2 = Ray::Call(Plus, rt1, 3);
-  auto rt3 = Ray::Call(Plus1, 3);
-  auto rt4 = Ray::Call(Plus, rt2, rt3);
+  auto rt0 = Ray::Task(Return1).Remote();
+  auto rt1 = Ray::Task(Plus1, rt0).Remote();
+  auto rt2 = Ray::Task(Plus, rt1, 3).Remote();
+  auto rt3 = Ray::Task(Plus1, 3).Remote();
+  auto rt4 = Ray::Task(Plus, rt2, rt3).Remote();
 
   int return0 = *(rt0.Get());
   int return1 = *(rt1.Get());
@@ -94,11 +94,11 @@ TEST(RayApiTest, CallWithObjectTest) {
 
 TEST(RayApiTest, ActorTest) {
   Ray::Init();
-  RayActor<Counter> actor = Ray::CreateActor(Counter::FactoryCreate);
-  auto rt1 = actor.Call(&Counter::Add, 1);
-  auto rt2 = actor.Call(&Counter::Add, 2);
-  auto rt3 = actor.Call(&Counter::Add, 3);
-  auto rt4 = actor.Call(&Counter::Add, rt3);
+  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate);
+  auto rt1 = actor.Task(&Counter::Add, 1).Remote();
+  auto rt2 = actor.Task(&Counter::Add, 2).Remote();
+  auto rt3 = actor.Task(&Counter::Add, 3).Remote();
+  auto rt4 = actor.Task(&Counter::Add, rt3).Remote();
 
   int return1 = *(rt1.Get());
   int return2 = *(rt2.Get());
@@ -124,7 +124,7 @@ TEST(RayApiTest, CompareWithFuture) {
 
   // Ray API
   Ray::Init();
-  auto f3 = Ray::Call(Plus1, 1);
+  auto f3 = Ray::Task(Plus1, 1).Remote();
   int rt3 = *f3.Get();
 
   EXPECT_EQ(rt1, 2);

--- a/cpp/src/ray/test/api_test.cc
+++ b/cpp/src/ray/test/api_test.cc
@@ -94,7 +94,7 @@ TEST(RayApiTest, CallWithObjectTest) {
 
 TEST(RayApiTest, ActorTest) {
   Ray::Init();
-  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate);
+  ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate).Remote();
   auto rt1 = actor.Task(&Counter::Add, 1).Remote();
   auto rt2 = actor.Task(&Counter::Add, 2).Remote();
   auto rt3 = actor.Task(&Counter::Add, 3).Remote();

--- a/cpp/src/ray/test/slow_function_test.cc
+++ b/cpp/src/ray/test/slow_function_test.cc
@@ -15,10 +15,10 @@ TEST(RaySlowFunctionTest, BaseTest) {
   Ray::Init();
   auto time1 = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
-  auto r0 = Ray::Call(slow_function, 1);
-  auto r1 = Ray::Call(slow_function, 2);
-  auto r2 = Ray::Call(slow_function, 3);
-  auto r3 = Ray::Call(slow_function, 4);
+  auto r0 = Ray::Task(slow_function, 1).Remote();
+  auto r1 = Ray::Task(slow_function, 2).Remote();
+  auto r2 = Ray::Task(slow_function, 3).Remote();
+  auto r3 = Ray::Task(slow_function, 4).Remote();
 
   int result0 = *(r0.Get());
   int result1 = *(r1.Get());


### PR DESCRIPTION
## Why are these changes needed?
Make C++ worker API similar to Java API and Python API, which is summarized in https://github.com/ray-project/ray/issues/7291#issuecomment-638582224.

The new C++ worker API like this:

#### common task
```
ObjectRef<int> = Ray::Task(Plus1, 3).Remote();
```
#### actor
```
ActorHandle<Counter> actor = Ray::Actor(Counter::FactoryCreate).Remote();
ObjectRef<int> = actor.Task(&Counter::Add, 5).Remote();
```

Also can see the example.cc or tests.

## Related issue number

#7291 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
