### PR TITLE
[Serve] Serialize Query object directly

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -96,13 +96,6 @@ def init(name=None,
     except ValueError:
         pass
 
-    # Register serialization context once
-    ray.register_custom_serializer(Query, Query.ray_serialize,
-                                   Query.ray_deserialize)
-    ray.register_custom_serializer(RequestMetadata,
-                                   RequestMetadata.ray_serialize,
-                                   RequestMetadata.ray_deserialize)
-
     # TODO(edoakes): for now, always start the HTTP proxy on the node that
     # serve.init() was run on. We should consider making this configurable
     # in the future.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -8,8 +8,6 @@ from ray.serve.handle import RayServeHandle
 from ray.serve.utils import (block_until_http_ready, format_actor_name)
 from ray.serve.exceptions import RayServeException
 from ray.serve.config import BackendConfig, ReplicaConfig
-from ray.serve.router import Query
-from ray.serve.request_params import RequestMetadata
 from ray.serve.metric import InMemoryExporter
 
 master_actor = None

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from collections import defaultdict
 from itertools import groupby
 from operator import attrgetter
+from typing import Union
 import time
 
 import ray
@@ -343,8 +344,9 @@ class RayServeWorker:
         self.batch_queue.set_config(self.config.max_batch_size or 1,
                                     self.config.batch_wait_timeout)
 
-    async def handle_request(self, request: bytes):
-        request = Query.ray_deserialize(request)
+    async def handle_request(self, request: Union[Query, bytes]):
+        if isinstance(request, bytes):
+            request = Query.ray_deserialize(request)
         logger.debug("Worker {} got request {}".format(self.name, request))
         request.async_future = asyncio.get_event_loop().create_future()
         self.batch_queue.put(request)

--- a/python/ray/serve/backend_worker.py
+++ b/python/ray/serve/backend_worker.py
@@ -343,8 +343,8 @@ class RayServeWorker:
         self.batch_queue.set_config(self.config.max_batch_size or 1,
                                     self.config.batch_wait_timeout)
 
-    async def handle_request(self, request: Query):
-        assert not isinstance(request, list)
+    async def handle_request(self, request: bytes):
+        request = Query.ray_deserialize(request)
         logger.debug("Worker {} got request {}".format(self.name, request))
         request.async_future = asyncio.get_event_loop().create_future()
         self.batch_queue.put(request)

--- a/python/ray/serve/router.py
+++ b/python/ray/serve/router.py
@@ -316,13 +316,14 @@ class Router:
         start = time.time()
         worker = self.replicas[backend_replica_tag]
         try:
+            object_ref = worker.handle_request.remote(req.ray_serialize())
             if req.is_shadow_query:
                 # No need to actually get the result, but we do need to wait
                 # until the call completes to mark the worker idle.
-                asyncio.wait([worker.handle_request.remote(req)])
+                await asyncio.wait([object_ref])
                 result = ""
             else:
-                result = await worker.handle_request.remote(req)
+                result = await object_ref
         except RayTaskError as error:
             self.num_error_backend_request.labels(backend=backend).add()
             result = error


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
This PR serializes the query object directly rather than go through the ray serialization context. When we serialize it directly, ray recognize the input is now bytes and it will skip the entire cloudpickle stack. This performance issue is identified by looking at the following flamegraph. The lower center/left stack is the serialization stack.

![image](https://user-images.githubusercontent.com/21118851/87492194-de4a5580-c5fe-11ea-8d8b-9292ccd8e1a7.png)

benchmark:

- Using config {'num_replicas': 8, 'max_concurrent_queries': 10000}
- Before: 2381 qps
- After: 2718 qps
- 14% increase in queries per second.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
