### PR TITLE
Fix WSL patch (it doesn't fall under "win32")

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from os.path import dirname
+import platform
 import sys
 
 logger = logging.getLogger(__name__)
@@ -36,8 +37,12 @@ sys.path.insert(0, thirdparty_files)
 
 if sys.platform == "win32":
     import ray.compat  # noqa: E402
-    ray.compat.patch_psutil()
     ray.compat.patch_redis_empty_recv()
+
+if (platform.system() == "Linux"
+    and "Microsoft".lower() in platform.release().lower()):
+    import ray.compat  # noqa: E402
+    ray.compat.patch_psutil()
 
 # Expose ray ABI symbols which may be dependent by other shared
 # libraries such as _streaming.so. See BUILD.bazel:_raylet

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -40,7 +40,7 @@ if sys.platform == "win32":
     ray.compat.patch_redis_empty_recv()
 
 if (platform.system() == "Linux"
-    and "Microsoft".lower() in platform.release().lower()):
+        and "Microsoft".lower() in platform.release().lower()):
     import ray.compat  # noqa: E402
     ray.compat.patch_psutil()
 

--- a/python/ray/compat.py
+++ b/python/ray/compat.py
@@ -26,34 +26,36 @@ def patch_redis_empty_recv():
 
 
 def patch_psutil():
-    if (platform.system() == "Linux"
-            and "Microsoft".lower() in platform.release().lower()):
-        # WSL's /proc/meminfo has an inconsistency where it
-        # nondeterministically omits a space after colons (after "SwapFree:"
-        # in my case).
-        # psutil then splits on spaces and then parses the wrong field,
-        # crashing on the 'int(fields[1])' expression in
-        # psutil._pslinux.virtual_memory().
-        # Workaround: We ensure there is a space following each colon.
+    """WSL's /proc/meminfo has an inconsistency where it
+    nondeterministically omits a space after colons (after "SwapFree:"
+    in my case).
+    psutil then splits on spaces and then parses the wrong field,
+    crashing on the 'int(fields[1])' expression in
+    psutil._pslinux.virtual_memory().
+    Workaround: We ensure there is a space following each colon.
+    """
+    assert (platform.system() == "Linux"
+            and "Microsoft".lower() in platform.release().lower())
+
+    try:
+        import psutil._pslinux
+    except ImportError:
+        psutil = None
+    psutil_open_binary = None
+    if psutil:
         try:
-            import psutil._pslinux
-        except ImportError:
-            psutil = None
-        psutil_open_binary = None
-        if psutil:
-            try:
-                psutil_open_binary = psutil._pslinux.open_binary
-            except AttributeError:
-                pass
-        # Only patch it if it doesn't seem to have been patched already
-        if psutil_open_binary and psutil_open_binary.__name__ == "open_binary":
+            psutil_open_binary = psutil._pslinux.open_binary
+        except AttributeError:
+            pass
+    # Only patch it if it doesn't seem to have been patched already
+    if psutil_open_binary and psutil_open_binary.__name__ == "open_binary":
 
-            def psutil_open_binary_patched(fname, *args, **kwargs):
-                f = psutil_open_binary(fname, *args, **kwargs)
-                if fname == "/proc/meminfo":
-                    with f:
-                        # Make sure there's a space after colons
-                        return io.BytesIO(f.read().replace(b":", b": "))
-                return f
+        def psutil_open_binary_patched(fname, *args, **kwargs):
+            f = psutil_open_binary(fname, *args, **kwargs)
+            if fname == "/proc/meminfo":
+                with f:
+                    # Make sure there's a space after colons
+                    return io.BytesIO(f.read().replace(b":", b": "))
+            return f
 
-            psutil._pslinux.open_binary = psutil_open_binary_patched
+        psutil._pslinux.open_binary = psutil_open_binary_patched


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixes OS detection mistake made while rebasing the patch to the latest master. (Accidentally put it under `if sys.platform == "win32"` condition.)

## Related issue number

#6808

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
