### PR TITLE
Add dashboard dependencies to default ray installation

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -70,33 +70,6 @@ For example, here are the Ray 0.9.0.dev0 wheels for Python 3.5, MacOS for commit
 
     pip install https://ray-wheels.s3-us-west-2.amazonaws.com/master/a0ba4499ac645c9d3e82e68f3a281e48ad57f873/ray-0.9.0.dev0-cp35-cp35m-macosx_10_13_intel.whl
 
-
-Installing Dashboard
---------------------
-
-The dashboard requires a few additional Python packages, which can be installed
-via pip.
-
-.. code-block:: bash
-
-  pip install ray[dashboard]
-
-The command ``ray.init()`` or ``ray start --head`` will print out the address of
-the dashboard. For example,
-
-.. code-block:: python
-
-  >>> import ray
-  >>> ray.init()
-  ======================================================================
-  View the dashboard at http://127.0.0.1:8265.
-  Note: If Ray is running on a remote node, you will need to set up an
-  SSH tunnel with local port forwarding in order to access the dashboard
-  in your browser, e.g. by running 'ssh -L 8265:127.0.0.1:8265
-  <username>@<host>'. Alternatively, you can set dashboard_host="0.0.0.0" in
-  the call to ray.init() to allow direct access from external machines.
-  ======================================================================
-
 .. _windows-support:
 
 Windows Support

--- a/python/setup.py
+++ b/python/setup.py
@@ -81,7 +81,7 @@ if "RAY_USE_NEW_GCS" in os.environ and os.environ["RAY_USE_NEW_GCS"] == "on":
 
 extras = {
     "debug": [],
-    "dashboard": ["requests", "gpustat"],
+    "dashboard": [],
     "serve": ["uvicorn", "flask", "blist", "requests"],
     "tune": ["tabulate", "tensorboardX", "pandas"]
 }
@@ -191,6 +191,7 @@ requires = [
     "colorama",
     "filelock",
     "google",
+    "gpustat",
     "grpcio",
     "jsonschema",
     "msgpack >= 0.6.0, < 2.0.0",
@@ -198,6 +199,7 @@ requires = [
     "protobuf >= 3.8.0",
     "py-spy >= 0.2.0",
     "pyyaml",
+    "requests", 
     "redis >= 3.3.2, < 3.5.0",
 ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -81,7 +81,6 @@ if "RAY_USE_NEW_GCS" in os.environ and os.environ["RAY_USE_NEW_GCS"] == "on":
 
 extras = {
     "debug": [],
-    "dashboard": [],
     "serve": ["uvicorn", "flask", "blist", "requests"],
     "tune": ["tabulate", "tensorboardX", "pandas"]
 }

--- a/python/setup.py
+++ b/python/setup.py
@@ -199,7 +199,7 @@ requires = [
     "protobuf >= 3.8.0",
     "py-spy >= 0.2.0",
     "pyyaml",
-    "requests", 
+    "requests",
     "redis >= 3.3.2, < 3.5.0",
 ]
 


### PR DESCRIPTION
…install to prevent the confusing scenario where a user might see the dashboard but, for example, GPU information will be imissing.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Currently, we include the dashboard in the default ray build and start it along with a cluster. However, we require a user to explicitly install the dashboard (e.g. `pip install ray[dashboard]`) in order to install `gpustats` and `requests`, two libraries on which the dashboard depends for full functionality. This means, for example, the dashboard may show a user "N/A" for their GPU information even though they have GPUs because the library isn't installed.

Thus, we will begin to install these packages with the default Ray build.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested (please justify below)

I tested this by changing the configuration, uninstalling ray and related libraries, reinstalling from source, and ensuring the two new libraries were installed.
