### PR TITLE
[CI] Do not run jenkins test on GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,18 +28,6 @@ jobs:
           - name: macos
             os: macos-10.15
             python-version: 3.6
-          - name: ubuntu-jenkins-tune
-            os: ubuntu-latest
-            python-version: 3.6
-            jenkins-test: RUN_TUNE_TESTS
-          - name: ubuntu-jenkins-doc
-            os: ubuntu-latest
-            python-version: 3.6
-            jenkins-test: RUN_DOC_TESTS
-          - name: ubuntu-jenkins-sgd
-            os: ubuntu-latest
-            python-version: 3.6
-            jenkins-test: RUN_SGD_TESTS
     env:
       BAZEL_CONFIG: ${{ matrix.config }}
       PYTHON: ${{ matrix.python-version }}
@@ -93,16 +81,8 @@ jobs:
         restore-keys: |
           pip-${{ runner.os }}-
           pip-
-    - name: Run Jenkins tests
-      shell: bash -e -o pipefail -l {0}
-      if: matrix.jenkins-test != ''
-      env:
-        SIGOPT_KEY: ${{ secrets.TUNE_SIGOPT_KEY }}
-        TEST_CASE: ${{ matrix.jenkins-test }}
-      run: env "${TEST_CASE}=1" HOME="${PWD}" ci/jenkins_tests/entry_point.sh
     - name: Run CI script
       shell: bash -e -o pipefail -l {0}
-      if: matrix.jenkins-test == ''
       env:
         BAZEL_CACHE_CREDENTIAL_B64: ${{ secrets.BAZEL_CACHE_CREDENTIAL_B64 }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
These tests were still covered by Jenkins. This should free up some concurrency slots for Ray master.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
