### PR TITLE
Add plasma store benchmark

### DIFF
--- a/python/ray/ray_perf.py
+++ b/python/ray/ray_perf.py
@@ -1,6 +1,7 @@
 """This is the script for `ray microbenchmark`."""
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -108,10 +109,13 @@ def main():
     check_optimized_build()
 
     print("Tip: set TESTS_TO_RUN='pattern' to run a subset of benchmarks")
-    ray.init()
+
+    ray.init(
+        _internal_config=json.dumps({
+            "put_small_object_in_memory_store": True
+        }))
 
     value = ray.put(0)
-    arr = np.zeros(100 * 1024 * 1024, dtype=np.int64)
 
     def get_small():
         ray.get(value)
@@ -123,11 +127,6 @@ def main():
 
     timeit("single client put calls", put_small)
 
-    def put_large():
-        ray.put(arr)
-
-    timeit("single client put gigabytes", put_large, 8 * 0.1)
-
     @ray.remote
     def do_put_small():
         for _ in range(100):
@@ -137,6 +136,26 @@ def main():
         ray.get([do_put_small.remote() for _ in range(10)])
 
     timeit("multi client put calls", put_multi_small, 1000)
+
+    ray.shutdown()
+    ray.init(
+        _internal_config=json.dumps({
+            "put_small_object_in_memory_store": False
+        }))
+
+    value = ray.put(0)
+    arr = np.zeros(100 * 1024 * 1024, dtype=np.int64)
+
+    timeit("single client get calls (Plasma Store)", get_small)
+
+    timeit("single client put calls (Plasma Store)", put_small)
+
+    timeit("multi client put calls (Plasma Store)", put_multi_small, 1000)
+
+    def put_large():
+        ray.put(arr)
+
+    timeit("single client put gigabytes", put_large, 8 * 0.1)
 
     @ray.remote
     def do_put():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Adding the missing benchmark to monitor object store performance for small objects. I have verified this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
