### PR TITLE
fix a bug that move a const variable

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -389,7 +389,7 @@ void WorkerPool::PushWorker(const std::shared_ptr<Worker> &worker) {
     // The worker is used for the actor creation task with dynamic options.
     // Put it into idle dedicated worker pool.
     const auto task_id = it->second;
-    state.idle_dedicated_workers[task_id] = std::move(worker);
+    state.idle_dedicated_workers[task_id] = worker;
   } else {
     // The worker is not used for the actor creation task without dynamic options.
     // Put the worker to the corresponding idle pool.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -394,9 +394,9 @@ void WorkerPool::PushWorker(const std::shared_ptr<Worker> &worker) {
     // The worker is not used for the actor creation task without dynamic options.
     // Put the worker to the corresponding idle pool.
     if (worker->GetActorId().IsNil()) {
-      state.idle.insert(std::move(worker));
+      state.idle.insert(worker);
     } else {
-      state.idle_actor[worker->GetActorId()] = std::move(worker);
+      state.idle_actor[worker->GetActorId()] = worker;
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
`worker` is a const variable, we should not use `std::move` on it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
