### PR TITLE
[autoscaler] Fix useless log message

### DIFF
--- a/python/ray/autoscaler/updater.py
+++ b/python/ray/autoscaler/updater.py
@@ -259,9 +259,9 @@ class SSHCommandRunner:
             "{}@{}".format(self.ssh_user, self.ssh_ip)
         ]
         if cmd:
+            final_cmd += with_interactive(cmd)
             logger.info(self.log_prefix +
                         "Running {}".format(" ".join(final_cmd)))
-            final_cmd += with_interactive(cmd)
         else:
             # We do this because `-o ControlMaster` causes the `-N` flag to
             # still create an interactive shell in some ssh versions.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The format string only includes the SSH part of the command and not the variable part. (i.e. it shows `ssh ... ... ... <username>@<host>` instead of `ssh ... ... ... <username>@<host> COMMAND`).


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
