### PR TITLE
Handle PlasmaStoreRunner::loop_ NULL case

### DIFF
--- a/src/ray/object_manager/plasma/store_runner.cc
+++ b/src/ray/object_manager/plasma/store_runner.cc
@@ -136,6 +136,8 @@ void PlasmaStoreRunner::Start() {
 void PlasmaStoreRunner::Stop() {
   if (loop_) {
     loop_->Stop();
+  } else {
+    ARROW_LOG(ERROR) << "Expected loop_ to be non-NULL; this may be a bug";
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?

It's unclear whether/when `PlasmaStoreRunner::loop_` can be `NULL`, so we should log an error in this case to aid debugging, but continue execution. (I've come across this case before, but I'm not currently sure how to reproduce it.)

## Related issue number

#9011

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
