### PR TITLE
Fix TestObjectTableResubscribe testcase bug

### DIFF
--- a/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/service_based_gcs_client_test.cc
@@ -981,12 +981,16 @@ TEST_F(ServiceBasedGcsClientTest, TestObjectTableResubscribe) {
 
   // Restart GCS.
   RestartGcsServer();
+  // When GCS client detects that GCS server has restarted, but the pub-sub server
+  // didn't restart, it will fetch the subscription data again from the GCS server, so
+  // `object2_change_count` plus 1.
+  WaitPendingDone(object2_change_count, 2);
 
   // Add location of object to GCS again and check if resubscribe works.
   ASSERT_TRUE(AddLocation(object1_id, node_id));
   WaitPendingDone(object1_change_count, 1);
   ASSERT_TRUE(AddLocation(object2_id, node_id));
-  WaitPendingDone(object2_change_count, 2);
+  WaitPendingDone(object2_change_count, 3);
 }
 
 TEST_F(ServiceBasedGcsClientTest, TestNodeTableResubscribe) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
When GCS client detects that GCS server has restarted, but the pub-sub server didn't restart, it will fetch the subscription data again from the GCS server, so `object2_change_count` plus 1.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
