### PR TITLE
Worker <> GPU Mapping Information in Dashboard

### DIFF
--- a/python/ray/dashboard/client/src/common/CustomTypography.tsx
+++ b/python/ray/dashboard/client/src/common/CustomTypography.tsx
@@ -1,9 +1,5 @@
+import { styled, Typography } from "@material-ui/core";
 
-import { Typography, styled } from "@material-ui/core";
-
-export const RightPaddedTypography = styled(Typography)(({
-   theme
-}) => ({
+export const RightPaddedTypography = styled(Typography)(({ theme }) => ({
   paddingRight: theme.spacing(1),
 }));
-

--- a/python/ray/dashboard/client/src/common/CustomTypography.tsx
+++ b/python/ray/dashboard/client/src/common/CustomTypography.tsx
@@ -1,0 +1,9 @@
+
+import { Typography, styled } from "@material-ui/core";
+
+export const RightPaddedTypography = styled(Typography)(({
+   theme
+}) => ({
+  paddingRight: theme.spacing(1),
+}));
+

--- a/python/ray/dashboard/client/src/common/UsageBar.tsx
+++ b/python/ray/dashboard/client/src/common/UsageBar.tsx
@@ -1,4 +1,4 @@
-import { createStyles, Theme, withStyles, WithStyles } from "@material-ui/core";
+import { createStyles, Theme, makeStyles, Typography} from "@material-ui/core";
 import React from "react";
 
 const blend = (
@@ -11,58 +11,54 @@ const blend = (
   b1 * (1 - ratio) + b2 * ratio,
 ];
 
-const styles = (theme: Theme) =>
+const useUsageBarStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       borderColor: theme.palette.divider,
       borderStyle: "solid",
       borderWidth: 1,
+      display: "flex",
+      flexGrow: 1,
     },
     inner: {
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),
     },
-  });
+  }));
 
-type Props = {
+type UsageBarProps = {
   percent: number;
   text: string;
 };
 
-class UsageBar extends React.Component<Props & WithStyles<typeof styles>> {
-  render() {
-    const { classes, text } = this.props;
+const UsageBar: React.FC<UsageBarProps> = ({percent, text}) => {
+  const classes = useUsageBarStyles();
+  const safePercent = Math.max(Math.min(percent, 100), 0);
+  const minColor = [0, 255, 0];
+  const maxColor = [255, 0, 0];
 
-    let { percent } = this.props;
-    percent = Math.max(percent, 0);
-    percent = Math.min(percent, 100);
+  const leftColor = minColor;
+  const rightColor = blend(minColor, maxColor, safePercent / 100);
+  const alpha = 0.2;
 
-    const minColor = [0, 255, 0];
-    const maxColor = [255, 0, 0];
+  const gradient = `
+    linear-gradient(
+      to right,
+      rgba(${leftColor.join(",")}, ${alpha}) 0%,
+      rgba(${rightColor.join(",")}, ${alpha}) ${safePercent}%,
+      transparent ${safePercent}%
+    )
+  `;
 
-    const leftColor = minColor;
-    const rightColor = blend(minColor, maxColor, percent / 100);
-    const alpha = 0.2;
-
-    const gradient = `
-      linear-gradient(
-        to right,
-        rgba(${leftColor.join(",")}, ${alpha}) 0%,
-        rgba(${rightColor.join(",")}, ${alpha}) ${percent}%,
-        transparent ${percent}%
-      )
-    `;
-
-    // Use a nested `div` here because the right border is affected by the
-    // gradient background otherwise.
-    return (
-      <div className={classes.root}>
-        <div className={classes.inner} style={{ background: gradient }}>
-          {text}
-        </div>
-      </div>
-    );
-  }
+  // Use a nested `span` here because the right border is affected by the
+  // gradient background otherwise.
+  return (
+    <span className={classes.root}>
+      <span className={classes.inner} style={{ background: gradient, flexGrow: 1 }}>
+        <Typography align="center">{text}</Typography>
+      </span>
+    </span>
+  );
 }
 
-export default withStyles(styles)(UsageBar);
+export default UsageBar;

--- a/python/ray/dashboard/client/src/common/UsageBar.tsx
+++ b/python/ray/dashboard/client/src/common/UsageBar.tsx
@@ -1,4 +1,4 @@
-import { createStyles, Theme, makeStyles, Typography} from "@material-ui/core";
+import { createStyles, makeStyles, Theme, Typography } from "@material-ui/core";
 import React from "react";
 
 const blend = (
@@ -24,14 +24,15 @@ const useUsageBarStyles = makeStyles((theme: Theme) =>
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),
     },
-  }));
+  }),
+);
 
 type UsageBarProps = {
   percent: number;
   text: string;
 };
 
-const UsageBar: React.FC<UsageBarProps> = ({percent, text}) => {
+const UsageBar: React.FC<UsageBarProps> = ({ percent, text }) => {
   const classes = useUsageBarStyles();
   const safePercent = Math.max(Math.min(percent, 100), 0);
   const minColor = [0, 255, 0];
@@ -54,11 +55,14 @@ const UsageBar: React.FC<UsageBarProps> = ({percent, text}) => {
   // gradient background otherwise.
   return (
     <span className={classes.root}>
-      <span className={classes.inner} style={{ background: gradient, flexGrow: 1 }}>
+      <span
+        className={classes.inner}
+        style={{ background: gradient, flexGrow: 1 }}
+      >
         <Typography align="center">{text}</Typography>
       </span>
     </span>
   );
-}
+};
 
 export default UsageBar;

--- a/python/ray/dashboard/client/src/common/formatUtils.ts
+++ b/python/ray/dashboard/client/src/common/formatUtils.ts
@@ -18,8 +18,10 @@ export const formatUsage = (
 };
 
 // Formats, e.g. 400 and 6000 as "400 MiB / 6000 MiB (6.7%)"
-export const MiBRatio = (used: number, total: number) =>
+export const MiBRatio = (used: number, total: number) => 
   `${used} MiB / ${total} MiB (${(100 * (used / total)).toFixed(1)}%)`;
+
+export const MiBRatioNoPercent = (used: number, total: number) => (`${used} MiB / ${total} MiB`);
 
 export const formatDuration = (durationInSeconds: number) => {
   const durationSeconds = Math.floor(durationInSeconds) % 60;

--- a/python/ray/dashboard/client/src/common/formatUtils.ts
+++ b/python/ray/dashboard/client/src/common/formatUtils.ts
@@ -18,10 +18,11 @@ export const formatUsage = (
 };
 
 // Formats, e.g. 400 and 6000 as "400 MiB / 6000 MiB (6.7%)"
-export const MiBRatio = (used: number, total: number) => 
+export const MiBRatio = (used: number, total: number) =>
   `${used} MiB / ${total} MiB (${(100 * (used / total)).toFixed(1)}%)`;
 
-export const MiBRatioNoPercent = (used: number, total: number) => (`${used} MiB / ${total} MiB`);
+export const MiBRatioNoPercent = (used: number, total: number) =>
+  `${used} MiB / ${total} MiB`;
 
 export const formatDuration = (durationInSeconds: number) => {
   const durationSeconds = Math.floor(durationInSeconds) % 60;

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -93,9 +93,15 @@ type WorkerGPUEntryProps = {
 
 const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   const { allocation, slot } = resourceSlot;
+  // This is a bit of  a dirty hack . For some reason, the slot GPU slot
+  // 0 as assigned always shows up as undefined in the API response.
+  // There are other times, such as a partial allocation, where we truly don't
+  // know the slot, however this will just plug the hole of 0s coming through
+  // as undefined. I have not been able to figure out the root cause.
+  const slotMsg = (allocation >= 1 && slot === undefined) ? "0" : "?";
   return (
     <Typography variant="body1">
-      [{slot ===  0 ? "!" : slot}]: {allocation}
+      [{slotMsg}]: {allocation}
     </Typography>
   );
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -98,7 +98,12 @@ const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   // There are other times, such as a partial allocation, where we truly don't
   // know the slot, however this will just plug the hole of 0s coming through
   // as undefined. I have not been able to figure out the root cause.
-  const slotMsg = (allocation >= 1 && slot === undefined) ? "0" : (slot === undefined) ? "?" : slot.toString();
+  const slotMsg =
+    allocation >= 1 && slot === undefined
+      ? "0"
+      : slot === undefined
+      ? "?"
+      : slot.toString();
   return (
     <Typography variant="body1">
       [{slotMsg}]: {allocation}

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -98,12 +98,11 @@ type WorkerGPUEntryProps = {
 
 const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({
   resourceSlot,
-  slot,
 }) => {
-  const { allocation } = resourceSlot;
+  const { allocation, slot } = resourceSlot;
   return (
     <Typography variant="h6">
-      [{slot}]: {allocation}
+      [{slot ?? "?"}]: {allocation}
     </Typography>
   );
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -77,7 +77,7 @@ const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
   return (
     <Box display="flex" style={{ minWidth: GPU_COL_WIDTH }}>
       <Tooltip title={gpu.name}>
-        <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
+        <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
       </Tooltip>
       <UsageBar
         percent={gpu.utilization_gpu}

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -1,9 +1,13 @@
-import { Typography, Tooltip, Box, styled, Theme, makeStyles, createStyles} from "@material-ui/core";
+import {
+  Box,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
 import React from "react";
+import { GPUStats, ResourceSlot } from "../../../../api";
+import { RightPaddedTypography } from "../../../../common/CustomTypography";
 import UsageBar from "../../../../common/UsageBar";
-import {RightPaddedTypography} from "../../../../common/CustomTypography";
 import { getWeightedAverage, sum } from "../../../../common/util";
-import { ResourceSlot, GPUStats, ResourceAllocations } from "../../../../api";
 import {
   ClusterFeatureComponent,
   Node,
@@ -15,7 +19,10 @@ const GPU_COL_WIDTH = 120;
 
 const clusterUtilization = (nodes: Array<Node>): number => {
   const utils = nodes
-    .map((node) => ({ weight: node.gpus.length, value: nodeAverageUtilization(node) }))
+    .map((node) => ({
+      weight: node.gpus.length,
+      value: nodeAverageUtilization(node),
+    }))
     .filter((util) => !isNaN(util.value));
   if (utils.length === 0) {
     return NaN;
@@ -51,16 +58,16 @@ export const ClusterGPU: ClusterFeatureComponent = ({ nodes }) => {
 };
 
 export const NodeGPU: NodeFeatureComponent = ({ node }) => {
-  const hasGPU = (node.gpus !== undefined) && (node.gpus.length !== 0)
+  const hasGPU = node.gpus !== undefined && node.gpus.length !== 0;
   return (
     <div style={{ minWidth: GPU_COL_WIDTH }}>
       {hasGPU ? (
         node.gpus.map((gpu, i) => <NodeGPUEntry gpu={gpu} slot={i} />)
       ) : (
-          <Typography color="textSecondary" component="span" variant="inherit">
-            N/A
-          </Typography>
-        )}
+        <Typography color="textSecondary" component="span" variant="inherit">
+          N/A
+        </Typography>
+      )}
     </div>
   );
 };
@@ -68,32 +75,38 @@ export const NodeGPU: NodeFeatureComponent = ({ node }) => {
 type NodeGPUEntryProps = {
   slot: number;
   gpu: GPUStats;
-}
+};
 
 const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
   return (
-    <Box display="flex" style={{minWidth: GPU_COL_WIDTH}}>
+    <Box display="flex" style={{ minWidth: GPU_COL_WIDTH }}>
       <Tooltip title={gpu.name}>
-          <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
+        <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
       </Tooltip>
-      <UsageBar percent={gpu.utilization_gpu} 
-                text={`${gpu.utilization_gpu.toFixed(1)}%`} />
+      <UsageBar
+        percent={gpu.utilization_gpu}
+        text={`${gpu.utilization_gpu.toFixed(1)}%`}
+      />
     </Box>
-  )
-}
+  );
+};
 
 type WorkerGPUEntryProps = {
   resourceSlot: ResourceSlot;
   slot: number;
-}
+};
 
-const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({resourceSlot, slot}) => {
-  const {allocation} = resourceSlot;
+const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({
+  resourceSlot,
+  slot,
+}) => {
+  const { allocation } = resourceSlot;
   return (
-    <Typography variant="h6">[{slot}]: {allocation}</Typography>
+    <Typography variant="h6">
+      [{slot}]: {allocation}
+    </Typography>
   );
-    
-}
+};
 
 export const WorkerGPU: WorkerFeatureComponent = ({ rayletWorker }) => {
   const workerRes = rayletWorker?.coreWorkerStats.usedResources;
@@ -106,9 +119,9 @@ export const WorkerGPU: WorkerFeatureComponent = ({ rayletWorker }) => {
       </Typography>
     );
   } else {
-    message = workerUsedGPUResources.resourceSlots.map(
-        (resourceSlot, i) => <WorkerGPUEntry resourceSlot={resourceSlot} slot={i} />
-      )
+    message = workerUsedGPUResources.resourceSlots.map((resourceSlot, i) => (
+      <WorkerGPUEntry resourceSlot={resourceSlot} slot={i} />
+    ));
   }
   return <div style={{ minWidth: 60 }}>{message}</div>;
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -1,8 +1,4 @@
-import {
-  Box,
-  Tooltip,
-  Typography,
-} from "@material-ui/core";
+import { Box, Tooltip, Typography } from "@material-ui/core";
 import React from "react";
 import { GPUStats, ResourceSlot } from "../../../../api";
 import { RightPaddedTypography } from "../../../../common/CustomTypography";
@@ -95,13 +91,11 @@ type WorkerGPUEntryProps = {
   resourceSlot: ResourceSlot;
 };
 
-const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({
-  resourceSlot,
-}) => {
+const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   const { allocation, slot } = resourceSlot;
   return (
     <Typography variant="h6">
-      [{slot ?? "?"}]: {allocation}
+      [{slot === undefined ? "?" : slot}]: {allocation}
     </Typography>
   );
 };
@@ -117,19 +111,19 @@ export const WorkerGPU: WorkerFeatureComponent = ({ rayletWorker }) => {
       </Typography>
     );
   } else {
-    message = workerUsedGPUResources.resourceSlots.sort((slot1, slot2) => {
-      if (!slot1.slot && !slot2.slot) {
-        return 0;
-      } else if (!slot1.slot) {
-        return 1;
-      } else if (!slot2.slot) {
-        return -1;
-      } else {
-        return slot1.slot - slot2.slot;
-      }
-    }).map(resourceSlot => (
-      <WorkerGPUEntry resourceSlot={resourceSlot} />
-    ));
+    message = workerUsedGPUResources.resourceSlots
+      .sort((slot1, slot2) => {
+        if (slot1.slot === undefined && slot2.slot === undefined) {
+          return 0;
+        } else if (slot1.slot === undefined) {
+          return 1;
+        } else if (slot2.slot === undefined) {
+          return -1;
+        } else {
+          return slot1.slot - slot2.slot;
+        }
+      })
+      .map((resourceSlot) => <WorkerGPUEntry resourceSlot={resourceSlot} />);
   }
   return <div style={{ minWidth: 60 }}>{message}</div>;
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -95,7 +95,7 @@ const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   const { allocation, slot } = resourceSlot;
   return (
     <Typography variant="body1">
-      [{slot === undefined ? "?" : slot}]: {allocation}
+      [{slot ===  0 ? "!" : slot}]: {allocation}
     </Typography>
   );
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -93,7 +93,6 @@ const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
 
 type WorkerGPUEntryProps = {
   resourceSlot: ResourceSlot;
-  slot: number;
 };
 
 const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({
@@ -118,8 +117,18 @@ export const WorkerGPU: WorkerFeatureComponent = ({ rayletWorker }) => {
       </Typography>
     );
   } else {
-    message = workerUsedGPUResources.resourceSlots.map((resourceSlot, i) => (
-      <WorkerGPUEntry resourceSlot={resourceSlot} slot={i} />
+    message = workerUsedGPUResources.resourceSlots.sort((slot1, slot2) => {
+      if (!slot1.slot && !slot2.slot) {
+        return 0;
+      } else if (!slot1.slot) {
+        return 1;
+      } else if (!slot2.slot) {
+        return -1;
+      } else {
+        return slot1.slot - slot2.slot;
+      }
+    }).map(resourceSlot => (
+      <WorkerGPUEntry resourceSlot={resourceSlot} />
     ));
   }
   return <div style={{ minWidth: 60 }}>{message}</div>;

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -98,7 +98,7 @@ const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   // There are other times, such as a partial allocation, where we truly don't
   // know the slot, however this will just plug the hole of 0s coming through
   // as undefined. I have not been able to figure out the root cause.
-  const slotMsg = (allocation >= 1 && slot === undefined) ? "0" : "?";
+  const slotMsg = (allocation >= 1 && slot === undefined) ? "0" : (slot === undefined) ? "?" : slot.toString();
   return (
     <Typography variant="body1">
       [{slotMsg}]: {allocation}

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GPU.tsx
@@ -94,7 +94,7 @@ type WorkerGPUEntryProps = {
 const WorkerGPUEntry: React.FC<WorkerGPUEntryProps> = ({ resourceSlot }) => {
   const { allocation, slot } = resourceSlot;
   return (
-    <Typography variant="h6">
+    <Typography variant="body1">
       [{slot === undefined ? "?" : slot}]: {allocation}
     </Typography>
   );

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -2,7 +2,7 @@ import { Box, Tooltip, Typography } from "@material-ui/core";
 import React from "react";
 import { GPUStats } from "../../../../api";
 import { RightPaddedTypography } from "../../../../common/CustomTypography";
-import { MiBRatio } from "../../../../common/formatUtils";
+import { MiBRatio, MiBRatioNoPercent } from "../../../../common/formatUtils";
 import UsageBar from "../../../../common/UsageBar";
 import { getWeightedAverage, sum } from "../../../../common/util";
 import {
@@ -92,14 +92,14 @@ const GRAMEntry: React.FC<GRAMEntryProps> = ({
   utilization,
   total,
 }) => {
-  const utilizationPercent = (utilization / total) * 100;
-  const ratioStr = MiBRatio(utilization, total);
+  const ratioStr = MiBRatioNoPercent(utilization, total);
   return (
     <Box display="flex" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
-        <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
+        <RightPaddedTypography variant="subtitle2">
+          [{slot}]: {ratioStr}
+        </RightPaddedTypography>
       </Tooltip>
-      <UsageBar percent={utilizationPercent} text={ratioStr} />
     </Box>
   );
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -1,8 +1,9 @@
-import { Typography } from "@material-ui/core";
+import { Typography, Tooltip, Box } from "@material-ui/core";
 import React from "react";
 import { GPUStats } from "../../../../api";
 import { MiBRatio } from "../../../../common/formatUtils";
 import UsageBar from "../../../../common/UsageBar";
+import {RightPaddedTypography} from "../../../../common/CustomTypography";
 import { getWeightedAverage, sum } from "../../../../common/util";
 import {
   ClusterFeatureComponent,
@@ -10,6 +11,8 @@ import {
   NodeFeatureComponent,
   WorkerFeatureComponent,
 } from "./types";
+
+const GRAM_COL_WIDTH = 120;
 
 const nodeGRAMUtilization = (node: Node) => {
   const utilization = (gpu: GPUStats) => gpu.memory_used / gpu.memory_total;
@@ -54,43 +57,68 @@ export const ClusterGRAM: ClusterFeatureComponent = ({ nodes }) => {
 };
 
 export const NodeGRAM: NodeFeatureComponent = ({ node }) => {
-  const gramUtil = nodeGRAMUtilization(node);
+  const nodeGRAMEntries = node.gpus.map((gpu, i) => {
+    const props = {
+      gpuName: gpu.name,
+      utilization: gpu.memory_used,
+      total: gpu.memory_total,
+      slot: i,
+    }
+    return <GRAMEntry {...props}/>
+  });
   return (
     <div style={{ minWidth: 60 }}>
-      {isNaN(gramUtil) ? (
+      {nodeGRAMEntries.length === 0 ? (
         <Typography color="textSecondary" component="span" variant="inherit">
           N/A
         </Typography>
       ) : (
-        <UsageBar percent={gramUtil} text={`${gramUtil.toFixed(1)}%`} />
+        <div style={{ minWidth: GRAM_COL_WIDTH }}>{nodeGRAMEntries}</div>
       )}
     </div>
   );
 };
 
-export const WorkerGRAM: WorkerFeatureComponent = ({ worker, node }) => {
-  const workerProcessPerGPU = node.gpus
-    .map((gpu) => gpu.processes)
-    .map((processes) =>
-      processes.find((process) => process.pid === worker.pid),
-    );
-  const workerUtilPerGPU = workerProcessPerGPU.map(
-    (proc) => proc?.gpu_memory_usage || 0,
-  );
-  const totalNodeGRAM = sum(node.gpus.map((gpu) => gpu.memory_total));
-  const usedGRAM = sum(workerUtilPerGPU);
+type GRAMEntryProps = {
+  gpuName: string,
+  slot: number,
+  utilization: number,
+  total: number,
+};
+
+const GRAMEntry: React.FC<GRAMEntryProps> = ({ gpuName, slot, utilization, total}) => {
+  const utilizationPercent = (utilization / total) * 100;
+  const ratioStr = MiBRatio(utilization, total);
   return (
-    <div style={{ minWidth: 60 }}>
-      {node.gpus.length === 0 ? (
-        <Typography color="textSecondary" component="span" variant="inherit">
-          N/A
-        </Typography>
-      ) : (
-        <UsageBar
-          percent={100 * (usedGRAM / totalNodeGRAM)}
-          text={MiBRatio(usedGRAM, totalNodeGRAM)}
-        />
-      )}
-    </div>
+    <Box display="flex" style={{minWidth: GRAM_COL_WIDTH}}>
+      <Tooltip title={gpuName}>
+          <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
+      </Tooltip>
+      <UsageBar percent={utilizationPercent} 
+                text={ratioStr} />
+    </Box>
+  )
+};
+
+export const WorkerGRAM: WorkerFeatureComponent = ({ worker, node }) => {
+  const workerGRAMEntries = node.gpus
+    .map((gpu, i) => {
+      const process = gpu.processes.find((process) => process.pid === worker.pid);
+      if (!process) return undefined;
+      const props = {
+        gpuName: gpu.name,
+        total: gpu.memory_total,
+        utilization: process.gpu_memory_usage,
+        slot: i,
+      };
+      return (<GRAMEntry {...props} />)
+    }).filter(entry => entry !== undefined);
+    
+  return workerGRAMEntries.length === 0 ? (
+      <Typography color="textSecondary" component="span" variant="inherit">
+        N/A
+      </Typography>
+  ) : (
+    <div style={{ minWidth: GRAM_COL_WIDTH }}>{workerGRAMEntries}</div>
   );
 };

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -1,9 +1,9 @@
-import { Typography, Tooltip, Box } from "@material-ui/core";
+import { Box, Tooltip, Typography } from "@material-ui/core";
 import React from "react";
 import { GPUStats } from "../../../../api";
+import { RightPaddedTypography } from "../../../../common/CustomTypography";
 import { MiBRatio } from "../../../../common/formatUtils";
 import UsageBar from "../../../../common/UsageBar";
-import {RightPaddedTypography} from "../../../../common/CustomTypography";
 import { getWeightedAverage, sum } from "../../../../common/util";
 import {
   ClusterFeatureComponent,
@@ -63,8 +63,8 @@ export const NodeGRAM: NodeFeatureComponent = ({ node }) => {
       utilization: gpu.memory_used,
       total: gpu.memory_total,
       slot: i,
-    }
-    return <GRAMEntry {...props}/>
+    };
+    return <GRAMEntry {...props} />;
   });
   return (
     <div style={{ minWidth: 60 }}>
@@ -80,44 +80,51 @@ export const NodeGRAM: NodeFeatureComponent = ({ node }) => {
 };
 
 type GRAMEntryProps = {
-  gpuName: string,
-  slot: number,
-  utilization: number,
-  total: number,
+  gpuName: string;
+  slot: number;
+  utilization: number;
+  total: number;
 };
 
-const GRAMEntry: React.FC<GRAMEntryProps> = ({ gpuName, slot, utilization, total}) => {
+const GRAMEntry: React.FC<GRAMEntryProps> = ({
+  gpuName,
+  slot,
+  utilization,
+  total,
+}) => {
   const utilizationPercent = (utilization / total) * 100;
   const ratioStr = MiBRatio(utilization, total);
   return (
-    <Box display="flex" style={{minWidth: GRAM_COL_WIDTH}}>
+    <Box display="flex" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
-          <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
+        <RightPaddedTypography variant="h6">[{slot}]:</RightPaddedTypography>
       </Tooltip>
-      <UsageBar percent={utilizationPercent} 
-                text={ratioStr} />
+      <UsageBar percent={utilizationPercent} text={ratioStr} />
     </Box>
-  )
+  );
 };
 
 export const WorkerGRAM: WorkerFeatureComponent = ({ worker, node }) => {
   const workerGRAMEntries = node.gpus
     .map((gpu, i) => {
-      const process = gpu.processes.find((process) => process.pid === worker.pid);
-      if (!process) return undefined;
+      const process = gpu.processes.find(
+        (process) => process.pid === worker.pid,
+      );
+      if (!process) {return undefined;}
       const props = {
         gpuName: gpu.name,
         total: gpu.memory_total,
         utilization: process.gpu_memory_usage,
         slot: i,
       };
-      return (<GRAMEntry {...props} />)
-    }).filter(entry => entry !== undefined);
-    
+      return <GRAMEntry {...props} />;
+    })
+    .filter((entry) => entry !== undefined);
+
   return workerGRAMEntries.length === 0 ? (
-      <Typography color="textSecondary" component="span" variant="inherit">
-        N/A
-      </Typography>
+    <Typography color="textSecondary" component="span" variant="inherit">
+      N/A
+    </Typography>
   ) : (
     <div style={{ minWidth: GRAM_COL_WIDTH }}>{workerGRAMEntries}</div>
   );

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -2,7 +2,7 @@ import { Box, Tooltip, Typography } from "@material-ui/core";
 import React from "react";
 import { GPUStats } from "../../../../api";
 import { RightPaddedTypography } from "../../../../common/CustomTypography";
-import { MiBRatio, MiBRatioNoPercent } from "../../../../common/formatUtils";
+import { MiBRatioNoPercent } from "../../../../common/formatUtils";
 import UsageBar from "../../../../common/UsageBar";
 import { getWeightedAverage, sum } from "../../../../common/util";
 import {

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -96,7 +96,7 @@ const GRAMEntry: React.FC<GRAMEntryProps> = ({
   return (
     <Box display="flex" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
-        <RightPaddedTypography variant="subtitle2">
+        <RightPaddedTypography variant="body1">
           [{slot}]: {ratioStr}
         </RightPaddedTypography>
       </Tooltip>

--- a/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
+++ b/python/ray/dashboard/client/src/pages/dashboard/node-info/features/GRAM.tsx
@@ -110,7 +110,9 @@ export const WorkerGRAM: WorkerFeatureComponent = ({ worker, node }) => {
       const process = gpu.processes.find(
         (process) => process.pid === worker.pid,
       );
-      if (!process) {return undefined;}
+      if (!process) {
+        return undefined;
+      }
       const props = {
         gpuName: gpu.name,
         total: gpu.memory_total,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Instead of having average utilization of GPUs for each node, this PR adds entries for each GPU's utilization independently.
In addition, this PR adds information about to which GPU each worker is assigned. 

This enables a workflow where, for example, a user sees that one of their GPUs is underutilized, then looks to see which worker is attached to that GPU, allowing them to link the underutilization to a specific worker, then to an actor or task.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
