### PR TITLE
[tune] Issue 8821: ExperimentAnalysis doesn't expand user

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -201,6 +201,10 @@ class ExperimentAnalysis(Analysis):
     """
 
     def __init__(self, experiment_checkpoint_path, trials=None):
+        experiment_checkpoint_path = os.path.expanduser(experiment_checkpoint_path)
+        if not os.path.isfile(experiment_checkpoint_path):
+            raise ValueError(
+                "{} is not a valid file; file representing the experiment state does not exist.".format(experiment_checkpoint_path))
         with open(experiment_checkpoint_path) as f:
             _experiment_state = json.load(f)
             self._experiment_state = _experiment_state

--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -201,6 +201,11 @@ class ExperimentAnalysis(Analysis):
     """
 
     def __init__(self, experiment_checkpoint_path, trials=None):
+        experiment_checkpoint_path = os.path.expanduser(
+            experiment_checkpoint_path)
+        if not os.path.isfile(experiment_checkpoint_path):
+            raise ValueError(
+                "{} is not a valid file.".format(experiment_checkpoint_path))
         with open(experiment_checkpoint_path) as f:
             _experiment_state = json.load(f)
             self._experiment_state = _experiment_state

--- a/python/ray/tune/tests/test_experiment_analysis_mem.py
+++ b/python/ray/tune/tests/test_experiment_analysis_mem.py
@@ -1,12 +1,15 @@
+import json
 import unittest
 import shutil
 import tempfile
+import os
 import random
 import pandas as pd
+import pytest
 import numpy as np
 
 import ray
-from ray.tune import run, Trainable, sample_from, Analysis, grid_search
+from ray.tune import run, Trainable, sample_from, ExperimentAnalysis, Analysis, grid_search
 from ray.tune.examples.async_hyperband_example import MyTrainableClass
 
 
@@ -37,14 +40,32 @@ class ExperimentAnalysisInMemorySuite(unittest.TestCase):
                 pass
 
         self.MockTrainable = MockTrainable
+        self.test_dir = tempfile.mkdtemp()
         ray.init(local_mode=False, num_cpus=1)
 
     def tearDown(self):
         shutil.rmtree(self.test_dir, ignore_errors=True)
         ray.shutdown()
 
+    def testInit(self):
+        experiment_checkpoint_path = os.path.join(self.test_dir, "experiment_state.json")
+        checkpoint_data = {"checkpoints": [
+        {"trainable_name": "MockTrainable",
+        "logdir": "/mock/test/MockTrainable_3_id=3_2020-07-12_17-07-27xwqh4_47"}]}
+
+        with open(experiment_checkpoint_path, "w") as f:
+            f.write(json.dumps(checkpoint_data))
+
+        experiment_analysis = ExperimentAnalysis(experiment_checkpoint_path)
+        self.assertEqual(len(experiment_analysis._checkpoints), 1)
+        self.assertTrue(experiment_analysis.trials is None)
+
+    def testInitException(self):
+        experiment_checkpoint_path = os.path.join(self.test_dir, "mock.json")
+        with pytest.raises(ValueError):
+            experiment_analysis = ExperimentAnalysis(experiment_checkpoint_path)
+
     def testCompareTrials(self):
-        self.test_dir = tempfile.mkdtemp()
         scores = np.asarray(list(self.MockTrainable.scores_dict.values()))
         scores_all = scores.flatten("F")
         scores_last = scores_all[5:]
@@ -126,7 +147,7 @@ class AnalysisSuite(unittest.TestCase):
         analysis = Analysis(self.test_dir)
         df = analysis.dataframe()
         self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertEquals(df.shape[0], self.num_samples * 2)
+        self.assertEqual(df.shape[0], self.num_samples * 2)
 
     def testBestLogdir(self):
         analysis = Analysis(self.test_dir)
@@ -134,17 +155,16 @@ class AnalysisSuite(unittest.TestCase):
         self.assertTrue(logdir.startswith(self.test_dir))
         logdir2 = analysis.get_best_logdir(self.metric, mode="min")
         self.assertTrue(logdir2.startswith(self.test_dir))
-        self.assertNotEquals(logdir, logdir2)
+        self.assertNotEqual(logdir, logdir2)
 
     def testBestConfigIsLogdir(self):
         analysis = Analysis(self.test_dir)
         for metric, mode in [(self.metric, "min"), (self.metric, "max")]:
             logdir = analysis.get_best_logdir(metric, mode=mode)
             best_config = analysis.get_best_config(metric, mode=mode)
-            self.assertEquals(analysis.get_all_configs()[logdir], best_config)
+            self.assertEqual(analysis.get_all_configs()[logdir], best_config)
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/test_experiment_analysis_mem.py
+++ b/python/ray/tune/tests/test_experiment_analysis_mem.py
@@ -9,7 +9,8 @@ import pytest
 import numpy as np
 
 import ray
-from ray.tune import run, Trainable, sample_from, ExperimentAnalysis, Analysis, grid_search
+from ray.tune import (run, Trainable, sample_from, Analysis,
+                      ExperimentAnalysis, grid_search)
 from ray.tune.examples.async_hyperband_example import MyTrainableClass
 
 
@@ -53,7 +54,7 @@ class ExperimentAnalysisInMemorySuite(unittest.TestCase):
         checkpoint_data = {
             "checkpoints": [{
                 "trainable_name": "MockTrainable",
-                "logdir": "/mock/test/MockTrainable_3_id=3_2020-07-12_17-07-27xwqh4_47"
+                "logdir": "/mock/test/MockTrainable_0_id=3_2020-07-12"
             }]
         }
 
@@ -67,8 +68,7 @@ class ExperimentAnalysisInMemorySuite(unittest.TestCase):
     def testInitException(self):
         experiment_checkpoint_path = os.path.join(self.test_dir, "mock.json")
         with pytest.raises(ValueError):
-            experiment_analysis = ExperimentAnalysis(
-                experiment_checkpoint_path)
+            ExperimentAnalysis(experiment_checkpoint_path)
 
     def testCompareTrials(self):
         scores = np.asarray(list(self.MockTrainable.scores_dict.values()))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fixes 8821 (small bug when using ~ to specify experiment checkpoint path without expanduser) and added unit tests 

## Related issue number

Closes #8821 

## Checks

- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
