### PR TITLE
Remove the RAY_CHECK in Worker::Port()

### DIFF
--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -65,7 +65,12 @@ Language Worker::GetLanguage() const { return language_; }
 const std::string Worker::IpAddress() const { return ip_address_; }
 
 int Worker::Port() const {
-  RAY_CHECK(port_ > 0);
+  // NOTE(kfstorm): Since `RayletClient::AnnounceWorkerPort` is an asynchronous
+  // operation, the worker may crash before the `AnnounceWorkerPort` request is received
+  // by raylet. In this case, Accessing `Worker::Port` in
+  // `NodeManager::ProcessDisconnectClientMessage` will fail the check. So disable the
+  // check here.
+  // RAY_CHECK(port_ > 0);
   return port_;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Since `RayletClient::AnnounceWorkerPort` is an asynchronous operation, the worker may crash before the `AnnounceWorkerPort` request is received by raylet. In this case, Accessing `Worker::Port` in `NodeManager::ProcessDisconnectClientMessage` will fail the check.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
