### PR TITLE
[Streaming] fix StreamingContext stop

### DIFF
--- a/streaming/java/streaming-api/src/main/java/io/ray/streaming/api/context/StreamingContext.java
+++ b/streaming/java/streaming-api/src/main/java/io/ray/streaming/api/context/StreamingContext.java
@@ -27,6 +27,8 @@ public class StreamingContext implements Serializable {
 
   private transient AtomicInteger idGenerator;
 
+  private boolean reuseExistingCluster;
+
   /**
    * The sinks of this streaming job.
    */
@@ -62,7 +64,8 @@ public class StreamingContext implements Serializable {
     jobGraph.printJobGraph();
     LOG.info("JobGraph digraph\n{}", jobGraph.generateDigraph());
 
-    if (Ray.internal() == null) {
+    reuseExistingCluster = Ray.internal() != null;
+    if (!reuseExistingCluster) {
       if (Config.MEMORY_CHANNEL.equalsIgnoreCase(jobConfig.get(Config.CHANNEL_TYPE))) {
         Preconditions.checkArgument(!jobGraph.isCrossLanguageGraph());
         ClusterStarter.startCluster(false, true);
@@ -101,7 +104,7 @@ public class StreamingContext implements Serializable {
   }
 
   public void stop() {
-    if (Ray.internal() != null) {
+    if (!reuseExistingCluster) {
       ClusterStarter.stopCluster(jobGraph.isCrossLanguageGraph());
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fix `StreamingContext#stop` stop ray cluster that is not created by `StreamingContext`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
