### PR TITLE
[core] Keep reference to pending futures

### DIFF
--- a/python/ray/async_compat.py
+++ b/python/ray/async_compat.py
@@ -41,7 +41,6 @@ def get_async(object_id):
     # Setup
     async_api_init()
     loop = asyncio.get_event_loop()
-    core_worker = ray.worker.global_worker.core_worker
 
     # Here's the callback used to implement async get logic.
     # What we want:
@@ -96,9 +95,7 @@ def get_async(object_id):
     inner_future = loop.create_future()
     # We must add the done_callback before sending to in_memory_store_get
     inner_future.add_done_callback(done_callback)
-    core_worker.in_memory_store_get_async(object_id, inner_future)
-    # A hack to keep reference to inner_future so it doesn't get GC.
-    user_future.inner_future = inner_future
+    ray.worker.global_worker.in_memory_store_get_async(object_id, inner_future)
     # A hack to keep a reference to the object ID for ref counting.
     user_future.object_id = object_id
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This avoids a bug where a segfault/error arises in `_raylet.async_set_result_callback`  because the referenced future gets removed. In some cases the error is that the Future is `None`, and in other cases it causes a segfault.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #9251

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
