### PR TITLE
[tune] fix pbt checkpoint_freq

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -181,6 +181,14 @@ py_test(
 )
 
 py_test(
+    name = "test_trial_scheduler_pbt",
+    size = "medium",
+    srcs = ["tests/test_trial_scheduler_pbt.py"],
+    deps = [":tune_lib"],
+    tags = ["exclusive"],
+)
+
+py_test(
     name = "test_tune_restore",
     size = "large",
     srcs = ["tests/test_tune_restore.py"],

--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -112,7 +112,8 @@ class CheckpointManager:
         self.newest_persistent_checkpoint = checkpoint
 
         # Remove the old checkpoint if it isn't one of the best ones.
-        if old_checkpoint.value and old_checkpoint not in self._membership:
+        if old_checkpoint.value and old_checkpoint not in self._membership \
+           and old_checkpoint.value != checkpoint.value:
             self.delete(old_checkpoint)
 
         try:

--- a/python/ray/tune/checkpoint_manager.py
+++ b/python/ray/tune/checkpoint_manager.py
@@ -109,11 +109,14 @@ class CheckpointManager:
             return
 
         old_checkpoint = self.newest_persistent_checkpoint
+
+        if old_checkpoint.value == checkpoint.value:
+            return
+
         self.newest_persistent_checkpoint = checkpoint
 
         # Remove the old checkpoint if it isn't one of the best ones.
-        if old_checkpoint.value and old_checkpoint not in self._membership \
-           and old_checkpoint.value != checkpoint.value:
+        if old_checkpoint.value and old_checkpoint not in self._membership:
             self.delete(old_checkpoint)
 
         try:

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -1,0 +1,90 @@
+import numpy as np
+import os
+import pickle
+import random
+import unittest
+import sys
+
+from ray import tune
+from ray.tune.schedulers import PopulationBasedTraining
+
+
+class MockTrainable(tune.Trainable):
+    def setup(self, config):
+        self.iter = 0
+        self.a = config["a"]
+        self.b = config["b"]
+        self.c = config["c"]
+
+    def step(self):
+        self.iter += 1
+        return {"mean_accuracy": (self.a - self.iter) * self.b}
+
+    def save_checkpoint(self, tmp_checkpoint_dir):
+        checkpoint_path = os.path.join(tmp_checkpoint_dir, "model.mock")
+        with open(checkpoint_path, "wb") as fp:
+            pickle.dump((self.a, self.b), fp)
+        return tmp_checkpoint_dir
+
+    def load_checkpoint(self, tmp_checkpoint_dir):
+        checkpoint_path = os.path.join(tmp_checkpoint_dir, "model.mock")
+        with open(checkpoint_path, "rb") as fp:
+            self.a, self.b = pickle.load(fp)
+
+
+class MockParam(object):
+    def __init__(self, params):
+        self._params = params
+        self._index = 0
+
+    def __call__(self, *args, **kwargs):
+        val = self._params[self._index % len(self._params)]
+        self._index += 1
+        return val
+
+
+class PopulationBasedTrainingResumeTest(unittest.TestCase):
+    def testPermutationContinuation(self):
+        """
+        Tests continuation of runs after permutation.
+        Sometimes, runs were continued from deleted checkpoints.
+        This deterministic initialisation would fail when the
+        fix was not applied.
+        See issues #9036, #9036
+        """
+        scheduler = PopulationBasedTraining(
+            time_attr="training_iteration",
+            metric="mean_accuracy",
+            mode="max",
+            perturbation_interval=1,
+            log_config=True,
+            hyperparam_mutations={"c": lambda: 1})
+
+        param_a = MockParam([10, 20, 30, 40])
+        param_b = MockParam([1.2, 0.9, 1.1, 0.8])
+
+        random.seed(100)
+        np.random.seed(1000)
+        tune.run(
+            MockTrainable,
+            config={
+                "a": tune.sample_from(lambda _: param_a()),
+                "b": tune.sample_from(lambda _: param_b()),
+                "c": 1
+            },
+            fail_fast=True,
+            num_samples=20,
+            global_checkpoint_period=1,
+            checkpoint_freq=1,
+            checkpoint_at_end=True,
+            keep_checkpoints_num=1,
+            checkpoint_score_attr="min-training_iteration",
+            scheduler=scheduler,
+            name="testPermutationContinuation",
+            stop={"training_iteration": 5})
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

The `CheckpointManager` keeps track of the `last_persistent_checkpoint`. However, this fails when the newest checkpoint is performing badly, and the `on_checkpoint()` method is called twice with the same checkpoint location. In that case, `last_persistent_checkpoint` points to a storage location that has been deleted.

With this PR, the old checkpoint directory is only deleted when it does not coincide with the new to-be-stored checkpoint.

This problem came up when resuming trials in PopulationBasedTraining. A previous PR #9470 tackled this problem, but introduced unwanted logic changes.

## Related issue number

Closes old PR #9470
Should fix #9036, #8441

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests

