### PR TITLE
[doc] [minor] Make API docs easier to find.

### DIFF
--- a/doc/source/package-ref.rst
+++ b/doc/source/package-ref.rst
@@ -1,5 +1,5 @@
-Ray Package Reference
-=====================
+API and Package Reference
+=========================
 
 Python API
 ----------


### PR DESCRIPTION
One of the main reason for going to the docs is that you are looking for the API. But finding the Ray API is surprisingly hard and searching for "API" doesn't help.

After this change, the API keyword appears.

<img width="1142" alt="Screen Shot 2020-07-20 at 11 20 44 PM" src="https://user-images.githubusercontent.com/249517/88019974-b156e080-cadf-11ea-9006-27c4f2f520f5.png">
