### PR TITLE
Fix core worker crash bug when multi-thread create actors

### DIFF
--- a/src/ray/core_worker/actor_manager.cc
+++ b/src/ray/core_worker/actor_manager.cc
@@ -89,9 +89,11 @@ bool ActorManager::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle,
     auto actor_notification_callback =
         std::bind(&ActorManager::HandleActorStateNotification, this,
                   std::placeholders::_1, std::placeholders::_2);
-
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
-        actor_id, actor_notification_callback, nullptr));
+    {
+      absl::MutexLock lock(&gcs_client_mutex_);
+      RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
+          actor_id, actor_notification_callback, nullptr));
+    }
 
     if (!RayConfig::instance().gcs_actor_service_enabled()) {
       RAY_CHECK(reference_counter_->SetDeleteCallback(

--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -132,8 +132,11 @@ class ActorManager {
   void HandleActorStateNotification(const ActorID &actor_id,
                                     const gcs::ActorTableData &actor_data);
 
-  /// GCS client
-  std::shared_ptr<gcs::GcsClient> gcs_client_;
+  /// Mutex to protect the gcs_client_ field.
+  /// NOTE: Now gcs client is not thread safe, so we add lock protection.
+  mutable absl::Mutex gcs_client_mutex_;
+  /// GCS client.
+  std::shared_ptr<gcs::GcsClient> gcs_client_ GUARDED_BY(gcs_client_mutex_);
 
   /// Interface to submit tasks directly to other actors.
   std::shared_ptr<CoreWorkerDirectActorTaskSubmitterInterface> direct_actor_submitter_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Now gcs client is not thread safe, so create java actors in parallel causes crash.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/9649
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
