### PR TITLE
[Tune] Copy default_columns in new ProgressReporter instances

### DIFF
--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -87,7 +87,7 @@ class TuneReporterBase(ProgressReporter):
                  max_progress_rows=20,
                  max_error_rows=20,
                  max_report_frequency=5):
-        self._metric_columns = metric_columns or self.DEFAULT_COLUMNS
+        self._metric_columns = metric_columns or self.DEFAULT_COLUMNS.copy()
         self._parameter_columns = parameter_columns or []
         self._max_progress_rows = max_progress_rows
         self._max_error_rows = max_error_rows


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Allows the creation of several progress reporters that don't share the dict containing the columns to report.

## Related issue number

Closes #8913 

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
