### PR TITLE
[tune] fix checkpoint bookkeeping, fixing pbt errors

### DIFF
--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -144,9 +144,12 @@ class CheckpointManager:
             # next on_checkpoint() call since it isn't in self._membership.
             self._delete(worst, remove_dir=False)
         else:
-            self.newest_persistent_checkpoint = Checkpoint(
-                Checkpoint.PERSISTENT, None)
-            self._update_newest_persistent_checkpoint()
+            if old_checkpoint in self._membership:
+                self.newest_persistent_checkpoint = old_checkpoint
+            else:
+                self.newest_persistent_checkpoint = Checkpoint(
+                    Checkpoint.PERSISTENT, None)
+                self._update_newest_persistent_checkpoint()
 
     def best_checkpoints(self):
         """Returns best PERSISTENT checkpoints, sorted by score."""

--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -94,6 +94,13 @@ class CheckpointManager:
             key=lambda c: c.result.get(TRAINING_ITERATION, -1))
         return newest_checkpoint
 
+    @property
+    def best_checkpoint(self):
+        best_checkpoints = self.best_checkpoints()
+        if best_checkpoints:
+            return best_checkpoints[0]
+        return None
+
     def on_checkpoint(self, checkpoint):
         """Starts tracking checkpoint metadata on checkpoint.
 

--- a/python/ray/tune/tests/test_checkpoint_manager.py
+++ b/python/ray/tune/tests/test_checkpoint_manager.py
@@ -40,7 +40,7 @@ class CheckpointManagerTest(unittest.TestCase):
             for i in range(3)
         ]
 
-        with patch.object(checkpoint_manager, "delete") as delete_mock:
+        with patch.object(checkpoint_manager, "delete_fn") as delete_mock:
             for j in range(3):
                 checkpoint_manager.on_checkpoint(checkpoints[j])
                 expected_deletes = 0 if j != 2 else 1

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -340,7 +340,7 @@ class Trial:
 
     def set_runner(self, runner):
         self.runner = runner
-        self.checkpoint_manager.delete = checkpoint_deleter(
+        self.checkpoint_manager.delete_fn = checkpoint_deleter(
             self._trainable_name(), runner)
 
     def set_location(self, location):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Tune's `CheckpointManager` did not reflect checkpoint deletions in `CheckpointManager.newest_persistent_checkpoint`, leading to errors when trying to resume trials. In the related issue, this was the case with a PopulationBasedTraining scheduler. Introducing bookkeeping here prevents Tune from trying to restore trials where the checkpoint has already been deleted.

The error observed in the issues seems to stem from the fact that the `CheckpointManager` deletes checkpoints according to `checkpoint_score_attr` (which can be changed by the user), but PBT has it's own internal state bookkeeping, only considering the latest checkpoints. Only when `checkpoint_score_attr` is unset, both strategies coincide. Thus, with this PR PBT will now also try to use the best available checkpoint if the latest is not available.

## Related issue number

Should fix #9036, #8441

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests

