### PR TITLE
[tune] Add np.bool8 and np.int to allowed HPARAMS types

### DIFF
--- a/python/ray/tune/logger.py
+++ b/python/ray/tune/logger.py
@@ -187,7 +187,7 @@ class TBXLogger(Logger):
     """
 
     # NoneType is not supported on the last TBX release yet.
-    VALID_HPARAMS = (str, bool, int, float, list)
+    VALID_HPARAMS = (str, bool, np.bool8, int, np.integer, float, list)
 
     def _init(self):
         try:

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import unittest
 import tempfile
 import shutil
+import numpy as np
 
 from ray.tune.logger import JsonLogger, CSVLogger, TBXLogger
 
@@ -46,7 +47,17 @@ class LoggerSuite(unittest.TestCase):
         logger.close()
 
     def testTBX(self):
-        config = {"a": 2, "b": [1, 2], "c": {"c": {"D": 123}}}
+        config = {
+            "a": 2,
+            "b": [1, 2],
+            "c": {
+                "c": {
+                    "D": 123
+                }
+            },
+            "d": np.int64(1),
+            "e": np.bool8(True)
+        }
         t = Trial(evaluated_params=config, trial_id="tbx")
         logger = TBXLogger(config=config, logdir=self.test_dir, trial=t)
         logger.on_result(result(0, 4))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

When providing parameters via tune.choice() that include integers or boolean, the values are not logged to TensorBoard's HPARAMS section. See #9268

## Related issue number

Closes #9268 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
