### PR TITLE
[GCS] Fix detached actor with empty name

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -659,7 +659,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
     gcs_actor_scheduler_->Schedule(actor);
   } else {
     // For detached actors, make sure to remove its name.
-    if (actor->IsDetached() && !actor->GetName().empty()) {
+    if (actor->IsDetached()) {
       auto it = named_actors_.find(actor->GetName());
       if (it != named_actors_.end()) {
         RAY_CHECK(it->second == actor->GetActorID());

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -390,7 +390,7 @@ Status GcsActorManager::RegisterActor(
   }
 
   auto actor = std::make_shared<GcsActor>(request);
-  if (actor->IsDetached() && !actor->GetName().empty()) {
+  if (!actor->GetName().empty()) {
     auto it = named_actors_.find(actor->GetName());
     if (it == named_actors_.end()) {
       named_actors_.emplace(actor->GetName(), actor->GetActorID());
@@ -659,7 +659,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
     gcs_actor_scheduler_->Schedule(actor);
   } else {
     // For detached actors, make sure to remove its name.
-    if (actor->IsDetached()) {
+    if (!actor->GetName().empty()) {
       auto it = named_actors_.find(actor->GetName());
       if (it != named_actors_.end()) {
         RAY_CHECK(it->second == actor->GetActorID());
@@ -746,7 +746,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
         auto actor = std::make_shared<GcsActor>(item.second);
         registered_actors_.emplace(item.first, actor);
 
-        if (actor->IsDetached() && !actor->GetName().empty()) {
+        if (!actor->GetName().empty()) {
           named_actors_.emplace(actor->GetName(), actor->GetActorID());
         }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -70,8 +70,6 @@ ActorID GcsActor::GetActorID() const {
 bool GcsActor::IsDetached() const { return actor_table_data_.is_detached(); }
 
 std::string GcsActor::GetName() const {
-  RAY_CHECK(actor_table_data_.is_detached())
-      << "Actor names are only valid for detached actors.";
   return actor_table_data_.name();
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -390,7 +390,7 @@ Status GcsActorManager::RegisterActor(
   }
 
   auto actor = std::make_shared<GcsActor>(request);
-  if (actor->IsDetached()) {
+  if (actor->IsDetached() && !actor->GetName().empty()) {
     auto it = named_actors_.find(actor->GetName());
     if (it == named_actors_.end()) {
       named_actors_.emplace(actor->GetName(), actor->GetActorID());
@@ -659,7 +659,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
     gcs_actor_scheduler_->Schedule(actor);
   } else {
     // For detached actors, make sure to remove its name.
-    if (actor->IsDetached()) {
+    if (actor->IsDetached() && !actor->GetName().empty()) {
       auto it = named_actors_.find(actor->GetName());
       if (it != named_actors_.end()) {
         RAY_CHECK(it->second == actor->GetActorID());
@@ -746,7 +746,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
         auto actor = std::make_shared<GcsActor>(item.second);
         registered_actors_.emplace(item.first, actor);
 
-        if (actor->IsDetached()) {
+        if (actor->IsDetached() && !actor->GetName().empty()) {
           named_actors_.emplace(actor->GetName(), actor->GetActorID());
         }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -658,7 +658,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
         }));
     gcs_actor_scheduler_->Schedule(actor);
   } else {
-    // For detached actors, make sure to remove its name.
+    // Remove actor from `named_actors_` if its name is not empty.
     if (!actor->GetName().empty()) {
       auto it = named_actors_.find(actor->GetName());
       if (it != named_actors_.end()) {

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -69,9 +69,7 @@ ActorID GcsActor::GetActorID() const {
 
 bool GcsActor::IsDetached() const { return actor_table_data_.is_detached(); }
 
-std::string GcsActor::GetName() const {
-  return actor_table_data_.name();
-}
+std::string GcsActor::GetName() const { return actor_table_data_.name(); }
 
 TaskSpecification GcsActor::GetCreationTaskSpecification() const {
   const auto &task_spec = actor_table_data_.task_spec();

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -275,7 +275,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// All registered actors (pending actors are also included).
   /// TODO(swang): Use unique_ptr instead of shared_ptr.
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> registered_actors_;
-  /// Maps detached actor names to their actor ID for lookups by name.
+  /// Maps actor names to their actor ID for lookups by name.
   absl::flat_hash_map<std::string, ActorID> named_actors_;
   /// The pending actors which will not be scheduled until there's a resource change.
   std::vector<std::shared_ptr<GcsActor>> pending_actors_;

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -410,20 +410,27 @@ TEST_F(GcsActorManagerTest, TestDetachedActorRestartWhenCreatorDead) {
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 }
 
-TEST_F(GcsActorManagerTest, TestDetachedActorWithEmptyName) {
+TEST_F(GcsActorManagerTest, TestActorWithEmptyName) {
   auto job_id = JobID::FromInt(1);
 
+  // Gen `CreateActorRequest` with an empty name.
+  // (name,actor_id) => ("", actor_id_1)
   auto request1 =
       Mocker::GenCreateActorRequest(job_id, 0, /*is_detached=*/true, /*name=*/"");
   Status status = gcs_actor_manager_->RegisterActor(
       request1, [](std::shared_ptr<gcs::GcsActor> actor) {});
+  // Ensure successful registration.
   ASSERT_TRUE(status.ok());
+  // Make sure actor who with empty name is not managered by named_actors_.
   ASSERT_TRUE(gcs_actor_manager_->GetActorIDByName("").IsNil());
 
+  // Gen another `CreateActorRequest` with an empty name.
+  // (name,actor_id) => ("", actor_id_2)
   auto request2 =
       Mocker::GenCreateActorRequest(job_id, 0, /*is_detached=*/true, /*name=*/"");
   status = gcs_actor_manager_->RegisterActor(request2,
                                              [](std::shared_ptr<gcs::GcsActor> actor) {});
+  // Ensure successful registration.
   ASSERT_TRUE(status.ok());
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -421,7 +421,7 @@ TEST_F(GcsActorManagerTest, TestActorWithEmptyName) {
       request1, [](std::shared_ptr<gcs::GcsActor> actor) {});
   // Ensure successful registration.
   ASSERT_TRUE(status.ok());
-  // Make sure actor who with empty name is not managered by named_actors_.
+  // Make sure actor who empty name is not treated as a named actor.
   ASSERT_TRUE(gcs_actor_manager_->GetActorIDByName("").IsNil());
 
   // Gen another `CreateActorRequest` with an empty name.

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -410,6 +410,23 @@ TEST_F(GcsActorManagerTest, TestDetachedActorRestartWhenCreatorDead) {
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 }
 
+TEST_F(GcsActorManagerTest, TestDetachedActorWithEmptyName) {
+  auto job_id = JobID::FromInt(1);
+
+  auto request1 =
+      Mocker::GenCreateActorRequest(job_id, 0, /*is_detached=*/true, /*name=*/"");
+  Status status = gcs_actor_manager_->RegisterActor(
+      request1, [](std::shared_ptr<gcs::GcsActor> actor) {});
+  ASSERT_TRUE(status.ok());
+  ASSERT_TRUE(gcs_actor_manager_->GetActorIDByName("").IsNil());
+
+  auto request2 =
+      Mocker::GenCreateActorRequest(job_id, 0, /*is_detached=*/true, /*name=*/"");
+  status = gcs_actor_manager_->RegisterActor(request2,
+                                             [](std::shared_ptr<gcs::GcsActor> actor) {});
+  ASSERT_TRUE(status.ok());
+}
+
 TEST_F(GcsActorManagerTest, TestNamedActors) {
   auto job_id_1 = JobID::FromInt(1);
   auto job_id_2 = JobID::FromInt(2);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
It will return `Status::Invalid(xxx)` when register two or more detached actor with empty name, which is not expected.

We should not manage unnamed actors by `named_actors_`.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #9282

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
