### PR TITLE
Pipelining task submission to workers

### DIFF
--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -90,3 +90,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool gcs_actor_service_enabled() const
 
         c_bool put_small_object_in_memory_store() const
+
+        uint32_t max_tasks_in_flight_per_worker() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -161,7 +161,7 @@ cdef class Config:
     @staticmethod
     def put_small_object_in_memory_store():
         return RayConfig.instance().put_small_object_in_memory_store()
-    
+
     @staticmethod
     def max_tasks_in_flight_per_worker():
         return RayConfig.instance().max_tasks_in_flight_per_worker()

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -161,3 +161,7 @@ cdef class Config:
     @staticmethod
     def put_small_object_in_memory_store():
         return RayConfig.instance().put_small_object_in_memory_store()
+    
+    @staticmethod
+    def max_tasks_in_flight_per_worker():
+        return RayConfig.instance().max_tasks_in_flight_per_worker()

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -326,6 +326,6 @@ RAY_CONFIG(int64_t, enable_metrics_collection, true)
 RAY_CONFIG(bool, put_small_object_in_memory_store, false)
 
 /// Maximum number of tasks that can be in flight between an owner and a worker for which
-/// the owner has been granted a lease. A value >1 is used when we want to enable pipelining
-/// task submission.
+/// the owner has been granted a lease. A value >1 is used when we want to enable
+/// pipelining task submission.
 RAY_CONFIG(uint32_t, max_tasks_in_flight_per_worker, 1)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -326,5 +326,6 @@ RAY_CONFIG(int64_t, enable_metrics_collection, true)
 RAY_CONFIG(bool, put_small_object_in_memory_store, false)
 
 /// Maximum number of tasks that can be in flight between an owner and a worker for which
-/// the owner has been granted a lease. A value >1 is used when we want to enable pipelining.
+/// the owner has been granted a lease. A value >1 is used when we want to enable pipelining
+/// task submission.
 RAY_CONFIG(uint32_t, max_tasks_in_flight_per_worker, 1)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -324,3 +324,7 @@ RAY_CONFIG(int64_t, enable_metrics_collection, true)
 
 /// Whether start the Plasma Store as a Raylet thread.
 RAY_CONFIG(bool, put_small_object_in_memory_store, false)
+
+/// Maximum number of tasks that can be in flight between an owner and a worker for which
+/// the owner has been granted a lease. A value >1 is used when we want to enable pipelining.
+RAY_CONFIG(uint32_t, max_tasks_in_flight_per_worker, 1)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -445,6 +445,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
           rpc_address_, local_raylet_client_, client_factory, raylet_client_factory,
           memory_store_, task_manager_, local_raylet_id,
           RayConfig::instance().worker_lease_timeout_milliseconds(),
+          RayConfig::instance().max_tasks_in_flight_per_worker(),
           std::move(actor_create_callback), boost::asio::steady_timer(io_service_)));
   future_resolver_.reset(new FutureResolver(memory_store_, client_factory, rpc_address_));
   // Unfortunately the raylet client has to be constructed after the receivers.

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -340,7 +340,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   ASSERT_EQ(worker_client->callbacks.size(), 1);
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
-  
+
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
@@ -1045,19 +1045,19 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
 
   // Set max_tasks_in_flight_per_worker to a value larger than 1 to enable the pipelining
-  // of task submissions. This is done by passing a max_tasks_in_flight_per_worker 
+  // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
   CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           max_tasks_in_flight_per_worker);
-  
+
   // Prepare 20 tasks and save them in a vector.
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
   std::vector<TaskSpecification> tasks;
-  for (int i=1; i<= 20; i++) {
+  for (int i = 1; i <= 20; i++) {
     tasks.push_back(BuildTaskSpec(empty_resources, empty_descriptor));
   }
   ASSERT_EQ(tasks.size(), 20);
@@ -1072,25 +1072,26 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, ClientID::Nil()));
   ASSERT_EQ(worker_client->callbacks.size(), 10);
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
-  
+
   // Last 10 tasks are pushed; no more workers are requested.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
   ASSERT_EQ(worker_client->callbacks.size(), 20);
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
 
-  for (int i=1; i<=20; i++) {
+  for (int i = 1; i <= 20; i++) {
     ASSERT_FALSE(worker_client->callbacks.empty());
     ASSERT_TRUE(worker_client->ReplyPushTask());
-    // No worker should be returned until all the tasks that were submitted to it have been completed.
-    // In our case, the first worker should only be returned after the 10th task has been executed.
-    // The second worker should only be returned at the end, or after the 20th task has been executed.
-      if (i < 10) {
-        ASSERT_EQ(raylet_client->num_workers_returned, 0);
-      } else if (i >= 10 && i < 20) {
-        ASSERT_EQ(raylet_client->num_workers_returned, 1);
-      } else if (i == 20) {
-        ASSERT_EQ(raylet_client->num_workers_returned, 2);
-      }
+    // No worker should be returned until all the tasks that were submitted to it have
+    // been completed. In our case, the first worker should only be returned after the
+    // 10th task has been executed. The second worker should only be returned at the end,
+    // or after the 20th task has been executed.
+    if (i < 10) {
+      ASSERT_EQ(raylet_client->num_workers_returned, 0);
+    } else if (i >= 10 && i < 20) {
+      ASSERT_EQ(raylet_client->num_workers_returned, 1);
+    } else if (i == 20) {
+      ASSERT_EQ(raylet_client->num_workers_returned, 2);
+    }
   }
 
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
@@ -1099,7 +1100,7 @@ TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
   ASSERT_EQ(task_finisher->num_tasks_complete, 20);
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
-  
+
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 }
 
@@ -1112,19 +1113,19 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
 
   // Set max_tasks_in_flight_per_worker to a value larger than 1 to enable the pipelining
-  // of task submissions. This is done by passing a max_tasks_in_flight_per_worker 
+  // of task submissions. This is done by passing a max_tasks_in_flight_per_worker
   // parameter to the CoreWorkerDirectTaskSubmitter.
   uint32_t max_tasks_in_flight_per_worker = 10;
   CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
                                           task_finisher, ClientID::Nil(), kLongTimeout,
                                           max_tasks_in_flight_per_worker);
-  
+
   // prepare 30 tasks and save them in a vector
   std::unordered_map<std::string, double> empty_resources;
   ray::FunctionDescriptor empty_descriptor =
       ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
   std::vector<TaskSpecification> tasks;
-  for (int i=0; i< 30; i++) {
+  for (int i = 0; i < 30; i++) {
     tasks.push_back(BuildTaskSpec(empty_resources, empty_descriptor));
   }
   ASSERT_EQ(tasks.size(), 30);
@@ -1143,7 +1144,7 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
 
   // Task 1-10 finish, Tasks 11-20 are scheduled on the same worker.
-  for (int i=1; i<=10; i++) {
+  for (int i = 1; i <= 10; i++) {
     ASSERT_TRUE(worker_client->ReplyPushTask());
   }
   ASSERT_EQ(worker_client->callbacks.size(), 10);
@@ -1151,7 +1152,7 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
 
   // Task 11-20 finish, Tasks 21-30 are scheduled on the same worker.
-  for (int i=11; i<=20; i++) {
+  for (int i = 11; i <= 20; i++) {
     ASSERT_TRUE(worker_client->ReplyPushTask());
   }
   ASSERT_EQ(worker_client->callbacks.size(), 10);
@@ -1160,7 +1161,7 @@ TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
   ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
 
   // Tasks 21-30 finish, and the worker is finally returned.
-  for (int i=21; i<=30; i++) {
+  for (int i = 21; i <= 30; i++) {
     ASSERT_TRUE(worker_client->ReplyPushTask());
   }
   ASSERT_EQ(raylet_client->num_workers_returned, 1);

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -340,7 +340,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   ASSERT_EQ(worker_client->callbacks.size(), 1);
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
   ASSERT_EQ(task_finisher->num_tasks_failed, 0);
-
+  
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
@@ -1034,6 +1034,139 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
   ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
   ASSERT_EQ(task_finisher->num_tasks_complete, 0);
   ASSERT_EQ(task_finisher->num_tasks_failed, 1);
+}
+
+TEST(DirectTaskTransportTest, TestPipeliningConcurrentWorkerLeases) {
+  rpc::Address address;
+  auto raylet_client = std::make_shared<MockRayletClient>();
+  auto worker_client = std::make_shared<MockWorkerClient>();
+  auto store = std::make_shared<CoreWorkerMemoryStore>();
+  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto task_finisher = std::make_shared<MockTaskFinisher>();
+
+  // setting max_tasks_in_flight_per_worker to a value larger than 1 to enable pipelining
+  // this should be done before instantiating the CoreWorkerDirectTaskSubmitter
+  std::unordered_map<std::string, std::string> config_map;
+  config_map["max_tasks_in_flight_per_worker"] = "10";
+  RayConfig::instance().initialize(config_map);
+  ASSERT_EQ(RayConfig::instance().max_tasks_in_flight_per_worker(), 10);
+
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+                                          task_finisher, ClientID::Nil(), kLongTimeout);
+  
+  // prepare 20 tasks and save them in a vector
+  std::unordered_map<std::string, double> empty_resources;
+  ray::FunctionDescriptor empty_descriptor =
+      ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
+  std::vector<TaskSpecification> tasks;
+  for (int i=0; i< 20; i++) {
+    tasks.push_back(BuildTaskSpec(empty_resources, empty_descriptor));
+  }
+  ASSERT_EQ(tasks.size(), 20);
+
+  // Submit the 20 tasks and check that one worker is requested
+  for (auto task : tasks) {
+    ASSERT_TRUE(submitter.SubmitTask(task).ok());
+  }
+  ASSERT_EQ(raylet_client->num_workers_requested, 1);
+
+  // First 10 tasks are pushed; worker 2 is requested.
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, ClientID::Nil()));
+  ASSERT_EQ(worker_client->callbacks.size(), 10);
+  ASSERT_EQ(raylet_client->num_workers_requested, 2);
+  
+  // Last 10 tasks are pushed; no more workers are requested.
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
+  ASSERT_EQ(worker_client->callbacks.size(), 20);
+  ASSERT_EQ(raylet_client->num_workers_requested, 2);
+  
+  // All workers returned.
+  while (!worker_client->callbacks.empty()) {
+    ASSERT_TRUE(worker_client->ReplyPushTask());
+  }
+
+  ASSERT_EQ(raylet_client->num_workers_requested, 2);
+  ASSERT_EQ(raylet_client->num_workers_returned, 2);
+  ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
+  ASSERT_EQ(task_finisher->num_tasks_complete, 20);
+  ASSERT_EQ(task_finisher->num_tasks_failed, 0);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 0);
+  
+  ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
+}
+
+TEST(DirectTaskTransportTest, TestPipeliningReuseWorkerLease) {
+  rpc::Address address;
+  auto raylet_client = std::make_shared<MockRayletClient>();
+  auto worker_client = std::make_shared<MockWorkerClient>();
+  auto store = std::make_shared<CoreWorkerMemoryStore>();
+  auto factory = [&](const rpc::Address &addr) { return worker_client; };
+  auto task_finisher = std::make_shared<MockTaskFinisher>();
+
+  // setting max_tasks_in_flight_per_worker to a value larger than 1 to enable pipelining
+  // this should be done before instantiating the CoreWorkerDirectTaskSubmitter
+  std::unordered_map<std::string, std::string> config_map;
+  config_map["max_tasks_in_flight_per_worker"] = "10";
+  RayConfig::instance().initialize(config_map);
+  ASSERT_EQ(RayConfig::instance().max_tasks_in_flight_per_worker(), 10);
+  CoreWorkerDirectTaskSubmitter submitter(address, raylet_client, factory, nullptr, store,
+                                          task_finisher, ClientID::Nil(), kLongTimeout);
+  
+  // prepare 30 tasks and save them in a vector
+  std::unordered_map<std::string, double> empty_resources;
+  ray::FunctionDescriptor empty_descriptor =
+      ray::FunctionDescriptorBuilder::BuildPython("", "", "", "");
+  std::vector<TaskSpecification> tasks;
+  for (int i=0; i< 30; i++) {
+    tasks.push_back(BuildTaskSpec(empty_resources, empty_descriptor));
+  }
+  ASSERT_EQ(tasks.size(), 30);
+
+  // Submit the 30 tasks and check that one worker is requested
+  for (auto task : tasks) {
+    ASSERT_TRUE(submitter.SubmitTask(task).ok());
+  }
+  ASSERT_EQ(raylet_client->num_workers_requested, 1);
+
+  // Task 1-10 are pushed, and a new worker is requested.
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, ClientID::Nil()));
+  ASSERT_EQ(worker_client->callbacks.size(), 10);
+  ASSERT_EQ(raylet_client->num_workers_requested, 2);
+  // The lease is not cancelled, as there is more work to do
+  ASSERT_EQ(raylet_client->num_leases_canceled, 0);
+
+  // Task 1-10 finish, Tasks 11-20 are scheduled on the same worker.
+  for (int i=1; i<=10; i++) {
+    ASSERT_TRUE(worker_client->ReplyPushTask());
+  }
+  ASSERT_EQ(worker_client->callbacks.size(), 10);
+  ASSERT_EQ(raylet_client->num_workers_returned, 0);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 0);
+
+  // Task 11-20 finish, Tasks 21-30 are scheduled on the same worker.
+  for (int i=11; i<=20; i++) {
+    ASSERT_TRUE(worker_client->ReplyPushTask());
+  }
+  ASSERT_EQ(worker_client->callbacks.size(), 10);
+  ASSERT_EQ(raylet_client->num_workers_returned, 0);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 1);
+  ASSERT_TRUE(raylet_client->ReplyCancelWorkerLease());
+
+  // Tasks 21-30 finish, and the worker is finally returned.
+  for (int i=21; i<=30; i++) {
+    ASSERT_TRUE(worker_client->ReplyPushTask());
+  }
+  ASSERT_EQ(raylet_client->num_workers_returned, 1);
+
+  // The second lease request is returned immediately.
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, ClientID::Nil()));
+  ASSERT_EQ(worker_client->callbacks.size(), 0);
+  ASSERT_EQ(raylet_client->num_workers_returned, 2);
+  ASSERT_EQ(raylet_client->num_workers_disconnected, 0);
+  ASSERT_EQ(task_finisher->num_tasks_complete, 30);
+  ASSERT_EQ(task_finisher->num_tasks_failed, 0);
+  ASSERT_EQ(raylet_client->num_leases_canceled, 1);
+  ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 }
 
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -86,7 +86,7 @@ void CoreWorkerDirectTaskSubmitter::AddWorkerLeaseClient(
     RAY_LOG(INFO) << "Connected to " << addr.ip_address << ":" << addr.port;
   }
   int64_t expiration = current_time_ms() + lease_timeout_ms_;
-  lease_entry new_lease_entry = {std::move(lease_client), expiration, 0};
+  LeaseEntry new_lease_entry = LeaseEntry(std::move(lease_client), expiration, 0);
   worker_to_lease_entry_.emplace(addr, new_lease_entry);
 }
 
@@ -95,22 +95,21 @@ void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(
     const google::protobuf::RepeatedPtrField<rpc::ResourceMapEntry> &assigned_resources) {
   
   auto &lease_entry = worker_to_lease_entry_[addr];
-  // Check that the lease client exists
-  if (!lease_entry.lease_client) {
+  if (!lease_entry.lease_client_) {
     return;
   }
-  RAY_CHECK(lease_entry.lease_client);
+  RAY_CHECK(lease_entry.lease_client_);
   
   auto queue_entry = task_queues_.find(scheduling_key);
   // Return the worker if there was an error executing the previous task,
   // the previous task is an actor creation task,
   // there are no more applicable queued tasks, or the lease is expired.
   if (was_error || queue_entry == task_queues_.end() ||
-      current_time_ms() > lease_entry.lease_expiration_time) {
+      current_time_ms() > lease_entry.lease_expiration_time_) {
     
     // Return the worker only if there are no tasks in flight
-    if (lease_entry.tasks_in_flight == 0) {
-      auto status = lease_entry.lease_client->ReturnWorker(addr.port, addr.worker_id, was_error);
+    if (lease_entry.tasks_in_flight_ == 0) {
+      auto status = lease_entry.lease_client_->ReturnWorker(addr.port, addr.worker_id, was_error);
       if (!status.ok()) {
         RAY_LOG(ERROR) << "Error returning worker to raylet: " << status.ToString();
       }
@@ -120,9 +119,9 @@ void CoreWorkerDirectTaskSubmitter::OnWorkerIdle(
   } else {
     auto &client = *client_cache_[addr];
 
-    while (!queue_entry->second.empty() && lease_entry.tasks_in_flight < max_tasks_in_flight_per_worker_) {
+    while (!queue_entry->second.empty() && lease_entry.tasks_in_flight_ < max_tasks_in_flight_per_worker_) {
       auto task_spec = queue_entry->second.front();
-      lease_entry.tasks_in_flight ++; // Increment the number of tasks in flight to the worker
+      lease_entry.tasks_in_flight_ ++; // Increment the number of tasks in flight to the worker
       executing_tasks_.emplace(task_spec.TaskId(), addr);
       PushNormalTask(addr, client, scheduling_key, task_spec, assigned_resources);
       queue_entry->second.pop_front();
@@ -289,8 +288,8 @@ void CoreWorkerDirectTaskSubmitter::PushNormalTask(
 
           // Decrement the number of tasks in flight to the worker
           auto &lease_entry = worker_to_lease_entry_[addr];
-          RAY_CHECK(lease_entry.tasks_in_flight > 0);
-          lease_entry.tasks_in_flight--;
+          RAY_CHECK(lease_entry.tasks_in_flight_ > 0);
+          lease_entry.tasks_in_flight_--;
         }
         if (reply.worker_exiting()) {
           // The worker is draining and will shutdown after it is done. Don't return

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -180,18 +180,25 @@ class CoreWorkerDirectTaskSubmitter {
 
   
   
-  /// A lease_entry struct is used to condense the metadata about a single executor:
+  /// A LeaseEntry struct is used to condense the metadata about a single executor:
   /// (1) The lease client through which the worker should be returned
   /// (2) The expiration time of a worker's lease.
   /// (3) The number of tasks that are currently in flight to the worker
-  typedef struct lease_entry {
-    std::shared_ptr<WorkerLeaseInterface> lease_client;
-    int64_t lease_expiration_time;
-    uint32_t tasks_in_flight;
-  } lease_entry;
+  struct LeaseEntry {
+    std::shared_ptr<WorkerLeaseInterface> lease_client_;
+    int64_t lease_expiration_time_;
+    uint32_t tasks_in_flight_;
 
-  // Map from worker address to a lease_entry struct containing the lease's metadata.
-  absl::flat_hash_map<rpc::WorkerAddress, lease_entry> worker_to_lease_entry_ GUARDED_BY(mu_);
+    LeaseEntry(std::shared_ptr<WorkerLeaseInterface> lease_client=nullptr,
+              int64_t lease_expiration_time=0,
+              uint32_t tasks_in_flight=0):
+              lease_client_(lease_client),
+              lease_expiration_time_(lease_expiration_time),
+              tasks_in_flight_(tasks_in_flight) {}
+  };
+
+  // Map from worker address to a LeaseEntry struct containing the lease's metadata.
+  absl::flat_hash_map<rpc::WorkerAddress, LeaseEntry> worker_to_lease_entry_ GUARDED_BY(mu_);
 
   // Keeps track of pending worker lease requests to the raylet.
   absl::flat_hash_map<SchedulingKey,

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -53,7 +53,9 @@ class CoreWorkerDirectTaskSubmitter {
       rpc::ClientFactoryFn client_factory, LeaseClientFactoryFn lease_client_factory,
       std::shared_ptr<CoreWorkerMemoryStore> store,
       std::shared_ptr<TaskFinisherInterface> task_finisher, ClientID local_raylet_id,
-      int64_t lease_timeout_ms, uint32_t max_tasks_in_flight_per_worker = RayConfig::instance().max_tasks_in_flight_per_worker(),
+      int64_t lease_timeout_ms,
+      uint32_t max_tasks_in_flight_per_worker =
+          RayConfig::instance().max_tasks_in_flight_per_worker(),
       std::function<Status(const TaskSpecification &, const gcs::StatusCallback &)>
           actor_create_callback = nullptr,
       absl::optional<boost::asio::steady_timer> cancel_timer = absl::nullopt)
@@ -175,11 +177,10 @@ class CoreWorkerDirectTaskSubmitter {
   absl::flat_hash_map<rpc::WorkerAddress, std::shared_ptr<rpc::CoreWorkerClientInterface>>
       client_cache_ GUARDED_BY(mu_);
 
-  // max_tasks_in_flight_per_worker_ limits the number of tasks that can be pipelined to a worker using a single lease.
+  // max_tasks_in_flight_per_worker_ limits the number of tasks that can be pipelined to a
+  // worker using a single lease.
   const uint32_t max_tasks_in_flight_per_worker_;
 
-  
-  
   /// A LeaseEntry struct is used to condense the metadata about a single executor:
   /// (1) The lease client through which the worker should be returned
   /// (2) The expiration time of a worker's lease.
@@ -189,16 +190,16 @@ class CoreWorkerDirectTaskSubmitter {
     int64_t lease_expiration_time_;
     uint32_t tasks_in_flight_;
 
-    LeaseEntry(std::shared_ptr<WorkerLeaseInterface> lease_client=nullptr,
-              int64_t lease_expiration_time=0,
-              uint32_t tasks_in_flight=0):
-              lease_client_(lease_client),
-              lease_expiration_time_(lease_expiration_time),
-              tasks_in_flight_(tasks_in_flight) {}
+    LeaseEntry(std::shared_ptr<WorkerLeaseInterface> lease_client = nullptr,
+               int64_t lease_expiration_time = 0, uint32_t tasks_in_flight = 0)
+        : lease_client_(lease_client),
+          lease_expiration_time_(lease_expiration_time),
+          tasks_in_flight_(tasks_in_flight) {}
   };
 
   // Map from worker address to a LeaseEntry struct containing the lease's metadata.
-  absl::flat_hash_map<rpc::WorkerAddress, LeaseEntry> worker_to_lease_entry_ GUARDED_BY(mu_);
+  absl::flat_hash_map<rpc::WorkerAddress, LeaseEntry> worker_to_lease_entry_
+      GUARDED_BY(mu_);
 
   // Keeps track of pending worker lease requests to the raylet.
   absl::flat_hash_map<SchedulingKey,
@@ -219,7 +220,6 @@ class CoreWorkerDirectTaskSubmitter {
 
   // Retries cancelation requests if they were not successful.
   absl::optional<boost::asio::steady_timer> cancel_retry_timer_;
-
 };
 
 };  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These changes are needed to increase the task processing throughput. Currently, each worker transmits only one task at a time, in an iterative fashion, to the workers that will execute them. Each tasks is only submitted when the previous one has completed and the owner has received a response from the worker that executed it. This approach can be optimized by pipelining the submission of tasks to workers. By doing that, we hide (as much as we can) the latency due to the transmission and processing of the tasks at the worker's side.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [TODO] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
