### PR TITLE
[autoscaler/docker] Relax missing docker section

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -322,7 +322,7 @@ class StandardAutoscaler:
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
             use_internal_ip=True,
-            docker_config=self.config.get("docker", None))
+            docker_config=self.config.get("docker"))
         updater.start()
         self.updaters[node_id] = updater
 
@@ -362,7 +362,7 @@ class StandardAutoscaler:
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
             use_internal_ip=True,
-            docker_config=self.config.get("docker", None))
+            docker_config=self.config.get("docker"))
         updater.start()
         self.updaters[node_id] = updater
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -322,7 +322,7 @@ class StandardAutoscaler:
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
             use_internal_ip=True,
-            docker_config=self.config["docker"])
+            docker_config=self.config.get("docker", None))
         updater.start()
         self.updaters[node_id] = updater
 
@@ -362,7 +362,7 @@ class StandardAutoscaler:
             runtime_hash=self.runtime_hash,
             process_runner=self.process_runner,
             use_internal_ip=True,
-            docker_config=self.config["docker"])
+            docker_config=self.config.get("docker", None))
         updater.start()
         self.updaters[node_id] = updater
 

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -152,7 +152,7 @@ def kill_node(config_file, yes, hard, override_cluster_name):
                 setup_commands=[],
                 ray_start_commands=[],
                 runtime_hash="",
-                docker_config=config.get("docker", None))
+                docker_config=config.get("docker"))
 
             _exec(updater, "ray stop", False, False)
 
@@ -291,7 +291,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             setup_commands=init_commands,
             ray_start_commands=ray_start_commands,
             runtime_hash=runtime_hash,
-            docker_config=config.get("docker", None))
+            docker_config=config.get("docker"))
         updater.start()
         updater.join()
 
@@ -412,7 +412,7 @@ def exec_cluster(config_file,
             setup_commands=[],
             ray_start_commands=[],
             runtime_hash="",
-            docker_config=config.get("docker", None))
+            docker_config=config.get("docker"))
 
         def wrap_docker(command):
             container_name = config["docker"]["container_name"]
@@ -534,7 +534,7 @@ def rsync(config_file,
                 setup_commands=[],
                 ray_start_commands=[],
                 runtime_hash="",
-                docker_config=config.get("docker", None))
+                docker_config=config.get("docker"))
             if down:
                 rsync = updater.rsync_down
             else:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -152,7 +152,7 @@ def kill_node(config_file, yes, hard, override_cluster_name):
                 setup_commands=[],
                 ray_start_commands=[],
                 runtime_hash="",
-                docker_config=config["docker"])
+                docker_config=config.get("docker", None))
 
             _exec(updater, "ray stop", False, False)
 
@@ -291,7 +291,7 @@ def get_or_create_head_node(config, config_file, no_restart, restart_only, yes,
             setup_commands=init_commands,
             ray_start_commands=ray_start_commands,
             runtime_hash=runtime_hash,
-            docker_config=config["docker"])
+            docker_config=config.get("docker", None))
         updater.start()
         updater.join()
 
@@ -412,7 +412,7 @@ def exec_cluster(config_file,
             setup_commands=[],
             ray_start_commands=[],
             runtime_hash="",
-            docker_config=config["docker"])
+            docker_config=config.get("docker", None))
 
         def wrap_docker(command):
             container_name = config["docker"]["container_name"]
@@ -534,7 +534,7 @@ def rsync(config_file,
                 setup_commands=[],
                 ray_start_commands=[],
                 runtime_hash="",
-                docker_config=config["docker"])
+                docker_config=config.get("docker", None))
             if down:
                 rsync = updater.rsync_down
             else:

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -23,7 +23,6 @@ def dockerize_if_needed(config):
     worker_docker_image = config["docker"].get("worker_image", docker_image)
     worker_run_options = config["docker"].get("worker_run_options", [])
 
-    ssh_user = config["auth"]["ssh_user"]
     if not docker_image and not (head_docker_image and worker_docker_image):
         if cname:
             logger.warning(
@@ -32,6 +31,7 @@ def dockerize_if_needed(config):
         return config
     else:
         assert cname, "Must provide container name!"
+    ssh_user = config["auth"]["ssh_user"]
     docker_mounts = {dst: dst for dst in config["file_mounts"]}
 
     if docker_pull:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This allows users (specifically of the K8 YAML) to not encounter problems where `docker=config["docker"]` throws a `KeyError` when trying to create a `NodeUpdaterThread`. This PR switches to a default `get` value of `None`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Addresses a problem on Ray Slack

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
