### PR TITLE
deserialize Tune checkpoint files to proper path under restore_from_object tmpdir

### DIFF
--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -125,7 +125,7 @@ class TrainableUtil:
         checkpoint_path = os.path.join(tmpdir, info["checkpoint_name"])
 
         for relpath_name, file_contents in data.items():
-            path = os.path.join(tmpdir, relpath_name)
+            path = os.path.join(checkpoint_path, relpath_name)
 
             # This may be a subdirectory, hence not just using tmpdir
             os.makedirs(os.path.dirname(path), exist_ok=True)


### PR DESCRIPTION
## Why are these changes needed?

#9146 reports a bug with Tune crashing when trying to resume/restore a checkpoint in Ray 0.8.5/0.8.6.
I traced this bug internally to `Trainable.restore_from_object()`, which deserializes checkpoint files under `tmpdir`, but then returns `checkpoint_path = os.path.join(tmpdir, info["checkpoint_name"])`, thus causing `Trainable._restore(checkpoint_dir=checkpoint_path)` to fail to locate the deserialized files on disk. Note that for these ray versions, `info["checkpoint_name"]=="checkpoint_###/"`

For a reason that I did not investigate, it appears that the HEAD of `master` branch resolved this bug, perhaps accidentally, since `info["checkpoint_name"]=="./"`. I argue that this change indirectly side-stepped the bug, hence I propose this single-variable change to address the underlying logic flaw.

Note that on the `master` branch, this change does not alter where files are deserialized to, since:
`checkpoint_path = os.path.join(tmpdir, info["checkpoint_name"])` == `os.path.join(tmpdir, "./")` and thus is equivalent to `tmpdir`. Again, this PR is meant to fix the underlying logic flaw directly, to prevent against the re-appearance of the bug in the future if `info["checkpoint_name"]` was changed.

## Related issue number

Relates to #9146 

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (please justify below)

Reason: single-variable change from path (`tmpdir`) to subpath (`checkpoint_path`).