### PR TITLE
Fix minor bug in Bazel files with strip_prefix

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -63,7 +63,11 @@ def auto_http_archive(*, name=None, url=None, urls=True,
         print("No implicit mirrors used because urls were explicitly provided")
 
     if strip_prefix == True:
-        strip_prefix = (url_path_parts[1] + "-" + url_filename_parts[0]
+        prefix_without_v = url_filename_parts[0]
+        if prefix_without_v.startswith("v") and prefix_without_v[1:2].isdigit():
+            # GitHub automatically strips a leading 'v' in version numbers
+            prefix_without_v = prefix_without_v[1:]
+        strip_prefix = (url_path_parts[1] + "-" + prefix_without_v
                         if is_github and url_path_parts[2:3] == ["archive"]
                         else url_filename_parts[0])
 


### PR DESCRIPTION
## Why are these changes needed?

GitHub automatically strips leading 'v' for archives referring to versions, which we don't currently handle.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
