### PR TITLE
Skip flaky test test_hybrid_stream.py

### DIFF
--- a/streaming/python/tests/test_hybrid_stream.py
+++ b/streaming/python/tests/test_hybrid_stream.py
@@ -19,6 +19,7 @@ def sink_func1(x):
     print("HybridStreamTest sink_func1 value:", x)
 
 
+@pytest.mark.skip(reason="This test currently fails.")
 def test_hybrid_stream():
     subprocess.check_call(
         ["bazel", "build", "//streaming/java:all_streaming_tests_deploy.jar"])

--- a/streaming/python/tests/test_hybrid_stream.py
+++ b/streaming/python/tests/test_hybrid_stream.py
@@ -1,8 +1,11 @@
 import json
+import os
+import subprocess
+
+import pytest
+
 import ray
 from ray.streaming import StreamingContext
-import subprocess
-import os
 
 
 def map_func1(x):


### PR DESCRIPTION
This test consistently fails, so let's add it back once we fix it.

If you look at the test code https://github.com/ray-project/ray/blob/91f630f70959098facef4ab4e1a98d1f48f9a586/streaming/python/tests/test_hybrid_stream.py#L51-L66 it looks like we are calling `time.sleep(3)` to wait for the file to be written. However, timing on Travis can be quite unpredictable and this leads to flaky tests. Also, maybe we should also flush the file in the `sink_func` just in case the file is not being flushed.

I also see the error "no module named protobuf", which may be relevant. https://travis-ci.com/github/ray-project/ray/jobs/365002442

cc @chaokunyang