### PR TITLE
Fix macos compliation bug

### DIFF
--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -336,6 +336,8 @@ class MockDependencyWaiter : public DependencyWaiter {
  public:
   MOCK_METHOD2(Wait, void(const std::vector<rpc::ObjectReference> &dependencies,
                           std::function<void()> on_dependencies_available));
+
+  virtual ~MockDependencyWaiter(){}
 };
 
 class MockWorkerContext : public WorkerContext {

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -337,7 +337,7 @@ class MockDependencyWaiter : public DependencyWaiter {
   MOCK_METHOD2(Wait, void(const std::vector<rpc::ObjectReference> &dependencies,
                           std::function<void()> on_dependencies_available));
 
-  virtual ~MockDependencyWaiter(){}
+  virtual ~MockDependencyWaiter() {}
 };
 
 class MockWorkerContext : public WorkerContext {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Seems like one of mock class doesn't have the virtual destructor. Let's see if it fixes the issue. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
