### PR TITLE
Remove arrow macros in plasma store

### DIFF
--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -123,7 +123,7 @@ std::shared_ptr<Buffer> MakeBufferFromGpuProcessHandle(GpuProcessHandle* handle)
 
 /// A Buffer class that automatically releases the backing plasma object
 /// when it goes out of scope. This is returned by Get.
-class ARROW_NO_EXPORT PlasmaBuffer : public Buffer {
+class RAY_NO_EXPORT PlasmaBuffer : public Buffer {
  public:
   ~PlasmaBuffer();
 
@@ -143,7 +143,7 @@ class ARROW_NO_EXPORT PlasmaBuffer : public Buffer {
 /// A mutable Buffer class that keeps the backing data alive by keeping a
 /// PlasmaClient shared pointer. This is returned by Create. Release will
 /// be called in the associated Seal call.
-class ARROW_NO_EXPORT PlasmaMutableBuffer : public MutableBuffer {
+class RAY_NO_EXPORT PlasmaMutableBuffer : public MutableBuffer {
  public:
   PlasmaMutableBuffer(std::shared_ptr<PlasmaClient::Impl> client, uint8_t* mutable_data,
                       int64_t data_size)
@@ -352,7 +352,7 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 #endif
 };
 
-PlasmaBuffer::~PlasmaBuffer() { ARROW_UNUSED(client_->Release(object_id_)); }
+PlasmaBuffer::~PlasmaBuffer() { RAY_UNUSED(client_->Release(object_id_)); }
 
 PlasmaClient::Impl::Impl() : store_conn_(0), store_capacity_(0) {
 #ifdef PLASMA_CUDA

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -24,9 +24,9 @@
 
 #include "arrow/buffer.h"
 #include "arrow/status.h"
-#include "arrow/util/macros.h"
-#include "arrow/util/visibility.h"
+
 #include "ray/object_manager/plasma/common.h"
+#include "ray/util/visibility.h"
 
 using arrow::Buffer;
 using arrow::Status;
@@ -43,7 +43,8 @@ struct ObjectBuffer {
   int device_num;
 };
 
-class ARROW_EXPORT PlasmaClient {
+// TODO(suquark): Maybe we should not export plasma later?
+class RAY_EXPORT PlasmaClient {
  public:
   PlasmaClient();
   ~PlasmaClient();
@@ -287,7 +288,7 @@ class ARROW_EXPORT PlasmaClient {
 
   bool IsInUse(const ObjectID& object_id);
 
-  class ARROW_NO_EXPORT Impl;
+  class RAY_NO_EXPORT Impl;
   std::shared_ptr<Impl> impl_;
 };
 

--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -44,15 +44,15 @@ enum class PlasmaErrorCode : int8_t {
   PlasmaObjectAlreadySealed = 4,
 };
 
-ARROW_EXPORT arrow::Status MakePlasmaError(PlasmaErrorCode code, std::string message);
+RAY_EXPORT arrow::Status MakePlasmaError(PlasmaErrorCode code, std::string message);
 /// Return true iff the status indicates an already existing Plasma object.
-ARROW_EXPORT bool IsPlasmaObjectExists(const arrow::Status& status);
+RAY_EXPORT bool IsPlasmaObjectExists(const arrow::Status& status);
 /// Return true iff the status indicates a non-existent Plasma object.
-ARROW_EXPORT bool IsPlasmaObjectNonexistent(const arrow::Status& status);
+RAY_EXPORT bool IsPlasmaObjectNonexistent(const arrow::Status& status);
 /// Return true iff the status indicates an already sealed Plasma object.
-ARROW_EXPORT bool IsPlasmaObjectAlreadySealed(const arrow::Status& status);
+RAY_EXPORT bool IsPlasmaObjectAlreadySealed(const arrow::Status& status);
 /// Return true iff the status indicates the Plasma store reached its capacity limit.
-ARROW_EXPORT bool IsPlasmaStoreFull(const arrow::Status& status);
+RAY_EXPORT bool IsPlasmaStoreFull(const arrow::Status& status);
 
 /// Size of object hash digests.
 constexpr int64_t kDigestSize = sizeof(uint64_t);

--- a/src/ray/object_manager/plasma/io.cc
+++ b/src/ray/object_manager/plasma/io.cc
@@ -22,7 +22,6 @@
 #include <sstream>
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 #include "ray/object_manager/plasma/common.h"
 #include "ray/object_manager/plasma/plasma_generated.h"

--- a/src/ray/object_manager/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
+++ b/src/ray/object_manager/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
@@ -28,8 +28,6 @@
 #include <string>
 #include <vector>
 
-#include "arrow/util/logging.h"
-
 #include "ray/object_manager/plasma/client.h"
 
 constexpr jsize OBJECT_ID_SIZE = sizeof(plasma::ObjectID) / sizeof(jbyte);

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -35,7 +35,6 @@
 #include "ray/object_manager/plasma/compat.h"
 
 #include "arrow/status.h"
-#include "arrow/util/macros.h"
 #include "ray/object_manager/plasma/common.h"
 #include "ray/util/logging.h"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR is one step for Plasma Store integration. It gets rid of arrow macros.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
