### PR TITLE
Fix pip and Bazel interaction messing up CI

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -233,13 +233,19 @@ install_go() {
   fi
 }
 
-bazel_ensure_buildable_on_windows() {
+_bazel_build_before_install() {
+  local target
   if [ "${OSTYPE}" = msys ]; then
-    # This performs as full of a build as possible, to ensure the repository always remains buildable on Windows.
+    # On Windows, we perform as full of a build as possible, to ensure the repository always remains buildable on Windows.
     # (Pip install will not perform a full build.)
-    # NOTE: Do not add build flags here. Use .bazelrc and --config instead.
-    bazel build -k "//:*"
+    target="//:*"
+  else
+    # Just build Python on other platforms.
+    # This because pip install captures & suppresses the build output, which causes a timeout on CI.
+    target="//:ray_pkg"
   fi
+  # NOTE: Do not add build flags here. Use .bazelrc and --config instead.
+  bazel build -k "${target}"
 }
 
 install_ray() {
@@ -247,7 +253,7 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
-    pip install -v -v -e .
+    pip install -v -e .
   )
 }
 
@@ -431,7 +437,7 @@ init() {
 }
 
 build() {
-  bazel_ensure_buildable_on_windows
+  _bazel_build_before_install
 
   if ! need_wheels; then
     install_ray

--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -253,7 +253,7 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
-    pip install -v -e .
+    keep_alive pip install -v -e .
   )
 }
 

--- a/python/build-wheel-windows.sh
+++ b/python/build-wheel-windows.sh
@@ -32,7 +32,7 @@ install_ray() {
     pip install wheel
 
     cd "${WORKSPACE_DIR}"/python
-    pip install -v -e .
+    "${WORKSPACE_DIR}"/ci/keep_alive pip install -v -e .
   )
 }
 


### PR DESCRIPTION
## Why are these changes needed?

`pip install` suppresses build outputs, which causes a timeout on CI.

Increasing the verbosity to avoid this seems to cause the output to become too verbose.

So just do a manual build before running `pip`, to ensure `pip` finishes quickly.

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
