### PR TITLE
[windows] Work around msgpack issue on PowerPC64LE

### DIFF
--- a/thirdparty/patches/msgpack-windows-iovec.patch
+++ b/thirdparty/patches/msgpack-windows-iovec.patch
@@ -1,7 +1,11 @@
 diff --git include/msgpack/v1/vrefbuffer.hpp include/msgpack/v1/vrefbuffer.hpp
 --- include/msgpack/v1/vrefbuffer.hpp
 +++ include/msgpack/v1/vrefbuffer.hpp
-@@ -28,4 +28,19 @@
+@@ -25,7 +25,22 @@
+-#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__)
++#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__unix__)
+ #include <sys/uio.h>
+ #else
 +#ifdef _WIN32
 +#ifndef _WS2DEF_
 +#include <Winsock2.h>


### PR DESCRIPTION
## Why are these changes needed?

On some compilers on RHEL 7.6 it appears msgpack's check for `__unix` doesn't work, so we also check for `__unix__`.

## Related issue number

Closes #9138.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
