### PR TITLE
Make process termination more robust

### DIFF
--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -399,10 +399,10 @@ void Process::Kill() {
       if (!::TerminateProcess(handle, ERROR_PROCESS_ABORTED)) {
         error = std::error_code(GetLastError(), std::system_category());
         if (error.value() == ERROR_ACCESS_DENIED) {
-          // This can occur under some circumstances if the process is already terminating
+          // This can occur in some situations if the process is already terminating.
           DWORD exit_code;
           if (GetExitCodeProcess(handle, &exit_code) && exit_code != STILL_ACTIVE) {
-            // The process is already terminating, so consider the killing successful
+            // The process is already terminating, so consider the killing successful.
             error = std::error_code();
           }
         }
@@ -417,7 +417,7 @@ void Process::Kill() {
       if (error.value() == ESRCH) {
         // The process died before our kill().
         // This is probably due to using FromPid().Kill() on a non-owned process.
-        // We got lucky here, because we could've kill a recycled PID.
+        // We got lucky here, because we could've killed a recycled PID.
         // To avoid this, do not kill a process that is not owned by us.
         // Instead, let its parent receive its SIGCHLD normally and call waitpid() on it.
         // (Exception: Tests might occasionally trigger this, but that should be benign.)

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -134,7 +134,8 @@ class ProcessFD {
       int r = read(pipefds[0], &pid, sizeof(pid));
       (void)r;  // can't do much if this fails, so ignore return value
     }
-    fd = pipefds[0];  // Use pipe to track process lifetime
+    // Use pipe to track process lifetime. (The pipe closes when process terminates.)
+    fd = pipefds[0];
     if (pid == -1) {
       ec = std::error_code(errno, std::system_category());
     }


### PR DESCRIPTION
## Why are these changes needed?

Process termination is a bit fragile right now. Sometimes it logs an incorrect failure message when a process is already terminating on Windows. And sometimes it avoids checking to see if the process is already terminated before calling `kill()`, when in fact this could be done in some circumstances under POSIX. This PR addresses these issues.

Note that process termination will still remain somewhat fragile under POSIX (at least as long as `SIGCHLD` is ignored), so that should still be done at some point.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
