### PR TITLE
Hotfix: Switch from GitHub checkout@v2 to checkout@v1 due to bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,7 @@ jobs:
         git config --global core.symlinks true && git config --global core.autocrlf false
         if command -v dpkg > /dev/null; then sudo dpkg-reconfigure debconf -f noninteractive -p high; fi
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # we need full history to diff against the original for linting etc.
-        fetch-depth: 0
+      uses: actions/checkout@v1
     - name: Configure AWS Credentials
       continue-on-error: true
       if: github.repository == 'ray-project/ray' && github.event_name != 'pull_request'


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

checkout@v2 seems to check out the wrong commit.

We no longer need it anyway, since we switched back to full clones.

## Related issue number

https://github.com/actions/checkout/issues/237#issuecomment-662662682

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
