### PR TITLE
[core] Disable flaky cancellation test

### DIFF
--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -1,10 +1,12 @@
-import pytest
-import ray
 import random
 import sys
 import time
-from ray.exceptions import RayTaskError, RayTimeoutError, \
-                            RayCancellationError, RayWorkerError
+
+import pytest
+
+import ray
+from ray.exceptions import RayCancellationError, RayTaskError, \
+                           RayTimeoutError, RayWorkerError
 from ray.test_utils import SignalActor
 
 
@@ -154,7 +156,9 @@ def test_comprehensive(ray_start_regular, use_force):
         ray.get(combo)
 
 
-@pytest.mark.parametrize("use_force", [True, False])
+# Running this test with use_force==False is flaky.
+# TODO(ilr): Look into the root of this flakiness.
+@pytest.mark.parametrize("use_force", [False])
 def test_stress(shutdown_only, use_force):
     ray.init(num_cpus=1)
 
@@ -180,9 +184,7 @@ def test_stress(shutdown_only, use_force):
     for done in cancelled:
         with pytest.raises(valid_exceptions(use_force)):
             ray.get(done)
-
-    for indx in range(len(tasks)):
-        t = tasks[indx]
+    for indx, t in enumerate(tasks):
         if sleep_or_no[indx]:
             ray.cancel(t, use_force)
             cancelled.add(t)

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -158,7 +158,7 @@ def test_comprehensive(ray_start_regular, use_force):
 
 # Running this test with use_force==False is flaky.
 # TODO(ilr): Look into the root of this flakiness.
-@pytest.mark.parametrize("use_force", [False])
+@pytest.mark.parametrize("use_force", [True])
 def test_stress(shutdown_only, use_force):
     ray.init(num_cpus=1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When `test_stress` is run with `use_force=False`, the test occasionally hangs. This should eventually be investigated more, but the importance of this is minimal because `use_force=True` works well and is a viable fallback.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
