### PR TITLE
Rename path variable due to zsh conflict

### DIFF
--- a/bazel/BUILD.redis
+++ b/bazel/BUILD.redis
@@ -15,8 +15,8 @@ genrule(
     ],
     cmd = """
         tmpdir="redis.tmp"
-        path=$(location Makefile)
-        cp -p -L -R -- "$${path%/*}" "$${tmpdir}"
+        p=$(location Makefile)
+        cp -p -L -R -- "$${p%/*}" "$${tmpdir}"
         chmod +x "$${tmpdir}"/deps/jemalloc/configure
         parallel="$$(getconf _NPROCESSORS_ONLN || echo 1)"
         make -s -C "$${tmpdir}" -j"$${parallel}" V=0 CFLAGS="$${CFLAGS-} -DLUA_USE_MKSTEMP -Wno-pragmas -Wno-empty-body"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

`path` is apparently reserved in `zsh`, and apparently Bazel invokes `zsh` instead of `bash` despite its documentation.

## Related issue number

Closes #9608

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
