### PR TITLE
[GCS] fix actor accessor initialize inside redis gcs client

### DIFF
--- a/src/ray/gcs/redis_gcs_client.cc
+++ b/src/ray/gcs/redis_gcs_client.cc
@@ -69,7 +69,12 @@ Status RedisGcsClient::Connect(boost::asio::io_service &io_service) {
   actor_checkpoint_id_table_.reset(new ActorCheckpointIdTable(shard_contexts, this));
   resource_table_.reset(new DynamicResourceTable({primary_context}, this));
   worker_failure_table_.reset(new WorkerFailureTable(shard_contexts, this));
-  actor_accessor_.reset(new RedisActorInfoAccessor(this));
+
+  if (RayConfig::instance().gcs_actor_service_enabled()) {
+    actor_accessor_.reset(new RedisActorInfoAccessor(this));
+  } else {
+    actor_accessor_.reset(new RedisLogBasedActorInfoAccessor(this));
+  }
   job_accessor_.reset(new RedisJobInfoAccessor(this));
   object_accessor_.reset(new RedisObjectInfoAccessor(this));
   node_accessor_.reset(new RedisNodeInfoAccessor(this));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

- We should use `RedisActorInfoAccessor` if `gcs_actor_service_enabled` is true, else `RedisLogBasedActorInfoAccessor` should be use. 

- `RedisActorInfoAccessor` is table-based accessor, while `RedisLogBasedActorInfoAccessor` is log-based accessor.

- It will cause format error iff we use the wrong accessor. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
