### PR TITLE
Fix Google log directory again

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -171,7 +171,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
         app_name_without_path = app_file_name;
       }
     }
-    google::SetLogFilenameExtension(app_name_without_path.c_str());
+    google::SetLogFilenameExtension((app_name_without_path + ".log.").c_str());
   }
   for (int lvl = 0; lvl < NUM_SEVERITIES; ++lvl) {
     if (log_dir_.empty()) {

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -178,7 +178,8 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
       google::SetStderrLogging(lvl);
       google::base::SetLogger(lvl, &stdout_logger_singleton);
     } else {
-      google::SetLogDestination(lvl, dir_ends_with_slash.c_str());
+      std::string prefix = dir_ends_with_slash + LogSeverityNames[lvl] + '.';
+      google::SetLogDestination(lvl, prefix.c_str());
     }
   }
 #endif


### PR DESCRIPTION
## Why are these changes needed?

It turns out glog [cannot log different severities to the same file](https://groups.google.com/d/msg/google-glog/3GmUtHBd0tQ/n0cDJTtA7FIJ).

Attempting to do so fails silently until the log file creation is triggered, at which point messages like these are printed:

```
(pid=4364) Could not create log file: File exists
(pid=4364) COULD NOT CREATE LOGFILE '20200620-175218.4364'!
```

So this PR uses different file names in different severities (and we add ".log" to the file names to make identifying logs easier).

## Related issue number

Fixes issue introduced in #9025.
Fixes #9082

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
