### PR TITLE
GCP authentication using oauth tokens

### DIFF
--- a/docker/autoscaler/requirements.txt
+++ b/docker/autoscaler/requirements.txt
@@ -23,3 +23,6 @@ mlflow
 kubernetes
 boto3
 ipython
+google-oauth
+google-api-python-client
+oauth2client

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -105,16 +105,16 @@ def generate_rsa_key_pair():
     return public_key, pem
 
 
-def _create_crm_service_account(gcp_credentials):
+def _create_crm_service_account(gcp_credentials=None):
     return discovery.build(
         "cloudresourcemanager", "v1", credentials=gcp_credentials)
 
 
-def _create_iam_service_account(gcp_credentials):
+def _create_iam_service_account(gcp_credentials=None):
     return discovery.build("iam", "v1", credentials=gcp_credentials)
 
 
-def _create_compute_service_account(gcp_credentials):
+def _create_compute_service_account(gcp_credentials=None):
     return discovery.build("compute", "v1", credentials=gcp_credentials)
 
 
@@ -142,9 +142,9 @@ def construct_clients_from_provider_config(provider_config):
                     "environment variable.")
         # If gcp_credentials is None, then discovery.build will search for
         # credentials in the local environment.
-        return _create_crm_service_account(None), \
-            _create_iam_service_account(None), \
-            _create_compute_service_account(None)
+        return _create_crm_service_account(), \
+            _create_iam_service_account(), \
+            _create_compute_service_account()
 
     assert ("type" in gcp_credentials and "credentials" in gcp_credentials), \
         "gcp_credentials cluster yaml field missing 'type'" \

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -152,7 +152,7 @@ def construct_clients_from_provider_config(provider_config):
                 "formatted improperly.")
         credentials = service_account.Credentials.from_service_account_info(
             service_account_info)
-    else:
+    elif cred_type == "credentials_token":
         # Otherwise the credentials type must be credentials_token.
         credentials = OAuthCredentials(credentials_field)
 

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -117,9 +117,9 @@ def _create_iam_service_account(gcp_credentials):
 def _create_compute_service_account(gcp_credentials):
     return discovery.build("compute", "v1", credentials=gcp_credentials)
 
+
 def _create_crm_oauth_token_request(token_request):
-    return discovery.build(
-        "cloudresourcemanager", "v1", http=token_request)
+    return discovery.build("cloudresourcemanager", "v1", http=token_request)
 
 
 def _create_iam_oauth_token_request(token_request):
@@ -145,12 +145,14 @@ def construct_clients_from_provider_config(provider_config):
         return None
 
     assert ("type" in gcp_credentials and "credentials" in gcp_credentials), \
-        "gcp_credentials cluster yaml field missing 'type' or 'credentials' fields."
+        "gcp_credentials cluster yaml field missing 'type'" \
+        " or 'credentials' fields."
     cred_type = gcp_credentials["type"]
     credentials_field = gcp_credentials["credentials"]
 
     assert (cred_type in ("service_account", "credentials_token")), \
-        "'GCP credentials type must either be 'service_account' or 'credentials_token'."
+        "'GCP credentials type must either be 'service_account'" \
+        " or 'credentials_token'."
 
     if cred_type == "service_account":
         # If parsing the gcp_credentials failed, then the user likely made a
@@ -158,20 +160,21 @@ def construct_clients_from_provider_config(provider_config):
         try:
             service_account_info = json.loads(credentials_field)
         except json.decoder.JSONDecodeError:
-            raise RuntimeError("gcp_credentials found in cluster yaml file but "
-                               "formatted improperly.")
+            raise RuntimeError(
+                "gcp_credentials found in cluster yaml file but "
+                "formatted improperly.")
         credentials = service_account.Credentials.from_service_account_info(
             service_account_info)
         return _create_crm_service_account(credentials), \
-               _create_iam_service_account(credentials), \
-               _create_compute_service_account(credentials)
+            _create_iam_service_account(credentials), \
+            _create_compute_service_account(credentials)
 
     # Otherwise the credentials type must be credentials_token.
     creds_from_token = AccessTokenCredentials(credentials_field, "MyAgent/1.0")
     token_request = creds_from_token.authorize(httplib2.Http())
     return _create_crm_oauth_token_request(token_request), \
-           _create_iam_oauth_token_request(token_request), \
-           _create_compute_oauth_token_request(token_request)
+        _create_iam_oauth_token_request(token_request), \
+        _create_compute_oauth_token_request(token_request)
 
 
 def bootstrap_gcp(config):

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -153,7 +153,7 @@ def construct_clients_from_provider_config(provider_config):
     credentials_field = gcp_credentials["credentials"]
 
     assert (cred_type in ("service_account", "credentials_token")), \
-        "'GCP credentials type must either be 'service_account'" \
+        "gcp_credentials type must either be 'service_account'" \
         " or 'credentials_token'."
 
     if cred_type == "service_account":

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -142,7 +142,9 @@ def construct_clients_from_provider_config(provider_config):
                     "environment variable.")
         # If gcp_credentials is None, then discovery.build will search for
         # credentials in the local environment.
-        return None
+        return _create_crm_service_account(None), \
+            _create_iam_service_account(None), \
+            _create_compute_service_account(None)
 
     assert ("type" in gcp_credentials and "credentials" in gcp_credentials), \
         "gcp_credentials cluster yaml field missing 'type'" \

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 from googleapiclient import discovery, errors
 from google.oauth2 import service_account
-from google.oauth2.credentials import Credentials
+from google.oauth2.credentials import Credentials as OAuthCredentials
 
 logger = logging.getLogger(__name__)
 
@@ -152,15 +152,13 @@ def construct_clients_from_provider_config(provider_config):
                 "formatted improperly.")
         credentials = service_account.Credentials.from_service_account_info(
             service_account_info)
-        return _create_crm(credentials), \
-            _create_iam(credentials), \
-            _create_compute(credentials)
+    else:
+        # Otherwise the credentials type must be credentials_token.
+        credentials = OAuthCredentials(credentials_field)
 
-    # Otherwise the credentials type must be credentials_token.
-    creds_from_token = Credentials(credentials_field)
-    return _create_crm(creds_from_token), \
-        _create_iam(creds_from_token), \
-        _create_compute(creds_from_token)
+    return _create_crm(credentials), \
+        _create_iam(credentials), \
+        _create_compute(credentials)
 
 
 def bootstrap_gcp(config):

--- a/python/ray/autoscaler/gcp/config.py
+++ b/python/ray/autoscaler/gcp/config.py
@@ -140,7 +140,7 @@ def construct_clients_from_provider_config(provider_config):
 
     cred_type = gcp_credentials["type"]
     credentials_field = gcp_credentials["credentials"]
-    __import__("ipdb").set_trace()
+
     if cred_type == "service_account":
         # If parsing the gcp_credentials failed, then the user likely made a
         # mistake in copying the credentials into the config yaml.

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -45,7 +45,6 @@ class GCPNodeProvider(NodeProvider):
         _, _, self.compute = construct_clients_from_provider_config(
             provider_config)
 
-
         # Cache of node objects from the last nodes() call. This avoids
         # excessive DescribeInstances requests.
         self.cached_nodes = {}

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -6,7 +6,7 @@ import logging
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 from ray.autoscaler.gcp.config import MAX_POLLS, POLL_INTERVAL, \
-        fetch_gcp_credentials_from_provider_config, _create_compute
+        construct_clients_from_provider_config
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,9 @@ class GCPNodeProvider(NodeProvider):
         NodeProvider.__init__(self, provider_config, cluster_name)
 
         self.lock = RLock()
-        gcp_credentials = fetch_gcp_credentials_from_provider_config(
+        _, _, self.compute = construct_clients_from_provider_config(
             provider_config)
 
-        self.compute = _create_compute(gcp_credentials)
 
         # Cache of node objects from the last nodes() call. This avoids
         # excessive DescribeInstances requests.

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -148,7 +148,8 @@
                     "properties": {
                         "type": {
                             "type": "string",
-                            "description": "credentials_token or service_account"
+                            "enum": ["credentials_token", "service_account"],
+                            "description": "Credentials type: either temporary OAuth 2.0 token or permanent service account credentials blob."
                         },
                         "credentials": {
                             "type": "string",

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -141,8 +141,20 @@
                     "description": "GCP globally unique project id"
                 },
                 "gcp_credentials": {
-                    "type": "string",
-                    "description": "JSON string constituting GCP credentials"
+                    "type": "object",
+                    "description": "Credentials for authenticating with the GCP client",
+                    "required": [ "type" ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "credentials_token or service_account"
+                        },
+                        "credentials": {
+                            "type": "string",
+                            "description": "Oauth token or JSON string constituting service account credentials"
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Previously you could only authenticate with the GCP using permanent service credentials. These were either the default credentials on your machine (specified through an env variable) or passed in through the gcp_credentials field in the cluster config yaml as a json string. This PR changes the gcp_credentials field to be a json object consisting of a type field and a credentials field. The type can either be "service_account" (which will have the same behavior as before) or "credentials_token" (i.e. a temporary oauth 2.0 authentication token). This change also adds support in the GCP autoscaler for authentication using these tokens.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

Tested manually by starting and updating a cluster with both types of credentials.