### PR TITLE
[STILL WIP: DONT REVIEW YET: RLlib] Fix valid-masking in APPO torch loss.

### DIFF
--- a/rllib/agents/ppo/appo_torch_policy.py
+++ b/rllib/agents/ppo/appo_torch_policy.py
@@ -66,7 +66,7 @@ class PPOSurrogateLoss:
             num_valid = torch.sum(valid_mask)
 
             def reduce_mean_valid(t):
-                return torch.sum(t * valid_mask) / num_valid
+                return torch.sum(t[valid_mask]) / num_valid
 
         else:
 
@@ -162,7 +162,7 @@ class VTraceSurrogateLoss:
             num_valid = torch.sum(valid_mask)
 
             def reduce_mean_valid(t):
-                return torch.sum(t * valid_mask) / num_valid
+                return torch.sum(t[valid_mask]) / num_valid
 
         else:
 

--- a/rllib/agents/ppo/ppo_torch_policy.py
+++ b/rllib/agents/ppo/ppo_torch_policy.py
@@ -104,8 +104,8 @@ class PPOLoss:
         else:
             self.mean_vf_loss = 0.0
             loss = torch.mean(-surrogate_loss +
-                                     cur_kl_coeff * action_kl -
-                                     entropy_coeff * curr_entropy)
+                              cur_kl_coeff * action_kl -
+                              entropy_coeff * curr_entropy)
         self.loss = loss
 
 

--- a/rllib/models/torch/misc.py
+++ b/rllib/models/torch/misc.py
@@ -1,7 +1,8 @@
 """ Code adapted from https://github.com/ikostrikov/pytorch-a3c"""
 import numpy as np
+from typing import Callable, Optional, Union
 
-from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.framework import get_activation_fn, try_import_torch
 
 torch, nn = try_import_torch()
 
@@ -88,12 +89,12 @@ class SlimFC(nn.Module):
     """Simple PyTorch version of `linear` function"""
 
     def __init__(self,
-                 in_size,
-                 out_size,
-                 initializer=None,
-                 activation_fn=None,
-                 use_bias=True,
-                 bias_init=0.0):
+                 in_size: int,
+                 out_size: int,
+                 initializer: Optional[Callable] = None,
+                 activation_fn: Optional[Union[str, Callable]] = None,
+                 use_bias: bool = True,
+                 bias_init: float = 0.0):
         super(SlimFC, self).__init__()
         layers = []
         linear = nn.Linear(in_size, out_size, bias=use_bias)
@@ -102,8 +103,9 @@ class SlimFC(nn.Module):
         if use_bias is True:
             nn.init.constant_(linear.bias, bias_init)
         layers.append(linear)
-        if activation_fn:
-            layers.append(activation_fn())
+        torch_activation_fn = get_activation_fn(activation_fn, "torch")
+        if torch_activation_fn:
+            layers.append(torch_activation_fn())
         self._model = nn.Sequential(*layers)
 
     def forward(self, x):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

In APPO's torch loss function, valid-masking for LSTM zero-padded sequences is still incorrect (after having been fixed for plain PPO).
This PR fixes that problem.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
