### PR TITLE
Fix lint in remote-watch.py

### DIFF
--- a/ci/remote-watch.py
+++ b/ci/remote-watch.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 """
 This command must be run in a git repository.
 
@@ -202,8 +201,8 @@ def monitor():
     expected_line = "{}\t{}".format(expected_sha, ref)
 
     if should_keep_alive(git("show", "-s", "--format=%B", "HEAD^-")):
-        logger.info("Not monitoring %s on %s due to keep-alive on: %s",
-                    ref, remote, expected_line)
+        logger.info("Not monitoring %s on %s due to keep-alive on: %s", ref,
+                    remote, expected_line)
         return
 
     logger.info("Monitoring %s (%s) for changes in %s: %s", remote,
@@ -224,14 +223,15 @@ def monitor():
                         ref, remote, expected_line)
             break
         elif status != 0:
-            logger.error("Error %d: unable to check %s on %s: %s",
-                         status, ref, remote, expected_line)
+            logger.error("Error %d: unable to check %s on %s: %s", status, ref,
+                         remote, expected_line)
         else:
             expected_line = detect_spurious_commit(line, expected_line, remote)
             if expected_line != line:
-                logger.info("Terminating job as %s has been updated on %s\n"
-                            "    from:\t%s\n"
-                            "    to:  \t%s", ref, remote, expected_line, line)
+                logger.info(
+                    "Terminating job as %s has been updated on %s\n"
+                    "    from:\t%s\n"
+                    "    to:  \t%s", ref, remote, expected_line, line)
                 time.sleep(1)  # wait for CI to flush output
                 break
 
@@ -253,8 +253,10 @@ def main(program, *args):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(levelname)s: %(message)s",
-                        stream=sys.stderr, level=logging.DEBUG)
+    logging.basicConfig(
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+        level=logging.DEBUG)
     try:
         raise SystemExit(main(*sys.argv) or 0)
     except KeyboardInterrupt:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
