### PR TITLE
Make pip install verbose

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -238,7 +238,7 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
-    pip install -v -e .
+    pip install -v -v -e .
   )
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Pip install seems to time out when the build hasn't happen beforehand. Make it verbose.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
