### PR TITLE
[RaySGD] Use device 0 if Cuda is not initialized

### DIFF
--- a/python/ray/util/sgd/torch/distributed_torch_runner.py
+++ b/python/ray/util/sgd/torch/distributed_torch_runner.py
@@ -333,6 +333,8 @@ class LocalDistributedRunner(DistributedTorchRunner):
         else:
             # Once cuda is initialized, torch.device ignores the os.env
             # so we have to set the right actual device.
+            if not torch.cuda.is_initialized():
+                reserved_cuda_device = "0"
             self._set_cuda_device(reserved_cuda_device)
 
     def _set_cuda_device(self, device_str):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If torch is not already initialized and CUDA_VISIBLE_DEVICES is has not been set, we want to make sure to set the cuda device to device 0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
