### PR TITLE
Combine different severities into the same log files

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -20,8 +20,10 @@
 
 #include <signal.h>
 #include <stdlib.h>
+
 #include <algorithm>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 
 #ifdef RAY_USE_GLOG
@@ -34,19 +36,23 @@
 namespace ray {
 
 #ifdef RAY_USE_GLOG
-struct StdoutLogger : public google::base::Logger {
+struct StreamLogger : public google::base::Logger {
+  std::ofstream out_;
+
+  std::ostream &out() { return out_.is_open() ? out_ : std::cout; }
+
   virtual void Write(bool /* should flush */, time_t /* timestamp */, const char *message,
                      int length) {
     // note: always flush otherwise it never shows up in raylet.out
-    std::cout << std::string(message, length) << std::flush;
+    out().write(message, length) << std::flush;
   }
 
-  virtual void Flush() { std::cout.flush(); }
+  virtual void Flush() { out().flush(); }
 
   virtual google::uint32 LogSize() { return 0; }
 };
 
-static StdoutLogger stdout_logger_singleton;
+static StreamLogger stream_logger_singleton;
 #endif
 
 // This is the default implementation of ray log,
@@ -171,16 +177,18 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
         app_name_without_path = app_file_name;
       }
     }
-    google::SetLogFilenameExtension((app_name_without_path + ".log.").c_str());
+    char buffer[80];
+    time_t rawtime;
+    time(&rawtime);
+    strftime(buffer, sizeof(buffer), "%Y%m%d-%H%M%S", localtime(&rawtime));
+    std::string path = dir_ends_with_slash + app_name_without_path + "." + buffer + "." +
+                       std::to_string(getpid()) + ".log";
+    stream_logger_singleton.out_.open(path.c_str(),
+                                      std::ios_base::app | std::ios_base::binary);
   }
   for (int lvl = 0; lvl < NUM_SEVERITIES; ++lvl) {
-    if (log_dir_.empty()) {
-      google::SetStderrLogging(lvl);
-      google::base::SetLogger(lvl, &stdout_logger_singleton);
-    } else {
-      std::string prefix = dir_ends_with_slash + LogSeverityNames[lvl] + '.';
-      google::SetLogDestination(lvl, prefix.c_str());
-    }
+    google::SetStderrLogging(lvl);
+    google::base::SetLogger(lvl, &stream_logger_singleton);
   }
 #endif
 }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -20,6 +20,7 @@
 
 #include <signal.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cstdlib>


### PR DESCRIPTION
## Why are these changes needed?

Different severities are currently logged across different files; we combine them into the same files here.

**Before merging:** Please double-check the behavior of this PR on both Mac and Linux. In particular, please ensure logging is correct for `DEBUG`, `INFO`, `WARNING`, _and_ `ERROR` severities.

Note:
- `DEBUG` [does not map to a GLOG severity](/google/glog/blob/28321d8959574a8268de3ebe41d40cf65415fc9b/src/logging.cc#L388), but messages under `DEBUG` should show up under `I` as always.
- This only affects a subset of processes, such as the Python driver and worker processes.
- The use of a PID in the file name is important as it prevents overwriting of logs generated by other processes.

## Related issue number

#9063

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
