### PR TITLE
[Streaming] Config macro init in proto format

### DIFF
--- a/streaming/src/config/streaming_config.cc
+++ b/streaming/src/config/streaming_config.cc
@@ -12,39 +12,34 @@ uint32_t StreamingConfig::DEFAULT_EMPTY_MESSAGE_TIME_INTERVAL = 20;
 // Time to force clean if barrier in queue, default 0ms
 const uint32_t StreamingConfig::MESSAGE_BUNDLE_MAX_SIZE = 2048;
 
+#define RESET_IF_INT_CONF(KEY, VALUE) \
+  if (0 != VALUE) {                   \
+    Set##KEY(VALUE);                  \
+  }
+#define RESET_IF_STR_CONF(KEY, VALUE) \
+  if (!VALUE.empty()) {               \
+    Set##KEY(VALUE);                  \
+  }
+#define RESET_IF_NOT_DEFAULT_CONF(KEY, VALUE, DEFAULT) \
+  if (DEFAULT != VALUE) {                              \
+    Set##KEY(VALUE);                                   \
+  }
+
 void StreamingConfig::FromProto(const uint8_t *data, uint32_t size) {
   proto::StreamingConfig config;
   STREAMING_CHECK(config.ParseFromArray(data, size)) << "Parse streaming conf failed";
-  if (!config.job_name().empty()) {
-    SetJobName(config.job_name());
-  }
-  if (!config.worker_name().empty()) {
-    SetWorkerName(config.worker_name());
-  }
-  if (!config.op_name().empty()) {
-    SetOpName(config.op_name());
-  }
-  if (config.role() != proto::NodeType::UNKNOWN) {
-    SetNodeType(config.role());
-  }
-  if (config.ring_buffer_capacity() != 0) {
-    SetRingBufferCapacity(config.ring_buffer_capacity());
-  }
-  if (config.empty_message_interval() != 0) {
-    SetEmptyMessageTimeInterval(config.empty_message_interval());
-  }
-  if (config.flow_control_type() != proto::FlowControlType::UNKNOWN_FLOW_CONTROL_TYPE) {
-    SetFlowControlType(config.flow_control_type());
-  }
-  if (config.writer_consumed_step() != 0) {
-    SetWriterConsumedStep(config.writer_consumed_step());
-  }
-  if (config.reader_consumed_step() != 0) {
-    SetReaderConsumedStep(config.reader_consumed_step());
-  }
-  if (config.event_driven_flow_control_interval()) {
-    SetReaderConsumedStep(config.event_driven_flow_control_interval());
-  }
+  RESET_IF_STR_CONF(JobName, config.job_name())
+  RESET_IF_STR_CONF(WorkerName, config.worker_name())
+  RESET_IF_STR_CONF(OpName, config.op_name())
+  RESET_IF_NOT_DEFAULT_CONF(NodeType, config.role(), proto::NodeType::UNKNOWN)
+  RESET_IF_INT_CONF(RingBufferCapacity, config.ring_buffer_capacity())
+  RESET_IF_INT_CONF(EmptyMessageTimeInterval, config.empty_message_interval())
+  RESET_IF_NOT_DEFAULT_CONF(FlowControlType, config.flow_control_type(),
+                            proto::FlowControlType::UNKNOWN_FLOW_CONTROL_TYPE)
+  RESET_IF_INT_CONF(WriterConsumedStep, config.writer_consumed_step())
+  RESET_IF_INT_CONF(ReaderConsumedStep, config.reader_consumed_step())
+  RESET_IF_INT_CONF(EventDrivenFlowControlInterval,
+                    config.event_driven_flow_control_interval())
   STREAMING_CHECK(writer_consumed_step_ >= reader_consumed_step_)
       << "Writer consuemd step " << writer_consumed_step_
       << "can not be smaller then reader consumed step " << reader_consumed_step_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Use three macroes for streaming config. It will be reseted if any message key has value differed from default value,
which make us easy to define more configuration items in streaming between java/python worker and cpp transfer. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
