### PR TITLE
Revert "Reset bool config by checking type first (#9247)"

### DIFF
--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -14,9 +14,7 @@
 
 #pragma once
 
-#include <algorithm>
 #include <sstream>
-#include <typeinfo>
 #include <unordered_map>
 
 #include "ray/util/logging.h"
@@ -52,17 +50,8 @@ class RayConfig {
 /// A helper macro that helps to set a value to a config item.
 #define RAY_CONFIG(type, name, default_value) \
   if (pair.first == #name) {                  \
-    if (typeid(type) == typeid(bool)) {       \
-       std::string value = pair.second;       \
-       std::transform(value.begin(),          \
-                      value.end(),            \
-                      value.begin(),          \
-                      ::tolower);             \
-       name##_ = value == "true";             \
-    } else {                                  \
-      std::istringstream stream(pair.second); \
-      stream >> name##_;                      \
-    }                                         \
+    std::istringstream stream(pair.second);   \
+    stream >> name##_;                        \
     continue;                                 \
   }
 


### PR DESCRIPTION
This reverts commit 8a1cc7f8f947949ec0a6022235cea978acc743ac.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR seems to break `test_reconstruction` when I tested locally. Let's verify by looking at CI.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
