### PR TITLE
[RLlib] Fix TorchDeterministic

### DIFF
--- a/rllib/models/torch/torch_action_dist.py
+++ b/rllib/models/torch/torch_action_dist.py
@@ -309,7 +309,7 @@ class TorchDeterministic(TorchDistributionWrapper):
 
     @override(TorchDistributionWrapper)
     def sampled_action_logp(self):
-        return 0.0
+        return torch.zeros((self.inputs.size()[0], ), dtype=torch.float32)
 
     @override(TorchDistributionWrapper)
     def sample(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

In the `TorchDeterministic` action distribution, the `sampled_action_logp` was hard coded to float(0.0) where it should be a zero tensor of the correct shape. This error resulted in issues in the sampler.
 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

The fix is one line and matches the other if-else statement in `ray/rllib/utils/exploration/stochastic_sampling.py` line 78 where the method is used.