### PR TITLE
[Serve] Improve buffering for simple cases

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -36,7 +36,10 @@ class BackendConfig:
             # timeout is default zero seconds, then we keep the existing
             # behavior to allow at most max batch size queries.
             if self.is_blocking and self.batch_wait_timeout == 0:
-                self.max_concurrent_queries = self.max_batch_size or 1
+                if self.max_batch_size:
+                    self.max_concurrent_queries = 2 * self.max_batch_size
+                else:
+                    self.max_concurrent_queries = 8
 
             # Pipeline/async mode: if the servable is not blocking,
             # router should just keep pushing queries to the worker


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Bumping the max_concurrent_queries for the model serving mode. This improve perf by 1.5x in the following benchmark scenario:
- one noop model
- two clients, sending ping-pong queries

before: 893 qps
after: 1375 qps

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
