### PR TITLE
[GCS] fix the fault tolerance about gcs node manager

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -63,8 +63,7 @@ def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
 
     We set the cluster to timeout nodes after 2 seconds of heartbeats. We then
     kill gcs server and remove the worker node and restart gcs server again to
-    check that the removed node is alive when the GCS server is just restarted
-    but dead finally.
+    check that the removed node will die finally.
     """
     cluster = ray_start_cluster_head
     worker = cluster.add_node()
@@ -101,16 +100,12 @@ def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
     # Restart gcs server process.
     cluster.head_node.start_gcs_server()
 
-    nodes = ray.nodes()
-    assert len(nodes) == 2
-    assert nodes[0]["alive"] and nodes[1]["alive"]
-
     def condition():
         nodes = ray.nodes()
         assert len(nodes) == 2
         for node in nodes:
             if node["NodeID"] == to_be_removed_node["NodeID"]:
-                return node["alive"]
+                return not node["alive"]
         return False
 
     # Wait for the removed node dead.

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -58,9 +58,9 @@ def test_gcs_server_restart_during_actor_creation(ray_start_regular):
 def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
     """Checks that the node failure detector is correct when gcs server restart.
 
-    We set the cluster to timeout nodes after 2 seconds of no timeouts. We
-    then remove a node, wait for 1 second and start gcs server again to check
-    that the alive node count is 2, then wait another 2 seconds to check that
+    We set the cluster to timeout nodes after 2 seconds of heartbeats. We
+    then remove a node and restart gcs server again to check
+    that the alive node count is 2, then wait another 2.5 seconds to check that
     the one of the node is timed out.
     """
     cluster = ray_start_cluster_head

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1,6 +1,9 @@
 import sys
 
 import ray
+import pytest
+import time
+from ray.test_utils import generate_internal_config_map
 
 
 @ray.remote
@@ -46,6 +49,43 @@ def test_gcs_server_restart_during_actor_creation(ray_start_regular):
     print("Ready objects is {}.".format(ready))
     print("Unready objects is {}.".format(unready))
     assert len(unready) == 0
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head",
+    [generate_internal_config_map(num_heartbeats_timeout=20)],
+    indirect=True)
+def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
+    """Checks that the node failure detector is correct when gcs server restart.
+
+    We set the cluster to timeout nodes after 2 seconds of no timeouts. We
+    then remove a node, wait for 1 second and start gcs server again to check
+    that the alive node count is 2, then wait another 2 seconds to check that
+    the one of the node is timed out.
+    """
+    cluster = ray_start_cluster_head
+    worker = cluster.add_node()
+    cluster.wait_for_nodes()
+
+    cluster.head_node.kill_gcs_server()
+    cluster.remove_node(worker, allow_graceful=False)
+
+    time.sleep(1)
+    cluster.head_node.start_gcs_server()
+
+    nodes = ray.nodes()
+    assert len(nodes) == 2
+    assert nodes[0]["alive"] and nodes[1]["alive"]
+
+    time.sleep(2.5)
+    nodes = ray.nodes()
+    assert len(nodes) == 2
+
+    dead_count = 0
+    for node in nodes:
+        if not node["alive"]:
+            dead_count += 1
+    assert dead_count == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -69,8 +69,6 @@ def test_node_failure_detector_when_gcs_server_restart(ray_start_cluster_head):
 
     cluster.head_node.kill_gcs_server()
     cluster.remove_node(worker, allow_graceful=False)
-
-    time.sleep(1)
     cluster.head_node.start_gcs_server()
 
     nodes = ray.nodes()

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -134,7 +134,7 @@ GcsNodeManager::GcsNodeManager(boost::asio::io_service &io_service,
                 RAY_CHECK_OK(
                     gcs_table_storage_->NodeResourceTable().Delete(node_id, on_done));
               };
-              RAY_CHECK_OK(gcs_table_storage_->NodeTable().Delete(node_id, on_done));
+              RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_done));
             }
           })),
       gcs_pub_sub_(gcs_pub_sub),
@@ -400,8 +400,6 @@ void GcsNodeManager::LoadInitialData(const EmptyCallback &done) {
           for (auto &item : result) {
             if (alive_nodes_.count(item.first)) {
               cluster_resources_[item.first] = item.second;
-            } else {
-              // TODO(Shanly): Delete dead node resources.
             }
           }
           RAY_LOG(INFO) << "Finished loading initial data.";

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -386,9 +386,8 @@ void GcsNodeManager::LoadInitialData(const EmptyCallback &done) {
                                const std::unordered_map<ClientID, GcsNodeInfo> &result) {
     for (auto &item : result) {
       if (item.second.state() == rpc::GcsNodeInfo::ALIVE) {
-        // 1. Add the alive node to `alive_nodes_`.
-        // 2. Add it to failure detector for monitoring.
-        // 3. Notify `node_added_listeners_`.
+        // Call `AddNode` for this node to make sure it is tracked by the failure
+        // detector.
         AddNode(std::make_shared<rpc::GcsNodeInfo>(item.second));
       } else if (item.second.state() == rpc::GcsNodeInfo::DEAD) {
         dead_nodes_.emplace(item.first, std::make_shared<rpc::GcsNodeInfo>(item.second));

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -140,6 +140,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// \param done Callback that will be called when load is complete.
   void LoadInitialData(const EmptyCallback &done);
 
+  /// Start node failure detector.
+  void StartNodeFailureDetector();
+
  protected:
   class NodeFailureDetector {
    public:
@@ -155,6 +158,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
         std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
         std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub,
         std::function<void(const ClientID &)> on_node_death_callback);
+
+    /// Start failure detector.
+    void Start();
 
     /// Register node to this detector.
     /// Only if the node has registered, its heartbeat data will be accepted.
@@ -203,6 +209,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
     absl::flat_hash_map<ClientID, rpc::HeartbeatTableData> heartbeat_buffer_;
     /// A publisher for publishing gcs messages.
     std::shared_ptr<gcs::GcsPubSub> gcs_pub_sub_;
+    /// Is the detect started.
+    bool is_started_ = false;
   };
 
  private:

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -119,6 +119,9 @@ void GcsServer::Start() {
 
         // Store gcs rpc server address in redis.
         StoreGcsServerAddressInRedis();
+
+        // Start node failure detector.
+        gcs_node_manager_->StartNodeFailureDetector();
         is_started_ = true;
       };
       gcs_actor_manager_->LoadInitialData(actor_manager_load_initial_data_callback);

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -120,7 +120,9 @@ void GcsServer::Start() {
         // Store gcs rpc server address in redis.
         StoreGcsServerAddressInRedis();
 
-        // Start node failure detector.
+        // Only after the rpc_server_ is running can the node failure detector be run.
+        // Otherwise the node failure detector will mistake some living nodes as dead
+        // as the timer inside node failure detector is already run.
         gcs_node_manager_->StartNodeFailureDetector();
         is_started_ = true;
       };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. When restart, the gcs node manager should load node info from storage and add the alive nodes to `node_failure_detector` so that the detector could detect them.
2. StartNodeFailureDetector after the rpc service of gcs server is started.

## Related issue number

<!-- For example: "Closes #1234" -->
Close #9379 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
