### PR TITLE
Fix clang-cl build

### DIFF
--- a/src/ray/gcs/asio.cc
+++ b/src/ray/gcs/asio.cc
@@ -16,6 +16,10 @@
 
 #include "ray/util/logging.h"
 
+extern "C" {
+#include "hiredis/async.h"
+}
+
 RedisAsioClient::RedisAsioClient(boost::asio::io_service &io_service,
                                  ray::gcs::RedisAsyncContext &redis_async_context)
     : redis_async_context_(redis_async_context),

--- a/src/ray/gcs/asio.h
+++ b/src/ray/gcs/asio.h
@@ -42,8 +42,6 @@
 #include <boost/asio/error.hpp>
 #include <boost/bind.hpp>
 
-#include "hiredis/async.h"
-#include "hiredis/hiredis.h"
 #include "ray/gcs/redis_async_context.h"
 
 class RedisAsioClient {

--- a/src/ray/gcs/gcs_client/service_based_gcs_client.cc
+++ b/src/ray/gcs/gcs_client/service_based_gcs_client.cc
@@ -17,6 +17,10 @@
 #include "ray/common/ray_config.h"
 #include "ray/gcs/gcs_client/service_based_accessor.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace ray {
 namespace gcs {
 

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -15,6 +15,10 @@
 #include "gcs_redis_failure_detector.h"
 #include "ray/common/ray_config.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace ray {
 namespace gcs {
 

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include "ray/common/status.h"
 
+// These are forward declarations from hiredis.
 extern "C" {
 struct redisAsyncContext;
 struct redisReply;

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -19,8 +19,9 @@
 #include "ray/common/status.h"
 
 extern "C" {
-#include "hiredis/async.h"
-#include "hiredis/hiredis.h"
+struct redisAsyncContext;
+struct redisReply;
+typedef void redisCallbackFn(struct redisAsyncContext *, void *, void *);
 }
 
 namespace ray {

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -18,6 +18,10 @@
 #include "ray/common/ray_config.h"
 #include "ray/gcs/redis_context.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace ray {
 
 namespace gcs {

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -445,6 +445,10 @@ Status RedisContext::PublishAsync(const std::string &channel, const std::string 
   return RunArgvAsync(args, redisCallback);
 }
 
+void RedisContext::FreeRedisReply(void *reply) { return freeReplyObject(reply); }
+
+int RedisContext::GetRedisError(redisContext *context) { return context->err; }
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -20,6 +20,10 @@
 #include "ray/common/ray_config.h"
 #include "ray/gcs/redis_gcs_client.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace {
 
 static const std::string kTableAppendCommand = "RAY.TABLE_APPEND";

--- a/src/ray/gcs/test/redis_gcs_client_test.cc
+++ b/src/ray/gcs/test/redis_gcs_client_test.cc
@@ -14,16 +14,15 @@
 
 #include "gtest/gtest.h"
 
-// TODO(pcm): get rid of this and replace with the type safe plasma event loop
-extern "C" {
-#include "hiredis/hiredis.h"
-}
-
 #include "ray/common/ray_config.h"
 #include "ray/common/test_util.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/gcs/redis_gcs_client.h"
 #include "ray/gcs/tables.h"
+
+extern "C" {
+#include "hiredis/hiredis.h"
+}
 
 namespace ray {
 

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -25,6 +25,10 @@
 #include "ray/object_manager/object_manager.h"
 #include "ray/util/filesystem.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace ray {
 
 using rpc::GcsNodeInfo;

--- a/src/ray/object_manager/test/object_manager_test.cc
+++ b/src/ray/object_manager/test/object_manager_test.cc
@@ -24,6 +24,10 @@
 #include "ray/common/test_util.h"
 #include "ray/util/filesystem.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace {
 int64_t wait_timeout_ms;
 }  // namespace


### PR DESCRIPTION
## Why are these changes needed?

Makes the newer version of hiredis buildable with Clang-Cl on Windows. It seems to not build currently due to dependence on `#include` order.

## Related issue number

#9289

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
