### PR TITLE
[docker] Pass `run` args into SSHCommandRunner

### DIFF
--- a/python/ray/autoscaler/command_runner.py
+++ b/python/ray/autoscaler/command_runner.py
@@ -396,8 +396,8 @@ class DockerCommandRunner(SSHCommandRunner):
             cmd,
             timeout=timeout,
             exit_on_fail=exit_on_fail,
-            port_forward=None,
-            with_output=False,
+            port_forward=port_forward,
+            with_output=with_output,
             ssh_options_override=ssh_options_override)
 
     def run_rsync_up(self, source, target):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Fixes a broken, untested piece of functionality in DockerCommandRunner

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
