### PR TITLE
Pandas fix

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -229,7 +229,7 @@ install_dependencies() {
       *) tf_version="${TF_VERSION:-2.1.0}";;
     esac
     pip_packages+=(scipy tensorflow=="${tf_version}" cython==0.29.0 gym \
-      opencv-python-headless pyyaml pandas==0.24.2 requests feather-format lxml openpyxl xlrd \
+      opencv-python-headless pyyaml pandas==1.0.5 requests feather-format lxml openpyxl xlrd \
       py-spy pytest pytest-timeout networkx tabulate aiohttp uvicorn dataclasses pygments werkzeug \
       kubernetes flask grpcio pytest-sugar pytest-rerunfailures pytest-asyncio scikit-learn==0.22.2 numba \
       Pillow prometheus_client boto3)


### PR DESCRIPTION
## Why are these changes needed?

The Windows build of Pandas seems to [have broken spontaneously](https://github.com/ray-project/ray/runs/791633312?check_suite_focus=true#step:6:2161), possibly due to a dependency or compiler update.

This PR uses the latest version of Pandas for the CI to get the build back up and running.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
