### PR TITLE
Move actor task submission to io service

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -109,7 +109,8 @@ include "includes/serialization.pxi"
 include "includes/libcoreworker.pxi"
 include "includes/global_state_accessor.pxi"
 
-# Expose GCC & Clang macro to report whether C++ optimizations were enabled during compilation.
+# Expose GCC & Clang macro to report whether C++ optimizations were enabled
+# during compilation.
 OPTIMIZED = __OPTIMIZE__
 
 logger = logging.getLogger(__name__)
@@ -954,11 +955,10 @@ cdef class CoreWorker:
             prepare_args(self, language, args, &args_vector)
 
             with nogil:
-                check_status(
-                    CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
-                        c_actor_id,
-                        ray_function,
-                        args_vector, task_options, &return_ids))
+                CCoreWorkerProcess.GetCoreWorker().SubmitActorTask(
+                    c_actor_id,
+                    ray_function,
+                    args_vector, task_options, &return_ids)
 
             return VectorToObjectIDs(return_ids)
 

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -89,7 +89,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const CRayFunction &function, const c_vector[CTaskArg] &args,
             const CActorCreationOptions &options,
             const c_string &extension_data, CActorID *actor_id)
-        CRayStatus SubmitActorTask(
+        void SubmitActorTask(
             const CActorID &actor_id, const CRayFunction &function,
             const c_vector[CTaskArg] &args, const CTaskOptions &options,
             c_vector[CObjectID] *return_ids)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1203,16 +1203,17 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
   return_ids->pop_back();
 
   // Submit task.
-  Status status;
   TaskSpecification task_spec = builder.Build();
   if (options_.is_local_mode) {
     ExecuteTaskLocalMode(task_spec, actor_id);
   } else {
     task_manager_->AddPendingTask(GetCallerId(), rpc_address_, task_spec,
                                   CurrentCallSite(), actor_handle->MaxTaskRetries());
-    status = direct_actor_submitter_->SubmitTask(task_spec);
+    io_service_.post([this, task_spec]() {
+      RAY_UNUSED(direct_actor_submitter_->SubmitTask(task_spec));
+    });
   }
-  return status;
+  return Status::OK();
 }
 
 Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1175,12 +1175,12 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   return status;
 }
 
-Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &function,
-                                   const std::vector<TaskArg> &args,
-                                   const TaskOptions &task_options,
-                                   std::vector<ObjectID> *return_ids) {
+void CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &function,
+                                 const std::vector<TaskArg> &args,
+                                 const TaskOptions &task_options,
+                                 std::vector<ObjectID> *return_ids) {
   ActorHandle *actor_handle = nullptr;
-  RAY_RETURN_NOT_OK(GetActorHandle(actor_id, &actor_handle));
+  RAY_CHECK_OK(GetActorHandle(actor_id, &actor_handle));
 
   // Add one for actor cursor object id for tasks.
   const int num_returns = task_options.num_returns + 1;
@@ -1213,7 +1213,6 @@ Status CoreWorker::SubmitActorTask(const ActorID &actor_id, const RayFunction &f
       RAY_UNUSED(direct_actor_submitter_->SubmitTask(task_spec));
     });
   }
-  return Status::OK();
 }
 
 Status CoreWorker::CancelTask(const ObjectID &object_id, bool force_kill) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -579,10 +579,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status error if the task is invalid or if the task submission
   /// failed. Tasks can be invalid for direct actor calls because not all tasks
   /// are currently supported.
-  Status SubmitActorTask(const ActorID &actor_id, const RayFunction &function,
-                         const std::vector<TaskArg> &args,
-                         const TaskOptions &task_options,
-                         std::vector<ObjectID> *return_ids);
+  void SubmitActorTask(const ActorID &actor_id, const RayFunction &function,
+                       const std::vector<TaskArg> &args, const TaskOptions &task_options,
+                       std::vector<ObjectID> *return_ids);
 
   /// Tell an actor to exit immediately, without completing outstanding work.
   ///

--- a/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_task_NativeTaskSubmitter.cc
@@ -170,10 +170,9 @@ Java_io_ray_runtime_task_NativeTaskSubmitter_nativeSubmitActorTask(
   auto task_options = ToTaskOptions(env, numReturns, callOptions);
 
   std::vector<ObjectID> return_ids;
-  auto status = ray::CoreWorkerProcess::GetCoreWorker().SubmitActorTask(
+  ray::CoreWorkerProcess::GetCoreWorker().SubmitActorTask(
       actor_id, ray_function, task_args, task_options, &return_ids);
 
-  THROW_EXCEPTION_AND_RETURN_IF_NOT_OK(env, status, nullptr);
   return NativeIdVectorToJavaByteArrayList(env, return_ids);
 }
 

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -236,8 +236,8 @@ int CoreWorkerTest::GetActorPid(const ActorID &actor_id,
   RayFunction func{Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                          "GetWorkerPid", "", "", "")};
 
-  RAY_CHECK_OK(CoreWorkerProcess::GetCoreWorker().SubmitActorTask(actor_id, func, args,
-                                                                  options, &return_ids));
+  CoreWorkerProcess::GetCoreWorker().SubmitActorTask(actor_id, func, args, options,
+                                                     &return_ids);
 
   std::vector<std::shared_ptr<ray::RayObject>> results;
   RAY_CHECK_OK(CoreWorkerProcess::GetCoreWorker().Get(return_ids, -1, &results));
@@ -317,7 +317,7 @@ void CoreWorkerTest::TestActorTask(std::unordered_map<std::string, double> &reso
       RayFunction func(ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                   "MergeInputArgsAsOutput", "", "", ""));
 
-      RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+      driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
       ASSERT_EQ(return_ids.size(), 1);
       ASSERT_TRUE(return_ids[0].IsReturnObject());
 
@@ -359,8 +359,7 @@ void CoreWorkerTest::TestActorTask(std::unordered_map<std::string, double> &reso
     std::vector<ObjectID> return_ids;
     RayFunction func(ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                 "MergeInputArgsAsOutput", "", "", ""));
-    auto status = driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
-    ASSERT_TRUE(status.ok());
+    driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
 
     ASSERT_EQ(return_ids.size(), 1);
 
@@ -423,7 +422,7 @@ void CoreWorkerTest::TestActorRestart(
       RayFunction func(ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                   "MergeInputArgsAsOutput", "", "", ""));
 
-      RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+      driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
       ASSERT_EQ(return_ids.size(), 1);
       // Verify if it's expected data.
       std::vector<std::shared_ptr<RayObject>> results;
@@ -466,7 +465,7 @@ void CoreWorkerTest::TestActorFailure(
       RayFunction func(ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                   "MergeInputArgsAsOutput", "", "", ""));
 
-      RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+      driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
 
       ASSERT_EQ(return_ids.size(), 1);
       all_results.emplace_back(std::make_pair(return_ids[0], buffer1));
@@ -617,7 +616,7 @@ TEST_F(SingleNodeTest, TestDirectActorTaskSubmissionPerf) {
     RayFunction func(ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                 "MergeInputArgsAsOutput", "", "", ""));
 
-    RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+    driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
     ASSERT_EQ(return_ids.size(), 1);
     object_ids.emplace_back(return_ids[0]);
   }

--- a/streaming/src/queue/transport.cc
+++ b/streaming/src/queue/transport.cc
@@ -29,11 +29,8 @@ void Transport::SendInternal(std::shared_ptr<LocalMemoryBuffer> buffer,
       std::move(buffer), meta, std::vector<ObjectID>(), true)));
 
   std::vector<std::shared_ptr<RayObject>> results;
-  ray::Status st = CoreWorkerProcess::GetCoreWorker().SubmitActorTask(
-      peer_actor_id_, function, args, options, &return_ids);
-  if (!st.ok()) {
-    STREAMING_LOG(ERROR) << "SubmitActorTask failed. " << st;
-  }
+  CoreWorkerProcess::GetCoreWorker().SubmitActorTask(peer_actor_id_, function, args,
+                                                     options, &return_ids);
 }
 
 void Transport::Send(std::shared_ptr<LocalMemoryBuffer> buffer) {

--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -91,7 +91,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     RayFunction func{ray::Language::PYTHON,
                      ray::FunctionDescriptorBuilder::BuildPython("", "", "init", "")};
 
-    RAY_CHECK_OK(driver.SubmitActorTask(self_actor_id, func, args, options, &return_ids));
+    driver.SubmitActorTask(self_actor_id, func, args, options, &return_ids);
   }
 
   void SubmitTestToActor(ActorID &actor_id, const std::string test) {
@@ -107,7 +107,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     RayFunction func{ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                 "", test, "execute_test", "")};
 
-    RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+    driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
   }
 
   bool CheckCurTest(ActorID &actor_id, const std::string test_name) {
@@ -123,7 +123,7 @@ class StreamingQueueTestBase : public ::testing::TestWithParam<uint64_t> {
     RayFunction func{ray::Language::PYTHON, ray::FunctionDescriptorBuilder::BuildPython(
                                                 "", "", "check_current_test_status", "")};
 
-    RAY_CHECK_OK(driver.SubmitActorTask(actor_id, func, args, options, &return_ids));
+    driver.SubmitActorTask(actor_id, func, args, options, &return_ids);
 
     std::vector<bool> wait_results;
     std::vector<std::shared_ptr<RayObject>> results;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
In the core worker, task submission is done in an io_service but actor submission is not. This PR moves the actor task submission to the separate thread. On my noisy laptop, the 1:n and n:n actor performance improved. 

Before
1:1 actor calls sync per second 3626.81 +- 255.68
1:1 actor calls async per second 7902.56 +- 289.24
1:1 actor calls concurrent per second 8561.52 +- 152.24
**1:n actor calls async per second 13691.98 +- 169.24
n:n actor calls async per second 18734.41 +- 1056.23
n:n actor calls with arg async per second 7855.78 +- 151.52**
1:1 async-actor calls sync per second 1565.4 +- 127.42
1:1 async-actor calls async per second 4522.68 +- 62.84
1:1 async-actor calls with args async per second 3137.27 +- 44.25
1:n async-actor calls async per second 7914.23 +- 354.85
n:n async-actor calls async per second 13744.6 +- 986.45

After
1:1 actor calls sync per second 3354.26 +- 44.29
1:1 actor calls async per second 8085.57 +- 54.05
1:1 actor calls concurrent per second 8551.75 +- 294.14
**1:n actor calls async per second 17456.68 +- 814.18
n:n actor calls async per second 21613.69 +- 2310.54
n:n actor calls with arg async per second 9613.99 +- 174.05**
1:1 async-actor calls sync per second 1565.17 +- 55.77
1:1 async-actor calls async per second 4352.79 +- 91.6
1:1 async-actor calls with args async per second 2975.68 +- 27.98
1:n async-actor calls async per second 8915.71 +- 427.51
n:n async-actor calls async per second 14003.63 +- 538.4

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
