### PR TITLE
[Serve] Use cloudpickle's default option

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -90,6 +90,14 @@ py_test(
     deps = [":serve_lib"],
 )
 
+py_test(
+    name = "test_regression",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive"],
+    deps = [":serve_lib"],
+)
+
 
 py_test(
     name = "test_util",

--- a/python/ray/serve/request_params.py
+++ b/python/ray/serve/request_params.py
@@ -42,7 +42,7 @@ class RequestMetadata:
         return current_time_ms + slo_ms
 
     def ray_serialize(self):
-        return pickle.dumps(self.__dict__, protocol=5)
+        return pickle.dumps(self.__dict__)
 
     @staticmethod
     def ray_deserialize(value):

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -50,7 +50,7 @@ class Query:
         # worker without removing async_future.
         clone = copy.copy(self).__dict__
         clone.pop("async_future")
-        return pickle.dumps(clone, protocol=5)
+        return pickle.dumps(clone)
 
     @staticmethod
     def ray_deserialize(value):

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -3,10 +3,10 @@ import copy
 from collections import defaultdict, deque
 import time
 from typing import DefaultDict, List
+import pickle
 
 import blist
 
-import ray.cloudpickle as pickle
 from ray.exceptions import RayTaskError
 
 import ray

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -5,6 +5,10 @@ from ray import serve
 
 
 def test_np_in_composed_model(serve_instance):
+    # https://github.com/ray-project/ray/issues/9441
+    # AttributeError: 'bytes' object has no attribute 'readonly'
+    # in cloudpickle _from_numpy_buffer
+
     def sum_model(_request, data=None):
         return np.sum(data)
 
@@ -23,7 +27,7 @@ def test_np_in_composed_model(serve_instance):
     serve.create_endpoint(
         "model", backend="model", route="/model", methods=['GET'])
 
-    result = requests.get('http://127.0.0.1:8000/model')
+    result = requests.get("http://127.0.0.1:8000/model")
     assert result.status_code == 200
     assert result.json() == 100.0
 

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -1,0 +1,34 @@
+import numpy as np
+import requests
+
+from ray import serve
+
+
+def test_np_in_composed_model(serve_instance):
+    def sum_model(_request, data=None):
+        return np.sum(data)
+
+    class ComposedModel:
+        def __init__(self):
+            self.model = serve.get_handle("sum_model")
+
+        async def __call__(self, _request):
+            data = np.ones((10, 10))
+            result = await self.model.remote(data=data)
+            return result
+
+    serve.create_backend("sum_model", sum_model)
+    serve.create_endpoint("sum_model", backend="sum_model")
+    serve.create_backend("model", ComposedModel)
+    serve.create_endpoint(
+        "model", backend="model", route="/model", methods=['GET'])
+
+    result = requests.get('http://127.0.0.1:8000/model')
+    assert result.status_code == 200
+    assert result.json() == 100.0
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is a quick bug fix for serialization issue that @dsuess discovered. (Thanks!) The fix is to use whatever default option for ray.cloudpickle.loads instead of defining protocol=5.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fix #9441 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
