### PR TITLE
[Autoscaler] Making bootstrap config part of the node provider interface

### DIFF
--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -399,3 +399,8 @@ class AWSNodeProvider(NodeProvider):
     def cleanup(self):
         self.tag_cache_update_event.set()
         self.tag_cache_kill_event.set()
+
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        from ray.autoscaler.aws.config import bootstrap_aws
+        return bootstrap_aws(cluster_config)

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -9,6 +9,7 @@ import botocore
 from botocore.config import Config
 
 from ray.autoscaler.node_provider import NodeProvider
+from ray.autoscaler.aws.config import bootstrap_aws
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME, \
     TAG_RAY_LAUNCH_CONFIG, TAG_RAY_NODE_TYPE, TAG_RAY_INSTANCE_TYPE
 from ray.ray_constants import BOTO_MAX_RETRIES, BOTO_CREATE_MAX_RETRIES
@@ -402,5 +403,4 @@ class AWSNodeProvider(NodeProvider):
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        from ray.autoscaler.aws.config import bootstrap_aws
         return bootstrap_aws(cluster_config)

--- a/python/ray/autoscaler/azure/node_provider.py
+++ b/python/ray/autoscaler/azure/node_provider.py
@@ -13,6 +13,7 @@ from azure.mgmt.resource.resources.models import DeploymentMode
 from knack.util import CLIError
 
 from ray.autoscaler.node_provider import NodeProvider
+from ray.autoscaler.azure.config import bootstrap_azure
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 
 VM_NAME_MAX_LEN = 64
@@ -294,5 +295,4 @@ class AzureNodeProvider(NodeProvider):
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        from ray.autoscaler.azure.config import bootstrap_azure
         return bootstrap_azure(cluster_config)

--- a/python/ray/autoscaler/azure/node_provider.py
+++ b/python/ray/autoscaler/azure/node_provider.py
@@ -291,7 +291,7 @@ class AzureNodeProvider(NodeProvider):
         if node_id in self.cached_nodes:
             return self.cached_nodes[node_id]
         return self._get_node(node_id=node_id)
-    
+
     @staticmethod
     def bootstrap_config(cluster_config):
         from ray.autoscaler.azure.config import bootstrap_azure

--- a/python/ray/autoscaler/azure/node_provider.py
+++ b/python/ray/autoscaler/azure/node_provider.py
@@ -291,3 +291,8 @@ class AzureNodeProvider(NodeProvider):
         if node_id in self.cached_nodes:
             return self.cached_nodes[node_id]
         return self._get_node(node_id=node_id)
+    
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        from ray.autoscaler.azure.config import bootstrap_azure
+        return bootstrap_azure(cluster_config)

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -116,7 +116,7 @@ def _bootstrap_config(config, no_config_cache=False):
     if not importer:
         raise NotImplementedError("Unsupported provider {}".format(
             config["provider"]))
-    
+
     provider_cls = importer(config["provider"])
     resolved_config = provider_cls.bootstrap_config(config)
     if not no_config_cache:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -111,8 +111,8 @@ def _bootstrap_config(config, no_config_cache=False):
         logger.info("Using cached config at {}".format(cache_key))
         return json.loads(open(cache_key).read())
     validate_config(config)
-    provider_cls = get_node_provider(config["provider"], config["cluster_name"])
-    resolved_config = provider_cls.bootstrap_config(config)
+    provider = get_node_provider(config["provider"], config["cluster_name"])
+    resolved_config = provider.bootstrap_config(config)
     if not no_config_cache:
         with open(cache_key, "w") as f:
             f.write(json.dumps(resolved_config))

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -117,8 +117,8 @@ def _bootstrap_config(config, no_config_cache=False):
         raise NotImplementedError("Unsupported provider {}".format(
             config["provider"]))
 
-    bootstrap_config, _ = importer()
-    resolved_config = bootstrap_config(config)
+    provider_cls = importer()
+    resolved_config = provider_cls.bootstrap_config(config)
     if not no_config_cache:
         with open(cache_key, "w") as f:
             f.write(json.dumps(resolved_config))

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -111,10 +111,12 @@ def _bootstrap_config(config, no_config_cache=False):
         logger.info("Using cached config at {}".format(cache_key))
         return json.loads(open(cache_key).read())
     validate_config(config)
+
     importer = NODE_PROVIDERS.get(config["provider"]["type"])
     if not importer:
         raise NotImplementedError("Unsupported provider {}".format(
             config["provider"]))
+    
     provider_cls = importer(config["provider"])
     resolved_config = provider_cls.bootstrap_config(config)
     if not no_config_cache:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -111,13 +111,7 @@ def _bootstrap_config(config, no_config_cache=False):
         logger.info("Using cached config at {}".format(cache_key))
         return json.loads(open(cache_key).read())
     validate_config(config)
-
-    importer = NODE_PROVIDERS.get(config["provider"]["type"])
-    if not importer:
-        raise NotImplementedError("Unsupported provider {}".format(
-            config["provider"]))
-
-    provider_cls = importer()
+    provider_cls = get_node_provider(config["provider"], config["cluster_name"])
     resolved_config = provider_cls.bootstrap_config(config)
     if not no_config_cache:
         with open(cache_key, "w") as f:

--- a/python/ray/autoscaler/commands.py
+++ b/python/ray/autoscaler/commands.py
@@ -20,7 +20,7 @@ import ray.services as services
 from ray.autoscaler.util import validate_config, hash_runtime_conf, \
     hash_launch_conf, prepare_config, DEBUG_AUTOSCALING_ERROR, \
     DEBUG_AUTOSCALING_STATUS
-from ray.autoscaler.node_provider import get_node_provider, NODE_PROVIDERS
+from ray.autoscaler.node_provider import get_node_provider
 from ray.autoscaler.tags import TAG_RAY_NODE_TYPE, TAG_RAY_LAUNCH_CONFIG, \
     TAG_RAY_NODE_NAME, NODE_TYPE_WORKER, NODE_TYPE_HEAD
 

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -240,3 +240,8 @@ class GCPNodeProvider(NodeProvider):
             return self.cached_nodes[node_id]
 
         return self._get_node(node_id)
+    
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        from ray.autoscaler.gcp.config import bootstrap_gcp
+        return bootstrap_gcp(cluster_config)

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -240,7 +240,7 @@ class GCPNodeProvider(NodeProvider):
             return self.cached_nodes[node_id]
 
         return self._get_node(node_id)
-    
+
     @staticmethod
     def bootstrap_config(cluster_config):
         from ray.autoscaler.gcp.config import bootstrap_gcp

--- a/python/ray/autoscaler/gcp/node_provider.py
+++ b/python/ray/autoscaler/gcp/node_provider.py
@@ -4,6 +4,7 @@ import time
 import logging
 
 from ray.autoscaler.node_provider import NodeProvider
+from ray.autoscaler.gcp.config import bootstrap_gcp
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 from ray.autoscaler.gcp.config import MAX_POLLS, POLL_INTERVAL, \
         fetch_gcp_credentials_from_provider_config, _create_compute
@@ -243,5 +244,4 @@ class GCPNodeProvider(NodeProvider):
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        from ray.autoscaler.gcp.config import bootstrap_gcp
         return bootstrap_gcp(cluster_config)

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -2,6 +2,7 @@ import logging
 
 from ray.autoscaler.kubernetes import core_api, log_prefix
 from ray.autoscaler.node_provider import NodeProvider
+from ray.autoscaler.kubernetes.config import bootstrap_kubernetes
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
 from ray.autoscaler.updater import KubernetesCommandRunner
 
@@ -100,5 +101,4 @@ class KubernetesNodeProvider(NodeProvider):
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        from ray.autoscaler.kubernetes.config import bootstrap_kubernetes
         return bootstrap_kubernetes(cluster_config)

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -97,3 +97,8 @@ class KubernetesNodeProvider(NodeProvider):
                            docker_config=None):
         return KubernetesCommandRunner(log_prefix, self.namespace, node_id,
                                        auth_config, process_runner)
+    
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        from ray.autoscaler.kubernetes.config import bootstrap_kubernetes
+        return bootstrap_kubernetes(cluster_config)

--- a/python/ray/autoscaler/kubernetes/node_provider.py
+++ b/python/ray/autoscaler/kubernetes/node_provider.py
@@ -97,7 +97,7 @@ class KubernetesNodeProvider(NodeProvider):
                            docker_config=None):
         return KubernetesCommandRunner(log_prefix, self.namespace, node_id,
                                        auth_config, process_runner)
-    
+
     @staticmethod
     def bootstrap_config(cluster_config):
         from ray.autoscaler.kubernetes.config import bootstrap_kubernetes

--- a/python/ray/autoscaler/local/node_provider.py
+++ b/python/ray/autoscaler/local/node_provider.py
@@ -147,3 +147,8 @@ class LocalNodeProvider(NodeProvider):
         info = workers[node_id]
         info["state"] = "terminated"
         self.state.put(node_id, info)
+    
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        from ray.autoscaler.local.config import bootstrap_local
+        return bootstrap_local(cluster_config)

--- a/python/ray/autoscaler/local/node_provider.py
+++ b/python/ray/autoscaler/local/node_provider.py
@@ -147,7 +147,7 @@ class LocalNodeProvider(NodeProvider):
         info = workers[node_id]
         info["state"] = "terminated"
         self.state.put(node_id, info)
-    
+
     @staticmethod
     def bootstrap_config(cluster_config):
         from ray.autoscaler.local.config import bootstrap_local

--- a/python/ray/autoscaler/local/node_provider.py
+++ b/python/ray/autoscaler/local/node_provider.py
@@ -6,6 +6,7 @@ import socket
 import logging
 
 from ray.autoscaler.node_provider import NodeProvider
+from ray.autoscaler.local.config import bootstrap_local
 from ray.autoscaler.tags import TAG_RAY_NODE_TYPE, NODE_TYPE_WORKER, \
     NODE_TYPE_HEAD
 
@@ -150,5 +151,4 @@ class LocalNodeProvider(NodeProvider):
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        from ray.autoscaler.local.config import bootstrap_local
         return bootstrap_local(cluster_config)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -9,33 +9,28 @@ logger = logging.getLogger(__name__)
 
 
 def import_aws():
-    from ray.autoscaler.aws.config import bootstrap_aws
     from ray.autoscaler.aws.node_provider import AWSNodeProvider
-    return bootstrap_aws, AWSNodeProvider
+    return AWSNodeProvider.bootstrap_config, AWSNodeProvider
 
 
 def import_gcp():
-    from ray.autoscaler.gcp.config import bootstrap_gcp
     from ray.autoscaler.gcp.node_provider import GCPNodeProvider
-    return bootstrap_gcp, GCPNodeProvider
+    return GCPNodeProvider.bootstrap_config, GCPNodeProvider
 
 
 def import_azure():
-    from ray.autoscaler.azure.config import bootstrap_azure
     from ray.autoscaler.azure.node_provider import AzureNodeProvider
-    return bootstrap_azure, AzureNodeProvider
+    return AzureNodeProvider.bootstrap_config, AzureNodeProvider
 
 
 def import_local():
-    from ray.autoscaler.local.config import bootstrap_local
     from ray.autoscaler.local.node_provider import LocalNodeProvider
-    return bootstrap_local, LocalNodeProvider
+    return LocalNodeProvider.bootstrap_config, LocalNodeProvider
 
 
 def import_kubernetes():
-    from ray.autoscaler.kubernetes.config import bootstrap_kubernetes
     from ray.autoscaler.kubernetes.node_provider import KubernetesNodeProvider
-    return bootstrap_kubernetes, KubernetesNodeProvider
+    return KubernetesNodeProvider.bootstrap_config, KubernetesNodeProvider
 
 
 def load_local_example_config():
@@ -69,13 +64,12 @@ def load_azure_example_config():
 def import_external():
     """Mock a normal provider importer."""
 
-    def return_it_back(config):
-        if config["provider"]["custom_bootstrap_config"]:
-            provider_cls = load_class(path=config["provider"]["module"])
-            config = provider_cls.bootstrap_config(config)
+    def return_bootstrap_config(config):
+        provider_cls = load_class(path=config["provider"]["module"])
+        config = provider_cls.bootstrap_config(config)
         return config
 
-    return return_it_back, None
+    return return_bootstrap_config, None
 
 
 NODE_PROVIDERS = {
@@ -229,6 +223,11 @@ class NodeProvider:
         This is an optional method only required if using the resource
         demand scheduler."""
         return None
+
+    @staticmethod
+    def bootstrap_config(cluster_config):
+        """Bootstraps the cluster config."""
+        return cluster_config
 
     def get_command_runner(self,
                            log_prefix,

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -10,27 +10,27 @@ logger = logging.getLogger(__name__)
 
 def import_aws():
     from ray.autoscaler.aws.node_provider import AWSNodeProvider
-    return AWSNodeProvider.bootstrap_config, AWSNodeProvider
+    return AWSNodeProvider
 
 
 def import_gcp():
     from ray.autoscaler.gcp.node_provider import GCPNodeProvider
-    return GCPNodeProvider.bootstrap_config, GCPNodeProvider
+    return GCPNodeProvider
 
 
 def import_azure():
     from ray.autoscaler.azure.node_provider import AzureNodeProvider
-    return AzureNodeProvider.bootstrap_config, AzureNodeProvider
+    return AzureNodeProvider
 
 
 def import_local():
     from ray.autoscaler.local.node_provider import LocalNodeProvider
-    return LocalNodeProvider.bootstrap_config, LocalNodeProvider
+    return LocalNodeProvider
 
 
 def import_kubernetes():
     from ray.autoscaler.kubernetes.node_provider import KubernetesNodeProvider
-    return KubernetesNodeProvider.bootstrap_config, KubernetesNodeProvider
+    return KubernetesNodeProvider
 
 
 def load_local_example_config():
@@ -118,7 +118,7 @@ def get_node_provider(provider_config, cluster_name):
     if importer is None:
         raise NotImplementedError("Unsupported node provider: {}".format(
             provider_config["type"]))
-    _, provider_cls = importer()
+    provider_cls = importer()
     return provider_cls(provider_config, cluster_name)
 
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -70,6 +70,9 @@ def import_external():
     """Mock a normal provider importer."""
 
     def return_it_back(config):
+        if config["provider"]["custom_bootstrap_config"]:
+            provider_cls = load_class(path=config["provider"]["module"])
+            config = provider_cls.bootstrap_config(config)
         return config
 
     return return_it_back, None

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -64,10 +64,10 @@ def load_azure_example_config():
 def import_external():
     """Mock a normal provider importer."""
 
-    def return_bootstrap_config(config):
+    def return_bootstrap_config(cluster_config):
         provider_cls = load_class(path=config["provider"]["module"])
-        config = provider_cls.bootstrap_config(config)
-        return config
+        config = provider_cls.bootstrap_config(cluster_config)
+        return cluster_config
 
     return return_bootstrap_config, None
 

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -215,7 +215,7 @@ class NodeProvider:
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        """Bootstraps the cluster config."""
+        """Bootstraps the cluster config by filling in env defaults if needed."""
         return cluster_config
 
     def get_command_runner(self,

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -215,7 +215,7 @@ class NodeProvider:
 
     @staticmethod
     def bootstrap_config(cluster_config):
-        """Bootstraps the cluster config by filling in env defaults if needed."""
+        """Bootstraps the cluster config by adding env defaults if needed."""
         return cluster_config
 
     def get_command_runner(self,

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -61,17 +61,6 @@ def load_azure_example_config():
         os.path.dirname(ray_azure.__file__), "example-full.yaml")
 
 
-def import_external():
-    """Mock a normal provider importer."""
-
-    def return_bootstrap_config(cluster_config):
-        provider_cls = load_class(path=config["provider"]["module"])
-        config = provider_cls.bootstrap_config(cluster_config)
-        return cluster_config
-
-    return return_bootstrap_config, None
-
-
 NODE_PROVIDERS = {
     "local": import_local,
     "aws": import_aws,
@@ -79,7 +68,7 @@ NODE_PROVIDERS = {
     "azure": import_azure,
     "kubernetes": import_kubernetes,
     "docker": None,
-    "external": import_external  # Import an external module
+    "external": None  # Import an external module
 }
 
 DEFAULT_CONFIGS = {

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -280,7 +280,7 @@ class LoadMetricsTest(unittest.TestCase):
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):
         NODE_PROVIDERS["mock"] = \
-            lambda x: self.create_provider
+            lambda config: self.create_provider
         self.provider = None
         self.tmpdir = tempfile.mkdtemp()
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -280,7 +280,7 @@ class LoadMetricsTest(unittest.TestCase):
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):
         NODE_PROVIDERS["mock"] = \
-            lambda: (None, self.create_provider)
+            lambda: self.create_provider
         self.provider = None
         self.tmpdir = tempfile.mkdtemp()
 

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -280,7 +280,7 @@ class LoadMetricsTest(unittest.TestCase):
 class AutoscalingTest(unittest.TestCase):
     def setUp(self):
         NODE_PROVIDERS["mock"] = \
-            lambda: self.create_provider
+            lambda x: self.create_provider
         self.provider = None
         self.tmpdir = tempfile.mkdtemp()
 


### PR DESCRIPTION

## Why are these changes needed?
Allows for having a custom bootstrap config function for external node providers

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
