### PR TITLE
[Core] Make worker_register_timeout_seconds configurable

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -47,6 +47,8 @@ cdef extern from "ray/common/ray_config.h" nogil:
 
         int64_t kill_worker_timeout_milliseconds() const
 
+        int64_t worker_register_timeout_seconds() const
+
         int64_t max_time_for_handler_milliseconds() const
 
         int64_t max_time_for_loop() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -56,7 +56,8 @@ cdef class Config:
 
     @staticmethod
     def raylet_client_connect_timeout_milliseconds():
-        return RayConfig.instance().raylet_client_connect_timeout_milliseconds()
+        return (RayConfig.instance()
+                .raylet_client_connect_timeout_milliseconds())
 
     @staticmethod
     def raylet_fetch_timeout_milliseconds():
@@ -79,6 +80,10 @@ cdef class Config:
     @staticmethod
     def kill_worker_timeout_milliseconds():
         return RayConfig.instance().kill_worker_timeout_milliseconds()
+
+    @staticmethod
+    def worker_register_timeout_seconds():
+        return RayConfig.instance().worker_register_timeout_seconds()
 
     @staticmethod
     def max_time_for_handler_milliseconds():

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -192,6 +192,10 @@ RAY_CONFIG(size_t, raylet_max_active_object_ids, 0)
 /// the worker SIGKILL.
 RAY_CONFIG(int64_t, kill_worker_timeout_milliseconds, 100)
 
+/// The duration that we wait after the worekr is launched before the
+/// starting_worker_timeout_callback() is called. 
+RAY_CONFIG(int64_t, worker_register_timeout_seconds, 30)
+
 /// This is a timeout used to cause failures in the plasma manager and raylet
 /// when certain event loop handlers take too long.
 RAY_CONFIG(int64_t, max_time_for_handler_milliseconds, 1000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -193,7 +193,7 @@ RAY_CONFIG(size_t, raylet_max_active_object_ids, 0)
 RAY_CONFIG(int64_t, kill_worker_timeout_milliseconds, 100)
 
 /// The duration that we wait after the worekr is launched before the
-/// starting_worker_timeout_callback() is called. 
+/// starting_worker_timeout_callback() is called.
 RAY_CONFIG(int64_t, worker_register_timeout_seconds, 30)
 
 /// This is a timeout used to cause failures in the plasma manager and raylet

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -250,9 +250,11 @@ Process WorkerPool::StartWorkerProcess(const Language &language,
 
 void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
                                               const Language &language) {
-  constexpr static size_t worker_register_timeout_seconds = 30;
   auto timer = std::make_shared<boost::asio::deadline_timer>(
-      *io_service_, boost::posix_time::seconds(worker_register_timeout_seconds));
+      *io_service_, boost::posix_time::seconds(
+        RayConfig::instance().worker_register_timeout_seconds()
+      )
+  );
   // Capture timer in lambda to copy it once, so that it can avoid destructing timer.
   timer->async_wait(
       [timer, language, proc, this](const boost::system::error_code e) -> void {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -252,9 +252,7 @@ void WorkerPool::MonitorStartingWorkerProcess(const Process &proc,
                                               const Language &language) {
   auto timer = std::make_shared<boost::asio::deadline_timer>(
       *io_service_, boost::posix_time::seconds(
-        RayConfig::instance().worker_register_timeout_seconds()
-      )
-  );
+                        RayConfig::instance().worker_register_timeout_seconds()));
   // Capture timer in lambda to copy it once, so that it can avoid destructing timer.
   timer->async_wait(
       [timer, language, proc, this](const boost::system::error_code e) -> void {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Currently, `worker_register_timeout_seconds` is hardcoded to 30 seconds.  This PR exposes it to make it configurable. This addresses the issue we have seen in our environment where the Ray workload runs inside Docker in which 30 timeout is kind of short.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #8890 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
