### PR TITLE
Fix copy to workspace

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1973,7 +1973,7 @@ genrule(
     outs = ["ray_pkg.out"],
     cmd = """
         if [ "$${OSTYPE-}" = "msys" ]; then
-            mv -f python/ray/_raylet.so python/ray/_raylet.pyd
+            ln -P -f -- python/ray/_raylet.so python/ray/_raylet.pyd
         fi
         # NOTE(hchen): Protobuf doesn't allow specifying Python package name. So we use this `sed`
         # command to change the import path in the generated file.

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -118,8 +118,8 @@ def copy_to_workspace(name, srcs, dstdir = ""):
             for f in {locations}; do
                 rm -f -- {dstdir}$${{f##*/}}
                 cp -f -- "$$f" {dstdir}
-                echo $$f {dstdir}$${{f##*/}}
-            done > $@
+            done
+            date > $@
         """.format(
             locations = src_locations,
             dstdir = "." + ("/" + dstdir.replace("\\", "/")).rstrip("/") + "/",
@@ -131,10 +131,9 @@ def copy_to_workspace(name, srcs, dstdir = ""):
             ) && (
                 for %f in ({locations}) do @(
                     (if exist {dstdir}%~nxf del /f /q {dstdir}%~nxf) &&
-                    copy /B /Y %f {dstdir} >NUL &&
-                    (echo %f {dstdir}%~nxf)
+                    copy /B /Y %f {dstdir} >NUL
                 )
-            ) > $@
+            ) && >$@ echo %TIME%
         """.replace("\r", "").replace("\n", " ").format(
             locations = src_locations,
             dstdir = "." + ("\\" + dstdir.replace("/", "\\")).rstrip("\\") + "\\",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Fixes a problem where our `copy_to_workspace` rule was using the same output file for different inputs, resulting in premature stopping of the build.

Also makes our `ray_pkg` `genrule` idempotent.

## Related issue number

#9314

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
