### PR TITLE
[HOTFIX]Fix compile direct_actor_transport_test on mac

### DIFF
--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -243,6 +243,8 @@ class DependencyWaiter {
   /// Calls `callback` once the specified objects become available.
   virtual void Wait(const std::vector<rpc::ObjectReference> &dependencies,
                     std::function<void()> on_dependencies_available) = 0;
+
+  virtual ~DependencyWaiter(){};
 };
 
 class DependencyWaiterImpl : public DependencyWaiter {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is a quick fix about build failure on mac. The library can not compile successfully. For detail message see: https://github.com/ray-project/ray/pull/9299/checks?check_run_id=855765063#step:6:298

## Related issue number

(introduced by https://github.com/ray-project/ray/pull/9299)

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
