### PR TITLE
[RLlib] Fix combination of lockstep and multiple agnts controlled by the same policy.

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -438,7 +438,7 @@ class MultiAgentBatch:
         steps = []
         for policy_id, batch in self.policy_batches.items():
             for row in batch.rows():
-                steps.append((row[SampleBatch.EPS_ID], row["t"], policy_id,
+                steps.append((row[SampleBatch.EPS_ID], row["t"], row["agent_index"], policy_id,
                               row))
         steps.sort()
 
@@ -458,7 +458,7 @@ class MultiAgentBatch:
         # For each unique env timestep.
         for _, group in itertools.groupby(steps, lambda x: x[:2]):
             # Accumulate into the current slice.
-            for _, _, policy_id, row in group:
+            for _, _, _, policy_id, row in group:
                 cur_slice[policy_id].add_values(**row)
             cur_slice_size += 1
             # Slice has reached target number of env steps.

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -438,8 +438,8 @@ class MultiAgentBatch:
         steps = []
         for policy_id, batch in self.policy_batches.items():
             for row in batch.rows():
-                steps.append((row[SampleBatch.EPS_ID], row["t"], row["agent_index"], policy_id,
-                              row))
+                steps.append((row[SampleBatch.EPS_ID], row["t"],
+                              row["agent_index"], policy_id, row))
         steps.sort()
 
         finished_slices = []


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Modification of MultiAgentBatch.timeslices to support the combination of lockstep and multiple agents controlled by the same policy.



## Related issue number

<!-- For example: "Closes #1234" -->
Closes #9295

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)
Fix is simple and was tested in my experiment.