### PR TITLE
[core] Return all GPUs for Local Mode

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -401,7 +401,8 @@ def get_gpu_ids():
         ]
         # Give all GPUs in local_mode.
         if global_worker.mode == LOCAL_MODE:
-            return global_worker.original_gpu_ids
+            max_gpus = global_worker.node.get_resource_spec().num_gpus
+            return global_worker.original_gpu_ids[:max_gpus]
 
     return assigned_ids
 

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -399,6 +399,9 @@ def get_gpu_ids():
         assigned_ids = [
             global_worker.original_gpu_ids[gpu_id] for gpu_id in assigned_ids
         ]
+        # Give all GPUs in local_mode.
+        if global_worker.mode == LOCAL_MODE:
+            return global_worker.original_gpu_ids
 
     return assigned_ids
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This allocates all visible GPUs to Local Mode tasks. Local Mode does not set requested resources because this is done in parts of the task submission process that local_mode bypases.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #8838
Closes #1221

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
