### PR TITLE
Skip uneeded steps on CI

### DIFF
--- a/ci/travis/ci.sh
+++ b/ci/travis/ci.sh
@@ -437,7 +437,9 @@ init() {
 }
 
 build() {
-  _bazel_build_before_install
+  if [ "${LINT-}" != 1 ]; then
+    _bazel_build_before_install
+  fi
 
   if ! need_wheels; then
     install_ray

--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -51,6 +51,12 @@ install_base() {
 }
 
 install_miniconda() {
+  if [ "${OSTYPE}" = msys ]; then
+    # Windows is on GitHub Actions, whose built-in Python installations we added direct support for.
+    python --version
+    return 0
+  fi
+
   local conda="${CONDA_EXE-}"  # Try to get the activated conda executable
 
   if [ -z "${conda}" ]; then  # If no conda is found, try to find it in PATH

--- a/python/build-wheel-windows.sh
+++ b/python/build-wheel-windows.sh
@@ -38,6 +38,8 @@ install_ray() {
 
 uninstall_ray() {
   pip uninstall -y ray
+
+  rm -r -f "${WORKSPACE_DIR}"/python/ray/thirdparty_files
 }
 
 build_wheel_windows() {


### PR DESCRIPTION
## Why are these changes needed?

- Miniconda takes a while to install, and we don't use it on Windows anymore.

- Avoid building when linting

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
