### PR TITLE
Refine GetNamedActorHandle acync rpc wait

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1377,13 +1377,9 @@ Status CoreWorker::GetNamedActorHandle(const std::string &name,
   // callback. There should be no risk of deadlock because we don't hold any
   // locks during the call and the RPCs run on a separate thread.
   ActorID actor_id;
-  std::shared_ptr<bool> ready = std::make_shared<bool>(false);
-  std::shared_ptr<std::mutex> m = std::make_shared<std::mutex>();
-  std::shared_ptr<std::condition_variable> cv =
-      std::make_shared<std::condition_variable>();
-  std::unique_lock<std::mutex> lk(*m);
+  auto ready_promise = std::promise<void>();
   RAY_CHECK_OK(gcs_client_->Actors().AsyncGetByName(
-      name, [this, &actor_id, name, ready, m, cv](
+      name, [this, &actor_id, name](
                 Status status, const boost::optional<gcs::ActorTableData> &result) {
         if (status.ok() && result) {
           auto actor_handle = std::unique_ptr<ActorHandle>(new ActorHandle(*result));
@@ -1394,19 +1390,12 @@ Status CoreWorker::GetNamedActorHandle(const std::string &name,
           // Use a NIL actor ID to signal that the actor wasn't found.
           actor_id = ActorID::Nil();
         }
-
-        // Notify the main thread that the RPC has finished.
-        {
-          std::unique_lock<std::mutex> lk(*m);
-          *ready = true;
-        }
-        cv->notify_one();
+        ready_promise.set_value();
       }));
 
   // Block until the RPC completes. Set a timeout to avoid hangs if the
   // GCS service crashes.
-  cv->wait_for(lk, std::chrono::seconds(5), [ready] { return *ready; });
-  if (!*ready) {
+  if (ready_promise.get_future().wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
     return Status::TimedOut("Timed out trying to get named actor.");
   }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1373,13 +1373,13 @@ Status CoreWorker::GetNamedActorHandle(const std::string &name,
 
   // This call needs to be blocking because we can't return until the actor
   // handle is created, which requires the response from the RPC. This is
-  // implemented using a condition variable that's captured in the RPC
-  // callback. There should be no risk of deadlock because we don't hold any
+  // implemented using a promise that's captured in the RPC callback. 
+  // There should be no risk of deadlock because we don't hold any
   // locks during the call and the RPCs run on a separate thread.
   ActorID actor_id;
   auto ready_promise = std::promise<void>();
   RAY_CHECK_OK(gcs_client_->Actors().AsyncGetByName(
-      name, [this, &actor_id, name](
+      name, [this, &actor_id, name, &ready_promise](
                 Status status, const boost::optional<gcs::ActorTableData> &result) {
         if (status.ok() && result) {
           auto actor_handle = std::unique_ptr<ActorHandle>(new ActorHandle(*result));

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1373,7 +1373,7 @@ Status CoreWorker::GetNamedActorHandle(const std::string &name,
 
   // This call needs to be blocking because we can't return until the actor
   // handle is created, which requires the response from the RPC. This is
-  // implemented using a promise that's captured in the RPC callback. 
+  // implemented using a promise that's captured in the RPC callback.
   // There should be no risk of deadlock because we don't hold any
   // locks during the call and the RPCs run on a separate thread.
   ActorID actor_id;
@@ -1395,7 +1395,8 @@ Status CoreWorker::GetNamedActorHandle(const std::string &name,
 
   // Block until the RPC completes. Set a timeout to avoid hangs if the
   // GCS service crashes.
-  if (ready_promise.get_future().wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+  if (ready_promise.get_future().wait_for(std::chrono::seconds(5)) !=
+      std::future_status::ready) {
     return Status::TimedOut("Timed out trying to get named actor.");
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Refine `CoreWorker::GetNamedActorHandle` acync rpc wait by `std::promise<void>`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
