### PR TITLE
Fix flaky test_dynres.py

### DIFF
--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -4,17 +4,9 @@ import time
 
 import ray
 import ray.cluster_utils
-import ray.test_utils
+from ray.test_utils import wait_for_condition
 
 logger = logging.getLogger(__name__)
-
-
-def wait_for_condition(condition_predictor):
-    return ray.test_utils.wait_for_condition(
-        condition_predictor,
-        timeout=5,
-        retry_interval_ms=500,
-    )
 
 
 def test_dynamic_res_creation(ray_start_regular):
@@ -55,7 +47,7 @@ def test_dynamic_res_deletion(shutdown_only):
         cluster_res = ray.cluster_resources()
         return res_name not in available_res and res_name not in cluster_res
 
-    ray.test_utils.wait_for_condition(check_resources)
+    wait_for_condition(check_resources)
 
 
 def test_dynamic_res_infeasible_rescheduling(ray_start_regular):

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -179,9 +179,6 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
         results.append(set_res.remote(res_name, res_capacity, nid))
     ray.get(results)
 
-    success = False
-    start_time = time.time()
-
     def check_resources():
         resources_created = []
         for nid in target_node_ids:

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -159,7 +159,6 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
     # specifier
     cluster = ray_start_cluster
 
-    TIMEOUT = 5
     res_name = "test_res"
     res_capacity = 1.0
     num_nodes = 3
@@ -183,16 +182,16 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
     success = False
     start_time = time.time()
 
-    while time.time() - start_time < TIMEOUT and not success:
-        resources_created = []
-        for nid in target_node_ids:
-            target_node = next(
-                node for node in ray.nodes() if node["NodeID"] == nid)
-            resources = target_node["Resources"]
-            resources_created.append(
-                resources.get(res_name, None) == res_capacity)
-        success = all(resources_created)
-    assert success
+    def check_resources():
+	resources_created = []
+	for nid in target_node_ids:
+	    target_node = next(
+		node for node in ray.nodes() if node["NodeID"] == nid)
+	    resources = target_node["Resources"]
+	    resources_created.append(resources.get(res_name, None) == res_capacity)
+	return all(resources_created)
+
+    wait_for_condition(check_resources)
 
 
 def test_dynamic_res_deletion_clientid(ray_start_cluster):

--- a/python/ray/tests/test_dynres.py
+++ b/python/ray/tests/test_dynres.py
@@ -183,13 +183,14 @@ def test_dynamic_res_creation_clientid_multiple(ray_start_cluster):
     start_time = time.time()
 
     def check_resources():
-	resources_created = []
-	for nid in target_node_ids:
-	    target_node = next(
-		node for node in ray.nodes() if node["NodeID"] == nid)
-	    resources = target_node["Resources"]
-	    resources_created.append(resources.get(res_name, None) == res_capacity)
-	return all(resources_created)
+        resources_created = []
+        for nid in target_node_ids:
+            target_node = next(
+                node for node in ray.nodes() if node["NodeID"] == nid)
+            resources = target_node["Resources"]
+            resources_created.append(
+                resources.get(res_name, None) == res_capacity)
+        return all(resources_created)
 
     wait_for_condition(check_resources)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Dynamic resource API is async, we should use `wait_for_condition` to wait for the operation to complete.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
