### PR TITLE
fixed simplex initialisation seeding bug

### DIFF
--- a/rllib/utils/spaces/simplex.py
+++ b/rllib/utils/spaces/simplex.py
@@ -33,9 +33,10 @@ class Simplex(gym.Space):
             self.concentration = [1] * self.dim
 
         super().__init__(shape, dtype)
-        self.np_random = np.random.RandomState()
 
     def seed(self, seed=None):
+        if self.np_random is None:
+            self.np_random = np.random.RandomState()
         self.np_random.seed(seed)
 
     def sample(self):


### PR DESCRIPTION
## Why are these changes needed?

Solves issue explained here: https://github.com/ray-project/ray/issues/9659

<!-- Please give a short summary of the change and the problem this solves. -->

Initialising the parent was running the seed method which then didn't work because self.np_random was equal to None

## Related issue number

#9659
