### PR TITLE
Fix Windows CI

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -179,8 +179,13 @@ def build(build_python, build_java):
                "Detected: {}\n  at: {!r}".format(sys.version, sys.executable))
         raise OSError(msg)
 
+    bazel_env = dict(os.environ, PYTHON3_BIN_PATH=sys.executable)
+
     if is_native_windows_or_msys():
-        BAZEL_SH = os.getenv("BAZEL_SH")
+        SHELL = bazel_env.get("SHELL")
+        if SHELL:
+            bazel_env.setdefault("BAZEL_SH", os.path.normpath(SHELL))
+        BAZEL_SH = bazel_env["BAZEL_SH"]
         SYSTEMROOT = os.getenv("SystemRoot")
         wsl_bash = os.path.join(SYSTEMROOT, "System32", "bash.exe")
         if (not BAZEL_SH) and SYSTEMROOT and os.path.isfile(wsl_bash):
@@ -223,7 +228,7 @@ def build(build_python, build_java):
     bazel_targets += ["//java:ray_java_pkg"] if build_java else []
     return subprocess.check_call(
         [bazel, "build", "--verbose_failures", "--"] + bazel_targets,
-        env=dict(os.environ, PYTHON3_BIN_PATH=sys.executable))
+        env=bazel_env)
 
 
 def walk_directory(directory):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

setup.py misdetects Bash from MSYS2 vs. WSL.

## Related issue number

#6082

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
