### PR TITLE
[Umbrella]increase threads number in gcs rpc server

### DIFF
--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -32,7 +32,7 @@ class GlobalStateAccessorTest : public ::testing::Test {
   void SetUp() override {
     config.grpc_server_port = 0;
     config.grpc_server_name = "MockedGcsServer";
-    config.grpc_server_thread_num = 1;
+    config.grpc_server_thread_num = 2;
     config.redis_address = "127.0.0.1";
     config.is_test = true;
     config.redis_port = TEST_REDIS_SERVER_PORTS.front();

--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -32,7 +32,7 @@ class ServiceBasedGcsClientTest : public ::testing::Test {
   void SetUp() override {
     config_.grpc_server_port = 0;
     config_.grpc_server_name = "MockedGcsServer";
-    config_.grpc_server_thread_num = 1;
+    config_.grpc_server_thread_num = 2;
     config_.redis_address = "127.0.0.1";
     config_.is_test = true;
     config_.redis_port = TEST_REDIS_SERVER_PORTS.front();

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -28,7 +28,7 @@ namespace gcs {
 struct GcsServerConfig {
   std::string grpc_server_name = "GcsServer";
   uint16_t grpc_server_port = 0;
-  uint16_t grpc_server_thread_num = 1;
+  uint16_t grpc_server_thread_num = 2;
   std::string redis_password;
   std::string redis_address;
   uint16_t redis_port = 6379;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
   ray::gcs::GcsServerConfig gcs_server_config;
   gcs_server_config.grpc_server_name = "GcsServer";
   gcs_server_config.grpc_server_port = gcs_server_port;
-  gcs_server_config.grpc_server_thread_num = 1;
+  gcs_server_config.grpc_server_thread_num = 2;
   gcs_server_config.redis_address = redis_address;
   gcs_server_config.redis_port = redis_port;
   gcs_server_config.redis_password = redis_password;

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -30,7 +30,7 @@ class GcsServerTest : public ::testing::Test {
     gcs::GcsServerConfig config;
     config.grpc_server_port = 0;
     config.grpc_server_name = "MockedGcsServer";
-    config.grpc_server_thread_num = 1;
+    config.grpc_server_thread_num = 2;
     config.redis_address = "127.0.0.1";
     config.is_test = true;
     config.redis_port = TEST_REDIS_SERVER_PORTS.front();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is a HEAD FIRST pr, NOT official, of opening up gcs multi threads processing.
Now we already have multi threads support in rpc requests dispatching, but we should use multi threads to processing requests, accessing IOs and sending replies.
We first file this pr to see if there's any problem in requests dispatching by increasing the thread number, then talk about the solutions and plans afterwards.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
