### PR TITLE
[Java] fix redis-server binary path

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -155,10 +155,12 @@ genrule(
     """,
 )
 
+# `//:redis-server`'s full path is `external/com_github_antirez_redis/redis-server`,
+# This rule removes the prefix, and only keeps `redis-server`.
 genrule(
-    name = "redis-server",
+    name = "redis-server-without-prefix",
     srcs = ["//:redis-server"],
-    outs = ["src/main/resources/redis-server"],
+    outs = ["redis-server"],
     cmd = "cp $< $@",
     output_to_bindir = 1,
 )
@@ -171,7 +173,7 @@ filegroup(
         "//:gcs_server",
         "//:libray_redis_module.so",
         "//:raylet",
-        ":redis-server",
+        ":redis-server-without-prefix",
     ],
 )
 

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -168,11 +168,11 @@ filegroup(
     name = "java_native_deps",
     srcs = [
         ":cp_plasma_store_server",
+        ":redis-server-without-prefix",
         "//:core_worker_library_java",
         "//:gcs_server",
         "//:libray_redis_module.so",
         "//:raylet",
-        ":redis-server-without-prefix",
     ],
 )
 

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -162,7 +162,6 @@ genrule(
     srcs = ["//:redis-server"],
     outs = ["redis-server"],
     cmd = "cp $< $@",
-    output_to_bindir = 1,
 )
 
 filegroup(

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -155,6 +155,14 @@ genrule(
     """,
 )
 
+genrule(
+    name = "redis-server",
+    srcs = ["//:redis-server"],
+    outs = ["src/main/resources/redis-server"],
+    cmd = "cp $< $@",
+    output_to_bindir = 1,
+)
+
 filegroup(
     name = "java_native_deps",
     srcs = [
@@ -163,7 +171,7 @@ filegroup(
         "//:gcs_server",
         "//:libray_redis_module.so",
         "//:raylet",
-        "//:redis-server",
+        ":redis-server",
     ],
 )
 

--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -253,7 +253,7 @@ public class RunManager {
 
   private String startRedisInstance(String ip, int port, String password, Integer shard) {
     final File redisServerFile = BinaryFileUtil.getFile(
-        rayConfig.sessionDir, BinaryFileUtil.REDIS_SERVER_BINARY_PATH);
+        rayConfig.sessionDir, BinaryFileUtil.REDIS_SERVER_BINARY_NAME);
     Preconditions.checkState(redisServerFile.setExecutable(true));
     List<String> command = Lists.newArrayList(
         // The redis-server executable file.

--- a/java/runtime/src/main/java/io/ray/runtime/util/BinaryFileUtil.java
+++ b/java/runtime/src/main/java/io/ray/runtime/util/BinaryFileUtil.java
@@ -11,9 +11,7 @@ import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 
 public class BinaryFileUtil {
-  // We use a path here because the top-level Bazel target is an alias
-  public static final String REDIS_SERVER_BINARY_PATH =
-      "external/com_github_antirez_redis/redis-server";
+  public static final String REDIS_SERVER_BINARY_NAME = "redis-server";
 
   public static final String GCS_SERVER_BINARY_NAME = "gcs_server";
 
@@ -32,11 +30,10 @@ public class BinaryFileUtil {
    * directory concurrently, this operation will be protected by a file lock.
    *
    * @param destDir  a directory to extract resource file to
-   * @param filePath resource file path
+   * @param fileName resource file name
    * @return extracted resource file
    */
-  public static File getFile(String destDir, String filePath) {
-    String fileName = new File(filePath).getName();
+  public static File getFile(String destDir, String fileName) {
     final File dir = new File(destDir);
     if (!dir.exists()) {
       try {
@@ -54,11 +51,11 @@ public class BinaryFileUtil {
       }
 
       // File does not exist.
-      try (InputStream is = BinaryFileUtil.class.getResourceAsStream("/" + filePath)) {
-        Preconditions.checkNotNull(is, "{} doesn't exist.", filePath);
+      try (InputStream is = BinaryFileUtil.class.getResourceAsStream("/" + fileName)) {
+        Preconditions.checkNotNull(is, "{} doesn't exist.", fileName);
         Files.copy(is, Paths.get(file.getCanonicalPath()));
       } catch (IOException e) {
-        throw new RuntimeException("Couldn't get temp file from resource " + filePath, e);
+        throw new RuntimeException("Couldn't get temp file from resource " + fileName, e);
       }
       return file;
     } catch (IOException e) {

--- a/java/test.sh
+++ b/java/test.sh
@@ -44,10 +44,9 @@ run_testng java -Dray.run-mode="SINGLE_PROCESS" -cp $ROOT_DIR/../bazel-bin/java/
 
 popd
 
-# Ensure mvn test works
-mvn test -pl test -Dtest="io.ray.test.HelloWorldTest"
-
 pushd $ROOT_DIR
 echo "Testing maven install."
 mvn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN clean install -DskipTests
+# Ensure mvn test works
+mvn test -pl test -Dtest="io.ray.test.HelloWorldTest"
 popd

--- a/java/test.sh
+++ b/java/test.sh
@@ -44,6 +44,9 @@ run_testng java -Dray.run-mode="SINGLE_PROCESS" -cp $ROOT_DIR/../bazel-bin/java/
 
 popd
 
+# Ensure mvn test works
+mvn test -pl test -Dtest="io.ray.test.HelloWorldTest"
+
 pushd $ROOT_DIR
 echo "Testing maven install."
 mvn -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN clean install -DskipTests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fix `redis-server` not found when running java from maven/IDE.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#9197 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
