### PR TITLE
[GCS]Open test_gcs_fault_tolerance testcase

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -468,8 +468,7 @@ py_test(
     name = "test_gcs_fault_tolerance",
     size = "medium",
     srcs = SRCS + ["test_gcs_fault_tolerance.py"],
-    # TODO(swang): Enable again once pubsub client supports GCS server restart.
-    tags = ["exclusive", "manual"],
+    tags = ["exclusive"],
     deps = ["//:ray_lib"],
 )
 

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -20,6 +20,9 @@ def increase(x):
     return x + 1
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_GCS_ACTOR_SERVICE_ENABLED") != "true",
+    reason=("This testcase can only be run when GCS actor management is on."))
 def test_gcs_server_restart(ray_start_regular):
     actor1 = Increase.remote()
     result = ray.get(actor1.method.remote(1))
@@ -39,6 +42,9 @@ def test_gcs_server_restart(ray_start_regular):
     assert result == 2
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_GCS_ACTOR_SERVICE_ENABLED") != "true",
+    reason=("This testcase can only be run when GCS actor management is on."))
 def test_gcs_server_restart_during_actor_creation(ray_start_regular):
     ids = []
     for i in range(0, 100):
@@ -54,6 +60,9 @@ def test_gcs_server_restart_during_actor_creation(ray_start_regular):
     assert len(unready) == 0
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_GCS_ACTOR_SERVICE_ENABLED") != "true",
+    reason=("This testcase can only be run when GCS actor management is on."))
 @pytest.mark.parametrize(
     "ray_start_cluster_head",
     [generate_internal_config_map(num_heartbeats_timeout=20)],

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
At present, the GCS server restart is ready, so we will open the test case by default.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
