### PR TITLE
Make test_utils.py use pipes to avoid file access conflicts on Windows

### DIFF
--- a/python/ray/serve/tests/test_persistence.py
+++ b/python/ray/serve/tests/test_persistence.py
@@ -1,8 +1,5 @@
-import os
-import subprocess
-import tempfile
-
 import ray
+import ray.test_utils
 from ray import serve
 
 
@@ -20,19 +17,10 @@ def driver(flask_request):
 serve.create_backend("driver", driver)
 serve.create_endpoint("driver", backend="driver", route="/driver")
 """.format(ray.worker._global_node._redis_address)
-
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-        path = f.name
-        f.write(script)
-
-    proc = subprocess.Popen(["python", path])
-    return_code = proc.wait(timeout=10)
-    assert return_code == 0
+    ray.test_utils.run_string_as_driver(script)
 
     handle = serve.get_handle("driver")
     assert ray.get(handle.remote()) == "OK!"
-
-    os.remove(path)
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -1,11 +1,10 @@
 import pytest
 import collections
-import subprocess
-import tempfile
 import os
 import unittest
 from unittest.mock import MagicMock, Mock
 
+from ray.test_utils import run_string_as_driver
 from ray.tune.trial import Trial
 from ray.tune.progress_reporter import (CLIReporter, _fair_filter_trials,
                                         trial_progress_str)
@@ -284,19 +283,15 @@ class ProgressReporterTest(unittest.TestCase):
     def testEndToEndReporting(self):
         try:
             os.environ["_TEST_TUNE_TRIAL_UUID"] = "xxxxx"
-            with tempfile.NamedTemporaryFile(suffix=".py") as f:
-                f.write(END_TO_END_COMMAND.encode("utf-8"))
-                f.flush()
-                output = subprocess.check_output(["python3", f.name])
-                output = output.decode("utf-8")
-                try:
-                    assert EXPECTED_END_TO_END_START in output
-                    assert EXPECTED_END_TO_END_END in output
-                except Exception:
-                    print("*** BEGIN OUTPUT ***")
-                    print(output)
-                    print("*** END OUTPUT ***")
-                    raise
+            output = run_string_as_driver(END_TO_END_COMMAND)
+            try:
+                assert EXPECTED_END_TO_END_START in output
+                assert EXPECTED_END_TO_END_END in output
+            except Exception:
+                print("*** BEGIN OUTPUT ***")
+                print(output)
+                print("*** END OUTPUT ***")
+                raise
         finally:
             del os.environ["_TEST_TUNE_TRIAL_UUID"]
 


### PR DESCRIPTION
## Why are these changes needed?

File sharing errors prevent Python from running temporary scripts on Windows.

Pipes avoid the need for temporary files entirely.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
