### PR TITLE
[Streaming] fix streaming redis interface not-found

### DIFF
--- a/streaming/src/test/queue_tests_base.h
+++ b/streaming/src/test/queue_tests_base.h
@@ -3,6 +3,10 @@
 #include "ray/common/test_util.h"
 #include "ray/util/filesystem.h"
 
+extern "C" {
+#include "hiredis/hiredis.h"
+}
+
 namespace ray {
 namespace streaming {
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Ray-streaming tests building is broken after this commit 06ed2313e2.
<!-- Please give a short summary of the change and the problem this solves. -->
```cpp
Use --sandbox_debug to see verbose messages from the sandbox
In file included from streaming/src/test/streaming_queue_tests.cc:14:
streaming/src/test/queue_tests_base.h:12:27: error: use of undeclared identifier 'redisConnect'
  redisContext *context = redisConnect("127.0.0.1", 6379);
                          ^
streaming/src/test/queue_tests_base.h:13:19: error: use of undeclared identifier 'redisCommand'
  freeReplyObject(redisCommand(context, "FLUSHALL"));
                  ^
streaming/src/test/queue_tests_base.h:14:19: error: use of undeclared identifier 'redisCommand'
  freeReplyObject(redisCommand(context, "SET NumRedisShards 1"));
                  ^
streaming/src/test/queue_tests_base.h:15:19: error: use of undeclared identifier 'redisCommand'
  freeReplyObject(redisCommand(context, "LPUSH RedisShards 127.0.0.1:6380"));
                  ^
streaming/src/test/queue_tests_base.h:16:3: error: use of undeclared identifier 'redisFree'
  redisFree(context);
```

So queue_tests_base should include new hredis header file for accessing redis. 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
