### PR TITLE
Split hiredis from Redis and use it directly

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1333,7 +1333,7 @@ cc_library(
 
 alias(
     name = "hiredis",
-    actual = "@com_github_antirez_redis//:hiredis",
+    actual = "@com_github_redis_hiredis//:hiredis",
 )
 
 cc_library(

--- a/bazel/BUILD.hiredis
+++ b/bazel/BUILD.hiredis
@@ -6,6 +6,8 @@ COPTS = [] + select({
     ],
 })
 
+# This library is for internal hiredis use, because hiredis assumes a
+# different include prefix for itself than external libraries do.
 cc_library(
     name = "_hiredis",
     hdrs = [

--- a/bazel/BUILD.hiredis
+++ b/bazel/BUILD.hiredis
@@ -1,0 +1,47 @@
+COPTS = [] + select({
+    "@bazel_tools//src/conditions:windows": [
+        "-D_CRT_DECLARE_NONSTDC_NAMES=0",  # don't define off_t, to avoid conflicts
+    ],
+    "//conditions:default": [
+    ],
+})
+
+cc_library(
+    name = "_hiredis",
+    hdrs = [
+        "dict.c",
+    ],
+    copts = COPTS,
+)
+
+cc_library(
+    name = "hiredis",
+    srcs = glob(
+        [
+            "*.c",
+            "*.h",
+        ],
+        exclude =
+        [
+            "test.c",
+        ],
+    ),
+    hdrs = glob([
+        "*.h",
+        "adapters/*.h",
+    ]),
+    copts = COPTS + select({
+        "@bazel_tools//src/conditions:windows": [
+            "-D" + "WIN32_REPLACE_FD_APIS",
+            "/FI" + "win32fd.h",
+        ],
+        "//conditions:default": [
+        ],
+    }),
+    include_prefix = "hiredis",
+    deps = [
+        ":_hiredis",
+        "@//:platform_shims",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -1,11 +1,3 @@
-COPTS = [] + select({
-    "@bazel_tools//src/conditions:windows": [
-        "-D_CRT_DECLARE_NONSTDC_NAMES=0",  # don't define off_t, to avoid conflicts
-    ],
-    "//conditions:default": [
-    ],
-})
-
 filegroup(
     name = "files",
     srcs = glob(["**"]),
@@ -25,7 +17,6 @@ cc_library(
     hdrs = [
         "deps/hiredis/dict.c",
     ],
-    copts = COPTS,
     strip_include_prefix = "deps/hiredis",
 )
 
@@ -45,19 +36,10 @@ cc_library(
         "deps/hiredis/*.h",
         "deps/hiredis/adapters/*.h",
     ]),
-    copts = COPTS + select({
-        "@bazel_tools//src/conditions:windows": [
-            "-D" + "WIN32_REPLACE_FD_APIS",
-            "/FI" + "win32fd.h",
-        ],
-        "//conditions:default": [
-        ],
-    }),
     includes = ["deps/hiredis"],
     strip_include_prefix = "deps",
     deps = [
         ":_hiredis",
-        "@//:platform_shims",
     ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -78,11 +78,20 @@ def ray_deps_setup():
         url = "https://github.com/antirez/redis/archive/5.0.9.tar.gz",
         sha256 = "db9bf149e237126f9bb5f40fb72f33701819555d06f16e9a38b4949794214201",
         patches = [
+            "//thirdparty/patches:redis-quiet.patch",
+        ],
+    )
+
+    auto_http_archive(
+        name = "com_github_redis_hiredis",
+        build_file = "//bazel:BUILD.hiredis",
+        url = "https://github.com/redis/hiredis/archive/33152ad163a21f568fb40eeeb88b79365886b4ea.tar.gz",
+        sha256 = "9a91274dfd131111227b39ffa3cf7b446fbbd7ee2e5a94c8e7d8ad334b4ff255",
+        patches = [
             "//thirdparty/patches:hiredis-connect-rename.patch",
             "//thirdparty/patches:hiredis-windows-sigpipe.patch",
             "//thirdparty/patches:hiredis-windows-sockets.patch",
             "//thirdparty/patches:hiredis-windows-strerror.patch",
-            "//thirdparty/patches:redis-quiet.patch",
         ],
     )
 

--- a/thirdparty/patches/hiredis-connect-rename.patch
+++ b/thirdparty/patches/hiredis-connect-rename.patch
@@ -1,6 +1,6 @@
-diff --git deps/hiredis/test.c deps/hiredis/test.c
---- deps/hiredis/test.c
-+++ deps/hiredis/test.c
+diff --git test.c test.c
+--- test.c
++++ test.c
 @@ -94,1 +94,1 @@
 -static redisContext *connect(struct config config) {
 +static redisContext *connect_(struct config config) {

--- a/thirdparty/patches/hiredis-windows-sigpipe.patch
+++ b/thirdparty/patches/hiredis-windows-sigpipe.patch
@@ -1,6 +1,6 @@
-diff --git deps/hiredis/test.c deps/hiredis/test.c
---- deps/hiredis/test.c
-+++ deps/hiredis/test.c
+diff --git test.c test.c
+--- test.c
++++ test.c
 @@ -762,2 +762,4 @@ int main(int argc, char **argv) {
 +#ifndef _WIN32
      /* Ignore broken pipe signal (for I/O error tests). */

--- a/thirdparty/patches/hiredis-windows-sockets.patch
+++ b/thirdparty/patches/hiredis-windows-sockets.patch
@@ -1,21 +1,21 @@
-diff --git deps/hiredis/hiredis.c deps/hiredis/hiredis.c
---- deps/hiredis/hiredis.c
-+++ deps/hiredis/hiredis.c
+diff --git hiredis.c hiredis.c
+--- hiredis.c
++++ hiredis.c
 @@ -620,1 +620,1 @@
 -        close(c->fd);
 +        redisContextCloseFd(c);
 @@ -648,1 +648,1 @@
 -        close(c->fd);
 +        redisContextCloseFd(c);
-diff --git deps/hiredis/net.h deps/hiredis/net.h
---- deps/hiredis/net.h
-+++ deps/hiredis/net.h
+diff --git net.h net.h
+--- net.h
++++ net.h
 @@ -44,1 +44,2 @@
 +void redisContextCloseFd(redisContext *c);
  int redisContextConnectTcp(redisContext *c, const char *addr, int port, const struct timeval *timeout);
-diff --git deps/hiredis/net.c deps/hiredis/net.c
---- deps/hiredis/net.c
-+++ deps/hiredis/net.c
+diff --git net.c net.c
+--- net.c
++++ net.c
 @@ -60,1 +60,1 @@
 -static void redisContextCloseFd(redisContext *c) {
 +void redisContextCloseFd(redisContext *c) {

--- a/thirdparty/patches/hiredis-windows-strerror.patch
+++ b/thirdparty/patches/hiredis-windows-strerror.patch
@@ -1,6 +1,6 @@
-diff --git deps/hiredis/hiredis.h deps/hiredis/hiredis.h
---- deps/hiredis/hiredis.h
-+++ deps/hiredis/hiredis.h
+diff --git hiredis.h hiredis.h
+--- hiredis.h
++++ hiredis.h
 @@ -87,5 +87,12 @@
 +#ifdef _WIN32
 +#define __redis_strerror_r(errno, buf, len)                                    \


### PR DESCRIPTION
## Why are these changes needed?

The upstream [hiredis repo](https://github.com/redis/hiredis) is separate from that of Redis, and it has been updated with various Windows patches recently.

We can't pull in the Windows patches quite yet, but this PR switches to that repo to allow us to update them independently in the future.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
