### PR TITLE
[RLlib] Issue 9568: `rllib train` framework in config gets overridden with tf

### DIFF
--- a/rllib/train.py
+++ b/rllib/train.py
@@ -180,22 +180,23 @@ def run(args, parser):
             parser.error("the following arguments are required: --run")
         if not exp.get("env") and not exp.get("config", {}).get("env"):
             parser.error("the following arguments are required: --env")
-        if args.eager:
-            exp["config"]["framework"] = "tfe"
-        elif args.torch:
+
+        if args.torch:
             exp["config"]["framework"] = "torch"
-        else:
-            exp["config"]["framework"] = "tf"
+        elif args.eager:
+            exp["config"]["framework"] = "tfe"
+
+        if args.trace:
+            if exp["config"]["framework"] not in ["tf2", "tfe"]:
+                raise ValueError("Must enable --eager to enable tracing.")
+            exp["config"]["eager_tracing"] = True
+
         if args.v:
             exp["config"]["log_level"] = "INFO"
             verbose = 2
         if args.vv:
             exp["config"]["log_level"] = "DEBUG"
             verbose = 3
-        if args.trace:
-            if exp["config"]["framework"] != "tfe":
-                raise ValueError("Must enable --eager to enable tracing.")
-            exp["config"]["eager_tracing"] = True
 
     if args.ray_num_nodes:
         cluster = Cluster()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

When running `rllib train` and specifying a framework via --config, it gets overridden by `tf`, unless one uses `--torch` or `--eager` command line flags.

<!-- Please give a short summary of the change and the problem this solves. -->

Issue #9568

<!-- For example: "Closes #1234" -->

Closes #9568 

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
