### PR TITLE
fix window jni unhappy compiler

### DIFF
--- a/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_metric_NativeMetric.cc
@@ -47,7 +47,7 @@ inline void MetricTransform(JNIEnv *env, jstring j_name, jstring j_description,
   // item when it already exists.
   std::transform(tag_key_str_list.begin(), tag_key_str_list.end(),
                  std::back_inserter(tag_keys),
-                 [](std::string tag_key) { return TagKeyType::Register(tag_key); });
+                 [](std::string &tag_key) { return TagKeyType::Register(tag_key); });
 }
 
 #ifdef __cplusplus
@@ -70,7 +70,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerGaugeNat
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
   auto *gauge = new ray::stats::Gauge(metric_name, description, unit, tag_keys);
-  return reinterpret_cast<long>(gauge);
+  return reinterpret_cast<jlong>(gauge);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNative(
@@ -83,7 +83,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerCountNat
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
   auto *count = new ray::stats::Count(metric_name, description, unit, tag_keys);
-  return reinterpret_cast<long>(count);
+  return reinterpret_cast<jlong>(count);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNative(
@@ -96,7 +96,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerSumNativ
   MetricTransform(env, j_name, j_description, j_unit, tag_key_list, &metric_name,
                   &description, &unit, tag_keys);
   auto *sum = new ray::stats::Sum(metric_name, description, unit, tag_keys);
-  return reinterpret_cast<long>(sum);
+  return reinterpret_cast<jlong>(sum);
 }
 
 JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogramNative(
@@ -114,7 +114,7 @@ JNIEXPORT jlong JNICALL Java_io_ray_runtime_metric_NativeMetric_registerHistogra
 
   auto *histogram =
       new ray::stats::Histogram(metric_name, description, unit, boundaries, tag_keys);
-  return reinterpret_cast<long>(histogram);
+  return reinterpret_cast<jlong>(histogram);
 }
 
 JNIEXPORT void JNICALL Java_io_ray_runtime_metric_NativeMetric_unregisterMetricNative(

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -290,7 +290,7 @@ inline void JavaLongArrayToNativeLongVector(JNIEnv *env, jlongArray long_array,
   jlong *long_array_ptr = env->GetLongArrayElements(long_array, nullptr);
   jsize vec_size = env->GetArrayLength(long_array);
   for (size_t i = 0; i < vec_size; ++i) {
-    native_vector->push_back(static_cast<long>(long_array_ptr[i]))
+    native_vector->push_back(static_cast<long>(long_array_ptr[i]));
   }
   env->ReleaseLongArrayElements(long_array, long_array_ptr, 0);
 }
@@ -301,7 +301,7 @@ inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv *env, jdoubleArray double
   jdouble *double_array_ptr = env->GetDoubleArrayElements(double_array, nullptr);
   jsize vec_size = env->GetArrayLength(double_array);
   for (size_t i = 0; i < vec_size; ++i) {
-    native_vector->push_back(static_cast<double>(double_array_ptr[i]))
+    native_vector->push_back(static_cast<double>(double_array_ptr[i]));
   }
   env->ReleaseDoubleArrayElements(double_array, double_array_ptr, 0);
 }

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -289,8 +289,9 @@ inline void JavaLongArrayToNativeLongVector(JNIEnv *env, jlongArray long_array,
                                             std::vector<long> *native_vector) {
   jlong *long_array_ptr = env->GetLongArrayElements(long_array, nullptr);
   jsize vec_size = env->GetArrayLength(long_array);
-  native_vector->insert(native_vector->begin(), long_array_ptr,
-                        long_array_ptr + vec_size);
+  for (size_t i = 0; i < vec_size; ++i) {
+    native_vector->push_back(static_cast<long>(long_array_ptr[i]))
+  }
   env->ReleaseLongArrayElements(long_array, long_array_ptr, 0);
 }
 
@@ -299,8 +300,9 @@ inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv *env, jdoubleArray double
                                                 std::vector<double> *native_vector) {
   jdouble *double_array_ptr = env->GetDoubleArrayElements(double_array, nullptr);
   jsize vec_size = env->GetArrayLength(double_array);
-  native_vector->insert(native_vector->begin(), double_array_ptr,
-                        double_array_ptr + vec_size);
+  for (size_t i = 0; i < vec_size; ++i) {
+    native_vector->push_back(static_cast<double>(double_array_ptr[i]))
+  }
   env->ReleaseDoubleArrayElements(double_array, double_array_ptr, 0);
 }
 

--- a/src/ray/core_worker/lib/java/jni_utils.h
+++ b/src/ray/core_worker/lib/java/jni_utils.h
@@ -289,7 +289,7 @@ inline void JavaLongArrayToNativeLongVector(JNIEnv *env, jlongArray long_array,
                                             std::vector<long> *native_vector) {
   jlong *long_array_ptr = env->GetLongArrayElements(long_array, nullptr);
   jsize vec_size = env->GetArrayLength(long_array);
-  for (size_t i = 0; i < vec_size; ++i) {
+  for (int i = 0; i < vec_size; ++i) {
     native_vector->push_back(static_cast<long>(long_array_ptr[i]));
   }
   env->ReleaseLongArrayElements(long_array, long_array_ptr, 0);
@@ -300,7 +300,7 @@ inline void JavaDoubleArrayToNativeDoubleVector(JNIEnv *env, jdoubleArray double
                                                 std::vector<double> *native_vector) {
   jdouble *double_array_ptr = env->GetDoubleArrayElements(double_array, nullptr);
   jsize vec_size = env->GetArrayLength(double_array);
-  for (size_t i = 0; i < vec_size; ++i) {
+  for (int i = 0; i < vec_size; ++i) {
     native_vector->push_back(static_cast<double>(double_array_ptr[i]));
   }
   env->ReleaseDoubleArrayElements(double_array, double_array_ptr, 0);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
https://github.com/ray-project/ray/runs/894122984#step:8:1096
Window warning for jni util function
```
VC\Tools\MSVC\14.26.28801\include\xmemory(671): error C2220: the following warning is treated as an error
src\ray\core_worker\lib\java\jni_utils.h(290): note: see reference to function template instantiation 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>> std::vector<_Ty,std::allocator<_Ty>>::insert<jlong*,0>(std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,_Iter,_Iter)' being compiled
        with: _Ty=long
              _Iter=jlong *
VC\Tools\MSVC\14.26.28801\include\xmemory(671): warning C4244: 'initializing': conversion from '__int64' to '_Objty', possible loss of data
        with: _Objty=long
```
## Why are these changes needed?
Convert jni/java type to native type safely.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
