### PR TITLE
[Core] Remove socket pair exchange in Plasma Store

### DIFF
--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
@@ -99,6 +99,8 @@ void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Stat
   for (size_t i = 0; i < object_notification->object_info()->size(); ++i) {
     auto object_info = object_notification->object_info()->Get(i);
     const ObjectID object_id = ObjectID::FromBinary(object_info->object_id()->str());
+    RAY_LOG(ERROR) << "Decode notification, ObjectID = " << object_id.Hex() << ", "
+                   << "is_deletion = " << object_info->is_deletion();
     if (object_info->is_deletion()) {
       ProcessStoreRemove(object_id);
     } else {

--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
@@ -99,7 +99,7 @@ void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Stat
   for (size_t i = 0; i < object_notification->object_info()->size(); ++i) {
     auto object_info = object_notification->object_info()->Get(i);
     const ObjectID object_id = ObjectID::FromBinary(object_info->object_id()->str());
-    RAY_LOG(ERROR) << "Decode notification, ObjectID = " << object_id.Hex() << ", "
+    RAY_LOG(DEBUG) << "Decode notification, ObjectID = " << object_id.Hex() << ", "
                    << "is_deletion = " << object_info->is_deletion();
     if (object_info->is_deletion()) {
       ProcessStoreRemove(object_id);

--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.cc
@@ -99,8 +99,6 @@ void ObjectStoreNotificationManagerIPC::ProcessStoreNotification(const ray::Stat
   for (size_t i = 0; i < object_notification->object_info()->size(); ++i) {
     auto object_info = object_notification->object_info()->Get(i);
     const ObjectID object_id = ObjectID::FromBinary(object_info->object_id()->str());
-    RAY_LOG(DEBUG) << "Decode notification, ObjectID = " << object_id.Hex() << ", "
-                   << "is_deletion = " << object_info->is_deletion();
     if (object_info->is_deletion()) {
       ProcessStoreRemove(object_id);
     } else {

--- a/src/ray/object_manager/notification/object_store_notification_manager_ipc.h
+++ b/src/ray/object_manager/notification/object_store_notification_manager_ipc.h
@@ -14,21 +14,15 @@
 
 #pragma once
 
-#include <list>
 #include <memory>
 #include <vector>
 
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
-#include <boost/bind.hpp>
-
-#include "ray/common/client_connection.h"
-#include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/notification/object_store_notification_manager.h"
-#include "ray/object_manager/plasma/client.h"
 
 namespace ray {
+
+class ServerConnection;
 
 /// \class ObjectStoreNotificationManagerIPC
 ///
@@ -53,13 +47,12 @@ class ObjectStoreNotificationManagerIPC : public ObjectStoreNotificationManager 
  private:
   /// Async loop for handling object store notifications.
   void NotificationWait();
-  void ProcessStoreLength(const boost::system::error_code &error);
-  void ProcessStoreNotification(const boost::system::error_code &error);
+  void ProcessStoreLength(const ray::Status &s);
+  void ProcessStoreNotification(const ray::Status &s);
 
-  plasma::PlasmaClient store_client_;
+  std::shared_ptr<ServerConnection> store_client_;
   int64_t length_;
   std::vector<uint8_t> notification_;
-  local_stream_socket socket_;
 
   /// Flag to indicate whether or not to exit the process when received socket
   /// error. When it is false, socket error will be ignored. This flag is needed

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -257,15 +257,6 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 
   Status Refresh(const std::vector<ObjectID>& object_ids);
 
-  Status Subscribe(int* fd);
-
-  Status GetNotification(int fd, ObjectID* object_id, int64_t* data_size,
-                         int64_t* metadata_size);
-
-  Status DecodeNotifications(const uint8_t* buffer, std::vector<ObjectID>* object_ids,
-                             std::vector<int64_t>* data_sizes,
-                             std::vector<int64_t>* metadata_sizes);
-
   Status Disconnect();
 
   std::string DebugString();
@@ -817,93 +808,6 @@ Status PlasmaClient::Impl::Refresh(const std::vector<ObjectID>& object_ids) {
   return ReadRefreshLRUReply(buffer.data(), buffer.size());
 }
 
-Status PlasmaClient::Impl::Subscribe(int* fd) {
-  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-
-  int sock[2];
-  // Create a non-blocking socket pair. This will only be used to send
-  // notifications from the Plasma store to the client.
-#ifdef _WINSOCKAPI_
-  SOCKET sockets[2] = { INVALID_SOCKET, INVALID_SOCKET };
-  socketpair(AF_INET, SOCK_STREAM, 0, sockets);
-  sock[0] = fh_open(sockets[0], -1);
-  sock[1] = fh_open(sockets[1], -1);
-#else
-  socketpair(AF_UNIX, SOCK_STREAM, 0, sock);
-#endif
-  // Make the socket non-blocking.
-#ifdef _WINSOCKAPI_
-  unsigned long value = 1;
-  RAY_CHECK(ioctlsocket(sock[1], FIONBIO, &value) == 0);
-#else
-  int flags = fcntl(sock[1], F_GETFL, 0);
-  RAY_CHECK(fcntl(sock[1], F_SETFL, flags | O_NONBLOCK) == 0);
-#endif
-  // Tell the Plasma store about the subscription.
-  RAY_RETURN_NOT_OK(SendSubscribeRequest(store_conn_));
-  // Send the file descriptor that the Plasma store should use to push
-  // notifications about sealed objects to this client.
-  RAY_CHECK(send_fd(store_conn_->fd, sock[1]) >= 0);
-  close(sock[1]);
-  // Return the file descriptor that the client should use to read notifications
-  // about sealed objects.
-  *fd = sock[0];
-  return Status::OK();
-}
-
-Status PlasmaClient::Impl::GetNotification(int fd, ObjectID* object_id,
-                                           int64_t* data_size, int64_t* metadata_size) {
-  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-
-  if (pending_notification_.empty()) {
-    auto message = ReadMessageAsync(fd);
-    if (message == NULL) {
-      return Status::IOError("Failed to read object notification from Plasma socket");
-    }
-
-    std::vector<ObjectID> object_ids;
-    std::vector<int64_t> data_sizes;
-    std::vector<int64_t> metadata_sizes;
-    RAY_RETURN_NOT_OK(
-        DecodeNotifications(message.get(), &object_ids, &data_sizes, &metadata_sizes));
-    for (size_t i = 0; i < object_ids.size(); ++i) {
-      pending_notification_.emplace_back(object_ids[i], data_sizes[i], metadata_sizes[i]);
-    }
-  }
-
-  auto notification = pending_notification_.front();
-  *object_id = std::get<0>(notification);
-  *data_size = std::get<1>(notification);
-  *metadata_size = std::get<2>(notification);
-
-  pending_notification_.pop_front();
-
-  return Status::OK();
-}
-
-Status PlasmaClient::Impl::DecodeNotifications(const uint8_t* buffer,
-                                               std::vector<ObjectID>* object_ids,
-                                               std::vector<int64_t>* data_sizes,
-                                               std::vector<int64_t>* metadata_sizes) {
-  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-  auto object_info = flatbuffers::GetRoot<ray::object_manager::protocol::PlasmaNotification>(buffer);
-
-  for (size_t i = 0; i < object_info->object_info()->size(); ++i) {
-    auto info = object_info->object_info()->Get(i);
-    ObjectID id = ObjectID::FromBinary(info->object_id()->str());
-    object_ids->push_back(id);
-    if (info->is_deletion()) {
-      data_sizes->push_back(-1);
-      metadata_sizes->push_back(-1);
-    } else {
-      data_sizes->push_back(info->data_size());
-      metadata_sizes->push_back(info->metadata_size());
-    }
-  }
-
-  return Status::OK();
-}
-
 Status PlasmaClient::Impl::Connect(const std::string& store_socket_name,
                                    const std::string& manager_socket_name,
                                    int release_delay, int num_retries) {
@@ -1028,20 +932,6 @@ Status PlasmaClient::Evict(int64_t num_bytes, int64_t& num_bytes_evicted) {
 
 Status PlasmaClient::Refresh(const std::vector<ObjectID>& object_ids) {
   return impl_->Refresh(object_ids);
-}
-
-Status PlasmaClient::Subscribe(int* fd) { return impl_->Subscribe(fd); }
-
-Status PlasmaClient::GetNotification(int fd, ObjectID* object_id, int64_t* data_size,
-                                     int64_t* metadata_size) {
-  return impl_->GetNotification(fd, object_id, data_size, metadata_size);
-}
-
-Status PlasmaClient::DecodeNotifications(const uint8_t* buffer,
-                                         std::vector<ObjectID>* object_ids,
-                                         std::vector<int64_t>* data_sizes,
-                                         std::vector<int64_t>* metadata_sizes) {
-  return impl_->DecodeNotifications(buffer, object_ids, data_sizes, metadata_sizes);
 }
 
 Status PlasmaClient::Disconnect() { return impl_->Disconnect(); }

--- a/src/ray/object_manager/plasma/client.h
+++ b/src/ray/object_manager/plasma/client.h
@@ -205,30 +205,6 @@ class RAY_EXPORT PlasmaClient {
   /// \return The return status.
   Status Refresh(const std::vector<ObjectID>& object_ids);
 
-  /// Subscribe to notifications when objects are sealed in the object store.
-  /// Whenever an object is sealed, a message will be written to the client
-  /// socket that is returned by this method.
-  ///
-  /// \param fd Out parameter for the file descriptor the client should use to
-  /// read notifications
-  ///         from the object store about sealed objects.
-  /// \return The return status.
-  Status Subscribe(int* fd);
-
-  /// Receive next object notification for this client if Subscribe has been called.
-  ///
-  /// \param fd The file descriptor we are reading the notification from.
-  /// \param object_id Out parameter, the object_id of the object that was sealed.
-  /// \param data_size Out parameter, the data size of the object that was sealed.
-  /// \param metadata_size Out parameter, the metadata size of the object that was sealed.
-  /// \return The return status.
-  Status GetNotification(int fd, ObjectID* object_id, int64_t* data_size,
-                         int64_t* metadata_size);
-
-  Status DecodeNotifications(const uint8_t* buffer, std::vector<ObjectID>* object_ids,
-                             std::vector<int64_t>* data_sizes,
-                             std::vector<int64_t>* metadata_sizes);
-
   /// Disconnect from the local plasma instance, including the local store and
   /// manager.
   ///

--- a/src/ray/object_manager/plasma/io.h
+++ b/src/ray/object_manager/plasma/io.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "ray/common/ray_config.h"
 #include "ray/common/status.h"
 #include "ray/object_manager/plasma/common.h"
 #include "ray/object_manager/plasma/compat.h"
@@ -46,7 +47,7 @@ enum class MessageType : int64_t;
 // TODO(pcm): Replace our own custom message header (message type,
 // message length, plasma protocol version) with one that is serialized
 // using flatbuffers.
-constexpr int64_t kPlasmaProtocolVersion = 0x0000000000000000;
+const int64_t kPlasmaProtocolVersion = RayConfig::instance().ray_cookie();
 
 Status WriteBytes(int fd, uint8_t* cursor, size_t length);
 

--- a/src/ray/object_manager/plasma/io.h
+++ b/src/ray/object_manager/plasma/io.h
@@ -44,10 +44,9 @@ enum class MessageType : int64_t;
 
 }  // namespace flatbuf
 
-// TODO(pcm): Replace our own custom message header (message type,
-// message length, plasma protocol version) with one that is serialized
-// using flatbuffers.
-const int64_t kPlasmaProtocolVersion = RayConfig::instance().ray_cookie();
+// TODO(suquark): We temporarily sync this with Ray cookie. This code will
+// be removed soon in later PRs.
+constexpr int64_t kPlasmaProtocolVersion = 0x5241590000000000;
 
 Status WriteBytes(int fd, uint8_t* cursor, size_t length);
 

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -70,7 +70,7 @@ constexpr int64_t kBlockSize = 64;
 
 /// Contains all information that is associated with a Plasma store client.
 struct Client {
-  explicit Client(int fd) : fd(fd), notification_fd(-1) {}
+  explicit Client(int fd) : fd(fd) {}
 
   ~Client();
 
@@ -82,10 +82,6 @@ struct Client {
 
   /// File descriptors that are used by this client.
   std::unordered_set<int> used_fds;
-
-  /// The file descriptor used to push notifications to client. This is only valid
-  /// if client subscribes to plasma store. -1 indicates invalid.
-  int notification_fd;
 
   std::string name = "anonymous_client";
 };
@@ -181,11 +177,6 @@ ObjectTableEntry* GetObjectTableEntry(PlasmaStoreInfo* store_info,
 ///        information.
 /// \return The errno set.
 int WarnIfSigpipe(int status, int client_sock);
-
-std::unique_ptr<uint8_t[]> CreateObjectInfoBuffer(ObjectInfoT* object_info);
-
-std::unique_ptr<uint8_t[]> CreatePlasmaNotificationBuffer(
-    const std::vector<ObjectInfoT>& object_info);
 
 /// Globally accessible reference to plasma store configuration.
 extern const PlasmaStoreInfo* plasma_config;

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -84,6 +84,10 @@ struct Client {
   std::unordered_set<int> used_fds;
 
   std::string name = "anonymous_client";
+
+  /// The object notifications for clients. We notify the client about the
+  /// objects in the order that the objects were sealed or deleted.
+  std::deque<std::unique_ptr<uint8_t[]>> object_notifications;
 };
 
 std::ostream &operator<<(std::ostream &os, const std::shared_ptr<Client> &client);

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -602,14 +602,6 @@ Status ReadGetReply(uint8_t* data, size_t size, ObjectID object_ids[],
   return Status::OK();
 }
 
-// Subscribe messages.
-
-Status SendSubscribeRequest(const std::shared_ptr<StoreConn> &store_conn) {
-  flatbuffers::FlatBufferBuilder fbb;
-  auto message = fb::CreatePlasmaSubscribeRequest(fbb);
-  return PlasmaSend(store_conn, MessageType::PlasmaSubscribeRequest, &fbb, message);
-}
-
 // Data messages.
 
 Status SendDataRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id, const char* address, int port) {

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -177,10 +177,6 @@ Status SendEvictReply(const std::shared_ptr<Client> &client, int64_t num_bytes);
 
 Status ReadEvictReply(uint8_t* data, size_t size, int64_t& num_bytes);
 
-/* Plasma Subscribe message functions. */
-
-Status SendSubscribeRequest(const std::shared_ptr<StoreConn> &store_conn);
-
 /* Data messages. */
 
 Status SendDataRequest(const std::shared_ptr<StoreConn> &store_conn, ObjectID object_id, const char* address, int port);

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -809,7 +809,7 @@ PlasmaStore::NotificationMap::iterator PlasmaStore::SendNotifications(
       });
       break;
     } else {
-      RAY_LOG(WARNING) << "Failed to send notification to client on fd " << client_fd
+      RAY_LOG(WARNING) << "Failed to send notification to client on fd " << client->fd
                        << ", errno = " << errno;
       if (errno == EPIPE) {
         closed = true;

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -167,8 +167,8 @@ class PlasmaStore {
   /// \param client The client that is disconnected.
   void DisconnectClient(const std::shared_ptr<Client> &client);
 
-  NotificationMap::iterator SendNotifications(
-      PlasmaStore::NotificationMap::iterator it, const std::vector<ObjectInfoT> &object_info);
+  Status SendNotifications(
+      const std::shared_ptr<Client>& client, const std::vector<ObjectInfoT> &object_info);
 
   Status ProcessMessage(const std::shared_ptr<Client> &client);
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -167,7 +167,8 @@ class PlasmaStore {
   /// \param client The client that is disconnected.
   void DisconnectClient(const std::shared_ptr<Client> &client);
 
-  NotificationMap::iterator SendNotifications(NotificationMap::iterator it);
+  NotificationMap::iterator SendNotifications(
+      PlasmaStore::NotificationMap::iterator it, const std::vector<ObjectInfoT> &object_info);
 
   Status ProcessMessage(const std::shared_ptr<Client> &client);
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -47,16 +47,8 @@ using flatbuf::PlasmaError;
 
 struct GetRequest;
 
-struct NotificationQueue {
-  /// The object notifications for clients. We notify the client about the
-  /// objects in the order that the objects were sealed or deleted.
-  std::deque<std::unique_ptr<uint8_t[]>> object_notifications;
-};
-
 class PlasmaStore {
  public:
-  using NotificationMap = std::unordered_map<std::shared_ptr<Client>, NotificationQueue>;
-
   // TODO: PascalCase PlasmaStore methods.
   PlasmaStore(EventLoop* loop, std::string directory, bool hugepages_enabled,
               const std::string& socket_name,
@@ -238,12 +230,8 @@ class PlasmaStore {
   /// A hash table mapping object IDs to a vector of the get requests that are
   /// waiting for the object to arrive.
   std::unordered_map<ObjectID, std::vector<GetRequest*>> object_get_requests_;
-  /// The pending notifications that have not been sent to subscribers because
-  /// the socket send buffers were full. This is a hash table from client file
-  /// descriptor to an array of object_ids to send to that client.
-  /// TODO(pcm): Consider putting this into the Client data structure and
-  /// reorganize the code slightly.
-  NotificationMap pending_notifications_;
+  /// The registered client for receiving notifications.
+  std::unordered_set<std::shared_ptr<Client>> notification_clients_;
 
   std::unordered_set<ObjectID> deletion_cache_;
 

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -55,7 +55,7 @@ struct NotificationQueue {
 
 class PlasmaStore {
  public:
-  using NotificationMap = std::unordered_map<int, NotificationQueue>;
+  using NotificationMap = std::unordered_map<std::shared_ptr<Client>, NotificationQueue>;
 
   // TODO: PascalCase PlasmaStore methods.
   PlasmaStore(EventLoop* loop, std::string directory, bool hugepages_enabled,
@@ -193,8 +193,6 @@ class PlasmaStore {
   void PushNotification(ObjectInfoT* object_notification);
 
   void PushNotifications(const std::vector<ObjectInfoT>& object_notifications);
-
-  void PushNotification(ObjectInfoT* object_notification, int client_fd);
 
   void AddToClientObjectIds(const ObjectID& object_id, ObjectTableEntry* entry,
                             const std::shared_ptr<Client> &client);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This is a subset of https://github.com/ray-project/ray/pull/9431. This PR re-implements object notification with boost::asio and get rids of the socket pair exchange hack. This will reduce the size of change of #9431, so we can fix windows issues faster.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
