### PR TITLE
Fix java named actor bug

### DIFF
--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -434,6 +434,9 @@ inline jobject NativeRayFunctionDescriptorToJavaStringList(
 
 // Return an actor fullname with job id prepended if this tis a global actor.
 inline std::string GetActorFullName(bool global, std::string name) {
+  if (name.empty()) {
+    return "";
+  }
   return global ? name
                 : ::ray::CoreWorkerProcess::GetCoreWorker().GetCurrentJobId().Hex() + "-" +
                       name;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Problem:
![image](https://user-images.githubusercontent.com/13081808/87907381-19350900-ca97-11ea-962e-21a873b61261.png)
![image](https://user-images.githubusercontent.com/13081808/87907388-1df9bd00-ca97-11ea-9031-ffc3a7660750.png)
If the actor name is not set, the job ID will be spliced, resulting in the actor creation failure.
Solution:
If the actor name is not set, return empty string directly.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
