### PR TITLE
[core] Handle out-of-order actor table notifications

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -167,6 +167,7 @@ def test_actor_restart(ray_init_with_task_retry_delay):
     results = [actor.increase.remote() for _ in range(100)]
     # Kill actor process, while the above task is still being executed.
     os.kill(pid, SIGKILL)
+    wait_for_pid_to_exit(pid)
     # Make sure that all tasks were executed in order before the actor's death.
     res = results.pop(0)
     i = 1
@@ -245,6 +246,7 @@ def test_actor_restart_with_retry(ray_init_with_task_retry_delay):
     results = [actor.increase.remote() for _ in range(100)]
     # Kill actor process, while the above task is still being executed.
     os.kill(pid, SIGKILL)
+    wait_for_pid_to_exit(pid)
     # Check that none of the tasks failed and the actor is restarted.
     seq = list(range(1, 101))
     results = ray.get(results)
@@ -265,6 +267,7 @@ def test_actor_restart_with_retry(ray_init_with_task_retry_delay):
     results = [actor.increase.remote() for _ in range(100)]
     pid = ray.get(actor.get_pid.remote())
     os.kill(pid, SIGKILL)
+    wait_for_pid_to_exit(pid)
     # The actor has exceeded max restarts, and this task should fail.
     with pytest.raises(ray.exceptions.RayActorError):
         ray.get(actor.increase.remote())

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -208,6 +208,7 @@ def test_actor_restart(ray_init_with_task_retry_delay):
     results = [actor.increase.remote() for _ in range(100)]
     pid = ray.get(actor.get_pid.remote())
     os.kill(pid, SIGKILL)
+    wait_for_pid_to_exit(pid)
     # The actor has exceeded max restarts, and this task should fail.
     with pytest.raises(ray.exceptions.RayActorError):
         ray.get(actor.increase.remote())

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -166,9 +166,9 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
   if (actor_data.state() == gcs::ActorTableData::PENDING) {
     // The actor is being created and not yet ready, just ignore!
   } else if (actor_data.state() == gcs::ActorTableData::RESTARTING) {
-    direct_actor_submitter_->DisconnectActor(actor_id, false);
+    direct_actor_submitter_->DisconnectActor(actor_id, actor_data.num_restarts(), false);
   } else if (actor_data.state() == gcs::ActorTableData::DEAD) {
-    direct_actor_submitter_->DisconnectActor(actor_id, true);
+    direct_actor_submitter_->DisconnectActor(actor_id, actor_data.num_restarts(), true);
     // We cannot erase the actor handle here because clients can still
     // submit tasks to dead actors. This also means we defer unsubscription,
     // otherwise we crash when bulk unsubscribing all actor handles.

--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -153,6 +153,16 @@ void ActorManager::WaitForActorOutOfScope(
 
 void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
                                                 const gcs::ActorTableData &actor_data) {
+  const auto &actor_state = gcs::ActorTableData::ActorState_Name(actor_data.state());
+  RAY_LOG(INFO) << "received notification on actor, state: " << actor_state
+                << ", actor_id: " << actor_id
+                << ", ip address: " << actor_data.address().ip_address()
+                << ", port: " << actor_data.address().port() << ", worker_id: "
+                << WorkerID::FromBinary(actor_data.address().worker_id())
+                << ", raylet_id: "
+                << ClientID::FromBinary(actor_data.address().raylet_id())
+                << ", num_restarts: " << actor_data.num_restarts();
+
   if (actor_data.state() == gcs::ActorTableData::PENDING) {
     // The actor is being created and not yet ready, just ignore!
   } else if (actor_data.state() == gcs::ActorTableData::RESTARTING) {
@@ -163,17 +173,9 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
     // submit tasks to dead actors. This also means we defer unsubscription,
     // otherwise we crash when bulk unsubscribing all actor handles.
   } else {
-    direct_actor_submitter_->ConnectActor(actor_id, actor_data.address());
+    direct_actor_submitter_->ConnectActor(actor_id, actor_data.address(),
+                                          actor_data.num_restarts());
   }
-
-  const auto &actor_state = gcs::ActorTableData::ActorState_Name(actor_data.state());
-  RAY_LOG(INFO) << "received notification on actor, state: " << actor_state
-                << ", actor_id: " << actor_id
-                << ", ip address: " << actor_data.address().ip_address()
-                << ", port: " << actor_data.address().port() << ", worker_id: "
-                << WorkerID::FromBinary(actor_data.address().worker_id())
-                << ", raylet_id: "
-                << ClientID::FromBinary(actor_data.address().raylet_id());
 }
 
 std::vector<ObjectID> ActorManager::GetActorHandleIDsFromHandles() {

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -77,7 +77,8 @@ class MockDirectActorSubmitter : public CoreWorkerDirectActorTaskSubmitterInterf
   MockDirectActorSubmitter() : CoreWorkerDirectActorTaskSubmitterInterface() {}
 
   MOCK_METHOD1(AddActorQueueIfNotExists, void(const ActorID &actor_id));
-  MOCK_METHOD2(ConnectActor, void(const ActorID &actor_id, const rpc::Address &address));
+  MOCK_METHOD3(ConnectActor, void(const ActorID &actor_id, const rpc::Address &address,
+                                  int64_t num_restarts));
   MOCK_METHOD2(DisconnectActor, void(const ActorID &actor_id, bool dead));
   MOCK_METHOD3(KillActor,
                void(const ActorID &actor_id, bool force_kill, bool no_restart));
@@ -189,7 +190,7 @@ TEST_F(ActorManagerTest, TestAddAndGetActorHandleEndToEnd) {
   ASSERT_TRUE(actor_handle_to_get->GetActorID() == actor_id);
 
   // Check after the actor is created, if it is connected to an actor.
-  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _)).Times(1);
+  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(1);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(
@@ -242,7 +243,7 @@ TEST_F(ActorManagerTest, RegisterActorHandles) {
 TEST_F(ActorManagerTest, TestActorStateNotificationPending) {
   ActorID actor_id = AddActorHandle();
   // Nothing happens if state is pending.
-  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _)).Times(0);
+  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
   EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(0);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
@@ -255,7 +256,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationPending) {
 TEST_F(ActorManagerTest, TestActorStateNotificationRestarting) {
   ActorID actor_id = AddActorHandle();
   // Should disconnect to an actor when actor is restarting.
-  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _)).Times(0);
+  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
   EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(1);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
@@ -268,7 +269,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationRestarting) {
 TEST_F(ActorManagerTest, TestActorStateNotificationDead) {
   ActorID actor_id = AddActorHandle();
   // Should disconnect to an actor when actor is dead.
-  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _)).Times(0);
+  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
   EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(1);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
@@ -281,7 +282,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationDead) {
 TEST_F(ActorManagerTest, TestActorStateNotificationAlive) {
   ActorID actor_id = AddActorHandle();
   // Should connect to an actor when actor is alive.
-  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _)).Times(1);
+  EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(1);
   EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(0);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -79,7 +79,8 @@ class MockDirectActorSubmitter : public CoreWorkerDirectActorTaskSubmitterInterf
   MOCK_METHOD1(AddActorQueueIfNotExists, void(const ActorID &actor_id));
   MOCK_METHOD3(ConnectActor, void(const ActorID &actor_id, const rpc::Address &address,
                                   int64_t num_restarts));
-  MOCK_METHOD2(DisconnectActor, void(const ActorID &actor_id, bool dead));
+  MOCK_METHOD3(DisconnectActor,
+               void(const ActorID &actor_id, int64_t num_restarts, bool dead));
   MOCK_METHOD3(KillActor,
                void(const ActorID &actor_id, bool force_kill, bool no_restart));
 
@@ -198,7 +199,7 @@ TEST_F(ActorManagerTest, TestAddAndGetActorHandleEndToEnd) {
   actor_info_accessor_->ActorStateNotificationPublished(actor_id, actor_table_data);
 
   // Now actor state is updated to DEAD. Make sure it is diconnected.
-  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(1);
+  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _, _)).Times(1);
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(
       rpc::ActorTableData_ActorState::ActorTableData_ActorState_DEAD);
@@ -244,7 +245,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationPending) {
   ActorID actor_id = AddActorHandle();
   // Nothing happens if state is pending.
   EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
-  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(0);
+  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _, _)).Times(0);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(
@@ -257,7 +258,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationRestarting) {
   ActorID actor_id = AddActorHandle();
   // Should disconnect to an actor when actor is restarting.
   EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
-  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(1);
+  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _, _)).Times(1);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(
@@ -270,7 +271,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationDead) {
   ActorID actor_id = AddActorHandle();
   // Should disconnect to an actor when actor is dead.
   EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(0);
-  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(1);
+  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _, _)).Times(1);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(
@@ -283,7 +284,7 @@ TEST_F(ActorManagerTest, TestActorStateNotificationAlive) {
   ActorID actor_id = AddActorHandle();
   // Should connect to an actor when actor is alive.
   EXPECT_CALL(*direct_actor_submitter_, ConnectActor(_, _, _)).Times(1);
-  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _)).Times(0);
+  EXPECT_CALL(*direct_actor_submitter_, DisconnectActor(_, _, _)).Times(0);
   rpc::ActorTableData actor_table_data;
   actor_table_data.set_actor_id(actor_id.Binary());
   actor_table_data.set_state(

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -127,11 +127,13 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
 
   auto queue = client_queues_.find(actor_id);
   RAY_CHECK(queue != client_queues_.end());
-  if (num_restarts <= queue->second.num_restarts) {
-    // This message is about an old version of the actor. Skip the connection.
+  if (num_restarts < queue->second.num_restarts) {
+    // This message is about an old version of the actor and the actor has
+    // already restarted since then. Skip the connection.
     return;
   }
 
+  queue->second.num_restarts = num_restarts;
   if (queue->second.rpc_client) {
     // Clear the client to the old version of the actor.
     DisconnectRpcClient(queue->second);
@@ -154,16 +156,16 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
 }
 
 void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
+                                                         int64_t num_restarts,
                                                          bool dead) {
   RAY_LOG(DEBUG) << "Disconnecting from actor " << actor_id;
   absl::MutexLock lock(&mu_);
   auto queue = client_queues_.find(actor_id);
   RAY_CHECK(queue != client_queues_.end());
-
-  if (dead) {
-    queue->second.state = rpc::ActorTableData::DEAD;
-  } else {
-    queue->second.state = rpc::ActorTableData::RESTARTING;
+  if (num_restarts <= queue->second.num_restarts && !dead) {
+    // This message is about an old version of the actor that has already been
+    // restarted successfully. Skip the message handling.
+    return;
   }
 
   // The actor failed, so erase the client for now. Either the actor is
@@ -171,8 +173,9 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(const ActorID &actor_id
   // restarted.
   DisconnectRpcClient(queue->second);
 
-  // If there are pending requests, treat the pending tasks as failed.
   if (dead) {
+    queue->second.state = rpc::ActorTableData::DEAD;
+    // If there are pending requests, treat the pending tasks as failed.
     RAY_LOG(INFO) << "Failing pending tasks for actor " << actor_id;
     auto &requests = queue->second.requests;
     auto head = requests.begin();
@@ -191,6 +194,11 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(const ActorID &actor_id
     // replies. They will be treated as failed once the connection dies.
     // We retain the sequencing information so that we can properly fail
     // any tasks submitted after the actor death.
+  } else if (queue->second.state != rpc::ActorTableData::DEAD) {
+    // Only update the actor's state if it is not permanently dead. The actor
+    // will eventually get restarted or marked as permanently dead.
+    queue->second.state = rpc::ActorTableData::RESTARTING;
+    queue->second.num_restarts = num_restarts;
   }
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -112,17 +112,29 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(TaskSpecification task_spe
   return Status::OK();
 }
 
+void CoreWorkerDirectActorTaskSubmitter::DisconnectRpcClient(ClientQueue &queue) {
+  queue.rpc_client = nullptr;
+  queue.worker_id.clear();
+  queue.pending_force_kill.reset();
+}
+
 void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
-                                                      const rpc::Address &address) {
+                                                      const rpc::Address &address,
+                                                      int64_t num_restarts) {
+  RAY_LOG(DEBUG) << "Connecting to actor " << actor_id << " at worker "
+                 << WorkerID::FromBinary(address.worker_id());
   absl::MutexLock lock(&mu_);
 
   auto queue = client_queues_.find(actor_id);
   RAY_CHECK(queue != client_queues_.end());
-  if (queue->second.rpc_client) {
-    // Skip reconnection if we already have a client to this actor.
-    // NOTE(swang): This seems to only trigger in multithreaded Java tests.
-    RAY_CHECK(queue->second.worker_id == address.worker_id());
+  if (num_restarts <= queue->second.num_restarts) {
+    // This message is about an old version of the actor. Skip the connection.
     return;
+  }
+
+  if (queue->second.rpc_client) {
+    // Clear the client to the old version of the actor.
+    DisconnectRpcClient(queue->second);
   }
 
   queue->second.state = rpc::ActorTableData::ALIVE;
@@ -143,6 +155,7 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
 
 void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
                                                          bool dead) {
+  RAY_LOG(DEBUG) << "Disconnecting from actor " << actor_id;
   absl::MutexLock lock(&mu_);
   auto queue = client_queues_.find(actor_id);
   RAY_CHECK(queue != client_queues_.end());
@@ -156,9 +169,7 @@ void CoreWorkerDirectActorTaskSubmitter::DisconnectActor(const ActorID &actor_id
   // The actor failed, so erase the client for now. Either the actor is
   // permanently dead or the new client will be inserted once the actor is
   // restarted.
-  queue->second.rpc_client = nullptr;
-  queue->second.worker_id.clear();
-  queue->second.pending_force_kill.reset();
+  DisconnectRpcClient(queue->second);
 
   // If there are pending requests, treat the pending tasks as failed.
   if (dead) {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -50,7 +50,8 @@ const int kMaxReorderWaitSeconds = 30;
 class CoreWorkerDirectActorTaskSubmitterInterface {
  public:
   virtual void AddActorQueueIfNotExists(const ActorID &actor_id) = 0;
-  virtual void ConnectActor(const ActorID &actor_id, const rpc::Address &address) = 0;
+  virtual void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
+                            int64_t num_restarts) = 0;
   virtual void DisconnectActor(const ActorID &actor_id, bool dead = false) = 0;
   virtual void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart) = 0;
 
@@ -95,7 +96,11 @@ class CoreWorkerDirectActorTaskSubmitter
   ///
   /// \param[in] actor_id Actor ID.
   /// \param[in] address The new address of the actor.
-  void ConnectActor(const ActorID &actor_id, const rpc::Address &address);
+  /// \param[in] num_restarts How many times this actor was alive
+  /// before. If we've already seen a later incarnation of the actor,
+  /// we will ignore the command to connect.
+  void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
+                    int64_t num_restarts);
 
   /// Disconnect from a failed actor.
   ///
@@ -111,6 +116,10 @@ class CoreWorkerDirectActorTaskSubmitter
     /// an RPC client to the actor. If this is DEAD, then all tasks in the
     /// queue will be marked failed and all other ClientQueue state is ignored.
     rpc::ActorTableData::ActorState state = rpc::ActorTableData::PENDING;
+    /// How many times this actor has restarted so far. Starts at -1 to
+    /// indicate that the actor is not yet created. This is used to drop stale
+    /// messages from the GCS.
+    int64_t num_restarts = -1;
     /// The RPC client. We use shared_ptr to enable shared_from_this for
     /// pending client callbacks.
     std::shared_ptr<rpc::CoreWorkerClientInterface> rpc_client = nullptr;
@@ -192,6 +201,9 @@ class CoreWorkerDirectActorTaskSubmitter
   /// \param[in] actor_id Actor ID.
   /// \return Void.
   void SendPendingTasks(const ActorID &actor_id) EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Disconnect the RPC client for an actor.
+  void DisconnectRpcClient(ClientQueue &queue) EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Whether the specified actor is alive.
   ///

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -52,7 +52,8 @@ class CoreWorkerDirectActorTaskSubmitterInterface {
   virtual void AddActorQueueIfNotExists(const ActorID &actor_id) = 0;
   virtual void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
                             int64_t num_restarts) = 0;
-  virtual void DisconnectActor(const ActorID &actor_id, bool dead = false) = 0;
+  virtual void DisconnectActor(const ActorID &actor_id, int64_t num_restarts,
+                               bool dead = false) = 0;
   virtual void KillActor(const ActorID &actor_id, bool force_kill, bool no_restart) = 0;
 
   virtual ~CoreWorkerDirectActorTaskSubmitterInterface() {}
@@ -96,16 +97,21 @@ class CoreWorkerDirectActorTaskSubmitter
   ///
   /// \param[in] actor_id Actor ID.
   /// \param[in] address The new address of the actor.
-  /// \param[in] num_restarts How many times this actor was alive
-  /// before. If we've already seen a later incarnation of the actor,
-  /// we will ignore the command to connect.
+  /// \param[in] num_restarts How many times this actor has been restarted
+  /// before. If we've already seen a later incarnation of the actor, we will
+  /// ignore the command to connect.
   void ConnectActor(const ActorID &actor_id, const rpc::Address &address,
                     int64_t num_restarts);
 
   /// Disconnect from a failed actor.
   ///
   /// \param[in] actor_id Actor ID.
-  void DisconnectActor(const ActorID &actor_id, bool dead = false);
+  /// \param[in] num_restarts How many times this actor has been restarted
+  /// before. If we've already seen a later incarnation of the actor, we will
+  /// ignore the command to connect.
+  /// \param[in] dead Whether the actor is permanently dead. In this case, all
+  /// pending tasks for the actor should be failed.
+  void DisconnectActor(const ActorID &actor_id, int64_t num_restarts, bool dead = false);
 
   /// Set the timerstamp for the caller.
   void SetCallerCreationTimestamp(int64_t timestamp);
@@ -116,7 +122,7 @@ class CoreWorkerDirectActorTaskSubmitter
     /// an RPC client to the actor. If this is DEAD, then all tasks in the
     /// queue will be marked failed and all other ClientQueue state is ignored.
     rpc::ActorTableData::ActorState state = rpc::ActorTableData::PENDING;
-    /// How many times this actor has restarted so far. Starts at -1 to
+    /// How many times this actor has been restarted before. Starts at -1 to
     /// indicate that the actor is not yet created. This is used to drop stale
     /// messages from the GCS.
     int64_t num_restarts = -1;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -652,7 +652,6 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
                    << " at node " << node_id << ", need_reschedule = " << need_reschedule
                    << ", remaining_restarts = " << remaining_restarts;
   if (remaining_restarts != 0) {
-    mutable_actor_table_data->set_num_restarts(++num_restarts);
     mutable_actor_table_data->set_state(rpc::ActorTableData::RESTARTING);
     const auto actor_table_data = actor->GetActorTableData();
     // Make sure to reset the address before flushing to GCS. Otherwise,
@@ -668,6 +667,7 @@ void GcsActorManager::ReconstructActor(const ActorID &actor_id, bool need_resche
                                              nullptr));
         }));
     gcs_actor_scheduler_->Schedule(actor);
+    mutable_actor_table_data->set_num_restarts(num_restarts + 1);
   } else {
     // Remove actor from `named_actors_` if its name is not empty.
     if (!actor->GetName().empty()) {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -127,7 +127,9 @@ message ActorTableData {
   // Max number of times this actor should be restarted,
   // a value of -1 indicates an infinite number of reconstruction attempts.
   int64 max_restarts = 7;
-  // Number of restarts that have already been performed on this actor.
+  // Number of restarts that have been successfully performed on this
+  // actor. This is the equal to the number of ALIVE messages that have been
+  // previously published for this actor.
   uint64 num_restarts = 8;
   // The address of the the actor.
   Address address = 9;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The GCS service seems to produce out-of-order pubsub notifications. This can cause problems when the client assumes that notifications come in a specific order, as we do for the actor table.

This fixes the issue by dropping stale actor table notifications at the client (the core worker).

This should also fix the flaky travis test `test_actor_advanced.py::test_reconstruction_suppression`.

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
