### PR TITLE
Register function race

### DIFF
--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -136,9 +136,13 @@ class ImportThread:
                         ray_constants.DUPLICATE_REMOTE_FUNCTION_THRESHOLD)
 
         if key.startswith(b"RemoteFunction"):
-            with profiling.profile("register_remote_function"):
-                (self.worker.function_actor_manager.
-                 fetch_and_register_remote_function(key))
+            # TODO (Alex): There's a race condition here if the worker is
+            # shutdown before the function finished registering (because core
+            # worker's global worker is unset before shutdown and is needed
+            # for profiling).
+            # with profiling.profile("register_remote_function"):
+            (self.worker.function_actor_manager.
+                fetch_and_register_remote_function(key))
         elif key.startswith(b"FunctionsToRun"):
             with profiling.profile("fetch_and_run_function"):
                 self.fetch_and_execute_function_to_run(key)

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -142,7 +142,7 @@ class ImportThread:
             # for profiling).
             # with profiling.profile("register_remote_function"):
             (self.worker.function_actor_manager.
-                fetch_and_register_remote_function(key))
+             fetch_and_register_remote_function(key))
         elif key.startswith(b"FunctionsToRun"):
             with profiling.profile("fetch_and_run_function"):
                 self.fetch_and_execute_function_to_run(key)

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -41,7 +41,7 @@ class RemoteFunction:
         _num_return_vals: The default number of return values for invocations
             of this remote function.
         _max_calls: The number of times a worker can execute this function
-            before executing.
+            before exiting.
         _decorator: An optional decorator that should be applied to the remote
             function invocation (as opposed to the function execution) before
             invoking the function. The decorator must return a function that

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -201,7 +201,8 @@ def test_profiling_api(ray_start_2_cpus):
             "ray.wait",
             "submit_task",
             "fetch_and_run_function",
-            "register_remote_function",
+            # TODO (Alex) :https://github.com/ray-project/ray/pull/9346
+            # "register_remote_function",
             "custom_event",  # This is the custom one from ray.profile.
         ]
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -148,11 +148,6 @@ void CoreWorkerProcess::EnsureInitialized() {
 CoreWorker &CoreWorkerProcess::GetCoreWorker() {
   EnsureInitialized();
   if (instance_->options_.num_workers == 1) {
-    // TODO(mehrdadn): Remove this when the bug is resolved.
-    // Somewhat consistently reproducible via
-    // python/ray/tests/test_basic.py::test_background_tasks_with_max_calls
-    // with -c opt on Windows.
-    RAY_CHECK(instance_->global_worker_) << "global_worker_ must not be NULL";
     return *instance_->global_worker_;
   }
   auto ptr = current_core_worker_.lock();

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -148,9 +148,11 @@ void CoreWorkerProcess::EnsureInitialized() {
 CoreWorker &CoreWorkerProcess::GetCoreWorker() {
   EnsureInitialized();
   if (instance_->options_.num_workers == 1) {
+    RAY_CHECK(instance_->global_worker_) << "global_worker_ must not be NULL";
     return *instance_->global_worker_;
   }
-  auto ptr = current_core_worker_.lock();
+
+    RAY_CHECK(instance_->global_worker_) << "global_worker_ must not be NULL";auto ptr = current_core_worker_.lock();
   RAY_CHECK(ptr != nullptr)
       << "The current thread is not bound with a core worker instance.";
   return *ptr;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -151,8 +151,7 @@ CoreWorker &CoreWorkerProcess::GetCoreWorker() {
     RAY_CHECK(instance_->global_worker_) << "global_worker_ must not be NULL";
     return *instance_->global_worker_;
   }
-
-    RAY_CHECK(instance_->global_worker_) << "global_worker_ must not be NULL";auto ptr = current_core_worker_.lock();
+  auto ptr = current_core_worker_.lock();
   RAY_CHECK(ptr != nullptr)
       << "The current thread is not bound with a core worker instance.";
   return *ptr;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This test fixes a race condition. Profiling relies upon core worker. When a worker is shutdown the core worker is unset first. The import thread could still be importing a new function which requires profiling though. 

## Related issue number

Unclear if this was the original bug in #7073, but that did reproduce it. 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
