### PR TITLE
Use UTF-8 for encoding of python code for collision hashing

### DIFF
--- a/python/ray/function_manager.py
+++ b/python/ray/function_manager.py
@@ -120,7 +120,7 @@ class FunctionActorManager:
             function_or_class.__name__ + ":" + string_file.getvalue())
 
         # Return a hash of the identifier in case it is too large.
-        return hashlib.sha1(collision_identifier.encode("ascii")).digest()
+        return hashlib.sha1(collision_identifier.encode("utf-8")).digest()
 
     def export(self, remote_function):
         """Pickle a remote function and export it to redis.

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -743,6 +743,14 @@ def test_object_id_backward_compatibility(ray_start_regular):
     assert isinstance(object_ref, ray.ObjectRef)
 
 
+def test_nonascii_in_function_body(ray_start_regular):
+
+    @ray.remote
+    def return_a_greek_char():
+        return "φ"
+
+    assert ray.get(return_a_greek_char.remote()) == "φ"
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -744,12 +744,12 @@ def test_object_id_backward_compatibility(ray_start_regular):
 
 
 def test_nonascii_in_function_body(ray_start_regular):
-
     @ray.remote
     def return_a_greek_char():
         return "φ"
 
     assert ray.get(return_a_greek_char.remote()) == "φ"
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

This PR allows using non-ascii characters within function body of `ray.remote` functions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/9585
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
