### PR TITLE
[RLlib] Add MADDPG learning confirmation test.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -1946,9 +1946,9 @@ py_test(
     name = "examples/two_step_game_maddpg",
     main = "examples/two_step_game.py",
     tags = ["examples", "examples_T"],
-    size = "large",
+    size = "small",
     srcs = ["examples/two_step_game.py"],
-    args = ["--stop-timesteps=2000", "--run=contrib/MADDPG"]
+    args = ["--as-test", "--stop-reward=7.5", "--run=contrib/MADDPG"]
 )
 
 py_test(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

MADDPG is currently not tested for learning capabilities.
- Switch option on examples/two_step_game.py to activate this as a learning test (stop-reward=7.5).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
