### PR TITLE
Fix bug that `test_multi_node.py::test_multi_driver_logging` hangs when GCS actor management is turned on

### DIFF
--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -638,6 +638,13 @@ def test_multi_driver_logging(ray_start_regular):
     driver2_wait = Semaphore.options(name="driver2_wait").remote(value=0)
     main_wait = Semaphore.options(name="main_wait").remote(value=0)
 
+    # The creation of an actor is asynchronous.
+    # We need to wait for the completion of the actor creation,
+    # otherwise we can't get the actor by name.
+    ray.get(driver1_wait.locked.remote())
+    ray.get(driver2_wait.locked.remote())
+    ray.get(main_wait.locked.remote())
+
     # Params are address, semaphore name, output1, output2
     driver_script_template = """
 import ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Problem:
The creation of an actor is asynchronous. If  get an actor by name before it is created, it will fail.
Solution:
We need to wait for the completion of the actor creation, otherwise we can't get the actor by name.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9505
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
