### PR TITLE
Fix log losses

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -237,6 +237,7 @@ void RayLog::UninstallSignalAction() {
 }
 
 void RayLog::ShutDownRayLog() {
+  stream_logger_singleton.out_.close();
 #ifdef RAY_USE_GLOG
   UninstallSignalAction();
   google::ShutdownGoogleLogging();

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -200,6 +200,7 @@ void RayLog::StartRayLog(const std::string &app_name, RayLogLevel severity_thres
     strftime(buffer, sizeof(buffer), "%Y%m%d-%H%M%S", localtime(&rawtime));
     std::string path = dir_ends_with_slash + app_name_without_path + "." + buffer + "." +
                        std::to_string(pid) + ".log";
+    stream_logger_singleton.out_.rdbuf()->pubsetbuf(0, 0);
     stream_logger_singleton.out_.open(path.c_str(),
                                       std::ios_base::app | std::ios_base::binary);
   }


### PR DESCRIPTION
## Why are these changes needed?

Some logging is lost due to the `std::ofstream` not being closed after log shutdown, which caused the subsequent `open` of the same `std::ofstream` object to fail.

Also disables buffering of the sink to avoid log message loss.

## Related issue number

Closes #9555

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
