### PR TITLE
[docker] Include base-deps image in rayproject Docker Hub

### DIFF
--- a/ci/travis/build-autoscaler-images.sh
+++ b/ci/travis/build-autoscaler-images.sh
@@ -15,15 +15,18 @@ if [[ "$TRAVIS" == "true" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     commit_sha=$(echo $TRAVIS_COMMIT | head -c 6)
     cp -r $ROOT_DIR/.whl $ROOT_DIR/docker/autoscaler/.whl
 
-    docker build -q -t rayproject/base-deps:$commit_sha docker/base-deps
-    docker push rayproject/base-deps:$commit_sha
+    docker build -q -t rayproject/base-deps docker/base-deps
 
     docker build \
         --build-arg WHEEL_PATH=".whl/$wheel" \
         --build-arg WHEEL_NAME=$wheel \
         -t rayproject/autoscaler:$commit_sha \
         $ROOT_DIR/docker/autoscaler
+
+    docker tag rayproject/base-deps rayproject/base-deps:$commit_sha 
+    docker push rayproject/base-deps:$commit_sha
     docker push rayproject/autoscaler:$commit_sha
+
 
     # We have a branch build, e.g. release/v0.7.0
     if [[ "$TRAVIS_BRANCH" != "master" ]]; then

--- a/ci/travis/build-autoscaler-images.sh
+++ b/ci/travis/build-autoscaler-images.sh
@@ -11,11 +11,12 @@ DOCKER_USERNAME="raytravisbot"
 if [[ "$TRAVIS" == "true" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-    docker build -q -t rayproject/base-deps docker/base-deps
-
     wheel=$(cd $ROOT_DIR/.whl; ls | grep cp36m-manylinux)
     commit_sha=$(echo $TRAVIS_COMMIT | head -c 6)
     cp -r $ROOT_DIR/.whl $ROOT_DIR/docker/autoscaler/.whl
+
+    docker build -q -t rayproject/base-deps:$commit_sha docker/base-deps
+    docker push rayproject/base-deps:$commit_sha
 
     docker build \
         --build-arg WHEEL_PATH=".whl/$wheel" \
@@ -29,10 +30,14 @@ if [[ "$TRAVIS" == "true" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
        # Replace / in branch name to - so it is legal tag name
        normalized_branch_name=$(echo $TRAVIS_BRANCH | sed -e "s/\//-/")
        docker tag rayproject/autoscaler:$commit_sha rayproject/autoscaler:$normalized_branch_name
+       docker tag rayproject/base-deps:$commit_sha rayproject/base-deps:$normalized_branch_name
        docker push rayproject/autoscaler:$normalized_branch_name
+       docker push rayproject/base-deps:$normalized_branch_name
     else
        docker tag rayproject/autoscaler:$commit_sha rayproject/autoscaler:latest
+       docker tag rayproject/base-deps:$commit_sha rayproject/base-deps:latest
        docker push rayproject/autoscaler:latest
+       docker push rayproject/base-deps:latest
     fi
 fi
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
The base image has the minimal requirements to run the auotoscaler. It is convenient because it is much smaller than the `rayproject/autoscaler` image. We already build it on each commit, but we might as well push it to docker hub. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
