### PR TITLE
[GCS]Fix lease worker leak bug when gcs server restarts

### DIFF
--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -112,6 +112,10 @@ class MockRayletClient : public WorkerLeaseInterface {
     return Status::OK();
   }
 
+  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override {
+    return Status::OK();
+  }
+
   ray::Status CancelWorkerLease(
       const TaskID &task_id,
       const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override {

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -112,7 +112,9 @@ class MockRayletClient : public WorkerLeaseInterface {
     return Status::OK();
   }
 
-  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &workers_in_use) override {
+  ray::Status ReleaseUnusedWorkers(
+      const std::vector<WorkerID> &workers_in_use,
+      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
     return Status::OK();
   }
 

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -115,7 +115,7 @@ class MockRayletClient : public WorkerLeaseInterface {
   ray::Status ReleaseUnusedWorkers(
       const std::vector<WorkerID> &workers_in_use,
       const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
-    return Status::OK();
+    return Status::NotImplemented("ReleaseUnusedWorkers is not supported.");
   }
 
   ray::Status CancelWorkerLease(

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -112,7 +112,7 @@ class MockRayletClient : public WorkerLeaseInterface {
     return Status::OK();
   }
 
-  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override {
+  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &workers_in_use) override {
     return Status::OK();
   }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -789,8 +789,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
     }
 
     // Notify raylets to release unused workers.
-    gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers,
-                                               [this]() { SchedulePendingActors(); });
+    gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
 
     RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
                    << ", and the number of created actors is " << created_actors_.size();

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -760,8 +760,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
   RAY_LOG(INFO) << "Loading initial data.";
   auto callback = [this,
                    done](const std::unordered_map<ActorID, ActorTableData> &result) {
-    std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
-        node_to_workers;
+    std::unordered_map<ClientID, std::vector<WorkerID>> node_to_workers;
     for (auto &item : result) {
       if (item.second.state() != ray::rpc::ActorTableData::DEAD) {
         auto actor = std::make_shared<GcsActor>(item.second);
@@ -783,8 +782,7 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
         }
 
         if (!actor->GetNodeID().IsNil() && !actor->GetWorkerID().IsNil()) {
-          node_to_workers[actor->GetNodeID()].first = actor->GetAddress();
-          node_to_workers[actor->GetNodeID()].second.emplace_back(actor->GetWorkerID());
+          node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
         }
       }
     }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -789,7 +789,8 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
     }
 
     // Notify raylets to release unused workers.
-    gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
+    gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers,
+                                               [this]() { SchedulePendingActors(); });
 
     RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
                    << ", and the number of created actors is " << created_actors_.size();

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -789,7 +789,9 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
     }
 
     // Notify raylets to release unused workers.
-    gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
+    if (RayConfig::instance().gcs_actor_service_enabled()) {
+      gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
+    }
 
     RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
                    << ", and the number of created actors is " << created_actors_.size();

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -781,7 +781,8 @@ void GcsActorManager::LoadInitialData(const EmptyCallback &done) {
           workers.emplace(actor->GetOwnerID(), Owner(std::move(client)));
         }
 
-        if (!actor->GetNodeID().IsNil() && !actor->GetWorkerID().IsNil()) {
+        if (!actor->GetWorkerID().IsNil()) {
+          RAY_CHECK(!actor->GetNodeID().IsNil());
           node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
         }
       }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -154,6 +154,15 @@ ActorID GcsActorScheduler::CancelOnWorker(const ClientID &node_id,
   return assigned_actor_id;
 }
 
+void GcsActorScheduler::ReleaseUnusedWorkers(
+    const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
+        &node_to_workers) {
+  for (auto &iter : node_to_workers) {
+    auto lease_client = GetOrConnectLeaseClient(iter.second.first);
+    RAY_CHECK_OK(lease_client->ReleaseUnusedWorkers(iter.second.second));
+  }
+}
+
 void GcsActorScheduler::LeaseWorkerFromNode(std::shared_ptr<GcsActor> actor,
                                             std::shared_ptr<rpc::GcsNodeInfo> node) {
   RAY_CHECK(actor && node);

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -155,29 +155,35 @@ ActorID GcsActorScheduler::CancelOnWorker(const ClientID &node_id,
 }
 
 void GcsActorScheduler::ReleaseUnusedWorkers(
-    const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
-    const EmptyCallback &callback) {
-  RAY_CHECK(callback);
+    const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) {
+  // The purpose of this function is to release leased workers that may be leaked.
+  // When GCS restarts, it doesn't know which workers it has leased in the previous
+  // lifecycle. In this case, GCS will send a list of worker ids that are still needed.
+  // And Raylet will release other leased workers.
   // If the node is dead, there is no need to send the request of release unused
   // workers.
   const auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
   for (const auto &alive_node : alive_nodes) {
+    const auto &node_id = alive_node.first;
+    nodes_of_releasing_unused_workers_.insert(node_id);
+
     rpc::Address address;
     address.set_raylet_id(alive_node.second->node_id());
     address.set_ip_address(alive_node.second->node_manager_address());
     address.set_port(alive_node.second->node_manager_port());
     auto lease_client = GetOrConnectLeaseClient(address);
     auto release_unused_workers_callback =
-        [callback](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
-          callback();
+        [this, node_id](const Status &status,
+                        const rpc::ReleaseUnusedWorkersReply &reply) {
+          nodes_of_releasing_unused_workers_.erase(node_id);
         };
     auto iter = node_to_workers.find(alive_node.first);
     if (iter != node_to_workers.end()) {
       RAY_CHECK_OK(lease_client->ReleaseUnusedWorkers(iter->second,
                                                       release_unused_workers_callback));
     } else {
-      // We need to send a request to each node, because it may be successful in the lease
-      // worker, but GCS server has not processed it before GCS server is restarted.
+      // When GCS restarts, the reply of RequestWorkerLease may not be processed, so some
+      // nodes do not have leased workers. In this case, GCS will send an empty list.
       RAY_CHECK_OK(
           lease_client->ReleaseUnusedWorkers({}, release_unused_workers_callback));
     }
@@ -272,8 +278,7 @@ void GcsActorScheduler::HandleWorkerLeasedReply(
     RAY_CHECK(!retry_at_raylet_address.raylet_id().empty());
     auto spill_back_node_id = ClientID::FromBinary(retry_at_raylet_address.raylet_id());
     auto spill_back_node = gcs_node_manager_.GetNode(spill_back_node_id);
-    if (spill_back_node != nullptr &&
-        !nodes_of_releasing_unused_workers_.contains(spill_back_node_id)) {
+    if (spill_back_node != nullptr) {
       actor->UpdateAddress(retry_at_raylet_address);
       RAY_CHECK(node_to_actors_when_leasing_[actor->GetNodeID()]
                     .emplace(actor->GetActorID())
@@ -391,27 +396,17 @@ void GcsActorScheduler::DoRetryCreatingActorOnWorker(
 
 std::shared_ptr<rpc::GcsNodeInfo> GcsActorScheduler::SelectNodeRandomly() const {
   auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
-  // When we select the available nodes, we need to filter out the nodes that are
-  // releasing unused workers, because we need to ensure that it releases unused workers
-  // before processing the lease worker request.
-  absl::flat_hash_map<ClientID, std::shared_ptr<rpc::GcsNodeInfo>> available_nodes;
-  for (auto &alive_node : alive_nodes) {
-    if (!nodes_of_releasing_unused_workers_.contains(alive_node.first)) {
-      available_nodes[alive_node.first] = alive_node.second;
-    }
-  }
-
-  if (available_nodes.empty()) {
+  if (alive_nodes.empty()) {
     return nullptr;
   }
 
   static std::mt19937_64 gen_(
       std::chrono::high_resolution_clock::now().time_since_epoch().count());
-  std::uniform_int_distribution<int> distribution(0, available_nodes.size() - 1);
+  std::uniform_int_distribution<int> distribution(0, alive_nodes.size() - 1);
   int key_index = distribution(gen_);
   int index = 0;
-  auto iter = available_nodes.begin();
-  for (; index != key_index && iter != available_nodes.end(); ++index, ++iter)
+  auto iter = alive_nodes.begin();
+  for (; index != key_index && iter != alive_nodes.end(); ++index, ++iter)
     ;
   return iter->second;
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -178,15 +178,13 @@ void GcsActorScheduler::ReleaseUnusedWorkers(
           nodes_of_releasing_unused_workers_.erase(node_id);
         };
     auto iter = node_to_workers.find(alive_node.first);
-    if (iter != node_to_workers.end()) {
-      RAY_CHECK_OK(lease_client->ReleaseUnusedWorkers(iter->second,
-                                                      release_unused_workers_callback));
-    } else {
-      // When GCS restarts, the reply of RequestWorkerLease may not be processed, so some
-      // nodes do not have leased workers. In this case, GCS will send an empty list.
-      RAY_CHECK_OK(
-          lease_client->ReleaseUnusedWorkers({}, release_unused_workers_callback));
-    }
+
+    // When GCS restarts, the reply of RequestWorkerLease may not be processed, so some
+    // nodes do not have leased workers. In this case, GCS will send an empty list.
+    auto workers_in_use =
+        iter != node_to_workers.end() ? iter->second : std::vector<WorkerID>{};
+    RAY_UNUSED(lease_client->ReleaseUnusedWorkers(workers_in_use,
+                                                  release_unused_workers_callback));
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -161,8 +161,6 @@ void GcsActorScheduler::ReleaseUnusedWorkers(
   // If the node is dead, there is no need to send the request of release unused
   // workers.
   const auto &alive_nodes = gcs_node_manager_.GetAllAliveNodes();
-  // We need to send a request to each node, because it may be successful in the lease
-  // worker, but GCS server has not processed it before GCS server is restarted.
   for (const auto &alive_node : alive_nodes) {
     rpc::Address address;
     address.set_raylet_id(alive_node.second->node_id());
@@ -178,6 +176,8 @@ void GcsActorScheduler::ReleaseUnusedWorkers(
       RAY_CHECK_OK(lease_client->ReleaseUnusedWorkers(iter->second,
                                                       release_unused_workers_callback));
     } else {
+      // We need to send a request to each node, because it may be successful in the lease
+      // worker, but GCS server has not processed it before GCS server is restarted.
       RAY_CHECK_OK(
           lease_client->ReleaseUnusedWorkers({}, release_unused_workers_callback));
     }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -157,10 +157,9 @@ ActorID GcsActorScheduler::CancelOnWorker(const ClientID &node_id,
 void GcsActorScheduler::ReleaseUnusedWorkers(
     const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) {
   for (auto &iter : node_to_workers) {
-    auto node = gcs_node_manager_.GetNode(iter.first);
     // If the node is dead, there is no need to send the request of release unused
     // workers.
-    if (node) {
+    if (auto node = gcs_node_manager_.GetNode(iter.first)) {
       rpc::Address address;
       address.set_raylet_id(node->node_id());
       address.set_ip_address(node->node_manager_address());

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -68,6 +68,13 @@ class GcsActorSchedulerInterface {
   /// \return ID of actor associated with the specified node id and worker id.
   virtual ActorID CancelOnWorker(const ClientID &node_id, const WorkerID &worker_id) = 0;
 
+  /// Notify raylets to release unused workers.
+  ///
+  /// \param node_to_workers Currently used workers.
+  virtual void ReleaseUnusedWorkers(
+      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
+          &node_to_workers) = 0;
+
   virtual ~GcsActorSchedulerInterface() {}
 };
 
@@ -131,6 +138,13 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// \param worker_id ID of the worker that the actor is creating on.
   /// \return ID of actor associated with the specified node id and worker id.
   ActorID CancelOnWorker(const ClientID &node_id, const WorkerID &worker_id) override;
+
+  /// Notify raylets to release unused workers.
+  ///
+  /// \param node_to_workers Currently used workers.
+  void ReleaseUnusedWorkers(
+      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
+          &node_to_workers) override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -70,9 +70,11 @@ class GcsActorSchedulerInterface {
 
   /// Notify raylets to release unused workers.
   ///
-  /// \param node_to_workers Currently used workers.
+  /// \param node_to_workers Workers used by each node.
+  /// \param callback Callback that will be called when a raylet releases unused workers.
   virtual void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) = 0;
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
+      const EmptyCallback &callback) = 0;
 
   virtual ~GcsActorSchedulerInterface() {}
 };
@@ -140,9 +142,11 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
 
   /// Notify raylets to release unused workers.
   ///
-  /// \param node_to_workers Currently used workers.
-  void ReleaseUnusedWorkers(const std::unordered_map<ClientID, std::vector<WorkerID>>
-                                &node_to_workers) override;
+  /// \param node_to_workers Workers used by each node.
+  /// \param callback Callback that will be called when a raylet releases unused workers.
+  void ReleaseUnusedWorkers(
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
+      const EmptyCallback &callback) override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It
@@ -297,6 +301,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   LeaseClientFactoryFn lease_client_factory_;
   /// Factory for producing new core worker clients.
   rpc::ClientFactoryFn client_factory_;
+  /// The nodes which are releasing unused workers.
+  absl::flat_hash_set<ClientID> nodes_of_releasing_unused_workers_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -72,8 +72,7 @@ class GcsActorSchedulerInterface {
   ///
   /// \param node_to_workers Currently used workers.
   virtual void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
-          &node_to_workers) = 0;
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) = 0;
 
   virtual ~GcsActorSchedulerInterface() {}
 };
@@ -142,9 +141,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Currently used workers.
-  void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
-          &node_to_workers) override;
+  void ReleaseUnusedWorkers(const std::unordered_map<ClientID, std::vector<WorkerID>>
+                                &node_to_workers) override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -71,10 +71,8 @@ class GcsActorSchedulerInterface {
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
-  /// \param callback Callback that will be called when a raylet releases unused workers.
   virtual void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
-      const EmptyCallback &callback) = 0;
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) = 0;
 
   virtual ~GcsActorSchedulerInterface() {}
 };
@@ -143,10 +141,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
-  /// \param callback Callback that will be called when a raylet releases unused workers.
-  void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
-      const EmptyCallback &callback) override;
+  void ReleaseUnusedWorkers(const std::unordered_map<ClientID, std::vector<WorkerID>>
+                                &node_to_workers) override;
 
  protected:
   /// The GcsLeasedWorker is kind of abstraction of remote leased worker inside raylet. It

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -33,7 +33,7 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
   void ReleaseUnusedWorkers(
       const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
-      const EmptyCallback &callback) {}
+      const gcs::EmptyCallback &callback) {}
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const ClientID &node_id));
   MOCK_METHOD2(CancelOnWorker,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -32,8 +32,7 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
   void Schedule(std::shared_ptr<gcs::GcsActor> actor) { actors.push_back(actor); }
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
   void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
-          &node_to_workers) {}
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) {}
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const ClientID &node_id));
   MOCK_METHOD2(CancelOnWorker,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -32,8 +32,7 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
   void Schedule(std::shared_ptr<gcs::GcsActor> actor) { actors.push_back(actor); }
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
   void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
-      const gcs::EmptyCallback &callback) {}
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) {}
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const ClientID &node_id));
   MOCK_METHOD2(CancelOnWorker,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -31,6 +31,9 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
 
   void Schedule(std::shared_ptr<gcs::GcsActor> actor) { actors.push_back(actor); }
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
+  void ReleaseUnusedWorkers(
+      const std::unordered_map<ClientID, std::pair<rpc::Address, std::vector<WorkerID>>>
+          &node_to_workers) {}
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const ClientID &node_id));
   MOCK_METHOD2(CancelOnWorker,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -32,7 +32,8 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
   void Schedule(std::shared_ptr<gcs::GcsActor> actor) { actors.push_back(actor); }
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
   void ReleaseUnusedWorkers(
-      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers) {}
+      const std::unordered_map<ClientID, std::vector<WorkerID>> &node_to_workers,
+      const EmptyCallback &callback) {}
 
   MOCK_METHOD1(CancelOnNode, std::vector<ActorID>(const ClientID &node_id));
   MOCK_METHOD2(CancelOnWorker,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -474,6 +474,9 @@ TEST_F(GcsActorSchedulerTest, TestReleaseUnusedWorkers) {
   ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
 
   // Release unused workers.
+  // Before the requested reply arrives, the actor bound to the leased worker can be
+  // created successfully. The actor not bound to the leased worker needs to wait for the
+  // reply to arrive.
   std::unordered_map<ClientID, std::vector<WorkerID>> node_to_workers;
   node_to_workers[node_id].push_back({WorkerID::FromRandom()});
   gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
@@ -508,6 +511,8 @@ TEST_F(GcsActorSchedulerTest, TestReleaseUnusedWorkers) {
   // Reschedule the actor with 1 available node.
   gcs_actor_scheduler_->Reschedule(actor);
   ASSERT_EQ(2, gcs_actor_scheduler_->num_retry_leasing_count_);
+
+  // The reply of the request arrives and the actor can start creating.
   ASSERT_TRUE(raylet_client_->ReplyReleaseUnusedWorkers());
   gcs_actor_scheduler_->TryLeaseWorkerFromNodeAgain(actor, node);
   ASSERT_EQ(2, gcs_actor_scheduler_->num_retry_leasing_count_);

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -483,53 +483,23 @@ TEST_F(GcsActorSchedulerTest, TestReleaseUnusedWorkers) {
   ASSERT_EQ(1, raylet_client_->num_release_unused_workers);
   ASSERT_EQ(1, raylet_client_->release_callbacks.size());
 
-  // 1.Actor is already tied to a leased worker.
+  // Actor is not tied to a leased worker.
   auto job_id = JobID::FromInt(1);
   auto create_actor_request = Mocker::GenCreateActorRequest(job_id);
   auto actor = std::make_shared<gcs::GcsActor>(create_actor_request);
-  rpc::Address address;
-  WorkerID worker_id = WorkerID::FromRandom();
-  address.set_raylet_id(node_id.Binary());
-  address.set_worker_id(worker_id.Binary());
-  actor->UpdateAddress(address);
 
-  // Reschedule the actor with 1 available node, and the actor creation request should be
-  // send to the worker.
-  gcs_actor_scheduler_->Reschedule(actor);
-  ASSERT_EQ(0, raylet_client_->num_workers_requested);
-  ASSERT_EQ(0, raylet_client_->callbacks.size());
-  ASSERT_EQ(1, worker_client_->callbacks.size());
-
-  // Reply the actor creation request, then the actor should be scheduled successfully.
-  ASSERT_TRUE(worker_client_->ReplyPushTask());
-  ASSERT_EQ(0, worker_client_->callbacks.size());
-
-  // 2.Actor is not tied to a leased worker.
-  actor->UpdateAddress(rpc::Address());
-  actor->GetMutableActorTableData()->clear_resource_mapping();
-
-  // Reschedule the actor with 1 available node.
-  gcs_actor_scheduler_->Reschedule(actor);
+  // The reply of ReleaseUnusedWorkers request is not returned, so the gcs actor scheduler
+  // will try to lease worker several times to reach the upper limit we set in
+  // MockedGcsActorScheduler::RetryLeasingWorkerFromNode function.
+  gcs_actor_scheduler_->Schedule(actor);
   ASSERT_EQ(2, gcs_actor_scheduler_->num_retry_leasing_count_);
+  ASSERT_EQ(raylet_client_->num_workers_requested, 0);
 
-  // The reply of the request arrives and the actor can start creating.
+  // The reply of the ReleaseUnusedWorkers request arrives and the gcs actor scheduler can
+  // select a node to send RequestWorkerLease request.
   ASSERT_TRUE(raylet_client_->ReplyReleaseUnusedWorkers());
   gcs_actor_scheduler_->TryLeaseWorkerFromNodeAgain(actor, node);
-  ASSERT_EQ(2, gcs_actor_scheduler_->num_retry_leasing_count_);
-
-  // Grant a worker, then the actor creation request should be send to the worker.
-  ASSERT_TRUE(raylet_client_->GrantWorkerLease(node->node_manager_address(),
-                                               node->node_manager_port(), worker_id,
-                                               node_id, ClientID::Nil()));
-  ASSERT_EQ(0, raylet_client_->callbacks.size());
-  ASSERT_EQ(1, worker_client_->callbacks.size());
-
-  // Reply the actor creation request, then the actor should be scheduled successfully.
-  ASSERT_TRUE(worker_client_->ReplyPushTask());
-  ASSERT_EQ(0, worker_client_->callbacks.size());
-
-  ASSERT_EQ(0, failure_actors_.size());
-  ASSERT_EQ(2, success_actors_.size());
+  ASSERT_EQ(raylet_client_->num_workers_requested, 1);
 }
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -79,6 +79,8 @@ struct GcsServerMocker {
     ray::Status ReleaseUnusedWorkers(
         const std::vector<WorkerID> &workers_in_use,
         const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
+      num_release_unused_workers += 1;
+      release_callbacks.push_back(callback);
       return Status::OK();
     }
 
@@ -133,15 +135,29 @@ struct GcsServerMocker {
       }
     }
 
+    bool ReplyReleaseUnusedWorkers() {
+      rpc::ReleaseUnusedWorkersReply reply;
+      if (release_callbacks.size() == 0) {
+        return false;
+      } else {
+        auto callback = release_callbacks.front();
+        callback(Status::OK(), reply);
+        release_callbacks.pop_front();
+        return true;
+      }
+    }
+
     ~MockRayletClient() {}
 
     int num_workers_requested = 0;
     int num_workers_returned = 0;
     int num_workers_disconnected = 0;
     int num_leases_canceled = 0;
+    int num_release_unused_workers = 0;
     ClientID node_id = ClientID::FromRandom();
     std::list<rpc::ClientCallback<rpc::RequestWorkerLeaseReply>> callbacks = {};
     std::list<rpc::ClientCallback<rpc::CancelWorkerLeaseReply>> cancel_callbacks = {};
+    std::list<rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply>> release_callbacks = {};
   };
 
   class MockRayletResourceClient : public ResourceReserveInterface {
@@ -199,11 +215,18 @@ struct GcsServerMocker {
       client_factory_ = std::move(client_factory);
     }
 
+    void TryLeaseWorkerFromNodeAgain(std::shared_ptr<gcs::GcsActor> actor,
+                                     std::shared_ptr<rpc::GcsNodeInfo> node) {
+      DoRetryLeasingWorkerFromNode(std::move(actor), std::move(node));
+    }
+
    protected:
     void RetryLeasingWorkerFromNode(std::shared_ptr<gcs::GcsActor> actor,
                                     std::shared_ptr<rpc::GcsNodeInfo> node) override {
       ++num_retry_leasing_count_;
-      DoRetryLeasingWorkerFromNode(actor, node);
+      if (num_retry_leasing_count_ <= 1) {
+        DoRetryLeasingWorkerFromNode(actor, node);
+      }
     }
 
     void RetryCreatingActorOnWorker(std::shared_ptr<gcs::GcsActor> actor,

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -77,7 +77,8 @@ struct GcsServerMocker {
     }
 
     ray::Status ReleaseUnusedWorkers(
-        const std::vector<WorkerID> &workers_in_use) override {
+        const std::vector<WorkerID> &workers_in_use,
+        const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
       return Status::OK();
     }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -76,7 +76,8 @@ struct GcsServerMocker {
       return Status::OK();
     }
 
-    ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override {
+    ray::Status ReleaseUnusedWorkers(
+        const std::vector<WorkerID> &workers_in_use) override {
       return Status::OK();
     }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -76,6 +76,10 @@ struct GcsServerMocker {
       return Status::OK();
     }
 
+    ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override {
+      return Status::OK();
+    }
+
     ray::Status CancelWorkerLease(
         const TaskID &task_id,
         const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) override {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -157,7 +157,8 @@ service NodeManagerService {
   // Release a worker back to its raylet.
   rpc ReturnWorker(ReturnWorkerRequest) returns (ReturnWorkerReply);
   // Notify raylet to release unused workers.
-  rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest) returns (ReleaseUnusedWorkersReply);
+  rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest)
+      returns (ReleaseUnusedWorkersReply);
   // Request resource from the raylet for a bundle.
   rpc RequestResourceReserve(RequestResourceReserveRequest)
       returns (RequestResourceReserveReply);

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -69,6 +69,13 @@ message ReturnWorkerRequest {
 message ReturnWorkerReply {
 }
 
+message ReleaseUnusedWorkersRequest {
+  repeated bytes worker_id_list = 1;
+}
+
+message ReleaseUnusedWorkersReply {
+}
+
 message CancelWorkerLeaseRequest {
   // The task to cancel.
   bytes task_id = 1;
@@ -149,6 +156,8 @@ service NodeManagerService {
   rpc RequestWorkerLease(RequestWorkerLeaseRequest) returns (RequestWorkerLeaseReply);
   // Release a worker back to its raylet.
   rpc ReturnWorker(ReturnWorkerRequest) returns (ReturnWorkerReply);
+  // Notify raylet to release unused workers.
+  rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest) returns (ReleaseUnusedWorkersReply);
   // Request resource from the raylet for a bundle.
   rpc RequestResourceReserve(RequestResourceReserveRequest)
       returns (RequestResourceReserveReply);

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -70,7 +70,7 @@ message ReturnWorkerReply {
 }
 
 message ReleaseUnusedWorkersRequest {
-  repeated bytes worker_id_list = 1;
+  repeated bytes worker_ids_in_use = 1;
 }
 
 message ReleaseUnusedWorkersReply {
@@ -156,7 +156,10 @@ service NodeManagerService {
   rpc RequestWorkerLease(RequestWorkerLeaseRequest) returns (RequestWorkerLeaseReply);
   // Release a worker back to its raylet.
   rpc ReturnWorker(ReturnWorkerRequest) returns (ReturnWorkerReply);
-  // Notify raylet to release unused workers.
+  // This method is only used by GCS, and the purpose is to release leased workers
+  // that may be leaked. When GCS restarts, it doesn't know which workers it has leased
+  // in the previous lifecycle. In this case, GCS will send a list of worker ids that
+  // are still needed. And Raylet will release other leased workers.
   rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest)
       returns (ReleaseUnusedWorkersReply);
   // Request resource from the raylet for a bundle.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1998,6 +1998,8 @@ void NodeManager::HandleReturnWorker(const rpc::ReturnWorkerRequest &request,
 void NodeManager::HandleReleaseUnusedWorkers(
     const rpc::ReleaseUnusedWorkersRequest &request,
     rpc::ReleaseUnusedWorkersReply *reply, rpc::SendReplyCallback send_reply_callback) {
+  // TODO(ffbin): At present, we have not cleaned up the lease worker requests that are
+  // still waiting to be scheduled, which will be implemented in the next pr.
   std::unordered_set<WorkerID> used_worker_ids;
   for (int index = 0; index < request.worker_id_list_size(); ++index) {
     auto worker_id = WorkerID::FromBinary(request.worker_id_list(index));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2008,7 +2008,8 @@ void NodeManager::HandleReleaseUnusedWorkers(
 
   std::vector<WorkerID> unused_worker_ids;
   for (auto &iter : leased_workers_) {
-    if (!used_worker_ids.count(iter.first)) {
+    // We need to exclude workers used by common tasks.
+    if (!iter.second->GetActorId().IsNil() && !used_worker_ids.count(iter.first)) {
       unused_worker_ids.emplace_back(iter.first);
     }
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2000,16 +2000,16 @@ void NodeManager::HandleReleaseUnusedWorkers(
     rpc::ReleaseUnusedWorkersReply *reply, rpc::SendReplyCallback send_reply_callback) {
   // TODO(ffbin): At present, we have not cleaned up the lease worker requests that are
   // still waiting to be scheduled, which will be implemented in the next pr.
-  std::unordered_set<WorkerID> used_worker_ids;
+  std::unordered_set<WorkerID> in_use_worker_ids;
   for (int index = 0; index < request.worker_id_list_size(); ++index) {
     auto worker_id = WorkerID::FromBinary(request.worker_id_list(index));
-    used_worker_ids.emplace(worker_id);
+    in_use_worker_ids.emplace(worker_id);
   }
 
   std::vector<WorkerID> unused_worker_ids;
   for (auto &iter : leased_workers_) {
     // We need to exclude workers used by common tasks.
-    if (!iter.second->GetActorId().IsNil() && !used_worker_ids.count(iter.first)) {
+    if (!iter.second->GetActorId().IsNil() && !in_use_worker_ids.count(iter.first)) {
       unused_worker_ids.emplace_back(iter.first);
     }
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2001,8 +2001,8 @@ void NodeManager::HandleReleaseUnusedWorkers(
   // TODO(ffbin): At present, we have not cleaned up the lease worker requests that are
   // still waiting to be scheduled, which will be implemented in the next pr.
   std::unordered_set<WorkerID> in_use_worker_ids;
-  for (int index = 0; index < request.worker_id_list_size(); ++index) {
-    auto worker_id = WorkerID::FromBinary(request.worker_id_list(index));
+  for (int index = 0; index < request.worker_ids_in_use_size(); ++index) {
+    auto worker_id = WorkerID::FromBinary(request.worker_ids_in_use(index));
     in_use_worker_ids.emplace(worker_id);
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2009,6 +2009,7 @@ void NodeManager::HandleReleaseUnusedWorkers(
   std::vector<WorkerID> unused_worker_ids;
   for (auto &iter : leased_workers_) {
     // We need to exclude workers used by common tasks.
+    // Because they are not used by GCS.
     if (!iter.second->GetActorId().IsNil() && !in_use_worker_ids.count(iter.first)) {
       unused_worker_ids.emplace_back(iter.first);
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1998,10 +1998,10 @@ void NodeManager::HandleReturnWorker(const rpc::ReturnWorkerRequest &request,
 void NodeManager::HandleReleaseUnusedWorkers(
     const rpc::ReleaseUnusedWorkersRequest &request,
     rpc::ReleaseUnusedWorkersReply *reply, rpc::SendReplyCallback send_reply_callback) {
-  std::unordered_map<WorkerID, bool> used_worker_ids;
+  std::unordered_set<WorkerID> used_worker_ids;
   for (int index = 0; index < request.worker_id_list_size(); ++index) {
     auto worker_id = WorkerID::FromBinary(request.worker_id_list(index));
-    used_worker_ids.emplace(worker_id, true);
+    used_worker_ids.emplace(worker_id);
   }
 
   std::vector<WorkerID> unused_worker_ids;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -617,6 +617,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
                           rpc::ReturnWorkerReply *reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle a `ReleaseUnusedWorkers` request.
+  void HandleReleaseUnusedWorkers(const rpc::ReleaseUnusedWorkersRequest &request,
+                                  rpc::ReleaseUnusedWorkersReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override;
+
   /// Handle a `ReturnWorker` request.
   void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &request,
                                rpc::CancelWorkerLeaseReply *reply,

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -318,6 +318,20 @@ Status raylet::RayletClient::ReturnWorker(int worker_port, const WorkerID &worke
       });
 }
 
+Status raylet::RayletClient::ReleaseUnusedWorkers(
+    const std::vector<WorkerID> &used_workers) {
+  rpc::ReleaseUnusedWorkersRequest request;
+  for (auto &worker_id : used_workers) {
+    request.add_worker_id_list(worker_id.Binary());
+  }
+  return grpc_client_->ReleaseUnusedWorkers(
+      request, [](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
+        if (!status.ok()) {
+          RAY_LOG(INFO) << "Error releasing workers: " << status;
+        }
+      });
+}
+
 ray::Status raylet::RayletClient::CancelWorkerLease(
     const TaskID &task_id,
     const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) {

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -319,16 +319,19 @@ Status raylet::RayletClient::ReturnWorker(int worker_port, const WorkerID &worke
 }
 
 Status raylet::RayletClient::ReleaseUnusedWorkers(
-    const std::vector<WorkerID> &workers_in_use) {
+    const std::vector<WorkerID> &workers_in_use,
+    const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) {
   rpc::ReleaseUnusedWorkersRequest request;
   for (auto &worker_id : workers_in_use) {
     request.add_worker_id_list(worker_id.Binary());
   }
   return grpc_client_->ReleaseUnusedWorkers(
-      request, [](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
+      request,
+      [callback](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
         if (!status.ok()) {
           RAY_LOG(INFO) << "Error releasing workers: " << status;
         }
+        callback(status, reply);
       });
 }
 

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -319,9 +319,9 @@ Status raylet::RayletClient::ReturnWorker(int worker_port, const WorkerID &worke
 }
 
 Status raylet::RayletClient::ReleaseUnusedWorkers(
-    const std::vector<WorkerID> &used_workers) {
+    const std::vector<WorkerID> &workers_in_use) {
   rpc::ReleaseUnusedWorkersRequest request;
-  for (auto &worker_id : used_workers) {
+  for (auto &worker_id : workers_in_use) {
     request.add_worker_id_list(worker_id.Binary());
   }
   return grpc_client_->ReleaseUnusedWorkers(

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -323,13 +323,15 @@ Status raylet::RayletClient::ReleaseUnusedWorkers(
     const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) {
   rpc::ReleaseUnusedWorkersRequest request;
   for (auto &worker_id : workers_in_use) {
-    request.add_worker_id_list(worker_id.Binary());
+    request.add_worker_ids_in_use(worker_id.Binary());
   }
   return grpc_client_->ReleaseUnusedWorkers(
       request,
       [callback](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
         if (!status.ok()) {
-          RAY_LOG(INFO) << "Error releasing workers: " << status;
+          RAY_LOG(WARNING)
+              << "Error releasing workers from raylet, the raylet may have died:"
+              << status;
         }
         callback(status, reply);
       });

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -74,9 +74,10 @@ class WorkerLeaseInterface {
                                    bool disconnect_worker) = 0;
 
   /// Notify raylets to release unused workers.
-  /// \param used_workers Currently used workers.
+  /// \param workers_in_use Workers currently in use.
   /// \return ray::Status
-  virtual ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) = 0;
+  virtual ray::Status ReleaseUnusedWorkers(
+      const std::vector<WorkerID> &workers_in_use) = 0;
 
   virtual ray::Status CancelWorkerLease(
       const TaskID &task_id,
@@ -326,7 +327,7 @@ class RayletClient : public PinObjectsInterface,
                            bool disconnect_worker) override;
 
   /// Implements WorkerLeaseInterface.
-  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override;
+  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &workers_in_use) override;
 
   ray::Status CancelWorkerLease(
       const TaskID &task_id,

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -73,6 +73,11 @@ class WorkerLeaseInterface {
   virtual ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,
                                    bool disconnect_worker) = 0;
 
+  /// Notify raylets to release unused workers.
+  /// \param used_workers Currently used workers.
+  /// \return ray::Status
+  virtual ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) = 0;
+
   virtual ray::Status CancelWorkerLease(
       const TaskID &task_id,
       const rpc::ClientCallback<rpc::CancelWorkerLeaseReply> &callback) = 0;
@@ -319,6 +324,9 @@ class RayletClient : public PinObjectsInterface,
   /// Implements WorkerLeaseInterface.
   ray::Status ReturnWorker(int worker_port, const WorkerID &worker_id,
                            bool disconnect_worker) override;
+
+  /// Implements WorkerLeaseInterface.
+  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &used_workers) override;
 
   ray::Status CancelWorkerLease(
       const TaskID &task_id,

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -75,9 +75,11 @@ class WorkerLeaseInterface {
 
   /// Notify raylets to release unused workers.
   /// \param workers_in_use Workers currently in use.
-  /// \return ray::Status
+  /// \param callback Callback that will be called after raylet completes the release of
+  /// unused workers. \return ray::Status
   virtual ray::Status ReleaseUnusedWorkers(
-      const std::vector<WorkerID> &workers_in_use) = 0;
+      const std::vector<WorkerID> &workers_in_use,
+      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) = 0;
 
   virtual ray::Status CancelWorkerLease(
       const TaskID &task_id,
@@ -327,7 +329,9 @@ class RayletClient : public PinObjectsInterface,
                            bool disconnect_worker) override;
 
   /// Implements WorkerLeaseInterface.
-  ray::Status ReleaseUnusedWorkers(const std::vector<WorkerID> &workers_in_use) override;
+  ray::Status ReleaseUnusedWorkers(
+      const std::vector<WorkerID> &workers_in_use,
+      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override;
 
   ray::Status CancelWorkerLease(
       const TaskID &task_id,

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -86,6 +86,9 @@ class NodeManagerWorkerClient
   /// Return a worker lease.
   RPC_CLIENT_METHOD(NodeManagerService, ReturnWorker, grpc_client_, )
 
+  /// Release unused workers.
+  RPC_CLIENT_METHOD(NodeManagerService, ReleaseUnusedWorkers, grpc_client_, )
+
   /// Cancel a pending worker lease request.
   RPC_CLIENT_METHOD(NodeManagerService, CancelWorkerLease, grpc_client_, )
 

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -26,6 +26,7 @@ namespace rpc {
 #define RAY_NODE_MANAGER_RPC_HANDLERS                             \
   RPC_SERVICE_HANDLER(NodeManagerService, RequestWorkerLease)     \
   RPC_SERVICE_HANDLER(NodeManagerService, ReturnWorker)           \
+  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedWorkers) \
   RPC_SERVICE_HANDLER(NodeManagerService, CancelWorkerLease)      \
   RPC_SERVICE_HANDLER(NodeManagerService, ForwardTask)            \
   RPC_SERVICE_HANDLER(NodeManagerService, PinObjectIDs)           \
@@ -56,6 +57,10 @@ class NodeManagerServiceHandler {
   virtual void HandleReturnWorker(const ReturnWorkerRequest &request,
                                   ReturnWorkerReply *reply,
                                   SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleReleaseUnusedWorkers(const ReleaseUnusedWorkersRequest &request,
+                                          ReleaseUnusedWorkersReply *reply,
+                                          SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleCancelWorkerLease(const rpc::CancelWorkerLeaseRequest &request,
                                        rpc::CancelWorkerLeaseReply *reply,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -26,7 +26,7 @@ namespace rpc {
 #define RAY_NODE_MANAGER_RPC_HANDLERS                             \
   RPC_SERVICE_HANDLER(NodeManagerService, RequestWorkerLease)     \
   RPC_SERVICE_HANDLER(NodeManagerService, ReturnWorker)           \
-  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedWorkers) \
+  RPC_SERVICE_HANDLER(NodeManagerService, ReleaseUnusedWorkers)   \
   RPC_SERVICE_HANDLER(NodeManagerService, CancelWorkerLease)      \
   RPC_SERVICE_HANDLER(NodeManagerService, ForwardTask)            \
   RPC_SERVICE_HANDLER(NodeManagerService, PinObjectIDs)           \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When GCS restarts, GCS client of Worker A detects that GCS server is restarted, and sends the create actor request again. It starts over the whole process and maybe picks up another Raylet or worker to schedule the actor.
Problem: GCS doesn’t know if it has leased an worker from another raylet for this actor before. Worker resources may be leaked.
Solution: GCS server sends each raylet which lease workers it uses. If raylet finds that a lease worker is not used, release the lease worker.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9286
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
