### PR TITLE
change error code name of boost timer

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -147,7 +147,7 @@ void ServiceBasedGcsClient::PeriodicallyCheckGcsServerAddress() {
   detect_timer_->expires_from_now(check_period);
   detect_timer_->async_wait([this](const boost::system::error_code &error) {
     if (error == boost::asio::error::operation_aborted) {
-      // `operation_canceled` is set when `detect_timer_` is canceled or destroyed.
+      // `operation_aborted` is set when `detect_timer_` is canceled or destroyed.
       return;
     }
     RAY_CHECK(!error) << "Checking gcs server address failed with error: "

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -146,7 +146,7 @@ void ServiceBasedGcsClient::PeriodicallyCheckGcsServerAddress() {
       RayConfig::instance().gcs_service_address_check_interval_milliseconds());
   detect_timer_->expires_from_now(check_period);
   detect_timer_->async_wait([this](const boost::system::error_code &error) {
-    if (error == boost::system::errc::operation_canceled) {
+    if (error == boost::asio::error::operation_aborted) {
       // `operation_canceled` is set when `detect_timer_` is canceled or destroyed.
       return;
     }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -100,7 +100,7 @@ void GcsNodeManager::NodeFailureDetector::ScheduleTick() {
   detect_timer_.expires_from_now(heartbeat_period);
   detect_timer_.async_wait([this](const boost::system::error_code &error) {
     if (error == boost::asio::error::operation_aborted) {
-      // `operation_canceled` is set when `detect_timer_` is canceled or destroyed.
+      // `operation_aborted` is set when `detect_timer_` is canceled or destroyed.
       // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
       return;
     }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -99,7 +99,7 @@ void GcsNodeManager::NodeFailureDetector::ScheduleTick() {
       RayConfig::instance().raylet_heartbeat_timeout_milliseconds());
   detect_timer_.expires_from_now(heartbeat_period);
   detect_timer_.async_wait([this](const boost::system::error_code &error) {
-    if (error == boost::system::errc::operation_canceled) {
+    if (error == boost::asio::error::operation_aborted) {
       // `operation_canceled` is set when `detect_timer_` is canceled or destroyed.
       // The Monitor lifetime may be short than the object who use it. (e.g. gcs_server)
       return;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -221,7 +221,7 @@ void GcsPlacementGroupScheduler::CancelResourceReserve(
           return_timer_.expires_from_now(boost::posix_time::milliseconds(5));
           return_timer_.async_wait(
               [this, bundle_spec, node](const boost::system::error_code &error) {
-                if (error == boost::system::errc::operation_canceled) {
+                if (error == boost::asio::error::operation_aborted) {
                   return;
                 } else {
                   CancelResourceReserve(bundle_spec, node);

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -52,7 +52,7 @@ void GcsRedisFailureDetector::ScheduleTick() {
       RayConfig::instance().gcs_redis_heartbeat_interval_milliseconds());
   detect_timer_.expires_from_now(detect_period);
   detect_timer_.async_wait([this](const boost::system::error_code &error) {
-    if (error == boost::system::errc::operation_canceled) {
+    if (error == boost::asio::error::operation_aborted) {
       return;
     }
     RAY_CHECK(!error) << "Detecting redis failed with error: " << error.message();

--- a/src/ray/util/asio_util.h
+++ b/src/ray/util/asio_util.h
@@ -21,7 +21,7 @@ inline void execute_after(boost::asio::io_context &io_context,
   auto timer = std::make_shared<boost::asio::deadline_timer>(io_context);
   timer->expires_from_now(boost::posix_time::milliseconds(delay_milliseconds));
   timer->async_wait([timer, fn](const boost::system::error_code &error) {
-    if (error != boost::system::errc::operation_canceled && fn) {
+    if (error != boost::asio::error::operation_aborted && fn) {
       fn();
     }
   });


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Although `boost::system::errc::operation_canceled` and `boost::asio::error::operation_aborted` have the same value, but in the document of `boost::asio::deadline_timer`, the error code is `boost::asio::error::operation_aborted`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
