### PR TITLE
Fix Java test crash due to incorrect destruction order

### DIFF
--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.cc
@@ -46,13 +46,6 @@ JNIEXPORT jboolean JNICALL Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeCon
   return gcs_accessor->Connect();
 }
 
-JNIEXPORT void JNICALL Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDisconnect(
-    JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
-  auto *gcs_accessor =
-      reinterpret_cast<ray::gcs::GlobalStateAccessor *>(gcs_accessor_ptr);
-  gcs_accessor->Disconnect();
-}
-
 JNIEXPORT jobject JNICALL Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeGetAllJobInfo(
     JNIEnv *env, jobject o, jlong gcs_accessor_ptr) {
   auto *gcs_accessor =

--- a/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_gcs_GlobalStateAccessor.h
@@ -52,14 +52,6 @@ Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeConnect(JNIEnv *, jobject, jlo
 
 /*
  * Class:     io_ray_runtime_gcs_GlobalStateAccessor
- * Method:    nativeDisconnect
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL
-Java_io_ray_runtime_gcs_GlobalStateAccessor_nativeDisconnect(JNIEnv *, jobject, jlong);
-
-/*
- * Class:     io_ray_runtime_gcs_GlobalStateAccessor
  * Method:    nativeGetAllJobInfo
  * Signature: (J)Ljava/util/List;
  */

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -46,11 +46,7 @@ GlobalStateAccessor::GlobalStateAccessor(const std::string &redis_address,
   promise.get_future().get();
 }
 
-GlobalStateAccessor::~GlobalStateAccessor() {
-  Disconnect();
-  io_service_->stop();
-  thread_io_service_->join();
-}
+GlobalStateAccessor::~GlobalStateAccessor() { Disconnect(); }
 
 bool GlobalStateAccessor::Connect() {
   if (!is_connected_) {
@@ -64,6 +60,8 @@ bool GlobalStateAccessor::Connect() {
 
 void GlobalStateAccessor::Disconnect() {
   if (is_connected_) {
+    io_service_->stop();
+    thread_io_service_->join();
     gcs_client_->Disconnect();
     is_connected_ = false;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
ServiceBasedGcsClient Disconnect function will destroy the redis GCS client, but the thread of IO service may not exit. In that case, the redis disconnect callback function will access the released memory. Therefore, we should wait for the IO service thread to exit before calling Disconnect function.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
