### PR TITLE
Remove unnecessary asan config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,11 +70,9 @@ build:tsan --linkopt -fsanitize=thread
 build:asan --strip=never
 build:asan --copt -g
 build:asan --copt -fsanitize=address
-build:asan --copt -fno-sanitize=vptr
 build:asan --copt -DADDRESS_SANITIZER
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
-build:asan --linkopt -fno-sanitize=vptr
 test:asan --jobs=1
 test:asan --test_env=ASAN_OPTIONS="detect_leaks=0"
 # This LD_PRELOAD is set for Travis. You will need to change it for local debugging.


### PR DESCRIPTION
Modify the configuration of Asan to be compatible with GCC 4.9.2.
