### PR TITLE
Fix memory leak in asyncio integration and small refactors

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1313,7 +1313,7 @@ cdef void async_set_result_callback(shared_ptr[CRayObject] obj,
         data_metadata_pairs, ids_to_deserialize)
     loop.call_soon_threadsafe(lambda: py_future.set_result(
         AsyncGetResponse(
-            plasma_fallback_id=None, result=objects[0])))
+            fallback_to_plasma=False, result=objects[0])))
 
 cdef void async_retry_with_plasma_callback(shared_ptr[CRayObject] obj,
                                            CObjectID object_id,
@@ -1322,5 +1322,5 @@ cdef void async_retry_with_plasma_callback(shared_ptr[CRayObject] obj,
     loop = py_future._loop
     loop.call_soon_threadsafe(lambda: py_future.set_result(
                 AsyncGetResponse(
-                    plasma_fallback_id=ObjectID(object_id.Binary()),
+                    fallback_to_plasma=True,
                     result=None)))

--- a/python/ray/async_compat.py
+++ b/python/ray/async_compat.py
@@ -13,7 +13,6 @@ except ImportError:
     uvloop = None
 
 import ray
-import gc
 
 
 def get_new_event_loop():

--- a/python/ray/experimental/async_plasma.py
+++ b/python/ray/experimental/async_plasma.py
@@ -47,6 +47,9 @@ class PlasmaEventHandler:
         ready, _ = ray.wait([object_id], timeout=0)
         if ready:
             self._complete_future(object_id)
+            return True
+        else:
+            return False
 
     def as_future(self, object_id, check_ready=True):
         """Turn an object_id into a Future object.
@@ -65,6 +68,7 @@ class PlasmaEventHandler:
         self._waiting_dict[object_id].append(future)
         if not self.check_immediately(object_id) and len(
                 self._waiting_dict[object_id]) == 1:
-            # Only subscribe once
+            # The future is still pending. Only subscribe once per
+            # object.
             self._worker.core_worker.subscribe_to_plasma_object(object_id)
         return future


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The asyncio integration was leaking references to the ObjectID for objects stored in plasma, causing the underlying values to get pinned forever. The leak was caused by a bug that tried to lookup the ObjectID as a key in a defaultdict that did not contain the ObjectID, causing the default value to get set forever.

This PR fixes the lookup bug. It also refactors some of the asyncio integration code to split out the callbacks for the different futures needed to fulfill an ObjectID's value. It also removes a temporary reference to the ObjectID that is not needed. This may have a slight benefit in performance, since we removed one access per future to the worker's `ReferenceCounter`.

## Related issue number

Closes #9134.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
