### PR TITLE
[BUILD]use first appearance of import when check order

### DIFF
--- a/ci/travis/check_import_order.py
+++ b/ci/travis/check_import_order.py
@@ -37,7 +37,7 @@ def check_import(file):
                 # - submodule import: `import ray.constants as ray_constants`
                 # - submodule import: `from ray import xyz`
                 if re.search(r"^\s*" + check + r"(\s*|\s+# noqa F401.*)$",
-                             line):
+                             line) and check_to_lines[check] == -1:
                     check_to_lines[check] = i
 
     for import_lib in ["import psutil", "import setproctitle"]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

in check_import_order.py we check if codes import ray before importing psutil/setproctitle using the line number we found in single file.

but the line number always point to the last line the import at. for example we have  real  `import ray` in file header and another `import ray` in functions like run_string_as_driver. we need add extra but unnecessary `import setproctitle` if we have a `import setproctitle` in file header. like this:

```
import ray
import setproctitle

....

def funciton_udf(file):
    driver = run_string_as_driver("""
import ray
import setproctitle (this one is not necessary but we must add it, otherwise the check import order will throw a check failed message)
.....
ray.init()
.....
```

We should use first appearance of import instead of last one when check import order.

## Related issue number

closes https://github.com/ray-project/ray/issues/8982

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
