### PR TITLE
Creating head node might take more than 50-30 seconds to show up.

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -228,7 +228,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
         start = time.time()
         head_node = None
         while True:
-            if time.time() - start > 5:
+            if time.time() - start > 50:
                 raise RuntimeError("Failed to create head node.")
             nodes = provider.non_terminated_nodes(head_node_tags)
             if len(nodes) == 1:


### PR DESCRIPTION
## Why are these changes needed?
if the head node is cached it might take more than 30-50 seconds to show up.

## Related issue number

Solves #6304 again! It might actually 30-50 seconds to show up on boto3.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
