### PR TITLE
[rllib] bugfix: import gym.wrappers in rllib/rollout.py

### DIFF
--- a/rllib/rollout.py
+++ b/rllib/rollout.py
@@ -10,6 +10,7 @@ import pickle
 import shelve
 
 import gym
+import gym.wrappers
 import ray
 from ray.rllib.env import MultiAgentEnv
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Just importing gym means that gym.wrappers is not available. This does not usually lead to a runtime error because gym.wrappers is imported elsewhere in the code of rllib. But I did run into problems with this. Just importing gym.wrappers in my own script made it work again. I then tested that the added import in this PR also fixes the problem for me.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR. ---> NO, because it wouldn't run. Flake8 errors out with ```flake8: error: unrecognized arguments: --inline-quotes --no-avoid-escape```
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below) ---> just added an import
