### PR TITLE
[cli] ray memory: added redis_password

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1113,12 +1113,17 @@ def statistics(address):
     required=False,
     type=str,
     help="Override the address to connect to.")
-def memory(address):
+@click.option(
+    "--redis_password",
+    required=False,
+    type=str,
+    help="Connect to ray with redis_password.")
+def memory(address, redis_password):
     """Print object references held in a Ray cluster."""
     if not address:
         address = services.find_redis_address_or_die()
     logger.info("Connecting to Ray instance at {}.".format(address))
-    ray.init(address=address)
+    ray.init(address=address, redis_password=redis_password)
     print(ray.internal.internal_api.memory_summary())
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1117,6 +1117,7 @@ def statistics(address):
     "--redis_password",
     required=False,
     type=str,
+    default=ray_constants.REDIS_DEFAULT_PASSWORD,
     help="Connect to ray with redis_password.")
 def memory(address, redis_password):
     """Print object references held in a Ray cluster."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
With the current Python memory script, there is no way to run `ray memory` with the redis_password.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Open #9446 

## Checks

- [ x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
   - [ x ] This PR is not tested (please justify below)
ray.init() has redis_password argument, so I don't need to test with new argument being added in ray.init through memory function

