### PR TITLE
[autoscaler] Better explain min/max/initial worker settings

### DIFF
--- a/python/ray/autoscaler/local/example-full.yaml
+++ b/python/ray/autoscaler/local/example-full.yaml
@@ -1,19 +1,19 @@
 # An unique identifier for the head node and workers of this cluster.
 cluster_name: default
 
-## NOTE: Typically for local clusters, min_workers == initial_workers == max_workers.
+## NOTE: Typically for local clusters, min_workers == initial_workers == max_workers == len(worker_ips).
 
 # The minimum number of workers nodes to launch in addition to the head
 # node. This number should be >= 0.
-# Typically, min_workers == initial_workers == max_workers.
+# Typically, min_workers == initial_workers == max_workers == len(worker_ips).
 min_workers: 0
 # The initial number of worker nodes to launch in addition to the head node.
-# Typically, min_workers == initial_workers == max_workers.
+# Typically, min_workers == initial_workers == max_workers == len(worker_ips).
 initial_workers: 0
 
 # The maximum number of workers nodes to launch in addition to the head node.
 # This takes precedence over min_workers.
-# Typically, min_workers == initial_workers == max_workers.
+# Typically, min_workers == initial_workers == max_workers == len(worker_ips).
 max_workers: 0
 
 # Autoscaling parameters.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This change adds that the number of workers on a local cluster should be equal to the number of IPs provided in `worker_ips`.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Some followups to #4902

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
