### PR TITLE
[core] Removes Error when Internal Config is not set

### DIFF
--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -813,14 +813,11 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetInternalConfig(
           callback(status,
                    std::unordered_map<std::string, std::string>(
                        reply.config().config().begin(), reply.config().config().end()));
-        } else {
-          if (!status.ok()) {
-            RAY_LOG(ERROR) << "Failed to get internal config: " << status.message();
-          } else {
-            RAY_LOG(DEBUG) << "No internal config was stored.";
-          }
-          callback(status, boost::none);
+        } else if (!status.ok()) {
+          RAY_LOG(ERROR) << "Failed to get internal config: " << status.message();
         }
+        RAY_LOG(DEBUG) << "No internal config was stored.";
+        callback(status, boost::none);
       });
   return Status::OK();
 }

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -797,6 +797,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncSetInternalConfig(
       request, [](const Status &status, const rpc::SetInternalConfigReply &reply) {
         if (!status.ok()) {
           RAY_LOG(ERROR) << "Failed to set internal config: " << status.message();
+        } else {
+          RAY_LOG(DEBUG) << "No internal config was stored.";
         }
       });
   return Status::OK();

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ray/gcs/gcs_client/service_based_accessor.h"
+
 #include "ray/gcs/gcs_client/service_based_gcs_client.h"
 
 namespace ray {
@@ -813,7 +814,9 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetInternalConfig(
                    std::unordered_map<std::string, std::string>(
                        reply.config().config().begin(), reply.config().config().end()));
         } else {
-          RAY_LOG(ERROR) << "Failed to get internal config: " << status.message();
+          if (!status.ok()) {
+            RAY_LOG(ERROR) << "Failed to get internal config: " << status.message();
+          }
           callback(status, boost::none);
         }
       });

--- a/src/ray/gcs/gcs_client/service_based_accessor.cc
+++ b/src/ray/gcs/gcs_client/service_based_accessor.cc
@@ -797,8 +797,6 @@ Status ServiceBasedNodeInfoAccessor::AsyncSetInternalConfig(
       request, [](const Status &status, const rpc::SetInternalConfigReply &reply) {
         if (!status.ok()) {
           RAY_LOG(ERROR) << "Failed to set internal config: " << status.message();
-        } else {
-          RAY_LOG(DEBUG) << "No internal config was stored.";
         }
       });
   return Status::OK();
@@ -818,6 +816,8 @@ Status ServiceBasedNodeInfoAccessor::AsyncGetInternalConfig(
         } else {
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Failed to get internal config: " << status.message();
+          } else {
+            RAY_LOG(DEBUG) << "No internal config was stored.";
           }
           callback(status, boost::none);
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Before this, an empty `internal_config` would trigger an `ERROR` level log message.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
