### PR TITLE
[autoscaler] Fix cluster_shutdown using wrong args

### DIFF
--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -137,7 +137,7 @@ def teardown_cluster(config_file, yes, workers_only, override_cluster_name,
 
     if not workers_only:
         try:
-            exec_cluster(config_file, "ray stop", False, False, False, False,
+            exec_cluster(config_file, "ray stop", "auto", False, False, False,
                          False, override_cluster_name, None, False)
         except Exception:
             logger.exception("Ignoring error attempting a clean shutdown.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Not updated by #9001

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
   - [X] **Tested** locally with `ray up <cluster_yaml>` and `ray down <cluster_yaml>`