### PR TITLE
Fix gcs_table_storage testcase bug

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
+++ b/src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h
@@ -79,7 +79,7 @@ class GcsTableStorageTestBase : public ::testing::Test {
 
   template <typename TABLE, typename KEY, typename VALUE>
   void Put(TABLE &table, const KEY &key, const VALUE &value) {
-    auto on_done = [this](Status status) { --pending_count_; };
+    auto on_done = [this](const Status &status) { --pending_count_; };
     ++pending_count_;
     RAY_CHECK_OK(table.Put(key, value, on_done));
     WaitPendingDone();
@@ -87,13 +87,17 @@ class GcsTableStorageTestBase : public ::testing::Test {
 
   template <typename TABLE, typename KEY, typename VALUE>
   int Get(TABLE &table, const KEY &key, std::vector<VALUE> &values) {
-    auto on_done = [this, &values](Status status, const boost::optional<VALUE> &result) {
+    auto on_done = [this, &values](const Status &status,
+                                   const boost::optional<VALUE> &result) {
       RAY_CHECK_OK(status);
-      --pending_count_;
       values.clear();
       if (result) {
         values.push_back(*result);
       }
+      // NOTE: The callback is executed in an asynchronous thread, so the modification of
+      // pending_count_ must be put last, otherwise the unmodified pending_count_ will be
+      // read outside.
+      --pending_count_;
     };
     ++pending_count_;
     RAY_CHECK_OK(table.Get(key, on_done));
@@ -105,13 +109,16 @@ class GcsTableStorageTestBase : public ::testing::Test {
   int GetByJobId(TABLE &table, const JobID &job_id, const KEY &key,
                  std::vector<VALUE> &values) {
     auto on_done = [this, &values](const std::unordered_map<KEY, VALUE> &result) {
-      --pending_count_;
       values.clear();
       if (!result.empty()) {
         for (auto &item : result) {
           values.push_back(item.second);
         }
       }
+      // NOTE: The callback is executed in an asynchronous thread, so the modification of
+      // pending_count_ must be put last, otherwise the unmodified pending_count_ will be
+      // read outside.
+      --pending_count_;
     };
     ++pending_count_;
     RAY_CHECK_OK(table.GetByJobId(job_id, on_done));
@@ -121,7 +128,7 @@ class GcsTableStorageTestBase : public ::testing::Test {
 
   template <typename TABLE, typename KEY>
   void Delete(TABLE &table, const KEY &key) {
-    auto on_done = [this](Status status) {
+    auto on_done = [this](const Status &status) {
       RAY_CHECK_OK(status);
       --pending_count_;
     };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Problem:
![image](https://user-images.githubusercontent.com/13081808/87114756-f4c17b80-c2a3-11ea-9fdd-199907cd53fa.png)

Solution:
The callback is executed in an asynchronous thread, so the modification of pending_count_ must be put last, otherwise the unmodified pending_count_ will be read outside.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
